### PR TITLE
[SPARK-40558][SQL] Add Reusable Exchange in Bloom creation side plan

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/BloomFilterMightContain.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/BloomFilterMightContain.scala
@@ -37,10 +37,14 @@ import org.apache.spark.util.sketch.BloomFilter
  *
  * @param bloomFilterExpression the Binary data of Bloom filter.
  * @param valueExpression the Long value to be tested for the membership of `bloomFilterExpression`.
+ * @param buildFromBroadcast indicate if `bloomFilterExpression` child plan is
+ *                           coming from BroadcastExchange
  */
 case class BloomFilterMightContain(
     bloomFilterExpression: Expression,
-    valueExpression: Expression) extends BinaryExpression with Predicate {
+    valueExpression: Expression,
+    buildFromBroadcast: Boolean = true)
+    extends BinaryExpression with Predicate {
 
   override def nullable: Boolean = true
   override def left: Expression = bloomFilterExpression

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PlanRuntimeBloomFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PlanRuntimeBloomFilters.scala
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import scala.annotation.tailrec
+
+import org.apache.spark.sql.{execution, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{BloomFilterMightContain, Literal}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.joins.SortMergeJoinExec
+
+/**
+ * A rule to add re-usuable Exchange in bloom creation plan.
+ * This is only used in Non-AQE execution flow.
+ */
+case class PlanRuntimeBloomFilters(sparkSession: SparkSession) extends Rule[SparkPlan] {
+
+  @tailrec
+  private def getFirstExchangeBelowSort(plan: SparkPlan): Option[ShuffleExchangeExec] = {
+    plan match {
+      case se: SortExec => getFirstExchangeBelowSort(se.child)
+      case see: ShuffleExchangeExec => Some(see)
+      case _ => None
+    }
+  }
+
+  private def getTargetExchangePartitioning(
+      rootPlan: SparkPlan,
+      buildPlan: SparkPlan): Option[Partitioning] = {
+    val nonOHA = buildPlan.find(!_.isInstanceOf[ObjectHashAggregateExec]).get
+    var matchingSide: BuildSide = null
+    val prunedJoin = rootPlan.find {
+      case SortMergeJoinExec(_, _, _, _, left, _, _) if left.sameResult(nonOHA) =>
+        matchingSide = BuildLeft
+        true
+      case SortMergeJoinExec(_, _, _, _, _, right, _) if right.sameResult(nonOHA) =>
+        matchingSide = BuildRight
+        true
+      case _ => false
+    }.get
+
+    val ensurePlan = EnsureRequirements().apply(prunedJoin).asInstanceOf[SortMergeJoinExec]
+    val targetExchange = matchingSide match {
+      case BuildLeft => getFirstExchangeBelowSort(ensurePlan.left)
+      case BuildRight => getFirstExchangeBelowSort(ensurePlan.right)
+    }
+
+    targetExchange.map(_.outputPartitioning)
+  }
+
+  private def getBloomChildPlan(plan: SparkPlan): SparkPlan = {
+    plan.find(!_.isInstanceOf[ObjectHashAggregateExec]).get
+  }
+
+  private def planBloom(
+      rootPlan: SparkPlan,
+      scalarSubquery: org.apache.spark.sql.catalyst.expressions.ScalarSubquery)
+      : Option[execution.ScalarSubquery] = {
+    // ScalarSubquery
+    //  SubqueryExec
+    //    OHA
+    //      Ex
+    //        OHA
+    val buildSparkPlan = QueryExecution.createSparkPlan(
+      sparkSession,
+      sparkSession.sessionState.planner,
+      scalarSubquery.plan)
+    val bloomChildPlan = getBloomChildPlan(buildSparkPlan)
+
+    val canReuseExchange = conf.exchangeReuseEnabled && rootPlan.exists {
+      case SortMergeJoinExec(_, _, _, _, left, right, _) =>
+        left.sameResult(bloomChildPlan) || right.sameResult(bloomChildPlan)
+      case _ => false
+    } &&
+      // As this rule runs before EnsureRequirements we need to check
+      // weather the pruned Join will introduced exchange or not which can be reused by bloom
+      getTargetExchangePartitioning(rootPlan, buildSparkPlan).isDefined
+
+    if (canReuseExchange) {
+      val executedPlan = QueryExecution.prepareExecutedPlan(sparkSession, buildSparkPlan)
+      val distribution = getTargetExchangePartitioning(rootPlan, buildSparkPlan)
+
+      // TODO:: Do this in unprepared plan as it can cause issue once codegen for OHA is introduced
+      val localAgg = executedPlan
+        .asInstanceOf[ObjectHashAggregateExec]
+        .child
+        .asInstanceOf[ShuffleExchangeExec]
+        .child
+        .asInstanceOf[ObjectHashAggregateExec]
+      val newPlanWithExchange = executedPlan transformUp {
+        case targetAgg: ObjectHashAggregateExec if targetAgg.eq(localAgg) =>
+          targetAgg.copy(child = ShuffleExchangeExec(distribution.get, targetAgg.child))
+      }
+
+      Some(
+        execution.ScalarSubquery(
+          SubqueryExec.createForScalarSubquery(
+            s"scalar-subquery#${scalarSubquery.exprId.id}",
+            newPlanWithExchange),
+          scalarSubquery.exprId))
+    } else None
+  }
+
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.cboEnabled || !conf.runtimeFilterBloomFilterEnabled) {
+      return plan
+    }
+
+    plan.transformAllExpressions {
+      case original @ BloomFilterMightContain(
+            scalarSubquery: org.apache.spark.sql.catalyst.expressions.ScalarSubquery,
+            _,
+            fromBroadcast) =>
+        planBloom(plan, scalarSubquery) match {
+          case Some(newSubquery) => original.copy(bloomFilterExpression = newSubquery)
+          case None if fromBroadcast => original
+          case None => Literal.TrueLiteral
+        }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -409,6 +409,9 @@ object QueryExecution {
     adaptiveExecutionRule.toSeq ++
     Seq(
       CoalesceBucketsInJoin,
+      // `PlanRuntimeBloomFilters` needs to be run before `PlanDynamicPruningFilters`
+      // to be able to use to compare similar plans when a bloom filter contains a DPP filter
+      PlanRuntimeBloomFilters(sparkSession),
       PlanDynamicPruningFilters(sparkSession),
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveRuntimeBloomFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveRuntimeBloomFilters.scala
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.expressions.{BloomFilterMightContain, Literal}
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{ScalarSubquery, SparkPlan, SubqueryExec}
+import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+
+/**
+ * A rule to add re-usuable Exchange in bloom creation plan.
+ * This is only used in AQE execution flow.
+ */
+object PlanAdaptiveRuntimeBloomFilters extends Rule[SparkPlan] with AdaptiveSparkPlanHelper {
+
+  private def findMatchingPlanInRootPlan(
+      rootPlan: SparkPlan,
+      plan: SparkPlan): Option[SparkPlan] = {
+    find(rootPlan) {
+      case ShuffleExchangeExec(_, child, _) => child.sameResult(plan)
+      case _ => false
+    }
+  }
+
+  private def getTargetExchangePartitioning(
+      rootPlan: SparkPlan,
+      buildPlan: SparkPlan): Partitioning = {
+    val bloomChildPlan = getBloomChildPlan(buildPlan)
+    val prunedExchange = findMatchingPlanInRootPlan(rootPlan, bloomChildPlan).get
+    prunedExchange.outputPartitioning
+  }
+
+  private def getBloomChildPlan(plan: SparkPlan): SparkPlan = {
+    // Returns plan just below local ObjectHashAggregate node of bloom creation plan
+    if (!plan.isInstanceOf[ObjectHashAggregateExec]) return plan
+
+    plan.asInstanceOf[ObjectHashAggregateExec].child match {
+      case oHA: ObjectHashAggregateExec =>
+        oHA.child
+      case sEE: ShuffleExchangeExec =>
+        sEE.child.asInstanceOf[ObjectHashAggregateExec].child
+      case e: SparkPlan => e
+    }
+  }
+
+  def isBloomExchangeRemoved(currentPlan: SparkPlan, newPlan: SparkPlan): Boolean = {
+    (currentPlan.asInstanceOf[ObjectHashAggregateExec].child match {
+      case ShuffleExchangeExec(
+            _,
+            ObjectHashAggregateExec(_, _, _, _, _, _, _, _, ShuffleExchangeExec(_, _, _)),
+            _) =>
+        true
+      case _ => false
+    }) && (newPlan.asInstanceOf[ObjectHashAggregateExec].child match {
+      case ShuffleExchangeExec(_, ObjectHashAggregateExec(_, _, _, _, _, _, _, _, child), _)
+          if !child.isInstanceOf[ShuffleExchangeExec] =>
+        true
+      case _ => false
+    })
+  }
+
+  def addNewExchangeNodeForBloom(plan: SparkPlan, distribution: Partitioning): SparkPlan = {
+    val localAgg = plan
+      .asInstanceOf[ObjectHashAggregateExec]
+      .child
+      .asInstanceOf[ShuffleExchangeExec]
+      .child
+      .asInstanceOf[ObjectHashAggregateExec]
+    plan transformUp {
+      case targetAgg: ObjectHashAggregateExec if targetAgg.eq(localAgg) =>
+        val exchangeExec = ShuffleExchangeExec(distribution, targetAgg.child)
+        exchangeExec.setLogicalLink(targetAgg.child.logicalLink.get)
+        targetAgg.copy(child = exchangeExec)
+    }
+  }
+
+  private def planBloom(
+      rootPlan: SparkPlan,
+      scalarSubquery: ScalarSubquery): Option[ScalarSubquery] = {
+    // ScalarSubquery
+    //  SubqueryExec
+    //    ASPE
+    //      OHA
+    //        Ex
+    //          OHA
+    val buildSparkPlan =
+      scalarSubquery.plan.child.asInstanceOf[AdaptiveSparkPlanExec].executedPlan
+    val bloomChildPlan = getBloomChildPlan(buildSparkPlan)
+    val canReuseExchange = conf.exchangeReuseEnabled &&
+      findMatchingPlanInRootPlan(rootPlan, bloomChildPlan).isDefined
+
+    if (canReuseExchange) {
+      val executedPlan = buildSparkPlan
+      val distribution = getTargetExchangePartitioning(rootPlan, buildSparkPlan)
+
+      val newPlanWithExchange = addNewExchangeNodeForBloom(executedPlan, distribution)
+
+      val newAdaptivePlan = scalarSubquery.plan.child
+        .asInstanceOf[AdaptiveSparkPlanExec]
+        .copy(inputPlan = newPlanWithExchange)
+      Some(
+        ScalarSubquery(
+          SubqueryExec.createForScalarSubquery(
+            s"scalar-subquery#${scalarSubquery.exprId.id}",
+            newAdaptivePlan),
+          scalarSubquery.exprId))
+    } else None
+  }
+
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.cboEnabled || !conf.runtimeFilterBloomFilterEnabled) {
+      return plan
+    }
+
+    val newPlan = plan.transformAllExpressions {
+      case original @ BloomFilterMightContain(scalarSubquery: ScalarSubquery, _, fromBroadcast) =>
+        planBloom(plan, scalarSubquery) match {
+          case Some(newSubquery) => original.copy(bloomFilterExpression = newSubquery)
+          case None if fromBroadcast => original
+          case None => Literal.TrueLiteral
+        }
+    }
+    newPlan
+  }
+}

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
@@ -61,7 +61,7 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : (((isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3)) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : ((((isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3)) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42), true)) AND true)
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
@@ -84,7 +84,7 @@ Input [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
 
 (8) Filter [codegen id : 4]
 Input [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
-Condition : isnotnull(ws_bill_customer_sk#6)
+Condition : (isnotnull(ws_bill_customer_sk#6) AND true)
 
 (9) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#9]
@@ -112,7 +112,7 @@ Input [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
 
 (14) Filter [codegen id : 6]
 Input [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
-Condition : isnotnull(cs_ship_customer_sk#11)
+Condition : (isnotnull(cs_ship_customer_sk#11) AND true)
 
 (15) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#13]
@@ -156,7 +156,7 @@ Input [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
 
 (24) Filter [codegen id : 10]
 Input [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
-Condition : isnotnull(ss_customer_sk#15)
+Condition : (isnotnull(ss_customer_sk#15) AND true)
 
 (25) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/explain.txt
@@ -1,8 +1,8 @@
 == Physical Plan ==
-* Sort (35)
-+- Exchange (34)
-   +- * Project (33)
-      +- * SortMergeJoin Inner (32)
+* Sort (32)
++- Exchange (31)
+   +- * Project (30)
+      +- * SortMergeJoin Inner (29)
          :- * Sort (26)
          :  +- Exchange (25)
          :     +- * Filter (24)
@@ -29,11 +29,8 @@
          :                             +- * Filter (16)
          :                                +- * ColumnarToRow (15)
          :                                   +- Scan parquet spark_catalog.default.household_demographics (14)
-         +- * Sort (31)
-            +- Exchange (30)
-               +- * Filter (29)
-                  +- * ColumnarToRow (28)
-                     +- Scan parquet spark_catalog.default.customer (27)
+         +- * Sort (28)
+            +- ReusedExchange (27)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -49,185 +46,216 @@ Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, 
 
 (3) Filter [codegen id : 4]
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
-Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
+Condition : (((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 40]
-Output [1]: [d_date_sk#7]
+(4) ReusedExchange [Reuses operator id: 44]
+Output [1]: [d_date_sk#9]
 
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
 Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
-Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
+Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#9]
 
 (7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
+Output [2]: [s_store_sk#10, s_county#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_county, [Appanoose County,Daviess County,Fairfield County,Raleigh County,Saginaw County,Sumner County,Williamson County,Ziebach County]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_county:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
+Input [2]: [s_store_sk#10, s_county#11]
 
 (9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : (s_county#9 IN (Saginaw County,Sumner County,Appanoose County,Daviess County,Fairfield County,Raleigh County,Ziebach County,Williamson County) AND isnotnull(s_store_sk#8))
+Input [2]: [s_store_sk#10, s_county#11]
+Condition : (s_county#11 IN (Saginaw County,Sumner County,Appanoose County,Daviess County,Fairfield County,Raleigh County,Ziebach County,Williamson County) AND isnotnull(s_store_sk#10))
 
 (10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
+Output [1]: [s_store_sk#10]
+Input [2]: [s_store_sk#10, s_county#11]
 
 (11) BroadcastExchange
-Input [1]: [s_store_sk#8]
+Input [1]: [s_store_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#10]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#10]
 
 (14) Scan parquet spark_catalog.default.household_demographics
-Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_vehicle_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,Unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (16) Filter [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : ((((isnotnull(hd_vehicle_count#13) AND ((hd_buy_potential#11 = >10000         ) OR (hd_buy_potential#11 = Unknown        ))) AND (hd_vehicle_count#13 > 0)) AND CASE WHEN (hd_vehicle_count#13 > 0) THEN ((cast(hd_dep_count#12 as double) / cast(hd_vehicle_count#13 as double)) > 1.2) END) AND isnotnull(hd_demo_sk#10))
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
+Condition : ((((isnotnull(hd_vehicle_count#15) AND ((hd_buy_potential#13 = >10000         ) OR (hd_buy_potential#13 = Unknown        ))) AND (hd_vehicle_count#15 > 0)) AND CASE WHEN (hd_vehicle_count#15 > 0) THEN ((cast(hd_dep_count#14 as double) / cast(hd_vehicle_count#15 as double)) > 1.2) END) AND isnotnull(hd_demo_sk#12))
 
 (17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [hd_demo_sk#12]
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (18) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [hd_demo_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#12]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#10]
+Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#12]
 
 (21) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#14]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Aggregate Attributes [1]: [count#16]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 
 (22) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Arguments: hashpartitioning(ss_ticket_number#4, ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (23) HashAggregate [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#16]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#16 AS cnt#17]
+Aggregate Attributes [1]: [count(1)#18]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#18 AS cnt#19]
 
 (24) Filter [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
-Condition : ((cnt#17 >= 15) AND (cnt#17 <= 20))
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
+Condition : ((cnt#19 >= 15) AND (cnt#19 <= 20))
 
 (25) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (26) Sort [codegen id : 6]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(27) ReusedExchange [Reuses operator id: 36]
+Output [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+
+(28) Sort [codegen id : 8]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 9]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#20]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 9]
+Output [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19, c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+
+(31) Exchange
+Input [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Arguments: rangepartitioning(c_last_name#23 ASC NULLS FIRST, c_first_name#22 ASC NULLS FIRST, c_salutation#21 ASC NULLS FIRST, c_preferred_cust_flag#24 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(32) Sort [codegen id : 10]
+Input [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Arguments: [c_last_name#23 ASC NULLS FIRST, c_first_name#22 ASC NULLS FIRST, c_salutation#21 ASC NULLS FIRST, c_preferred_cust_flag#24 DESC NULLS LAST], true, 0
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (39)
++- Exchange (38)
+   +- ObjectHashAggregate (37)
+      +- Exchange (36)
+         +- * Filter (35)
+            +- * ColumnarToRow (34)
+               +- Scan parquet spark_catalog.default.customer (33)
+
+
+(33) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string>
 
-(28) ColumnarToRow [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(34) ColumnarToRow [codegen id : 1]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
 
-(29) Filter [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Condition : isnotnull(c_customer_sk#18)
+(35) Filter [codegen id : 1]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Condition : isnotnull(c_customer_sk#20)
 
-(30) Exchange
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(36) Exchange
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(31) Sort [codegen id : 8]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+(37) ObjectHashAggregate
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#25]
+Results [1]: [buf#26]
 
-(32) SortMergeJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
-Join type: Inner
-Join condition: None
+(38) Exchange
+Input [1]: [buf#26]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(33) Project [codegen id : 9]
-Output [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17, c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(39) ObjectHashAggregate
+Input [1]: [buf#26]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)#27]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)#27 AS bloomFilter#28]
 
-(34) Exchange
-Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: rangepartitioning(c_last_name#21 ASC NULLS FIRST, c_first_name#20 ASC NULLS FIRST, c_salutation#19 ASC NULLS FIRST, c_preferred_cust_flag#22 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) Sort [codegen id : 10]
-Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: [c_last_name#21 ASC NULLS FIRST, c_first_name#20 ASC NULLS FIRST, c_salutation#19 ASC NULLS FIRST, c_preferred_cust_flag#22 DESC NULLS LAST], true, 0
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (40)
-+- * Project (39)
-   +- * Filter (38)
-      +- * ColumnarToRow (37)
-         +- Scan parquet spark_catalog.default.date_dim (36)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (44)
++- * Project (43)
+   +- * Filter (42)
+      +- * ColumnarToRow (41)
+         +- Scan parquet spark_catalog.default.date_dim (40)
 
 
-(36) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(40) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#9, d_year#29, d_dom#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(And(GreaterThanOrEqual(d_dom,1),LessThanOrEqual(d_dom,3)),And(GreaterThanOrEqual(d_dom,25),LessThanOrEqual(d_dom,28))), In(d_year, [1998,1999,2000]), GreaterThanOrEqual(d_date_sk,2450816), LessThanOrEqual(d_date_sk,2451910), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
-(37) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(41) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
 
-(38) Filter [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
-Condition : (((((((d_dom#24 >= 1) AND (d_dom#24 <= 3)) OR ((d_dom#24 >= 25) AND (d_dom#24 <= 28))) AND d_year#23 IN (1998,1999,2000)) AND (d_date_sk#7 >= 2450816)) AND (d_date_sk#7 <= 2451910)) AND isnotnull(d_date_sk#7))
+(42) Filter [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
+Condition : (((((((d_dom#30 >= 1) AND (d_dom#30 <= 3)) OR ((d_dom#30 >= 25) AND (d_dom#30 <= 28))) AND d_year#29 IN (1998,1999,2000)) AND (d_date_sk#9 >= 2450816)) AND (d_date_sk#9 <= 2451910)) AND isnotnull(d_date_sk#9))
 
-(39) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(43) Project [codegen id : 1]
+Output [1]: [d_date_sk#9]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
 
-(40) BroadcastExchange
-Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+(44) BroadcastExchange
+Input [1]: [d_date_sk#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/simplified.txt
@@ -24,6 +24,16 @@ WholeStageCodegen (10)
                                               Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                   Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                            Exchange [c_customer_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [c_customer_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
@@ -38,7 +48,7 @@ WholeStageCodegen (10)
                                                   InputAdapter
                                                     ReusedExchange [d_date_sk] #4
                                               InputAdapter
-                                                BroadcastExchange #5
+                                                BroadcastExchange #7
                                                   WholeStageCodegen (2)
                                                     Project [s_store_sk]
                                                       Filter [s_county,s_store_sk]
@@ -46,7 +56,7 @@ WholeStageCodegen (10)
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.store [s_store_sk,s_county]
                                           InputAdapter
-                                            BroadcastExchange #6
+                                            BroadcastExchange #8
                                               WholeStageCodegen (3)
                                                 Project [hd_demo_sk]
                                                   Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
@@ -57,9 +67,4 @@ WholeStageCodegen (10)
                 WholeStageCodegen (8)
                   Sort [c_customer_sk]
                     InputAdapter
-                      Exchange [c_customer_sk] #7
-                        WholeStageCodegen (7)
-                          Filter [c_customer_sk]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
+                      ReusedExchange [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
@@ -82,7 +82,7 @@ Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 
 (6) Filter [codegen id : 1]
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(d_week_seq#5, 42)))
+Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(d_week_seq#5, 42), true))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
@@ -203,7 +203,7 @@ Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 
 (31) Filter [codegen id : 5]
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#52, [id=#53], xxhash64(d_week_seq#5, 42)))
+Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#52, [id=#53], xxhash64(d_week_seq#5, 42), true))
 
 (32) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/explain.txt
@@ -1,7 +1,7 @@
 == Physical Plan ==
-TakeOrderedAndProject (33)
-+- * Project (32)
-   +- * SortMergeJoin Inner (31)
+TakeOrderedAndProject (30)
++- * Project (29)
+   +- * SortMergeJoin Inner (28)
       :- * Sort (25)
       :  +- Exchange (24)
       :     +- * HashAggregate (23)
@@ -27,11 +27,8 @@ TakeOrderedAndProject (33)
       :                          +- * Filter (16)
       :                             +- * ColumnarToRow (15)
       :                                +- Scan parquet spark_catalog.default.store (14)
-      +- * Sort (30)
-         +- Exchange (29)
-            +- * Filter (28)
-               +- * ColumnarToRow (27)
-                  +- Scan parquet spark_catalog.default.customer (26)
+      +- * Sort (27)
+         +- ReusedExchange (26)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -47,177 +44,208 @@ Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_tic
 
 (3) Filter [codegen id : 4]
 Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8]
-Condition : ((isnotnull(ss_store_sk#4) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
+Condition : (((isnotnull(ss_store_sk#4) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1)) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 38]
-Output [1]: [d_date_sk#10]
+(4) ReusedExchange [Reuses operator id: 42]
+Output [1]: [d_date_sk#12]
 
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#10]
+Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
 Output [7]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8, d_date_sk#10]
+Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8, d_date_sk#12]
 
 (7) Scan parquet spark_catalog.default.household_demographics
-Output [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [Or(EqualTo(hd_dep_count,8),GreaterThan(hd_vehicle_count,0)), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (9) Filter [codegen id : 2]
-Input [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : (((hd_dep_count#12 = 8) OR (hd_vehicle_count#13 > 0)) AND isnotnull(hd_demo_sk#11))
+Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
+Condition : (((hd_dep_count#14 = 8) OR (hd_vehicle_count#15 > 0)) AND isnotnull(hd_demo_sk#13))
 
 (10) Project [codegen id : 2]
-Output [1]: [hd_demo_sk#11]
-Input [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [hd_demo_sk#13]
+Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (11) BroadcastExchange
-Input [1]: [hd_demo_sk#11]
+Input [1]: [hd_demo_sk#13]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#11]
+Right keys [1]: [hd_demo_sk#13]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, hd_demo_sk#11]
+Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, hd_demo_sk#13]
 
 (14) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#14, s_number_employees#15, s_city#16]
+Output [3]: [s_store_sk#16, s_number_employees#17, s_city#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_number_employees), GreaterThanOrEqual(s_number_employees,200), LessThanOrEqual(s_number_employees,295), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_number_employees:int,s_city:string>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [3]: [s_store_sk#14, s_number_employees#15, s_city#16]
+Input [3]: [s_store_sk#16, s_number_employees#17, s_city#18]
 
 (16) Filter [codegen id : 3]
-Input [3]: [s_store_sk#14, s_number_employees#15, s_city#16]
-Condition : (((isnotnull(s_number_employees#15) AND (s_number_employees#15 >= 200)) AND (s_number_employees#15 <= 295)) AND isnotnull(s_store_sk#14))
+Input [3]: [s_store_sk#16, s_number_employees#17, s_city#18]
+Condition : (((isnotnull(s_number_employees#17) AND (s_number_employees#17 >= 200)) AND (s_number_employees#17 <= 295)) AND isnotnull(s_store_sk#16))
 
 (17) Project [codegen id : 3]
-Output [2]: [s_store_sk#14, s_city#16]
-Input [3]: [s_store_sk#14, s_number_employees#15, s_city#16]
+Output [2]: [s_store_sk#16, s_city#18]
+Input [3]: [s_store_sk#16, s_number_employees#17, s_city#18]
 
 (18) BroadcastExchange
-Input [2]: [s_store_sk#14, s_city#16]
+Input [2]: [s_store_sk#16, s_city#18]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
-Right keys [1]: [s_store_sk#14]
+Right keys [1]: [s_store_sk#16]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
-Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_city#16]
-Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_store_sk#14, s_city#16]
+Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_city#18]
+Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_store_sk#16, s_city#18]
 
 (21) HashAggregate [codegen id : 4]
-Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_city#16]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16]
+Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_city#18]
+Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18]
 Functions [2]: [partial_sum(UnscaledValue(ss_coupon_amt#6)), partial_sum(UnscaledValue(ss_net_profit#7))]
-Aggregate Attributes [2]: [sum#17, sum#18]
-Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16, sum#19, sum#20]
+Aggregate Attributes [2]: [sum#19, sum#20]
+Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18, sum#21, sum#22]
 
 (22) Exchange
-Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16, sum#19, sum#20]
-Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18, sum#21, sum#22]
+Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (23) HashAggregate [codegen id : 5]
-Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16, sum#19, sum#20]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16]
+Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18, sum#21, sum#22]
+Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18]
 Functions [2]: [sum(UnscaledValue(ss_coupon_amt#6)), sum(UnscaledValue(ss_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ss_coupon_amt#6))#21, sum(UnscaledValue(ss_net_profit#7))#22]
-Results [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#16, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#6))#21,17,2) AS amt#23, MakeDecimal(sum(UnscaledValue(ss_net_profit#7))#22,17,2) AS profit#24]
+Aggregate Attributes [2]: [sum(UnscaledValue(ss_coupon_amt#6))#23, sum(UnscaledValue(ss_net_profit#7))#24]
+Results [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#18, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#6))#23,17,2) AS amt#25, MakeDecimal(sum(UnscaledValue(ss_net_profit#7))#24,17,2) AS profit#26]
 
 (24) Exchange
-Input [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#16, amt#23, profit#24]
+Input [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#18, amt#25, profit#26]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (25) Sort [codegen id : 6]
-Input [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#16, amt#23, profit#24]
+Input [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#18, amt#25, profit#26]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(26) Scan parquet spark_catalog.default.customer
-Output [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
+(26) ReusedExchange [Reuses operator id: 34]
+Output [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+
+(27) Sort [codegen id : 8]
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+Arguments: [c_customer_sk#27 ASC NULLS FIRST], false, 0
+
+(28) SortMergeJoin [codegen id : 9]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#27]
+Join type: Inner
+Join condition: None
+
+(29) Project [codegen id : 9]
+Output [7]: [c_last_name#29, c_first_name#28, substr(s_city#18, 1, 30) AS substr(s_city, 1, 30)#30, ss_ticket_number#5, amt#25, profit#26, s_city#18]
+Input [8]: [ss_ticket_number#5, ss_customer_sk#1, s_city#18, amt#25, profit#26, c_customer_sk#27, c_first_name#28, c_last_name#29]
+
+(30) TakeOrderedAndProject
+Input [7]: [c_last_name#29, c_first_name#28, substr(s_city, 1, 30)#30, ss_ticket_number#5, amt#25, profit#26, s_city#18]
+Arguments: 100, [c_last_name#29 ASC NULLS FIRST, c_first_name#28 ASC NULLS FIRST, substr(s_city#18, 1, 30) ASC NULLS FIRST, profit#26 ASC NULLS FIRST], [c_last_name#29, c_first_name#28, substr(s_city, 1, 30)#30, ss_ticket_number#5, amt#25, profit#26]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (37)
++- Exchange (36)
+   +- ObjectHashAggregate (35)
+      +- Exchange (34)
+         +- * Filter (33)
+            +- * ColumnarToRow (32)
+               +- Scan parquet spark_catalog.default.customer (31)
+
+
+(31) Scan parquet spark_catalog.default.customer
+Output [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
+(32) ColumnarToRow [codegen id : 1]
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
 
-(28) Filter [codegen id : 7]
-Input [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
-Condition : isnotnull(c_customer_sk#25)
+(33) Filter [codegen id : 1]
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+Condition : isnotnull(c_customer_sk#27)
 
-(29) Exchange
-Input [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
-Arguments: hashpartitioning(c_customer_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(34) Exchange
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+Arguments: hashpartitioning(c_customer_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(30) Sort [codegen id : 8]
-Input [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
-Arguments: [c_customer_sk#25 ASC NULLS FIRST], false, 0
+(35) ObjectHashAggregate
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#27, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#31]
+Results [1]: [buf#32]
 
-(31) SortMergeJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#25]
-Join type: Inner
-Join condition: None
+(36) Exchange
+Input [1]: [buf#32]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
-(32) Project [codegen id : 9]
-Output [7]: [c_last_name#27, c_first_name#26, substr(s_city#16, 1, 30) AS substr(s_city, 1, 30)#28, ss_ticket_number#5, amt#23, profit#24, s_city#16]
-Input [8]: [ss_ticket_number#5, ss_customer_sk#1, s_city#16, amt#23, profit#24, c_customer_sk#25, c_first_name#26, c_last_name#27]
+(37) ObjectHashAggregate
+Input [1]: [buf#32]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#27, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#27, 42), 2000000, 16000000, 0, 0)#33]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#27, 42), 2000000, 16000000, 0, 0)#33 AS bloomFilter#34]
 
-(33) TakeOrderedAndProject
-Input [7]: [c_last_name#27, c_first_name#26, substr(s_city, 1, 30)#28, ss_ticket_number#5, amt#23, profit#24, s_city#16]
-Arguments: 100, [c_last_name#27 ASC NULLS FIRST, c_first_name#26 ASC NULLS FIRST, substr(s_city#16, 1, 30) ASC NULLS FIRST, profit#24 ASC NULLS FIRST], [c_last_name#27, c_first_name#26, substr(s_city, 1, 30)#28, ss_ticket_number#5, amt#23, profit#24]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (38)
-+- * Project (37)
-   +- * Filter (36)
-      +- * ColumnarToRow (35)
-         +- Scan parquet spark_catalog.default.date_dim (34)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
+BroadcastExchange (42)
++- * Project (41)
+   +- * Filter (40)
+      +- * ColumnarToRow (39)
+         +- Scan parquet spark_catalog.default.date_dim (38)
 
 
-(34) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_year#29, d_dow#30]
+(38) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#12, d_year#35, d_dow#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dow), EqualTo(d_dow,1), In(d_year, [1998,1999,2000]), GreaterThanOrEqual(d_date_sk,2450819), LessThanOrEqual(d_date_sk,2451904), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
-(35) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#29, d_dow#30]
+(39) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#12, d_year#35, d_dow#36]
 
-(36) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#29, d_dow#30]
-Condition : (((((isnotnull(d_dow#30) AND (d_dow#30 = 1)) AND d_year#29 IN (1998,1999,2000)) AND (d_date_sk#10 >= 2450819)) AND (d_date_sk#10 <= 2451904)) AND isnotnull(d_date_sk#10))
+(40) Filter [codegen id : 1]
+Input [3]: [d_date_sk#12, d_year#35, d_dow#36]
+Condition : (((((isnotnull(d_dow#36) AND (d_dow#36 = 1)) AND d_year#35 IN (1998,1999,2000)) AND (d_date_sk#12 >= 2450819)) AND (d_date_sk#12 <= 2451904)) AND isnotnull(d_date_sk#12))
 
-(37) Project [codegen id : 1]
-Output [1]: [d_date_sk#10]
-Input [3]: [d_date_sk#10, d_year#29, d_dow#30]
+(41) Project [codegen id : 1]
+Output [1]: [d_date_sk#12]
+Input [3]: [d_date_sk#12, d_year#35, d_dow#36]
 
-(38) BroadcastExchange
-Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+(42) BroadcastExchange
+Input [1]: [d_date_sk#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/simplified.txt
@@ -20,6 +20,16 @@ TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 
                                       Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
                                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                           Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
+                                            Subquery #2
+                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                Exchange #4
+                                                  ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                    Exchange [c_customer_sk] #5
+                                                      WholeStageCodegen (1)
+                                                        Filter [c_customer_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit,ss_sold_date_sk]
@@ -34,7 +44,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 
                                           InputAdapter
                                             ReusedExchange [d_date_sk] #3
                                       InputAdapter
-                                        BroadcastExchange #4
+                                        BroadcastExchange #6
                                           WholeStageCodegen (2)
                                             Project [hd_demo_sk]
                                               Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
@@ -42,7 +52,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
                                   InputAdapter
-                                    BroadcastExchange #5
+                                    BroadcastExchange #7
                                       WholeStageCodegen (3)
                                         Project [s_store_sk,s_city]
                                           Filter [s_number_employees,s_store_sk]
@@ -53,9 +63,4 @@ TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 
           WholeStageCodegen (8)
             Sort [c_customer_sk]
               InputAdapter
-                Exchange [c_customer_sk] #6
-                  WholeStageCodegen (7)
-                    Filter [c_customer_sk]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
+                ReusedExchange [c_customer_sk,c_first_name,c_last_name] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
@@ -1,55 +1,53 @@
 == Physical Plan ==
-TakeOrderedAndProject (51)
-+- * HashAggregate (50)
-   +- Exchange (49)
-      +- * HashAggregate (48)
-         +- * Project (47)
-            +- * SortMergeJoin Inner (46)
-               :- * Sort (40)
-               :  +- Exchange (39)
-               :     +- * Project (38)
-               :        +- * BroadcastHashJoin Inner BuildRight (37)
-               :           :- * Project (31)
-               :           :  +- * Filter (30)
-               :           :     +- * SortMergeJoin ExistenceJoin(exists#1) (29)
-               :           :        :- * SortMergeJoin ExistenceJoin(exists#2) (21)
-               :           :        :  :- * SortMergeJoin LeftSemi (13)
+TakeOrderedAndProject (49)
++- * HashAggregate (48)
+   +- Exchange (47)
+      +- * HashAggregate (46)
+         +- * Project (45)
+            +- * SortMergeJoin Inner (44)
+               :- * Sort (41)
+               :  +- Exchange (40)
+               :     +- * Project (39)
+               :        +- * BroadcastHashJoin Inner BuildRight (38)
+               :           :- * Project (32)
+               :           :  +- * Filter (31)
+               :           :     +- * SortMergeJoin ExistenceJoin(exists#1) (30)
+               :           :        :- * SortMergeJoin ExistenceJoin(exists#2) (22)
+               :           :        :  :- * SortMergeJoin LeftSemi (14)
                :           :        :  :  :- * Sort (5)
                :           :        :  :  :  +- Exchange (4)
                :           :        :  :  :     +- * Filter (3)
                :           :        :  :  :        +- * ColumnarToRow (2)
                :           :        :  :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :           :        :  :  +- * Sort (12)
-               :           :        :  :     +- Exchange (11)
-               :           :        :  :        +- * Project (10)
-               :           :        :  :           +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :        :  :              :- * ColumnarToRow (7)
-               :           :        :  :              :  +- Scan parquet spark_catalog.default.store_sales (6)
-               :           :        :  :              +- ReusedExchange (8)
-               :           :        :  +- * Sort (20)
-               :           :        :     +- Exchange (19)
-               :           :        :        +- * Project (18)
-               :           :        :           +- * BroadcastHashJoin Inner BuildRight (17)
-               :           :        :              :- * ColumnarToRow (15)
-               :           :        :              :  +- Scan parquet spark_catalog.default.web_sales (14)
-               :           :        :              +- ReusedExchange (16)
-               :           :        +- * Sort (28)
-               :           :           +- Exchange (27)
-               :           :              +- * Project (26)
-               :           :                 +- * BroadcastHashJoin Inner BuildRight (25)
-               :           :                    :- * ColumnarToRow (23)
-               :           :                    :  +- Scan parquet spark_catalog.default.catalog_sales (22)
-               :           :                    +- ReusedExchange (24)
-               :           +- BroadcastExchange (36)
-               :              +- * Project (35)
-               :                 +- * Filter (34)
-               :                    +- * ColumnarToRow (33)
-               :                       +- Scan parquet spark_catalog.default.customer_address (32)
-               +- * Sort (45)
-                  +- Exchange (44)
-                     +- * Filter (43)
-                        +- * ColumnarToRow (42)
-                           +- Scan parquet spark_catalog.default.customer_demographics (41)
+               :           :        :  :  +- * Sort (13)
+               :           :        :  :     +- Exchange (12)
+               :           :        :  :        +- * Project (11)
+               :           :        :  :           +- * BroadcastHashJoin Inner BuildRight (10)
+               :           :        :  :              :- * Filter (8)
+               :           :        :  :              :  +- * ColumnarToRow (7)
+               :           :        :  :              :     +- Scan parquet spark_catalog.default.store_sales (6)
+               :           :        :  :              +- ReusedExchange (9)
+               :           :        :  +- * Sort (21)
+               :           :        :     +- Exchange (20)
+               :           :        :        +- * Project (19)
+               :           :        :           +- * BroadcastHashJoin Inner BuildRight (18)
+               :           :        :              :- * ColumnarToRow (16)
+               :           :        :              :  +- Scan parquet spark_catalog.default.web_sales (15)
+               :           :        :              +- ReusedExchange (17)
+               :           :        +- * Sort (29)
+               :           :           +- Exchange (28)
+               :           :              +- * Project (27)
+               :           :                 +- * BroadcastHashJoin Inner BuildRight (26)
+               :           :                    :- * ColumnarToRow (24)
+               :           :                    :  +- Scan parquet spark_catalog.default.catalog_sales (23)
+               :           :                    +- ReusedExchange (25)
+               :           +- BroadcastExchange (37)
+               :              +- * Project (36)
+               :                 +- * Filter (35)
+               :                    +- * ColumnarToRow (34)
+               :                       +- Scan parquet spark_catalog.default.customer_address (33)
+               +- * Sort (43)
+                  +- ReusedExchange (42)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -64,7 +62,7 @@ Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
-Condition : ((isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(c_current_addr_sk#5, 42)))
+Condition : (((isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(c_current_addr_sk#5, 42), true)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(c_current_cdemo_sk#4, 42), false))
 
 (4) Exchange
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
@@ -75,298 +73,333 @@ Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 Arguments: [c_customer_sk#3 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_customer_sk#8, ss_sold_date_sk#9]
+Output [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#9), dynamicpruningexpression(ss_sold_date_sk#9 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#11), dynamicpruningexpression(ss_sold_date_sk#11 IN dynamicpruning#12)]
 ReadSchema: struct<ss_customer_sk:int>
 
 (7) ColumnarToRow [codegen id : 4]
-Input [2]: [ss_customer_sk#8, ss_sold_date_sk#9]
+Input [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
 
-(8) ReusedExchange [Reuses operator id: 63]
-Output [1]: [d_date_sk#11]
+(8) Filter [codegen id : 4]
+Input [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
+Condition : true
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#9]
-Right keys [1]: [d_date_sk#11]
+(9) ReusedExchange [Reuses operator id: 68]
+Output [1]: [d_date_sk#13]
+
+(10) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [1]: [ss_customer_sk#8]
-Input [3]: [ss_customer_sk#8, ss_sold_date_sk#9, d_date_sk#11]
+(11) Project [codegen id : 4]
+Output [1]: [ss_customer_sk#10]
+Input [3]: [ss_customer_sk#10, ss_sold_date_sk#11, d_date_sk#13]
 
-(11) Exchange
-Input [1]: [ss_customer_sk#8]
-Arguments: hashpartitioning(ss_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(12) Exchange
+Input [1]: [ss_customer_sk#10]
+Arguments: hashpartitioning(ss_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) Sort [codegen id : 5]
-Input [1]: [ss_customer_sk#8]
-Arguments: [ss_customer_sk#8 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [1]: [ss_customer_sk#10]
+Arguments: [ss_customer_sk#10 ASC NULLS FIRST], false, 0
 
-(13) SortMergeJoin [codegen id : 6]
+(14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [ss_customer_sk#8]
+Right keys [1]: [ss_customer_sk#10]
 Join type: LeftSemi
 Join condition: None
 
-(14) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#12, ws_sold_date_sk#13]
+(15) Scan parquet spark_catalog.default.web_sales
+Output [2]: [ws_bill_customer_sk#14, ws_sold_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#13), dynamicpruningexpression(ws_sold_date_sk#13 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#15), dynamicpruningexpression(ws_sold_date_sk#15 IN dynamicpruning#12)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(15) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_bill_customer_sk#12, ws_sold_date_sk#13]
+(16) ColumnarToRow [codegen id : 8]
+Input [2]: [ws_bill_customer_sk#14, ws_sold_date_sk#15]
 
-(16) ReusedExchange [Reuses operator id: 63]
-Output [1]: [d_date_sk#14]
+(17) ReusedExchange [Reuses operator id: 68]
+Output [1]: [d_date_sk#16]
 
-(17) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#13]
-Right keys [1]: [d_date_sk#14]
+(18) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [ws_sold_date_sk#15]
+Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 8]
-Output [1]: [ws_bill_customer_sk#12]
-Input [3]: [ws_bill_customer_sk#12, ws_sold_date_sk#13, d_date_sk#14]
+(19) Project [codegen id : 8]
+Output [1]: [ws_bill_customer_sk#14]
+Input [3]: [ws_bill_customer_sk#14, ws_sold_date_sk#15, d_date_sk#16]
 
-(19) Exchange
-Input [1]: [ws_bill_customer_sk#12]
-Arguments: hashpartitioning(ws_bill_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(20) Exchange
+Input [1]: [ws_bill_customer_sk#14]
+Arguments: hashpartitioning(ws_bill_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) Sort [codegen id : 9]
-Input [1]: [ws_bill_customer_sk#12]
-Arguments: [ws_bill_customer_sk#12 ASC NULLS FIRST], false, 0
+(21) Sort [codegen id : 9]
+Input [1]: [ws_bill_customer_sk#14]
+Arguments: [ws_bill_customer_sk#14 ASC NULLS FIRST], false, 0
 
-(21) SortMergeJoin [codegen id : 10]
+(22) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [ws_bill_customer_sk#12]
+Right keys [1]: [ws_bill_customer_sk#14]
 Join type: ExistenceJoin(exists#2)
 Join condition: None
 
-(22) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ship_customer_sk#15, cs_sold_date_sk#16]
+(23) Scan parquet spark_catalog.default.catalog_sales
+Output [2]: [cs_ship_customer_sk#17, cs_sold_date_sk#18]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#16), dynamicpruningexpression(cs_sold_date_sk#16 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#18), dynamicpruningexpression(cs_sold_date_sk#18 IN dynamicpruning#12)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(23) ColumnarToRow [codegen id : 12]
-Input [2]: [cs_ship_customer_sk#15, cs_sold_date_sk#16]
+(24) ColumnarToRow [codegen id : 12]
+Input [2]: [cs_ship_customer_sk#17, cs_sold_date_sk#18]
 
-(24) ReusedExchange [Reuses operator id: 63]
-Output [1]: [d_date_sk#17]
+(25) ReusedExchange [Reuses operator id: 68]
+Output [1]: [d_date_sk#19]
 
-(25) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [cs_sold_date_sk#16]
-Right keys [1]: [d_date_sk#17]
+(26) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [cs_sold_date_sk#18]
+Right keys [1]: [d_date_sk#19]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 12]
-Output [1]: [cs_ship_customer_sk#15]
-Input [3]: [cs_ship_customer_sk#15, cs_sold_date_sk#16, d_date_sk#17]
+(27) Project [codegen id : 12]
+Output [1]: [cs_ship_customer_sk#17]
+Input [3]: [cs_ship_customer_sk#17, cs_sold_date_sk#18, d_date_sk#19]
 
-(27) Exchange
-Input [1]: [cs_ship_customer_sk#15]
-Arguments: hashpartitioning(cs_ship_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(28) Exchange
+Input [1]: [cs_ship_customer_sk#17]
+Arguments: hashpartitioning(cs_ship_customer_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) Sort [codegen id : 13]
-Input [1]: [cs_ship_customer_sk#15]
-Arguments: [cs_ship_customer_sk#15 ASC NULLS FIRST], false, 0
+(29) Sort [codegen id : 13]
+Input [1]: [cs_ship_customer_sk#17]
+Arguments: [cs_ship_customer_sk#17 ASC NULLS FIRST], false, 0
 
-(29) SortMergeJoin [codegen id : 15]
+(30) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [cs_ship_customer_sk#15]
+Right keys [1]: [cs_ship_customer_sk#17]
 Join type: ExistenceJoin(exists#1)
 Join condition: None
 
-(30) Filter [codegen id : 15]
+(31) Filter [codegen id : 15]
 Input [5]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5, exists#2, exists#1]
 Condition : (exists#2 OR exists#1)
 
-(31) Project [codegen id : 15]
+(32) Project [codegen id : 15]
 Output [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Input [5]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5, exists#2, exists#1]
 
-(32) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
+(33) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#20, ca_county#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Jefferson County,La Porte County,Rush County,Toole County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(33) ColumnarToRow [codegen id : 14]
-Input [2]: [ca_address_sk#18, ca_county#19]
+(34) ColumnarToRow [codegen id : 14]
+Input [2]: [ca_address_sk#20, ca_county#21]
 
-(34) Filter [codegen id : 14]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#18))
+(35) Filter [codegen id : 14]
+Input [2]: [ca_address_sk#20, ca_county#21]
+Condition : (ca_county#21 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#20))
 
-(35) Project [codegen id : 14]
-Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
+(36) Project [codegen id : 14]
+Output [1]: [ca_address_sk#20]
+Input [2]: [ca_address_sk#20, ca_county#21]
 
-(36) BroadcastExchange
-Input [1]: [ca_address_sk#18]
+(37) BroadcastExchange
+Input [1]: [ca_address_sk#20]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(37) BroadcastHashJoin [codegen id : 15]
+(38) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#5]
-Right keys [1]: [ca_address_sk#18]
+Right keys [1]: [ca_address_sk#20]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 15]
+(39) Project [codegen id : 15]
 Output [1]: [c_current_cdemo_sk#4]
-Input [3]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#18]
+Input [3]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#20]
 
-(39) Exchange
+(40) Exchange
 Input [1]: [c_current_cdemo_sk#4]
 Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(40) Sort [codegen id : 16]
+(41) Sort [codegen id : 16]
 Input [1]: [c_current_cdemo_sk#4]
 Arguments: [c_current_cdemo_sk#4 ASC NULLS FIRST], false, 0
 
-(41) Scan parquet spark_catalog.default.customer_demographics
-Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(42) ReusedExchange [Reuses operator id: 60]
+Output [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+
+(43) Sort [codegen id : 18]
+Input [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+Arguments: [cd_demo_sk#22 ASC NULLS FIRST], false, 0
+
+(44) SortMergeJoin [codegen id : 19]
+Left keys [1]: [c_current_cdemo_sk#4]
+Right keys [1]: [cd_demo_sk#22]
+Join type: Inner
+Join condition: None
+
+(45) Project [codegen id : 19]
+Output [8]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+Input [10]: [c_current_cdemo_sk#4, cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+
+(46) HashAggregate [codegen id : 19]
+Input [8]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+Keys [8]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#31]
+Results [9]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30, count#32]
+
+(47) Exchange
+Input [9]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30, count#32]
+Arguments: hashpartitioning(cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(48) HashAggregate [codegen id : 20]
+Input [9]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30, count#32]
+Keys [8]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#33]
+Results [14]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, count(1)#33 AS cnt1#34, cd_purchase_estimate#26, count(1)#33 AS cnt2#35, cd_credit_rating#27, count(1)#33 AS cnt3#36, cd_dep_count#28, count(1)#33 AS cnt4#37, cd_dep_employed_count#29, count(1)#33 AS cnt5#38, cd_dep_college_count#30, count(1)#33 AS cnt6#39]
+
+(49) TakeOrderedAndProject
+Input [14]: [cd_gender#23, cd_marital_status#24, cd_education_status#25, cnt1#34, cd_purchase_estimate#26, cnt2#35, cd_credit_rating#27, cnt3#36, cd_dep_count#28, cnt4#37, cd_dep_employed_count#29, cnt5#38, cd_dep_college_count#30, cnt6#39]
+Arguments: 100, [cd_gender#23 ASC NULLS FIRST, cd_marital_status#24 ASC NULLS FIRST, cd_education_status#25 ASC NULLS FIRST, cd_purchase_estimate#26 ASC NULLS FIRST, cd_credit_rating#27 ASC NULLS FIRST, cd_dep_count#28 ASC NULLS FIRST, cd_dep_employed_count#29 ASC NULLS FIRST, cd_dep_college_count#30 ASC NULLS FIRST], [cd_gender#23, cd_marital_status#24, cd_education_status#25, cnt1#34, cd_purchase_estimate#26, cnt2#35, cd_credit_rating#27, cnt3#36, cd_dep_count#28, cnt4#37, cd_dep_employed_count#29, cnt5#38, cd_dep_college_count#30, cnt6#39]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (56)
++- Exchange (55)
+   +- ObjectHashAggregate (54)
+      +- * Project (53)
+         +- * Filter (52)
+            +- * ColumnarToRow (51)
+               +- Scan parquet spark_catalog.default.customer_address (50)
+
+
+(50) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#20, ca_county#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [In(ca_county, [Dona Ana County,Jefferson County,La Porte County,Rush County,Toole County]), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_county:string>
+
+(51) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_county#21]
+
+(52) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_county#21]
+Condition : (ca_county#21 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#20))
+
+(53) Project [codegen id : 1]
+Output [1]: [ca_address_sk#20]
+Input [2]: [ca_address_sk#20, ca_county#21]
+
+(54) ObjectHashAggregate
+Input [1]: [ca_address_sk#20]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 2555, 20440, 0, 0)]
+Aggregate Attributes [1]: [buf#40]
+Results [1]: [buf#41]
+
+(55) Exchange
+Input [1]: [buf#41]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+
+(56) ObjectHashAggregate
+Input [1]: [buf#41]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 2555, 20440, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 2555, 20440, 0, 0)#42]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 2555, 20440, 0, 0)#42 AS bloomFilter#43]
+
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (63)
++- Exchange (62)
+   +- ObjectHashAggregate (61)
+      +- Exchange (60)
+         +- * Filter (59)
+            +- * ColumnarToRow (58)
+               +- Scan parquet spark_catalog.default.customer_demographics (57)
+
+
+(57) Scan parquet spark_catalog.default.customer_demographics
+Output [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(42) ColumnarToRow [codegen id : 17]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(58) ColumnarToRow [codegen id : 1]
+Input [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
 
-(43) Filter [codegen id : 17]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Condition : isnotnull(cd_demo_sk#20)
+(59) Filter [codegen id : 1]
+Input [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+Condition : isnotnull(cd_demo_sk#22)
 
-(44) Exchange
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Arguments: hashpartitioning(cd_demo_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(60) Exchange
+Input [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
+Arguments: hashpartitioning(cd_demo_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(45) Sort [codegen id : 18]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Arguments: [cd_demo_sk#20 ASC NULLS FIRST], false, 0
-
-(46) SortMergeJoin [codegen id : 19]
-Left keys [1]: [c_current_cdemo_sk#4]
-Right keys [1]: [cd_demo_sk#20]
-Join type: Inner
-Join condition: None
-
-(47) Project [codegen id : 19]
-Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Input [10]: [c_current_cdemo_sk#4, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-
-(48) HashAggregate [codegen id : 19]
-Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#29]
-Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-
-(49) Exchange
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(50) HashAggregate [codegen id : 20]
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#31]
-Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
-
-(51) TakeOrderedAndProject
-Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
-Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
-ObjectHashAggregate (58)
-+- Exchange (57)
-   +- ObjectHashAggregate (56)
-      +- * Project (55)
-         +- * Filter (54)
-            +- * ColumnarToRow (53)
-               +- Scan parquet spark_catalog.default.customer_address (52)
-
-
-(52) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [In(ca_county, [Dona Ana County,Jefferson County,La Porte County,Rush County,Toole County]), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_county:string>
-
-(53) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
-
-(54) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#18))
-
-(55) Project [codegen id : 1]
-Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
-
-(56) ObjectHashAggregate
-Input [1]: [ca_address_sk#18]
+(61) ObjectHashAggregate
+Input [9]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_education_status#25, cd_purchase_estimate#26, cd_credit_rating#27, cd_dep_count#28, cd_dep_employed_count#29, cd_dep_college_count#30]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 20440, 0, 0)]
-Aggregate Attributes [1]: [buf#38]
-Results [1]: [buf#39]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#44]
+Results [1]: [buf#45]
 
-(57) Exchange
-Input [1]: [buf#39]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+(62) Exchange
+Input [1]: [buf#45]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(58) ObjectHashAggregate
-Input [1]: [buf#39]
+(63) ObjectHashAggregate
+Input [1]: [buf#45]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 20440, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 20440, 0, 0)#40]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 20440, 0, 0)#40 AS bloomFilter#41]
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)#46]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)#46 AS bloomFilter#47]
 
-Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (63)
-+- * Project (62)
-   +- * Filter (61)
-      +- * ColumnarToRow (60)
-         +- Scan parquet spark_catalog.default.date_dim (59)
+Subquery:3 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
+BroadcastExchange (68)
++- * Project (67)
+   +- * Filter (66)
+      +- * ColumnarToRow (65)
+         +- Scan parquet spark_catalog.default.date_dim (64)
 
 
-(59) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#11, d_year#42, d_moy#43]
+(64) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#13, d_year#48, d_moy#49]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,1), LessThanOrEqual(d_moy,4), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(60) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
+(65) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#13, d_year#48, d_moy#49]
 
-(61) Filter [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
-Condition : (((((isnotnull(d_year#42) AND isnotnull(d_moy#43)) AND (d_year#42 = 2002)) AND (d_moy#43 >= 1)) AND (d_moy#43 <= 4)) AND isnotnull(d_date_sk#11))
+(66) Filter [codegen id : 1]
+Input [3]: [d_date_sk#13, d_year#48, d_moy#49]
+Condition : (((((isnotnull(d_year#48) AND isnotnull(d_moy#49)) AND (d_year#48 = 2002)) AND (d_moy#49 >= 1)) AND (d_moy#49 <= 4)) AND isnotnull(d_date_sk#13))
 
-(62) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
+(67) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [3]: [d_date_sk#13, d_year#48, d_moy#49]
 
-(63) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(68) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#13 IN dynamicpruning#10
+Subquery:4 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#15 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 22 Hosting Expression = cs_sold_date_sk#16 IN dynamicpruning#10
+Subquery:5 Hosting operator id = 23 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/simplified.txt
@@ -41,6 +41,16 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                                                                  Subquery #2
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
+                                                                      Exchange #5
+                                                                        ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                          Exchange [cd_demo_sk] #6
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [cd_demo_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
@@ -48,53 +58,54 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                       WholeStageCodegen (5)
                                                         Sort [ss_customer_sk]
                                                           InputAdapter
-                                                            Exchange [ss_customer_sk] #5
+                                                            Exchange [ss_customer_sk] #7
                                                               WholeStageCodegen (4)
                                                                 Project [ss_customer_sk]
                                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                          SubqueryBroadcast [d_date_sk] #2
-                                                                            BroadcastExchange #6
-                                                                              WholeStageCodegen (1)
-                                                                                Project [d_date_sk]
-                                                                                  Filter [d_year,d_moy,d_date_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                    Filter
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                            SubqueryBroadcast [d_date_sk] #3
+                                                                              BroadcastExchange #8
+                                                                                WholeStageCodegen (1)
+                                                                                  Project [d_date_sk]
+                                                                                    Filter [d_year,d_moy,d_date_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk] #6
+                                                                      ReusedExchange [d_date_sk] #8
                                               InputAdapter
                                                 WholeStageCodegen (9)
                                                   Sort [ws_bill_customer_sk]
                                                     InputAdapter
-                                                      Exchange [ws_bill_customer_sk] #7
+                                                      Exchange [ws_bill_customer_sk] #9
                                                         WholeStageCodegen (8)
                                                           Project [ws_bill_customer_sk]
                                                             BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                    ReusedSubquery [d_date_sk] #2
+                                                                    ReusedSubquery [d_date_sk] #3
                                                               InputAdapter
-                                                                ReusedExchange [d_date_sk] #6
+                                                                ReusedExchange [d_date_sk] #8
                                         InputAdapter
                                           WholeStageCodegen (13)
                                             Sort [cs_ship_customer_sk]
                                               InputAdapter
-                                                Exchange [cs_ship_customer_sk] #8
+                                                Exchange [cs_ship_customer_sk] #10
                                                   WholeStageCodegen (12)
                                                     Project [cs_ship_customer_sk]
                                                       BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                         ColumnarToRow
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                              ReusedSubquery [d_date_sk] #2
+                                                              ReusedSubquery [d_date_sk] #3
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #6
+                                                          ReusedExchange [d_date_sk] #8
                                   InputAdapter
-                                    BroadcastExchange #9
+                                    BroadcastExchange #11
                                       WholeStageCodegen (14)
                                         Project [ca_address_sk]
                                           Filter [ca_county,ca_address_sk]
@@ -105,9 +116,4 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                     WholeStageCodegen (18)
                       Sort [cd_demo_sk]
                         InputAdapter
-                          Exchange [cd_demo_sk] #10
-                            WholeStageCodegen (17)
-                              Filter [cd_demo_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
+                          ReusedExchange [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11.sf100/explain.txt
@@ -1,19 +1,19 @@
 == Physical Plan ==
-TakeOrderedAndProject (80)
-+- * Project (79)
-   +- * SortMergeJoin Inner (78)
-      :- * Project (60)
-      :  +- * SortMergeJoin Inner (59)
-      :     :- * Project (40)
-      :     :  +- * SortMergeJoin Inner (39)
-      :     :     :- * Sort (21)
-      :     :     :  +- Exchange (20)
-      :     :     :     +- * Filter (19)
-      :     :     :        +- * HashAggregate (18)
-      :     :     :           +- Exchange (17)
-      :     :     :              +- * HashAggregate (16)
-      :     :     :                 +- * Project (15)
-      :     :     :                    +- * SortMergeJoin Inner (14)
+TakeOrderedAndProject (77)
++- * Project (76)
+   +- * SortMergeJoin Inner (75)
+      :- * Project (57)
+      :  +- * SortMergeJoin Inner (56)
+      :     :- * Project (37)
+      :     :  +- * SortMergeJoin Inner (36)
+      :     :     :- * Sort (18)
+      :     :     :  +- Exchange (17)
+      :     :     :     +- * Filter (16)
+      :     :     :        +- * HashAggregate (15)
+      :     :     :           +- Exchange (14)
+      :     :     :              +- * HashAggregate (13)
+      :     :     :                 +- * Project (12)
+      :     :     :                    +- * SortMergeJoin Inner (11)
       :     :     :                       :- * Sort (8)
       :     :     :                       :  +- Exchange (7)
       :     :     :                       :     +- * Project (6)
@@ -22,63 +22,60 @@ TakeOrderedAndProject (80)
       :     :     :                       :           :  +- * ColumnarToRow (2)
       :     :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (1)
       :     :     :                       :           +- ReusedExchange (4)
-      :     :     :                       +- * Sort (13)
-      :     :     :                          +- Exchange (12)
-      :     :     :                             +- * Filter (11)
-      :     :     :                                +- * ColumnarToRow (10)
-      :     :     :                                   +- Scan parquet spark_catalog.default.customer (9)
-      :     :     +- * Sort (38)
-      :     :        +- Exchange (37)
-      :     :           +- * HashAggregate (36)
-      :     :              +- Exchange (35)
-      :     :                 +- * HashAggregate (34)
-      :     :                    +- * Project (33)
-      :     :                       +- * SortMergeJoin Inner (32)
-      :     :                          :- * Sort (29)
-      :     :                          :  +- Exchange (28)
-      :     :                          :     +- * Project (27)
-      :     :                          :        +- * BroadcastHashJoin Inner BuildRight (26)
-      :     :                          :           :- * Filter (24)
-      :     :                          :           :  +- * ColumnarToRow (23)
-      :     :                          :           :     +- Scan parquet spark_catalog.default.store_sales (22)
-      :     :                          :           +- ReusedExchange (25)
-      :     :                          +- * Sort (31)
-      :     :                             +- ReusedExchange (30)
-      :     +- * Sort (58)
-      :        +- Exchange (57)
-      :           +- * Filter (56)
-      :              +- * HashAggregate (55)
-      :                 +- Exchange (54)
-      :                    +- * HashAggregate (53)
-      :                       +- * Project (52)
-      :                          +- * SortMergeJoin Inner (51)
-      :                             :- * Sort (48)
-      :                             :  +- Exchange (47)
-      :                             :     +- * Project (46)
-      :                             :        +- * BroadcastHashJoin Inner BuildRight (45)
-      :                             :           :- * Filter (43)
-      :                             :           :  +- * ColumnarToRow (42)
-      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (41)
-      :                             :           +- ReusedExchange (44)
-      :                             +- * Sort (50)
-      :                                +- ReusedExchange (49)
-      +- * Sort (77)
-         +- Exchange (76)
-            +- * HashAggregate (75)
-               +- Exchange (74)
-                  +- * HashAggregate (73)
-                     +- * Project (72)
-                        +- * SortMergeJoin Inner (71)
-                           :- * Sort (68)
-                           :  +- Exchange (67)
-                           :     +- * Project (66)
-                           :        +- * BroadcastHashJoin Inner BuildRight (65)
-                           :           :- * Filter (63)
-                           :           :  +- * ColumnarToRow (62)
-                           :           :     +- Scan parquet spark_catalog.default.web_sales (61)
-                           :           +- ReusedExchange (64)
-                           +- * Sort (70)
-                              +- ReusedExchange (69)
+      :     :     :                       +- * Sort (10)
+      :     :     :                          +- ReusedExchange (9)
+      :     :     +- * Sort (35)
+      :     :        +- Exchange (34)
+      :     :           +- * HashAggregate (33)
+      :     :              +- Exchange (32)
+      :     :                 +- * HashAggregate (31)
+      :     :                    +- * Project (30)
+      :     :                       +- * SortMergeJoin Inner (29)
+      :     :                          :- * Sort (26)
+      :     :                          :  +- Exchange (25)
+      :     :                          :     +- * Project (24)
+      :     :                          :        +- * BroadcastHashJoin Inner BuildRight (23)
+      :     :                          :           :- * Filter (21)
+      :     :                          :           :  +- * ColumnarToRow (20)
+      :     :                          :           :     +- Scan parquet spark_catalog.default.store_sales (19)
+      :     :                          :           +- ReusedExchange (22)
+      :     :                          +- * Sort (28)
+      :     :                             +- ReusedExchange (27)
+      :     +- * Sort (55)
+      :        +- Exchange (54)
+      :           +- * Filter (53)
+      :              +- * HashAggregate (52)
+      :                 +- Exchange (51)
+      :                    +- * HashAggregate (50)
+      :                       +- * Project (49)
+      :                          +- * SortMergeJoin Inner (48)
+      :                             :- * Sort (45)
+      :                             :  +- Exchange (44)
+      :                             :     +- * Project (43)
+      :                             :        +- * BroadcastHashJoin Inner BuildRight (42)
+      :                             :           :- * Filter (40)
+      :                             :           :  +- * ColumnarToRow (39)
+      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (38)
+      :                             :           +- ReusedExchange (41)
+      :                             +- * Sort (47)
+      :                                +- ReusedExchange (46)
+      +- * Sort (74)
+         +- Exchange (73)
+            +- * HashAggregate (72)
+               +- Exchange (71)
+                  +- * HashAggregate (70)
+                     +- * Project (69)
+                        +- * SortMergeJoin Inner (68)
+                           :- * Sort (65)
+                           :  +- Exchange (64)
+                           :     +- * Project (63)
+                           :        +- * BroadcastHashJoin Inner BuildRight (62)
+                           :           :- * Filter (60)
+                           :           :  +- * ColumnarToRow (59)
+                           :           :     +- Scan parquet spark_catalog.default.web_sales (58)
+                           :           +- ReusedExchange (61)
+                           +- * Sort (67)
+                              +- ReusedExchange (66)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -94,394 +91,400 @@ Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, ss_sol
 
 (3) Filter [codegen id : 2]
 Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, ss_sold_date_sk#4]
-Condition : isnotnull(ss_customer_sk#1)
+Condition : (isnotnull(ss_customer_sk#1) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 84]
-Output [2]: [d_date_sk#6, d_year#7]
+(4) ReusedExchange [Reuses operator id: 88]
+Output [2]: [d_date_sk#8, d_year#9]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
-Output [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
-Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, ss_sold_date_sk#4, d_date_sk#6, d_year#7]
+Output [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
+Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, ss_sold_date_sk#4, d_date_sk#8, d_year#9]
 
 (7) Exchange
-Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
+Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (8) Sort [codegen id : 3]
-Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
+Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer
-Output [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
+(9) ReusedExchange [Reuses operator id: 81]
+Output [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+
+(10) Sort [codegen id : 5]
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Arguments: [c_customer_sk#10 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#10]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [10]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
+Input [12]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9, c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+
+(13) HashAggregate [codegen id : 6]
+Input [10]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
+Keys [8]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Functions [1]: [partial_sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))]
+Aggregate Attributes [1]: [sum#18]
+Results [9]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, sum#19]
+
+(14) Exchange
+Input [9]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, sum#19]
+Arguments: hashpartitioning(c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [9]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, sum#19]
+Keys [8]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Functions [1]: [sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))]
+Aggregate Attributes [1]: [sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))#20]
+Results [2]: [c_customer_id#11 AS customer_id#21, MakeDecimal(sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))#20,18,2) AS year_total#22]
+
+(16) Filter [codegen id : 7]
+Input [2]: [customer_id#21, year_total#22]
+Condition : (isnotnull(year_total#22) AND (year_total#22 > 0.00))
+
+(17) Exchange
+Input [2]: [customer_id#21, year_total#22]
+Arguments: hashpartitioning(customer_id#21, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(18) Sort [codegen id : 8]
+Input [2]: [customer_id#21, year_total#22]
+Arguments: [customer_id#21 ASC NULLS FIRST], false, 0
+
+(19) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, ss_sold_date_sk#26]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#26), dynamicpruningexpression(ss_sold_date_sk#26 IN dynamicpruning#27)]
+PushedFilters: [IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_customer_sk:int,ss_ext_discount_amt:decimal(7,2),ss_ext_list_price:decimal(7,2)>
+
+(20) ColumnarToRow [codegen id : 10]
+Input [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, ss_sold_date_sk#26]
+
+(21) Filter [codegen id : 10]
+Input [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, ss_sold_date_sk#26]
+Condition : (isnotnull(ss_customer_sk#23) AND might_contain(Subquery scalar-subquery#28, [id=#29], xxhash64(ss_customer_sk#23, 42), false))
+
+(22) ReusedExchange [Reuses operator id: 99]
+Output [2]: [d_date_sk#30, d_year#31]
+
+(23) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#26]
+Right keys [1]: [d_date_sk#30]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 10]
+Output [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Input [6]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, ss_sold_date_sk#26, d_date_sk#30, d_year#31]
+
+(25) Exchange
+Input [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Arguments: hashpartitioning(ss_customer_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) Sort [codegen id : 11]
+Input [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Arguments: [ss_customer_sk#23 ASC NULLS FIRST], false, 0
+
+(27) ReusedExchange [Reuses operator id: 81]
+Output [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+
+(28) Sort [codegen id : 13]
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Arguments: [c_customer_sk#32 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 14]
+Left keys [1]: [ss_customer_sk#23]
+Right keys [1]: [c_customer_sk#32]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 14]
+Output [10]: [c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Input [12]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31, c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+
+(31) HashAggregate [codegen id : 14]
+Input [10]: [c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Keys [8]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Functions [1]: [partial_sum(UnscaledValue((ss_ext_list_price#25 - ss_ext_discount_amt#24)))]
+Aggregate Attributes [1]: [sum#40]
+Results [9]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, sum#41]
+
+(32) Exchange
+Input [9]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, sum#41]
+Arguments: hashpartitioning(c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(33) HashAggregate [codegen id : 15]
+Input [9]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, sum#41]
+Keys [8]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Functions [1]: [sum(UnscaledValue((ss_ext_list_price#25 - ss_ext_discount_amt#24)))]
+Aggregate Attributes [1]: [sum(UnscaledValue((ss_ext_list_price#25 - ss_ext_discount_amt#24)))#20]
+Results [3]: [c_customer_id#33 AS customer_id#42, c_preferred_cust_flag#36 AS customer_preferred_cust_flag#43, MakeDecimal(sum(UnscaledValue((ss_ext_list_price#25 - ss_ext_discount_amt#24)))#20,18,2) AS year_total#44]
+
+(34) Exchange
+Input [3]: [customer_id#42, customer_preferred_cust_flag#43, year_total#44]
+Arguments: hashpartitioning(customer_id#42, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(35) Sort [codegen id : 16]
+Input [3]: [customer_id#42, customer_preferred_cust_flag#43, year_total#44]
+Arguments: [customer_id#42 ASC NULLS FIRST], false, 0
+
+(36) SortMergeJoin [codegen id : 17]
+Left keys [1]: [customer_id#21]
+Right keys [1]: [customer_id#42]
+Join type: Inner
+Join condition: None
+
+(37) Project [codegen id : 17]
+Output [4]: [customer_id#21, year_total#22, customer_preferred_cust_flag#43, year_total#44]
+Input [5]: [customer_id#21, year_total#22, customer_id#42, customer_preferred_cust_flag#43, year_total#44]
+
+(38) Scan parquet spark_catalog.default.web_sales
+Output [4]: [ws_bill_customer_sk#45, ws_ext_discount_amt#46, ws_ext_list_price#47, ws_sold_date_sk#48]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#48), dynamicpruningexpression(ws_sold_date_sk#48 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_list_price:decimal(7,2)>
+
+(39) ColumnarToRow [codegen id : 19]
+Input [4]: [ws_bill_customer_sk#45, ws_ext_discount_amt#46, ws_ext_list_price#47, ws_sold_date_sk#48]
+
+(40) Filter [codegen id : 19]
+Input [4]: [ws_bill_customer_sk#45, ws_ext_discount_amt#46, ws_ext_list_price#47, ws_sold_date_sk#48]
+Condition : (isnotnull(ws_bill_customer_sk#45) AND might_contain(ReusedSubquery Subquery scalar-subquery#28, [id=#29], xxhash64(ws_bill_customer_sk#45, 42), false))
+
+(41) ReusedExchange [Reuses operator id: 88]
+Output [2]: [d_date_sk#49, d_year#50]
+
+(42) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [ws_sold_date_sk#48]
+Right keys [1]: [d_date_sk#49]
+Join type: Inner
+Join condition: None
+
+(43) Project [codegen id : 19]
+Output [4]: [ws_bill_customer_sk#45, ws_ext_discount_amt#46, ws_ext_list_price#47, d_year#50]
+Input [6]: [ws_bill_customer_sk#45, ws_ext_discount_amt#46, ws_ext_list_price#47, ws_sold_date_sk#48, d_date_sk#49, d_year#50]
+
+(44) Exchange
+Input [4]: [ws_bill_customer_sk#45, ws_ext_discount_amt#46, ws_ext_list_price#47, d_year#50]
+Arguments: hashpartitioning(ws_bill_customer_sk#45, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(45) Sort [codegen id : 20]
+Input [4]: [ws_bill_customer_sk#45, ws_ext_discount_amt#46, ws_ext_list_price#47, d_year#50]
+Arguments: [ws_bill_customer_sk#45 ASC NULLS FIRST], false, 0
+
+(46) ReusedExchange [Reuses operator id: 81]
+Output [8]: [c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58]
+
+(47) Sort [codegen id : 22]
+Input [8]: [c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58]
+Arguments: [c_customer_sk#51 ASC NULLS FIRST], false, 0
+
+(48) SortMergeJoin [codegen id : 23]
+Left keys [1]: [ws_bill_customer_sk#45]
+Right keys [1]: [c_customer_sk#51]
+Join type: Inner
+Join condition: None
+
+(49) Project [codegen id : 23]
+Output [10]: [c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58, ws_ext_discount_amt#46, ws_ext_list_price#47, d_year#50]
+Input [12]: [ws_bill_customer_sk#45, ws_ext_discount_amt#46, ws_ext_list_price#47, d_year#50, c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58]
+
+(50) HashAggregate [codegen id : 23]
+Input [10]: [c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58, ws_ext_discount_amt#46, ws_ext_list_price#47, d_year#50]
+Keys [8]: [c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58, d_year#50]
+Functions [1]: [partial_sum(UnscaledValue((ws_ext_list_price#47 - ws_ext_discount_amt#46)))]
+Aggregate Attributes [1]: [sum#59]
+Results [9]: [c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58, d_year#50, sum#60]
+
+(51) Exchange
+Input [9]: [c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58, d_year#50, sum#60]
+Arguments: hashpartitioning(c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58, d_year#50, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(52) HashAggregate [codegen id : 24]
+Input [9]: [c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58, d_year#50, sum#60]
+Keys [8]: [c_customer_id#52, c_first_name#53, c_last_name#54, c_preferred_cust_flag#55, c_birth_country#56, c_login#57, c_email_address#58, d_year#50]
+Functions [1]: [sum(UnscaledValue((ws_ext_list_price#47 - ws_ext_discount_amt#46)))]
+Aggregate Attributes [1]: [sum(UnscaledValue((ws_ext_list_price#47 - ws_ext_discount_amt#46)))#61]
+Results [2]: [c_customer_id#52 AS customer_id#62, MakeDecimal(sum(UnscaledValue((ws_ext_list_price#47 - ws_ext_discount_amt#46)))#61,18,2) AS year_total#63]
+
+(53) Filter [codegen id : 24]
+Input [2]: [customer_id#62, year_total#63]
+Condition : (isnotnull(year_total#63) AND (year_total#63 > 0.00))
+
+(54) Exchange
+Input [2]: [customer_id#62, year_total#63]
+Arguments: hashpartitioning(customer_id#62, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(55) Sort [codegen id : 25]
+Input [2]: [customer_id#62, year_total#63]
+Arguments: [customer_id#62 ASC NULLS FIRST], false, 0
+
+(56) SortMergeJoin [codegen id : 26]
+Left keys [1]: [customer_id#21]
+Right keys [1]: [customer_id#62]
+Join type: Inner
+Join condition: None
+
+(57) Project [codegen id : 26]
+Output [5]: [customer_id#21, year_total#22, customer_preferred_cust_flag#43, year_total#44, year_total#63]
+Input [6]: [customer_id#21, year_total#22, customer_preferred_cust_flag#43, year_total#44, customer_id#62, year_total#63]
+
+(58) Scan parquet spark_catalog.default.web_sales
+Output [4]: [ws_bill_customer_sk#64, ws_ext_discount_amt#65, ws_ext_list_price#66, ws_sold_date_sk#67]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#67), dynamicpruningexpression(ws_sold_date_sk#67 IN dynamicpruning#27)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_list_price:decimal(7,2)>
+
+(59) ColumnarToRow [codegen id : 28]
+Input [4]: [ws_bill_customer_sk#64, ws_ext_discount_amt#65, ws_ext_list_price#66, ws_sold_date_sk#67]
+
+(60) Filter [codegen id : 28]
+Input [4]: [ws_bill_customer_sk#64, ws_ext_discount_amt#65, ws_ext_list_price#66, ws_sold_date_sk#67]
+Condition : (isnotnull(ws_bill_customer_sk#64) AND might_contain(ReusedSubquery Subquery scalar-subquery#28, [id=#29], xxhash64(ws_bill_customer_sk#64, 42), false))
+
+(61) ReusedExchange [Reuses operator id: 99]
+Output [2]: [d_date_sk#68, d_year#69]
+
+(62) BroadcastHashJoin [codegen id : 28]
+Left keys [1]: [ws_sold_date_sk#67]
+Right keys [1]: [d_date_sk#68]
+Join type: Inner
+Join condition: None
+
+(63) Project [codegen id : 28]
+Output [4]: [ws_bill_customer_sk#64, ws_ext_discount_amt#65, ws_ext_list_price#66, d_year#69]
+Input [6]: [ws_bill_customer_sk#64, ws_ext_discount_amt#65, ws_ext_list_price#66, ws_sold_date_sk#67, d_date_sk#68, d_year#69]
+
+(64) Exchange
+Input [4]: [ws_bill_customer_sk#64, ws_ext_discount_amt#65, ws_ext_list_price#66, d_year#69]
+Arguments: hashpartitioning(ws_bill_customer_sk#64, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(65) Sort [codegen id : 29]
+Input [4]: [ws_bill_customer_sk#64, ws_ext_discount_amt#65, ws_ext_list_price#66, d_year#69]
+Arguments: [ws_bill_customer_sk#64 ASC NULLS FIRST], false, 0
+
+(66) ReusedExchange [Reuses operator id: 81]
+Output [8]: [c_customer_sk#70, c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77]
+
+(67) Sort [codegen id : 31]
+Input [8]: [c_customer_sk#70, c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77]
+Arguments: [c_customer_sk#70 ASC NULLS FIRST], false, 0
+
+(68) SortMergeJoin [codegen id : 32]
+Left keys [1]: [ws_bill_customer_sk#64]
+Right keys [1]: [c_customer_sk#70]
+Join type: Inner
+Join condition: None
+
+(69) Project [codegen id : 32]
+Output [10]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, ws_ext_discount_amt#65, ws_ext_list_price#66, d_year#69]
+Input [12]: [ws_bill_customer_sk#64, ws_ext_discount_amt#65, ws_ext_list_price#66, d_year#69, c_customer_sk#70, c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77]
+
+(70) HashAggregate [codegen id : 32]
+Input [10]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, ws_ext_discount_amt#65, ws_ext_list_price#66, d_year#69]
+Keys [8]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#69]
+Functions [1]: [partial_sum(UnscaledValue((ws_ext_list_price#66 - ws_ext_discount_amt#65)))]
+Aggregate Attributes [1]: [sum#78]
+Results [9]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#69, sum#79]
+
+(71) Exchange
+Input [9]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#69, sum#79]
+Arguments: hashpartitioning(c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#69, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(72) HashAggregate [codegen id : 33]
+Input [9]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#69, sum#79]
+Keys [8]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#69]
+Functions [1]: [sum(UnscaledValue((ws_ext_list_price#66 - ws_ext_discount_amt#65)))]
+Aggregate Attributes [1]: [sum(UnscaledValue((ws_ext_list_price#66 - ws_ext_discount_amt#65)))#61]
+Results [2]: [c_customer_id#71 AS customer_id#80, MakeDecimal(sum(UnscaledValue((ws_ext_list_price#66 - ws_ext_discount_amt#65)))#61,18,2) AS year_total#81]
+
+(73) Exchange
+Input [2]: [customer_id#80, year_total#81]
+Arguments: hashpartitioning(customer_id#80, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(74) Sort [codegen id : 34]
+Input [2]: [customer_id#80, year_total#81]
+Arguments: [customer_id#80 ASC NULLS FIRST], false, 0
+
+(75) SortMergeJoin [codegen id : 35]
+Left keys [1]: [customer_id#21]
+Right keys [1]: [customer_id#80]
+Join type: Inner
+Join condition: (CASE WHEN (year_total#63 > 0.00) THEN (year_total#81 / year_total#63) END > CASE WHEN (year_total#22 > 0.00) THEN (year_total#44 / year_total#22) END)
+
+(76) Project [codegen id : 35]
+Output [1]: [customer_preferred_cust_flag#43]
+Input [7]: [customer_id#21, year_total#22, customer_preferred_cust_flag#43, year_total#44, year_total#63, customer_id#80, year_total#81]
+
+(77) TakeOrderedAndProject
+Input [1]: [customer_preferred_cust_flag#43]
+Arguments: 100, [customer_preferred_cust_flag#43 ASC NULLS FIRST], [customer_preferred_cust_flag#43]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (84)
++- Exchange (83)
+   +- ObjectHashAggregate (82)
+      +- Exchange (81)
+         +- * Filter (80)
+            +- * ColumnarToRow (79)
+               +- Scan parquet spark_catalog.default.customer (78)
+
+
+(78) Scan parquet spark_catalog.default.customer
+Output [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(10) ColumnarToRow [codegen id : 4]
-Input [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-
-(11) Filter [codegen id : 4]
-Input [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Condition : (isnotnull(c_customer_sk#8) AND isnotnull(c_customer_id#9))
-
-(12) Exchange
-Input [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Arguments: hashpartitioning(c_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(13) Sort [codegen id : 5]
-Input [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Arguments: [c_customer_sk#8 ASC NULLS FIRST], false, 0
-
-(14) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#8]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [10]: [c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
-Input [12]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7, c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-
-(16) HashAggregate [codegen id : 6]
-Input [10]: [c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
-Keys [8]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Functions [1]: [partial_sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))]
-Aggregate Attributes [1]: [sum#16]
-Results [9]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, sum#17]
-
-(17) Exchange
-Input [9]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, sum#17]
-Arguments: hashpartitioning(c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [9]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, sum#17]
-Keys [8]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Functions [1]: [sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))]
-Aggregate Attributes [1]: [sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))#18]
-Results [2]: [c_customer_id#9 AS customer_id#19, MakeDecimal(sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))#18,18,2) AS year_total#20]
-
-(19) Filter [codegen id : 7]
-Input [2]: [customer_id#19, year_total#20]
-Condition : (isnotnull(year_total#20) AND (year_total#20 > 0.00))
-
-(20) Exchange
-Input [2]: [customer_id#19, year_total#20]
-Arguments: hashpartitioning(customer_id#19, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(21) Sort [codegen id : 8]
-Input [2]: [customer_id#19, year_total#20]
-Arguments: [customer_id#19 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, ss_sold_date_sk#24]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#24), dynamicpruningexpression(ss_sold_date_sk#24 IN dynamicpruning#25)]
-PushedFilters: [IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_customer_sk:int,ss_ext_discount_amt:decimal(7,2),ss_ext_list_price:decimal(7,2)>
-
-(23) ColumnarToRow [codegen id : 10]
-Input [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, ss_sold_date_sk#24]
-
-(24) Filter [codegen id : 10]
-Input [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, ss_sold_date_sk#24]
-Condition : isnotnull(ss_customer_sk#21)
-
-(25) ReusedExchange [Reuses operator id: 88]
-Output [2]: [d_date_sk#26, d_year#27]
-
-(26) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#24]
-Right keys [1]: [d_date_sk#26]
-Join type: Inner
-Join condition: None
-
-(27) Project [codegen id : 10]
-Output [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Input [6]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, ss_sold_date_sk#24, d_date_sk#26, d_year#27]
-
-(28) Exchange
-Input [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Arguments: hashpartitioning(ss_customer_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(29) Sort [codegen id : 11]
-Input [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Arguments: [ss_customer_sk#21 ASC NULLS FIRST], false, 0
-
-(30) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#28, c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-
-(31) Sort [codegen id : 13]
-Input [8]: [c_customer_sk#28, c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 14]
-Left keys [1]: [ss_customer_sk#21]
-Right keys [1]: [c_customer_sk#28]
-Join type: Inner
-Join condition: None
-
-(33) Project [codegen id : 14]
-Output [10]: [c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Input [12]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27, c_customer_sk#28, c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-
-(34) HashAggregate [codegen id : 14]
-Input [10]: [c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Keys [8]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-Functions [1]: [partial_sum(UnscaledValue((ss_ext_list_price#23 - ss_ext_discount_amt#22)))]
-Aggregate Attributes [1]: [sum#36]
-Results [9]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, sum#37]
-
-(35) Exchange
-Input [9]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, sum#37]
-Arguments: hashpartitioning(c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(36) HashAggregate [codegen id : 15]
-Input [9]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, sum#37]
-Keys [8]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-Functions [1]: [sum(UnscaledValue((ss_ext_list_price#23 - ss_ext_discount_amt#22)))]
-Aggregate Attributes [1]: [sum(UnscaledValue((ss_ext_list_price#23 - ss_ext_discount_amt#22)))#18]
-Results [3]: [c_customer_id#29 AS customer_id#38, c_preferred_cust_flag#32 AS customer_preferred_cust_flag#39, MakeDecimal(sum(UnscaledValue((ss_ext_list_price#23 - ss_ext_discount_amt#22)))#18,18,2) AS year_total#40]
-
-(37) Exchange
-Input [3]: [customer_id#38, customer_preferred_cust_flag#39, year_total#40]
-Arguments: hashpartitioning(customer_id#38, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(38) Sort [codegen id : 16]
-Input [3]: [customer_id#38, customer_preferred_cust_flag#39, year_total#40]
-Arguments: [customer_id#38 ASC NULLS FIRST], false, 0
-
-(39) SortMergeJoin [codegen id : 17]
-Left keys [1]: [customer_id#19]
-Right keys [1]: [customer_id#38]
-Join type: Inner
-Join condition: None
-
-(40) Project [codegen id : 17]
-Output [4]: [customer_id#19, year_total#20, customer_preferred_cust_flag#39, year_total#40]
-Input [5]: [customer_id#19, year_total#20, customer_id#38, customer_preferred_cust_flag#39, year_total#40]
-
-(41) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_bill_customer_sk#41, ws_ext_discount_amt#42, ws_ext_list_price#43, ws_sold_date_sk#44]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#44), dynamicpruningexpression(ws_sold_date_sk#44 IN dynamicpruning#5)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_list_price:decimal(7,2)>
-
-(42) ColumnarToRow [codegen id : 19]
-Input [4]: [ws_bill_customer_sk#41, ws_ext_discount_amt#42, ws_ext_list_price#43, ws_sold_date_sk#44]
-
-(43) Filter [codegen id : 19]
-Input [4]: [ws_bill_customer_sk#41, ws_ext_discount_amt#42, ws_ext_list_price#43, ws_sold_date_sk#44]
-Condition : isnotnull(ws_bill_customer_sk#41)
-
-(44) ReusedExchange [Reuses operator id: 84]
-Output [2]: [d_date_sk#45, d_year#46]
-
-(45) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_sold_date_sk#44]
-Right keys [1]: [d_date_sk#45]
-Join type: Inner
-Join condition: None
-
-(46) Project [codegen id : 19]
-Output [4]: [ws_bill_customer_sk#41, ws_ext_discount_amt#42, ws_ext_list_price#43, d_year#46]
-Input [6]: [ws_bill_customer_sk#41, ws_ext_discount_amt#42, ws_ext_list_price#43, ws_sold_date_sk#44, d_date_sk#45, d_year#46]
-
-(47) Exchange
-Input [4]: [ws_bill_customer_sk#41, ws_ext_discount_amt#42, ws_ext_list_price#43, d_year#46]
-Arguments: hashpartitioning(ws_bill_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(48) Sort [codegen id : 20]
-Input [4]: [ws_bill_customer_sk#41, ws_ext_discount_amt#42, ws_ext_list_price#43, d_year#46]
-Arguments: [ws_bill_customer_sk#41 ASC NULLS FIRST], false, 0
-
-(49) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#47, c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54]
-
-(50) Sort [codegen id : 22]
-Input [8]: [c_customer_sk#47, c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54]
-Arguments: [c_customer_sk#47 ASC NULLS FIRST], false, 0
-
-(51) SortMergeJoin [codegen id : 23]
-Left keys [1]: [ws_bill_customer_sk#41]
-Right keys [1]: [c_customer_sk#47]
-Join type: Inner
-Join condition: None
-
-(52) Project [codegen id : 23]
-Output [10]: [c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54, ws_ext_discount_amt#42, ws_ext_list_price#43, d_year#46]
-Input [12]: [ws_bill_customer_sk#41, ws_ext_discount_amt#42, ws_ext_list_price#43, d_year#46, c_customer_sk#47, c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54]
-
-(53) HashAggregate [codegen id : 23]
-Input [10]: [c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54, ws_ext_discount_amt#42, ws_ext_list_price#43, d_year#46]
-Keys [8]: [c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54, d_year#46]
-Functions [1]: [partial_sum(UnscaledValue((ws_ext_list_price#43 - ws_ext_discount_amt#42)))]
-Aggregate Attributes [1]: [sum#55]
-Results [9]: [c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54, d_year#46, sum#56]
-
-(54) Exchange
-Input [9]: [c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54, d_year#46, sum#56]
-Arguments: hashpartitioning(c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54, d_year#46, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(55) HashAggregate [codegen id : 24]
-Input [9]: [c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54, d_year#46, sum#56]
-Keys [8]: [c_customer_id#48, c_first_name#49, c_last_name#50, c_preferred_cust_flag#51, c_birth_country#52, c_login#53, c_email_address#54, d_year#46]
-Functions [1]: [sum(UnscaledValue((ws_ext_list_price#43 - ws_ext_discount_amt#42)))]
-Aggregate Attributes [1]: [sum(UnscaledValue((ws_ext_list_price#43 - ws_ext_discount_amt#42)))#57]
-Results [2]: [c_customer_id#48 AS customer_id#58, MakeDecimal(sum(UnscaledValue((ws_ext_list_price#43 - ws_ext_discount_amt#42)))#57,18,2) AS year_total#59]
-
-(56) Filter [codegen id : 24]
-Input [2]: [customer_id#58, year_total#59]
-Condition : (isnotnull(year_total#59) AND (year_total#59 > 0.00))
-
-(57) Exchange
-Input [2]: [customer_id#58, year_total#59]
-Arguments: hashpartitioning(customer_id#58, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(58) Sort [codegen id : 25]
-Input [2]: [customer_id#58, year_total#59]
-Arguments: [customer_id#58 ASC NULLS FIRST], false, 0
-
-(59) SortMergeJoin [codegen id : 26]
-Left keys [1]: [customer_id#19]
-Right keys [1]: [customer_id#58]
-Join type: Inner
-Join condition: None
-
-(60) Project [codegen id : 26]
-Output [5]: [customer_id#19, year_total#20, customer_preferred_cust_flag#39, year_total#40, year_total#59]
-Input [6]: [customer_id#19, year_total#20, customer_preferred_cust_flag#39, year_total#40, customer_id#58, year_total#59]
-
-(61) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_bill_customer_sk#60, ws_ext_discount_amt#61, ws_ext_list_price#62, ws_sold_date_sk#63]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#63), dynamicpruningexpression(ws_sold_date_sk#63 IN dynamicpruning#25)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_list_price:decimal(7,2)>
-
-(62) ColumnarToRow [codegen id : 28]
-Input [4]: [ws_bill_customer_sk#60, ws_ext_discount_amt#61, ws_ext_list_price#62, ws_sold_date_sk#63]
-
-(63) Filter [codegen id : 28]
-Input [4]: [ws_bill_customer_sk#60, ws_ext_discount_amt#61, ws_ext_list_price#62, ws_sold_date_sk#63]
-Condition : isnotnull(ws_bill_customer_sk#60)
-
-(64) ReusedExchange [Reuses operator id: 88]
-Output [2]: [d_date_sk#64, d_year#65]
-
-(65) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [ws_sold_date_sk#63]
-Right keys [1]: [d_date_sk#64]
-Join type: Inner
-Join condition: None
-
-(66) Project [codegen id : 28]
-Output [4]: [ws_bill_customer_sk#60, ws_ext_discount_amt#61, ws_ext_list_price#62, d_year#65]
-Input [6]: [ws_bill_customer_sk#60, ws_ext_discount_amt#61, ws_ext_list_price#62, ws_sold_date_sk#63, d_date_sk#64, d_year#65]
-
-(67) Exchange
-Input [4]: [ws_bill_customer_sk#60, ws_ext_discount_amt#61, ws_ext_list_price#62, d_year#65]
-Arguments: hashpartitioning(ws_bill_customer_sk#60, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(68) Sort [codegen id : 29]
-Input [4]: [ws_bill_customer_sk#60, ws_ext_discount_amt#61, ws_ext_list_price#62, d_year#65]
-Arguments: [ws_bill_customer_sk#60 ASC NULLS FIRST], false, 0
-
-(69) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#66, c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73]
-
-(70) Sort [codegen id : 31]
-Input [8]: [c_customer_sk#66, c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73]
-Arguments: [c_customer_sk#66 ASC NULLS FIRST], false, 0
-
-(71) SortMergeJoin [codegen id : 32]
-Left keys [1]: [ws_bill_customer_sk#60]
-Right keys [1]: [c_customer_sk#66]
-Join type: Inner
-Join condition: None
-
-(72) Project [codegen id : 32]
-Output [10]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, ws_ext_discount_amt#61, ws_ext_list_price#62, d_year#65]
-Input [12]: [ws_bill_customer_sk#60, ws_ext_discount_amt#61, ws_ext_list_price#62, d_year#65, c_customer_sk#66, c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73]
-
-(73) HashAggregate [codegen id : 32]
-Input [10]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, ws_ext_discount_amt#61, ws_ext_list_price#62, d_year#65]
-Keys [8]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65]
-Functions [1]: [partial_sum(UnscaledValue((ws_ext_list_price#62 - ws_ext_discount_amt#61)))]
-Aggregate Attributes [1]: [sum#74]
-Results [9]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65, sum#75]
-
-(74) Exchange
-Input [9]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65, sum#75]
-Arguments: hashpartitioning(c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(75) HashAggregate [codegen id : 33]
-Input [9]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65, sum#75]
-Keys [8]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65]
-Functions [1]: [sum(UnscaledValue((ws_ext_list_price#62 - ws_ext_discount_amt#61)))]
-Aggregate Attributes [1]: [sum(UnscaledValue((ws_ext_list_price#62 - ws_ext_discount_amt#61)))#57]
-Results [2]: [c_customer_id#67 AS customer_id#76, MakeDecimal(sum(UnscaledValue((ws_ext_list_price#62 - ws_ext_discount_amt#61)))#57,18,2) AS year_total#77]
-
-(76) Exchange
-Input [2]: [customer_id#76, year_total#77]
-Arguments: hashpartitioning(customer_id#76, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(77) Sort [codegen id : 34]
-Input [2]: [customer_id#76, year_total#77]
-Arguments: [customer_id#76 ASC NULLS FIRST], false, 0
-
-(78) SortMergeJoin [codegen id : 35]
-Left keys [1]: [customer_id#19]
-Right keys [1]: [customer_id#76]
-Join type: Inner
-Join condition: (CASE WHEN (year_total#59 > 0.00) THEN (year_total#77 / year_total#59) END > CASE WHEN (year_total#20 > 0.00) THEN (year_total#40 / year_total#20) END)
-
-(79) Project [codegen id : 35]
-Output [1]: [customer_preferred_cust_flag#39]
-Input [7]: [customer_id#19, year_total#20, customer_preferred_cust_flag#39, year_total#40, year_total#59, customer_id#76, year_total#77]
-
-(80) TakeOrderedAndProject
-Input [1]: [customer_preferred_cust_flag#39]
-Arguments: 100, [customer_preferred_cust_flag#39 ASC NULLS FIRST], [customer_preferred_cust_flag#39]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (84)
-+- * Filter (83)
-   +- * ColumnarToRow (82)
-      +- Scan parquet spark_catalog.default.date_dim (81)
-
-
-(81) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#6, d_year#7]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int>
-
-(82) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#6, d_year#7]
-
-(83) Filter [codegen id : 1]
-Input [2]: [d_date_sk#6, d_year#7]
-Condition : ((isnotnull(d_year#7) AND (d_year#7 = 2001)) AND isnotnull(d_date_sk#6))
-
-(84) BroadcastExchange
-Input [2]: [d_date_sk#6, d_year#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
-
-Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#24 IN dynamicpruning#25
+(79) ColumnarToRow [codegen id : 1]
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+
+(80) Filter [codegen id : 1]
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Condition : (isnotnull(c_customer_sk#10) AND isnotnull(c_customer_id#11))
+
+(81) Exchange
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Arguments: hashpartitioning(c_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(82) ObjectHashAggregate
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#10, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#82]
+Results [1]: [buf#83]
+
+(83) Exchange
+Input [1]: [buf#83]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(84) ObjectHashAggregate
+Input [1]: [buf#83]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#10, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#10, 42), 2000000, 16000000, 0, 0)#84]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#10, 42), 2000000, 16000000, 0, 0)#84 AS bloomFilter#85]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (88)
 +- * Filter (87)
    +- * ColumnarToRow (86)
@@ -489,25 +492,100 @@ BroadcastExchange (88)
 
 
 (85) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#26, d_year#27]
+Output [2]: [d_date_sk#8, d_year#9]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int>
+
+(86) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#8, d_year#9]
+
+(87) Filter [codegen id : 1]
+Input [2]: [d_date_sk#8, d_year#9]
+Condition : ((isnotnull(d_year#9) AND (d_year#9 = 2001)) AND isnotnull(d_date_sk#8))
+
+(88) BroadcastExchange
+Input [2]: [d_date_sk#8, d_year#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+
+Subquery:3 Hosting operator id = 21 Hosting Expression = Subquery scalar-subquery#28, [id=#29]
+ObjectHashAggregate (95)
++- Exchange (94)
+   +- ObjectHashAggregate (93)
+      +- Exchange (92)
+         +- * Filter (91)
+            +- * ColumnarToRow (90)
+               +- Scan parquet spark_catalog.default.customer (89)
+
+
+(89) Scan parquet spark_catalog.default.customer
+Output [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
+ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
+
+(90) ColumnarToRow [codegen id : 1]
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+
+(91) Filter [codegen id : 1]
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_customer_id#33))
+
+(92) Exchange
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Arguments: hashpartitioning(c_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(93) ObjectHashAggregate
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#32, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#86]
+Results [1]: [buf#87]
+
+(94) Exchange
+Input [1]: [buf#87]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(95) ObjectHashAggregate
+Input [1]: [buf#87]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#32, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#32, 42), 2000000, 16000000, 0, 0)#88]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#32, 42), 2000000, 16000000, 0, 0)#88 AS bloomFilter#89]
+
+Subquery:4 Hosting operator id = 19 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#27
+BroadcastExchange (99)
++- * Filter (98)
+   +- * ColumnarToRow (97)
+      +- Scan parquet spark_catalog.default.date_dim (96)
+
+
+(96) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#30, d_year#31]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(86) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#26, d_year#27]
+(97) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#30, d_year#31]
 
-(87) Filter [codegen id : 1]
-Input [2]: [d_date_sk#26, d_year#27]
-Condition : ((isnotnull(d_year#27) AND (d_year#27 = 2002)) AND isnotnull(d_date_sk#26))
+(98) Filter [codegen id : 1]
+Input [2]: [d_date_sk#30, d_year#31]
+Condition : ((isnotnull(d_year#31) AND (d_year#31 = 2002)) AND isnotnull(d_date_sk#30))
 
-(88) BroadcastExchange
-Input [2]: [d_date_sk#26, d_year#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+(99) BroadcastExchange
+Input [2]: [d_date_sk#30, d_year#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
 
-Subquery:3 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#44 IN dynamicpruning#5
+Subquery:5 Hosting operator id = 40 Hosting Expression = ReusedSubquery Subquery scalar-subquery#28, [id=#29]
 
-Subquery:4 Hosting operator id = 61 Hosting Expression = ws_sold_date_sk#63 IN dynamicpruning#25
+Subquery:6 Hosting operator id = 38 Hosting Expression = ws_sold_date_sk#48 IN dynamicpruning#5
+
+Subquery:7 Hosting operator id = 60 Hosting Expression = ReusedSubquery Subquery scalar-subquery#28, [id=#29]
+
+Subquery:8 Hosting operator id = 58 Hosting Expression = ws_sold_date_sk#67 IN dynamicpruning#27
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11.sf100/simplified.txt
@@ -33,6 +33,16 @@ TakeOrderedAndProject [customer_preferred_cust_flag]
                                                                 Project [ss_customer_sk,ss_ext_discount_amt,ss_ext_list_price,d_year]
                                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                     Filter [ss_customer_sk]
+                                                                      Subquery #2
+                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                          Exchange #5
+                                                                            ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                              Exchange [c_customer_sk] #6
+                                                                                WholeStageCodegen (1)
+                                                                                  Filter [c_customer_sk,c_customer_id]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
                                                                       ColumnarToRow
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_discount_amt,ss_ext_list_price,ss_sold_date_sk]
@@ -49,21 +59,16 @@ TakeOrderedAndProject [customer_preferred_cust_flag]
                                                       WholeStageCodegen (5)
                                                         Sort [c_customer_sk]
                                                           InputAdapter
-                                                            Exchange [c_customer_sk] #5
-                                                              WholeStageCodegen (4)
-                                                                Filter [c_customer_sk,c_customer_id]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
+                                                            ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
                         InputAdapter
                           WholeStageCodegen (16)
                             Sort [customer_id]
                               InputAdapter
-                                Exchange [customer_id] #6
+                                Exchange [customer_id] #7
                                   WholeStageCodegen (15)
                                     HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,sum] [sum(UnscaledValue((ss_ext_list_price - ss_ext_discount_amt))),customer_id,customer_preferred_cust_flag,year_total,sum]
                                       InputAdapter
-                                        Exchange [c_customer_id,c_first_name,c_last_name,d_year,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #7
+                                        Exchange [c_customer_id,c_first_name,c_last_name,d_year,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #8
                                           WholeStageCodegen (14)
                                             HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ss_ext_list_price,ss_ext_discount_amt] [sum,sum]
                                               Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ss_ext_discount_amt,ss_ext_list_price,d_year]
@@ -72,38 +77,48 @@ TakeOrderedAndProject [customer_preferred_cust_flag]
                                                     WholeStageCodegen (11)
                                                       Sort [ss_customer_sk]
                                                         InputAdapter
-                                                          Exchange [ss_customer_sk] #8
+                                                          Exchange [ss_customer_sk] #9
                                                             WholeStageCodegen (10)
                                                               Project [ss_customer_sk,ss_ext_discount_amt,ss_ext_list_price,d_year]
                                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                   Filter [ss_customer_sk]
+                                                                    Subquery #4
+                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                        Exchange #11
+                                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                            Exchange [c_customer_sk] #12
+                                                                              WholeStageCodegen (1)
+                                                                                Filter [c_customer_sk,c_customer_id]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_discount_amt,ss_ext_list_price,ss_sold_date_sk]
-                                                                          SubqueryBroadcast [d_date_sk] #2
-                                                                            BroadcastExchange #9
+                                                                          SubqueryBroadcast [d_date_sk] #3
+                                                                            BroadcastExchange #10
                                                                               WholeStageCodegen (1)
                                                                                 Filter [d_year,d_date_sk]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                   InputAdapter
-                                                                    ReusedExchange [d_date_sk,d_year] #9
+                                                                    ReusedExchange [d_date_sk,d_year] #10
                                                   InputAdapter
                                                     WholeStageCodegen (13)
                                                       Sort [c_customer_sk]
                                                         InputAdapter
-                                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
                 InputAdapter
                   WholeStageCodegen (25)
                     Sort [customer_id]
                       InputAdapter
-                        Exchange [customer_id] #10
+                        Exchange [customer_id] #13
                           WholeStageCodegen (24)
                             Filter [year_total]
                               HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum] [sum(UnscaledValue((ws_ext_list_price - ws_ext_discount_amt))),customer_id,year_total,sum]
                                 InputAdapter
-                                  Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #11
+                                  Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #14
                                     WholeStageCodegen (23)
                                       HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,ws_ext_list_price,ws_ext_discount_amt] [sum,sum]
                                         Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ws_ext_discount_amt,ws_ext_list_price,d_year]
@@ -112,11 +127,12 @@ TakeOrderedAndProject [customer_preferred_cust_flag]
                                               WholeStageCodegen (20)
                                                 Sort [ws_bill_customer_sk]
                                                   InputAdapter
-                                                    Exchange [ws_bill_customer_sk] #12
+                                                    Exchange [ws_bill_customer_sk] #15
                                                       WholeStageCodegen (19)
                                                         Project [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_list_price,d_year]
                                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                             Filter [ws_bill_customer_sk]
+                                                              ReusedSubquery [bloomFilter] #4
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_list_price,ws_sold_date_sk]
@@ -127,16 +143,16 @@ TakeOrderedAndProject [customer_preferred_cust_flag]
                                               WholeStageCodegen (22)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
         InputAdapter
           WholeStageCodegen (34)
             Sort [customer_id]
               InputAdapter
-                Exchange [customer_id] #13
+                Exchange [customer_id] #16
                   WholeStageCodegen (33)
                     HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum] [sum(UnscaledValue((ws_ext_list_price - ws_ext_discount_amt))),customer_id,year_total,sum]
                       InputAdapter
-                        Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #14
+                        Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #17
                           WholeStageCodegen (32)
                             HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,ws_ext_list_price,ws_ext_discount_amt] [sum,sum]
                               Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ws_ext_discount_amt,ws_ext_list_price,d_year]
@@ -145,19 +161,20 @@ TakeOrderedAndProject [customer_preferred_cust_flag]
                                     WholeStageCodegen (29)
                                       Sort [ws_bill_customer_sk]
                                         InputAdapter
-                                          Exchange [ws_bill_customer_sk] #15
+                                          Exchange [ws_bill_customer_sk] #18
                                             WholeStageCodegen (28)
                                               Project [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_list_price,d_year]
                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                   Filter [ws_bill_customer_sk]
+                                                    ReusedSubquery [bloomFilter] #4
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_list_price,ws_sold_date_sk]
-                                                          ReusedSubquery [d_date_sk] #2
+                                                          ReusedSubquery [d_date_sk] #3
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk,d_year] #9
+                                                    ReusedExchange [d_date_sk,d_year] #10
                                   InputAdapter
                                     WholeStageCodegen (31)
                                       Sort [c_customer_sk]
                                         InputAdapter
-                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/explain.txt
@@ -1,27 +1,24 @@
 == Physical Plan ==
-TakeOrderedAndProject (23)
-+- * Project (22)
-   +- Window (21)
-      +- * Sort (20)
-         +- Exchange (19)
-            +- * HashAggregate (18)
-               +- Exchange (17)
-                  +- * HashAggregate (16)
-                     +- * Project (15)
-                        +- * BroadcastHashJoin Inner BuildRight (14)
-                           :- * Project (12)
-                           :  +- * SortMergeJoin Inner (11)
+TakeOrderedAndProject (20)
++- * Project (19)
+   +- Window (18)
+      +- * Sort (17)
+         +- Exchange (16)
+            +- * HashAggregate (15)
+               +- Exchange (14)
+                  +- * HashAggregate (13)
+                     +- * Project (12)
+                        +- * BroadcastHashJoin Inner BuildRight (11)
+                           :- * Project (9)
+                           :  +- * SortMergeJoin Inner (8)
                            :     :- * Sort (5)
                            :     :  +- Exchange (4)
                            :     :     +- * Filter (3)
                            :     :        +- * ColumnarToRow (2)
                            :     :           +- Scan parquet spark_catalog.default.web_sales (1)
-                           :     +- * Sort (10)
-                           :        +- Exchange (9)
-                           :           +- * Filter (8)
-                           :              +- * ColumnarToRow (7)
-                           :                 +- Scan parquet spark_catalog.default.item (6)
-                           +- ReusedExchange (13)
+                           :     +- * Sort (7)
+                           :        +- ReusedExchange (6)
+                           +- ReusedExchange (10)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -37,7 +34,7 @@ Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
-Condition : isnotnull(ws_item_sk#1)
+Condition : (isnotnull(ws_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ws_item_sk#1, 42), false))
 
 (4) Exchange
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
@@ -47,119 +44,150 @@ Arguments: hashpartitioning(ws_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
 Arguments: [ws_item_sk#1 ASC NULLS FIRST], false, 0
 
-(6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(6) ReusedExchange [Reuses operator id: 24]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(7) Sort [codegen id : 4]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
+
+(8) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ws_item_sk#1]
+Right keys [1]: [i_item_sk#7]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 6]
+Output [7]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(10) ReusedExchange [Reuses operator id: 32]
+Output [1]: [d_date_sk#13]
+
+(11) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#3]
+Right keys [1]: [d_date_sk#13]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [6]: [ws_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
+
+(13) HashAggregate [codegen id : 6]
+Input [6]: [ws_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+
+(14) Exchange
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#2))#16]
+Results [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS _w0#18, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS _w1#19, i_item_id#8]
+
+(16) Exchange
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(17) Sort [codegen id : 8]
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
+
+(18) Window
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: [sum(_w1#19) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#20], [i_class#11]
+
+(19) Project [codegen id : 9]
+Output [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#20) AS revenueratio#21, i_item_id#8]
+Input [9]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8, _we0#20]
+
+(20) TakeOrderedAndProject
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21, i_item_id#8]
+Arguments: 100, [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#21 ASC NULLS FIRST], [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (27)
++- Exchange (26)
+   +- ObjectHashAggregate (25)
+      +- Exchange (24)
+         +- * Filter (23)
+            +- * ColumnarToRow (22)
+               +- Scan parquet spark_catalog.default.item (21)
+
+
+(21) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
-(7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(22) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+(23) Filter [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
-(9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(24) Exchange
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+(25) ObjectHashAggregate
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [buf#22]
+Results [1]: [buf#23]
 
-(11) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ws_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
+(26) Exchange
+Input [1]: [buf#23]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
-(12) Project [codegen id : 6]
-Output [7]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(27) ObjectHashAggregate
+Input [1]: [buf#23]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24 AS bloomFilter#25]
 
-(13) ReusedExchange [Reuses operator id: 28]
-Output [1]: [d_date_sk#11]
-
-(14) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [6]: [ws_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
-
-(16) HashAggregate [codegen id : 6]
-Input [6]: [ws_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-
-(17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#2))#14]
-Results [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS _w0#16, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS _w1#17, i_item_id#6]
-
-(19) Exchange
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(20) Sort [codegen id : 8]
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
-
-(21) Window
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: [sum(_w1#17) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#18], [i_class#9]
-
-(22) Project [codegen id : 9]
-Output [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#18) AS revenueratio#19, i_item_id#6]
-Input [9]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6, _we0#18]
-
-(23) TakeOrderedAndProject
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19, i_item_id#6]
-Arguments: 100, [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#19 ASC NULLS FIRST], [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (28)
-+- * Project (27)
-   +- * Filter (26)
-      +- * ColumnarToRow (25)
-         +- Scan parquet spark_catalog.default.date_dim (24)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (32)
++- * Project (31)
+   +- * Filter (30)
+      +- * ColumnarToRow (29)
+         +- Scan parquet spark_catalog.default.date_dim (28)
 
 
-(24) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#20]
+(28) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(25) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
+(29) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(26) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
-Condition : (((isnotnull(d_date#20) AND (d_date#20 >= 1999-02-22)) AND (d_date#20 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(30) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
+Condition : (((isnotnull(d_date#26) AND (d_date#26 >= 1999-02-22)) AND (d_date#26 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(27) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#20]
+(31) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(28) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(32) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/simplified.txt
@@ -24,6 +24,16 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                               Exchange [ws_item_sk] #3
                                                 WholeStageCodegen (1)
                                                   Filter [ws_item_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 489600, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                            Exchange [i_item_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [i_category,i_item_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
@@ -39,11 +49,6 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                         WholeStageCodegen (4)
                                           Sort [i_item_sk]
                                             InputAdapter
-                                              Exchange [i_item_sk] #5
-                                                WholeStageCodegen (3)
-                                                  Filter [i_category,i_item_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
+                                              ReusedExchange [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category] #6
                                   InputAdapter
                                     ReusedExchange [d_date_sk] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
@@ -1,10 +1,10 @@
 == Physical Plan ==
-TakeOrderedAndProject (123)
-+- * HashAggregate (122)
-   +- Exchange (121)
-      +- * HashAggregate (120)
-         +- * Expand (119)
-            +- Union (118)
+TakeOrderedAndProject (131)
++- * HashAggregate (130)
+   +- Exchange (129)
+      +- * HashAggregate (128)
+         +- * Expand (127)
+            +- Union (126)
                :- * Project (79)
                :  +- * Filter (78)
                :     +- * HashAggregate (77)
@@ -84,13 +84,13 @@ TakeOrderedAndProject (123)
                :                          :           +- Scan parquet spark_catalog.default.item (64)
                :                          +- * Sort (70)
                :                             +- ReusedExchange (69)
-               :- * Project (98)
-               :  +- * Filter (97)
-               :     +- * HashAggregate (96)
-               :        +- Exchange (95)
-               :           +- * HashAggregate (94)
-               :              +- * Project (93)
-               :                 +- * BroadcastHashJoin Inner BuildRight (92)
+               :- * Project (106)
+               :  +- * Filter (105)
+               :     +- * HashAggregate (104)
+               :        +- Exchange (103)
+               :           +- * HashAggregate (102)
+               :              +- * Project (101)
+               :                 +- * BroadcastHashJoin Inner BuildRight (100)
                :                    :- * Project (90)
                :                    :  +- * BroadcastHashJoin Inner BuildRight (89)
                :                    :     :- * SortMergeJoin LeftSemi (87)
@@ -102,26 +102,34 @@ TakeOrderedAndProject (123)
                :                    :     :  +- * Sort (86)
                :                    :     :     +- ReusedExchange (85)
                :                    :     +- ReusedExchange (88)
-               :                    +- ReusedExchange (91)
-               +- * Project (117)
-                  +- * Filter (116)
-                     +- * HashAggregate (115)
-                        +- Exchange (114)
-                           +- * HashAggregate (113)
-                              +- * Project (112)
-                                 +- * BroadcastHashJoin Inner BuildRight (111)
-                                    :- * Project (109)
-                                    :  +- * BroadcastHashJoin Inner BuildRight (108)
-                                    :     :- * SortMergeJoin LeftSemi (106)
-                                    :     :  :- * Sort (103)
-                                    :     :  :  +- Exchange (102)
-                                    :     :  :     +- * Filter (101)
-                                    :     :  :        +- * ColumnarToRow (100)
-                                    :     :  :           +- Scan parquet spark_catalog.default.web_sales (99)
-                                    :     :  +- * Sort (105)
-                                    :     :     +- ReusedExchange (104)
-                                    :     +- ReusedExchange (107)
-                                    +- ReusedExchange (110)
+               :                    +- BroadcastExchange (99)
+               :                       +- * SortMergeJoin LeftSemi (98)
+               :                          :- * Sort (95)
+               :                          :  +- Exchange (94)
+               :                          :     +- * Filter (93)
+               :                          :        +- * ColumnarToRow (92)
+               :                          :           +- Scan parquet spark_catalog.default.item (91)
+               :                          +- * Sort (97)
+               :                             +- ReusedExchange (96)
+               +- * Project (125)
+                  +- * Filter (124)
+                     +- * HashAggregate (123)
+                        +- Exchange (122)
+                           +- * HashAggregate (121)
+                              +- * Project (120)
+                                 +- * BroadcastHashJoin Inner BuildRight (119)
+                                    :- * Project (117)
+                                    :  +- * BroadcastHashJoin Inner BuildRight (116)
+                                    :     :- * SortMergeJoin LeftSemi (114)
+                                    :     :  :- * Sort (111)
+                                    :     :  :  +- Exchange (110)
+                                    :     :  :     +- * Filter (109)
+                                    :     :  :        +- * ColumnarToRow (108)
+                                    :     :  :           +- Scan parquet spark_catalog.default.web_sales (107)
+                                    :     :  +- * Sort (113)
+                                    :     :     +- ReusedExchange (112)
+                                    :     +- ReusedExchange (115)
+                                    +- ReusedExchange (118)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -176,7 +184,7 @@ Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 Condition : isnotnull(ss_item_sk#10)
 
-(12) ReusedExchange [Reuses operator id: 152]
+(12) ReusedExchange [Reuses operator id: 160]
 Output [1]: [d_date_sk#13]
 
 (13) BroadcastHashJoin [codegen id : 11]
@@ -226,7 +234,7 @@ Input [2]: [cs_item_sk#18, cs_sold_date_sk#19]
 Input [2]: [cs_item_sk#18, cs_sold_date_sk#19]
 Condition : isnotnull(cs_item_sk#18)
 
-(23) ReusedExchange [Reuses operator id: 152]
+(23) ReusedExchange [Reuses operator id: 160]
 Output [1]: [d_date_sk#20]
 
 (24) BroadcastHashJoin [codegen id : 8]
@@ -336,7 +344,7 @@ Input [2]: [ws_item_sk#28, ws_sold_date_sk#29]
 Input [2]: [ws_item_sk#28, ws_sold_date_sk#29]
 Condition : isnotnull(ws_item_sk#28)
 
-(46) ReusedExchange [Reuses operator id: 152]
+(46) ReusedExchange [Reuses operator id: 160]
 Output [1]: [d_date_sk#30]
 
 (47) BroadcastHashJoin [codegen id : 16]
@@ -404,7 +412,7 @@ Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(61) ReusedExchange [Reuses operator id: 147]
+(61) ReusedExchange [Reuses operator id: 155]
 Output [1]: [d_date_sk#36]
 
 (62) BroadcastHashJoin [codegen id : 43]
@@ -528,7 +536,7 @@ Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(88) ReusedExchange [Reuses operator id: 147]
+(88) ReusedExchange [Reuses operator id: 155]
 Output [1]: [d_date_sk#61]
 
 (89) BroadcastHashJoin [codegen id : 87]
@@ -541,46 +549,82 @@ Join condition: None
 Output [3]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59]
 Input [5]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, d_date_sk#61]
 
-(91) ReusedExchange [Reuses operator id: 72]
+(91) Scan parquet spark_catalog.default.item
 Output [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(92) BroadcastHashJoin [codegen id : 87]
+(92) ColumnarToRow [codegen id : 66]
+Input [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
+
+(93) Filter [codegen id : 66]
+Input [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
+Condition : (isnotnull(i_item_sk#62) AND true)
+
+(94) Exchange
+Input [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
+Arguments: hashpartitioning(i_item_sk#62, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(95) Sort [codegen id : 67]
+Input [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
+Arguments: [i_item_sk#62 ASC NULLS FIRST], false, 0
+
+(96) ReusedExchange [Reuses operator id: 58]
+Output [1]: [ss_item_sk#35]
+
+(97) Sort [codegen id : 85]
+Input [1]: [ss_item_sk#35]
+Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
+
+(98) SortMergeJoin [codegen id : 86]
+Left keys [1]: [i_item_sk#62]
+Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
+Join condition: None
+
+(99) BroadcastExchange
+Input [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=16]
+
+(100) BroadcastHashJoin [codegen id : 87]
 Left keys [1]: [cs_item_sk#57]
 Right keys [1]: [i_item_sk#62]
 Join type: Inner
 Join condition: None
 
-(93) Project [codegen id : 87]
+(101) Project [codegen id : 87]
 Output [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#63, i_class_id#64, i_category_id#65]
 Input [7]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
 
-(94) HashAggregate [codegen id : 87]
+(102) HashAggregate [codegen id : 87]
 Input [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#63, i_class_id#64, i_category_id#65]
 Keys [3]: [i_brand_id#63, i_class_id#64, i_category_id#65]
 Functions [2]: [partial_sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59)), partial_count(1)]
 Aggregate Attributes [3]: [sum#66, isEmpty#67, count#68]
 Results [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
 
-(95) Exchange
+(103) Exchange
 Input [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
-Arguments: hashpartitioning(i_brand_id#63, i_class_id#64, i_category_id#65, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Arguments: hashpartitioning(i_brand_id#63, i_class_id#64, i_category_id#65, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(96) HashAggregate [codegen id : 88]
+(104) HashAggregate [codegen id : 88]
 Input [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
 Keys [3]: [i_brand_id#63, i_class_id#64, i_category_id#65]
 Functions [2]: [sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59)), count(1)]
 Aggregate Attributes [2]: [sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59))#72, count(1)#73]
 Results [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum((cast(cs_quantity#58 as decimal(10,0)) * cs_list_price#59))#72 AS sales#74, count(1)#73 AS number_sales#75]
 
-(97) Filter [codegen id : 88]
+(105) Filter [codegen id : 88]
 Input [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sales#74, number_sales#75]
 Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
 
-(98) Project [codegen id : 88]
+(106) Project [codegen id : 88]
 Output [6]: [sales#74, number_sales#75, catalog AS channel#76, i_brand_id#63, i_class_id#64, i_category_id#65]
 Input [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sales#74, number_sales#75]
 
-(99) Scan parquet spark_catalog.default.web_sales
+(107) Scan parquet spark_catalog.default.web_sales
 Output [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 Batched: true
 Location: InMemoryFileIndex []
@@ -588,303 +632,303 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#80), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(100) ColumnarToRow [codegen id : 89]
+(108) ColumnarToRow [codegen id : 89]
 Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 
-(101) Filter [codegen id : 89]
+(109) Filter [codegen id : 89]
 Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 Condition : isnotnull(ws_item_sk#77)
 
-(102) Exchange
+(110) Exchange
 Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
-Arguments: hashpartitioning(ws_item_sk#77, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Arguments: hashpartitioning(ws_item_sk#77, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(103) Sort [codegen id : 90]
+(111) Sort [codegen id : 90]
 Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 Arguments: [ws_item_sk#77 ASC NULLS FIRST], false, 0
 
-(104) ReusedExchange [Reuses operator id: 58]
+(112) ReusedExchange [Reuses operator id: 58]
 Output [1]: [ss_item_sk#35]
 
-(105) Sort [codegen id : 108]
+(113) Sort [codegen id : 108]
 Input [1]: [ss_item_sk#35]
 Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 
-(106) SortMergeJoin [codegen id : 131]
+(114) SortMergeJoin [codegen id : 131]
 Left keys [1]: [ws_item_sk#77]
 Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(107) ReusedExchange [Reuses operator id: 147]
+(115) ReusedExchange [Reuses operator id: 155]
 Output [1]: [d_date_sk#81]
 
-(108) BroadcastHashJoin [codegen id : 131]
+(116) BroadcastHashJoin [codegen id : 131]
 Left keys [1]: [ws_sold_date_sk#80]
 Right keys [1]: [d_date_sk#81]
 Join type: Inner
 Join condition: None
 
-(109) Project [codegen id : 131]
+(117) Project [codegen id : 131]
 Output [3]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79]
 Input [5]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, d_date_sk#81]
 
-(110) ReusedExchange [Reuses operator id: 72]
+(118) ReusedExchange [Reuses operator id: 99]
 Output [4]: [i_item_sk#82, i_brand_id#83, i_class_id#84, i_category_id#85]
 
-(111) BroadcastHashJoin [codegen id : 131]
+(119) BroadcastHashJoin [codegen id : 131]
 Left keys [1]: [ws_item_sk#77]
 Right keys [1]: [i_item_sk#82]
 Join type: Inner
 Join condition: None
 
-(112) Project [codegen id : 131]
+(120) Project [codegen id : 131]
 Output [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#83, i_class_id#84, i_category_id#85]
 Input [7]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, i_item_sk#82, i_brand_id#83, i_class_id#84, i_category_id#85]
 
-(113) HashAggregate [codegen id : 131]
+(121) HashAggregate [codegen id : 131]
 Input [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#83, i_class_id#84, i_category_id#85]
 Keys [3]: [i_brand_id#83, i_class_id#84, i_category_id#85]
 Functions [2]: [partial_sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79)), partial_count(1)]
 Aggregate Attributes [3]: [sum#86, isEmpty#87, count#88]
 Results [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#89, isEmpty#90, count#91]
 
-(114) Exchange
+(122) Exchange
 Input [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#89, isEmpty#90, count#91]
-Arguments: hashpartitioning(i_brand_id#83, i_class_id#84, i_category_id#85, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Arguments: hashpartitioning(i_brand_id#83, i_class_id#84, i_category_id#85, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(115) HashAggregate [codegen id : 132]
+(123) HashAggregate [codegen id : 132]
 Input [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#89, isEmpty#90, count#91]
 Keys [3]: [i_brand_id#83, i_class_id#84, i_category_id#85]
 Functions [2]: [sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79)), count(1)]
 Aggregate Attributes [2]: [sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79))#92, count(1)#93]
 Results [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum((cast(ws_quantity#78 as decimal(10,0)) * ws_list_price#79))#92 AS sales#94, count(1)#93 AS number_sales#95]
 
-(116) Filter [codegen id : 132]
+(124) Filter [codegen id : 132]
 Input [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sales#94, number_sales#95]
 Condition : (isnotnull(sales#94) AND (cast(sales#94 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
 
-(117) Project [codegen id : 132]
+(125) Project [codegen id : 132]
 Output [6]: [sales#94, number_sales#95, web AS channel#96, i_brand_id#83, i_class_id#84, i_category_id#85]
 Input [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sales#94, number_sales#95]
 
-(118) Union
+(126) Union
 
-(119) Expand [codegen id : 133]
+(127) Expand [codegen id : 133]
 Input [6]: [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56]
 Arguments: [[sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56, 0], [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, null, 1], [sales#49, number_sales#50, channel#53, i_brand_id#54, null, null, 3], [sales#49, number_sales#50, channel#53, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 
-(120) HashAggregate [codegen id : 133]
+(128) HashAggregate [codegen id : 133]
 Input [7]: [sales#49, number_sales#50, channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 Keys [5]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 Functions [2]: [partial_sum(sales#49), partial_sum(number_sales#50)]
 Aggregate Attributes [3]: [sum#102, isEmpty#103, sum#104]
 Results [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
 
-(121) Exchange
+(129) Exchange
 Input [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
-Arguments: hashpartitioning(channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+Arguments: hashpartitioning(channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(122) HashAggregate [codegen id : 134]
+(130) HashAggregate [codegen id : 134]
 Input [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
 Keys [5]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 Functions [2]: [sum(sales#49), sum(number_sales#50)]
 Aggregate Attributes [2]: [sum(sales#49)#108, sum(number_sales#50)#109]
 Results [6]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales#49)#108 AS sum(sales)#110, sum(number_sales#50)#109 AS sum(number_sales)#111]
 
-(123) TakeOrderedAndProject
+(131) TakeOrderedAndProject
 Input [6]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales)#110, sum(number_sales)#111]
 Arguments: 100, [channel#97 ASC NULLS FIRST, i_brand_id#98 ASC NULLS FIRST, i_class_id#99 ASC NULLS FIRST, i_category_id#100 ASC NULLS FIRST], [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales)#110, sum(number_sales)#111]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 78 Hosting Expression = Subquery scalar-subquery#51, [id=#52]
-* HashAggregate (142)
-+- Exchange (141)
-   +- * HashAggregate (140)
-      +- Union (139)
-         :- * Project (128)
-         :  +- * BroadcastHashJoin Inner BuildRight (127)
-         :     :- * ColumnarToRow (125)
-         :     :  +- Scan parquet spark_catalog.default.store_sales (124)
-         :     +- ReusedExchange (126)
-         :- * Project (133)
-         :  +- * BroadcastHashJoin Inner BuildRight (132)
-         :     :- * ColumnarToRow (130)
-         :     :  +- Scan parquet spark_catalog.default.catalog_sales (129)
-         :     +- ReusedExchange (131)
-         +- * Project (138)
-            +- * BroadcastHashJoin Inner BuildRight (137)
-               :- * ColumnarToRow (135)
-               :  +- Scan parquet spark_catalog.default.web_sales (134)
-               +- ReusedExchange (136)
+* HashAggregate (150)
++- Exchange (149)
+   +- * HashAggregate (148)
+      +- Union (147)
+         :- * Project (136)
+         :  +- * BroadcastHashJoin Inner BuildRight (135)
+         :     :- * ColumnarToRow (133)
+         :     :  +- Scan parquet spark_catalog.default.store_sales (132)
+         :     +- ReusedExchange (134)
+         :- * Project (141)
+         :  +- * BroadcastHashJoin Inner BuildRight (140)
+         :     :- * ColumnarToRow (138)
+         :     :  +- Scan parquet spark_catalog.default.catalog_sales (137)
+         :     +- ReusedExchange (139)
+         +- * Project (146)
+            +- * BroadcastHashJoin Inner BuildRight (145)
+               :- * ColumnarToRow (143)
+               :  +- Scan parquet spark_catalog.default.web_sales (142)
+               +- ReusedExchange (144)
 
 
-(124) Scan parquet spark_catalog.default.store_sales
+(132) Scan parquet spark_catalog.default.store_sales
 Output [3]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#114), dynamicpruningexpression(ss_sold_date_sk#114 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(125) ColumnarToRow [codegen id : 2]
+(133) ColumnarToRow [codegen id : 2]
 Input [3]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114]
 
-(126) ReusedExchange [Reuses operator id: 152]
+(134) ReusedExchange [Reuses operator id: 160]
 Output [1]: [d_date_sk#115]
 
-(127) BroadcastHashJoin [codegen id : 2]
+(135) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#114]
 Right keys [1]: [d_date_sk#115]
 Join type: Inner
 Join condition: None
 
-(128) Project [codegen id : 2]
+(136) Project [codegen id : 2]
 Output [2]: [ss_quantity#112 AS quantity#116, ss_list_price#113 AS list_price#117]
 Input [4]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114, d_date_sk#115]
 
-(129) Scan parquet spark_catalog.default.catalog_sales
+(137) Scan parquet spark_catalog.default.catalog_sales
 Output [3]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#120), dynamicpruningexpression(cs_sold_date_sk#120 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(130) ColumnarToRow [codegen id : 4]
+(138) ColumnarToRow [codegen id : 4]
 Input [3]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120]
 
-(131) ReusedExchange [Reuses operator id: 152]
+(139) ReusedExchange [Reuses operator id: 160]
 Output [1]: [d_date_sk#121]
 
-(132) BroadcastHashJoin [codegen id : 4]
+(140) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#120]
 Right keys [1]: [d_date_sk#121]
 Join type: Inner
 Join condition: None
 
-(133) Project [codegen id : 4]
+(141) Project [codegen id : 4]
 Output [2]: [cs_quantity#118 AS quantity#122, cs_list_price#119 AS list_price#123]
 Input [4]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120, d_date_sk#121]
 
-(134) Scan parquet spark_catalog.default.web_sales
+(142) Scan parquet spark_catalog.default.web_sales
 Output [3]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#126), dynamicpruningexpression(ws_sold_date_sk#126 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(135) ColumnarToRow [codegen id : 6]
+(143) ColumnarToRow [codegen id : 6]
 Input [3]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126]
 
-(136) ReusedExchange [Reuses operator id: 152]
+(144) ReusedExchange [Reuses operator id: 160]
 Output [1]: [d_date_sk#127]
 
-(137) BroadcastHashJoin [codegen id : 6]
+(145) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#126]
 Right keys [1]: [d_date_sk#127]
 Join type: Inner
 Join condition: None
 
-(138) Project [codegen id : 6]
+(146) Project [codegen id : 6]
 Output [2]: [ws_quantity#124 AS quantity#128, ws_list_price#125 AS list_price#129]
 Input [4]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126, d_date_sk#127]
 
-(139) Union
+(147) Union
 
-(140) HashAggregate [codegen id : 7]
+(148) HashAggregate [codegen id : 7]
 Input [2]: [quantity#116, list_price#117]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#116 as decimal(10,0)) * list_price#117))]
 Aggregate Attributes [2]: [sum#130, count#131]
 Results [2]: [sum#132, count#133]
 
-(141) Exchange
+(149) Exchange
 Input [2]: [sum#132, count#133]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
 
-(142) HashAggregate [codegen id : 8]
+(150) HashAggregate [codegen id : 8]
 Input [2]: [sum#132, count#133]
 Keys: []
 Functions [1]: [avg((cast(quantity#116 as decimal(10,0)) * list_price#117))]
 Aggregate Attributes [1]: [avg((cast(quantity#116 as decimal(10,0)) * list_price#117))#134]
 Results [1]: [avg((cast(quantity#116 as decimal(10,0)) * list_price#117))#134 AS average_sales#135]
 
-Subquery:2 Hosting operator id = 124 Hosting Expression = ss_sold_date_sk#114 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 132 Hosting Expression = ss_sold_date_sk#114 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 129 Hosting Expression = cs_sold_date_sk#120 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 137 Hosting Expression = cs_sold_date_sk#120 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 134 Hosting Expression = ws_sold_date_sk#126 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 142 Hosting Expression = ws_sold_date_sk#126 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (147)
-+- * Project (146)
-   +- * Filter (145)
-      +- * ColumnarToRow (144)
-         +- Scan parquet spark_catalog.default.date_dim (143)
+BroadcastExchange (155)
++- * Project (154)
+   +- * Filter (153)
+      +- * ColumnarToRow (152)
+         +- Scan parquet spark_catalog.default.date_dim (151)
 
 
-(143) Scan parquet spark_catalog.default.date_dim
+(151) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#36, d_year#136, d_moy#137]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(144) ColumnarToRow [codegen id : 1]
+(152) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#36, d_year#136, d_moy#137]
 
-(145) Filter [codegen id : 1]
+(153) Filter [codegen id : 1]
 Input [3]: [d_date_sk#36, d_year#136, d_moy#137]
 Condition : ((((isnotnull(d_year#136) AND isnotnull(d_moy#137)) AND (d_year#136 = 2001)) AND (d_moy#137 = 11)) AND isnotnull(d_date_sk#36))
 
-(146) Project [codegen id : 1]
+(154) Project [codegen id : 1]
 Output [1]: [d_date_sk#36]
 Input [3]: [d_date_sk#36, d_year#136, d_moy#137]
 
-(147) BroadcastExchange
+(155) BroadcastExchange
 Input [1]: [d_date_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=22]
 
 Subquery:6 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
-BroadcastExchange (152)
-+- * Project (151)
-   +- * Filter (150)
-      +- * ColumnarToRow (149)
-         +- Scan parquet spark_catalog.default.date_dim (148)
+BroadcastExchange (160)
++- * Project (159)
+   +- * Filter (158)
+      +- * ColumnarToRow (157)
+         +- Scan parquet spark_catalog.default.date_dim (156)
 
 
-(148) Scan parquet spark_catalog.default.date_dim
+(156) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#13, d_year#138]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(149) ColumnarToRow [codegen id : 1]
+(157) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#13, d_year#138]
 
-(150) Filter [codegen id : 1]
+(158) Filter [codegen id : 1]
 Input [2]: [d_date_sk#13, d_year#138]
 Condition : (((isnotnull(d_year#138) AND (d_year#138 >= 1999)) AND (d_year#138 <= 2001)) AND isnotnull(d_date_sk#13))
 
-(151) Project [codegen id : 1]
+(159) Project [codegen id : 1]
 Output [1]: [d_date_sk#13]
 Input [2]: [d_date_sk#13, d_year#138]
 
-(152) BroadcastExchange
+(160) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=23]
 
 Subquery:7 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#19 IN dynamicpruning#12
 
 Subquery:8 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 97 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
+Subquery:9 Hosting operator id = 105 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
 
 Subquery:10 Hosting operator id = 80 Hosting Expression = cs_sold_date_sk#60 IN dynamicpruning#5
 
-Subquery:11 Hosting operator id = 116 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
+Subquery:11 Hosting operator id = 124 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
 
-Subquery:12 Hosting operator id = 99 Hosting Expression = ws_sold_date_sk#80 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 107 Hosting Expression = ws_sold_date_sk#80 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/simplified.txt
@@ -231,14 +231,31 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                             InputAdapter
                                               ReusedExchange [d_date_sk] #4
                                         InputAdapter
-                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                                          BroadcastExchange #20
+                                            WholeStageCodegen (86)
+                                              SortMergeJoin [i_item_sk,ss_item_sk]
+                                                InputAdapter
+                                                  WholeStageCodegen (67)
+                                                    Sort [i_item_sk]
+                                                      InputAdapter
+                                                        Exchange [i_item_sk] #21
+                                                          WholeStageCodegen (66)
+                                                            Filter [i_item_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                InputAdapter
+                                                  WholeStageCodegen (85)
+                                                    Sort [ss_item_sk]
+                                                      InputAdapter
+                                                        ReusedExchange [ss_item_sk] #5
                     WholeStageCodegen (132)
                       Project [sales,number_sales,i_brand_id,i_class_id,i_category_id]
                         Filter [sales]
                           ReusedSubquery [average_sales] #3
                           HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ws_quantity as decimal(10,0)) * ws_list_price)),count(1),sales,number_sales,sum,isEmpty,count]
                             InputAdapter
-                              Exchange [i_brand_id,i_class_id,i_category_id] #20
+                              Exchange [i_brand_id,i_class_id,i_category_id] #22
                                 WholeStageCodegen (131)
                                   HashAggregate [i_brand_id,i_class_id,i_category_id,ws_quantity,ws_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                                     Project [ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
@@ -250,7 +267,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                                 WholeStageCodegen (90)
                                                   Sort [ws_item_sk]
                                                     InputAdapter
-                                                      Exchange [ws_item_sk] #21
+                                                      Exchange [ws_item_sk] #23
                                                         WholeStageCodegen (89)
                                                           Filter [ws_item_sk]
                                                             ColumnarToRow
@@ -265,4 +282,4 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                             InputAdapter
                                               ReusedExchange [d_date_sk] #4
                                         InputAdapter
-                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #20

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15.sf100/explain.txt
@@ -1,10 +1,10 @@
 == Physical Plan ==
-TakeOrderedAndProject (28)
-+- * HashAggregate (27)
-   +- Exchange (26)
-      +- * HashAggregate (25)
-         +- * Project (24)
-            +- * SortMergeJoin Inner (23)
+TakeOrderedAndProject (16)
++- * HashAggregate (15)
+   +- Exchange (14)
+      +- * HashAggregate (13)
+         +- * Project (12)
+            +- * SortMergeJoin Inner (11)
                :- * Sort (8)
                :  +- Exchange (7)
                :     +- * Project (6)
@@ -13,20 +13,8 @@ TakeOrderedAndProject (28)
                :           :  +- * ColumnarToRow (2)
                :           :     +- Scan parquet spark_catalog.default.catalog_sales (1)
                :           +- ReusedExchange (4)
-               +- * Sort (22)
-                  +- Exchange (21)
-                     +- * Project (20)
-                        +- * SortMergeJoin Inner (19)
-                           :- * Sort (13)
-                           :  +- Exchange (12)
-                           :     +- * Filter (11)
-                           :        +- * ColumnarToRow (10)
-                           :           +- Scan parquet spark_catalog.default.customer (9)
-                           +- * Sort (18)
-                              +- Exchange (17)
-                                 +- * Filter (16)
-                                    +- * ColumnarToRow (15)
-                                       +- Scan parquet spark_catalog.default.customer_address (14)
+               +- * Sort (10)
+                  +- ReusedExchange (9)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -42,20 +30,20 @@ Input [3]: [cs_bill_customer_sk#1, cs_sales_price#2, cs_sold_date_sk#3]
 
 (3) Filter [codegen id : 2]
 Input [3]: [cs_bill_customer_sk#1, cs_sales_price#2, cs_sold_date_sk#3]
-Condition : isnotnull(cs_bill_customer_sk#1)
+Condition : (isnotnull(cs_bill_customer_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(cs_bill_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 33]
-Output [1]: [d_date_sk#5]
+(4) ReusedExchange [Reuses operator id: 37]
+Output [1]: [d_date_sk#7]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [cs_sold_date_sk#3]
-Right keys [1]: [d_date_sk#5]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
 Output [2]: [cs_bill_customer_sk#1, cs_sales_price#2]
-Input [4]: [cs_bill_customer_sk#1, cs_sales_price#2, cs_sold_date_sk#3, d_date_sk#5]
+Input [4]: [cs_bill_customer_sk#1, cs_sales_price#2, cs_sold_date_sk#3, d_date_sk#7]
 
 (7) Exchange
 Input [2]: [cs_bill_customer_sk#1, cs_sales_price#2]
@@ -65,130 +53,170 @@ Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [pla
 Input [2]: [cs_bill_customer_sk#1, cs_sales_price#2]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#6, c_current_addr_sk#7]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
+(9) ReusedExchange [Reuses operator id: 29]
+Output [3]: [c_customer_sk#8, ca_state#9, ca_zip#10]
 
-(10) ColumnarToRow [codegen id : 4]
-Input [2]: [c_customer_sk#6, c_current_addr_sk#7]
+(10) Sort [codegen id : 9]
+Input [3]: [c_customer_sk#8, ca_state#9, ca_zip#10]
+Arguments: [c_customer_sk#8 ASC NULLS FIRST], false, 0
 
-(11) Filter [codegen id : 4]
-Input [2]: [c_customer_sk#6, c_current_addr_sk#7]
-Condition : (isnotnull(c_customer_sk#6) AND isnotnull(c_current_addr_sk#7))
-
-(12) Exchange
-Input [2]: [c_customer_sk#6, c_current_addr_sk#7]
-Arguments: hashpartitioning(c_current_addr_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(13) Sort [codegen id : 5]
-Input [2]: [c_customer_sk#6, c_current_addr_sk#7]
-Arguments: [c_current_addr_sk#7 ASC NULLS FIRST], false, 0
-
-(14) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#8, ca_state#9, ca_zip#10]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_zip:string>
-
-(15) ColumnarToRow [codegen id : 6]
-Input [3]: [ca_address_sk#8, ca_state#9, ca_zip#10]
-
-(16) Filter [codegen id : 6]
-Input [3]: [ca_address_sk#8, ca_state#9, ca_zip#10]
-Condition : isnotnull(ca_address_sk#8)
-
-(17) Exchange
-Input [3]: [ca_address_sk#8, ca_state#9, ca_zip#10]
-Arguments: hashpartitioning(ca_address_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) Sort [codegen id : 7]
-Input [3]: [ca_address_sk#8, ca_state#9, ca_zip#10]
-Arguments: [ca_address_sk#8 ASC NULLS FIRST], false, 0
-
-(19) SortMergeJoin [codegen id : 8]
-Left keys [1]: [c_current_addr_sk#7]
-Right keys [1]: [ca_address_sk#8]
-Join type: Inner
-Join condition: None
-
-(20) Project [codegen id : 8]
-Output [3]: [c_customer_sk#6, ca_state#9, ca_zip#10]
-Input [5]: [c_customer_sk#6, c_current_addr_sk#7, ca_address_sk#8, ca_state#9, ca_zip#10]
-
-(21) Exchange
-Input [3]: [c_customer_sk#6, ca_state#9, ca_zip#10]
-Arguments: hashpartitioning(c_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(22) Sort [codegen id : 9]
-Input [3]: [c_customer_sk#6, ca_state#9, ca_zip#10]
-Arguments: [c_customer_sk#6 ASC NULLS FIRST], false, 0
-
-(23) SortMergeJoin [codegen id : 10]
+(11) SortMergeJoin [codegen id : 10]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#6]
+Right keys [1]: [c_customer_sk#8]
 Join type: Inner
 Join condition: ((substr(ca_zip#10, 1, 5) IN (85669,86197,88274,83405,86475,85392,85460,80348,81792) OR ca_state#9 IN (CA,WA,GA)) OR (cs_sales_price#2 > 500.00))
 
-(24) Project [codegen id : 10]
+(12) Project [codegen id : 10]
 Output [2]: [cs_sales_price#2, ca_zip#10]
-Input [5]: [cs_bill_customer_sk#1, cs_sales_price#2, c_customer_sk#6, ca_state#9, ca_zip#10]
+Input [5]: [cs_bill_customer_sk#1, cs_sales_price#2, c_customer_sk#8, ca_state#9, ca_zip#10]
 
-(25) HashAggregate [codegen id : 10]
+(13) HashAggregate [codegen id : 10]
 Input [2]: [cs_sales_price#2, ca_zip#10]
 Keys [1]: [ca_zip#10]
 Functions [1]: [partial_sum(UnscaledValue(cs_sales_price#2))]
 Aggregate Attributes [1]: [sum#11]
 Results [2]: [ca_zip#10, sum#12]
 
-(26) Exchange
+(14) Exchange
 Input [2]: [ca_zip#10, sum#12]
-Arguments: hashpartitioning(ca_zip#10, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Arguments: hashpartitioning(ca_zip#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(27) HashAggregate [codegen id : 11]
+(15) HashAggregate [codegen id : 11]
 Input [2]: [ca_zip#10, sum#12]
 Keys [1]: [ca_zip#10]
 Functions [1]: [sum(UnscaledValue(cs_sales_price#2))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#2))#13]
 Results [2]: [ca_zip#10, MakeDecimal(sum(UnscaledValue(cs_sales_price#2))#13,17,2) AS sum(cs_sales_price)#14]
 
-(28) TakeOrderedAndProject
+(16) TakeOrderedAndProject
 Input [2]: [ca_zip#10, sum(cs_sales_price)#14]
 Arguments: 100, [ca_zip#10 ASC NULLS FIRST], [ca_zip#10, sum(cs_sales_price)#14]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (33)
-+- * Project (32)
-   +- * Filter (31)
-      +- * ColumnarToRow (30)
-         +- Scan parquet spark_catalog.default.date_dim (29)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (32)
++- Exchange (31)
+   +- ObjectHashAggregate (30)
+      +- Exchange (29)
+         +- * Project (28)
+            +- * SortMergeJoin Inner (27)
+               :- * Sort (21)
+               :  +- Exchange (20)
+               :     +- * Filter (19)
+               :        +- * ColumnarToRow (18)
+               :           +- Scan parquet spark_catalog.default.customer (17)
+               +- * Sort (26)
+                  +- Exchange (25)
+                     +- * Filter (24)
+                        +- * ColumnarToRow (23)
+                           +- Scan parquet spark_catalog.default.customer_address (22)
 
 
-(29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#5, d_year#15, d_qoy#16]
+(17) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#8, c_current_addr_sk#15]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
+
+(18) ColumnarToRow [codegen id : 1]
+Input [2]: [c_customer_sk#8, c_current_addr_sk#15]
+
+(19) Filter [codegen id : 1]
+Input [2]: [c_customer_sk#8, c_current_addr_sk#15]
+Condition : (isnotnull(c_customer_sk#8) AND isnotnull(c_current_addr_sk#15))
+
+(20) Exchange
+Input [2]: [c_customer_sk#8, c_current_addr_sk#15]
+Arguments: hashpartitioning(c_current_addr_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(21) Sort [codegen id : 2]
+Input [2]: [c_customer_sk#8, c_current_addr_sk#15]
+Arguments: [c_current_addr_sk#15 ASC NULLS FIRST], false, 0
+
+(22) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#16, ca_state#9, ca_zip#10]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_zip:string>
+
+(23) ColumnarToRow [codegen id : 3]
+Input [3]: [ca_address_sk#16, ca_state#9, ca_zip#10]
+
+(24) Filter [codegen id : 3]
+Input [3]: [ca_address_sk#16, ca_state#9, ca_zip#10]
+Condition : isnotnull(ca_address_sk#16)
+
+(25) Exchange
+Input [3]: [ca_address_sk#16, ca_state#9, ca_zip#10]
+Arguments: hashpartitioning(ca_address_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) Sort [codegen id : 4]
+Input [3]: [ca_address_sk#16, ca_state#9, ca_zip#10]
+Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
+
+(27) SortMergeJoin [codegen id : 5]
+Left keys [1]: [c_current_addr_sk#15]
+Right keys [1]: [ca_address_sk#16]
+Join type: Inner
+Join condition: None
+
+(28) Project [codegen id : 5]
+Output [3]: [c_customer_sk#8, ca_state#9, ca_zip#10]
+Input [5]: [c_customer_sk#8, c_current_addr_sk#15, ca_address_sk#16, ca_state#9, ca_zip#10]
+
+(29) Exchange
+Input [3]: [c_customer_sk#8, ca_state#9, ca_zip#10]
+Arguments: hashpartitioning(c_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(30) ObjectHashAggregate
+Input [3]: [c_customer_sk#8, ca_state#9, ca_zip#10]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2120804, 16966432, 0, 0)]
+Aggregate Attributes [1]: [buf#17]
+Results [1]: [buf#18]
+
+(31) Exchange
+Input [1]: [buf#18]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+
+(32) ObjectHashAggregate
+Input [1]: [buf#18]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2120804, 16966432, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2120804, 16966432, 0, 0)#19]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2120804, 16966432, 0, 0)#19 AS bloomFilter#20]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (37)
++- * Project (36)
+   +- * Filter (35)
+      +- * ColumnarToRow (34)
+         +- Scan parquet spark_catalog.default.date_dim (33)
+
+
+(33) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#7, d_year#21, d_qoy#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(30) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#5, d_year#15, d_qoy#16]
+(34) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#7, d_year#21, d_qoy#22]
 
-(31) Filter [codegen id : 1]
-Input [3]: [d_date_sk#5, d_year#15, d_qoy#16]
-Condition : ((((isnotnull(d_qoy#16) AND isnotnull(d_year#15)) AND (d_qoy#16 = 2)) AND (d_year#15 = 2001)) AND isnotnull(d_date_sk#5))
+(35) Filter [codegen id : 1]
+Input [3]: [d_date_sk#7, d_year#21, d_qoy#22]
+Condition : ((((isnotnull(d_qoy#22) AND isnotnull(d_year#21)) AND (d_qoy#22 = 2)) AND (d_year#21 = 2001)) AND isnotnull(d_date_sk#7))
 
-(32) Project [codegen id : 1]
-Output [1]: [d_date_sk#5]
-Input [3]: [d_date_sk#5, d_year#15, d_qoy#16]
+(36) Project [codegen id : 1]
+Output [1]: [d_date_sk#7]
+Input [3]: [d_date_sk#7, d_year#21, d_qoy#22]
 
-(33) BroadcastExchange
-Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+(37) BroadcastExchange
+Input [1]: [d_date_sk#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15.sf100/simplified.txt
@@ -16,6 +16,34 @@ TakeOrderedAndProject [ca_zip,sum(cs_sales_price)]
                               Project [cs_bill_customer_sk,cs_sales_price]
                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                   Filter [cs_bill_customer_sk]
+                                    Subquery #2
+                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2120804, 16966432, 0, 0),bloomFilter,buf]
+                                        Exchange #4
+                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                            Exchange [c_customer_sk] #5
+                                              WholeStageCodegen (5)
+                                                Project [c_customer_sk,ca_state,ca_zip]
+                                                  SortMergeJoin [c_current_addr_sk,ca_address_sk]
+                                                    InputAdapter
+                                                      WholeStageCodegen (2)
+                                                        Sort [c_current_addr_sk]
+                                                          InputAdapter
+                                                            Exchange [c_current_addr_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [c_customer_sk,c_current_addr_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                                                    InputAdapter
+                                                      WholeStageCodegen (4)
+                                                        Sort [ca_address_sk]
+                                                          InputAdapter
+                                                            Exchange [ca_address_sk] #7
+                                                              WholeStageCodegen (3)
+                                                                Filter [ca_address_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_zip]
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_sales_price,cs_sold_date_sk]
@@ -33,27 +61,4 @@ TakeOrderedAndProject [ca_zip,sum(cs_sales_price)]
                     WholeStageCodegen (9)
                       Sort [c_customer_sk]
                         InputAdapter
-                          Exchange [c_customer_sk] #4
-                            WholeStageCodegen (8)
-                              Project [c_customer_sk,ca_state,ca_zip]
-                                SortMergeJoin [c_current_addr_sk,ca_address_sk]
-                                  InputAdapter
-                                    WholeStageCodegen (5)
-                                      Sort [c_current_addr_sk]
-                                        InputAdapter
-                                          Exchange [c_current_addr_sk] #5
-                                            WholeStageCodegen (4)
-                                              Filter [c_customer_sk,c_current_addr_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
-                                  InputAdapter
-                                    WholeStageCodegen (7)
-                                      Sort [ca_address_sk]
-                                        InputAdapter
-                                          Exchange [ca_address_sk] #6
-                                            WholeStageCodegen (6)
-                                              Filter [ca_address_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_zip]
+                          ReusedExchange [c_customer_sk,ca_state,ca_zip] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
@@ -58,7 +58,7 @@ Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_wareho
 
 (3) Filter [codegen id : 1]
 Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cs_sold_date_sk#8]
-Condition : (((((isnotnull(cs_ship_date_sk#1) AND isnotnull(cs_ship_addr_sk#2)) AND isnotnull(cs_call_center_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(cs_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_call_center_sk#3, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(cs_ship_date_sk#1) AND isnotnull(cs_ship_addr_sk#2)) AND isnotnull(cs_call_center_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(cs_ship_addr_sk#2, 42), true)) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_call_center_sk#3, 42), true)) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_ship_date_sk#1, 42), true))
 
 (4) Project [codegen id : 1]
 Output [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
@@ -1,18 +1,18 @@
 == Physical Plan ==
-TakeOrderedAndProject (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * Project (45)
-            +- * SortMergeJoin Inner (44)
-               :- * Sort (35)
-               :  +- Exchange (34)
-               :     +- * Project (33)
-               :        +- * SortMergeJoin Inner (32)
-               :           :- * Sort (23)
-               :           :  +- Exchange (22)
-               :           :     +- * Project (21)
-               :           :        +- * SortMergeJoin Inner (20)
+TakeOrderedAndProject (46)
++- * HashAggregate (45)
+   +- Exchange (44)
+      +- * HashAggregate (43)
+         +- * Project (42)
+            +- * SortMergeJoin Inner (41)
+               :- * Sort (32)
+               :  +- Exchange (31)
+               :     +- * Project (30)
+               :        +- * SortMergeJoin Inner (29)
+               :           :- * Sort (20)
+               :           :  +- Exchange (19)
+               :           :     +- * Project (18)
+               :           :        +- * SortMergeJoin Inner (17)
                :           :           :- * Sort (14)
                :           :           :  +- Exchange (13)
                :           :           :     +- * Project (12)
@@ -27,27 +27,24 @@ TakeOrderedAndProject (49)
                :           :           :              +- * Filter (9)
                :           :           :                 +- * ColumnarToRow (8)
                :           :           :                    +- Scan parquet spark_catalog.default.store (7)
-               :           :           +- * Sort (19)
-               :           :              +- Exchange (18)
-               :           :                 +- * Filter (17)
-               :           :                    +- * ColumnarToRow (16)
-               :           :                       +- Scan parquet spark_catalog.default.item (15)
-               :           +- * Sort (31)
-               :              +- Exchange (30)
-               :                 +- * Project (29)
-               :                    +- * BroadcastHashJoin Inner BuildRight (28)
-               :                       :- * Filter (26)
-               :                       :  +- * ColumnarToRow (25)
-               :                       :     +- Scan parquet spark_catalog.default.store_returns (24)
-               :                       +- ReusedExchange (27)
-               +- * Sort (43)
-                  +- Exchange (42)
-                     +- * Project (41)
-                        +- * BroadcastHashJoin Inner BuildRight (40)
-                           :- * Filter (38)
-                           :  +- * ColumnarToRow (37)
-                           :     +- Scan parquet spark_catalog.default.catalog_sales (36)
-                           +- ReusedExchange (39)
+               :           :           +- * Sort (16)
+               :           :              +- ReusedExchange (15)
+               :           +- * Sort (28)
+               :              +- Exchange (27)
+               :                 +- * Project (26)
+               :                    +- * BroadcastHashJoin Inner BuildRight (25)
+               :                       :- * Filter (23)
+               :                       :  +- * ColumnarToRow (22)
+               :                       :     +- Scan parquet spark_catalog.default.store_returns (21)
+               :                       +- ReusedExchange (24)
+               +- * Sort (40)
+                  +- Exchange (39)
+                     +- * Project (38)
+                        +- * BroadcastHashJoin Inner BuildRight (37)
+                           :- * Filter (35)
+                           :  +- * ColumnarToRow (34)
+                           :     +- Scan parquet spark_catalog.default.catalog_sales (33)
+                           +- ReusedExchange (36)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -63,281 +60,312 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 3]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3))
+Condition : ((((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ss_item_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 54]
-Output [1]: [d_date_sk#8]
+(4) ReusedExchange [Reuses operator id: 58]
+Output [1]: [d_date_sk#10]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#6]
-Right keys [1]: [d_date_sk#8]
+Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6, d_date_sk#8]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6, d_date_sk#10]
 
 (7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#9, s_state#10]
+Output [2]: [s_store_sk#11, s_state#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#9, s_state#10]
+Input [2]: [s_store_sk#11, s_state#12]
 
 (9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#9, s_state#10]
-Condition : isnotnull(s_store_sk#9)
+Input [2]: [s_store_sk#11, s_state#12]
+Condition : isnotnull(s_store_sk#11)
 
 (10) BroadcastExchange
-Input [2]: [s_store_sk#9, s_state#10]
+Input [2]: [s_store_sk#11, s_state#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#9]
+Right keys [1]: [s_store_sk#11]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, s_store_sk#9, s_state#10]
+Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#12]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, s_store_sk#11, s_state#12]
 
 (13) Exchange
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10]
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#12]
 Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10]
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#12]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
+(15) ReusedExchange [Reuses operator id: 50]
+Output [3]: [i_item_sk#13, i_item_id#14, i_item_desc#15]
+
+(16) Sort [codegen id : 6]
+Input [3]: [i_item_sk#13, i_item_id#14, i_item_desc#15]
+Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
+
+(17) SortMergeJoin [codegen id : 7]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#13]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 7]
+Output [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#12, i_item_id#14, i_item_desc#15]
+Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#12, i_item_sk#13, i_item_id#14, i_item_desc#15]
+
+(19) Exchange
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#12, i_item_id#14, i_item_desc#15]
+Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) Sort [codegen id : 8]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#12, i_item_id#14, i_item_desc#15]
+Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
+
+(21) Scan parquet spark_catalog.default.store_returns
+Output [5]: [sr_item_sk#16, sr_customer_sk#17, sr_ticket_number#18, sr_return_quantity#19, sr_returned_date_sk#20]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(sr_returned_date_sk#20), dynamicpruningexpression(sr_returned_date_sk#20 IN dynamicpruning#21)]
+PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
+ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_return_quantity:int>
+
+(22) ColumnarToRow [codegen id : 10]
+Input [5]: [sr_item_sk#16, sr_customer_sk#17, sr_ticket_number#18, sr_return_quantity#19, sr_returned_date_sk#20]
+
+(23) Filter [codegen id : 10]
+Input [5]: [sr_item_sk#16, sr_customer_sk#17, sr_ticket_number#18, sr_return_quantity#19, sr_returned_date_sk#20]
+Condition : ((isnotnull(sr_customer_sk#17) AND isnotnull(sr_item_sk#16)) AND isnotnull(sr_ticket_number#18))
+
+(24) ReusedExchange [Reuses operator id: 63]
+Output [1]: [d_date_sk#22]
+
+(25) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [sr_returned_date_sk#20]
+Right keys [1]: [d_date_sk#22]
+Join type: Inner
+Join condition: None
+
+(26) Project [codegen id : 10]
+Output [4]: [sr_item_sk#16, sr_customer_sk#17, sr_ticket_number#18, sr_return_quantity#19]
+Input [6]: [sr_item_sk#16, sr_customer_sk#17, sr_ticket_number#18, sr_return_quantity#19, sr_returned_date_sk#20, d_date_sk#22]
+
+(27) Exchange
+Input [4]: [sr_item_sk#16, sr_customer_sk#17, sr_ticket_number#18, sr_return_quantity#19]
+Arguments: hashpartitioning(sr_customer_sk#17, sr_item_sk#16, sr_ticket_number#18, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(28) Sort [codegen id : 11]
+Input [4]: [sr_item_sk#16, sr_customer_sk#17, sr_ticket_number#18, sr_return_quantity#19]
+Arguments: [sr_customer_sk#17 ASC NULLS FIRST, sr_item_sk#16 ASC NULLS FIRST, sr_ticket_number#18 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 12]
+Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
+Right keys [3]: [sr_customer_sk#17, sr_item_sk#16, sr_ticket_number#18]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 12]
+Output [7]: [ss_quantity#5, s_state#12, i_item_id#14, i_item_desc#15, sr_item_sk#16, sr_customer_sk#17, sr_return_quantity#19]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#12, i_item_id#14, i_item_desc#15, sr_item_sk#16, sr_customer_sk#17, sr_ticket_number#18, sr_return_quantity#19]
+
+(31) Exchange
+Input [7]: [ss_quantity#5, s_state#12, i_item_id#14, i_item_desc#15, sr_item_sk#16, sr_customer_sk#17, sr_return_quantity#19]
+Arguments: hashpartitioning(sr_customer_sk#17, sr_item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(32) Sort [codegen id : 13]
+Input [7]: [ss_quantity#5, s_state#12, i_item_id#14, i_item_desc#15, sr_item_sk#16, sr_customer_sk#17, sr_return_quantity#19]
+Arguments: [sr_customer_sk#17 ASC NULLS FIRST, sr_item_sk#16 ASC NULLS FIRST], false, 0
+
+(33) Scan parquet spark_catalog.default.catalog_sales
+Output [4]: [cs_bill_customer_sk#23, cs_item_sk#24, cs_quantity#25, cs_sold_date_sk#26]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#26), dynamicpruningexpression(cs_sold_date_sk#26 IN dynamicpruning#21)]
+PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
+
+(34) ColumnarToRow [codegen id : 15]
+Input [4]: [cs_bill_customer_sk#23, cs_item_sk#24, cs_quantity#25, cs_sold_date_sk#26]
+
+(35) Filter [codegen id : 15]
+Input [4]: [cs_bill_customer_sk#23, cs_item_sk#24, cs_quantity#25, cs_sold_date_sk#26]
+Condition : (isnotnull(cs_bill_customer_sk#23) AND isnotnull(cs_item_sk#24))
+
+(36) ReusedExchange [Reuses operator id: 63]
+Output [1]: [d_date_sk#27]
+
+(37) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [cs_sold_date_sk#26]
+Right keys [1]: [d_date_sk#27]
+Join type: Inner
+Join condition: None
+
+(38) Project [codegen id : 15]
+Output [3]: [cs_bill_customer_sk#23, cs_item_sk#24, cs_quantity#25]
+Input [5]: [cs_bill_customer_sk#23, cs_item_sk#24, cs_quantity#25, cs_sold_date_sk#26, d_date_sk#27]
+
+(39) Exchange
+Input [3]: [cs_bill_customer_sk#23, cs_item_sk#24, cs_quantity#25]
+Arguments: hashpartitioning(cs_bill_customer_sk#23, cs_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(40) Sort [codegen id : 16]
+Input [3]: [cs_bill_customer_sk#23, cs_item_sk#24, cs_quantity#25]
+Arguments: [cs_bill_customer_sk#23 ASC NULLS FIRST, cs_item_sk#24 ASC NULLS FIRST], false, 0
+
+(41) SortMergeJoin [codegen id : 17]
+Left keys [2]: [sr_customer_sk#17, sr_item_sk#16]
+Right keys [2]: [cs_bill_customer_sk#23, cs_item_sk#24]
+Join type: Inner
+Join condition: None
+
+(42) Project [codegen id : 17]
+Output [6]: [ss_quantity#5, sr_return_quantity#19, cs_quantity#25, s_state#12, i_item_id#14, i_item_desc#15]
+Input [10]: [ss_quantity#5, s_state#12, i_item_id#14, i_item_desc#15, sr_item_sk#16, sr_customer_sk#17, sr_return_quantity#19, cs_bill_customer_sk#23, cs_item_sk#24, cs_quantity#25]
+
+(43) HashAggregate [codegen id : 17]
+Input [6]: [ss_quantity#5, sr_return_quantity#19, cs_quantity#25, s_state#12, i_item_id#14, i_item_desc#15]
+Keys [3]: [i_item_id#14, i_item_desc#15, s_state#12]
+Functions [9]: [partial_count(ss_quantity#5), partial_avg(ss_quantity#5), partial_stddev_samp(cast(ss_quantity#5 as double)), partial_count(sr_return_quantity#19), partial_avg(sr_return_quantity#19), partial_stddev_samp(cast(sr_return_quantity#19 as double)), partial_count(cs_quantity#25), partial_avg(cs_quantity#25), partial_stddev_samp(cast(cs_quantity#25 as double))]
+Aggregate Attributes [18]: [count#28, sum#29, count#30, n#31, avg#32, m2#33, count#34, sum#35, count#36, n#37, avg#38, m2#39, count#40, sum#41, count#42, n#43, avg#44, m2#45]
+Results [21]: [i_item_id#14, i_item_desc#15, s_state#12, count#46, sum#47, count#48, n#49, avg#50, m2#51, count#52, sum#53, count#54, n#55, avg#56, m2#57, count#58, sum#59, count#60, n#61, avg#62, m2#63]
+
+(44) Exchange
+Input [21]: [i_item_id#14, i_item_desc#15, s_state#12, count#46, sum#47, count#48, n#49, avg#50, m2#51, count#52, sum#53, count#54, n#55, avg#56, m2#57, count#58, sum#59, count#60, n#61, avg#62, m2#63]
+Arguments: hashpartitioning(i_item_id#14, i_item_desc#15, s_state#12, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(45) HashAggregate [codegen id : 18]
+Input [21]: [i_item_id#14, i_item_desc#15, s_state#12, count#46, sum#47, count#48, n#49, avg#50, m2#51, count#52, sum#53, count#54, n#55, avg#56, m2#57, count#58, sum#59, count#60, n#61, avg#62, m2#63]
+Keys [3]: [i_item_id#14, i_item_desc#15, s_state#12]
+Functions [9]: [count(ss_quantity#5), avg(ss_quantity#5), stddev_samp(cast(ss_quantity#5 as double)), count(sr_return_quantity#19), avg(sr_return_quantity#19), stddev_samp(cast(sr_return_quantity#19 as double)), count(cs_quantity#25), avg(cs_quantity#25), stddev_samp(cast(cs_quantity#25 as double))]
+Aggregate Attributes [9]: [count(ss_quantity#5)#64, avg(ss_quantity#5)#65, stddev_samp(cast(ss_quantity#5 as double))#66, count(sr_return_quantity#19)#67, avg(sr_return_quantity#19)#68, stddev_samp(cast(sr_return_quantity#19 as double))#69, count(cs_quantity#25)#70, avg(cs_quantity#25)#71, stddev_samp(cast(cs_quantity#25 as double))#72]
+Results [15]: [i_item_id#14, i_item_desc#15, s_state#12, count(ss_quantity#5)#64 AS store_sales_quantitycount#73, avg(ss_quantity#5)#65 AS store_sales_quantityave#74, stddev_samp(cast(ss_quantity#5 as double))#66 AS store_sales_quantitystdev#75, (stddev_samp(cast(ss_quantity#5 as double))#66 / avg(ss_quantity#5)#65) AS store_sales_quantitycov#76, count(sr_return_quantity#19)#67 AS as_store_returns_quantitycount#77, avg(sr_return_quantity#19)#68 AS as_store_returns_quantityave#78, stddev_samp(cast(sr_return_quantity#19 as double))#69 AS as_store_returns_quantitystdev#79, (stddev_samp(cast(sr_return_quantity#19 as double))#69 / avg(sr_return_quantity#19)#68) AS store_returns_quantitycov#80, count(cs_quantity#25)#70 AS catalog_sales_quantitycount#81, avg(cs_quantity#25)#71 AS catalog_sales_quantityave#82, (stddev_samp(cast(cs_quantity#25 as double))#72 / avg(cs_quantity#25)#71) AS catalog_sales_quantitystdev#83, (stddev_samp(cast(cs_quantity#25 as double))#72 / avg(cs_quantity#25)#71) AS catalog_sales_quantitycov#84]
+
+(46) TakeOrderedAndProject
+Input [15]: [i_item_id#14, i_item_desc#15, s_state#12, store_sales_quantitycount#73, store_sales_quantityave#74, store_sales_quantitystdev#75, store_sales_quantitycov#76, as_store_returns_quantitycount#77, as_store_returns_quantityave#78, as_store_returns_quantitystdev#79, store_returns_quantitycov#80, catalog_sales_quantitycount#81, catalog_sales_quantityave#82, catalog_sales_quantitystdev#83, catalog_sales_quantitycov#84]
+Arguments: 100, [i_item_id#14 ASC NULLS FIRST, i_item_desc#15 ASC NULLS FIRST, s_state#12 ASC NULLS FIRST], [i_item_id#14, i_item_desc#15, s_state#12, store_sales_quantitycount#73, store_sales_quantityave#74, store_sales_quantitystdev#75, store_sales_quantitycov#76, as_store_returns_quantitycount#77, as_store_returns_quantityave#78, as_store_returns_quantitystdev#79, store_returns_quantitycov#80, catalog_sales_quantitycount#81, catalog_sales_quantityave#82, catalog_sales_quantitystdev#83, catalog_sales_quantitycov#84]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (53)
++- Exchange (52)
+   +- ObjectHashAggregate (51)
+      +- Exchange (50)
+         +- * Filter (49)
+            +- * ColumnarToRow (48)
+               +- Scan parquet spark_catalog.default.item (47)
+
+
+(47) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#13, i_item_id#14, i_item_desc#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
+(48) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#13, i_item_id#14, i_item_desc#15]
 
-(17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
-Condition : isnotnull(i_item_sk#11)
+(49) Filter [codegen id : 1]
+Input [3]: [i_item_sk#13, i_item_id#14, i_item_desc#15]
+Condition : isnotnull(i_item_sk#13)
 
-(18) Exchange
-Input [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
-Arguments: hashpartitioning(i_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(50) Exchange
+Input [3]: [i_item_sk#13, i_item_id#14, i_item_desc#15]
+Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
-Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
+(51) ObjectHashAggregate
+Input [3]: [i_item_sk#13, i_item_id#14, i_item_desc#15]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#13, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#85]
+Results [1]: [buf#86]
 
-(20) SortMergeJoin [codegen id : 7]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#11]
-Join type: Inner
-Join condition: None
+(52) Exchange
+Input [1]: [buf#86]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(21) Project [codegen id : 7]
-Output [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_sk#11, i_item_id#12, i_item_desc#13]
+(53) ObjectHashAggregate
+Input [1]: [buf#86]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 204000, 1632000, 0, 0)#87]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 204000, 1632000, 0, 0)#87 AS bloomFilter#88]
 
-(22) Exchange
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13]
-Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(23) Sort [codegen id : 8]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
-
-(24) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17, sr_returned_date_sk#18]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(sr_returned_date_sk#18), dynamicpruningexpression(sr_returned_date_sk#18 IN dynamicpruning#19)]
-PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
-ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_return_quantity:int>
-
-(25) ColumnarToRow [codegen id : 10]
-Input [5]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17, sr_returned_date_sk#18]
-
-(26) Filter [codegen id : 10]
-Input [5]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17, sr_returned_date_sk#18]
-Condition : ((isnotnull(sr_customer_sk#15) AND isnotnull(sr_item_sk#14)) AND isnotnull(sr_ticket_number#16))
-
-(27) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#20]
-
-(28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [sr_returned_date_sk#18]
-Right keys [1]: [d_date_sk#20]
-Join type: Inner
-Join condition: None
-
-(29) Project [codegen id : 10]
-Output [4]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17]
-Input [6]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17, sr_returned_date_sk#18, d_date_sk#20]
-
-(30) Exchange
-Input [4]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17]
-Arguments: hashpartitioning(sr_customer_sk#15, sr_item_sk#14, sr_ticket_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(31) Sort [codegen id : 11]
-Input [4]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17]
-Arguments: [sr_customer_sk#15 ASC NULLS FIRST, sr_item_sk#14 ASC NULLS FIRST, sr_ticket_number#16 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 12]
-Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
-Right keys [3]: [sr_customer_sk#15, sr_item_sk#14, sr_ticket_number#16]
-Join type: Inner
-Join condition: None
-
-(33) Project [codegen id : 12]
-Output [7]: [ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_return_quantity#17]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17]
-
-(34) Exchange
-Input [7]: [ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_return_quantity#17]
-Arguments: hashpartitioning(sr_customer_sk#15, sr_item_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) Sort [codegen id : 13]
-Input [7]: [ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_return_quantity#17]
-Arguments: [sr_customer_sk#15 ASC NULLS FIRST, sr_item_sk#14 ASC NULLS FIRST], false, 0
-
-(36) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23, cs_sold_date_sk#24]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#24), dynamicpruningexpression(cs_sold_date_sk#24 IN dynamicpruning#19)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
-ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
-
-(37) ColumnarToRow [codegen id : 15]
-Input [4]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23, cs_sold_date_sk#24]
-
-(38) Filter [codegen id : 15]
-Input [4]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23, cs_sold_date_sk#24]
-Condition : (isnotnull(cs_bill_customer_sk#21) AND isnotnull(cs_item_sk#22))
-
-(39) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#25]
-
-(40) BroadcastHashJoin [codegen id : 15]
-Left keys [1]: [cs_sold_date_sk#24]
-Right keys [1]: [d_date_sk#25]
-Join type: Inner
-Join condition: None
-
-(41) Project [codegen id : 15]
-Output [3]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23]
-Input [5]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23, cs_sold_date_sk#24, d_date_sk#25]
-
-(42) Exchange
-Input [3]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23]
-Arguments: hashpartitioning(cs_bill_customer_sk#21, cs_item_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(43) Sort [codegen id : 16]
-Input [3]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23]
-Arguments: [cs_bill_customer_sk#21 ASC NULLS FIRST, cs_item_sk#22 ASC NULLS FIRST], false, 0
-
-(44) SortMergeJoin [codegen id : 17]
-Left keys [2]: [sr_customer_sk#15, sr_item_sk#14]
-Right keys [2]: [cs_bill_customer_sk#21, cs_item_sk#22]
-Join type: Inner
-Join condition: None
-
-(45) Project [codegen id : 17]
-Output [6]: [ss_quantity#5, sr_return_quantity#17, cs_quantity#23, s_state#10, i_item_id#12, i_item_desc#13]
-Input [10]: [ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_return_quantity#17, cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23]
-
-(46) HashAggregate [codegen id : 17]
-Input [6]: [ss_quantity#5, sr_return_quantity#17, cs_quantity#23, s_state#10, i_item_id#12, i_item_desc#13]
-Keys [3]: [i_item_id#12, i_item_desc#13, s_state#10]
-Functions [9]: [partial_count(ss_quantity#5), partial_avg(ss_quantity#5), partial_stddev_samp(cast(ss_quantity#5 as double)), partial_count(sr_return_quantity#17), partial_avg(sr_return_quantity#17), partial_stddev_samp(cast(sr_return_quantity#17 as double)), partial_count(cs_quantity#23), partial_avg(cs_quantity#23), partial_stddev_samp(cast(cs_quantity#23 as double))]
-Aggregate Attributes [18]: [count#26, sum#27, count#28, n#29, avg#30, m2#31, count#32, sum#33, count#34, n#35, avg#36, m2#37, count#38, sum#39, count#40, n#41, avg#42, m2#43]
-Results [21]: [i_item_id#12, i_item_desc#13, s_state#10, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
-
-(47) Exchange
-Input [21]: [i_item_id#12, i_item_desc#13, s_state#10, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
-Arguments: hashpartitioning(i_item_id#12, i_item_desc#13, s_state#10, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(48) HashAggregate [codegen id : 18]
-Input [21]: [i_item_id#12, i_item_desc#13, s_state#10, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
-Keys [3]: [i_item_id#12, i_item_desc#13, s_state#10]
-Functions [9]: [count(ss_quantity#5), avg(ss_quantity#5), stddev_samp(cast(ss_quantity#5 as double)), count(sr_return_quantity#17), avg(sr_return_quantity#17), stddev_samp(cast(sr_return_quantity#17 as double)), count(cs_quantity#23), avg(cs_quantity#23), stddev_samp(cast(cs_quantity#23 as double))]
-Aggregate Attributes [9]: [count(ss_quantity#5)#62, avg(ss_quantity#5)#63, stddev_samp(cast(ss_quantity#5 as double))#64, count(sr_return_quantity#17)#65, avg(sr_return_quantity#17)#66, stddev_samp(cast(sr_return_quantity#17 as double))#67, count(cs_quantity#23)#68, avg(cs_quantity#23)#69, stddev_samp(cast(cs_quantity#23 as double))#70]
-Results [15]: [i_item_id#12, i_item_desc#13, s_state#10, count(ss_quantity#5)#62 AS store_sales_quantitycount#71, avg(ss_quantity#5)#63 AS store_sales_quantityave#72, stddev_samp(cast(ss_quantity#5 as double))#64 AS store_sales_quantitystdev#73, (stddev_samp(cast(ss_quantity#5 as double))#64 / avg(ss_quantity#5)#63) AS store_sales_quantitycov#74, count(sr_return_quantity#17)#65 AS as_store_returns_quantitycount#75, avg(sr_return_quantity#17)#66 AS as_store_returns_quantityave#76, stddev_samp(cast(sr_return_quantity#17 as double))#67 AS as_store_returns_quantitystdev#77, (stddev_samp(cast(sr_return_quantity#17 as double))#67 / avg(sr_return_quantity#17)#66) AS store_returns_quantitycov#78, count(cs_quantity#23)#68 AS catalog_sales_quantitycount#79, avg(cs_quantity#23)#69 AS catalog_sales_quantityave#80, (stddev_samp(cast(cs_quantity#23 as double))#70 / avg(cs_quantity#23)#69) AS catalog_sales_quantitystdev#81, (stddev_samp(cast(cs_quantity#23 as double))#70 / avg(cs_quantity#23)#69) AS catalog_sales_quantitycov#82]
-
-(49) TakeOrderedAndProject
-Input [15]: [i_item_id#12, i_item_desc#13, s_state#10, store_sales_quantitycount#71, store_sales_quantityave#72, store_sales_quantitystdev#73, store_sales_quantitycov#74, as_store_returns_quantitycount#75, as_store_returns_quantityave#76, as_store_returns_quantitystdev#77, store_returns_quantitycov#78, catalog_sales_quantitycount#79, catalog_sales_quantityave#80, catalog_sales_quantitystdev#81, catalog_sales_quantitycov#82]
-Arguments: 100, [i_item_id#12 ASC NULLS FIRST, i_item_desc#13 ASC NULLS FIRST, s_state#10 ASC NULLS FIRST], [i_item_id#12, i_item_desc#13, s_state#10, store_sales_quantitycount#71, store_sales_quantityave#72, store_sales_quantitystdev#73, store_sales_quantitycov#74, as_store_returns_quantitycount#75, as_store_returns_quantityave#76, as_store_returns_quantitystdev#77, store_returns_quantitycov#78, catalog_sales_quantitycount#79, catalog_sales_quantityave#80, catalog_sales_quantitystdev#81, catalog_sales_quantitycov#82]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
-BroadcastExchange (54)
-+- * Project (53)
-   +- * Filter (52)
-      +- * ColumnarToRow (51)
-         +- Scan parquet spark_catalog.default.date_dim (50)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (58)
++- * Project (57)
+   +- * Filter (56)
+      +- * ColumnarToRow (55)
+         +- Scan parquet spark_catalog.default.date_dim (54)
 
 
-(50) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#8, d_quarter_name#83]
+(54) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#10, d_quarter_name#89]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_quarter_name), EqualTo(d_quarter_name,2001Q1), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_quarter_name:string>
 
-(51) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#8, d_quarter_name#83]
+(55) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#10, d_quarter_name#89]
 
-(52) Filter [codegen id : 1]
-Input [2]: [d_date_sk#8, d_quarter_name#83]
-Condition : ((isnotnull(d_quarter_name#83) AND (d_quarter_name#83 = 2001Q1)) AND isnotnull(d_date_sk#8))
+(56) Filter [codegen id : 1]
+Input [2]: [d_date_sk#10, d_quarter_name#89]
+Condition : ((isnotnull(d_quarter_name#89) AND (d_quarter_name#89 = 2001Q1)) AND isnotnull(d_date_sk#10))
 
-(53) Project [codegen id : 1]
-Output [1]: [d_date_sk#8]
-Input [2]: [d_date_sk#8, d_quarter_name#83]
+(57) Project [codegen id : 1]
+Output [1]: [d_date_sk#10]
+Input [2]: [d_date_sk#10, d_quarter_name#89]
 
-(54) BroadcastExchange
-Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+(58) BroadcastExchange
+Input [1]: [d_date_sk#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#18 IN dynamicpruning#19
-BroadcastExchange (59)
-+- * Project (58)
-   +- * Filter (57)
-      +- * ColumnarToRow (56)
-         +- Scan parquet spark_catalog.default.date_dim (55)
+Subquery:3 Hosting operator id = 21 Hosting Expression = sr_returned_date_sk#20 IN dynamicpruning#21
+BroadcastExchange (63)
++- * Project (62)
+   +- * Filter (61)
+      +- * ColumnarToRow (60)
+         +- Scan parquet spark_catalog.default.date_dim (59)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#20, d_quarter_name#84]
+(59) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#22, d_quarter_name#90]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_quarter_name, [2001Q1,2001Q2,2001Q3]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_quarter_name:string>
 
-(56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#20, d_quarter_name#84]
+(60) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#22, d_quarter_name#90]
 
-(57) Filter [codegen id : 1]
-Input [2]: [d_date_sk#20, d_quarter_name#84]
-Condition : (d_quarter_name#84 IN (2001Q1,2001Q2,2001Q3) AND isnotnull(d_date_sk#20))
+(61) Filter [codegen id : 1]
+Input [2]: [d_date_sk#22, d_quarter_name#90]
+Condition : (d_quarter_name#90 IN (2001Q1,2001Q2,2001Q3) AND isnotnull(d_date_sk#22))
 
-(58) Project [codegen id : 1]
-Output [1]: [d_date_sk#20]
-Input [2]: [d_date_sk#20, d_quarter_name#84]
+(62) Project [codegen id : 1]
+Output [1]: [d_date_sk#22]
+Input [2]: [d_date_sk#22, d_quarter_name#90]
 
-(59) BroadcastExchange
-Input [1]: [d_date_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(63) BroadcastExchange
+Input [1]: [d_date_sk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#19
+Subquery:4 Hosting operator id = 33 Hosting Expression = cs_sold_date_sk#26 IN dynamicpruning#21
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/simplified.txt
@@ -34,6 +34,16 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                                                   Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_quantity]
                                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                       Filter [ss_customer_sk,ss_item_sk,ss_ticket_number,ss_store_sk]
+                                                                        Subquery #2
+                                                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                            Exchange #6
+                                                                              ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                Exchange [i_item_sk] #7
+                                                                                  WholeStageCodegen (1)
+                                                                                    Filter [i_item_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
                                                                         ColumnarToRow
                                                                           InputAdapter
                                                                             Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_quantity,ss_sold_date_sk]
@@ -48,7 +58,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                                                       InputAdapter
                                                                         ReusedExchange [d_date_sk] #5
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
+                                                                    BroadcastExchange #8
                                                                       WholeStageCodegen (2)
                                                                         Filter [s_store_sk]
                                                                           ColumnarToRow
@@ -58,17 +68,12 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                                     WholeStageCodegen (6)
                                                       Sort [i_item_sk]
                                                         InputAdapter
-                                                          Exchange [i_item_sk] #7
-                                                            WholeStageCodegen (5)
-                                                              Filter [i_item_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
+                                                          ReusedExchange [i_item_sk,i_item_id,i_item_desc] #7
                                   InputAdapter
                                     WholeStageCodegen (11)
                                       Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
                                         InputAdapter
-                                          Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #8
+                                          Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #9
                                             WholeStageCodegen (10)
                                               Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity]
                                                 BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
@@ -76,8 +81,8 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity,sr_returned_date_sk]
-                                                          SubqueryBroadcast [d_date_sk] #2
-                                                            BroadcastExchange #9
+                                                          SubqueryBroadcast [d_date_sk] #3
+                                                            BroadcastExchange #10
                                                               WholeStageCodegen (1)
                                                                 Project [d_date_sk]
                                                                   Filter [d_quarter_name,d_date_sk]
@@ -85,12 +90,12 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.date_dim [d_date_sk,d_quarter_name]
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #9
+                                                    ReusedExchange [d_date_sk] #10
                   InputAdapter
                     WholeStageCodegen (16)
                       Sort [cs_bill_customer_sk,cs_item_sk]
                         InputAdapter
-                          Exchange [cs_bill_customer_sk,cs_item_sk] #10
+                          Exchange [cs_bill_customer_sk,cs_item_sk] #11
                             WholeStageCodegen (15)
                               Project [cs_bill_customer_sk,cs_item_sk,cs_quantity]
                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
@@ -98,6 +103,6 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
-                                          ReusedSubquery [d_date_sk] #2
+                                          ReusedSubquery [d_date_sk] #3
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #9
+                                    ReusedExchange [d_date_sk] #10

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
@@ -1,11 +1,11 @@
 == Physical Plan ==
-TakeOrderedAndProject (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * Expand (45)
-            +- * Project (44)
-               +- * SortMergeJoin Inner (43)
+TakeOrderedAndProject (30)
++- * HashAggregate (29)
+   +- Exchange (28)
+      +- * HashAggregate (27)
+         +- * Expand (26)
+            +- * Project (25)
+               +- * SortMergeJoin Inner (24)
                   :- * Sort (21)
                   :  +- Exchange (20)
                   :     +- * Project (19)
@@ -27,27 +27,8 @@ TakeOrderedAndProject (49)
                   :              +- * Filter (16)
                   :                 +- * ColumnarToRow (15)
                   :                    +- Scan parquet spark_catalog.default.item (14)
-                  +- * Sort (42)
-                     +- Exchange (41)
-                        +- * Project (40)
-                           +- * SortMergeJoin Inner (39)
-                              :- * Sort (33)
-                              :  +- Exchange (32)
-                              :     +- * Project (31)
-                              :        +- * BroadcastHashJoin Inner BuildRight (30)
-                              :           :- * Project (25)
-                              :           :  +- * Filter (24)
-                              :           :     +- * ColumnarToRow (23)
-                              :           :        +- Scan parquet spark_catalog.default.customer (22)
-                              :           +- BroadcastExchange (29)
-                              :              +- * Filter (28)
-                              :                 +- * ColumnarToRow (27)
-                              :                    +- Scan parquet spark_catalog.default.customer_address (26)
-                              +- * Sort (38)
-                                 +- Exchange (37)
-                                    +- * Filter (36)
-                                       +- * ColumnarToRow (35)
-                                          +- Scan parquet spark_catalog.default.customer_demographics (34)
+                  +- * Sort (23)
+                     +- ReusedExchange (22)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -63,249 +44,296 @@ Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity
 
 (3) Filter [codegen id : 4]
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
-Condition : ((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3))
+Condition : (((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3)) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_bill_customer_sk#1, 42), false))
 
 (4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Output [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_education_status), EqualTo(cd_gender,F), EqualTo(cd_education_status,Unknown             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_education_status:string,cd_dep_count:int>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 
 (6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
-Condition : ((((isnotnull(cd_gender#12) AND isnotnull(cd_education_status#13)) AND (cd_gender#12 = F)) AND (cd_education_status#13 = Unknown             )) AND isnotnull(cd_demo_sk#11))
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
+Condition : ((((isnotnull(cd_gender#14) AND isnotnull(cd_education_status#15)) AND (cd_gender#14 = F)) AND (cd_education_status#15 = Unknown             )) AND isnotnull(cd_demo_sk#13))
 
 (7) Project [codegen id : 1]
-Output [2]: [cd_demo_sk#11, cd_dep_count#14]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Output [2]: [cd_demo_sk#13, cd_dep_count#16]
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 
 (8) BroadcastExchange
-Input [2]: [cd_demo_sk#11, cd_dep_count#14]
+Input [2]: [cd_demo_sk#13, cd_dep_count#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#11]
+Right keys [1]: [cd_demo_sk#13]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14]
-Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#11, cd_dep_count#14]
+Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16]
+Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#13, cd_dep_count#16]
 
-(11) ReusedExchange [Reuses operator id: 54]
-Output [1]: [d_date_sk#15]
+(11) ReusedExchange [Reuses operator id: 58]
+Output [1]: [d_date_sk#17]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#9]
-Right keys [1]: [d_date_sk#15]
+Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14, d_date_sk#15]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16, d_date_sk#17]
 
 (14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#16, i_item_id#17]
+Output [2]: [i_item_sk#18, i_item_id#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [2]: [i_item_sk#16, i_item_id#17]
+Input [2]: [i_item_sk#18, i_item_id#19]
 
 (16) Filter [codegen id : 3]
-Input [2]: [i_item_sk#16, i_item_id#17]
-Condition : isnotnull(i_item_sk#16)
+Input [2]: [i_item_sk#18, i_item_id#19]
+Condition : isnotnull(i_item_sk#18)
 
 (17) BroadcastExchange
-Input [2]: [i_item_sk#16, i_item_id#17]
+Input [2]: [i_item_sk#18, i_item_id#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_item_sk#3]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_sk#16, i_item_id#17]
+Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_sk#18, i_item_id#19]
 
 (20) Exchange
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
 Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) Sort [codegen id : 5]
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(22) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+(22) ReusedExchange [Reuses operator id: 50]
+Output [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+
+(23) Sort [codegen id : 12]
+Input [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(24) SortMergeJoin [codegen id : 13]
+Left keys [1]: [cs_bill_customer_sk#1]
+Right keys [1]: [c_customer_sk#20]
+Join type: Inner
+Join condition: None
+
+(25) Project [codegen id : 13]
+Output [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_id#19, ca_country#24, ca_state#23, ca_county#22]
+Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19, c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+
+(26) Expand [codegen id : 13]
+Input [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_id#19, ca_country#24, ca_state#23, ca_county#22]
+Arguments: [[cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_id#19, ca_country#24, ca_state#23, ca_county#22, 0], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_id#19, ca_country#24, ca_state#23, null, 1], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_id#19, ca_country#24, null, null, 3], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_id#19, null, null, null, 7], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, null, null, null, null, 15]], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_id#25, ca_country#26, ca_state#27, ca_county#28, spark_grouping_id#29]
+
+(27) HashAggregate [codegen id : 13]
+Input [12]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_id#25, ca_country#26, ca_state#27, ca_county#28, spark_grouping_id#29]
+Keys [5]: [i_item_id#25, ca_country#26, ca_state#27, ca_county#28, spark_grouping_id#29]
+Functions [7]: [partial_avg(cast(cs_quantity#4 as decimal(12,2))), partial_avg(cast(cs_list_price#5 as decimal(12,2))), partial_avg(cast(cs_coupon_amt#7 as decimal(12,2))), partial_avg(cast(cs_sales_price#6 as decimal(12,2))), partial_avg(cast(cs_net_profit#8 as decimal(12,2))), partial_avg(cast(c_birth_year#21 as decimal(12,2))), partial_avg(cast(cd_dep_count#16 as decimal(12,2)))]
+Aggregate Attributes [14]: [sum#30, count#31, sum#32, count#33, sum#34, count#35, sum#36, count#37, sum#38, count#39, sum#40, count#41, sum#42, count#43]
+Results [19]: [i_item_id#25, ca_country#26, ca_state#27, ca_county#28, spark_grouping_id#29, sum#44, count#45, sum#46, count#47, sum#48, count#49, sum#50, count#51, sum#52, count#53, sum#54, count#55, sum#56, count#57]
+
+(28) Exchange
+Input [19]: [i_item_id#25, ca_country#26, ca_state#27, ca_county#28, spark_grouping_id#29, sum#44, count#45, sum#46, count#47, sum#48, count#49, sum#50, count#51, sum#52, count#53, sum#54, count#55, sum#56, count#57]
+Arguments: hashpartitioning(i_item_id#25, ca_country#26, ca_state#27, ca_county#28, spark_grouping_id#29, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(29) HashAggregate [codegen id : 14]
+Input [19]: [i_item_id#25, ca_country#26, ca_state#27, ca_county#28, spark_grouping_id#29, sum#44, count#45, sum#46, count#47, sum#48, count#49, sum#50, count#51, sum#52, count#53, sum#54, count#55, sum#56, count#57]
+Keys [5]: [i_item_id#25, ca_country#26, ca_state#27, ca_county#28, spark_grouping_id#29]
+Functions [7]: [avg(cast(cs_quantity#4 as decimal(12,2))), avg(cast(cs_list_price#5 as decimal(12,2))), avg(cast(cs_coupon_amt#7 as decimal(12,2))), avg(cast(cs_sales_price#6 as decimal(12,2))), avg(cast(cs_net_profit#8 as decimal(12,2))), avg(cast(c_birth_year#21 as decimal(12,2))), avg(cast(cd_dep_count#16 as decimal(12,2)))]
+Aggregate Attributes [7]: [avg(cast(cs_quantity#4 as decimal(12,2)))#58, avg(cast(cs_list_price#5 as decimal(12,2)))#59, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#60, avg(cast(cs_sales_price#6 as decimal(12,2)))#61, avg(cast(cs_net_profit#8 as decimal(12,2)))#62, avg(cast(c_birth_year#21 as decimal(12,2)))#63, avg(cast(cd_dep_count#16 as decimal(12,2)))#64]
+Results [11]: [i_item_id#25, ca_country#26, ca_state#27, ca_county#28, avg(cast(cs_quantity#4 as decimal(12,2)))#58 AS agg1#65, avg(cast(cs_list_price#5 as decimal(12,2)))#59 AS agg2#66, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#60 AS agg3#67, avg(cast(cs_sales_price#6 as decimal(12,2)))#61 AS agg4#68, avg(cast(cs_net_profit#8 as decimal(12,2)))#62 AS agg5#69, avg(cast(c_birth_year#21 as decimal(12,2)))#63 AS agg6#70, avg(cast(cd_dep_count#16 as decimal(12,2)))#64 AS agg7#71]
+
+(30) TakeOrderedAndProject
+Input [11]: [i_item_id#25, ca_country#26, ca_state#27, ca_county#28, agg1#65, agg2#66, agg3#67, agg4#68, agg5#69, agg6#70, agg7#71]
+Arguments: 100, [ca_country#26 ASC NULLS FIRST, ca_state#27 ASC NULLS FIRST, ca_county#28 ASC NULLS FIRST, i_item_id#25 ASC NULLS FIRST], [i_item_id#25, ca_country#26, ca_state#27, ca_county#28, agg1#65, agg2#66, agg3#67, agg4#68, agg5#69, agg6#70, agg7#71]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+ObjectHashAggregate (53)
++- Exchange (52)
+   +- ObjectHashAggregate (51)
+      +- Exchange (50)
+         +- * Project (49)
+            +- * SortMergeJoin Inner (48)
+               :- * Sort (42)
+               :  +- Exchange (41)
+               :     +- * Project (40)
+               :        +- * BroadcastHashJoin Inner BuildRight (39)
+               :           :- * Project (34)
+               :           :  +- * Filter (33)
+               :           :     +- * ColumnarToRow (32)
+               :           :        +- Scan parquet spark_catalog.default.customer (31)
+               :           +- BroadcastExchange (38)
+               :              +- * Filter (37)
+               :                 +- * ColumnarToRow (36)
+               :                    +- Scan parquet spark_catalog.default.customer_address (35)
+               +- * Sort (47)
+                  +- Exchange (46)
+                     +- * Filter (45)
+                        +- * ColumnarToRow (44)
+                           +- Scan parquet spark_catalog.default.customer_demographics (43)
+
+
+(31) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_current_cdemo_sk#72, c_current_addr_sk#73, c_birth_month#74, c_birth_year#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [In(c_birth_month, [1,12,2,6,8,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
 
-(23) ColumnarToRow [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+(32) ColumnarToRow [codegen id : 2]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#72, c_current_addr_sk#73, c_birth_month#74, c_birth_year#21]
 
-(24) Filter [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Condition : (((c_birth_month#21 IN (1,6,8,9,12,2) AND isnotnull(c_customer_sk#18)) AND isnotnull(c_current_cdemo_sk#19)) AND isnotnull(c_current_addr_sk#20))
+(33) Filter [codegen id : 2]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#72, c_current_addr_sk#73, c_birth_month#74, c_birth_year#21]
+Condition : (((c_birth_month#74 IN (1,6,8,9,12,2) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#72)) AND isnotnull(c_current_addr_sk#73))
 
-(25) Project [codegen id : 7]
-Output [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+(34) Project [codegen id : 2]
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#72, c_current_addr_sk#73, c_birth_year#21]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#72, c_current_addr_sk#73, c_birth_month#74, c_birth_year#21]
 
-(26) Scan parquet spark_catalog.default.customer_address
-Output [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+(35) Scan parquet spark_catalog.default.customer_address
+Output [4]: [ca_address_sk#75, ca_county#22, ca_state#23, ca_country#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [IN,MS,ND,NM,OK,VA]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string,ca_state:string,ca_country:string>
 
-(27) ColumnarToRow [codegen id : 6]
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+(36) ColumnarToRow [codegen id : 1]
+Input [4]: [ca_address_sk#75, ca_county#22, ca_state#23, ca_country#24]
 
-(28) Filter [codegen id : 6]
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-Condition : (ca_state#25 IN (MS,IN,ND,OK,NM,VA) AND isnotnull(ca_address_sk#23))
+(37) Filter [codegen id : 1]
+Input [4]: [ca_address_sk#75, ca_county#22, ca_state#23, ca_country#24]
+Condition : (ca_state#23 IN (MS,IN,ND,OK,NM,VA) AND isnotnull(ca_address_sk#75))
 
-(29) BroadcastExchange
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
+(38) BroadcastExchange
+Input [4]: [ca_address_sk#75, ca_county#22, ca_state#23, ca_country#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(30) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [c_current_addr_sk#20]
-Right keys [1]: [ca_address_sk#23]
+(39) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [c_current_addr_sk#73]
+Right keys [1]: [ca_address_sk#75]
 Join type: Inner
 Join condition: None
 
-(31) Project [codegen id : 7]
-Output [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Input [8]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22, ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+(40) Project [codegen id : 2]
+Output [6]: [c_customer_sk#20, c_current_cdemo_sk#72, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Input [8]: [c_customer_sk#20, c_current_cdemo_sk#72, c_current_addr_sk#73, c_birth_year#21, ca_address_sk#75, ca_county#22, ca_state#23, ca_country#24]
 
-(32) Exchange
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_current_cdemo_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(41) Exchange
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#72, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Arguments: hashpartitioning(c_current_cdemo_sk#72, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(33) Sort [codegen id : 8]
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: [c_current_cdemo_sk#19 ASC NULLS FIRST], false, 0
+(42) Sort [codegen id : 3]
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#72, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Arguments: [c_current_cdemo_sk#72 ASC NULLS FIRST], false, 0
 
-(34) Scan parquet spark_catalog.default.customer_demographics
-Output [1]: [cd_demo_sk#27]
+(43) Scan parquet spark_catalog.default.customer_demographics
+Output [1]: [cd_demo_sk#76]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int>
 
-(35) ColumnarToRow [codegen id : 9]
-Input [1]: [cd_demo_sk#27]
+(44) ColumnarToRow [codegen id : 4]
+Input [1]: [cd_demo_sk#76]
 
-(36) Filter [codegen id : 9]
-Input [1]: [cd_demo_sk#27]
-Condition : isnotnull(cd_demo_sk#27)
+(45) Filter [codegen id : 4]
+Input [1]: [cd_demo_sk#76]
+Condition : isnotnull(cd_demo_sk#76)
 
-(37) Exchange
-Input [1]: [cd_demo_sk#27]
-Arguments: hashpartitioning(cd_demo_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(46) Exchange
+Input [1]: [cd_demo_sk#76]
+Arguments: hashpartitioning(cd_demo_sk#76, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(38) Sort [codegen id : 10]
-Input [1]: [cd_demo_sk#27]
-Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
+(47) Sort [codegen id : 5]
+Input [1]: [cd_demo_sk#76]
+Arguments: [cd_demo_sk#76 ASC NULLS FIRST], false, 0
 
-(39) SortMergeJoin [codegen id : 11]
-Left keys [1]: [c_current_cdemo_sk#19]
-Right keys [1]: [cd_demo_sk#27]
+(48) SortMergeJoin [codegen id : 6]
+Left keys [1]: [c_current_cdemo_sk#72]
+Right keys [1]: [cd_demo_sk#76]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 11]
-Output [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Input [7]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26, cd_demo_sk#27]
+(49) Project [codegen id : 6]
+Output [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Input [7]: [c_customer_sk#20, c_current_cdemo_sk#72, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24, cd_demo_sk#76]
 
-(41) Exchange
-Input [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(50) Exchange
+Input [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(42) Sort [codegen id : 12]
-Input [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+(51) ObjectHashAggregate
+Input [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 280323, 2242584, 0, 0)]
+Aggregate Attributes [1]: [buf#77]
+Results [1]: [buf#78]
 
-(43) SortMergeJoin [codegen id : 13]
-Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
-Join type: Inner
-Join condition: None
+(52) Exchange
+Input [1]: [buf#78]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(44) Project [codegen id : 13]
-Output [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
+(53) ObjectHashAggregate
+Input [1]: [buf#78]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 280323, 2242584, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 280323, 2242584, 0, 0)#79]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 280323, 2242584, 0, 0)#79 AS bloomFilter#80]
 
-(45) Expand [codegen id : 13]
-Input [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Arguments: [[cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24, 0], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, null, 1], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, null, null, 3], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, null, null, null, 7], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, null, null, null, null, 15]], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-
-(46) HashAggregate [codegen id : 13]
-Input [12]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-Keys [5]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-Functions [7]: [partial_avg(cast(cs_quantity#4 as decimal(12,2))), partial_avg(cast(cs_list_price#5 as decimal(12,2))), partial_avg(cast(cs_coupon_amt#7 as decimal(12,2))), partial_avg(cast(cs_sales_price#6 as decimal(12,2))), partial_avg(cast(cs_net_profit#8 as decimal(12,2))), partial_avg(cast(c_birth_year#22 as decimal(12,2))), partial_avg(cast(cd_dep_count#14 as decimal(12,2)))]
-Aggregate Attributes [14]: [sum#33, count#34, sum#35, count#36, sum#37, count#38, sum#39, count#40, sum#41, count#42, sum#43, count#44, sum#45, count#46]
-Results [19]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, sum#47, count#48, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60]
-
-(47) Exchange
-Input [19]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, sum#47, count#48, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60]
-Arguments: hashpartitioning(i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(48) HashAggregate [codegen id : 14]
-Input [19]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, sum#47, count#48, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60]
-Keys [5]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-Functions [7]: [avg(cast(cs_quantity#4 as decimal(12,2))), avg(cast(cs_list_price#5 as decimal(12,2))), avg(cast(cs_coupon_amt#7 as decimal(12,2))), avg(cast(cs_sales_price#6 as decimal(12,2))), avg(cast(cs_net_profit#8 as decimal(12,2))), avg(cast(c_birth_year#22 as decimal(12,2))), avg(cast(cd_dep_count#14 as decimal(12,2)))]
-Aggregate Attributes [7]: [avg(cast(cs_quantity#4 as decimal(12,2)))#61, avg(cast(cs_list_price#5 as decimal(12,2)))#62, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#63, avg(cast(cs_sales_price#6 as decimal(12,2)))#64, avg(cast(cs_net_profit#8 as decimal(12,2)))#65, avg(cast(c_birth_year#22 as decimal(12,2)))#66, avg(cast(cd_dep_count#14 as decimal(12,2)))#67]
-Results [11]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, avg(cast(cs_quantity#4 as decimal(12,2)))#61 AS agg1#68, avg(cast(cs_list_price#5 as decimal(12,2)))#62 AS agg2#69, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#63 AS agg3#70, avg(cast(cs_sales_price#6 as decimal(12,2)))#64 AS agg4#71, avg(cast(cs_net_profit#8 as decimal(12,2)))#65 AS agg5#72, avg(cast(c_birth_year#22 as decimal(12,2)))#66 AS agg6#73, avg(cast(cd_dep_count#14 as decimal(12,2)))#67 AS agg7#74]
-
-(49) TakeOrderedAndProject
-Input [11]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, agg1#68, agg2#69, agg3#70, agg4#71, agg5#72, agg6#73, agg7#74]
-Arguments: 100, [ca_country#29 ASC NULLS FIRST, ca_state#30 ASC NULLS FIRST, ca_county#31 ASC NULLS FIRST, i_item_id#28 ASC NULLS FIRST], [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, agg1#68, agg2#69, agg3#70, agg4#71, agg5#72, agg6#73, agg7#74]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (54)
-+- * Project (53)
-   +- * Filter (52)
-      +- * ColumnarToRow (51)
-         +- Scan parquet spark_catalog.default.date_dim (50)
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+BroadcastExchange (58)
++- * Project (57)
+   +- * Filter (56)
+      +- * ColumnarToRow (55)
+         +- Scan parquet spark_catalog.default.date_dim (54)
 
 
-(50) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#15, d_year#75]
+(54) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#17, d_year#81]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(51) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#75]
+(55) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#17, d_year#81]
 
-(52) Filter [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#75]
-Condition : ((isnotnull(d_year#75) AND (d_year#75 = 1998)) AND isnotnull(d_date_sk#15))
+(56) Filter [codegen id : 1]
+Input [2]: [d_date_sk#17, d_year#81]
+Condition : ((isnotnull(d_year#81) AND (d_year#81 = 1998)) AND isnotnull(d_date_sk#17))
 
-(53) Project [codegen id : 1]
-Output [1]: [d_date_sk#15]
-Input [2]: [d_date_sk#15, d_year#75]
+(57) Project [codegen id : 1]
+Output [1]: [d_date_sk#17]
+Input [2]: [d_date_sk#17, d_year#81]
 
-(54) BroadcastExchange
-Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+(58) BroadcastExchange
+Input [1]: [d_date_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/simplified.txt
@@ -21,6 +21,44 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
                                           BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
                                             Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
+                                              Subquery #2
+                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 280323, 2242584, 0, 0),bloomFilter,buf]
+                                                  Exchange #4
+                                                    ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                      Exchange [c_customer_sk] #5
+                                                        WholeStageCodegen (6)
+                                                          Project [c_customer_sk,c_birth_year,ca_county,ca_state,ca_country]
+                                                            SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (3)
+                                                                  Sort [c_current_cdemo_sk]
+                                                                    InputAdapter
+                                                                      Exchange [c_current_cdemo_sk] #6
+                                                                        WholeStageCodegen (2)
+                                                                          Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_county,ca_state,ca_country]
+                                                                            BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                                                              Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
+                                                                                Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
+                                                                              InputAdapter
+                                                                                BroadcastExchange #7
+                                                                                  WholeStageCodegen (1)
+                                                                                    Filter [ca_state,ca_address_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state,ca_country]
+                                                              InputAdapter
+                                                                WholeStageCodegen (5)
+                                                                  Sort [cd_demo_sk]
+                                                                    InputAdapter
+                                                                      Exchange [cd_demo_sk] #8
+                                                                        WholeStageCodegen (4)
+                                                                          Filter [cd_demo_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
@@ -33,7 +71,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                             InputAdapter
-                                              BroadcastExchange #4
+                                              BroadcastExchange #9
                                                 WholeStageCodegen (1)
                                                   Project [cd_demo_sk,cd_dep_count]
                                                     Filter [cd_gender,cd_education_status,cd_demo_sk]
@@ -43,7 +81,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
-                                      BroadcastExchange #5
+                                      BroadcastExchange #10
                                         WholeStageCodegen (3)
                                           Filter [i_item_sk]
                                             ColumnarToRow
@@ -53,37 +91,4 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                       WholeStageCodegen (12)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #6
-                              WholeStageCodegen (11)
-                                Project [c_customer_sk,c_birth_year,ca_county,ca_state,ca_country]
-                                  SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (8)
-                                        Sort [c_current_cdemo_sk]
-                                          InputAdapter
-                                            Exchange [c_current_cdemo_sk] #7
-                                              WholeStageCodegen (7)
-                                                Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_county,ca_state,ca_country]
-                                                  BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                                                    Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
-                                                      Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
-                                                    InputAdapter
-                                                      BroadcastExchange #8
-                                                        WholeStageCodegen (6)
-                                                          Filter [ca_state,ca_address_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state,ca_country]
-                                    InputAdapter
-                                      WholeStageCodegen (10)
-                                        Sort [cd_demo_sk]
-                                          InputAdapter
-                                            Exchange [cd_demo_sk] #9
-                                              WholeStageCodegen (9)
-                                                Filter [cd_demo_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
+                            ReusedExchange [c_customer_sk,c_birth_year,ca_county,ca_state,ca_country] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
@@ -1,10 +1,10 @@
 == Physical Plan ==
-TakeOrderedAndProject (41)
-+- * HashAggregate (40)
-   +- Exchange (39)
-      +- * HashAggregate (38)
-         +- * Project (37)
-            +- * SortMergeJoin Inner (36)
+TakeOrderedAndProject (29)
++- * HashAggregate (28)
+   +- Exchange (27)
+      +- * HashAggregate (26)
+         +- * Project (25)
+            +- * SortMergeJoin Inner (24)
                :- * Sort (21)
                :  +- Exchange (20)
                :     +- * Project (19)
@@ -26,20 +26,8 @@ TakeOrderedAndProject (41)
                :              +- * Filter (16)
                :                 +- * ColumnarToRow (15)
                :                    +- Scan parquet spark_catalog.default.store (14)
-               +- * Sort (35)
-                  +- Exchange (34)
-                     +- * Project (33)
-                        +- * SortMergeJoin Inner (32)
-                           :- * Sort (26)
-                           :  +- Exchange (25)
-                           :     +- * Filter (24)
-                           :        +- * ColumnarToRow (23)
-                           :           +- Scan parquet spark_catalog.default.customer (22)
-                           +- * Sort (31)
-                              +- Exchange (30)
-                                 +- * Filter (29)
-                                    +- * ColumnarToRow (28)
-                                       +- Scan parquet spark_catalog.default.customer_address (27)
+               +- * Sort (23)
+                  +- ReusedExchange (22)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -55,213 +43,253 @@ Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4,
 
 (3) Filter [codegen id : 4]
 Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
-Condition : ((isnotnull(ss_item_sk#1) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_store_sk#3))
+Condition : (((isnotnull(ss_item_sk#1) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_store_sk#3)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_customer_sk#2, 42), false))
 
 (4) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, i_manager_id#12]
+Output [6]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, i_manager_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,8), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manufact_id:int,i_manufact:string,i_manager_id:int>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, i_manager_id#14]
 
 (6) Filter [codegen id : 1]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, i_manager_id#12]
-Condition : ((isnotnull(i_manager_id#12) AND (i_manager_id#12 = 8)) AND isnotnull(i_item_sk#7))
+Input [6]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, i_manager_id#14]
+Condition : ((isnotnull(i_manager_id#14) AND (i_manager_id#14 = 8)) AND isnotnull(i_item_sk#9))
 
 (7) Project [codegen id : 1]
-Output [5]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, i_manager_id#12]
+Output [5]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
+Input [6]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, i_manager_id#14]
 
 (8) BroadcastExchange
-Input [5]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
+Input [5]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [8]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
+Output [8]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 
-(11) ReusedExchange [Reuses operator id: 46]
-Output [1]: [d_date_sk#13]
+(11) ReusedExchange [Reuses operator id: 50]
+Output [1]: [d_date_sk#15]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#13]
+Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
-Output [7]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Input [9]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, d_date_sk#13]
+Output [7]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
+Input [9]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, d_date_sk#15]
 
 (14) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#14, s_zip#15]
+Output [2]: [s_store_sk#16, s_zip#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_zip:string>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [2]: [s_store_sk#14, s_zip#15]
+Input [2]: [s_store_sk#16, s_zip#17]
 
 (16) Filter [codegen id : 3]
-Input [2]: [s_store_sk#14, s_zip#15]
-Condition : (isnotnull(s_zip#15) AND isnotnull(s_store_sk#14))
+Input [2]: [s_store_sk#16, s_zip#17]
+Condition : (isnotnull(s_zip#17) AND isnotnull(s_store_sk#16))
 
 (17) BroadcastExchange
-Input [2]: [s_store_sk#14, s_zip#15]
+Input [2]: [s_store_sk#16, s_zip#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#14]
+Right keys [1]: [s_store_sk#16]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_zip#15]
-Input [9]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_store_sk#14, s_zip#15]
+Output [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, s_zip#17]
+Input [9]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, s_store_sk#16, s_zip#17]
 
 (20) Exchange
-Input [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_zip#15]
+Input [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, s_zip#17]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) Sort [codegen id : 5]
-Input [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_zip#15]
+Input [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, s_zip#17]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
-(22) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#16, c_current_addr_sk#17]
+(22) ReusedExchange [Reuses operator id: 42]
+Output [2]: [c_customer_sk#18, ca_zip#19]
+
+(23) Sort [codegen id : 11]
+Input [2]: [c_customer_sk#18, ca_zip#19]
+Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+
+(24) SortMergeJoin [codegen id : 12]
+Left keys [1]: [ss_customer_sk#2]
+Right keys [1]: [c_customer_sk#18]
+Join type: Inner
+Join condition: NOT (substr(ca_zip#19, 1, 5) = substr(s_zip#17, 1, 5))
+
+(25) Project [codegen id : 12]
+Output [5]: [ss_ext_sales_price#4, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
+Input [9]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, s_zip#17, c_customer_sk#18, ca_zip#19]
+
+(26) HashAggregate [codegen id : 12]
+Input [5]: [ss_ext_sales_price#4, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
+Keys [4]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#4))]
+Aggregate Attributes [1]: [sum#20]
+Results [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#21]
+
+(27) Exchange
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#21]
+Arguments: hashpartitioning(i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(28) HashAggregate [codegen id : 13]
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#21]
+Keys [4]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#4))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#4))#22]
+Results [5]: [i_brand_id#10 AS brand_id#23, i_brand#11 AS brand#24, i_manufact_id#12, i_manufact#13, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#22,17,2) AS ext_price#25]
+
+(29) TakeOrderedAndProject
+Input [5]: [brand_id#23, brand#24, i_manufact_id#12, i_manufact#13, ext_price#25]
+Arguments: 100, [ext_price#25 DESC NULLS LAST, brand#24 ASC NULLS FIRST, brand_id#23 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST, i_manufact#13 ASC NULLS FIRST], [brand_id#23, brand#24, i_manufact_id#12, i_manufact#13, ext_price#25]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (45)
++- Exchange (44)
+   +- ObjectHashAggregate (43)
+      +- Exchange (42)
+         +- * Project (41)
+            +- * SortMergeJoin Inner (40)
+               :- * Sort (34)
+               :  +- Exchange (33)
+               :     +- * Filter (32)
+               :        +- * ColumnarToRow (31)
+               :           +- Scan parquet spark_catalog.default.customer (30)
+               +- * Sort (39)
+                  +- Exchange (38)
+                     +- * Filter (37)
+                        +- * ColumnarToRow (36)
+                           +- Scan parquet spark_catalog.default.customer_address (35)
+
+
+(30) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#18, c_current_addr_sk#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(23) ColumnarToRow [codegen id : 6]
-Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
+(31) ColumnarToRow [codegen id : 1]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#26]
 
-(24) Filter [codegen id : 6]
-Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
-Condition : (isnotnull(c_customer_sk#16) AND isnotnull(c_current_addr_sk#17))
+(32) Filter [codegen id : 1]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#26]
+Condition : (isnotnull(c_customer_sk#18) AND isnotnull(c_current_addr_sk#26))
 
-(25) Exchange
-Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
-Arguments: hashpartitioning(c_current_addr_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(33) Exchange
+Input [2]: [c_customer_sk#18, c_current_addr_sk#26]
+Arguments: hashpartitioning(c_current_addr_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(26) Sort [codegen id : 7]
-Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
-Arguments: [c_current_addr_sk#17 ASC NULLS FIRST], false, 0
+(34) Sort [codegen id : 2]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#26]
+Arguments: [c_current_addr_sk#26 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_zip#19]
+(35) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#27, ca_zip#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_address_sk:int,ca_zip:string>
 
-(28) ColumnarToRow [codegen id : 8]
-Input [2]: [ca_address_sk#18, ca_zip#19]
+(36) ColumnarToRow [codegen id : 3]
+Input [2]: [ca_address_sk#27, ca_zip#19]
 
-(29) Filter [codegen id : 8]
-Input [2]: [ca_address_sk#18, ca_zip#19]
-Condition : (isnotnull(ca_address_sk#18) AND isnotnull(ca_zip#19))
+(37) Filter [codegen id : 3]
+Input [2]: [ca_address_sk#27, ca_zip#19]
+Condition : (isnotnull(ca_address_sk#27) AND isnotnull(ca_zip#19))
 
-(30) Exchange
-Input [2]: [ca_address_sk#18, ca_zip#19]
-Arguments: hashpartitioning(ca_address_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(38) Exchange
+Input [2]: [ca_address_sk#27, ca_zip#19]
+Arguments: hashpartitioning(ca_address_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(31) Sort [codegen id : 9]
-Input [2]: [ca_address_sk#18, ca_zip#19]
-Arguments: [ca_address_sk#18 ASC NULLS FIRST], false, 0
+(39) Sort [codegen id : 4]
+Input [2]: [ca_address_sk#27, ca_zip#19]
+Arguments: [ca_address_sk#27 ASC NULLS FIRST], false, 0
 
-(32) SortMergeJoin [codegen id : 10]
-Left keys [1]: [c_current_addr_sk#17]
-Right keys [1]: [ca_address_sk#18]
+(40) SortMergeJoin [codegen id : 5]
+Left keys [1]: [c_current_addr_sk#26]
+Right keys [1]: [ca_address_sk#27]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 10]
-Output [2]: [c_customer_sk#16, ca_zip#19]
-Input [4]: [c_customer_sk#16, c_current_addr_sk#17, ca_address_sk#18, ca_zip#19]
+(41) Project [codegen id : 5]
+Output [2]: [c_customer_sk#18, ca_zip#19]
+Input [4]: [c_customer_sk#18, c_current_addr_sk#26, ca_address_sk#27, ca_zip#19]
 
-(34) Exchange
-Input [2]: [c_customer_sk#16, ca_zip#19]
-Arguments: hashpartitioning(c_customer_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(42) Exchange
+Input [2]: [c_customer_sk#18, ca_zip#19]
+Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(35) Sort [codegen id : 11]
-Input [2]: [c_customer_sk#16, ca_zip#19]
-Arguments: [c_customer_sk#16 ASC NULLS FIRST], false, 0
+(43) ObjectHashAggregate
+Input [2]: [c_customer_sk#18, ca_zip#19]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#18, 42), 2120803, 16966424, 0, 0)]
+Aggregate Attributes [1]: [buf#28]
+Results [1]: [buf#29]
 
-(36) SortMergeJoin [codegen id : 12]
-Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#16]
-Join type: Inner
-Join condition: NOT (substr(ca_zip#19, 1, 5) = substr(s_zip#15, 1, 5))
+(44) Exchange
+Input [1]: [buf#29]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(37) Project [codegen id : 12]
-Output [5]: [ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Input [9]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_zip#15, c_customer_sk#16, ca_zip#19]
+(45) ObjectHashAggregate
+Input [1]: [buf#29]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#18, 42), 2120803, 16966424, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#18, 42), 2120803, 16966424, 0, 0)#30]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#18, 42), 2120803, 16966424, 0, 0)#30 AS bloomFilter#31]
 
-(38) HashAggregate [codegen id : 12]
-Input [5]: [ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Keys [4]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#4))]
-Aggregate Attributes [1]: [sum#20]
-Results [5]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11, sum#21]
-
-(39) Exchange
-Input [5]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11, sum#21]
-Arguments: hashpartitioning(i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(40) HashAggregate [codegen id : 13]
-Input [5]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11, sum#21]
-Keys [4]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#4))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#4))#22]
-Results [5]: [i_brand_id#8 AS brand_id#23, i_brand#9 AS brand#24, i_manufact_id#10, i_manufact#11, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#22,17,2) AS ext_price#25]
-
-(41) TakeOrderedAndProject
-Input [5]: [brand_id#23, brand#24, i_manufact_id#10, i_manufact#11, ext_price#25]
-Arguments: 100, [ext_price#25 DESC NULLS LAST, brand#24 ASC NULLS FIRST, brand_id#23 ASC NULLS FIRST, i_manufact_id#10 ASC NULLS FIRST, i_manufact#11 ASC NULLS FIRST], [brand_id#23, brand#24, i_manufact_id#10, i_manufact#11, ext_price#25]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (46)
-+- * Project (45)
-   +- * Filter (44)
-      +- * ColumnarToRow (43)
-         +- Scan parquet spark_catalog.default.date_dim (42)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (50)
++- * Project (49)
+   +- * Filter (48)
+      +- * ColumnarToRow (47)
+         +- Scan parquet spark_catalog.default.date_dim (46)
 
 
-(42) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#13, d_year#26, d_moy#27]
+(46) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#15, d_year#32, d_moy#33]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(43) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#13, d_year#26, d_moy#27]
+(47) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#15, d_year#32, d_moy#33]
 
-(44) Filter [codegen id : 1]
-Input [3]: [d_date_sk#13, d_year#26, d_moy#27]
-Condition : ((((isnotnull(d_moy#27) AND isnotnull(d_year#26)) AND (d_moy#27 = 11)) AND (d_year#26 = 1998)) AND isnotnull(d_date_sk#13))
+(48) Filter [codegen id : 1]
+Input [3]: [d_date_sk#15, d_year#32, d_moy#33]
+Condition : ((((isnotnull(d_moy#33) AND isnotnull(d_year#32)) AND (d_moy#33 = 11)) AND (d_year#32 = 1998)) AND isnotnull(d_date_sk#15))
 
-(45) Project [codegen id : 1]
-Output [1]: [d_date_sk#13]
-Input [3]: [d_date_sk#13, d_year#26, d_moy#27]
+(49) Project [codegen id : 1]
+Output [1]: [d_date_sk#15]
+Input [3]: [d_date_sk#15, d_year#32, d_moy#33]
 
-(46) BroadcastExchange
-Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+(50) BroadcastExchange
+Input [1]: [d_date_sk#15]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/simplified.txt
@@ -20,6 +20,34 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
                                       Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
                                         BroadcastHashJoin [ss_item_sk,i_item_sk]
                                           Filter [ss_item_sk,ss_customer_sk,ss_store_sk]
+                                            Subquery #2
+                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2120803, 16966424, 0, 0),bloomFilter,buf]
+                                                Exchange #4
+                                                  ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                    Exchange [c_customer_sk] #5
+                                                      WholeStageCodegen (5)
+                                                        Project [c_customer_sk,ca_zip]
+                                                          SortMergeJoin [c_current_addr_sk,ca_address_sk]
+                                                            InputAdapter
+                                                              WholeStageCodegen (2)
+                                                                Sort [c_current_addr_sk]
+                                                                  InputAdapter
+                                                                    Exchange [c_current_addr_sk] #6
+                                                                      WholeStageCodegen (1)
+                                                                        Filter [c_customer_sk,c_current_addr_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                                                            InputAdapter
+                                                              WholeStageCodegen (4)
+                                                                Sort [ca_address_sk]
+                                                                  InputAdapter
+                                                                    Exchange [ca_address_sk] #7
+                                                                      WholeStageCodegen (3)
+                                                                        Filter [ca_address_sk,ca_zip]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_zip]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
@@ -32,7 +60,7 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                           InputAdapter
-                                            BroadcastExchange #4
+                                            BroadcastExchange #8
                                               WholeStageCodegen (1)
                                                 Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
                                                   Filter [i_manager_id,i_item_sk]
@@ -42,7 +70,7 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
                                       InputAdapter
                                         ReusedExchange [d_date_sk] #3
                                   InputAdapter
-                                    BroadcastExchange #5
+                                    BroadcastExchange #9
                                       WholeStageCodegen (3)
                                         Filter [s_zip,s_store_sk]
                                           ColumnarToRow
@@ -52,27 +80,4 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
                     WholeStageCodegen (11)
                       Sort [c_customer_sk]
                         InputAdapter
-                          Exchange [c_customer_sk] #6
-                            WholeStageCodegen (10)
-                              Project [c_customer_sk,ca_zip]
-                                SortMergeJoin [c_current_addr_sk,ca_address_sk]
-                                  InputAdapter
-                                    WholeStageCodegen (7)
-                                      Sort [c_current_addr_sk]
-                                        InputAdapter
-                                          Exchange [c_current_addr_sk] #7
-                                            WholeStageCodegen (6)
-                                              Filter [c_customer_sk,c_current_addr_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
-                                  InputAdapter
-                                    WholeStageCodegen (9)
-                                      Sort [ca_address_sk]
-                                        InputAdapter
-                                          Exchange [ca_address_sk] #8
-                                            WholeStageCodegen (8)
-                                              Filter [ca_address_sk,ca_zip]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_zip]
+                          ReusedExchange [c_customer_sk,ca_zip] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
@@ -94,7 +94,7 @@ Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 
 (10) Filter [codegen id : 3]
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
-Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(d_week_seq#10, 42)))
+Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(d_week_seq#10, 42), true))
 
 (11) BroadcastExchange
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
@@ -202,7 +202,7 @@ Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 
 (33) Filter [codegen id : 8]
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
-Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(Subquery scalar-subquery#52, [id=#53], xxhash64(d_week_seq#10, 42)))
+Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(Subquery scalar-subquery#52, [id=#53], xxhash64(d_week_seq#10, 42), true))
 
 (34) BroadcastExchange
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/explain.txt
@@ -1,27 +1,24 @@
 == Physical Plan ==
-TakeOrderedAndProject (23)
-+- * Project (22)
-   +- Window (21)
-      +- * Sort (20)
-         +- Exchange (19)
-            +- * HashAggregate (18)
-               +- Exchange (17)
-                  +- * HashAggregate (16)
-                     +- * Project (15)
-                        +- * BroadcastHashJoin Inner BuildRight (14)
-                           :- * Project (12)
-                           :  +- * SortMergeJoin Inner (11)
+TakeOrderedAndProject (20)
++- * Project (19)
+   +- Window (18)
+      +- * Sort (17)
+         +- Exchange (16)
+            +- * HashAggregate (15)
+               +- Exchange (14)
+                  +- * HashAggregate (13)
+                     +- * Project (12)
+                        +- * BroadcastHashJoin Inner BuildRight (11)
+                           :- * Project (9)
+                           :  +- * SortMergeJoin Inner (8)
                            :     :- * Sort (5)
                            :     :  +- Exchange (4)
                            :     :     +- * Filter (3)
                            :     :        +- * ColumnarToRow (2)
                            :     :           +- Scan parquet spark_catalog.default.catalog_sales (1)
-                           :     +- * Sort (10)
-                           :        +- Exchange (9)
-                           :           +- * Filter (8)
-                           :              +- * ColumnarToRow (7)
-                           :                 +- Scan parquet spark_catalog.default.item (6)
-                           +- ReusedExchange (13)
+                           :     +- * Sort (7)
+                           :        +- ReusedExchange (6)
+                           +- ReusedExchange (10)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -37,7 +34,7 @@ Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
-Condition : isnotnull(cs_item_sk#1)
+Condition : (isnotnull(cs_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(cs_item_sk#1, 42), false))
 
 (4) Exchange
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
@@ -47,119 +44,150 @@ Arguments: hashpartitioning(cs_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
 Arguments: [cs_item_sk#1 ASC NULLS FIRST], false, 0
 
-(6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(6) ReusedExchange [Reuses operator id: 24]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(7) Sort [codegen id : 4]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
+
+(8) SortMergeJoin [codegen id : 6]
+Left keys [1]: [cs_item_sk#1]
+Right keys [1]: [i_item_sk#7]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 6]
+Output [7]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(10) ReusedExchange [Reuses operator id: 32]
+Output [1]: [d_date_sk#13]
+
+(11) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#3]
+Right keys [1]: [d_date_sk#13]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [6]: [cs_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
+
+(13) HashAggregate [codegen id : 6]
+Input [6]: [cs_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [partial_sum(UnscaledValue(cs_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+
+(14) Exchange
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [sum(UnscaledValue(cs_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#2))#16]
+Results [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS _w0#18, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS _w1#19, i_item_id#8]
+
+(16) Exchange
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(17) Sort [codegen id : 8]
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
+
+(18) Window
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: [sum(_w1#19) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#20], [i_class#11]
+
+(19) Project [codegen id : 9]
+Output [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#20) AS revenueratio#21, i_item_id#8]
+Input [9]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8, _we0#20]
+
+(20) TakeOrderedAndProject
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21, i_item_id#8]
+Arguments: 100, [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#21 ASC NULLS FIRST], [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (27)
++- Exchange (26)
+   +- ObjectHashAggregate (25)
+      +- Exchange (24)
+         +- * Filter (23)
+            +- * ColumnarToRow (22)
+               +- Scan parquet spark_catalog.default.item (21)
+
+
+(21) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
-(7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(22) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+(23) Filter [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
-(9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(24) Exchange
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+(25) ObjectHashAggregate
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [buf#22]
+Results [1]: [buf#23]
 
-(11) SortMergeJoin [codegen id : 6]
-Left keys [1]: [cs_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
+(26) Exchange
+Input [1]: [buf#23]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
-(12) Project [codegen id : 6]
-Output [7]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(27) ObjectHashAggregate
+Input [1]: [buf#23]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24 AS bloomFilter#25]
 
-(13) ReusedExchange [Reuses operator id: 28]
-Output [1]: [d_date_sk#11]
-
-(14) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [cs_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [6]: [cs_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
-
-(16) HashAggregate [codegen id : 6]
-Input [6]: [cs_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [partial_sum(UnscaledValue(cs_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-
-(17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [sum(UnscaledValue(cs_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#2))#14]
-Results [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS _w0#16, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS _w1#17, i_item_id#6]
-
-(19) Exchange
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(20) Sort [codegen id : 8]
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
-
-(21) Window
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: [sum(_w1#17) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#18], [i_class#9]
-
-(22) Project [codegen id : 9]
-Output [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#18) AS revenueratio#19, i_item_id#6]
-Input [9]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6, _we0#18]
-
-(23) TakeOrderedAndProject
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19, i_item_id#6]
-Arguments: 100, [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#19 ASC NULLS FIRST], [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (28)
-+- * Project (27)
-   +- * Filter (26)
-      +- * ColumnarToRow (25)
-         +- Scan parquet spark_catalog.default.date_dim (24)
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (32)
++- * Project (31)
+   +- * Filter (30)
+      +- * ColumnarToRow (29)
+         +- Scan parquet spark_catalog.default.date_dim (28)
 
 
-(24) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#20]
+(28) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(25) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
+(29) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(26) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
-Condition : (((isnotnull(d_date#20) AND (d_date#20 >= 1999-02-22)) AND (d_date#20 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(30) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
+Condition : (((isnotnull(d_date#26) AND (d_date#26 >= 1999-02-22)) AND (d_date#26 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(27) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#20]
+(31) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(28) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(32) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/simplified.txt
@@ -24,6 +24,16 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                               Exchange [cs_item_sk] #3
                                                 WholeStageCodegen (1)
                                                   Filter [cs_item_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 489600, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                            Exchange [i_item_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [i_category,i_item_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
@@ -39,11 +49,6 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                         WholeStageCodegen (4)
                                           Sort [i_item_sk]
                                             InputAdapter
-                                              Exchange [i_item_sk] #5
-                                                WholeStageCodegen (3)
-                                                  Filter [i_category,i_item_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
+                                              ReusedExchange [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category] #6
                                   InputAdapter
                                     ReusedExchange [d_date_sk] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/explain.txt
@@ -1,94 +1,90 @@
 == Physical Plan ==
-* HashAggregate (90)
-+- Exchange (89)
-   +- * HashAggregate (88)
-      +- Union (87)
-         :- * Project (51)
-         :  +- * BroadcastHashJoin Inner BuildRight (50)
-         :     :- * Project (48)
-         :     :  +- * SortMergeJoin LeftSemi (47)
-         :     :     :- * Sort (28)
-         :     :     :  +- Exchange (27)
-         :     :     :     +- * Project (26)
-         :     :     :        +- * SortMergeJoin LeftSemi (25)
-         :     :     :           :- * Sort (4)
-         :     :     :           :  +- Exchange (3)
-         :     :     :           :     +- * ColumnarToRow (2)
-         :     :     :           :        +- Scan parquet spark_catalog.default.catalog_sales (1)
-         :     :     :           +- * Sort (24)
-         :     :     :              +- * Project (23)
-         :     :     :                 +- * Filter (22)
-         :     :     :                    +- * HashAggregate (21)
-         :     :     :                       +- * HashAggregate (20)
-         :     :     :                          +- * Project (19)
-         :     :     :                             +- * SortMergeJoin Inner (18)
-         :     :     :                                :- * Sort (12)
-         :     :     :                                :  +- Exchange (11)
-         :     :     :                                :     +- * Project (10)
-         :     :     :                                :        +- * BroadcastHashJoin Inner BuildRight (9)
-         :     :     :                                :           :- * Filter (7)
-         :     :     :                                :           :  +- * ColumnarToRow (6)
-         :     :     :                                :           :     +- Scan parquet spark_catalog.default.store_sales (5)
-         :     :     :                                :           +- ReusedExchange (8)
-         :     :     :                                +- * Sort (17)
-         :     :     :                                   +- Exchange (16)
-         :     :     :                                      +- * Filter (15)
-         :     :     :                                         +- * ColumnarToRow (14)
-         :     :     :                                            +- Scan parquet spark_catalog.default.item (13)
-         :     :     +- * Sort (46)
-         :     :        +- * Project (45)
-         :     :           +- * Filter (44)
-         :     :              +- * HashAggregate (43)
-         :     :                 +- * HashAggregate (42)
-         :     :                    +- * Project (41)
-         :     :                       +- * SortMergeJoin Inner (40)
-         :     :                          :- * Sort (34)
-         :     :                          :  +- Exchange (33)
-         :     :                          :     +- * Project (32)
-         :     :                          :        +- * Filter (31)
-         :     :                          :           +- * ColumnarToRow (30)
-         :     :                          :              +- Scan parquet spark_catalog.default.store_sales (29)
-         :     :                          +- * Sort (39)
-         :     :                             +- Exchange (38)
-         :     :                                +- * Filter (37)
-         :     :                                   +- * ColumnarToRow (36)
-         :     :                                      +- Scan parquet spark_catalog.default.customer (35)
-         :     +- ReusedExchange (49)
-         +- * Project (86)
-            +- * BroadcastHashJoin Inner BuildRight (85)
-               :- * Project (83)
-               :  +- * SortMergeJoin LeftSemi (82)
-               :     :- * Sort (70)
-               :     :  +- Exchange (69)
-               :     :     +- * Project (68)
-               :     :        +- * SortMergeJoin LeftSemi (67)
-               :     :           :- * Sort (55)
-               :     :           :  +- Exchange (54)
-               :     :           :     +- * ColumnarToRow (53)
-               :     :           :        +- Scan parquet spark_catalog.default.web_sales (52)
-               :     :           +- * Sort (66)
-               :     :              +- * Project (65)
-               :     :                 +- * Filter (64)
-               :     :                    +- * HashAggregate (63)
-               :     :                       +- * HashAggregate (62)
-               :     :                          +- * Project (61)
-               :     :                             +- * SortMergeJoin Inner (60)
-               :     :                                :- * Sort (57)
-               :     :                                :  +- ReusedExchange (56)
-               :     :                                +- * Sort (59)
-               :     :                                   +- ReusedExchange (58)
-               :     +- * Sort (81)
-               :        +- * Project (80)
-               :           +- * Filter (79)
-               :              +- * HashAggregate (78)
-               :                 +- * HashAggregate (77)
-               :                    +- * Project (76)
-               :                       +- * SortMergeJoin Inner (75)
-               :                          :- * Sort (72)
-               :                          :  +- ReusedExchange (71)
-               :                          +- * Sort (74)
-               :                             +- ReusedExchange (73)
-               +- ReusedExchange (84)
+* HashAggregate (86)
++- Exchange (85)
+   +- * HashAggregate (84)
+      +- Union (83)
+         :- * Project (46)
+         :  +- * BroadcastHashJoin Inner BuildRight (45)
+         :     :- * Project (43)
+         :     :  +- * SortMergeJoin LeftSemi (42)
+         :     :     :- * Sort (26)
+         :     :     :  +- Exchange (25)
+         :     :     :     +- * Project (24)
+         :     :     :        +- * SortMergeJoin LeftSemi (23)
+         :     :     :           :- * Sort (5)
+         :     :     :           :  +- Exchange (4)
+         :     :     :           :     +- * Filter (3)
+         :     :     :           :        +- * ColumnarToRow (2)
+         :     :     :           :           +- Scan parquet spark_catalog.default.catalog_sales (1)
+         :     :     :           +- * Sort (22)
+         :     :     :              +- * Project (21)
+         :     :     :                 +- * Filter (20)
+         :     :     :                    +- * HashAggregate (19)
+         :     :     :                       +- * HashAggregate (18)
+         :     :     :                          +- * Project (17)
+         :     :     :                             +- * SortMergeJoin Inner (16)
+         :     :     :                                :- * Sort (13)
+         :     :     :                                :  +- Exchange (12)
+         :     :     :                                :     +- * Project (11)
+         :     :     :                                :        +- * BroadcastHashJoin Inner BuildRight (10)
+         :     :     :                                :           :- * Filter (8)
+         :     :     :                                :           :  +- * ColumnarToRow (7)
+         :     :     :                                :           :     +- Scan parquet spark_catalog.default.store_sales (6)
+         :     :     :                                :           +- ReusedExchange (9)
+         :     :     :                                +- * Sort (15)
+         :     :     :                                   +- ReusedExchange (14)
+         :     :     +- * Sort (41)
+         :     :        +- * Project (40)
+         :     :           +- * Filter (39)
+         :     :              +- * HashAggregate (38)
+         :     :                 +- * HashAggregate (37)
+         :     :                    +- * Project (36)
+         :     :                       +- * SortMergeJoin Inner (35)
+         :     :                          :- * Sort (32)
+         :     :                          :  +- Exchange (31)
+         :     :                          :     +- * Project (30)
+         :     :                          :        +- * Filter (29)
+         :     :                          :           +- * ColumnarToRow (28)
+         :     :                          :              +- Scan parquet spark_catalog.default.store_sales (27)
+         :     :                          +- * Sort (34)
+         :     :                             +- ReusedExchange (33)
+         :     +- ReusedExchange (44)
+         +- * Project (82)
+            +- * BroadcastHashJoin Inner BuildRight (81)
+               :- * Project (79)
+               :  +- * SortMergeJoin LeftSemi (78)
+               :     :- * Sort (66)
+               :     :  +- Exchange (65)
+               :     :     +- * Project (64)
+               :     :        +- * SortMergeJoin LeftSemi (63)
+               :     :           :- * Sort (51)
+               :     :           :  +- Exchange (50)
+               :     :           :     +- * Filter (49)
+               :     :           :        +- * ColumnarToRow (48)
+               :     :           :           +- Scan parquet spark_catalog.default.web_sales (47)
+               :     :           +- * Sort (62)
+               :     :              +- * Project (61)
+               :     :                 +- * Filter (60)
+               :     :                    +- * HashAggregate (59)
+               :     :                       +- * HashAggregate (58)
+               :     :                          +- * Project (57)
+               :     :                             +- * SortMergeJoin Inner (56)
+               :     :                                :- * Sort (53)
+               :     :                                :  +- ReusedExchange (52)
+               :     :                                +- * Sort (55)
+               :     :                                   +- ReusedExchange (54)
+               :     +- * Sort (77)
+               :        +- * Project (76)
+               :           +- * Filter (75)
+               :              +- * HashAggregate (74)
+               :                 +- * HashAggregate (73)
+               :                    +- * Project (72)
+               :                       +- * SortMergeJoin Inner (71)
+               :                          :- * Sort (68)
+               :                          :  +- ReusedExchange (67)
+               :                          +- * Sort (70)
+               :                             +- ReusedExchange (69)
+               +- ReusedExchange (80)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -101,15 +97,19 @@ ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int,cs_lis
 (2) ColumnarToRow [codegen id : 1]
 Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 
-(3) Exchange
+(3) Filter [codegen id : 1]
+Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
+Condition : (true AND true)
+
+(4) Exchange
 Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Arguments: hashpartitioning(cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(4) Sort [codegen id : 2]
+(5) Sort [codegen id : 2]
 Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Arguments: [cs_item_sk#2 ASC NULLS FIRST], false, 0
 
-(5) Scan parquet spark_catalog.default.store_sales
+(6) Scan parquet spark_catalog.default.store_sales
 Output [2]: [ss_item_sk#7, ss_sold_date_sk#8]
 Batched: true
 Location: InMemoryFileIndex []
@@ -117,595 +117,707 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#8), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(6) ColumnarToRow [codegen id : 4]
+(7) ColumnarToRow [codegen id : 4]
 Input [2]: [ss_item_sk#7, ss_sold_date_sk#8]
 
-(7) Filter [codegen id : 4]
+(8) Filter [codegen id : 4]
 Input [2]: [ss_item_sk#7, ss_sold_date_sk#8]
-Condition : isnotnull(ss_item_sk#7)
+Condition : (isnotnull(ss_item_sk#7) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ss_item_sk#7, 42), false))
 
-(8) ReusedExchange [Reuses operator id: 100]
-Output [2]: [d_date_sk#10, d_date#11]
+(9) ReusedExchange [Reuses operator id: 103]
+Output [2]: [d_date_sk#12, d_date#13]
 
-(9) BroadcastHashJoin [codegen id : 4]
+(10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#10]
+Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [2]: [ss_item_sk#7, d_date#11]
-Input [4]: [ss_item_sk#7, ss_sold_date_sk#8, d_date_sk#10, d_date#11]
+(11) Project [codegen id : 4]
+Output [2]: [ss_item_sk#7, d_date#13]
+Input [4]: [ss_item_sk#7, ss_sold_date_sk#8, d_date_sk#12, d_date#13]
 
-(11) Exchange
-Input [2]: [ss_item_sk#7, d_date#11]
+(12) Exchange
+Input [2]: [ss_item_sk#7, d_date#13]
 Arguments: hashpartitioning(ss_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) Sort [codegen id : 5]
-Input [2]: [ss_item_sk#7, d_date#11]
+(13) Sort [codegen id : 5]
+Input [2]: [ss_item_sk#7, d_date#13]
 Arguments: [ss_item_sk#7 ASC NULLS FIRST], false, 0
 
-(13) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#12, i_item_desc#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_item_desc:string>
+(14) ReusedExchange [Reuses operator id: 95]
+Output [2]: [i_item_sk#14, i_item_desc#15]
 
-(14) ColumnarToRow [codegen id : 6]
-Input [2]: [i_item_sk#12, i_item_desc#13]
+(15) Sort [codegen id : 7]
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Arguments: [i_item_sk#14 ASC NULLS FIRST], false, 0
 
-(15) Filter [codegen id : 6]
-Input [2]: [i_item_sk#12, i_item_desc#13]
-Condition : isnotnull(i_item_sk#12)
-
-(16) Exchange
-Input [2]: [i_item_sk#12, i_item_desc#13]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(17) Sort [codegen id : 7]
-Input [2]: [i_item_sk#12, i_item_desc#13]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
-
-(18) SortMergeJoin [codegen id : 8]
+(16) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#7]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#14]
 Join type: Inner
 Join condition: None
 
-(19) Project [codegen id : 8]
-Output [3]: [d_date#11, i_item_sk#12, substr(i_item_desc#13, 1, 30) AS _groupingexpression#14]
-Input [4]: [ss_item_sk#7, d_date#11, i_item_sk#12, i_item_desc#13]
+(17) Project [codegen id : 8]
+Output [3]: [d_date#13, i_item_sk#14, substr(i_item_desc#15, 1, 30) AS _groupingexpression#16]
+Input [4]: [ss_item_sk#7, d_date#13, i_item_sk#14, i_item_desc#15]
 
-(20) HashAggregate [codegen id : 8]
-Input [3]: [d_date#11, i_item_sk#12, _groupingexpression#14]
-Keys [3]: [_groupingexpression#14, i_item_sk#12, d_date#11]
+(18) HashAggregate [codegen id : 8]
+Input [3]: [d_date#13, i_item_sk#14, _groupingexpression#16]
+Keys [3]: [_groupingexpression#16, i_item_sk#14, d_date#13]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#15]
-Results [4]: [_groupingexpression#14, i_item_sk#12, d_date#11, count#16]
+Aggregate Attributes [1]: [count#17]
+Results [4]: [_groupingexpression#16, i_item_sk#14, d_date#13, count#18]
 
-(21) HashAggregate [codegen id : 8]
-Input [4]: [_groupingexpression#14, i_item_sk#12, d_date#11, count#16]
-Keys [3]: [_groupingexpression#14, i_item_sk#12, d_date#11]
+(19) HashAggregate [codegen id : 8]
+Input [4]: [_groupingexpression#16, i_item_sk#14, d_date#13, count#18]
+Keys [3]: [_groupingexpression#16, i_item_sk#14, d_date#13]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#17]
-Results [2]: [i_item_sk#12 AS item_sk#18, count(1)#17 AS cnt#19]
+Aggregate Attributes [1]: [count(1)#19]
+Results [2]: [i_item_sk#14 AS item_sk#20, count(1)#19 AS cnt#21]
 
-(22) Filter [codegen id : 8]
-Input [2]: [item_sk#18, cnt#19]
-Condition : (cnt#19 > 4)
+(20) Filter [codegen id : 8]
+Input [2]: [item_sk#20, cnt#21]
+Condition : (cnt#21 > 4)
 
-(23) Project [codegen id : 8]
-Output [1]: [item_sk#18]
-Input [2]: [item_sk#18, cnt#19]
+(21) Project [codegen id : 8]
+Output [1]: [item_sk#20]
+Input [2]: [item_sk#20, cnt#21]
 
-(24) Sort [codegen id : 8]
-Input [1]: [item_sk#18]
-Arguments: [item_sk#18 ASC NULLS FIRST], false, 0
+(22) Sort [codegen id : 8]
+Input [1]: [item_sk#20]
+Arguments: [item_sk#20 ASC NULLS FIRST], false, 0
 
-(25) SortMergeJoin [codegen id : 9]
+(23) SortMergeJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [item_sk#18]
+Right keys [1]: [item_sk#20]
 Join type: LeftSemi
 Join condition: None
 
-(26) Project [codegen id : 9]
+(24) Project [codegen id : 9]
 Output [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 
-(27) Exchange
+(25) Exchange
 Input [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
-Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(28) Sort [codegen id : 10]
+(26) Sort [codegen id : 10]
 Input [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(29) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, ss_sold_date_sk#23]
+(27) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, ss_sold_date_sk#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
-(30) ColumnarToRow [codegen id : 11]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, ss_sold_date_sk#23]
+(28) ColumnarToRow [codegen id : 11]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, ss_sold_date_sk#25]
 
-(31) Filter [codegen id : 11]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, ss_sold_date_sk#23]
-Condition : isnotnull(ss_customer_sk#20)
+(29) Filter [codegen id : 11]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, ss_sold_date_sk#25]
+Condition : (isnotnull(ss_customer_sk#22) AND might_contain(Subquery scalar-subquery#26, [id=#27], xxhash64(ss_customer_sk#22, 42), false))
 
-(32) Project [codegen id : 11]
-Output [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, ss_sold_date_sk#23]
+(30) Project [codegen id : 11]
+Output [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, ss_sold_date_sk#25]
 
-(33) Exchange
-Input [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Arguments: hashpartitioning(ss_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(31) Exchange
+Input [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Arguments: hashpartitioning(ss_customer_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(34) Sort [codegen id : 12]
-Input [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Arguments: [ss_customer_sk#20 ASC NULLS FIRST], false, 0
+(32) Sort [codegen id : 12]
+Input [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Arguments: [ss_customer_sk#22 ASC NULLS FIRST], false, 0
 
-(35) Scan parquet spark_catalog.default.customer
-Output [1]: [c_customer_sk#24]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk)]
-ReadSchema: struct<c_customer_sk:int>
+(33) ReusedExchange [Reuses operator id: 136]
+Output [1]: [c_customer_sk#28]
 
-(36) ColumnarToRow [codegen id : 13]
-Input [1]: [c_customer_sk#24]
+(34) Sort [codegen id : 14]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(37) Filter [codegen id : 13]
-Input [1]: [c_customer_sk#24]
-Condition : isnotnull(c_customer_sk#24)
-
-(38) Exchange
-Input [1]: [c_customer_sk#24]
-Arguments: hashpartitioning(c_customer_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(39) Sort [codegen id : 14]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
-
-(40) SortMergeJoin [codegen id : 15]
-Left keys [1]: [ss_customer_sk#20]
-Right keys [1]: [c_customer_sk#24]
+(35) SortMergeJoin [codegen id : 15]
+Left keys [1]: [ss_customer_sk#22]
+Right keys [1]: [c_customer_sk#28]
 Join type: Inner
 Join condition: None
 
-(41) Project [codegen id : 15]
-Output [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
+(36) Project [codegen id : 15]
+Output [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
 
-(42) HashAggregate [codegen id : 15]
-Input [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [partial_sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [2]: [sum#25, isEmpty#26]
-Results [3]: [c_customer_sk#24, sum#27, isEmpty#28]
+(37) HashAggregate [codegen id : 15]
+Input [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [partial_sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [2]: [sum#29, isEmpty#30]
+Results [3]: [c_customer_sk#28, sum#31, isEmpty#32]
 
-(43) HashAggregate [codegen id : 15]
-Input [3]: [c_customer_sk#24, sum#27, isEmpty#28]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29]
-Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29 AS ssales#30]
+(38) HashAggregate [codegen id : 15]
+Input [3]: [c_customer_sk#28, sum#31, isEmpty#32]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33]
+Results [2]: [c_customer_sk#28, sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33 AS ssales#34]
 
-(44) Filter [codegen id : 15]
-Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#32])))
+(39) Filter [codegen id : 15]
+Input [2]: [c_customer_sk#28, ssales#34]
+Condition : (isnotnull(ssales#34) AND (cast(ssales#34 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#35, [id=#36])))
 
-(45) Project [codegen id : 15]
-Output [1]: [c_customer_sk#24]
-Input [2]: [c_customer_sk#24, ssales#30]
+(40) Project [codegen id : 15]
+Output [1]: [c_customer_sk#28]
+Input [2]: [c_customer_sk#28, ssales#34]
 
-(46) Sort [codegen id : 15]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+(41) Sort [codegen id : 15]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(47) SortMergeJoin [codegen id : 17]
+(42) SortMergeJoin [codegen id : 17]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#24]
+Right keys [1]: [c_customer_sk#28]
 Join type: LeftSemi
 Join condition: None
 
-(48) Project [codegen id : 17]
+(43) Project [codegen id : 17]
 Output [3]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Input [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 
-(49) ReusedExchange [Reuses operator id: 95]
-Output [1]: [d_date_sk#33]
+(44) ReusedExchange [Reuses operator id: 91]
+Output [1]: [d_date_sk#37]
 
-(50) BroadcastHashJoin [codegen id : 17]
+(45) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#33]
+Right keys [1]: [d_date_sk#37]
 Join type: Inner
 Join condition: None
 
-(51) Project [codegen id : 17]
-Output [1]: [(cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4) AS sales#34]
-Input [4]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#33]
+(46) Project [codegen id : 17]
+Output [1]: [(cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4) AS sales#38]
+Input [4]: [cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#37]
 
-(52) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+(47) Scan parquet spark_catalog.default.web_sales
+Output [5]: [ws_item_sk#39, ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#39), dynamicpruningexpression(ws_sold_date_sk#39 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#43), dynamicpruningexpression(ws_sold_date_sk#43 IN dynamicpruning#6)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(53) ColumnarToRow [codegen id : 18]
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+(48) ColumnarToRow [codegen id : 18]
+Input [5]: [ws_item_sk#39, ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
 
-(54) Exchange
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: hashpartitioning(ws_item_sk#35, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(49) Filter [codegen id : 18]
+Input [5]: [ws_item_sk#39, ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
+Condition : (true AND true)
 
-(55) Sort [codegen id : 19]
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: [ws_item_sk#35 ASC NULLS FIRST], false, 0
+(50) Exchange
+Input [5]: [ws_item_sk#39, ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
+Arguments: hashpartitioning(ws_item_sk#39, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(56) ReusedExchange [Reuses operator id: 11]
-Output [2]: [ss_item_sk#7, d_date#11]
+(51) Sort [codegen id : 19]
+Input [5]: [ws_item_sk#39, ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
+Arguments: [ws_item_sk#39 ASC NULLS FIRST], false, 0
 
-(57) Sort [codegen id : 22]
-Input [2]: [ss_item_sk#7, d_date#11]
+(52) ReusedExchange [Reuses operator id: 12]
+Output [2]: [ss_item_sk#7, d_date#13]
+
+(53) Sort [codegen id : 22]
+Input [2]: [ss_item_sk#7, d_date#13]
 Arguments: [ss_item_sk#7 ASC NULLS FIRST], false, 0
 
-(58) ReusedExchange [Reuses operator id: 16]
-Output [2]: [i_item_sk#12, i_item_desc#13]
+(54) ReusedExchange [Reuses operator id: 95]
+Output [2]: [i_item_sk#14, i_item_desc#15]
 
-(59) Sort [codegen id : 24]
-Input [2]: [i_item_sk#12, i_item_desc#13]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+(55) Sort [codegen id : 24]
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Arguments: [i_item_sk#14 ASC NULLS FIRST], false, 0
 
-(60) SortMergeJoin [codegen id : 25]
+(56) SortMergeJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#7]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#14]
 Join type: Inner
 Join condition: None
+
+(57) Project [codegen id : 25]
+Output [3]: [d_date#13, i_item_sk#14, substr(i_item_desc#15, 1, 30) AS _groupingexpression#16]
+Input [4]: [ss_item_sk#7, d_date#13, i_item_sk#14, i_item_desc#15]
+
+(58) HashAggregate [codegen id : 25]
+Input [3]: [d_date#13, i_item_sk#14, _groupingexpression#16]
+Keys [3]: [_groupingexpression#16, i_item_sk#14, d_date#13]
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#17]
+Results [4]: [_groupingexpression#16, i_item_sk#14, d_date#13, count#18]
+
+(59) HashAggregate [codegen id : 25]
+Input [4]: [_groupingexpression#16, i_item_sk#14, d_date#13, count#18]
+Keys [3]: [_groupingexpression#16, i_item_sk#14, d_date#13]
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#19]
+Results [2]: [i_item_sk#14 AS item_sk#20, count(1)#19 AS cnt#21]
+
+(60) Filter [codegen id : 25]
+Input [2]: [item_sk#20, cnt#21]
+Condition : (cnt#21 > 4)
 
 (61) Project [codegen id : 25]
-Output [3]: [d_date#11, i_item_sk#12, substr(i_item_desc#13, 1, 30) AS _groupingexpression#14]
-Input [4]: [ss_item_sk#7, d_date#11, i_item_sk#12, i_item_desc#13]
+Output [1]: [item_sk#20]
+Input [2]: [item_sk#20, cnt#21]
 
-(62) HashAggregate [codegen id : 25]
-Input [3]: [d_date#11, i_item_sk#12, _groupingexpression#14]
-Keys [3]: [_groupingexpression#14, i_item_sk#12, d_date#11]
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#15]
-Results [4]: [_groupingexpression#14, i_item_sk#12, d_date#11, count#16]
+(62) Sort [codegen id : 25]
+Input [1]: [item_sk#20]
+Arguments: [item_sk#20 ASC NULLS FIRST], false, 0
 
-(63) HashAggregate [codegen id : 25]
-Input [4]: [_groupingexpression#14, i_item_sk#12, d_date#11, count#16]
-Keys [3]: [_groupingexpression#14, i_item_sk#12, d_date#11]
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#17]
-Results [2]: [i_item_sk#12 AS item_sk#18, count(1)#17 AS cnt#19]
-
-(64) Filter [codegen id : 25]
-Input [2]: [item_sk#18, cnt#19]
-Condition : (cnt#19 > 4)
-
-(65) Project [codegen id : 25]
-Output [1]: [item_sk#18]
-Input [2]: [item_sk#18, cnt#19]
-
-(66) Sort [codegen id : 25]
-Input [1]: [item_sk#18]
-Arguments: [item_sk#18 ASC NULLS FIRST], false, 0
-
-(67) SortMergeJoin [codegen id : 26]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [item_sk#18]
+(63) SortMergeJoin [codegen id : 26]
+Left keys [1]: [ws_item_sk#39]
+Right keys [1]: [item_sk#20]
 Join type: LeftSemi
 Join condition: None
 
-(68) Project [codegen id : 26]
-Output [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Input [5]: [ws_item_sk#35, ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+(64) Project [codegen id : 26]
+Output [4]: [ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
+Input [5]: [ws_item_sk#39, ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
 
-(69) Exchange
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: hashpartitioning(ws_bill_customer_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(65) Exchange
+Input [4]: [ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
+Arguments: hashpartitioning(ws_bill_customer_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(70) Sort [codegen id : 27]
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Arguments: [ws_bill_customer_sk#36 ASC NULLS FIRST], false, 0
+(66) Sort [codegen id : 27]
+Input [4]: [ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
+Arguments: [ws_bill_customer_sk#40 ASC NULLS FIRST], false, 0
 
-(71) ReusedExchange [Reuses operator id: 33]
-Output [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
+(67) ReusedExchange [Reuses operator id: 31]
+Output [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
 
-(72) Sort [codegen id : 29]
-Input [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Arguments: [ss_customer_sk#20 ASC NULLS FIRST], false, 0
+(68) Sort [codegen id : 29]
+Input [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Arguments: [ss_customer_sk#22 ASC NULLS FIRST], false, 0
 
-(73) ReusedExchange [Reuses operator id: 38]
-Output [1]: [c_customer_sk#24]
+(69) ReusedExchange [Reuses operator id: 136]
+Output [1]: [c_customer_sk#28]
 
-(74) Sort [codegen id : 31]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+(70) Sort [codegen id : 31]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(75) SortMergeJoin [codegen id : 32]
-Left keys [1]: [ss_customer_sk#20]
-Right keys [1]: [c_customer_sk#24]
+(71) SortMergeJoin [codegen id : 32]
+Left keys [1]: [ss_customer_sk#22]
+Right keys [1]: [c_customer_sk#28]
 Join type: Inner
 Join condition: None
+
+(72) Project [codegen id : 32]
+Output [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+
+(73) HashAggregate [codegen id : 32]
+Input [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [partial_sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [2]: [sum#29, isEmpty#30]
+Results [3]: [c_customer_sk#28, sum#31, isEmpty#32]
+
+(74) HashAggregate [codegen id : 32]
+Input [3]: [c_customer_sk#28, sum#31, isEmpty#32]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33]
+Results [2]: [c_customer_sk#28, sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33 AS ssales#34]
+
+(75) Filter [codegen id : 32]
+Input [2]: [c_customer_sk#28, ssales#34]
+Condition : (isnotnull(ssales#34) AND (cast(ssales#34 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#35, [id=#36])))
 
 (76) Project [codegen id : 32]
-Output [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
+Output [1]: [c_customer_sk#28]
+Input [2]: [c_customer_sk#28, ssales#34]
 
-(77) HashAggregate [codegen id : 32]
-Input [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [partial_sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [2]: [sum#25, isEmpty#26]
-Results [3]: [c_customer_sk#24, sum#27, isEmpty#28]
+(77) Sort [codegen id : 32]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(78) HashAggregate [codegen id : 32]
-Input [3]: [c_customer_sk#24, sum#27, isEmpty#28]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29]
-Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29 AS ssales#30]
-
-(79) Filter [codegen id : 32]
-Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
-
-(80) Project [codegen id : 32]
-Output [1]: [c_customer_sk#24]
-Input [2]: [c_customer_sk#24, ssales#30]
-
-(81) Sort [codegen id : 32]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
-
-(82) SortMergeJoin [codegen id : 34]
-Left keys [1]: [ws_bill_customer_sk#36]
-Right keys [1]: [c_customer_sk#24]
+(78) SortMergeJoin [codegen id : 34]
+Left keys [1]: [ws_bill_customer_sk#40]
+Right keys [1]: [c_customer_sk#28]
 Join type: LeftSemi
 Join condition: None
 
-(83) Project [codegen id : 34]
-Output [3]: [ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
-Input [4]: [ws_bill_customer_sk#36, ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39]
+(79) Project [codegen id : 34]
+Output [3]: [ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
+Input [4]: [ws_bill_customer_sk#40, ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43]
 
-(84) ReusedExchange [Reuses operator id: 95]
-Output [1]: [d_date_sk#40]
+(80) ReusedExchange [Reuses operator id: 91]
+Output [1]: [d_date_sk#44]
 
-(85) BroadcastHashJoin [codegen id : 34]
-Left keys [1]: [ws_sold_date_sk#39]
-Right keys [1]: [d_date_sk#40]
+(81) BroadcastHashJoin [codegen id : 34]
+Left keys [1]: [ws_sold_date_sk#43]
+Right keys [1]: [d_date_sk#44]
 Join type: Inner
 Join condition: None
 
-(86) Project [codegen id : 34]
-Output [1]: [(cast(ws_quantity#37 as decimal(10,0)) * ws_list_price#38) AS sales#41]
-Input [4]: [ws_quantity#37, ws_list_price#38, ws_sold_date_sk#39, d_date_sk#40]
+(82) Project [codegen id : 34]
+Output [1]: [(cast(ws_quantity#41 as decimal(10,0)) * ws_list_price#42) AS sales#45]
+Input [4]: [ws_quantity#41, ws_list_price#42, ws_sold_date_sk#43, d_date_sk#44]
 
-(87) Union
+(83) Union
 
-(88) HashAggregate [codegen id : 35]
-Input [1]: [sales#34]
+(84) HashAggregate [codegen id : 35]
+Input [1]: [sales#38]
 Keys: []
-Functions [1]: [partial_sum(sales#34)]
-Aggregate Attributes [2]: [sum#42, isEmpty#43]
-Results [2]: [sum#44, isEmpty#45]
+Functions [1]: [partial_sum(sales#38)]
+Aggregate Attributes [2]: [sum#46, isEmpty#47]
+Results [2]: [sum#48, isEmpty#49]
 
-(89) Exchange
-Input [2]: [sum#44, isEmpty#45]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+(85) Exchange
+Input [2]: [sum#48, isEmpty#49]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(90) HashAggregate [codegen id : 36]
-Input [2]: [sum#44, isEmpty#45]
+(86) HashAggregate [codegen id : 36]
+Input [2]: [sum#48, isEmpty#49]
 Keys: []
-Functions [1]: [sum(sales#34)]
-Aggregate Attributes [1]: [sum(sales#34)#46]
-Results [1]: [sum(sales#34)#46 AS sum(sales)#47]
+Functions [1]: [sum(sales#38)]
+Aggregate Attributes [1]: [sum(sales#38)#50]
+Results [1]: [sum(sales#38)#50 AS sum(sales)#51]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (95)
-+- * Project (94)
-   +- * Filter (93)
-      +- * ColumnarToRow (92)
-         +- Scan parquet spark_catalog.default.date_dim (91)
+BroadcastExchange (91)
++- * Project (90)
+   +- * Filter (89)
+      +- * ColumnarToRow (88)
+         +- Scan parquet spark_catalog.default.date_dim (87)
 
 
-(91) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#33, d_year#48, d_moy#49]
+(87) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#37, d_year#52, d_moy#53]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,2), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(92) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#48, d_moy#49]
+(88) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#37, d_year#52, d_moy#53]
 
-(93) Filter [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#48, d_moy#49]
-Condition : ((((isnotnull(d_year#48) AND isnotnull(d_moy#49)) AND (d_year#48 = 2000)) AND (d_moy#49 = 2)) AND isnotnull(d_date_sk#33))
+(89) Filter [codegen id : 1]
+Input [3]: [d_date_sk#37, d_year#52, d_moy#53]
+Condition : ((((isnotnull(d_year#52) AND isnotnull(d_moy#53)) AND (d_year#52 = 2000)) AND (d_moy#53 = 2)) AND isnotnull(d_date_sk#37))
 
-(94) Project [codegen id : 1]
-Output [1]: [d_date_sk#33]
-Input [3]: [d_date_sk#33, d_year#48, d_moy#49]
+(90) Project [codegen id : 1]
+Output [1]: [d_date_sk#37]
+Input [3]: [d_date_sk#37, d_year#52, d_moy#53]
 
-(95) BroadcastExchange
-Input [1]: [d_date_sk#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(91) BroadcastExchange
+Input [1]: [d_date_sk#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
-Subquery:2 Hosting operator id = 5 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (100)
-+- * Project (99)
-   +- * Filter (98)
-      +- * ColumnarToRow (97)
-         +- Scan parquet spark_catalog.default.date_dim (96)
+Subquery:2 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (98)
++- Exchange (97)
+   +- ObjectHashAggregate (96)
+      +- Exchange (95)
+         +- * Filter (94)
+            +- * ColumnarToRow (93)
+               +- Scan parquet spark_catalog.default.item (92)
 
 
-(96) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_date#11, d_year#50]
+(92) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#14, i_item_desc#15]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_item_desc:string>
+
+(93) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#14, i_item_desc#15]
+
+(94) Filter [codegen id : 1]
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Condition : isnotnull(i_item_sk#14)
+
+(95) Exchange
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Arguments: hashpartitioning(i_item_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(96) ObjectHashAggregate
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#14, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#54]
+Results [1]: [buf#55]
+
+(97) Exchange
+Input [1]: [buf#55]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+
+(98) ObjectHashAggregate
+Input [1]: [buf#55]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 204000, 1632000, 0, 0)#56]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 204000, 1632000, 0, 0)#56 AS bloomFilter#57]
+
+Subquery:3 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
+BroadcastExchange (103)
++- * Project (102)
+   +- * Filter (101)
+      +- * ColumnarToRow (100)
+         +- Scan parquet spark_catalog.default.date_dim (99)
+
+
+(99) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#12, d_date#13, d_year#58]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_year:int>
 
-(97) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#50]
+(100) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#12, d_date#13, d_year#58]
 
-(98) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#50]
-Condition : (d_year#50 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
+(101) Filter [codegen id : 1]
+Input [3]: [d_date_sk#12, d_date#13, d_year#58]
+Condition : (d_year#58 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#12))
 
-(99) Project [codegen id : 1]
-Output [2]: [d_date_sk#10, d_date#11]
-Input [3]: [d_date_sk#10, d_date#11, d_year#50]
+(102) Project [codegen id : 1]
+Output [2]: [d_date_sk#12, d_date#13]
+Input [3]: [d_date_sk#12, d_date#13, d_year#58]
 
-(100) BroadcastExchange
-Input [2]: [d_date_sk#10, d_date#11]
+(103) BroadcastExchange
+Input [2]: [d_date_sk#12, d_date#13]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:3 Hosting operator id = 44 Hosting Expression = Subquery scalar-subquery#31, [id=#32]
-* HashAggregate (117)
-+- Exchange (116)
-   +- * HashAggregate (115)
-      +- * HashAggregate (114)
-         +- * HashAggregate (113)
-            +- * Project (112)
-               +- * SortMergeJoin Inner (111)
-                  :- * Sort (108)
-                  :  +- Exchange (107)
-                  :     +- * Project (106)
-                  :        +- * BroadcastHashJoin Inner BuildRight (105)
-                  :           :- * Filter (103)
-                  :           :  +- * ColumnarToRow (102)
-                  :           :     +- Scan parquet spark_catalog.default.store_sales (101)
-                  :           +- ReusedExchange (104)
-                  +- * Sort (110)
-                     +- ReusedExchange (109)
+Subquery:4 Hosting operator id = 39 Hosting Expression = Subquery scalar-subquery#35, [id=#36]
+* HashAggregate (120)
++- Exchange (119)
+   +- * HashAggregate (118)
+      +- * HashAggregate (117)
+         +- * HashAggregate (116)
+            +- * Project (115)
+               +- * SortMergeJoin Inner (114)
+                  :- * Sort (111)
+                  :  +- Exchange (110)
+                  :     +- * Project (109)
+                  :        +- * BroadcastHashJoin Inner BuildRight (108)
+                  :           :- * Filter (106)
+                  :           :  +- * ColumnarToRow (105)
+                  :           :     +- Scan parquet spark_catalog.default.store_sales (104)
+                  :           +- ReusedExchange (107)
+                  +- * Sort (113)
+                     +- ReusedExchange (112)
 
 
-(101) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#51, ss_quantity#52, ss_sales_price#53, ss_sold_date_sk#54]
+(104) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_customer_sk#59, ss_quantity#60, ss_sales_price#61, ss_sold_date_sk#62]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#54), dynamicpruningexpression(ss_sold_date_sk#54 IN dynamicpruning#55)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#62), dynamicpruningexpression(ss_sold_date_sk#62 IN dynamicpruning#63)]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
-(102) ColumnarToRow [codegen id : 2]
-Input [4]: [ss_customer_sk#51, ss_quantity#52, ss_sales_price#53, ss_sold_date_sk#54]
+(105) ColumnarToRow [codegen id : 2]
+Input [4]: [ss_customer_sk#59, ss_quantity#60, ss_sales_price#61, ss_sold_date_sk#62]
 
-(103) Filter [codegen id : 2]
-Input [4]: [ss_customer_sk#51, ss_quantity#52, ss_sales_price#53, ss_sold_date_sk#54]
-Condition : isnotnull(ss_customer_sk#51)
+(106) Filter [codegen id : 2]
+Input [4]: [ss_customer_sk#59, ss_quantity#60, ss_sales_price#61, ss_sold_date_sk#62]
+Condition : (isnotnull(ss_customer_sk#59) AND might_contain(Subquery scalar-subquery#64, [id=#65], xxhash64(ss_customer_sk#59, 42), false))
 
-(104) ReusedExchange [Reuses operator id: 122]
-Output [1]: [d_date_sk#56]
+(107) ReusedExchange [Reuses operator id: 132]
+Output [1]: [d_date_sk#66]
 
-(105) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#54]
-Right keys [1]: [d_date_sk#56]
+(108) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_sold_date_sk#62]
+Right keys [1]: [d_date_sk#66]
 Join type: Inner
 Join condition: None
 
-(106) Project [codegen id : 2]
-Output [3]: [ss_customer_sk#51, ss_quantity#52, ss_sales_price#53]
-Input [5]: [ss_customer_sk#51, ss_quantity#52, ss_sales_price#53, ss_sold_date_sk#54, d_date_sk#56]
+(109) Project [codegen id : 2]
+Output [3]: [ss_customer_sk#59, ss_quantity#60, ss_sales_price#61]
+Input [5]: [ss_customer_sk#59, ss_quantity#60, ss_sales_price#61, ss_sold_date_sk#62, d_date_sk#66]
 
-(107) Exchange
-Input [3]: [ss_customer_sk#51, ss_quantity#52, ss_sales_price#53]
-Arguments: hashpartitioning(ss_customer_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(110) Exchange
+Input [3]: [ss_customer_sk#59, ss_quantity#60, ss_sales_price#61]
+Arguments: hashpartitioning(ss_customer_sk#59, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(108) Sort [codegen id : 3]
-Input [3]: [ss_customer_sk#51, ss_quantity#52, ss_sales_price#53]
-Arguments: [ss_customer_sk#51 ASC NULLS FIRST], false, 0
+(111) Sort [codegen id : 3]
+Input [3]: [ss_customer_sk#59, ss_quantity#60, ss_sales_price#61]
+Arguments: [ss_customer_sk#59 ASC NULLS FIRST], false, 0
 
-(109) ReusedExchange [Reuses operator id: 38]
-Output [1]: [c_customer_sk#57]
+(112) ReusedExchange [Reuses operator id: 136]
+Output [1]: [c_customer_sk#67]
 
-(110) Sort [codegen id : 5]
-Input [1]: [c_customer_sk#57]
-Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
+(113) Sort [codegen id : 5]
+Input [1]: [c_customer_sk#67]
+Arguments: [c_customer_sk#67 ASC NULLS FIRST], false, 0
 
-(111) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#51]
-Right keys [1]: [c_customer_sk#57]
+(114) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#59]
+Right keys [1]: [c_customer_sk#67]
 Join type: Inner
 Join condition: None
 
-(112) Project [codegen id : 6]
-Output [3]: [ss_quantity#52, ss_sales_price#53, c_customer_sk#57]
-Input [4]: [ss_customer_sk#51, ss_quantity#52, ss_sales_price#53, c_customer_sk#57]
+(115) Project [codegen id : 6]
+Output [3]: [ss_quantity#60, ss_sales_price#61, c_customer_sk#67]
+Input [4]: [ss_customer_sk#59, ss_quantity#60, ss_sales_price#61, c_customer_sk#67]
 
-(113) HashAggregate [codegen id : 6]
-Input [3]: [ss_quantity#52, ss_sales_price#53, c_customer_sk#57]
-Keys [1]: [c_customer_sk#57]
-Functions [1]: [partial_sum((cast(ss_quantity#52 as decimal(10,0)) * ss_sales_price#53))]
-Aggregate Attributes [2]: [sum#58, isEmpty#59]
-Results [3]: [c_customer_sk#57, sum#60, isEmpty#61]
+(116) HashAggregate [codegen id : 6]
+Input [3]: [ss_quantity#60, ss_sales_price#61, c_customer_sk#67]
+Keys [1]: [c_customer_sk#67]
+Functions [1]: [partial_sum((cast(ss_quantity#60 as decimal(10,0)) * ss_sales_price#61))]
+Aggregate Attributes [2]: [sum#68, isEmpty#69]
+Results [3]: [c_customer_sk#67, sum#70, isEmpty#71]
 
-(114) HashAggregate [codegen id : 6]
-Input [3]: [c_customer_sk#57, sum#60, isEmpty#61]
-Keys [1]: [c_customer_sk#57]
-Functions [1]: [sum((cast(ss_quantity#52 as decimal(10,0)) * ss_sales_price#53))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#52 as decimal(10,0)) * ss_sales_price#53))#62]
-Results [1]: [sum((cast(ss_quantity#52 as decimal(10,0)) * ss_sales_price#53))#62 AS csales#63]
+(117) HashAggregate [codegen id : 6]
+Input [3]: [c_customer_sk#67, sum#70, isEmpty#71]
+Keys [1]: [c_customer_sk#67]
+Functions [1]: [sum((cast(ss_quantity#60 as decimal(10,0)) * ss_sales_price#61))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#60 as decimal(10,0)) * ss_sales_price#61))#72]
+Results [1]: [sum((cast(ss_quantity#60 as decimal(10,0)) * ss_sales_price#61))#72 AS csales#73]
 
-(115) HashAggregate [codegen id : 6]
-Input [1]: [csales#63]
+(118) HashAggregate [codegen id : 6]
+Input [1]: [csales#73]
 Keys: []
-Functions [1]: [partial_max(csales#63)]
-Aggregate Attributes [1]: [max#64]
-Results [1]: [max#65]
+Functions [1]: [partial_max(csales#73)]
+Aggregate Attributes [1]: [max#74]
+Results [1]: [max#75]
 
-(116) Exchange
-Input [1]: [max#65]
+(119) Exchange
+Input [1]: [max#75]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
-(117) HashAggregate [codegen id : 7]
-Input [1]: [max#65]
+(120) HashAggregate [codegen id : 7]
+Input [1]: [max#75]
 Keys: []
-Functions [1]: [max(csales#63)]
-Aggregate Attributes [1]: [max(csales#63)#66]
-Results [1]: [max(csales#63)#66 AS tpcds_cmax#67]
+Functions [1]: [max(csales#73)]
+Aggregate Attributes [1]: [max(csales#73)#76]
+Results [1]: [max(csales#73)#76 AS tpcds_cmax#77]
 
-Subquery:4 Hosting operator id = 101 Hosting Expression = ss_sold_date_sk#54 IN dynamicpruning#55
-BroadcastExchange (122)
-+- * Project (121)
-   +- * Filter (120)
-      +- * ColumnarToRow (119)
-         +- Scan parquet spark_catalog.default.date_dim (118)
+Subquery:5 Hosting operator id = 106 Hosting Expression = Subquery scalar-subquery#64, [id=#65]
+ObjectHashAggregate (127)
++- Exchange (126)
+   +- ObjectHashAggregate (125)
+      +- Exchange (124)
+         +- * Filter (123)
+            +- * ColumnarToRow (122)
+               +- Scan parquet spark_catalog.default.customer (121)
 
 
-(118) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#56, d_year#68]
+(121) Scan parquet spark_catalog.default.customer
+Output [1]: [c_customer_sk#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int>
+
+(122) ColumnarToRow [codegen id : 1]
+Input [1]: [c_customer_sk#28]
+
+(123) Filter [codegen id : 1]
+Input [1]: [c_customer_sk#28]
+Condition : isnotnull(c_customer_sk#28)
+
+(124) Exchange
+Input [1]: [c_customer_sk#28]
+Arguments: hashpartitioning(c_customer_sk#67, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(125) ObjectHashAggregate
+Input [1]: [c_customer_sk#28]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#78]
+Results [1]: [buf#79]
+
+(126) Exchange
+Input [1]: [buf#79]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
+
+(127) ObjectHashAggregate
+Input [1]: [buf#79]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)#80]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)#80 AS bloomFilter#81]
+
+Subquery:6 Hosting operator id = 104 Hosting Expression = ss_sold_date_sk#62 IN dynamicpruning#63
+BroadcastExchange (132)
++- * Project (131)
+   +- * Filter (130)
+      +- * ColumnarToRow (129)
+         +- Scan parquet spark_catalog.default.date_dim (128)
+
+
+(128) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#66, d_year#82]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(119) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#56, d_year#68]
+(129) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#66, d_year#82]
 
-(120) Filter [codegen id : 1]
-Input [2]: [d_date_sk#56, d_year#68]
-Condition : (d_year#68 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#56))
+(130) Filter [codegen id : 1]
+Input [2]: [d_date_sk#66, d_year#82]
+Condition : (d_year#82 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#66))
 
-(121) Project [codegen id : 1]
-Output [1]: [d_date_sk#56]
-Input [2]: [d_date_sk#56, d_year#68]
+(131) Project [codegen id : 1]
+Output [1]: [d_date_sk#66]
+Input [2]: [d_date_sk#66, d_year#82]
 
-(122) BroadcastExchange
-Input [1]: [d_date_sk#56]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+(132) BroadcastExchange
+Input [1]: [d_date_sk#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
 
-Subquery:5 Hosting operator id = 52 Hosting Expression = ws_sold_date_sk#39 IN dynamicpruning#6
+Subquery:7 Hosting operator id = 29 Hosting Expression = Subquery scalar-subquery#26, [id=#27]
+ObjectHashAggregate (139)
++- Exchange (138)
+   +- ObjectHashAggregate (137)
+      +- Exchange (136)
+         +- * Filter (135)
+            +- * ColumnarToRow (134)
+               +- Scan parquet spark_catalog.default.customer (133)
 
-Subquery:6 Hosting operator id = 79 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+
+(133) Scan parquet spark_catalog.default.customer
+Output [1]: [c_customer_sk#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int>
+
+(134) ColumnarToRow [codegen id : 1]
+Input [1]: [c_customer_sk#28]
+
+(135) Filter [codegen id : 1]
+Input [1]: [c_customer_sk#28]
+Condition : isnotnull(c_customer_sk#28)
+
+(136) Exchange
+Input [1]: [c_customer_sk#28]
+Arguments: hashpartitioning(c_customer_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+
+(137) ObjectHashAggregate
+Input [1]: [c_customer_sk#28]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#78]
+Results [1]: [buf#79]
+
+(138) Exchange
+Input [1]: [buf#79]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+
+(139) ObjectHashAggregate
+Input [1]: [buf#79]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)#80]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)#80 AS bloomFilter#81]
+
+Subquery:8 Hosting operator id = 47 Hosting Expression = ws_sold_date_sk#43 IN dynamicpruning#6
+
+Subquery:9 Hosting operator id = 75 Hosting Expression = ReusedSubquery Subquery scalar-subquery#35, [id=#36]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/simplified.txt
@@ -25,17 +25,18 @@ WholeStageCodegen (36)
                                                 InputAdapter
                                                   Exchange [cs_item_sk] #3
                                                     WholeStageCodegen (1)
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sold_date_sk]
-                                                            SubqueryBroadcast [d_date_sk] #1
-                                                              BroadcastExchange #4
-                                                                WholeStageCodegen (1)
-                                                                  Project [d_date_sk]
-                                                                    Filter [d_year,d_moy,d_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                      Filter
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sold_date_sk]
+                                                              SubqueryBroadcast [d_date_sk] #1
+                                                                BroadcastExchange #4
+                                                                  WholeStageCodegen (1)
+                                                                    Project [d_date_sk]
+                                                                      Filter [d_year,d_moy,d_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                           InputAdapter
                                             WholeStageCodegen (8)
                                               Sort [item_sk]
@@ -54,6 +55,16 @@ WholeStageCodegen (36)
                                                                         Project [ss_item_sk,d_date]
                                                                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                             Filter [ss_item_sk]
+                                                                              Subquery #3
+                                                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                                  Exchange #7
+                                                                                    ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                      Exchange [i_item_sk] #8
+                                                                                        WholeStageCodegen (1)
+                                                                                          Filter [i_item_sk]
+                                                                                            ColumnarToRow
+                                                                                              InputAdapter
+                                                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
                                                                               ColumnarToRow
                                                                                 InputAdapter
                                                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sold_date_sk]
@@ -71,22 +82,17 @@ WholeStageCodegen (36)
                                                               WholeStageCodegen (7)
                                                                 Sort [i_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [i_item_sk] #7
-                                                                      WholeStageCodegen (6)
-                                                                        Filter [i_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
+                                                                    ReusedExchange [i_item_sk,i_item_desc] #8
                           InputAdapter
                             WholeStageCodegen (15)
                               Sort [c_customer_sk]
                                 Project [c_customer_sk]
                                   Filter [ssales]
-                                    Subquery #3
+                                    Subquery #5
                                       WholeStageCodegen (7)
                                         HashAggregate [max] [max(csales),tpcds_cmax,max]
                                           InputAdapter
-                                            Exchange #10
+                                            Exchange #12
                                               WholeStageCodegen (6)
                                                 HashAggregate [csales] [max,max]
                                                   HashAggregate [c_customer_sk,sum,isEmpty] [sum((cast(ss_quantity as decimal(10,0)) * ss_sales_price)),csales,sum,isEmpty]
@@ -97,16 +103,26 @@ WholeStageCodegen (36)
                                                             WholeStageCodegen (3)
                                                               Sort [ss_customer_sk]
                                                                 InputAdapter
-                                                                  Exchange [ss_customer_sk] #11
+                                                                  Exchange [ss_customer_sk] #13
                                                                     WholeStageCodegen (2)
                                                                       Project [ss_customer_sk,ss_quantity,ss_sales_price]
                                                                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                           Filter [ss_customer_sk]
+                                                                            Subquery #7
+                                                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                                Exchange #15
+                                                                                  ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                                    Exchange [c_customer_sk] #16
+                                                                                      WholeStageCodegen (1)
+                                                                                        Filter [c_customer_sk]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet spark_catalog.default.customer [c_customer_sk]
                                                                             ColumnarToRow
                                                                               InputAdapter
                                                                                 Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_quantity,ss_sales_price,ss_sold_date_sk]
-                                                                                  SubqueryBroadcast [d_date_sk] #4
-                                                                                    BroadcastExchange #12
+                                                                                  SubqueryBroadcast [d_date_sk] #6
+                                                                                    BroadcastExchange #14
                                                                                       WholeStageCodegen (1)
                                                                                         Project [d_date_sk]
                                                                                           Filter [d_year,d_date_sk]
@@ -114,12 +130,12 @@ WholeStageCodegen (36)
                                                                                               InputAdapter
                                                                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                           InputAdapter
-                                                                            ReusedExchange [d_date_sk] #12
+                                                                            ReusedExchange [d_date_sk] #14
                                                           InputAdapter
                                                             WholeStageCodegen (5)
                                                               Sort [c_customer_sk]
                                                                 InputAdapter
-                                                                  ReusedExchange [c_customer_sk] #9
+                                                                  ReusedExchange [c_customer_sk] #11
                                     HashAggregate [c_customer_sk,sum,isEmpty] [sum((cast(ss_quantity as decimal(10,0)) * ss_sales_price)),ssales,sum,isEmpty]
                                       HashAggregate [c_customer_sk,ss_quantity,ss_sales_price] [sum,isEmpty,sum,isEmpty]
                                         Project [ss_quantity,ss_sales_price,c_customer_sk]
@@ -128,10 +144,20 @@ WholeStageCodegen (36)
                                               WholeStageCodegen (12)
                                                 Sort [ss_customer_sk]
                                                   InputAdapter
-                                                    Exchange [ss_customer_sk] #8
+                                                    Exchange [ss_customer_sk] #9
                                                       WholeStageCodegen (11)
                                                         Project [ss_customer_sk,ss_quantity,ss_sales_price]
                                                           Filter [ss_customer_sk]
+                                                            Subquery #4
+                                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                Exchange #10
+                                                                  ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                    Exchange [c_customer_sk] #11
+                                                                      WholeStageCodegen (1)
+                                                                        Filter [c_customer_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.customer [c_customer_sk]
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_quantity,ss_sales_price,ss_sold_date_sk]
@@ -139,12 +165,7 @@ WholeStageCodegen (36)
                                               WholeStageCodegen (14)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    Exchange [c_customer_sk] #9
-                                                      WholeStageCodegen (13)
-                                                        Filter [c_customer_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.customer [c_customer_sk]
+                                                    ReusedExchange [c_customer_sk] #11
                       InputAdapter
                         ReusedExchange [d_date_sk] #4
                 WholeStageCodegen (34)
@@ -156,7 +177,7 @@ WholeStageCodegen (36)
                             WholeStageCodegen (27)
                               Sort [ws_bill_customer_sk]
                                 InputAdapter
-                                  Exchange [ws_bill_customer_sk] #13
+                                  Exchange [ws_bill_customer_sk] #17
                                     WholeStageCodegen (26)
                                       Project [ws_bill_customer_sk,ws_quantity,ws_list_price,ws_sold_date_sk]
                                         SortMergeJoin [ws_item_sk,item_sk]
@@ -164,12 +185,13 @@ WholeStageCodegen (36)
                                             WholeStageCodegen (19)
                                               Sort [ws_item_sk]
                                                 InputAdapter
-                                                  Exchange [ws_item_sk] #14
+                                                  Exchange [ws_item_sk] #18
                                                     WholeStageCodegen (18)
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_list_price,ws_sold_date_sk]
-                                                            ReusedSubquery [d_date_sk] #1
+                                                      Filter
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_list_price,ws_sold_date_sk]
+                                                              ReusedSubquery [d_date_sk] #1
                                           InputAdapter
                                             WholeStageCodegen (25)
                                               Sort [item_sk]
@@ -188,13 +210,13 @@ WholeStageCodegen (36)
                                                               WholeStageCodegen (24)
                                                                 Sort [i_item_sk]
                                                                   InputAdapter
-                                                                    ReusedExchange [i_item_sk,i_item_desc] #7
+                                                                    ReusedExchange [i_item_sk,i_item_desc] #8
                           InputAdapter
                             WholeStageCodegen (32)
                               Sort [c_customer_sk]
                                 Project [c_customer_sk]
                                   Filter [ssales]
-                                    ReusedSubquery [tpcds_cmax] #3
+                                    ReusedSubquery [tpcds_cmax] #5
                                     HashAggregate [c_customer_sk,sum,isEmpty] [sum((cast(ss_quantity as decimal(10,0)) * ss_sales_price)),ssales,sum,isEmpty]
                                       HashAggregate [c_customer_sk,ss_quantity,ss_sales_price] [sum,isEmpty,sum,isEmpty]
                                         Project [ss_quantity,ss_sales_price,c_customer_sk]
@@ -203,11 +225,11 @@ WholeStageCodegen (36)
                                               WholeStageCodegen (29)
                                                 Sort [ss_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [ss_customer_sk,ss_quantity,ss_sales_price] #8
+                                                    ReusedExchange [ss_customer_sk,ss_quantity,ss_sales_price] #9
                                             InputAdapter
                                               WholeStageCodegen (31)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [c_customer_sk] #9
+                                                    ReusedExchange [c_customer_sk] #11
                       InputAdapter
                         ReusedExchange [d_date_sk] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/explain.txt
@@ -1,30 +1,30 @@
 == Physical Plan ==
 TakeOrderedAndProject (129)
 +- Union (128)
-   :- * HashAggregate (73)
-   :  +- Exchange (72)
-   :     +- * HashAggregate (71)
-   :        +- * Project (70)
-   :           +- * SortMergeJoin Inner (69)
-   :              :- * Project (51)
-   :              :  +- * BroadcastHashJoin Inner BuildRight (50)
-   :              :     :- * SortMergeJoin LeftSemi (48)
-   :              :     :  :- * Sort (29)
-   :              :     :  :  +- Exchange (28)
-   :              :     :  :     +- * Project (27)
-   :              :     :  :        +- * SortMergeJoin LeftSemi (26)
+   :- * HashAggregate (70)
+   :  +- Exchange (69)
+   :     +- * HashAggregate (68)
+   :        +- * Project (67)
+   :           +- * SortMergeJoin Inner (66)
+   :              :- * Project (45)
+   :              :  +- * BroadcastHashJoin Inner BuildRight (44)
+   :              :     :- * SortMergeJoin LeftSemi (42)
+   :              :     :  :- * Sort (26)
+   :              :     :  :  +- Exchange (25)
+   :              :     :  :     +- * Project (24)
+   :              :     :  :        +- * SortMergeJoin LeftSemi (23)
    :              :     :  :           :- * Sort (5)
    :              :     :  :           :  +- Exchange (4)
    :              :     :  :           :     +- * Filter (3)
    :              :     :  :           :        +- * ColumnarToRow (2)
    :              :     :  :           :           +- Scan parquet spark_catalog.default.catalog_sales (1)
-   :              :     :  :           +- * Sort (25)
-   :              :     :  :              +- * Project (24)
-   :              :     :  :                 +- * Filter (23)
-   :              :     :  :                    +- * HashAggregate (22)
-   :              :     :  :                       +- * HashAggregate (21)
-   :              :     :  :                          +- * Project (20)
-   :              :     :  :                             +- * SortMergeJoin Inner (19)
+   :              :     :  :           +- * Sort (22)
+   :              :     :  :              +- * Project (21)
+   :              :     :  :                 +- * Filter (20)
+   :              :     :  :                    +- * HashAggregate (19)
+   :              :     :  :                       +- * HashAggregate (18)
+   :              :     :  :                          +- * Project (17)
+   :              :     :  :                             +- * SortMergeJoin Inner (16)
    :              :     :  :                                :- * Sort (13)
    :              :     :  :                                :  +- Exchange (12)
    :              :     :  :                                :     +- * Project (11)
@@ -33,90 +33,87 @@ TakeOrderedAndProject (129)
    :              :     :  :                                :           :  +- * ColumnarToRow (7)
    :              :     :  :                                :           :     +- Scan parquet spark_catalog.default.store_sales (6)
    :              :     :  :                                :           +- ReusedExchange (9)
-   :              :     :  :                                +- * Sort (18)
-   :              :     :  :                                   +- Exchange (17)
-   :              :     :  :                                      +- * Filter (16)
-   :              :     :  :                                         +- * ColumnarToRow (15)
-   :              :     :  :                                            +- Scan parquet spark_catalog.default.item (14)
-   :              :     :  +- * Sort (47)
-   :              :     :     +- * Project (46)
-   :              :     :        +- * Filter (45)
-   :              :     :           +- * HashAggregate (44)
-   :              :     :              +- * HashAggregate (43)
-   :              :     :                 +- * Project (42)
-   :              :     :                    +- * SortMergeJoin Inner (41)
-   :              :     :                       :- * Sort (35)
-   :              :     :                       :  +- Exchange (34)
-   :              :     :                       :     +- * Project (33)
-   :              :     :                       :        +- * Filter (32)
-   :              :     :                       :           +- * ColumnarToRow (31)
-   :              :     :                       :              +- Scan parquet spark_catalog.default.store_sales (30)
-   :              :     :                       +- * Sort (40)
-   :              :     :                          +- Exchange (39)
-   :              :     :                             +- * Filter (38)
-   :              :     :                                +- * ColumnarToRow (37)
-   :              :     :                                   +- Scan parquet spark_catalog.default.customer (36)
-   :              :     +- ReusedExchange (49)
-   :              +- * SortMergeJoin LeftSemi (68)
-   :                 :- * Sort (56)
-   :                 :  +- Exchange (55)
-   :                 :     +- * Filter (54)
-   :                 :        +- * ColumnarToRow (53)
-   :                 :           +- Scan parquet spark_catalog.default.customer (52)
-   :                 +- * Sort (67)
-   :                    +- * Project (66)
-   :                       +- * Filter (65)
-   :                          +- * HashAggregate (64)
-   :                             +- * HashAggregate (63)
-   :                                +- * Project (62)
-   :                                   +- * SortMergeJoin Inner (61)
-   :                                      :- * Sort (58)
-   :                                      :  +- ReusedExchange (57)
-   :                                      +- * Sort (60)
-   :                                         +- ReusedExchange (59)
+   :              :     :  :                                +- * Sort (15)
+   :              :     :  :                                   +- ReusedExchange (14)
+   :              :     :  +- * Sort (41)
+   :              :     :     +- * Project (40)
+   :              :     :        +- * Filter (39)
+   :              :     :           +- * HashAggregate (38)
+   :              :     :              +- * HashAggregate (37)
+   :              :     :                 +- * Project (36)
+   :              :     :                    +- * SortMergeJoin Inner (35)
+   :              :     :                       :- * Sort (32)
+   :              :     :                       :  +- Exchange (31)
+   :              :     :                       :     +- * Project (30)
+   :              :     :                       :        +- * Filter (29)
+   :              :     :                       :           +- * ColumnarToRow (28)
+   :              :     :                       :              +- Scan parquet spark_catalog.default.store_sales (27)
+   :              :     :                       +- * Sort (34)
+   :              :     :                          +- ReusedExchange (33)
+   :              :     +- ReusedExchange (43)
+   :              +- * SortMergeJoin LeftSemi (65)
+   :                 :- * Sort (50)
+   :                 :  +- Exchange (49)
+   :                 :     +- * Filter (48)
+   :                 :        +- * ColumnarToRow (47)
+   :                 :           +- Scan parquet spark_catalog.default.customer (46)
+   :                 +- * Sort (64)
+   :                    +- * Project (63)
+   :                       +- * Filter (62)
+   :                          +- * HashAggregate (61)
+   :                             +- * HashAggregate (60)
+   :                                +- * Project (59)
+   :                                   +- * SortMergeJoin Inner (58)
+   :                                      :- * Sort (52)
+   :                                      :  +- ReusedExchange (51)
+   :                                      +- * Sort (57)
+   :                                         +- Exchange (56)
+   :                                            +- * Filter (55)
+   :                                               +- * ColumnarToRow (54)
+   :                                                  +- Scan parquet spark_catalog.default.customer (53)
    +- * HashAggregate (127)
       +- Exchange (126)
          +- * HashAggregate (125)
             +- * Project (124)
                +- * SortMergeJoin Inner (123)
-                  :- * Project (108)
-                  :  +- * BroadcastHashJoin Inner BuildRight (107)
-                  :     :- * SortMergeJoin LeftSemi (105)
-                  :     :  :- * Sort (93)
-                  :     :  :  +- Exchange (92)
-                  :     :  :     +- * Project (91)
-                  :     :  :        +- * SortMergeJoin LeftSemi (90)
-                  :     :  :           :- * Sort (78)
-                  :     :  :           :  +- Exchange (77)
-                  :     :  :           :     +- * Filter (76)
-                  :     :  :           :        +- * ColumnarToRow (75)
-                  :     :  :           :           +- Scan parquet spark_catalog.default.web_sales (74)
-                  :     :  :           +- * Sort (89)
-                  :     :  :              +- * Project (88)
-                  :     :  :                 +- * Filter (87)
-                  :     :  :                    +- * HashAggregate (86)
-                  :     :  :                       +- * HashAggregate (85)
-                  :     :  :                          +- * Project (84)
-                  :     :  :                             +- * SortMergeJoin Inner (83)
-                  :     :  :                                :- * Sort (80)
-                  :     :  :                                :  +- ReusedExchange (79)
-                  :     :  :                                +- * Sort (82)
-                  :     :  :                                   +- ReusedExchange (81)
-                  :     :  +- * Sort (104)
-                  :     :     +- * Project (103)
-                  :     :        +- * Filter (102)
-                  :     :           +- * HashAggregate (101)
-                  :     :              +- * HashAggregate (100)
-                  :     :                 +- * Project (99)
-                  :     :                    +- * SortMergeJoin Inner (98)
-                  :     :                       :- * Sort (95)
-                  :     :                       :  +- ReusedExchange (94)
-                  :     :                       +- * Sort (97)
-                  :     :                          +- ReusedExchange (96)
-                  :     +- ReusedExchange (106)
+                  :- * Project (105)
+                  :  +- * BroadcastHashJoin Inner BuildRight (104)
+                  :     :- * SortMergeJoin LeftSemi (102)
+                  :     :  :- * Sort (90)
+                  :     :  :  +- Exchange (89)
+                  :     :  :     +- * Project (88)
+                  :     :  :        +- * SortMergeJoin LeftSemi (87)
+                  :     :  :           :- * Sort (75)
+                  :     :  :           :  +- Exchange (74)
+                  :     :  :           :     +- * Filter (73)
+                  :     :  :           :        +- * ColumnarToRow (72)
+                  :     :  :           :           +- Scan parquet spark_catalog.default.web_sales (71)
+                  :     :  :           +- * Sort (86)
+                  :     :  :              +- * Project (85)
+                  :     :  :                 +- * Filter (84)
+                  :     :  :                    +- * HashAggregate (83)
+                  :     :  :                       +- * HashAggregate (82)
+                  :     :  :                          +- * Project (81)
+                  :     :  :                             +- * SortMergeJoin Inner (80)
+                  :     :  :                                :- * Sort (77)
+                  :     :  :                                :  +- ReusedExchange (76)
+                  :     :  :                                +- * Sort (79)
+                  :     :  :                                   +- ReusedExchange (78)
+                  :     :  +- * Sort (101)
+                  :     :     +- * Project (100)
+                  :     :        +- * Filter (99)
+                  :     :           +- * HashAggregate (98)
+                  :     :              +- * HashAggregate (97)
+                  :     :                 +- * Project (96)
+                  :     :                    +- * SortMergeJoin Inner (95)
+                  :     :                       :- * Sort (92)
+                  :     :                       :  +- ReusedExchange (91)
+                  :     :                       +- * Sort (94)
+                  :     :                          +- ReusedExchange (93)
+                  :     +- ReusedExchange (103)
                   +- * SortMergeJoin LeftSemi (122)
-                     :- * Sort (110)
-                     :  +- ReusedExchange (109)
+                     :- * Sort (107)
+                     :  +- ReusedExchange (106)
                      +- * Sort (121)
                         +- * Project (120)
                            +- * Filter (119)
@@ -124,10 +121,13 @@ TakeOrderedAndProject (129)
                                  +- * HashAggregate (117)
                                     +- * Project (116)
                                        +- * SortMergeJoin Inner (115)
-                                          :- * Sort (112)
-                                          :  +- ReusedExchange (111)
+                                          :- * Sort (109)
+                                          :  +- ReusedExchange (108)
                                           +- * Sort (114)
-                                             +- ReusedExchange (113)
+                                             +- Exchange (113)
+                                                +- * Filter (112)
+                                                   +- * ColumnarToRow (111)
+                                                      +- Scan parquet spark_catalog.default.customer (110)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -143,7 +143,7 @@ Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4,
 
 (3) Filter [codegen id : 1]
 Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
-Condition : isnotnull(cs_bill_customer_sk#1)
+Condition : ((isnotnull(cs_bill_customer_sk#1) AND true) AND true)
 
 (4) Exchange
 Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
@@ -166,570 +166,570 @@ Input [2]: [ss_item_sk#7, ss_sold_date_sk#8]
 
 (8) Filter [codegen id : 4]
 Input [2]: [ss_item_sk#7, ss_sold_date_sk#8]
-Condition : isnotnull(ss_item_sk#7)
+Condition : (isnotnull(ss_item_sk#7) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ss_item_sk#7, 42), false))
 
-(9) ReusedExchange [Reuses operator id: 139]
-Output [2]: [d_date_sk#10, d_date#11]
+(9) ReusedExchange [Reuses operator id: 146]
+Output [2]: [d_date_sk#12, d_date#13]
 
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#10]
+Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
-Output [2]: [ss_item_sk#7, d_date#11]
-Input [4]: [ss_item_sk#7, ss_sold_date_sk#8, d_date_sk#10, d_date#11]
+Output [2]: [ss_item_sk#7, d_date#13]
+Input [4]: [ss_item_sk#7, ss_sold_date_sk#8, d_date_sk#12, d_date#13]
 
 (12) Exchange
-Input [2]: [ss_item_sk#7, d_date#11]
+Input [2]: [ss_item_sk#7, d_date#13]
 Arguments: hashpartitioning(ss_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (13) Sort [codegen id : 5]
-Input [2]: [ss_item_sk#7, d_date#11]
+Input [2]: [ss_item_sk#7, d_date#13]
 Arguments: [ss_item_sk#7 ASC NULLS FIRST], false, 0
 
-(14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#12, i_item_desc#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_item_desc:string>
+(14) ReusedExchange [Reuses operator id: 138]
+Output [2]: [i_item_sk#14, i_item_desc#15]
 
-(15) ColumnarToRow [codegen id : 6]
-Input [2]: [i_item_sk#12, i_item_desc#13]
+(15) Sort [codegen id : 7]
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Arguments: [i_item_sk#14 ASC NULLS FIRST], false, 0
 
-(16) Filter [codegen id : 6]
-Input [2]: [i_item_sk#12, i_item_desc#13]
-Condition : isnotnull(i_item_sk#12)
-
-(17) Exchange
-Input [2]: [i_item_sk#12, i_item_desc#13]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) Sort [codegen id : 7]
-Input [2]: [i_item_sk#12, i_item_desc#13]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
-
-(19) SortMergeJoin [codegen id : 8]
+(16) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#7]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#14]
 Join type: Inner
 Join condition: None
 
-(20) Project [codegen id : 8]
-Output [3]: [d_date#11, i_item_sk#12, substr(i_item_desc#13, 1, 30) AS _groupingexpression#14]
-Input [4]: [ss_item_sk#7, d_date#11, i_item_sk#12, i_item_desc#13]
+(17) Project [codegen id : 8]
+Output [3]: [d_date#13, i_item_sk#14, substr(i_item_desc#15, 1, 30) AS _groupingexpression#16]
+Input [4]: [ss_item_sk#7, d_date#13, i_item_sk#14, i_item_desc#15]
 
-(21) HashAggregate [codegen id : 8]
-Input [3]: [d_date#11, i_item_sk#12, _groupingexpression#14]
-Keys [3]: [_groupingexpression#14, i_item_sk#12, d_date#11]
+(18) HashAggregate [codegen id : 8]
+Input [3]: [d_date#13, i_item_sk#14, _groupingexpression#16]
+Keys [3]: [_groupingexpression#16, i_item_sk#14, d_date#13]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#15]
-Results [4]: [_groupingexpression#14, i_item_sk#12, d_date#11, count#16]
+Aggregate Attributes [1]: [count#17]
+Results [4]: [_groupingexpression#16, i_item_sk#14, d_date#13, count#18]
 
-(22) HashAggregate [codegen id : 8]
-Input [4]: [_groupingexpression#14, i_item_sk#12, d_date#11, count#16]
-Keys [3]: [_groupingexpression#14, i_item_sk#12, d_date#11]
+(19) HashAggregate [codegen id : 8]
+Input [4]: [_groupingexpression#16, i_item_sk#14, d_date#13, count#18]
+Keys [3]: [_groupingexpression#16, i_item_sk#14, d_date#13]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#17]
-Results [2]: [i_item_sk#12 AS item_sk#18, count(1)#17 AS cnt#19]
+Aggregate Attributes [1]: [count(1)#19]
+Results [2]: [i_item_sk#14 AS item_sk#20, count(1)#19 AS cnt#21]
 
-(23) Filter [codegen id : 8]
-Input [2]: [item_sk#18, cnt#19]
-Condition : (cnt#19 > 4)
+(20) Filter [codegen id : 8]
+Input [2]: [item_sk#20, cnt#21]
+Condition : (cnt#21 > 4)
 
-(24) Project [codegen id : 8]
-Output [1]: [item_sk#18]
-Input [2]: [item_sk#18, cnt#19]
+(21) Project [codegen id : 8]
+Output [1]: [item_sk#20]
+Input [2]: [item_sk#20, cnt#21]
 
-(25) Sort [codegen id : 8]
-Input [1]: [item_sk#18]
-Arguments: [item_sk#18 ASC NULLS FIRST], false, 0
+(22) Sort [codegen id : 8]
+Input [1]: [item_sk#20]
+Arguments: [item_sk#20 ASC NULLS FIRST], false, 0
 
-(26) SortMergeJoin [codegen id : 9]
+(23) SortMergeJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [item_sk#18]
+Right keys [1]: [item_sk#20]
 Join type: LeftSemi
 Join condition: None
 
-(27) Project [codegen id : 9]
+(24) Project [codegen id : 9]
 Output [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Input [5]: [cs_bill_customer_sk#1, cs_item_sk#2, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 
-(28) Exchange
+(25) Exchange
 Input [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
-Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(29) Sort [codegen id : 10]
+(26) Sort [codegen id : 10]
 Input [4]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(30) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, ss_sold_date_sk#23]
+(27) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, ss_sold_date_sk#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
-(31) ColumnarToRow [codegen id : 11]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, ss_sold_date_sk#23]
+(28) ColumnarToRow [codegen id : 11]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, ss_sold_date_sk#25]
 
-(32) Filter [codegen id : 11]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, ss_sold_date_sk#23]
-Condition : isnotnull(ss_customer_sk#20)
+(29) Filter [codegen id : 11]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, ss_sold_date_sk#25]
+Condition : (isnotnull(ss_customer_sk#22) AND might_contain(Subquery scalar-subquery#26, [id=#27], xxhash64(ss_customer_sk#22, 42), false))
 
-(33) Project [codegen id : 11]
-Output [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, ss_sold_date_sk#23]
+(30) Project [codegen id : 11]
+Output [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, ss_sold_date_sk#25]
 
-(34) Exchange
-Input [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Arguments: hashpartitioning(ss_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(31) Exchange
+Input [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Arguments: hashpartitioning(ss_customer_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(35) Sort [codegen id : 12]
-Input [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Arguments: [ss_customer_sk#20 ASC NULLS FIRST], false, 0
+(32) Sort [codegen id : 12]
+Input [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Arguments: [ss_customer_sk#22 ASC NULLS FIRST], false, 0
 
-(36) Scan parquet spark_catalog.default.customer
-Output [1]: [c_customer_sk#24]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk)]
-ReadSchema: struct<c_customer_sk:int>
+(33) ReusedExchange [Reuses operator id: 179]
+Output [1]: [c_customer_sk#28]
 
-(37) ColumnarToRow [codegen id : 13]
-Input [1]: [c_customer_sk#24]
+(34) Sort [codegen id : 14]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(38) Filter [codegen id : 13]
-Input [1]: [c_customer_sk#24]
-Condition : isnotnull(c_customer_sk#24)
-
-(39) Exchange
-Input [1]: [c_customer_sk#24]
-Arguments: hashpartitioning(c_customer_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(40) Sort [codegen id : 14]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
-
-(41) SortMergeJoin [codegen id : 15]
-Left keys [1]: [ss_customer_sk#20]
-Right keys [1]: [c_customer_sk#24]
+(35) SortMergeJoin [codegen id : 15]
+Left keys [1]: [ss_customer_sk#22]
+Right keys [1]: [c_customer_sk#28]
 Join type: Inner
 Join condition: None
 
-(42) Project [codegen id : 15]
-Output [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
+(36) Project [codegen id : 15]
+Output [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
 
-(43) HashAggregate [codegen id : 15]
-Input [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [partial_sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [2]: [sum#25, isEmpty#26]
-Results [3]: [c_customer_sk#24, sum#27, isEmpty#28]
+(37) HashAggregate [codegen id : 15]
+Input [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [partial_sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [2]: [sum#29, isEmpty#30]
+Results [3]: [c_customer_sk#28, sum#31, isEmpty#32]
 
-(44) HashAggregate [codegen id : 15]
-Input [3]: [c_customer_sk#24, sum#27, isEmpty#28]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29]
-Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29 AS ssales#30]
+(38) HashAggregate [codegen id : 15]
+Input [3]: [c_customer_sk#28, sum#31, isEmpty#32]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33]
+Results [2]: [c_customer_sk#28, sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33 AS ssales#34]
 
-(45) Filter [codegen id : 15]
-Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#31, [id=#32])))
+(39) Filter [codegen id : 15]
+Input [2]: [c_customer_sk#28, ssales#34]
+Condition : (isnotnull(ssales#34) AND (cast(ssales#34 as decimal(38,8)) > (0.500000 * Subquery scalar-subquery#35, [id=#36])))
 
-(46) Project [codegen id : 15]
-Output [1]: [c_customer_sk#24]
-Input [2]: [c_customer_sk#24, ssales#30]
+(40) Project [codegen id : 15]
+Output [1]: [c_customer_sk#28]
+Input [2]: [c_customer_sk#28, ssales#34]
 
-(47) Sort [codegen id : 15]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+(41) Sort [codegen id : 15]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(48) SortMergeJoin [codegen id : 17]
+(42) SortMergeJoin [codegen id : 17]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#24]
+Right keys [1]: [c_customer_sk#28]
 Join type: LeftSemi
 Join condition: None
 
-(49) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#33]
+(43) ReusedExchange [Reuses operator id: 134]
+Output [1]: [d_date_sk#37]
 
-(50) BroadcastHashJoin [codegen id : 17]
+(44) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#33]
+Right keys [1]: [d_date_sk#37]
 Join type: Inner
 Join condition: None
 
-(51) Project [codegen id : 17]
+(45) Project [codegen id : 17]
 Output [3]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4]
-Input [5]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#33]
+Input [5]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, cs_sold_date_sk#5, d_date_sk#37]
 
-(52) Scan parquet spark_catalog.default.customer
-Output [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
+(46) Scan parquet spark_catalog.default.customer
+Output [3]: [c_customer_sk#38, c_first_name#39, c_last_name#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
-(53) ColumnarToRow [codegen id : 18]
-Input [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
+(47) ColumnarToRow [codegen id : 18]
+Input [3]: [c_customer_sk#38, c_first_name#39, c_last_name#40]
 
-(54) Filter [codegen id : 18]
-Input [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
-Condition : isnotnull(c_customer_sk#34)
+(48) Filter [codegen id : 18]
+Input [3]: [c_customer_sk#38, c_first_name#39, c_last_name#40]
+Condition : isnotnull(c_customer_sk#38)
 
-(55) Exchange
-Input [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
-Arguments: hashpartitioning(c_customer_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(49) Exchange
+Input [3]: [c_customer_sk#38, c_first_name#39, c_last_name#40]
+Arguments: hashpartitioning(c_customer_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(56) Sort [codegen id : 19]
-Input [3]: [c_customer_sk#34, c_first_name#35, c_last_name#36]
-Arguments: [c_customer_sk#34 ASC NULLS FIRST], false, 0
+(50) Sort [codegen id : 19]
+Input [3]: [c_customer_sk#38, c_first_name#39, c_last_name#40]
+Arguments: [c_customer_sk#38 ASC NULLS FIRST], false, 0
 
-(57) ReusedExchange [Reuses operator id: 34]
-Output [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
+(51) ReusedExchange [Reuses operator id: 31]
+Output [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
 
-(58) Sort [codegen id : 21]
-Input [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Arguments: [ss_customer_sk#20 ASC NULLS FIRST], false, 0
+(52) Sort [codegen id : 21]
+Input [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Arguments: [ss_customer_sk#22 ASC NULLS FIRST], false, 0
 
-(59) ReusedExchange [Reuses operator id: 39]
-Output [1]: [c_customer_sk#24]
+(53) Scan parquet spark_catalog.default.customer
+Output [1]: [c_customer_sk#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int>
 
-(60) Sort [codegen id : 23]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+(54) ColumnarToRow [codegen id : 22]
+Input [1]: [c_customer_sk#28]
 
-(61) SortMergeJoin [codegen id : 24]
-Left keys [1]: [ss_customer_sk#20]
-Right keys [1]: [c_customer_sk#24]
+(55) Filter [codegen id : 22]
+Input [1]: [c_customer_sk#28]
+Condition : (isnotnull(c_customer_sk#28) AND might_contain(Subquery scalar-subquery#41, [id=#42], xxhash64(c_customer_sk#28, 42), false))
+
+(56) Exchange
+Input [1]: [c_customer_sk#28]
+Arguments: hashpartitioning(c_customer_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(57) Sort [codegen id : 23]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
+
+(58) SortMergeJoin [codegen id : 24]
+Left keys [1]: [ss_customer_sk#22]
+Right keys [1]: [c_customer_sk#28]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 24]
-Output [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
+(59) Project [codegen id : 24]
+Output [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
 
-(63) HashAggregate [codegen id : 24]
-Input [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [partial_sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [2]: [sum#25, isEmpty#26]
-Results [3]: [c_customer_sk#24, sum#27, isEmpty#28]
+(60) HashAggregate [codegen id : 24]
+Input [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [partial_sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [2]: [sum#29, isEmpty#30]
+Results [3]: [c_customer_sk#28, sum#31, isEmpty#32]
 
-(64) HashAggregate [codegen id : 24]
-Input [3]: [c_customer_sk#24, sum#27, isEmpty#28]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29]
-Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29 AS ssales#30]
+(61) HashAggregate [codegen id : 24]
+Input [3]: [c_customer_sk#28, sum#31, isEmpty#32]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33]
+Results [2]: [c_customer_sk#28, sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33 AS ssales#34]
 
-(65) Filter [codegen id : 24]
-Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+(62) Filter [codegen id : 24]
+Input [2]: [c_customer_sk#28, ssales#34]
+Condition : (isnotnull(ssales#34) AND (cast(ssales#34 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#35, [id=#36])))
 
-(66) Project [codegen id : 24]
-Output [1]: [c_customer_sk#24]
-Input [2]: [c_customer_sk#24, ssales#30]
+(63) Project [codegen id : 24]
+Output [1]: [c_customer_sk#28]
+Input [2]: [c_customer_sk#28, ssales#34]
 
-(67) Sort [codegen id : 24]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+(64) Sort [codegen id : 24]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(68) SortMergeJoin [codegen id : 25]
-Left keys [1]: [c_customer_sk#34]
-Right keys [1]: [c_customer_sk#24]
+(65) SortMergeJoin [codegen id : 25]
+Left keys [1]: [c_customer_sk#38]
+Right keys [1]: [c_customer_sk#28]
 Join type: LeftSemi
 Join condition: None
 
-(69) SortMergeJoin [codegen id : 26]
+(66) SortMergeJoin [codegen id : 26]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#34]
+Right keys [1]: [c_customer_sk#38]
 Join type: Inner
 Join condition: None
 
-(70) Project [codegen id : 26]
-Output [4]: [cs_quantity#3, cs_list_price#4, c_first_name#35, c_last_name#36]
-Input [6]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, c_customer_sk#34, c_first_name#35, c_last_name#36]
+(67) Project [codegen id : 26]
+Output [4]: [cs_quantity#3, cs_list_price#4, c_first_name#39, c_last_name#40]
+Input [6]: [cs_bill_customer_sk#1, cs_quantity#3, cs_list_price#4, c_customer_sk#38, c_first_name#39, c_last_name#40]
 
-(71) HashAggregate [codegen id : 26]
-Input [4]: [cs_quantity#3, cs_list_price#4, c_first_name#35, c_last_name#36]
-Keys [2]: [c_last_name#36, c_first_name#35]
+(68) HashAggregate [codegen id : 26]
+Input [4]: [cs_quantity#3, cs_list_price#4, c_first_name#39, c_last_name#40]
+Keys [2]: [c_last_name#40, c_first_name#39]
 Functions [1]: [partial_sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))]
-Aggregate Attributes [2]: [sum#37, isEmpty#38]
-Results [4]: [c_last_name#36, c_first_name#35, sum#39, isEmpty#40]
+Aggregate Attributes [2]: [sum#43, isEmpty#44]
+Results [4]: [c_last_name#40, c_first_name#39, sum#45, isEmpty#46]
 
-(72) Exchange
-Input [4]: [c_last_name#36, c_first_name#35, sum#39, isEmpty#40]
-Arguments: hashpartitioning(c_last_name#36, c_first_name#35, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(69) Exchange
+Input [4]: [c_last_name#40, c_first_name#39, sum#45, isEmpty#46]
+Arguments: hashpartitioning(c_last_name#40, c_first_name#39, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(73) HashAggregate [codegen id : 27]
-Input [4]: [c_last_name#36, c_first_name#35, sum#39, isEmpty#40]
-Keys [2]: [c_last_name#36, c_first_name#35]
+(70) HashAggregate [codegen id : 27]
+Input [4]: [c_last_name#40, c_first_name#39, sum#45, isEmpty#46]
+Keys [2]: [c_last_name#40, c_first_name#39]
 Functions [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))]
-Aggregate Attributes [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#41]
-Results [3]: [c_last_name#36, c_first_name#35, sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#41 AS sales#42]
+Aggregate Attributes [1]: [sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#47]
+Results [3]: [c_last_name#40, c_first_name#39, sum((cast(cs_quantity#3 as decimal(10,0)) * cs_list_price#4))#47 AS sales#48]
 
-(74) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+(71) Scan parquet spark_catalog.default.web_sales
+Output [5]: [ws_item_sk#49, ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#47), dynamicpruningexpression(ws_sold_date_sk#47 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#53), dynamicpruningexpression(ws_sold_date_sk#53 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(75) ColumnarToRow [codegen id : 28]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+(72) ColumnarToRow [codegen id : 28]
+Input [5]: [ws_item_sk#49, ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
 
-(76) Filter [codegen id : 28]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Condition : isnotnull(ws_bill_customer_sk#44)
+(73) Filter [codegen id : 28]
+Input [5]: [ws_item_sk#49, ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
+Condition : ((isnotnull(ws_bill_customer_sk#50) AND true) AND true)
 
-(77) Exchange
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: hashpartitioning(ws_item_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+(74) Exchange
+Input [5]: [ws_item_sk#49, ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
+Arguments: hashpartitioning(ws_item_sk#49, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(78) Sort [codegen id : 29]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: [ws_item_sk#43 ASC NULLS FIRST], false, 0
+(75) Sort [codegen id : 29]
+Input [5]: [ws_item_sk#49, ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
+Arguments: [ws_item_sk#49 ASC NULLS FIRST], false, 0
 
-(79) ReusedExchange [Reuses operator id: 12]
-Output [2]: [ss_item_sk#7, d_date#11]
+(76) ReusedExchange [Reuses operator id: 12]
+Output [2]: [ss_item_sk#7, d_date#13]
 
-(80) Sort [codegen id : 32]
-Input [2]: [ss_item_sk#7, d_date#11]
+(77) Sort [codegen id : 32]
+Input [2]: [ss_item_sk#7, d_date#13]
 Arguments: [ss_item_sk#7 ASC NULLS FIRST], false, 0
 
-(81) ReusedExchange [Reuses operator id: 17]
-Output [2]: [i_item_sk#12, i_item_desc#13]
+(78) ReusedExchange [Reuses operator id: 138]
+Output [2]: [i_item_sk#14, i_item_desc#15]
 
-(82) Sort [codegen id : 34]
-Input [2]: [i_item_sk#12, i_item_desc#13]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+(79) Sort [codegen id : 34]
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Arguments: [i_item_sk#14 ASC NULLS FIRST], false, 0
 
-(83) SortMergeJoin [codegen id : 35]
+(80) SortMergeJoin [codegen id : 35]
 Left keys [1]: [ss_item_sk#7]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#14]
 Join type: Inner
 Join condition: None
 
-(84) Project [codegen id : 35]
-Output [3]: [d_date#11, i_item_sk#12, substr(i_item_desc#13, 1, 30) AS _groupingexpression#14]
-Input [4]: [ss_item_sk#7, d_date#11, i_item_sk#12, i_item_desc#13]
+(81) Project [codegen id : 35]
+Output [3]: [d_date#13, i_item_sk#14, substr(i_item_desc#15, 1, 30) AS _groupingexpression#16]
+Input [4]: [ss_item_sk#7, d_date#13, i_item_sk#14, i_item_desc#15]
 
-(85) HashAggregate [codegen id : 35]
-Input [3]: [d_date#11, i_item_sk#12, _groupingexpression#14]
-Keys [3]: [_groupingexpression#14, i_item_sk#12, d_date#11]
+(82) HashAggregate [codegen id : 35]
+Input [3]: [d_date#13, i_item_sk#14, _groupingexpression#16]
+Keys [3]: [_groupingexpression#16, i_item_sk#14, d_date#13]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#15]
-Results [4]: [_groupingexpression#14, i_item_sk#12, d_date#11, count#16]
+Aggregate Attributes [1]: [count#17]
+Results [4]: [_groupingexpression#16, i_item_sk#14, d_date#13, count#18]
 
-(86) HashAggregate [codegen id : 35]
-Input [4]: [_groupingexpression#14, i_item_sk#12, d_date#11, count#16]
-Keys [3]: [_groupingexpression#14, i_item_sk#12, d_date#11]
+(83) HashAggregate [codegen id : 35]
+Input [4]: [_groupingexpression#16, i_item_sk#14, d_date#13, count#18]
+Keys [3]: [_groupingexpression#16, i_item_sk#14, d_date#13]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#17]
-Results [2]: [i_item_sk#12 AS item_sk#18, count(1)#17 AS cnt#19]
+Aggregate Attributes [1]: [count(1)#19]
+Results [2]: [i_item_sk#14 AS item_sk#20, count(1)#19 AS cnt#21]
 
-(87) Filter [codegen id : 35]
-Input [2]: [item_sk#18, cnt#19]
-Condition : (cnt#19 > 4)
+(84) Filter [codegen id : 35]
+Input [2]: [item_sk#20, cnt#21]
+Condition : (cnt#21 > 4)
 
-(88) Project [codegen id : 35]
-Output [1]: [item_sk#18]
-Input [2]: [item_sk#18, cnt#19]
+(85) Project [codegen id : 35]
+Output [1]: [item_sk#20]
+Input [2]: [item_sk#20, cnt#21]
 
-(89) Sort [codegen id : 35]
-Input [1]: [item_sk#18]
-Arguments: [item_sk#18 ASC NULLS FIRST], false, 0
+(86) Sort [codegen id : 35]
+Input [1]: [item_sk#20]
+Arguments: [item_sk#20 ASC NULLS FIRST], false, 0
 
-(90) SortMergeJoin [codegen id : 36]
-Left keys [1]: [ws_item_sk#43]
-Right keys [1]: [item_sk#18]
+(87) SortMergeJoin [codegen id : 36]
+Left keys [1]: [ws_item_sk#49]
+Right keys [1]: [item_sk#20]
 Join type: LeftSemi
 Join condition: None
 
-(91) Project [codegen id : 36]
-Output [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Input [5]: [ws_item_sk#43, ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
+(88) Project [codegen id : 36]
+Output [4]: [ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
+Input [5]: [ws_item_sk#49, ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
 
-(92) Exchange
-Input [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: hashpartitioning(ws_bill_customer_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(89) Exchange
+Input [4]: [ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
+Arguments: hashpartitioning(ws_bill_customer_sk#50, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(93) Sort [codegen id : 37]
-Input [4]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47]
-Arguments: [ws_bill_customer_sk#44 ASC NULLS FIRST], false, 0
+(90) Sort [codegen id : 37]
+Input [4]: [ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53]
+Arguments: [ws_bill_customer_sk#50 ASC NULLS FIRST], false, 0
 
-(94) ReusedExchange [Reuses operator id: 34]
-Output [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
+(91) ReusedExchange [Reuses operator id: 31]
+Output [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
 
-(95) Sort [codegen id : 39]
-Input [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Arguments: [ss_customer_sk#20 ASC NULLS FIRST], false, 0
+(92) Sort [codegen id : 39]
+Input [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Arguments: [ss_customer_sk#22 ASC NULLS FIRST], false, 0
 
-(96) ReusedExchange [Reuses operator id: 39]
-Output [1]: [c_customer_sk#24]
+(93) ReusedExchange [Reuses operator id: 179]
+Output [1]: [c_customer_sk#28]
 
-(97) Sort [codegen id : 41]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+(94) Sort [codegen id : 41]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(98) SortMergeJoin [codegen id : 42]
-Left keys [1]: [ss_customer_sk#20]
-Right keys [1]: [c_customer_sk#24]
+(95) SortMergeJoin [codegen id : 42]
+Left keys [1]: [ss_customer_sk#22]
+Right keys [1]: [c_customer_sk#28]
 Join type: Inner
 Join condition: None
 
-(99) Project [codegen id : 42]
-Output [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
+(96) Project [codegen id : 42]
+Output [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
 
-(100) HashAggregate [codegen id : 42]
-Input [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [partial_sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [2]: [sum#25, isEmpty#26]
-Results [3]: [c_customer_sk#24, sum#27, isEmpty#28]
+(97) HashAggregate [codegen id : 42]
+Input [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [partial_sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [2]: [sum#29, isEmpty#30]
+Results [3]: [c_customer_sk#28, sum#31, isEmpty#32]
 
-(101) HashAggregate [codegen id : 42]
-Input [3]: [c_customer_sk#24, sum#27, isEmpty#28]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29]
-Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29 AS ssales#30]
+(98) HashAggregate [codegen id : 42]
+Input [3]: [c_customer_sk#28, sum#31, isEmpty#32]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33]
+Results [2]: [c_customer_sk#28, sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33 AS ssales#34]
 
-(102) Filter [codegen id : 42]
-Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+(99) Filter [codegen id : 42]
+Input [2]: [c_customer_sk#28, ssales#34]
+Condition : (isnotnull(ssales#34) AND (cast(ssales#34 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#35, [id=#36])))
 
-(103) Project [codegen id : 42]
-Output [1]: [c_customer_sk#24]
-Input [2]: [c_customer_sk#24, ssales#30]
+(100) Project [codegen id : 42]
+Output [1]: [c_customer_sk#28]
+Input [2]: [c_customer_sk#28, ssales#34]
 
-(104) Sort [codegen id : 42]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+(101) Sort [codegen id : 42]
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
-(105) SortMergeJoin [codegen id : 44]
-Left keys [1]: [ws_bill_customer_sk#44]
-Right keys [1]: [c_customer_sk#24]
+(102) SortMergeJoin [codegen id : 44]
+Left keys [1]: [ws_bill_customer_sk#50]
+Right keys [1]: [c_customer_sk#28]
 Join type: LeftSemi
 Join condition: None
 
-(106) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#48]
+(103) ReusedExchange [Reuses operator id: 134]
+Output [1]: [d_date_sk#54]
 
-(107) BroadcastHashJoin [codegen id : 44]
-Left keys [1]: [ws_sold_date_sk#47]
-Right keys [1]: [d_date_sk#48]
+(104) BroadcastHashJoin [codegen id : 44]
+Left keys [1]: [ws_sold_date_sk#53]
+Right keys [1]: [d_date_sk#54]
 Join type: Inner
 Join condition: None
 
-(108) Project [codegen id : 44]
-Output [3]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46]
-Input [5]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, ws_sold_date_sk#47, d_date_sk#48]
+(105) Project [codegen id : 44]
+Output [3]: [ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52]
+Input [5]: [ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, ws_sold_date_sk#53, d_date_sk#54]
 
-(109) ReusedExchange [Reuses operator id: 55]
-Output [3]: [c_customer_sk#49, c_first_name#50, c_last_name#51]
+(106) ReusedExchange [Reuses operator id: 49]
+Output [3]: [c_customer_sk#55, c_first_name#56, c_last_name#57]
 
-(110) Sort [codegen id : 46]
-Input [3]: [c_customer_sk#49, c_first_name#50, c_last_name#51]
-Arguments: [c_customer_sk#49 ASC NULLS FIRST], false, 0
+(107) Sort [codegen id : 46]
+Input [3]: [c_customer_sk#55, c_first_name#56, c_last_name#57]
+Arguments: [c_customer_sk#55 ASC NULLS FIRST], false, 0
 
-(111) ReusedExchange [Reuses operator id: 34]
-Output [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
+(108) ReusedExchange [Reuses operator id: 31]
+Output [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
 
-(112) Sort [codegen id : 48]
-Input [3]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22]
-Arguments: [ss_customer_sk#20 ASC NULLS FIRST], false, 0
+(109) Sort [codegen id : 48]
+Input [3]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24]
+Arguments: [ss_customer_sk#22 ASC NULLS FIRST], false, 0
 
-(113) ReusedExchange [Reuses operator id: 39]
-Output [1]: [c_customer_sk#24]
+(110) Scan parquet spark_catalog.default.customer
+Output [1]: [c_customer_sk#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int>
+
+(111) ColumnarToRow [codegen id : 49]
+Input [1]: [c_customer_sk#28]
+
+(112) Filter [codegen id : 49]
+Input [1]: [c_customer_sk#28]
+Condition : (isnotnull(c_customer_sk#28) AND might_contain(Subquery scalar-subquery#58, [id=#59], xxhash64(c_customer_sk#28, 42), false))
+
+(113) Exchange
+Input [1]: [c_customer_sk#28]
+Arguments: hashpartitioning(c_customer_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (114) Sort [codegen id : 50]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
 (115) SortMergeJoin [codegen id : 51]
-Left keys [1]: [ss_customer_sk#20]
-Right keys [1]: [c_customer_sk#24]
+Left keys [1]: [ss_customer_sk#22]
+Right keys [1]: [c_customer_sk#28]
 Join type: Inner
 Join condition: None
 
 (116) Project [codegen id : 51]
-Output [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Input [4]: [ss_customer_sk#20, ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
+Output [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Input [4]: [ss_customer_sk#22, ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
 
 (117) HashAggregate [codegen id : 51]
-Input [3]: [ss_quantity#21, ss_sales_price#22, c_customer_sk#24]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [partial_sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [2]: [sum#25, isEmpty#26]
-Results [3]: [c_customer_sk#24, sum#27, isEmpty#28]
+Input [3]: [ss_quantity#23, ss_sales_price#24, c_customer_sk#28]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [partial_sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [2]: [sum#29, isEmpty#30]
+Results [3]: [c_customer_sk#28, sum#31, isEmpty#32]
 
 (118) HashAggregate [codegen id : 51]
-Input [3]: [c_customer_sk#24, sum#27, isEmpty#28]
-Keys [1]: [c_customer_sk#24]
-Functions [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29]
-Results [2]: [c_customer_sk#24, sum((cast(ss_quantity#21 as decimal(10,0)) * ss_sales_price#22))#29 AS ssales#30]
+Input [3]: [c_customer_sk#28, sum#31, isEmpty#32]
+Keys [1]: [c_customer_sk#28]
+Functions [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33]
+Results [2]: [c_customer_sk#28, sum((cast(ss_quantity#23 as decimal(10,0)) * ss_sales_price#24))#33 AS ssales#34]
 
 (119) Filter [codegen id : 51]
-Input [2]: [c_customer_sk#24, ssales#30]
-Condition : (isnotnull(ssales#30) AND (cast(ssales#30 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#31, [id=#32])))
+Input [2]: [c_customer_sk#28, ssales#34]
+Condition : (isnotnull(ssales#34) AND (cast(ssales#34 as decimal(38,8)) > (0.500000 * ReusedSubquery Subquery scalar-subquery#35, [id=#36])))
 
 (120) Project [codegen id : 51]
-Output [1]: [c_customer_sk#24]
-Input [2]: [c_customer_sk#24, ssales#30]
+Output [1]: [c_customer_sk#28]
+Input [2]: [c_customer_sk#28, ssales#34]
 
 (121) Sort [codegen id : 51]
-Input [1]: [c_customer_sk#24]
-Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+Input [1]: [c_customer_sk#28]
+Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 
 (122) SortMergeJoin [codegen id : 52]
-Left keys [1]: [c_customer_sk#49]
-Right keys [1]: [c_customer_sk#24]
+Left keys [1]: [c_customer_sk#55]
+Right keys [1]: [c_customer_sk#28]
 Join type: LeftSemi
 Join condition: None
 
 (123) SortMergeJoin [codegen id : 53]
-Left keys [1]: [ws_bill_customer_sk#44]
-Right keys [1]: [c_customer_sk#49]
+Left keys [1]: [ws_bill_customer_sk#50]
+Right keys [1]: [c_customer_sk#55]
 Join type: Inner
 Join condition: None
 
 (124) Project [codegen id : 53]
-Output [4]: [ws_quantity#45, ws_list_price#46, c_first_name#50, c_last_name#51]
-Input [6]: [ws_bill_customer_sk#44, ws_quantity#45, ws_list_price#46, c_customer_sk#49, c_first_name#50, c_last_name#51]
+Output [4]: [ws_quantity#51, ws_list_price#52, c_first_name#56, c_last_name#57]
+Input [6]: [ws_bill_customer_sk#50, ws_quantity#51, ws_list_price#52, c_customer_sk#55, c_first_name#56, c_last_name#57]
 
 (125) HashAggregate [codegen id : 53]
-Input [4]: [ws_quantity#45, ws_list_price#46, c_first_name#50, c_last_name#51]
-Keys [2]: [c_last_name#51, c_first_name#50]
-Functions [1]: [partial_sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))]
-Aggregate Attributes [2]: [sum#52, isEmpty#53]
-Results [4]: [c_last_name#51, c_first_name#50, sum#54, isEmpty#55]
+Input [4]: [ws_quantity#51, ws_list_price#52, c_first_name#56, c_last_name#57]
+Keys [2]: [c_last_name#57, c_first_name#56]
+Functions [1]: [partial_sum((cast(ws_quantity#51 as decimal(10,0)) * ws_list_price#52))]
+Aggregate Attributes [2]: [sum#60, isEmpty#61]
+Results [4]: [c_last_name#57, c_first_name#56, sum#62, isEmpty#63]
 
 (126) Exchange
-Input [4]: [c_last_name#51, c_first_name#50, sum#54, isEmpty#55]
-Arguments: hashpartitioning(c_last_name#51, c_first_name#50, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [4]: [c_last_name#57, c_first_name#56, sum#62, isEmpty#63]
+Arguments: hashpartitioning(c_last_name#57, c_first_name#56, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (127) HashAggregate [codegen id : 54]
-Input [4]: [c_last_name#51, c_first_name#50, sum#54, isEmpty#55]
-Keys [2]: [c_last_name#51, c_first_name#50]
-Functions [1]: [sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))]
-Aggregate Attributes [1]: [sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))#56]
-Results [3]: [c_last_name#51, c_first_name#50, sum((cast(ws_quantity#45 as decimal(10,0)) * ws_list_price#46))#56 AS sales#57]
+Input [4]: [c_last_name#57, c_first_name#56, sum#62, isEmpty#63]
+Keys [2]: [c_last_name#57, c_first_name#56]
+Functions [1]: [sum((cast(ws_quantity#51 as decimal(10,0)) * ws_list_price#52))]
+Aggregate Attributes [1]: [sum((cast(ws_quantity#51 as decimal(10,0)) * ws_list_price#52))#64]
+Results [3]: [c_last_name#57, c_first_name#56, sum((cast(ws_quantity#51 as decimal(10,0)) * ws_list_price#52))#64 AS sales#65]
 
 (128) Union
 
 (129) TakeOrderedAndProject
-Input [3]: [c_last_name#36, c_first_name#35, sales#42]
-Arguments: 100, [c_last_name#36 ASC NULLS FIRST, c_first_name#35 ASC NULLS FIRST, sales#42 ASC NULLS FIRST], [c_last_name#36, c_first_name#35, sales#42]
+Input [3]: [c_last_name#40, c_first_name#39, sales#48]
+Arguments: 100, [c_last_name#40 ASC NULLS FIRST, c_first_name#39 ASC NULLS FIRST, sales#48 ASC NULLS FIRST], [c_last_name#40, c_first_name#39, sales#48]
 
 ===== Subqueries =====
 
@@ -742,198 +742,410 @@ BroadcastExchange (134)
 
 
 (130) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#33, d_year#58, d_moy#59]
+Output [3]: [d_date_sk#37, d_year#66, d_moy#67]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,2), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (131) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#58, d_moy#59]
+Input [3]: [d_date_sk#37, d_year#66, d_moy#67]
 
 (132) Filter [codegen id : 1]
-Input [3]: [d_date_sk#33, d_year#58, d_moy#59]
-Condition : ((((isnotnull(d_year#58) AND isnotnull(d_moy#59)) AND (d_year#58 = 2000)) AND (d_moy#59 = 2)) AND isnotnull(d_date_sk#33))
+Input [3]: [d_date_sk#37, d_year#66, d_moy#67]
+Condition : ((((isnotnull(d_year#66) AND isnotnull(d_moy#67)) AND (d_year#66 = 2000)) AND (d_moy#67 = 2)) AND isnotnull(d_date_sk#37))
 
 (133) Project [codegen id : 1]
-Output [1]: [d_date_sk#33]
-Input [3]: [d_date_sk#33, d_year#58, d_moy#59]
+Output [1]: [d_date_sk#37]
+Input [3]: [d_date_sk#37, d_year#66, d_moy#67]
 
 (134) BroadcastExchange
-Input [1]: [d_date_sk#33]
+Input [1]: [d_date_sk#37]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
-Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (139)
-+- * Project (138)
-   +- * Filter (137)
-      +- * ColumnarToRow (136)
-         +- Scan parquet spark_catalog.default.date_dim (135)
+Subquery:2 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (141)
++- Exchange (140)
+   +- ObjectHashAggregate (139)
+      +- Exchange (138)
+         +- * Filter (137)
+            +- * ColumnarToRow (136)
+               +- Scan parquet spark_catalog.default.item (135)
 
 
-(135) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_date#11, d_year#60]
+(135) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#14, i_item_desc#15]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_item_desc:string>
+
+(136) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#14, i_item_desc#15]
+
+(137) Filter [codegen id : 1]
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Condition : isnotnull(i_item_sk#14)
+
+(138) Exchange
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Arguments: hashpartitioning(i_item_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(139) ObjectHashAggregate
+Input [2]: [i_item_sk#14, i_item_desc#15]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#14, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#68]
+Results [1]: [buf#69]
+
+(140) Exchange
+Input [1]: [buf#69]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(141) ObjectHashAggregate
+Input [1]: [buf#69]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 204000, 1632000, 0, 0)#70]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 204000, 1632000, 0, 0)#70 AS bloomFilter#71]
+
+Subquery:3 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
+BroadcastExchange (146)
++- * Project (145)
+   +- * Filter (144)
+      +- * ColumnarToRow (143)
+         +- Scan parquet spark_catalog.default.date_dim (142)
+
+
+(142) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#12, d_date#13, d_year#72]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_year:int>
 
-(136) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#60]
+(143) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#12, d_date#13, d_year#72]
 
-(137) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_date#11, d_year#60]
-Condition : (d_year#60 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#10))
+(144) Filter [codegen id : 1]
+Input [3]: [d_date_sk#12, d_date#13, d_year#72]
+Condition : (d_year#72 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#12))
 
-(138) Project [codegen id : 1]
-Output [2]: [d_date_sk#10, d_date#11]
-Input [3]: [d_date_sk#10, d_date#11, d_year#60]
+(145) Project [codegen id : 1]
+Output [2]: [d_date_sk#12, d_date#13]
+Input [3]: [d_date_sk#12, d_date#13, d_year#72]
 
-(139) BroadcastExchange
-Input [2]: [d_date_sk#10, d_date#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
+(146) BroadcastExchange
+Input [2]: [d_date_sk#12, d_date#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
-Subquery:3 Hosting operator id = 45 Hosting Expression = Subquery scalar-subquery#31, [id=#32]
-* HashAggregate (156)
-+- Exchange (155)
-   +- * HashAggregate (154)
-      +- * HashAggregate (153)
-         +- * HashAggregate (152)
-            +- * Project (151)
-               +- * SortMergeJoin Inner (150)
-                  :- * Sort (147)
-                  :  +- Exchange (146)
-                  :     +- * Project (145)
-                  :        +- * BroadcastHashJoin Inner BuildRight (144)
-                  :           :- * Filter (142)
-                  :           :  +- * ColumnarToRow (141)
-                  :           :     +- Scan parquet spark_catalog.default.store_sales (140)
-                  :           +- ReusedExchange (143)
-                  +- * Sort (149)
-                     +- ReusedExchange (148)
+Subquery:4 Hosting operator id = 39 Hosting Expression = Subquery scalar-subquery#35, [id=#36]
+* HashAggregate (163)
++- Exchange (162)
+   +- * HashAggregate (161)
+      +- * HashAggregate (160)
+         +- * HashAggregate (159)
+            +- * Project (158)
+               +- * SortMergeJoin Inner (157)
+                  :- * Sort (154)
+                  :  +- Exchange (153)
+                  :     +- * Project (152)
+                  :        +- * BroadcastHashJoin Inner BuildRight (151)
+                  :           :- * Filter (149)
+                  :           :  +- * ColumnarToRow (148)
+                  :           :     +- Scan parquet spark_catalog.default.store_sales (147)
+                  :           +- ReusedExchange (150)
+                  +- * Sort (156)
+                     +- ReusedExchange (155)
 
 
-(140) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#61, ss_quantity#62, ss_sales_price#63, ss_sold_date_sk#64]
+(147) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_customer_sk#73, ss_quantity#74, ss_sales_price#75, ss_sold_date_sk#76]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#64), dynamicpruningexpression(ss_sold_date_sk#64 IN dynamicpruning#65)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#76), dynamicpruningexpression(ss_sold_date_sk#76 IN dynamicpruning#77)]
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
-(141) ColumnarToRow [codegen id : 2]
-Input [4]: [ss_customer_sk#61, ss_quantity#62, ss_sales_price#63, ss_sold_date_sk#64]
+(148) ColumnarToRow [codegen id : 2]
+Input [4]: [ss_customer_sk#73, ss_quantity#74, ss_sales_price#75, ss_sold_date_sk#76]
 
-(142) Filter [codegen id : 2]
-Input [4]: [ss_customer_sk#61, ss_quantity#62, ss_sales_price#63, ss_sold_date_sk#64]
-Condition : isnotnull(ss_customer_sk#61)
+(149) Filter [codegen id : 2]
+Input [4]: [ss_customer_sk#73, ss_quantity#74, ss_sales_price#75, ss_sold_date_sk#76]
+Condition : (isnotnull(ss_customer_sk#73) AND might_contain(Subquery scalar-subquery#78, [id=#79], xxhash64(ss_customer_sk#73, 42), false))
 
-(143) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#66]
+(150) ReusedExchange [Reuses operator id: 175]
+Output [1]: [d_date_sk#80]
 
-(144) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#64]
-Right keys [1]: [d_date_sk#66]
+(151) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_sold_date_sk#76]
+Right keys [1]: [d_date_sk#80]
 Join type: Inner
 Join condition: None
 
-(145) Project [codegen id : 2]
-Output [3]: [ss_customer_sk#61, ss_quantity#62, ss_sales_price#63]
-Input [5]: [ss_customer_sk#61, ss_quantity#62, ss_sales_price#63, ss_sold_date_sk#64, d_date_sk#66]
+(152) Project [codegen id : 2]
+Output [3]: [ss_customer_sk#73, ss_quantity#74, ss_sales_price#75]
+Input [5]: [ss_customer_sk#73, ss_quantity#74, ss_sales_price#75, ss_sold_date_sk#76, d_date_sk#80]
 
-(146) Exchange
-Input [3]: [ss_customer_sk#61, ss_quantity#62, ss_sales_price#63]
-Arguments: hashpartitioning(ss_customer_sk#61, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+(153) Exchange
+Input [3]: [ss_customer_sk#73, ss_quantity#74, ss_sales_price#75]
+Arguments: hashpartitioning(ss_customer_sk#73, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(147) Sort [codegen id : 3]
-Input [3]: [ss_customer_sk#61, ss_quantity#62, ss_sales_price#63]
-Arguments: [ss_customer_sk#61 ASC NULLS FIRST], false, 0
+(154) Sort [codegen id : 3]
+Input [3]: [ss_customer_sk#73, ss_quantity#74, ss_sales_price#75]
+Arguments: [ss_customer_sk#73 ASC NULLS FIRST], false, 0
 
-(148) ReusedExchange [Reuses operator id: 39]
-Output [1]: [c_customer_sk#67]
+(155) ReusedExchange [Reuses operator id: 179]
+Output [1]: [c_customer_sk#81]
 
-(149) Sort [codegen id : 5]
-Input [1]: [c_customer_sk#67]
-Arguments: [c_customer_sk#67 ASC NULLS FIRST], false, 0
+(156) Sort [codegen id : 5]
+Input [1]: [c_customer_sk#81]
+Arguments: [c_customer_sk#81 ASC NULLS FIRST], false, 0
 
-(150) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#61]
-Right keys [1]: [c_customer_sk#67]
+(157) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#73]
+Right keys [1]: [c_customer_sk#81]
 Join type: Inner
 Join condition: None
 
-(151) Project [codegen id : 6]
-Output [3]: [ss_quantity#62, ss_sales_price#63, c_customer_sk#67]
-Input [4]: [ss_customer_sk#61, ss_quantity#62, ss_sales_price#63, c_customer_sk#67]
+(158) Project [codegen id : 6]
+Output [3]: [ss_quantity#74, ss_sales_price#75, c_customer_sk#81]
+Input [4]: [ss_customer_sk#73, ss_quantity#74, ss_sales_price#75, c_customer_sk#81]
 
-(152) HashAggregate [codegen id : 6]
-Input [3]: [ss_quantity#62, ss_sales_price#63, c_customer_sk#67]
-Keys [1]: [c_customer_sk#67]
-Functions [1]: [partial_sum((cast(ss_quantity#62 as decimal(10,0)) * ss_sales_price#63))]
-Aggregate Attributes [2]: [sum#68, isEmpty#69]
-Results [3]: [c_customer_sk#67, sum#70, isEmpty#71]
+(159) HashAggregate [codegen id : 6]
+Input [3]: [ss_quantity#74, ss_sales_price#75, c_customer_sk#81]
+Keys [1]: [c_customer_sk#81]
+Functions [1]: [partial_sum((cast(ss_quantity#74 as decimal(10,0)) * ss_sales_price#75))]
+Aggregate Attributes [2]: [sum#82, isEmpty#83]
+Results [3]: [c_customer_sk#81, sum#84, isEmpty#85]
 
-(153) HashAggregate [codegen id : 6]
-Input [3]: [c_customer_sk#67, sum#70, isEmpty#71]
-Keys [1]: [c_customer_sk#67]
-Functions [1]: [sum((cast(ss_quantity#62 as decimal(10,0)) * ss_sales_price#63))]
-Aggregate Attributes [1]: [sum((cast(ss_quantity#62 as decimal(10,0)) * ss_sales_price#63))#72]
-Results [1]: [sum((cast(ss_quantity#62 as decimal(10,0)) * ss_sales_price#63))#72 AS csales#73]
+(160) HashAggregate [codegen id : 6]
+Input [3]: [c_customer_sk#81, sum#84, isEmpty#85]
+Keys [1]: [c_customer_sk#81]
+Functions [1]: [sum((cast(ss_quantity#74 as decimal(10,0)) * ss_sales_price#75))]
+Aggregate Attributes [1]: [sum((cast(ss_quantity#74 as decimal(10,0)) * ss_sales_price#75))#86]
+Results [1]: [sum((cast(ss_quantity#74 as decimal(10,0)) * ss_sales_price#75))#86 AS csales#87]
 
-(154) HashAggregate [codegen id : 6]
-Input [1]: [csales#73]
+(161) HashAggregate [codegen id : 6]
+Input [1]: [csales#87]
 Keys: []
-Functions [1]: [partial_max(csales#73)]
-Aggregate Attributes [1]: [max#74]
-Results [1]: [max#75]
+Functions [1]: [partial_max(csales#87)]
+Aggregate Attributes [1]: [max#88]
+Results [1]: [max#89]
 
-(155) Exchange
-Input [1]: [max#75]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
+(162) Exchange
+Input [1]: [max#89]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
 
-(156) HashAggregate [codegen id : 7]
-Input [1]: [max#75]
+(163) HashAggregate [codegen id : 7]
+Input [1]: [max#89]
 Keys: []
-Functions [1]: [max(csales#73)]
-Aggregate Attributes [1]: [max(csales#73)#76]
-Results [1]: [max(csales#73)#76 AS tpcds_cmax#77]
+Functions [1]: [max(csales#87)]
+Aggregate Attributes [1]: [max(csales#87)#90]
+Results [1]: [max(csales#87)#90 AS tpcds_cmax#91]
 
-Subquery:4 Hosting operator id = 140 Hosting Expression = ss_sold_date_sk#64 IN dynamicpruning#65
-BroadcastExchange (161)
-+- * Project (160)
-   +- * Filter (159)
-      +- * ColumnarToRow (158)
-         +- Scan parquet spark_catalog.default.date_dim (157)
+Subquery:5 Hosting operator id = 149 Hosting Expression = Subquery scalar-subquery#78, [id=#79]
+ObjectHashAggregate (170)
++- Exchange (169)
+   +- ObjectHashAggregate (168)
+      +- Exchange (167)
+         +- * Filter (166)
+            +- * ColumnarToRow (165)
+               +- Scan parquet spark_catalog.default.customer (164)
 
 
-(157) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#66, d_year#78]
+(164) Scan parquet spark_catalog.default.customer
+Output [1]: [c_customer_sk#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int>
+
+(165) ColumnarToRow [codegen id : 1]
+Input [1]: [c_customer_sk#28]
+
+(166) Filter [codegen id : 1]
+Input [1]: [c_customer_sk#28]
+Condition : isnotnull(c_customer_sk#28)
+
+(167) Exchange
+Input [1]: [c_customer_sk#28]
+Arguments: hashpartitioning(c_customer_sk#81, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(168) ObjectHashAggregate
+Input [1]: [c_customer_sk#28]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#92]
+Results [1]: [buf#93]
+
+(169) Exchange
+Input [1]: [buf#93]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+
+(170) ObjectHashAggregate
+Input [1]: [buf#93]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)#94]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)#94 AS bloomFilter#95]
+
+Subquery:6 Hosting operator id = 147 Hosting Expression = ss_sold_date_sk#76 IN dynamicpruning#77
+BroadcastExchange (175)
++- * Project (174)
+   +- * Filter (173)
+      +- * ColumnarToRow (172)
+         +- Scan parquet spark_catalog.default.date_dim (171)
+
+
+(171) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#80, d_year#96]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [2000,2001,2002,2003]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(158) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#66, d_year#78]
+(172) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#80, d_year#96]
 
-(159) Filter [codegen id : 1]
-Input [2]: [d_date_sk#66, d_year#78]
-Condition : (d_year#78 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#66))
+(173) Filter [codegen id : 1]
+Input [2]: [d_date_sk#80, d_year#96]
+Condition : (d_year#96 IN (2000,2001,2002,2003) AND isnotnull(d_date_sk#80))
 
-(160) Project [codegen id : 1]
-Output [1]: [d_date_sk#66]
-Input [2]: [d_date_sk#66, d_year#78]
+(174) Project [codegen id : 1]
+Output [1]: [d_date_sk#80]
+Input [2]: [d_date_sk#80, d_year#96]
 
-(161) BroadcastExchange
-Input [1]: [d_date_sk#66]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
+(175) BroadcastExchange
+Input [1]: [d_date_sk#80]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
 
-Subquery:5 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+Subquery:7 Hosting operator id = 29 Hosting Expression = Subquery scalar-subquery#26, [id=#27]
+ObjectHashAggregate (182)
++- Exchange (181)
+   +- ObjectHashAggregate (180)
+      +- Exchange (179)
+         +- * Filter (178)
+            +- * ColumnarToRow (177)
+               +- Scan parquet spark_catalog.default.customer (176)
 
-Subquery:6 Hosting operator id = 74 Hosting Expression = ws_sold_date_sk#47 IN dynamicpruning#6
 
-Subquery:7 Hosting operator id = 102 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+(176) Scan parquet spark_catalog.default.customer
+Output [1]: [c_customer_sk#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int>
 
-Subquery:8 Hosting operator id = 119 Hosting Expression = ReusedSubquery Subquery scalar-subquery#31, [id=#32]
+(177) ColumnarToRow [codegen id : 1]
+Input [1]: [c_customer_sk#28]
+
+(178) Filter [codegen id : 1]
+Input [1]: [c_customer_sk#28]
+Condition : isnotnull(c_customer_sk#28)
+
+(179) Exchange
+Input [1]: [c_customer_sk#28]
+Arguments: hashpartitioning(c_customer_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+
+(180) ObjectHashAggregate
+Input [1]: [c_customer_sk#28]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#92]
+Results [1]: [buf#93]
+
+(181) Exchange
+Input [1]: [buf#93]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
+
+(182) ObjectHashAggregate
+Input [1]: [buf#93]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)#94]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#28, 42), 2000000, 16000000, 0, 0)#94 AS bloomFilter#95]
+
+Subquery:8 Hosting operator id = 62 Hosting Expression = ReusedSubquery Subquery scalar-subquery#35, [id=#36]
+
+Subquery:9 Hosting operator id = 55 Hosting Expression = Subquery scalar-subquery#41, [id=#42]
+ObjectHashAggregate (186)
++- Exchange (185)
+   +- ObjectHashAggregate (184)
+      +- ReusedExchange (183)
+
+
+(183) ReusedExchange [Reuses operator id: 49]
+Output [3]: [c_customer_sk#38, c_first_name#39, c_last_name#40]
+
+(184) ObjectHashAggregate
+Input [3]: [c_customer_sk#38, c_first_name#39, c_last_name#40]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#38, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#97]
+Results [1]: [buf#98]
+
+(185) Exchange
+Input [1]: [buf#98]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=23]
+
+(186) ObjectHashAggregate
+Input [1]: [buf#98]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#38, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#38, 42), 2000000, 16000000, 0, 0)#99]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#38, 42), 2000000, 16000000, 0, 0)#99 AS bloomFilter#100]
+
+Subquery:10 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#53 IN dynamicpruning#6
+
+Subquery:11 Hosting operator id = 99 Hosting Expression = ReusedSubquery Subquery scalar-subquery#35, [id=#36]
+
+Subquery:12 Hosting operator id = 119 Hosting Expression = ReusedSubquery Subquery scalar-subquery#35, [id=#36]
+
+Subquery:13 Hosting operator id = 112 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
+ObjectHashAggregate (193)
++- Exchange (192)
+   +- ObjectHashAggregate (191)
+      +- Exchange (190)
+         +- * Filter (189)
+            +- * ColumnarToRow (188)
+               +- Scan parquet spark_catalog.default.customer (187)
+
+
+(187) Scan parquet spark_catalog.default.customer
+Output [3]: [c_customer_sk#55, c_first_name#56, c_last_name#57]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
+
+(188) ColumnarToRow [codegen id : 1]
+Input [3]: [c_customer_sk#55, c_first_name#56, c_last_name#57]
+
+(189) Filter [codegen id : 1]
+Input [3]: [c_customer_sk#55, c_first_name#56, c_last_name#57]
+Condition : isnotnull(c_customer_sk#55)
+
+(190) Exchange
+Input [3]: [c_customer_sk#55, c_first_name#56, c_last_name#57]
+Arguments: hashpartitioning(c_customer_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=24]
+
+(191) ObjectHashAggregate
+Input [3]: [c_customer_sk#55, c_first_name#56, c_last_name#57]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#55, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#101]
+Results [1]: [buf#102]
+
+(192) Exchange
+Input [1]: [buf#102]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=25]
+
+(193) ObjectHashAggregate
+Input [1]: [buf#102]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#55, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#55, 42), 2000000, 16000000, 0, 0)#103]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#55, 42), 2000000, 16000000, 0, 0)#103 AS bloomFilter#104]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/simplified.txt
@@ -57,6 +57,16 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                                             Project [ss_item_sk,d_date]
                                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                                 Filter [ss_item_sk]
+                                                                                  Subquery #3
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #7
+                                                                                        ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                          Exchange [i_item_sk] #8
+                                                                                            WholeStageCodegen (1)
+                                                                                              Filter [i_item_sk]
+                                                                                                ColumnarToRow
+                                                                                                  InputAdapter
+                                                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sold_date_sk]
@@ -74,22 +84,17 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                                   WholeStageCodegen (7)
                                                                     Sort [i_item_sk]
                                                                       InputAdapter
-                                                                        Exchange [i_item_sk] #7
-                                                                          WholeStageCodegen (6)
-                                                                            Filter [i_item_sk]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
+                                                                        ReusedExchange [i_item_sk,i_item_desc] #8
                               InputAdapter
                                 WholeStageCodegen (15)
                                   Sort [c_customer_sk]
                                     Project [c_customer_sk]
                                       Filter [ssales]
-                                        Subquery #3
+                                        Subquery #5
                                           WholeStageCodegen (7)
                                             HashAggregate [max] [max(csales),tpcds_cmax,max]
                                               InputAdapter
-                                                Exchange #10
+                                                Exchange #12
                                                   WholeStageCodegen (6)
                                                     HashAggregate [csales] [max,max]
                                                       HashAggregate [c_customer_sk,sum,isEmpty] [sum((cast(ss_quantity as decimal(10,0)) * ss_sales_price)),csales,sum,isEmpty]
@@ -100,16 +105,26 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                                 WholeStageCodegen (3)
                                                                   Sort [ss_customer_sk]
                                                                     InputAdapter
-                                                                      Exchange [ss_customer_sk] #11
+                                                                      Exchange [ss_customer_sk] #13
                                                                         WholeStageCodegen (2)
                                                                           Project [ss_customer_sk,ss_quantity,ss_sales_price]
                                                                             BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                               Filter [ss_customer_sk]
+                                                                                Subquery #7
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #15
+                                                                                      ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                                        Exchange [c_customer_sk] #16
+                                                                                          WholeStageCodegen (1)
+                                                                                            Filter [c_customer_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_quantity,ss_sales_price,ss_sold_date_sk]
-                                                                                      SubqueryBroadcast [d_date_sk] #4
-                                                                                        BroadcastExchange #12
+                                                                                      SubqueryBroadcast [d_date_sk] #6
+                                                                                        BroadcastExchange #14
                                                                                           WholeStageCodegen (1)
                                                                                             Project [d_date_sk]
                                                                                               Filter [d_year,d_date_sk]
@@ -117,12 +132,12 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                                                                   InputAdapter
                                                                                                     Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                               InputAdapter
-                                                                                ReusedExchange [d_date_sk] #12
+                                                                                ReusedExchange [d_date_sk] #14
                                                               InputAdapter
                                                                 WholeStageCodegen (5)
                                                                   Sort [c_customer_sk]
                                                                     InputAdapter
-                                                                      ReusedExchange [c_customer_sk] #9
+                                                                      ReusedExchange [c_customer_sk] #11
                                         HashAggregate [c_customer_sk,sum,isEmpty] [sum((cast(ss_quantity as decimal(10,0)) * ss_sales_price)),ssales,sum,isEmpty]
                                           HashAggregate [c_customer_sk,ss_quantity,ss_sales_price] [sum,isEmpty,sum,isEmpty]
                                             Project [ss_quantity,ss_sales_price,c_customer_sk]
@@ -131,10 +146,20 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                   WholeStageCodegen (12)
                                                     Sort [ss_customer_sk]
                                                       InputAdapter
-                                                        Exchange [ss_customer_sk] #8
+                                                        Exchange [ss_customer_sk] #9
                                                           WholeStageCodegen (11)
                                                             Project [ss_customer_sk,ss_quantity,ss_sales_price]
                                                               Filter [ss_customer_sk]
+                                                                Subquery #4
+                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                    Exchange #10
+                                                                      ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                        Exchange [c_customer_sk] #11
+                                                                          WholeStageCodegen (1)
+                                                                            Filter [c_customer_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk]
                                                                 ColumnarToRow
                                                                   InputAdapter
                                                                     Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_quantity,ss_sales_price,ss_sold_date_sk]
@@ -142,12 +167,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                   WholeStageCodegen (14)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #9
-                                                          WholeStageCodegen (13)
-                                                            Filter [c_customer_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk]
+                                                        ReusedExchange [c_customer_sk] #11
                             InputAdapter
                               ReusedExchange [d_date_sk] #4
                     InputAdapter
@@ -157,7 +177,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                             WholeStageCodegen (19)
                               Sort [c_customer_sk]
                                 InputAdapter
-                                  Exchange [c_customer_sk] #13
+                                  Exchange [c_customer_sk] #17
                                     WholeStageCodegen (18)
                                       Filter [c_customer_sk]
                                         ColumnarToRow
@@ -168,7 +188,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                               Sort [c_customer_sk]
                                 Project [c_customer_sk]
                                   Filter [ssales]
-                                    ReusedSubquery [tpcds_cmax] #3
+                                    ReusedSubquery [tpcds_cmax] #5
                                     HashAggregate [c_customer_sk,sum,isEmpty] [sum((cast(ss_quantity as decimal(10,0)) * ss_sales_price)),ssales,sum,isEmpty]
                                       HashAggregate [c_customer_sk,ss_quantity,ss_sales_price] [sum,isEmpty,sum,isEmpty]
                                         Project [ss_quantity,ss_sales_price,c_customer_sk]
@@ -177,16 +197,26 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                               WholeStageCodegen (21)
                                                 Sort [ss_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [ss_customer_sk,ss_quantity,ss_sales_price] #8
+                                                    ReusedExchange [ss_customer_sk,ss_quantity,ss_sales_price] #9
                                             InputAdapter
                                               WholeStageCodegen (23)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [c_customer_sk] #9
+                                                    Exchange [c_customer_sk] #18
+                                                      WholeStageCodegen (22)
+                                                        Filter [c_customer_sk]
+                                                          Subquery #8
+                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                              Exchange #19
+                                                                ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #17
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.customer [c_customer_sk]
     WholeStageCodegen (54)
       HashAggregate [c_last_name,c_first_name,sum,isEmpty] [sum((cast(ws_quantity as decimal(10,0)) * ws_list_price)),sales,sum,isEmpty]
         InputAdapter
-          Exchange [c_last_name,c_first_name] #14
+          Exchange [c_last_name,c_first_name] #20
             WholeStageCodegen (53)
               HashAggregate [c_last_name,c_first_name,ws_quantity,ws_list_price] [sum,isEmpty,sum,isEmpty]
                 Project [ws_quantity,ws_list_price,c_first_name,c_last_name]
@@ -200,7 +230,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                 WholeStageCodegen (37)
                                   Sort [ws_bill_customer_sk]
                                     InputAdapter
-                                      Exchange [ws_bill_customer_sk] #15
+                                      Exchange [ws_bill_customer_sk] #21
                                         WholeStageCodegen (36)
                                           Project [ws_bill_customer_sk,ws_quantity,ws_list_price,ws_sold_date_sk]
                                             SortMergeJoin [ws_item_sk,item_sk]
@@ -208,7 +238,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                 WholeStageCodegen (29)
                                                   Sort [ws_item_sk]
                                                     InputAdapter
-                                                      Exchange [ws_item_sk] #16
+                                                      Exchange [ws_item_sk] #22
                                                         WholeStageCodegen (28)
                                                           Filter [ws_bill_customer_sk]
                                                             ColumnarToRow
@@ -233,13 +263,13 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                                   WholeStageCodegen (34)
                                                                     Sort [i_item_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [i_item_sk,i_item_desc] #7
+                                                                        ReusedExchange [i_item_sk,i_item_desc] #8
                               InputAdapter
                                 WholeStageCodegen (42)
                                   Sort [c_customer_sk]
                                     Project [c_customer_sk]
                                       Filter [ssales]
-                                        ReusedSubquery [tpcds_cmax] #3
+                                        ReusedSubquery [tpcds_cmax] #5
                                         HashAggregate [c_customer_sk,sum,isEmpty] [sum((cast(ss_quantity as decimal(10,0)) * ss_sales_price)),ssales,sum,isEmpty]
                                           HashAggregate [c_customer_sk,ss_quantity,ss_sales_price] [sum,isEmpty,sum,isEmpty]
                                             Project [ss_quantity,ss_sales_price,c_customer_sk]
@@ -248,12 +278,12 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                                   WholeStageCodegen (39)
                                                     Sort [ss_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [ss_customer_sk,ss_quantity,ss_sales_price] #8
+                                                        ReusedExchange [ss_customer_sk,ss_quantity,ss_sales_price] #9
                                                 InputAdapter
                                                   WholeStageCodegen (41)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [c_customer_sk] #9
+                                                        ReusedExchange [c_customer_sk] #11
                             InputAdapter
                               ReusedExchange [d_date_sk] #4
                     InputAdapter
@@ -263,13 +293,13 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                             WholeStageCodegen (46)
                               Sort [c_customer_sk]
                                 InputAdapter
-                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #13
+                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #17
                           InputAdapter
                             WholeStageCodegen (51)
                               Sort [c_customer_sk]
                                 Project [c_customer_sk]
                                   Filter [ssales]
-                                    ReusedSubquery [tpcds_cmax] #3
+                                    ReusedSubquery [tpcds_cmax] #5
                                     HashAggregate [c_customer_sk,sum,isEmpty] [sum((cast(ss_quantity as decimal(10,0)) * ss_sales_price)),ssales,sum,isEmpty]
                                       HashAggregate [c_customer_sk,ss_quantity,ss_sales_price] [sum,isEmpty,sum,isEmpty]
                                         Project [ss_quantity,ss_sales_price,c_customer_sk]
@@ -278,9 +308,24 @@ TakeOrderedAndProject [c_last_name,c_first_name,sales]
                                               WholeStageCodegen (48)
                                                 Sort [ss_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [ss_customer_sk,ss_quantity,ss_sales_price] #8
+                                                    ReusedExchange [ss_customer_sk,ss_quantity,ss_sales_price] #9
                                             InputAdapter
                                               WholeStageCodegen (50)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [c_customer_sk] #9
+                                                    Exchange [c_customer_sk] #23
+                                                      WholeStageCodegen (49)
+                                                        Filter [c_customer_sk]
+                                                          Subquery #9
+                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                              Exchange #24
+                                                                ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                  Exchange [c_customer_sk] #25
+                                                                    WholeStageCodegen (1)
+                                                                      Filter [c_customer_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.customer [c_customer_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -1,19 +1,19 @@
 == Physical Plan ==
-* Filter (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * HashAggregate (45)
-            +- Exchange (44)
-               +- * HashAggregate (43)
-                  +- * Project (42)
-                     +- * BroadcastHashJoin Inner BuildRight (41)
-                        :- * Project (29)
-                        :  +- * SortMergeJoin Inner (28)
-                        :     :- * Sort (21)
-                        :     :  +- Exchange (20)
-                        :     :     +- * Project (19)
-                        :     :        +- * SortMergeJoin Inner (18)
+* Filter (46)
++- * HashAggregate (45)
+   +- Exchange (44)
+      +- * HashAggregate (43)
+         +- * HashAggregate (42)
+            +- Exchange (41)
+               +- * HashAggregate (40)
+                  +- * Project (39)
+                     +- * BroadcastHashJoin Inner BuildRight (38)
+                        :- * Project (26)
+                        :  +- * SortMergeJoin Inner (25)
+                        :     :- * Sort (18)
+                        :     :  +- Exchange (17)
+                        :     :     +- * Project (16)
+                        :     :        +- * SortMergeJoin Inner (15)
                         :     :           :- * Sort (12)
                         :     :           :  +- Exchange (11)
                         :     :           :     +- * Project (10)
@@ -26,28 +26,25 @@
                         :     :           :              +- * Filter (7)
                         :     :           :                 +- * ColumnarToRow (6)
                         :     :           :                    +- Scan parquet spark_catalog.default.item (5)
-                        :     :           +- * Sort (17)
-                        :     :              +- Exchange (16)
-                        :     :                 +- * Filter (15)
-                        :     :                    +- * ColumnarToRow (14)
-                        :     :                       +- Scan parquet spark_catalog.default.customer (13)
-                        :     +- * Sort (27)
-                        :        +- Exchange (26)
-                        :           +- * Project (25)
-                        :              +- * Filter (24)
-                        :                 +- * ColumnarToRow (23)
-                        :                    +- Scan parquet spark_catalog.default.store_returns (22)
-                        +- BroadcastExchange (40)
-                           +- * Project (39)
-                              +- * BroadcastHashJoin Inner BuildLeft (38)
-                                 :- BroadcastExchange (34)
-                                 :  +- * Project (33)
-                                 :     +- * Filter (32)
-                                 :        +- * ColumnarToRow (31)
-                                 :           +- Scan parquet spark_catalog.default.store (30)
-                                 +- * Filter (37)
-                                    +- * ColumnarToRow (36)
-                                       +- Scan parquet spark_catalog.default.customer_address (35)
+                        :     :           +- * Sort (14)
+                        :     :              +- ReusedExchange (13)
+                        :     +- * Sort (24)
+                        :        +- Exchange (23)
+                        :           +- * Project (22)
+                        :              +- * Filter (21)
+                        :                 +- * ColumnarToRow (20)
+                        :                    +- Scan parquet spark_catalog.default.store_returns (19)
+                        +- BroadcastExchange (37)
+                           +- * Project (36)
+                              +- * BroadcastHashJoin Inner BuildLeft (35)
+                                 :- BroadcastExchange (31)
+                                 :  +- * Project (30)
+                                 :     +- * Filter (29)
+                                 :        +- * ColumnarToRow (28)
+                                 :           +- Scan parquet spark_catalog.default.store (27)
+                                 +- * Filter (34)
+                                    +- * ColumnarToRow (33)
+                                       +- Scan parquet spark_catalog.default.customer_address (32)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -62,490 +59,615 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2))
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_customer_sk#2, 42), false))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
 (5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,pale                ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
 (7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Condition : ((isnotnull(i_color#10) AND (i_color#10 = pale                )) AND isnotnull(i_item_sk#7))
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Condition : ((isnotnull(i_color#12) AND (i_color#12 = pale                )) AND isnotnull(i_item_sk#9))
 
 (8) BroadcastExchange
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
 (11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
-(13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
-ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
+(13) ReusedExchange [Reuses operator id: 111]
+Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
-(14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+(14) Sort [codegen id : 5]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
 
-(15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Condition : (isnotnull(c_customer_sk#13) AND isnotnull(c_birth_country#16))
-
-(16) Exchange
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(c_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
-
-(18) SortMergeJoin [codegen id : 6]
+(15) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#13]
+Right keys [1]: [c_customer_sk#15]
 Join type: Inner
 Join condition: None
 
-(19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+(16) Project [codegen id : 6]
+Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
-(20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(17) Exchange
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+(18) Sort [codegen id : 7]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+(19) Scan parquet spark_catalog.default.store_returns
+Output [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
-(23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+(20) ColumnarToRow [codegen id : 8]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 
-(24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
-Condition : (isnotnull(sr_ticket_number#18) AND isnotnull(sr_item_sk#17))
+(21) Filter [codegen id : 8]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Condition : (isnotnull(sr_ticket_number#20) AND isnotnull(sr_item_sk#19))
 
-(25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#17, sr_ticket_number#18]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+(22) Project [codegen id : 8]
+Output [2]: [sr_item_sk#19, sr_ticket_number#20]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 
-(26) Exchange
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: hashpartitioning(sr_ticket_number#18, sr_item_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(23) Exchange
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST], false, 0
+(24) Sort [codegen id : 9]
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
 
-(28) SortMergeJoin [codegen id : 12]
+(25) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, sr_item_sk#17, sr_ticket_number#18]
+(26) Project [codegen id : 12]
+Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
 
-(30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(27) Scan parquet spark_catalog.default.store
+Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
-(31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(28) ColumnarToRow [codegen id : 10]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
-Condition : (((isnotnull(s_market_id#22) AND (s_market_id#22 = 8)) AND isnotnull(s_store_sk#20)) AND isnotnull(s_zip#24))
+(29) Filter [codegen id : 10]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
 
-(33) Project [codegen id : 10]
-Output [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(30) Project [codegen id : 10]
+Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(34) BroadcastExchange
-Input [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
+(31) BroadcastExchange
+Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=5]
 
-(35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
+(32) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(36) ColumnarToRow
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
+(33) ColumnarToRow
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 
-(37) Filter
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
+(34) Filter
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
 
-(38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#24]
-Right keys [1]: [ca_zip#26]
+(35) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [s_zip#26]
+Right keys [1]: [ca_zip#28]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
-Output [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
-Input [7]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24, ca_state#25, ca_zip#26, ca_country#27]
+(36) Project [codegen id : 11]
+Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
 
-(40) BroadcastExchange
-Input [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
+(37) BroadcastExchange
+Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=6]
 
-(41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#16]
-Right keys [2]: [s_store_sk#20, upper(ca_country#27)]
+(38) BroadcastHashJoin [codegen id : 12]
+Left keys [2]: [ss_store_sk#3, c_birth_country#18]
+Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
 Join type: Inner
 Join condition: None
 
-(42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
+(39) Project [codegen id : 12]
+Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 
-(43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
+(40) HashAggregate [codegen id : 12]
+Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#28]
-Results [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
+Aggregate Attributes [1]: [sum#30]
+Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+
+(41) Exchange
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(42) HashAggregate [codegen id : 13]
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
+Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
+
+(43) HashAggregate [codegen id : 13]
+Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
+Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
+Functions [1]: [partial_sum(netpaid#33)]
+Aggregate Attributes [2]: [sum#34, isEmpty#35]
+Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
 
 (44) Exchange
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#30]
-Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#30,17,2) AS netpaid#31]
+(45) HashAggregate [codegen id : 14]
+Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
+Functions [1]: [sum(netpaid#33)]
+Aggregate Attributes [1]: [sum(netpaid#33)#38]
+Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
 
-(46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, netpaid#31]
-Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
-Functions [1]: [partial_sum(netpaid#31)]
-Aggregate Attributes [2]: [sum#32, isEmpty#33]
-Results [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-
-(47) Exchange
-Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
-Functions [1]: [sum(netpaid#31)]
-Aggregate Attributes [1]: [sum(netpaid#31)#36]
-Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, sum(netpaid#31)#36 AS paid#37]
-
-(49) Filter [codegen id : 14]
-Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, paid#37]
-Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#39] as decimal(33,8))))
+(46) Filter [codegen id : 14]
+Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
+Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#38, [id=#39]
-* HashAggregate (96)
-+- Exchange (95)
-   +- * HashAggregate (94)
-      +- * HashAggregate (93)
-         +- Exchange (92)
-            +- * HashAggregate (91)
-               +- * Project (90)
-                  +- * SortMergeJoin Inner (89)
-                     :- * Sort (83)
-                     :  +- Exchange (82)
-                     :     +- * Project (81)
-                     :        +- * SortMergeJoin Inner (80)
-                     :           :- * Sort (77)
-                     :           :  +- Exchange (76)
-                     :           :     +- * Project (75)
-                     :           :        +- * SortMergeJoin Inner (74)
-                     :           :           :- * Sort (71)
-                     :           :           :  +- Exchange (70)
-                     :           :           :     +- * Project (69)
-                     :           :           :        +- * SortMergeJoin Inner (68)
-                     :           :           :           :- * Sort (62)
-                     :           :           :           :  +- Exchange (61)
-                     :           :           :           :     +- * Project (60)
-                     :           :           :           :        +- * BroadcastHashJoin Inner BuildRight (59)
-                     :           :           :           :           :- * Project (53)
-                     :           :           :           :           :  +- * Filter (52)
-                     :           :           :           :           :     +- * ColumnarToRow (51)
-                     :           :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (50)
-                     :           :           :           :           +- BroadcastExchange (58)
-                     :           :           :           :              +- * Project (57)
-                     :           :           :           :                 +- * Filter (56)
-                     :           :           :           :                    +- * ColumnarToRow (55)
-                     :           :           :           :                       +- Scan parquet spark_catalog.default.store (54)
-                     :           :           :           +- * Sort (67)
-                     :           :           :              +- Exchange (66)
-                     :           :           :                 +- * Filter (65)
-                     :           :           :                    +- * ColumnarToRow (64)
-                     :           :           :                       +- Scan parquet spark_catalog.default.item (63)
-                     :           :           +- * Sort (73)
-                     :           :              +- ReusedExchange (72)
-                     :           +- * Sort (79)
-                     :              +- ReusedExchange (78)
-                     +- * Sort (88)
-                        +- Exchange (87)
-                           +- * Filter (86)
-                              +- * ColumnarToRow (85)
-                                 +- Scan parquet spark_catalog.default.customer_address (84)
+Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+* HashAggregate (93)
++- Exchange (92)
+   +- * HashAggregate (91)
+      +- * HashAggregate (90)
+         +- Exchange (89)
+            +- * HashAggregate (88)
+               +- * Project (87)
+                  +- * SortMergeJoin Inner (86)
+                     :- * Sort (80)
+                     :  +- Exchange (79)
+                     :     +- * Project (78)
+                     :        +- * SortMergeJoin Inner (77)
+                     :           :- * Sort (74)
+                     :           :  +- Exchange (73)
+                     :           :     +- * Project (72)
+                     :           :        +- * SortMergeJoin Inner (71)
+                     :           :           :- * Sort (65)
+                     :           :           :  +- Exchange (64)
+                     :           :           :     +- * Project (63)
+                     :           :           :        +- * SortMergeJoin Inner (62)
+                     :           :           :           :- * Sort (59)
+                     :           :           :           :  +- Exchange (58)
+                     :           :           :           :     +- * Project (57)
+                     :           :           :           :        +- * BroadcastHashJoin Inner BuildRight (56)
+                     :           :           :           :           :- * Project (50)
+                     :           :           :           :           :  +- * Filter (49)
+                     :           :           :           :           :     +- * ColumnarToRow (48)
+                     :           :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (47)
+                     :           :           :           :           +- BroadcastExchange (55)
+                     :           :           :           :              +- * Project (54)
+                     :           :           :           :                 +- * Filter (53)
+                     :           :           :           :                    +- * ColumnarToRow (52)
+                     :           :           :           :                       +- Scan parquet spark_catalog.default.store (51)
+                     :           :           :           +- * Sort (61)
+                     :           :           :              +- ReusedExchange (60)
+                     :           :           +- * Sort (70)
+                     :           :              +- Exchange (69)
+                     :           :                 +- * Filter (68)
+                     :           :                    +- * ColumnarToRow (67)
+                     :           :                       +- Scan parquet spark_catalog.default.customer (66)
+                     :           +- * Sort (76)
+                     :              +- ReusedExchange (75)
+                     +- * Sort (85)
+                        +- Exchange (84)
+                           +- * Filter (83)
+                              +- * ColumnarToRow (82)
+                                 +- Scan parquet spark_catalog.default.customer_address (81)
 
 
-(50) Scan parquet spark_catalog.default.store_sales
+(47) Scan parquet spark_catalog.default.store_sales
 Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
-(51) ColumnarToRow [codegen id : 2]
+(48) ColumnarToRow [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
-(52) Filter [codegen id : 2]
+(49) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2))
+Condition : (((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#42, [id=#43], xxhash64(ss_item_sk#1, 42), false)) AND true)
 
-(53) Project [codegen id : 2]
+(50) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
-(54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(51) Scan parquet spark_catalog.default.store
+Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
-(55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(52) ColumnarToRow [codegen id : 1]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
-Condition : (((isnotnull(s_market_id#22) AND (s_market_id#22 = 8)) AND isnotnull(s_store_sk#20)) AND isnotnull(s_zip#24))
+(53) Filter [codegen id : 1]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Condition : ((((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26)) AND might_contain(Subquery scalar-subquery#44, [id=#45].bloomFilter, xxhash64(s_zip#26, 42), false))
 
-(57) Project [codegen id : 1]
-Output [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(54) Project [codegen id : 1]
+Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(58) BroadcastExchange
-Input [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(55) BroadcastExchange
+Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-(59) BroadcastHashJoin [codegen id : 2]
+(56) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#20]
+Right keys [1]: [s_store_sk#22]
 Join type: Inner
 Join condition: None
 
-(60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
+(57) Project [codegen id : 2]
+Output [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26]
+Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
 
-(61) Exchange
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(58) Exchange
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24]
+(59) Sort [codegen id : 3]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
+(60) ReusedExchange [Reuses operator id: 97]
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
-(64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+(61) Sort [codegen id : 5]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: [i_item_sk#9 ASC NULLS FIRST], false, 0
 
-(65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Condition : isnotnull(i_item_sk#7)
-
-(66) Exchange
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
-
-(68) SortMergeJoin [codegen id : 6]
+(62) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
-(69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+(63) Project [codegen id : 6]
+Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
-(70) Exchange
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+(64) Exchange
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+(65) Sort [codegen id : 7]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
-(72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+(66) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
-(73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
+(67) ColumnarToRow [codegen id : 8]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
-(74) SortMergeJoin [codegen id : 10]
+(68) Filter [codegen id : 8]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Condition : ((isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18)) AND might_contain(ReusedSubquery Subquery scalar-subquery#44, [id=#45].bloomFilter, xxhash64(c_birth_country#18, 42), false))
+
+(69) Exchange
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(70) Sort [codegen id : 9]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
+
+(71) SortMergeJoin [codegen id : 10]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#13]
+Right keys [1]: [c_customer_sk#15]
 Join type: Inner
 Join condition: None
 
-(75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [16]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+(72) Project [codegen id : 10]
+Output [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [16]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
-(76) Exchange
-Input [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+(73) Exchange
+Input [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+(74) Sort [codegen id : 11]
+Input [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#17, sr_ticket_number#18]
+(75) ReusedExchange [Reuses operator id: 23]
+Output [2]: [sr_item_sk#19, sr_ticket_number#20]
 
-(79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST], false, 0
+(76) Sort [codegen id : 13]
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
 
-(80) SortMergeJoin [codegen id : 14]
+(77) SortMergeJoin [codegen id : 14]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
 Join type: Inner
 Join condition: None
 
-(81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [16]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, sr_item_sk#17, sr_ticket_number#18]
+(78) Project [codegen id : 14]
+Output [12]: [ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [16]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
 
-(82) Exchange
-Input [12]: [ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(c_birth_country#16, s_zip#24, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+(79) Exchange
+Input [12]: [ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(c_birth_country#18, s_zip#26, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: [c_birth_country#16 ASC NULLS FIRST, s_zip#24 ASC NULLS FIRST], false, 0
+(80) Sort [codegen id : 15]
+Input [12]: [ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [c_birth_country#18 ASC NULLS FIRST, s_zip#26 ASC NULLS FIRST], false, 0
 
-(84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
+(81) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
+(82) ColumnarToRow [codegen id : 16]
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 
-(86) Filter [codegen id : 16]
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
+(83) Filter [codegen id : 16]
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
 
-(87) Exchange
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Arguments: hashpartitioning(upper(ca_country#27), ca_zip#26, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+(84) Exchange
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Arguments: hashpartitioning(upper(ca_country#29), ca_zip#28, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(88) Sort [codegen id : 17]
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Arguments: [upper(ca_country#27) ASC NULLS FIRST, ca_zip#26 ASC NULLS FIRST], false, 0
+(85) Sort [codegen id : 17]
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Arguments: [upper(ca_country#29) ASC NULLS FIRST, ca_zip#28 ASC NULLS FIRST], false, 0
 
-(89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#16, s_zip#24]
-Right keys [2]: [upper(ca_country#27), ca_zip#26]
+(86) SortMergeJoin [codegen id : 18]
+Left keys [2]: [c_birth_country#18, s_zip#26]
+Right keys [2]: [upper(ca_country#29), ca_zip#28]
 Join type: Inner
 Join condition: None
 
-(90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Input [15]: [ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, ca_state#25, ca_zip#26, ca_country#27]
+(87) Project [codegen id : 18]
+Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Input [15]: [ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, ca_state#27, ca_zip#28, ca_country#29]
 
-(91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
+(88) HashAggregate [codegen id : 18]
+Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#40]
-Results [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#41]
+Aggregate Attributes [1]: [sum#46]
+Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#47]
+
+(89) Exchange
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#47]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(90) HashAggregate [codegen id : 19]
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#47]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
+
+(91) HashAggregate [codegen id : 19]
+Input [1]: [netpaid#33]
+Keys: []
+Functions [1]: [partial_avg(netpaid#33)]
+Aggregate Attributes [2]: [sum#48, count#49]
+Results [2]: [sum#50, count#51]
 
 (92) Exchange
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#41]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [2]: [sum#50, count#51]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
 
-(93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#41]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#30]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#30,17,2) AS netpaid#31]
-
-(94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#31]
+(93) HashAggregate [codegen id : 20]
+Input [2]: [sum#50, count#51]
 Keys: []
-Functions [1]: [partial_avg(netpaid#31)]
-Aggregate Attributes [2]: [sum#42, count#43]
-Results [2]: [sum#44, count#45]
+Functions [1]: [avg(netpaid#33)]
+Aggregate Attributes [1]: [avg(netpaid#33)#52]
+Results [1]: [(0.05 * avg(netpaid#33)#52) AS (0.05 * avg(netpaid))#53]
 
-(95) Exchange
-Input [2]: [sum#44, count#45]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+Subquery:2 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#42, [id=#43]
+ObjectHashAggregate (100)
++- Exchange (99)
+   +- ObjectHashAggregate (98)
+      +- Exchange (97)
+         +- * Filter (96)
+            +- * ColumnarToRow (95)
+               +- Scan parquet spark_catalog.default.item (94)
 
-(96) HashAggregate [codegen id : 20]
-Input [2]: [sum#44, count#45]
+
+(94) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
+
+(95) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+
+(96) Filter [codegen id : 1]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Condition : isnotnull(i_item_sk#9)
+
+(97) Exchange
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: hashpartitioning(i_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(98) ObjectHashAggregate
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Keys: []
-Functions [1]: [avg(netpaid#31)]
-Aggregate Attributes [1]: [avg(netpaid#31)#46]
-Results [1]: [(0.05 * avg(netpaid#31)#46) AS (0.05 * avg(netpaid))#47]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#9, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#54]
+Results [1]: [buf#55]
+
+(99) Exchange
+Input [1]: [buf#55]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+
+(100) ObjectHashAggregate
+Input [1]: [buf#55]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#9, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#9, 42), 204000, 1632000, 0, 0)#56]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#9, 42), 204000, 1632000, 0, 0)#56 AS bloomFilter#57]
+
+Subquery:3 Hosting operator id = 53 Hosting Expression = Subquery scalar-subquery#44, [id=#45]
+* Project (107)
++- ObjectHashAggregate (106)
+   +- Exchange (105)
+      +- ObjectHashAggregate (104)
+         +- * Filter (103)
+            +- * ColumnarToRow (102)
+               +- Scan parquet spark_catalog.default.customer_address (101)
+
+
+(101) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_zip#28, ca_country#29]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
+ReadSchema: struct<ca_zip:string,ca_country:string>
+
+(102) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_zip#28, ca_country#29]
+
+(103) Filter [codegen id : 1]
+Input [2]: [ca_zip#28, ca_country#29]
+Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
+
+(104) ObjectHashAggregate
+Input [2]: [ca_zip#28, ca_country#29]
+Keys: []
+Functions [2]: [partial_bloom_filter_agg(xxhash64(ca_zip#28, 42), 940448, 7523584, 0, 0), partial_bloom_filter_agg(xxhash64(upper(ca_country#29), 42), 940448, 7523584, 0, 0)]
+Aggregate Attributes [2]: [buf#58, buf#59]
+Results [2]: [buf#60, buf#61]
+
+(105) Exchange
+Input [2]: [buf#60, buf#61]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+
+(106) ObjectHashAggregate
+Input [2]: [buf#60, buf#61]
+Keys: []
+Functions [2]: [bloom_filter_agg(xxhash64(ca_zip#28, 42), 940448, 7523584, 0, 0), bloom_filter_agg(xxhash64(upper(ca_country#29), 42), 940448, 7523584, 0, 0)]
+Aggregate Attributes [2]: [bloom_filter_agg(xxhash64(ca_zip#28, 42), 940448, 7523584, 0, 0)#62, bloom_filter_agg(xxhash64(upper(ca_country#29), 42), 940448, 7523584, 0, 0)#63]
+Results [2]: [bloom_filter_agg(xxhash64(ca_zip#28, 42), 940448, 7523584, 0, 0)#62 AS bloomFilter#64, bloom_filter_agg(xxhash64(upper(ca_country#29), 42), 940448, 7523584, 0, 0)#63 AS bloomFilter#65]
+
+(107) Project [codegen id : 2]
+Output [1]: [named_struct(bloomFilter, bloomFilter#64, bloomFilter, bloomFilter#65) AS mergedValue#66]
+Input [2]: [bloomFilter#64, bloomFilter#65]
+
+Subquery:4 Hosting operator id = 68 Hosting Expression = ReusedSubquery Subquery scalar-subquery#44, [id=#45]
+
+Subquery:5 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (114)
++- Exchange (113)
+   +- ObjectHashAggregate (112)
+      +- Exchange (111)
+         +- * Filter (110)
+            +- * ColumnarToRow (109)
+               +- Scan parquet spark_catalog.default.customer (108)
+
+
+(108) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
+
+(109) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+
+(110) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18))
+
+(111) Exchange
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+
+(112) ObjectHashAggregate
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#15, 42), 1930374, 15442992, 0, 0)]
+Aggregate Attributes [1]: [buf#67]
+Results [1]: [buf#68]
+
+(113) Exchange
+Input [1]: [buf#68]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
+
+(114) ObjectHashAggregate
+Input [1]: [buf#68]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#15, 42), 1930374, 15442992, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#15, 42), 1930374, 15442992, 0, 0)#69]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#15, 42), 1930374, 15442992, 0, 0)#69 AS bloomFilter#70]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
@@ -1,15 +1,15 @@
 WholeStageCodegen (14)
   Filter [paid]
-    Subquery #1
+    Subquery #2
       WholeStageCodegen (20)
         HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
           InputAdapter
-            Exchange #10
+            Exchange #11
               WholeStageCodegen (19)
                 HashAggregate [netpaid] [sum,count,sum,count]
                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                     InputAdapter
-                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #11
+                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #12
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
@@ -18,7 +18,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (15)
                                     Sort [c_birth_country,s_zip]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #12
+                                        Exchange [c_birth_country,s_zip] #13
                                           WholeStageCodegen (14)
                                             Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                               SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
@@ -26,7 +26,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (11)
                                                     Sort [ss_ticket_number,ss_item_sk]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #13
+                                                        Exchange [ss_ticket_number,ss_item_sk] #14
                                                           WholeStageCodegen (10)
                                                             Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                                               SortMergeJoin [ss_customer_sk,c_customer_sk]
@@ -34,7 +34,7 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (7)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #14
+                                                                        Exchange [ss_customer_sk] #15
                                                                           WholeStageCodegen (6)
                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                               SortMergeJoin [ss_item_sk,i_item_sk]
@@ -42,20 +42,42 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (3)
                                                                                     Sort [ss_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #15
+                                                                                        Exchange [ss_item_sk] #16
                                                                                           WholeStageCodegen (2)
                                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
                                                                                               BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                                                                 Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                                                   Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                                    Subquery #3
+                                                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                                                        Exchange #17
+                                                                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                                            Exchange [i_item_sk] #18
+                                                                                                              WholeStageCodegen (1)
+                                                                                                                Filter [i_item_sk]
+                                                                                                                  ColumnarToRow
+                                                                                                                    InputAdapter
+                                                                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                                                     ColumnarToRow
                                                                                                       InputAdapter
                                                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                                 InputAdapter
-                                                                                                  BroadcastExchange #16
+                                                                                                  BroadcastExchange #19
                                                                                                     WholeStageCodegen (1)
                                                                                                       Project [s_store_sk,s_store_name,s_state,s_zip]
                                                                                                         Filter [s_market_id,s_store_sk,s_zip]
+                                                                                                          Subquery #4
+                                                                                                            WholeStageCodegen (2)
+                                                                                                              Project [bloomFilter,bloomFilter]
+                                                                                                                InputAdapter
+                                                                                                                  ObjectHashAggregate [buf,buf] [bloom_filter_agg(xxhash64(ca_zip, 42), 940448, 7523584, 0, 0),bloom_filter_agg(xxhash64(upper(ca_country), 42), 940448, 7523584, 0, 0),bloomFilter,bloomFilter,buf,buf]
+                                                                                                                    Exchange #20
+                                                                                                                      ObjectHashAggregate [ca_zip,ca_country] [buf,buf,buf,buf]
+                                                                                                                        WholeStageCodegen (1)
+                                                                                                                          Filter [ca_country,ca_zip]
+                                                                                                                            ColumnarToRow
+                                                                                                                              InputAdapter
+                                                                                                                                Scan parquet spark_catalog.default.customer_address [ca_zip,ca_country]
                                                                                                           ColumnarToRow
                                                                                                             InputAdapter
                                                                                                               Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
@@ -63,27 +85,28 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (5)
                                                                                     Sort [i_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [i_item_sk] #17
-                                                                                          WholeStageCodegen (4)
-                                                                                            Filter [i_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                                        ReusedExchange [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id] #18
                                                                 InputAdapter
                                                                   WholeStageCodegen (9)
                                                                     Sort [c_customer_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #6
+                                                                        Exchange [c_customer_sk] #21
+                                                                          WholeStageCodegen (8)
+                                                                            Filter [c_customer_sk,c_birth_country]
+                                                                              ReusedSubquery [mergedValue] #4
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [sr_ticket_number,sr_item_sk]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #7
+                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
                                 InputAdapter
                                   WholeStageCodegen (17)
                                     Sort [ca_country,ca_zip]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #18
+                                        Exchange [ca_country,ca_zip] #22
                                           WholeStageCodegen (16)
                                             Filter [ca_country,ca_zip]
                                               ColumnarToRow
@@ -121,11 +144,21 @@ WholeStageCodegen (14)
                                                               BroadcastHashJoin [ss_item_sk,i_item_sk]
                                                                 Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                   Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                    Subquery #1
+                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 1930374, 15442992, 0, 0),bloomFilter,buf]
+                                                                        Exchange #5
+                                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                            Exchange [c_customer_sk] #6
+                                                                              WholeStageCodegen (1)
+                                                                                Filter [c_customer_sk,c_birth_country]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                 InputAdapter
-                                                                  BroadcastExchange #5
+                                                                  BroadcastExchange #7
                                                                     WholeStageCodegen (1)
                                                                       Filter [i_color,i_item_sk]
                                                                         ColumnarToRow
@@ -135,17 +168,12 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #6
-                                                          WholeStageCodegen (4)
-                                                            Filter [c_customer_sk,c_birth_country]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
+                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #6
                                 InputAdapter
                                   WholeStageCodegen (9)
                                     Sort [sr_ticket_number,sr_item_sk]
                                       InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #7
+                                        Exchange [sr_ticket_number,sr_item_sk] #8
                                           WholeStageCodegen (8)
                                             Project [sr_item_sk,sr_ticket_number]
                                               Filter [sr_ticket_number,sr_item_sk]
@@ -153,12 +181,12 @@ WholeStageCodegen (14)
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                             InputAdapter
-                              BroadcastExchange #8
+                              BroadcastExchange #9
                                 WholeStageCodegen (11)
                                   Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
                                     BroadcastHashJoin [s_zip,ca_zip]
                                       InputAdapter
-                                        BroadcastExchange #9
+                                        BroadcastExchange #10
                                           WholeStageCodegen (10)
                                             Project [s_store_sk,s_store_name,s_state,s_zip]
                                               Filter [s_market_id,s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -1,19 +1,19 @@
 == Physical Plan ==
-* Filter (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * HashAggregate (45)
-            +- Exchange (44)
-               +- * HashAggregate (43)
-                  +- * Project (42)
-                     +- * BroadcastHashJoin Inner BuildRight (41)
-                        :- * Project (29)
-                        :  +- * SortMergeJoin Inner (28)
-                        :     :- * Sort (21)
-                        :     :  +- Exchange (20)
-                        :     :     +- * Project (19)
-                        :     :        +- * SortMergeJoin Inner (18)
+* Filter (46)
++- * HashAggregate (45)
+   +- Exchange (44)
+      +- * HashAggregate (43)
+         +- * HashAggregate (42)
+            +- Exchange (41)
+               +- * HashAggregate (40)
+                  +- * Project (39)
+                     +- * BroadcastHashJoin Inner BuildRight (38)
+                        :- * Project (26)
+                        :  +- * SortMergeJoin Inner (25)
+                        :     :- * Sort (18)
+                        :     :  +- Exchange (17)
+                        :     :     +- * Project (16)
+                        :     :        +- * SortMergeJoin Inner (15)
                         :     :           :- * Sort (12)
                         :     :           :  +- Exchange (11)
                         :     :           :     +- * Project (10)
@@ -26,28 +26,25 @@
                         :     :           :              +- * Filter (7)
                         :     :           :                 +- * ColumnarToRow (6)
                         :     :           :                    +- Scan parquet spark_catalog.default.item (5)
-                        :     :           +- * Sort (17)
-                        :     :              +- Exchange (16)
-                        :     :                 +- * Filter (15)
-                        :     :                    +- * ColumnarToRow (14)
-                        :     :                       +- Scan parquet spark_catalog.default.customer (13)
-                        :     +- * Sort (27)
-                        :        +- Exchange (26)
-                        :           +- * Project (25)
-                        :              +- * Filter (24)
-                        :                 +- * ColumnarToRow (23)
-                        :                    +- Scan parquet spark_catalog.default.store_returns (22)
-                        +- BroadcastExchange (40)
-                           +- * Project (39)
-                              +- * BroadcastHashJoin Inner BuildLeft (38)
-                                 :- BroadcastExchange (34)
-                                 :  +- * Project (33)
-                                 :     +- * Filter (32)
-                                 :        +- * ColumnarToRow (31)
-                                 :           +- Scan parquet spark_catalog.default.store (30)
-                                 +- * Filter (37)
-                                    +- * ColumnarToRow (36)
-                                       +- Scan parquet spark_catalog.default.customer_address (35)
+                        :     :           +- * Sort (14)
+                        :     :              +- ReusedExchange (13)
+                        :     +- * Sort (24)
+                        :        +- Exchange (23)
+                        :           +- * Project (22)
+                        :              +- * Filter (21)
+                        :                 +- * ColumnarToRow (20)
+                        :                    +- Scan parquet spark_catalog.default.store_returns (19)
+                        +- BroadcastExchange (37)
+                           +- * Project (36)
+                              +- * BroadcastHashJoin Inner BuildLeft (35)
+                                 :- BroadcastExchange (31)
+                                 :  +- * Project (30)
+                                 :     +- * Filter (29)
+                                 :        +- * ColumnarToRow (28)
+                                 :           +- Scan parquet spark_catalog.default.store (27)
+                                 +- * Filter (34)
+                                    +- * ColumnarToRow (33)
+                                       +- Scan parquet spark_catalog.default.customer_address (32)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -62,490 +59,615 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2))
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_customer_sk#2, 42), false))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
 (5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,chiffon             ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
 (7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Condition : ((isnotnull(i_color#10) AND (i_color#10 = chiffon             )) AND isnotnull(i_item_sk#7))
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Condition : ((isnotnull(i_color#12) AND (i_color#12 = chiffon             )) AND isnotnull(i_item_sk#9))
 
 (8) BroadcastExchange
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
 (11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
-(13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
-ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
+(13) ReusedExchange [Reuses operator id: 111]
+Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
-(14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+(14) Sort [codegen id : 5]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
 
-(15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Condition : (isnotnull(c_customer_sk#13) AND isnotnull(c_birth_country#16))
-
-(16) Exchange
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(c_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
-
-(18) SortMergeJoin [codegen id : 6]
+(15) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#13]
+Right keys [1]: [c_customer_sk#15]
 Join type: Inner
 Join condition: None
 
-(19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+(16) Project [codegen id : 6]
+Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
-(20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(17) Exchange
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+(18) Sort [codegen id : 7]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+(19) Scan parquet spark_catalog.default.store_returns
+Output [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
-(23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+(20) ColumnarToRow [codegen id : 8]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 
-(24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
-Condition : (isnotnull(sr_ticket_number#18) AND isnotnull(sr_item_sk#17))
+(21) Filter [codegen id : 8]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Condition : (isnotnull(sr_ticket_number#20) AND isnotnull(sr_item_sk#19))
 
-(25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#17, sr_ticket_number#18]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+(22) Project [codegen id : 8]
+Output [2]: [sr_item_sk#19, sr_ticket_number#20]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 
-(26) Exchange
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: hashpartitioning(sr_ticket_number#18, sr_item_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(23) Exchange
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST], false, 0
+(24) Sort [codegen id : 9]
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
 
-(28) SortMergeJoin [codegen id : 12]
+(25) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, sr_item_sk#17, sr_ticket_number#18]
+(26) Project [codegen id : 12]
+Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
 
-(30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(27) Scan parquet spark_catalog.default.store
+Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
-(31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(28) ColumnarToRow [codegen id : 10]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
-Condition : (((isnotnull(s_market_id#22) AND (s_market_id#22 = 8)) AND isnotnull(s_store_sk#20)) AND isnotnull(s_zip#24))
+(29) Filter [codegen id : 10]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
 
-(33) Project [codegen id : 10]
-Output [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(30) Project [codegen id : 10]
+Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(34) BroadcastExchange
-Input [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
+(31) BroadcastExchange
+Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=5]
 
-(35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
+(32) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(36) ColumnarToRow
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
+(33) ColumnarToRow
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 
-(37) Filter
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
+(34) Filter
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
 
-(38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#24]
-Right keys [1]: [ca_zip#26]
+(35) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [s_zip#26]
+Right keys [1]: [ca_zip#28]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
-Output [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
-Input [7]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24, ca_state#25, ca_zip#26, ca_country#27]
+(36) Project [codegen id : 11]
+Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
 
-(40) BroadcastExchange
-Input [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
+(37) BroadcastExchange
+Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=6]
 
-(41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#16]
-Right keys [2]: [s_store_sk#20, upper(ca_country#27)]
+(38) BroadcastHashJoin [codegen id : 12]
+Left keys [2]: [ss_store_sk#3, c_birth_country#18]
+Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
 Join type: Inner
 Join condition: None
 
-(42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
+(39) Project [codegen id : 12]
+Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 
-(43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
+(40) HashAggregate [codegen id : 12]
+Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#28]
-Results [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
+Aggregate Attributes [1]: [sum#30]
+Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+
+(41) Exchange
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(42) HashAggregate [codegen id : 13]
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
+Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
+
+(43) HashAggregate [codegen id : 13]
+Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
+Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
+Functions [1]: [partial_sum(netpaid#33)]
+Aggregate Attributes [2]: [sum#34, isEmpty#35]
+Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
 
 (44) Exchange
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#30]
-Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#30,17,2) AS netpaid#31]
+(45) HashAggregate [codegen id : 14]
+Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
+Functions [1]: [sum(netpaid#33)]
+Aggregate Attributes [1]: [sum(netpaid#33)#38]
+Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
 
-(46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, netpaid#31]
-Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
-Functions [1]: [partial_sum(netpaid#31)]
-Aggregate Attributes [2]: [sum#32, isEmpty#33]
-Results [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-
-(47) Exchange
-Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
-Functions [1]: [sum(netpaid#31)]
-Aggregate Attributes [1]: [sum(netpaid#31)#36]
-Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, sum(netpaid#31)#36 AS paid#37]
-
-(49) Filter [codegen id : 14]
-Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, paid#37]
-Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#39] as decimal(33,8))))
+(46) Filter [codegen id : 14]
+Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
+Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#38, [id=#39]
-* HashAggregate (96)
-+- Exchange (95)
-   +- * HashAggregate (94)
-      +- * HashAggregate (93)
-         +- Exchange (92)
-            +- * HashAggregate (91)
-               +- * Project (90)
-                  +- * SortMergeJoin Inner (89)
-                     :- * Sort (83)
-                     :  +- Exchange (82)
-                     :     +- * Project (81)
-                     :        +- * SortMergeJoin Inner (80)
-                     :           :- * Sort (77)
-                     :           :  +- Exchange (76)
-                     :           :     +- * Project (75)
-                     :           :        +- * SortMergeJoin Inner (74)
-                     :           :           :- * Sort (71)
-                     :           :           :  +- Exchange (70)
-                     :           :           :     +- * Project (69)
-                     :           :           :        +- * SortMergeJoin Inner (68)
-                     :           :           :           :- * Sort (62)
-                     :           :           :           :  +- Exchange (61)
-                     :           :           :           :     +- * Project (60)
-                     :           :           :           :        +- * BroadcastHashJoin Inner BuildRight (59)
-                     :           :           :           :           :- * Project (53)
-                     :           :           :           :           :  +- * Filter (52)
-                     :           :           :           :           :     +- * ColumnarToRow (51)
-                     :           :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (50)
-                     :           :           :           :           +- BroadcastExchange (58)
-                     :           :           :           :              +- * Project (57)
-                     :           :           :           :                 +- * Filter (56)
-                     :           :           :           :                    +- * ColumnarToRow (55)
-                     :           :           :           :                       +- Scan parquet spark_catalog.default.store (54)
-                     :           :           :           +- * Sort (67)
-                     :           :           :              +- Exchange (66)
-                     :           :           :                 +- * Filter (65)
-                     :           :           :                    +- * ColumnarToRow (64)
-                     :           :           :                       +- Scan parquet spark_catalog.default.item (63)
-                     :           :           +- * Sort (73)
-                     :           :              +- ReusedExchange (72)
-                     :           +- * Sort (79)
-                     :              +- ReusedExchange (78)
-                     +- * Sort (88)
-                        +- Exchange (87)
-                           +- * Filter (86)
-                              +- * ColumnarToRow (85)
-                                 +- Scan parquet spark_catalog.default.customer_address (84)
+Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+* HashAggregate (93)
++- Exchange (92)
+   +- * HashAggregate (91)
+      +- * HashAggregate (90)
+         +- Exchange (89)
+            +- * HashAggregate (88)
+               +- * Project (87)
+                  +- * SortMergeJoin Inner (86)
+                     :- * Sort (80)
+                     :  +- Exchange (79)
+                     :     +- * Project (78)
+                     :        +- * SortMergeJoin Inner (77)
+                     :           :- * Sort (74)
+                     :           :  +- Exchange (73)
+                     :           :     +- * Project (72)
+                     :           :        +- * SortMergeJoin Inner (71)
+                     :           :           :- * Sort (65)
+                     :           :           :  +- Exchange (64)
+                     :           :           :     +- * Project (63)
+                     :           :           :        +- * SortMergeJoin Inner (62)
+                     :           :           :           :- * Sort (59)
+                     :           :           :           :  +- Exchange (58)
+                     :           :           :           :     +- * Project (57)
+                     :           :           :           :        +- * BroadcastHashJoin Inner BuildRight (56)
+                     :           :           :           :           :- * Project (50)
+                     :           :           :           :           :  +- * Filter (49)
+                     :           :           :           :           :     +- * ColumnarToRow (48)
+                     :           :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (47)
+                     :           :           :           :           +- BroadcastExchange (55)
+                     :           :           :           :              +- * Project (54)
+                     :           :           :           :                 +- * Filter (53)
+                     :           :           :           :                    +- * ColumnarToRow (52)
+                     :           :           :           :                       +- Scan parquet spark_catalog.default.store (51)
+                     :           :           :           +- * Sort (61)
+                     :           :           :              +- ReusedExchange (60)
+                     :           :           +- * Sort (70)
+                     :           :              +- Exchange (69)
+                     :           :                 +- * Filter (68)
+                     :           :                    +- * ColumnarToRow (67)
+                     :           :                       +- Scan parquet spark_catalog.default.customer (66)
+                     :           +- * Sort (76)
+                     :              +- ReusedExchange (75)
+                     +- * Sort (85)
+                        +- Exchange (84)
+                           +- * Filter (83)
+                              +- * ColumnarToRow (82)
+                                 +- Scan parquet spark_catalog.default.customer_address (81)
 
 
-(50) Scan parquet spark_catalog.default.store_sales
+(47) Scan parquet spark_catalog.default.store_sales
 Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
-(51) ColumnarToRow [codegen id : 2]
+(48) ColumnarToRow [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
-(52) Filter [codegen id : 2]
+(49) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2))
+Condition : (((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#42, [id=#43], xxhash64(ss_item_sk#1, 42), false)) AND true)
 
-(53) Project [codegen id : 2]
+(50) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
-(54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(51) Scan parquet spark_catalog.default.store
+Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
-(55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(52) ColumnarToRow [codegen id : 1]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
-Condition : (((isnotnull(s_market_id#22) AND (s_market_id#22 = 8)) AND isnotnull(s_store_sk#20)) AND isnotnull(s_zip#24))
+(53) Filter [codegen id : 1]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Condition : ((((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26)) AND might_contain(Subquery scalar-subquery#44, [id=#45].bloomFilter, xxhash64(s_zip#26, 42), false))
 
-(57) Project [codegen id : 1]
-Output [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+(54) Project [codegen id : 1]
+Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(58) BroadcastExchange
-Input [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(55) BroadcastExchange
+Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-(59) BroadcastHashJoin [codegen id : 2]
+(56) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#20]
+Right keys [1]: [s_store_sk#22]
 Join type: Inner
 Join condition: None
 
-(60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
+(57) Project [codegen id : 2]
+Output [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26]
+Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
 
-(61) Exchange
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(58) Exchange
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24]
+(59) Sort [codegen id : 3]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
+(60) ReusedExchange [Reuses operator id: 97]
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
-(64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+(61) Sort [codegen id : 5]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: [i_item_sk#9 ASC NULLS FIRST], false, 0
 
-(65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Condition : isnotnull(i_item_sk#7)
-
-(66) Exchange
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
-
-(68) SortMergeJoin [codegen id : 6]
+(62) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
-(69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+(63) Project [codegen id : 6]
+Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
-(70) Exchange
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+(64) Exchange
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+(65) Sort [codegen id : 7]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
-(72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+(66) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
-(73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
+(67) ColumnarToRow [codegen id : 8]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
-(74) SortMergeJoin [codegen id : 10]
+(68) Filter [codegen id : 8]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Condition : ((isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18)) AND might_contain(ReusedSubquery Subquery scalar-subquery#44, [id=#45].bloomFilter, xxhash64(c_birth_country#18, 42), false))
+
+(69) Exchange
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(70) Sort [codegen id : 9]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
+
+(71) SortMergeJoin [codegen id : 10]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#13]
+Right keys [1]: [c_customer_sk#15]
 Join type: Inner
 Join condition: None
 
-(75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [16]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+(72) Project [codegen id : 10]
+Output [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [16]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
-(76) Exchange
-Input [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+(73) Exchange
+Input [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+(74) Sort [codegen id : 11]
+Input [14]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#17, sr_ticket_number#18]
+(75) ReusedExchange [Reuses operator id: 23]
+Output [2]: [sr_item_sk#19, sr_ticket_number#20]
 
-(79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST], false, 0
+(76) Sort [codegen id : 13]
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
 
-(80) SortMergeJoin [codegen id : 14]
+(77) SortMergeJoin [codegen id : 14]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
 Join type: Inner
 Join condition: None
 
-(81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [16]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, sr_item_sk#17, sr_ticket_number#18]
+(78) Project [codegen id : 14]
+Output [12]: [ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [16]: [ss_item_sk#1, ss_ticket_number#4, ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
 
-(82) Exchange
-Input [12]: [ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(c_birth_country#16, s_zip#24, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+(79) Exchange
+Input [12]: [ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(c_birth_country#18, s_zip#26, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: [c_birth_country#16 ASC NULLS FIRST, s_zip#24 ASC NULLS FIRST], false, 0
+(80) Sort [codegen id : 15]
+Input [12]: [ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [c_birth_country#18 ASC NULLS FIRST, s_zip#26 ASC NULLS FIRST], false, 0
 
-(84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
+(81) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
+(82) ColumnarToRow [codegen id : 16]
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 
-(86) Filter [codegen id : 16]
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
+(83) Filter [codegen id : 16]
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
 
-(87) Exchange
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Arguments: hashpartitioning(upper(ca_country#27), ca_zip#26, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+(84) Exchange
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Arguments: hashpartitioning(upper(ca_country#29), ca_zip#28, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(88) Sort [codegen id : 17]
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Arguments: [upper(ca_country#27) ASC NULLS FIRST, ca_zip#26 ASC NULLS FIRST], false, 0
+(85) Sort [codegen id : 17]
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Arguments: [upper(ca_country#29) ASC NULLS FIRST, ca_zip#28 ASC NULLS FIRST], false, 0
 
-(89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#16, s_zip#24]
-Right keys [2]: [upper(ca_country#27), ca_zip#26]
+(86) SortMergeJoin [codegen id : 18]
+Left keys [2]: [c_birth_country#18, s_zip#26]
+Right keys [2]: [upper(ca_country#29), ca_zip#28]
 Join type: Inner
 Join condition: None
 
-(90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Input [15]: [ss_net_paid#5, s_store_name#21, s_state#23, s_zip#24, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, ca_state#25, ca_zip#26, ca_country#27]
+(87) Project [codegen id : 18]
+Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Input [15]: [ss_net_paid#5, s_store_name#23, s_state#25, s_zip#26, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, ca_state#27, ca_zip#28, ca_country#29]
 
-(91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
+(88) HashAggregate [codegen id : 18]
+Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#40]
-Results [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#41]
+Aggregate Attributes [1]: [sum#46]
+Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#47]
+
+(89) Exchange
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#47]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(90) HashAggregate [codegen id : 19]
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#47]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
+
+(91) HashAggregate [codegen id : 19]
+Input [1]: [netpaid#33]
+Keys: []
+Functions [1]: [partial_avg(netpaid#33)]
+Aggregate Attributes [2]: [sum#48, count#49]
+Results [2]: [sum#50, count#51]
 
 (92) Exchange
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#41]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [2]: [sum#50, count#51]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
 
-(93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#41]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#30]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#30,17,2) AS netpaid#31]
-
-(94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#31]
+(93) HashAggregate [codegen id : 20]
+Input [2]: [sum#50, count#51]
 Keys: []
-Functions [1]: [partial_avg(netpaid#31)]
-Aggregate Attributes [2]: [sum#42, count#43]
-Results [2]: [sum#44, count#45]
+Functions [1]: [avg(netpaid#33)]
+Aggregate Attributes [1]: [avg(netpaid#33)#52]
+Results [1]: [(0.05 * avg(netpaid#33)#52) AS (0.05 * avg(netpaid))#53]
 
-(95) Exchange
-Input [2]: [sum#44, count#45]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+Subquery:2 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#42, [id=#43]
+ObjectHashAggregate (100)
++- Exchange (99)
+   +- ObjectHashAggregate (98)
+      +- Exchange (97)
+         +- * Filter (96)
+            +- * ColumnarToRow (95)
+               +- Scan parquet spark_catalog.default.item (94)
 
-(96) HashAggregate [codegen id : 20]
-Input [2]: [sum#44, count#45]
+
+(94) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
+
+(95) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+
+(96) Filter [codegen id : 1]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Condition : isnotnull(i_item_sk#9)
+
+(97) Exchange
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: hashpartitioning(i_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(98) ObjectHashAggregate
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Keys: []
-Functions [1]: [avg(netpaid#31)]
-Aggregate Attributes [1]: [avg(netpaid#31)#46]
-Results [1]: [(0.05 * avg(netpaid#31)#46) AS (0.05 * avg(netpaid))#47]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#9, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#54]
+Results [1]: [buf#55]
+
+(99) Exchange
+Input [1]: [buf#55]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+
+(100) ObjectHashAggregate
+Input [1]: [buf#55]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#9, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#9, 42), 204000, 1632000, 0, 0)#56]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#9, 42), 204000, 1632000, 0, 0)#56 AS bloomFilter#57]
+
+Subquery:3 Hosting operator id = 53 Hosting Expression = Subquery scalar-subquery#44, [id=#45]
+* Project (107)
++- ObjectHashAggregate (106)
+   +- Exchange (105)
+      +- ObjectHashAggregate (104)
+         +- * Filter (103)
+            +- * ColumnarToRow (102)
+               +- Scan parquet spark_catalog.default.customer_address (101)
+
+
+(101) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_zip#28, ca_country#29]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
+ReadSchema: struct<ca_zip:string,ca_country:string>
+
+(102) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_zip#28, ca_country#29]
+
+(103) Filter [codegen id : 1]
+Input [2]: [ca_zip#28, ca_country#29]
+Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
+
+(104) ObjectHashAggregate
+Input [2]: [ca_zip#28, ca_country#29]
+Keys: []
+Functions [2]: [partial_bloom_filter_agg(xxhash64(ca_zip#28, 42), 940448, 7523584, 0, 0), partial_bloom_filter_agg(xxhash64(upper(ca_country#29), 42), 940448, 7523584, 0, 0)]
+Aggregate Attributes [2]: [buf#58, buf#59]
+Results [2]: [buf#60, buf#61]
+
+(105) Exchange
+Input [2]: [buf#60, buf#61]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+
+(106) ObjectHashAggregate
+Input [2]: [buf#60, buf#61]
+Keys: []
+Functions [2]: [bloom_filter_agg(xxhash64(ca_zip#28, 42), 940448, 7523584, 0, 0), bloom_filter_agg(xxhash64(upper(ca_country#29), 42), 940448, 7523584, 0, 0)]
+Aggregate Attributes [2]: [bloom_filter_agg(xxhash64(ca_zip#28, 42), 940448, 7523584, 0, 0)#62, bloom_filter_agg(xxhash64(upper(ca_country#29), 42), 940448, 7523584, 0, 0)#63]
+Results [2]: [bloom_filter_agg(xxhash64(ca_zip#28, 42), 940448, 7523584, 0, 0)#62 AS bloomFilter#64, bloom_filter_agg(xxhash64(upper(ca_country#29), 42), 940448, 7523584, 0, 0)#63 AS bloomFilter#65]
+
+(107) Project [codegen id : 2]
+Output [1]: [named_struct(bloomFilter, bloomFilter#64, bloomFilter, bloomFilter#65) AS mergedValue#66]
+Input [2]: [bloomFilter#64, bloomFilter#65]
+
+Subquery:4 Hosting operator id = 68 Hosting Expression = ReusedSubquery Subquery scalar-subquery#44, [id=#45]
+
+Subquery:5 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (114)
++- Exchange (113)
+   +- ObjectHashAggregate (112)
+      +- Exchange (111)
+         +- * Filter (110)
+            +- * ColumnarToRow (109)
+               +- Scan parquet spark_catalog.default.customer (108)
+
+
+(108) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
+
+(109) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+
+(110) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18))
+
+(111) Exchange
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+
+(112) ObjectHashAggregate
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#15, 42), 1930374, 15442992, 0, 0)]
+Aggregate Attributes [1]: [buf#67]
+Results [1]: [buf#68]
+
+(113) Exchange
+Input [1]: [buf#68]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
+
+(114) ObjectHashAggregate
+Input [1]: [buf#68]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#15, 42), 1930374, 15442992, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#15, 42), 1930374, 15442992, 0, 0)#69]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#15, 42), 1930374, 15442992, 0, 0)#69 AS bloomFilter#70]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
@@ -1,15 +1,15 @@
 WholeStageCodegen (14)
   Filter [paid]
-    Subquery #1
+    Subquery #2
       WholeStageCodegen (20)
         HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
           InputAdapter
-            Exchange #10
+            Exchange #11
               WholeStageCodegen (19)
                 HashAggregate [netpaid] [sum,count,sum,count]
                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                     InputAdapter
-                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #11
+                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #12
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
@@ -18,7 +18,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (15)
                                     Sort [c_birth_country,s_zip]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #12
+                                        Exchange [c_birth_country,s_zip] #13
                                           WholeStageCodegen (14)
                                             Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                               SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
@@ -26,7 +26,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (11)
                                                     Sort [ss_ticket_number,ss_item_sk]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #13
+                                                        Exchange [ss_ticket_number,ss_item_sk] #14
                                                           WholeStageCodegen (10)
                                                             Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                                               SortMergeJoin [ss_customer_sk,c_customer_sk]
@@ -34,7 +34,7 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (7)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #14
+                                                                        Exchange [ss_customer_sk] #15
                                                                           WholeStageCodegen (6)
                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                               SortMergeJoin [ss_item_sk,i_item_sk]
@@ -42,20 +42,42 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (3)
                                                                                     Sort [ss_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #15
+                                                                                        Exchange [ss_item_sk] #16
                                                                                           WholeStageCodegen (2)
                                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
                                                                                               BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                                                                 Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                                                   Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                                    Subquery #3
+                                                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                                                        Exchange #17
+                                                                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                                            Exchange [i_item_sk] #18
+                                                                                                              WholeStageCodegen (1)
+                                                                                                                Filter [i_item_sk]
+                                                                                                                  ColumnarToRow
+                                                                                                                    InputAdapter
+                                                                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                                                     ColumnarToRow
                                                                                                       InputAdapter
                                                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                                 InputAdapter
-                                                                                                  BroadcastExchange #16
+                                                                                                  BroadcastExchange #19
                                                                                                     WholeStageCodegen (1)
                                                                                                       Project [s_store_sk,s_store_name,s_state,s_zip]
                                                                                                         Filter [s_market_id,s_store_sk,s_zip]
+                                                                                                          Subquery #4
+                                                                                                            WholeStageCodegen (2)
+                                                                                                              Project [bloomFilter,bloomFilter]
+                                                                                                                InputAdapter
+                                                                                                                  ObjectHashAggregate [buf,buf] [bloom_filter_agg(xxhash64(ca_zip, 42), 940448, 7523584, 0, 0),bloom_filter_agg(xxhash64(upper(ca_country), 42), 940448, 7523584, 0, 0),bloomFilter,bloomFilter,buf,buf]
+                                                                                                                    Exchange #20
+                                                                                                                      ObjectHashAggregate [ca_zip,ca_country] [buf,buf,buf,buf]
+                                                                                                                        WholeStageCodegen (1)
+                                                                                                                          Filter [ca_country,ca_zip]
+                                                                                                                            ColumnarToRow
+                                                                                                                              InputAdapter
+                                                                                                                                Scan parquet spark_catalog.default.customer_address [ca_zip,ca_country]
                                                                                                           ColumnarToRow
                                                                                                             InputAdapter
                                                                                                               Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
@@ -63,27 +85,28 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (5)
                                                                                     Sort [i_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [i_item_sk] #17
-                                                                                          WholeStageCodegen (4)
-                                                                                            Filter [i_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                                        ReusedExchange [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id] #18
                                                                 InputAdapter
                                                                   WholeStageCodegen (9)
                                                                     Sort [c_customer_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #6
+                                                                        Exchange [c_customer_sk] #21
+                                                                          WholeStageCodegen (8)
+                                                                            Filter [c_customer_sk,c_birth_country]
+                                                                              ReusedSubquery [mergedValue] #4
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [sr_ticket_number,sr_item_sk]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #7
+                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
                                 InputAdapter
                                   WholeStageCodegen (17)
                                     Sort [ca_country,ca_zip]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #18
+                                        Exchange [ca_country,ca_zip] #22
                                           WholeStageCodegen (16)
                                             Filter [ca_country,ca_zip]
                                               ColumnarToRow
@@ -121,11 +144,21 @@ WholeStageCodegen (14)
                                                               BroadcastHashJoin [ss_item_sk,i_item_sk]
                                                                 Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                   Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                    Subquery #1
+                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 1930374, 15442992, 0, 0),bloomFilter,buf]
+                                                                        Exchange #5
+                                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                            Exchange [c_customer_sk] #6
+                                                                              WholeStageCodegen (1)
+                                                                                Filter [c_customer_sk,c_birth_country]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                 InputAdapter
-                                                                  BroadcastExchange #5
+                                                                  BroadcastExchange #7
                                                                     WholeStageCodegen (1)
                                                                       Filter [i_color,i_item_sk]
                                                                         ColumnarToRow
@@ -135,17 +168,12 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #6
-                                                          WholeStageCodegen (4)
-                                                            Filter [c_customer_sk,c_birth_country]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
+                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #6
                                 InputAdapter
                                   WholeStageCodegen (9)
                                     Sort [sr_ticket_number,sr_item_sk]
                                       InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #7
+                                        Exchange [sr_ticket_number,sr_item_sk] #8
                                           WholeStageCodegen (8)
                                             Project [sr_item_sk,sr_ticket_number]
                                               Filter [sr_ticket_number,sr_item_sk]
@@ -153,12 +181,12 @@ WholeStageCodegen (14)
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                             InputAdapter
-                              BroadcastExchange #8
+                              BroadcastExchange #9
                                 WholeStageCodegen (11)
                                   Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
                                     BroadcastHashJoin [s_zip,ca_zip]
                                       InputAdapter
-                                        BroadcastExchange #9
+                                        BroadcastExchange #10
                                           WholeStageCodegen (10)
                                             Project [s_store_sk,s_store_name,s_state,s_zip]
                                               Filter [s_market_id,s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
@@ -1,18 +1,18 @@
 == Physical Plan ==
-TakeOrderedAndProject (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * Project (45)
-            +- * SortMergeJoin Inner (44)
-               :- * Sort (35)
-               :  +- Exchange (34)
-               :     +- * Project (33)
-               :        +- * SortMergeJoin Inner (32)
-               :           :- * Sort (23)
-               :           :  +- Exchange (22)
-               :           :     +- * Project (21)
-               :           :        +- * SortMergeJoin Inner (20)
+TakeOrderedAndProject (40)
++- * HashAggregate (39)
+   +- Exchange (38)
+      +- * HashAggregate (37)
+         +- * Project (36)
+            +- * SortMergeJoin Inner (35)
+               :- * Sort (26)
+               :  +- Exchange (25)
+               :     +- * Project (24)
+               :        +- * SortMergeJoin Inner (23)
+               :           :- * Sort (20)
+               :           :  +- Exchange (19)
+               :           :     +- * Project (18)
+               :           :        +- * SortMergeJoin Inner (17)
                :           :           :- * Sort (14)
                :           :           :  +- Exchange (13)
                :           :           :     +- * Project (12)
@@ -27,27 +27,18 @@ TakeOrderedAndProject (49)
                :           :           :              +- * Filter (9)
                :           :           :                 +- * ColumnarToRow (8)
                :           :           :                    +- Scan parquet spark_catalog.default.store (7)
-               :           :           +- * Sort (19)
-               :           :              +- Exchange (18)
-               :           :                 +- * Filter (17)
-               :           :                    +- * ColumnarToRow (16)
-               :           :                       +- Scan parquet spark_catalog.default.item (15)
-               :           +- * Sort (31)
-               :              +- Exchange (30)
-               :                 +- * Project (29)
-               :                    +- * BroadcastHashJoin Inner BuildRight (28)
-               :                       :- * Filter (26)
-               :                       :  +- * ColumnarToRow (25)
-               :                       :     +- Scan parquet spark_catalog.default.store_returns (24)
-               :                       +- ReusedExchange (27)
-               +- * Sort (43)
-                  +- Exchange (42)
-                     +- * Project (41)
-                        +- * BroadcastHashJoin Inner BuildRight (40)
-                           :- * Filter (38)
-                           :  +- * ColumnarToRow (37)
-                           :     +- Scan parquet spark_catalog.default.catalog_sales (36)
-                           +- ReusedExchange (39)
+               :           :           +- * Sort (16)
+               :           :              +- ReusedExchange (15)
+               :           +- * Sort (22)
+               :              +- ReusedExchange (21)
+               +- * Sort (34)
+                  +- Exchange (33)
+                     +- * Project (32)
+                        +- * BroadcastHashJoin Inner BuildRight (31)
+                           :- * Filter (29)
+                           :  +- * ColumnarToRow (28)
+                           :     +- Scan parquet spark_catalog.default.catalog_sales (27)
+                           +- ReusedExchange (30)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -63,281 +54,374 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 3]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3))
+Condition : ((((((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ss_item_sk#1, 42), false)) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ss_customer_sk#2, 42), false)) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ss_ticket_number#4, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 54]
-Output [1]: [d_date_sk#8]
+(4) ReusedExchange [Reuses operator id: 71]
+Output [1]: [d_date_sk#14]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#6]
-Right keys [1]: [d_date_sk#8]
+Right keys [1]: [d_date_sk#14]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, ss_sold_date_sk#6, d_date_sk#8]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, ss_sold_date_sk#6, d_date_sk#14]
 
 (7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+Output [3]: [s_store_sk#15, s_store_id#16, s_store_name#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string,s_store_name:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+Input [3]: [s_store_sk#15, s_store_id#16, s_store_name#17]
 
 (9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Condition : isnotnull(s_store_sk#9)
+Input [3]: [s_store_sk#15, s_store_id#16, s_store_name#17]
+Condition : isnotnull(s_store_sk#15)
 
 (10) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+Input [3]: [s_store_sk#15, s_store_id#16, s_store_name#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#9]
+Right keys [1]: [s_store_sk#15]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, s_store_sk#9, s_store_id#10, s_store_name#11]
+Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#16, s_store_name#17]
+Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, s_store_sk#15, s_store_id#16, s_store_name#17]
 
 (13) Exchange
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11]
+Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#16, s_store_name#17]
 Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11]
+Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#16, s_store_name#17]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
+(15) ReusedExchange [Reuses operator id: 44]
+Output [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+
+(16) Sort [codegen id : 6]
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+Arguments: [i_item_sk#18 ASC NULLS FIRST], false, 0
+
+(17) SortMergeJoin [codegen id : 7]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#18]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 7]
+Output [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_sk#18, i_item_id#19, i_item_desc#20]
+
+(19) Exchange
+Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) Sort [codegen id : 8]
+Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
+
+(21) ReusedExchange [Reuses operator id: 54]
+Output [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24]
+
+(22) Sort [codegen id : 11]
+Input [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24]
+Arguments: [sr_customer_sk#22 ASC NULLS FIRST, sr_item_sk#21 ASC NULLS FIRST, sr_ticket_number#23 ASC NULLS FIRST], false, 0
+
+(23) SortMergeJoin [codegen id : 12]
+Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
+Right keys [3]: [sr_customer_sk#22, sr_item_sk#21, sr_ticket_number#23]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 12]
+Output [8]: [ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_net_loss#24]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24]
+
+(25) Exchange
+Input [8]: [ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_net_loss#24]
+Arguments: hashpartitioning(sr_customer_sk#22, sr_item_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) Sort [codegen id : 13]
+Input [8]: [ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_net_loss#24]
+Arguments: [sr_customer_sk#22 ASC NULLS FIRST, sr_item_sk#21 ASC NULLS FIRST], false, 0
+
+(27) Scan parquet spark_catalog.default.catalog_sales
+Output [4]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_net_profit#27, cs_sold_date_sk#28]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#28), dynamicpruningexpression(cs_sold_date_sk#28 IN dynamicpruning#29)]
+PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_net_profit:decimal(7,2)>
+
+(28) ColumnarToRow [codegen id : 15]
+Input [4]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_net_profit#27, cs_sold_date_sk#28]
+
+(29) Filter [codegen id : 15]
+Input [4]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_net_profit#27, cs_sold_date_sk#28]
+Condition : (isnotnull(cs_bill_customer_sk#25) AND isnotnull(cs_item_sk#26))
+
+(30) ReusedExchange [Reuses operator id: 62]
+Output [1]: [d_date_sk#30]
+
+(31) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [cs_sold_date_sk#28]
+Right keys [1]: [d_date_sk#30]
+Join type: Inner
+Join condition: None
+
+(32) Project [codegen id : 15]
+Output [3]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_net_profit#27]
+Input [5]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_net_profit#27, cs_sold_date_sk#28, d_date_sk#30]
+
+(33) Exchange
+Input [3]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_net_profit#27]
+Arguments: hashpartitioning(cs_bill_customer_sk#25, cs_item_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(34) Sort [codegen id : 16]
+Input [3]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_net_profit#27]
+Arguments: [cs_bill_customer_sk#25 ASC NULLS FIRST, cs_item_sk#26 ASC NULLS FIRST], false, 0
+
+(35) SortMergeJoin [codegen id : 17]
+Left keys [2]: [sr_customer_sk#22, sr_item_sk#21]
+Right keys [2]: [cs_bill_customer_sk#25, cs_item_sk#26]
+Join type: Inner
+Join condition: None
+
+(36) Project [codegen id : 17]
+Output [7]: [ss_net_profit#5, sr_net_loss#24, cs_net_profit#27, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Input [11]: [ss_net_profit#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_net_loss#24, cs_bill_customer_sk#25, cs_item_sk#26, cs_net_profit#27]
+
+(37) HashAggregate [codegen id : 17]
+Input [7]: [ss_net_profit#5, sr_net_loss#24, cs_net_profit#27, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Keys [4]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17]
+Functions [3]: [partial_sum(UnscaledValue(ss_net_profit#5)), partial_sum(UnscaledValue(sr_net_loss#24)), partial_sum(UnscaledValue(cs_net_profit#27))]
+Aggregate Attributes [3]: [sum#31, sum#32, sum#33]
+Results [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, sum#34, sum#35, sum#36]
+
+(38) Exchange
+Input [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, sum#34, sum#35, sum#36]
+Arguments: hashpartitioning(i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(39) HashAggregate [codegen id : 18]
+Input [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, sum#34, sum#35, sum#36]
+Keys [4]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17]
+Functions [3]: [sum(UnscaledValue(ss_net_profit#5)), sum(UnscaledValue(sr_net_loss#24)), sum(UnscaledValue(cs_net_profit#27))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_net_profit#5))#37, sum(UnscaledValue(sr_net_loss#24))#38, sum(UnscaledValue(cs_net_profit#27))#39]
+Results [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, MakeDecimal(sum(UnscaledValue(ss_net_profit#5))#37,17,2) AS store_sales_profit#40, MakeDecimal(sum(UnscaledValue(sr_net_loss#24))#38,17,2) AS store_returns_loss#41, MakeDecimal(sum(UnscaledValue(cs_net_profit#27))#39,17,2) AS catalog_sales_profit#42]
+
+(40) TakeOrderedAndProject
+Input [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, store_sales_profit#40, store_returns_loss#41, catalog_sales_profit#42]
+Arguments: 100, [i_item_id#19 ASC NULLS FIRST, i_item_desc#20 ASC NULLS FIRST, s_store_id#16 ASC NULLS FIRST, s_store_name#17 ASC NULLS FIRST], [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, store_sales_profit#40, store_returns_loss#41, catalog_sales_profit#42]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (47)
++- Exchange (46)
+   +- ObjectHashAggregate (45)
+      +- Exchange (44)
+         +- * Filter (43)
+            +- * ColumnarToRow (42)
+               +- Scan parquet spark_catalog.default.item (41)
+
+
+(41) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
+(42) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
 
-(17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Condition : isnotnull(i_item_sk#12)
+(43) Filter [codegen id : 1]
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+Condition : isnotnull(i_item_sk#18)
 
-(18) Exchange
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(44) Exchange
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+Arguments: hashpartitioning(i_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+(45) ObjectHashAggregate
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#43]
+Results [1]: [buf#44]
 
-(20) SortMergeJoin [codegen id : 7]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#12]
-Join type: Inner
-Join condition: None
+(46) Exchange
+Input [1]: [buf#44]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(21) Project [codegen id : 7]
-Output [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_sk#12, i_item_id#13, i_item_desc#14]
+(47) ObjectHashAggregate
+Input [1]: [buf#44]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)#45]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)#45 AS bloomFilter#46]
 
-(22) Exchange
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (57)
++- Exchange (56)
+   +- ObjectHashAggregate (55)
+      +- Exchange (54)
+         +- * Project (53)
+            +- * BroadcastHashJoin Inner BuildRight (52)
+               :- * Filter (50)
+               :  +- * ColumnarToRow (49)
+               :     +- Scan parquet spark_catalog.default.store_returns (48)
+               +- ReusedExchange (51)
 
-(23) Sort [codegen id : 8]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
 
-(24) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18, sr_returned_date_sk#19]
+(48) Scan parquet spark_catalog.default.store_returns
+Output [5]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24, sr_returned_date_sk#47]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(sr_returned_date_sk#19), dynamicpruningexpression(sr_returned_date_sk#19 IN dynamicpruning#20)]
+PartitionFilters: [isnotnull(sr_returned_date_sk#47), dynamicpruningexpression(sr_returned_date_sk#47 IN dynamicpruning#29)]
 PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_net_loss:decimal(7,2)>
 
-(25) ColumnarToRow [codegen id : 10]
-Input [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18, sr_returned_date_sk#19]
+(49) ColumnarToRow [codegen id : 2]
+Input [5]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24, sr_returned_date_sk#47]
 
-(26) Filter [codegen id : 10]
-Input [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18, sr_returned_date_sk#19]
-Condition : ((isnotnull(sr_customer_sk#16) AND isnotnull(sr_item_sk#15)) AND isnotnull(sr_ticket_number#17))
+(50) Filter [codegen id : 2]
+Input [5]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24, sr_returned_date_sk#47]
+Condition : ((isnotnull(sr_customer_sk#22) AND isnotnull(sr_item_sk#21)) AND isnotnull(sr_ticket_number#23))
 
-(27) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#21]
+(51) ReusedExchange [Reuses operator id: 62]
+Output [1]: [d_date_sk#48]
 
-(28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [sr_returned_date_sk#19]
-Right keys [1]: [d_date_sk#21]
+(52) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [sr_returned_date_sk#47]
+Right keys [1]: [d_date_sk#48]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 10]
-Output [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18]
-Input [6]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18, sr_returned_date_sk#19, d_date_sk#21]
+(53) Project [codegen id : 2]
+Output [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24]
+Input [6]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24, sr_returned_date_sk#47, d_date_sk#48]
 
-(30) Exchange
-Input [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18]
-Arguments: hashpartitioning(sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(54) Exchange
+Input [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24]
+Arguments: hashpartitioning(sr_customer_sk#22, sr_item_sk#21, sr_ticket_number#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(31) Sort [codegen id : 11]
-Input [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18]
-Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST], false, 0
+(55) ObjectHashAggregate
+Input [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_customer_sk#22, 42), 2834632, 22677056, 0, 0)]
+Aggregate Attributes [1]: [buf#49]
+Results [1]: [buf#50]
 
-(32) SortMergeJoin [codegen id : 12]
-Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
-Right keys [3]: [sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17]
-Join type: Inner
-Join condition: None
+(56) Exchange
+Input [1]: [buf#50]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(33) Project [codegen id : 12]
-Output [8]: [ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_net_loss#18]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18]
+(57) ObjectHashAggregate
+Input [1]: [buf#50]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#22, 42), 2834632, 22677056, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#22, 42), 2834632, 22677056, 0, 0)#51]
+Results [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#22, 42), 2834632, 22677056, 0, 0)#51 AS bloomFilter#52]
 
-(34) Exchange
-Input [8]: [ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_net_loss#18]
-Arguments: hashpartitioning(sr_customer_sk#16, sr_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) Sort [codegen id : 13]
-Input [8]: [ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_net_loss#18]
-Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST], false, 0
-
-(36) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24, cs_sold_date_sk#25]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#25), dynamicpruningexpression(cs_sold_date_sk#25 IN dynamicpruning#20)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
-ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_net_profit:decimal(7,2)>
-
-(37) ColumnarToRow [codegen id : 15]
-Input [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24, cs_sold_date_sk#25]
-
-(38) Filter [codegen id : 15]
-Input [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24, cs_sold_date_sk#25]
-Condition : (isnotnull(cs_bill_customer_sk#22) AND isnotnull(cs_item_sk#23))
-
-(39) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#26]
-
-(40) BroadcastHashJoin [codegen id : 15]
-Left keys [1]: [cs_sold_date_sk#25]
-Right keys [1]: [d_date_sk#26]
-Join type: Inner
-Join condition: None
-
-(41) Project [codegen id : 15]
-Output [3]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24]
-Input [5]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24, cs_sold_date_sk#25, d_date_sk#26]
-
-(42) Exchange
-Input [3]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24]
-Arguments: hashpartitioning(cs_bill_customer_sk#22, cs_item_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(43) Sort [codegen id : 16]
-Input [3]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24]
-Arguments: [cs_bill_customer_sk#22 ASC NULLS FIRST, cs_item_sk#23 ASC NULLS FIRST], false, 0
-
-(44) SortMergeJoin [codegen id : 17]
-Left keys [2]: [sr_customer_sk#16, sr_item_sk#15]
-Right keys [2]: [cs_bill_customer_sk#22, cs_item_sk#23]
-Join type: Inner
-Join condition: None
-
-(45) Project [codegen id : 17]
-Output [7]: [ss_net_profit#5, sr_net_loss#18, cs_net_profit#24, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Input [11]: [ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_net_loss#18, cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24]
-
-(46) HashAggregate [codegen id : 17]
-Input [7]: [ss_net_profit#5, sr_net_loss#18, cs_net_profit#24, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Keys [4]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11]
-Functions [3]: [partial_sum(UnscaledValue(ss_net_profit#5)), partial_sum(UnscaledValue(sr_net_loss#18)), partial_sum(UnscaledValue(cs_net_profit#24))]
-Aggregate Attributes [3]: [sum#27, sum#28, sum#29]
-Results [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#30, sum#31, sum#32]
-
-(47) Exchange
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#30, sum#31, sum#32]
-Arguments: hashpartitioning(i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(48) HashAggregate [codegen id : 18]
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#30, sum#31, sum#32]
-Keys [4]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11]
-Functions [3]: [sum(UnscaledValue(ss_net_profit#5)), sum(UnscaledValue(sr_net_loss#18)), sum(UnscaledValue(cs_net_profit#24))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_net_profit#5))#33, sum(UnscaledValue(sr_net_loss#18))#34, sum(UnscaledValue(cs_net_profit#24))#35]
-Results [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, MakeDecimal(sum(UnscaledValue(ss_net_profit#5))#33,17,2) AS store_sales_profit#36, MakeDecimal(sum(UnscaledValue(sr_net_loss#18))#34,17,2) AS store_returns_loss#37, MakeDecimal(sum(UnscaledValue(cs_net_profit#24))#35,17,2) AS catalog_sales_profit#38]
-
-(49) TakeOrderedAndProject
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, store_sales_profit#36, store_returns_loss#37, catalog_sales_profit#38]
-Arguments: 100, [i_item_id#13 ASC NULLS FIRST, i_item_desc#14 ASC NULLS FIRST, s_store_id#10 ASC NULLS FIRST, s_store_name#11 ASC NULLS FIRST], [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, store_sales_profit#36, store_returns_loss#37, catalog_sales_profit#38]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
-BroadcastExchange (54)
-+- * Project (53)
-   +- * Filter (52)
-      +- * ColumnarToRow (51)
-         +- Scan parquet spark_catalog.default.date_dim (50)
+Subquery:3 Hosting operator id = 48 Hosting Expression = sr_returned_date_sk#47 IN dynamicpruning#29
+BroadcastExchange (62)
++- * Project (61)
+   +- * Filter (60)
+      +- * ColumnarToRow (59)
+         +- Scan parquet spark_catalog.default.date_dim (58)
 
 
-(50) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#8, d_year#39, d_moy#40]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,4), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
-
-(51) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#39, d_moy#40]
-
-(52) Filter [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#39, d_moy#40]
-Condition : ((((isnotnull(d_moy#40) AND isnotnull(d_year#39)) AND (d_moy#40 = 4)) AND (d_year#39 = 2001)) AND isnotnull(d_date_sk#8))
-
-(53) Project [codegen id : 1]
-Output [1]: [d_date_sk#8]
-Input [3]: [d_date_sk#8, d_year#39, d_moy#40]
-
-(54) BroadcastExchange
-Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
-
-Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#19 IN dynamicpruning#20
-BroadcastExchange (59)
-+- * Project (58)
-   +- * Filter (57)
-      +- * ColumnarToRow (56)
-         +- Scan parquet spark_catalog.default.date_dim (55)
-
-
-(55) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#21, d_year#41, d_moy#42]
+(58) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#48, d_year#53, d_moy#54]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,10), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(56) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#21, d_year#41, d_moy#42]
+(59) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#48, d_year#53, d_moy#54]
 
-(57) Filter [codegen id : 1]
-Input [3]: [d_date_sk#21, d_year#41, d_moy#42]
-Condition : (((((isnotnull(d_moy#42) AND isnotnull(d_year#41)) AND (d_moy#42 >= 4)) AND (d_moy#42 <= 10)) AND (d_year#41 = 2001)) AND isnotnull(d_date_sk#21))
+(60) Filter [codegen id : 1]
+Input [3]: [d_date_sk#48, d_year#53, d_moy#54]
+Condition : (((((isnotnull(d_moy#54) AND isnotnull(d_year#53)) AND (d_moy#54 >= 4)) AND (d_moy#54 <= 10)) AND (d_year#53 = 2001)) AND isnotnull(d_date_sk#48))
 
-(58) Project [codegen id : 1]
-Output [1]: [d_date_sk#21]
-Input [3]: [d_date_sk#21, d_year#41, d_moy#42]
+(61) Project [codegen id : 1]
+Output [1]: [d_date_sk#48]
+Input [3]: [d_date_sk#48, d_year#53, d_moy#54]
 
-(59) BroadcastExchange
-Input [1]: [d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(62) BroadcastExchange
+Input [1]: [d_date_sk#48]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#25 IN dynamicpruning#20
+Subquery:4 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
+ObjectHashAggregate (66)
++- Exchange (65)
+   +- ObjectHashAggregate (64)
+      +- ReusedExchange (63)
+
+
+(63) ReusedExchange [Reuses operator id: 54]
+Output [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24]
+
+(64) ObjectHashAggregate
+Input [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_net_loss#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_ticket_number#23, 42), 2834632, 22677056, 0, 0)]
+Aggregate Attributes [1]: [buf#55]
+Results [1]: [buf#56]
+
+(65) Exchange
+Input [1]: [buf#56]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+
+(66) ObjectHashAggregate
+Input [1]: [buf#56]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#23, 42), 2834632, 22677056, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#23, 42), 2834632, 22677056, 0, 0)#57]
+Results [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#23, 42), 2834632, 22677056, 0, 0)#57 AS bloomFilter#58]
+
+Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (71)
++- * Project (70)
+   +- * Filter (69)
+      +- * ColumnarToRow (68)
+         +- Scan parquet spark_catalog.default.date_dim (67)
+
+
+(67) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#14, d_year#59, d_moy#60]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,4), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
+
+(68) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#14, d_year#59, d_moy#60]
+
+(69) Filter [codegen id : 1]
+Input [3]: [d_date_sk#14, d_year#59, d_moy#60]
+Condition : ((((isnotnull(d_moy#60) AND isnotnull(d_year#59)) AND (d_moy#60 = 4)) AND (d_year#59 = 2001)) AND isnotnull(d_date_sk#14))
+
+(70) Project [codegen id : 1]
+Output [1]: [d_date_sk#14]
+Input [3]: [d_date_sk#14, d_year#59, d_moy#60]
+
+(71) BroadcastExchange
+Input [1]: [d_date_sk#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
+
+Subquery:6 Hosting operator id = 27 Hosting Expression = cs_sold_date_sk#28 IN dynamicpruning#29
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/simplified.txt
@@ -34,6 +34,43 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                                   Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_profit]
                                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                       Filter [ss_customer_sk,ss_item_sk,ss_ticket_number,ss_store_sk]
+                                                                        Subquery #2
+                                                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                            Exchange #6
+                                                                              ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                Exchange [i_item_sk] #7
+                                                                                  WholeStageCodegen (1)
+                                                                                    Filter [i_item_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
+                                                                        Subquery #3
+                                                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_customer_sk, 42), 2834632, 22677056, 0, 0),bloomFilter,buf]
+                                                                            Exchange #8
+                                                                              ObjectHashAggregate [sr_customer_sk] [buf,buf]
+                                                                                Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #9
+                                                                                  WholeStageCodegen (2)
+                                                                                    Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss]
+                                                                                      BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                                                        Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss,sr_returned_date_sk]
+                                                                                                SubqueryBroadcast [d_date_sk] #4
+                                                                                                  BroadcastExchange #10
+                                                                                                    WholeStageCodegen (1)
+                                                                                                      Project [d_date_sk]
+                                                                                                        Filter [d_moy,d_year,d_date_sk]
+                                                                                                          ColumnarToRow
+                                                                                                            InputAdapter
+                                                                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                                        InputAdapter
+                                                                                          ReusedExchange [d_date_sk] #10
+                                                                        Subquery #5
+                                                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_ticket_number, 42), 2834632, 22677056, 0, 0),bloomFilter,buf]
+                                                                            Exchange #11
+                                                                              ObjectHashAggregate [sr_ticket_number] [buf,buf]
+                                                                                ReusedExchange [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss] #9
                                                                         ColumnarToRow
                                                                           InputAdapter
                                                                             Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_profit,ss_sold_date_sk]
@@ -48,7 +85,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                                       InputAdapter
                                                                         ReusedExchange [d_date_sk] #5
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
+                                                                    BroadcastExchange #12
                                                                       WholeStageCodegen (2)
                                                                         Filter [s_store_sk]
                                                                           ColumnarToRow
@@ -58,39 +95,17 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                     WholeStageCodegen (6)
                                                       Sort [i_item_sk]
                                                         InputAdapter
-                                                          Exchange [i_item_sk] #7
-                                                            WholeStageCodegen (5)
-                                                              Filter [i_item_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
+                                                          ReusedExchange [i_item_sk,i_item_id,i_item_desc] #7
                                   InputAdapter
                                     WholeStageCodegen (11)
                                       Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
                                         InputAdapter
-                                          Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #8
-                                            WholeStageCodegen (10)
-                                              Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss]
-                                                BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                  Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss,sr_returned_date_sk]
-                                                          SubqueryBroadcast [d_date_sk] #2
-                                                            BroadcastExchange #9
-                                                              WholeStageCodegen (1)
-                                                                Project [d_date_sk]
-                                                                  Filter [d_moy,d_year,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #9
+                                          ReusedExchange [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss] #9
                   InputAdapter
                     WholeStageCodegen (16)
                       Sort [cs_bill_customer_sk,cs_item_sk]
                         InputAdapter
-                          Exchange [cs_bill_customer_sk,cs_item_sk] #10
+                          Exchange [cs_bill_customer_sk,cs_item_sk] #13
                             WholeStageCodegen (15)
                               Project [cs_bill_customer_sk,cs_item_sk,cs_net_profit]
                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
@@ -98,6 +113,6 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_net_profit,cs_sold_date_sk]
-                                          ReusedSubquery [d_date_sk] #2
+                                          ReusedSubquery [d_date_sk] #4
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #9
+                                    ReusedExchange [d_date_sk] #10

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
@@ -1,18 +1,18 @@
 == Physical Plan ==
-TakeOrderedAndProject (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * Project (45)
-            +- * SortMergeJoin Inner (44)
-               :- * Sort (35)
-               :  +- Exchange (34)
-               :     +- * Project (33)
-               :        +- * SortMergeJoin Inner (32)
-               :           :- * Sort (23)
-               :           :  +- Exchange (22)
-               :           :     +- * Project (21)
-               :           :        +- * SortMergeJoin Inner (20)
+TakeOrderedAndProject (40)
++- * HashAggregate (39)
+   +- Exchange (38)
+      +- * HashAggregate (37)
+         +- * Project (36)
+            +- * SortMergeJoin Inner (35)
+               :- * Sort (26)
+               :  +- Exchange (25)
+               :     +- * Project (24)
+               :        +- * SortMergeJoin Inner (23)
+               :           :- * Sort (20)
+               :           :  +- Exchange (19)
+               :           :     +- * Project (18)
+               :           :        +- * SortMergeJoin Inner (17)
                :           :           :- * Sort (14)
                :           :           :  +- Exchange (13)
                :           :           :     +- * Project (12)
@@ -27,27 +27,18 @@ TakeOrderedAndProject (49)
                :           :           :              +- * Filter (9)
                :           :           :                 +- * ColumnarToRow (8)
                :           :           :                    +- Scan parquet spark_catalog.default.store (7)
-               :           :           +- * Sort (19)
-               :           :              +- Exchange (18)
-               :           :                 +- * Filter (17)
-               :           :                    +- * ColumnarToRow (16)
-               :           :                       +- Scan parquet spark_catalog.default.item (15)
-               :           +- * Sort (31)
-               :              +- Exchange (30)
-               :                 +- * Project (29)
-               :                    +- * BroadcastHashJoin Inner BuildRight (28)
-               :                       :- * Filter (26)
-               :                       :  +- * ColumnarToRow (25)
-               :                       :     +- Scan parquet spark_catalog.default.store_returns (24)
-               :                       +- ReusedExchange (27)
-               +- * Sort (43)
-                  +- Exchange (42)
-                     +- * Project (41)
-                        +- * BroadcastHashJoin Inner BuildRight (40)
-                           :- * Filter (38)
-                           :  +- * ColumnarToRow (37)
-                           :     +- Scan parquet spark_catalog.default.catalog_sales (36)
-                           +- ReusedExchange (39)
+               :           :           +- * Sort (16)
+               :           :              +- ReusedExchange (15)
+               :           +- * Sort (22)
+               :              +- ReusedExchange (21)
+               +- * Sort (34)
+                  +- Exchange (33)
+                     +- * Project (32)
+                        +- * BroadcastHashJoin Inner BuildRight (31)
+                           :- * Filter (29)
+                           :  +- * ColumnarToRow (28)
+                           :     +- Scan parquet spark_catalog.default.catalog_sales (27)
+                           +- ReusedExchange (30)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -63,309 +54,402 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 3]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3))
+Condition : ((((((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ss_item_sk#1, 42), false)) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ss_customer_sk#2, 42), false)) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ss_ticket_number#4, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 54]
-Output [1]: [d_date_sk#8]
+(4) ReusedExchange [Reuses operator id: 71]
+Output [1]: [d_date_sk#14]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#6]
-Right keys [1]: [d_date_sk#8]
+Right keys [1]: [d_date_sk#14]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6, d_date_sk#8]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6, d_date_sk#14]
 
 (7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+Output [3]: [s_store_sk#15, s_store_id#16, s_store_name#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string,s_store_name:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+Input [3]: [s_store_sk#15, s_store_id#16, s_store_name#17]
 
 (9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Condition : isnotnull(s_store_sk#9)
+Input [3]: [s_store_sk#15, s_store_id#16, s_store_name#17]
+Condition : isnotnull(s_store_sk#15)
 
 (10) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+Input [3]: [s_store_sk#15, s_store_id#16, s_store_name#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#9]
+Right keys [1]: [s_store_sk#15]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, s_store_sk#9, s_store_id#10, s_store_name#11]
+Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#16, s_store_name#17]
+Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, s_store_sk#15, s_store_id#16, s_store_name#17]
 
 (13) Exchange
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11]
+Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#16, s_store_name#17]
 Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11]
+Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#16, s_store_name#17]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
+(15) ReusedExchange [Reuses operator id: 44]
+Output [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+
+(16) Sort [codegen id : 6]
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+Arguments: [i_item_sk#18 ASC NULLS FIRST], false, 0
+
+(17) SortMergeJoin [codegen id : 7]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#18]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 7]
+Output [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#16, s_store_name#17, i_item_sk#18, i_item_id#19, i_item_desc#20]
+
+(19) Exchange
+Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) Sort [codegen id : 8]
+Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
+
+(21) ReusedExchange [Reuses operator id: 54]
+Output [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24]
+
+(22) Sort [codegen id : 11]
+Input [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24]
+Arguments: [sr_customer_sk#22 ASC NULLS FIRST, sr_item_sk#21 ASC NULLS FIRST, sr_ticket_number#23 ASC NULLS FIRST], false, 0
+
+(23) SortMergeJoin [codegen id : 12]
+Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
+Right keys [3]: [sr_customer_sk#22, sr_item_sk#21, sr_ticket_number#23]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 12]
+Output [8]: [ss_quantity#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_return_quantity#24]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24]
+
+(25) Exchange
+Input [8]: [ss_quantity#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_return_quantity#24]
+Arguments: hashpartitioning(sr_customer_sk#22, sr_item_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) Sort [codegen id : 13]
+Input [8]: [ss_quantity#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_return_quantity#24]
+Arguments: [sr_customer_sk#22 ASC NULLS FIRST, sr_item_sk#21 ASC NULLS FIRST], false, 0
+
+(27) Scan parquet spark_catalog.default.catalog_sales
+Output [4]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_quantity#27, cs_sold_date_sk#28]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#28), dynamicpruningexpression(cs_sold_date_sk#28 IN dynamicpruning#29)]
+PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
+
+(28) ColumnarToRow [codegen id : 15]
+Input [4]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_quantity#27, cs_sold_date_sk#28]
+
+(29) Filter [codegen id : 15]
+Input [4]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_quantity#27, cs_sold_date_sk#28]
+Condition : (isnotnull(cs_bill_customer_sk#25) AND isnotnull(cs_item_sk#26))
+
+(30) ReusedExchange [Reuses operator id: 76]
+Output [1]: [d_date_sk#30]
+
+(31) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [cs_sold_date_sk#28]
+Right keys [1]: [d_date_sk#30]
+Join type: Inner
+Join condition: None
+
+(32) Project [codegen id : 15]
+Output [3]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_quantity#27]
+Input [5]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_quantity#27, cs_sold_date_sk#28, d_date_sk#30]
+
+(33) Exchange
+Input [3]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_quantity#27]
+Arguments: hashpartitioning(cs_bill_customer_sk#25, cs_item_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(34) Sort [codegen id : 16]
+Input [3]: [cs_bill_customer_sk#25, cs_item_sk#26, cs_quantity#27]
+Arguments: [cs_bill_customer_sk#25 ASC NULLS FIRST, cs_item_sk#26 ASC NULLS FIRST], false, 0
+
+(35) SortMergeJoin [codegen id : 17]
+Left keys [2]: [sr_customer_sk#22, sr_item_sk#21]
+Right keys [2]: [cs_bill_customer_sk#25, cs_item_sk#26]
+Join type: Inner
+Join condition: None
+
+(36) Project [codegen id : 17]
+Output [7]: [ss_quantity#5, sr_return_quantity#24, cs_quantity#27, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Input [11]: [ss_quantity#5, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20, sr_item_sk#21, sr_customer_sk#22, sr_return_quantity#24, cs_bill_customer_sk#25, cs_item_sk#26, cs_quantity#27]
+
+(37) HashAggregate [codegen id : 17]
+Input [7]: [ss_quantity#5, sr_return_quantity#24, cs_quantity#27, s_store_id#16, s_store_name#17, i_item_id#19, i_item_desc#20]
+Keys [4]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17]
+Functions [3]: [partial_sum(ss_quantity#5), partial_sum(sr_return_quantity#24), partial_sum(cs_quantity#27)]
+Aggregate Attributes [3]: [sum#31, sum#32, sum#33]
+Results [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, sum#34, sum#35, sum#36]
+
+(38) Exchange
+Input [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, sum#34, sum#35, sum#36]
+Arguments: hashpartitioning(i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(39) HashAggregate [codegen id : 18]
+Input [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, sum#34, sum#35, sum#36]
+Keys [4]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17]
+Functions [3]: [sum(ss_quantity#5), sum(sr_return_quantity#24), sum(cs_quantity#27)]
+Aggregate Attributes [3]: [sum(ss_quantity#5)#37, sum(sr_return_quantity#24)#38, sum(cs_quantity#27)#39]
+Results [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, sum(ss_quantity#5)#37 AS store_sales_quantity#40, sum(sr_return_quantity#24)#38 AS store_returns_quantity#41, sum(cs_quantity#27)#39 AS catalog_sales_quantity#42]
+
+(40) TakeOrderedAndProject
+Input [7]: [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, store_sales_quantity#40, store_returns_quantity#41, catalog_sales_quantity#42]
+Arguments: 100, [i_item_id#19 ASC NULLS FIRST, i_item_desc#20 ASC NULLS FIRST, s_store_id#16 ASC NULLS FIRST, s_store_name#17 ASC NULLS FIRST], [i_item_id#19, i_item_desc#20, s_store_id#16, s_store_name#17, store_sales_quantity#40, store_returns_quantity#41, catalog_sales_quantity#42]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (47)
++- Exchange (46)
+   +- ObjectHashAggregate (45)
+      +- Exchange (44)
+         +- * Filter (43)
+            +- * ColumnarToRow (42)
+               +- Scan parquet spark_catalog.default.item (41)
+
+
+(41) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
+(42) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
 
-(17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Condition : isnotnull(i_item_sk#12)
+(43) Filter [codegen id : 1]
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+Condition : isnotnull(i_item_sk#18)
 
-(18) Exchange
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(44) Exchange
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+Arguments: hashpartitioning(i_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+(45) ObjectHashAggregate
+Input [3]: [i_item_sk#18, i_item_id#19, i_item_desc#20]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#43]
+Results [1]: [buf#44]
 
-(20) SortMergeJoin [codegen id : 7]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#12]
-Join type: Inner
-Join condition: None
+(46) Exchange
+Input [1]: [buf#44]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(21) Project [codegen id : 7]
-Output [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_sk#12, i_item_id#13, i_item_desc#14]
+(47) ObjectHashAggregate
+Input [1]: [buf#44]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)#45]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)#45 AS bloomFilter#46]
 
-(22) Exchange
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (57)
++- Exchange (56)
+   +- ObjectHashAggregate (55)
+      +- Exchange (54)
+         +- * Project (53)
+            +- * BroadcastHashJoin Inner BuildRight (52)
+               :- * Filter (50)
+               :  +- * ColumnarToRow (49)
+               :     +- Scan parquet spark_catalog.default.store_returns (48)
+               +- ReusedExchange (51)
 
-(23) Sort [codegen id : 8]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
 
-(24) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18, sr_returned_date_sk#19]
+(48) Scan parquet spark_catalog.default.store_returns
+Output [5]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24, sr_returned_date_sk#47]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(sr_returned_date_sk#19), dynamicpruningexpression(sr_returned_date_sk#19 IN dynamicpruning#20)]
+PartitionFilters: [isnotnull(sr_returned_date_sk#47), dynamicpruningexpression(sr_returned_date_sk#47 IN dynamicpruning#48)]
 PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_return_quantity:int>
 
-(25) ColumnarToRow [codegen id : 10]
-Input [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18, sr_returned_date_sk#19]
+(49) ColumnarToRow [codegen id : 2]
+Input [5]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24, sr_returned_date_sk#47]
 
-(26) Filter [codegen id : 10]
-Input [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18, sr_returned_date_sk#19]
-Condition : ((isnotnull(sr_customer_sk#16) AND isnotnull(sr_item_sk#15)) AND isnotnull(sr_ticket_number#17))
+(50) Filter [codegen id : 2]
+Input [5]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24, sr_returned_date_sk#47]
+Condition : ((isnotnull(sr_customer_sk#22) AND isnotnull(sr_item_sk#21)) AND isnotnull(sr_ticket_number#23))
 
-(27) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#21]
+(51) ReusedExchange [Reuses operator id: 62]
+Output [1]: [d_date_sk#49]
 
-(28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [sr_returned_date_sk#19]
-Right keys [1]: [d_date_sk#21]
+(52) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [sr_returned_date_sk#47]
+Right keys [1]: [d_date_sk#49]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 10]
-Output [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18]
-Input [6]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18, sr_returned_date_sk#19, d_date_sk#21]
+(53) Project [codegen id : 2]
+Output [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24]
+Input [6]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24, sr_returned_date_sk#47, d_date_sk#49]
 
-(30) Exchange
-Input [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18]
-Arguments: hashpartitioning(sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(54) Exchange
+Input [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24]
+Arguments: hashpartitioning(sr_customer_sk#22, sr_item_sk#21, sr_ticket_number#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(31) Sort [codegen id : 11]
-Input [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18]
-Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST], false, 0
+(55) ObjectHashAggregate
+Input [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_customer_sk#22, 42), 1417316, 11338528, 0, 0)]
+Aggregate Attributes [1]: [buf#50]
+Results [1]: [buf#51]
 
-(32) SortMergeJoin [codegen id : 12]
-Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
-Right keys [3]: [sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17]
-Join type: Inner
-Join condition: None
+(56) Exchange
+Input [1]: [buf#51]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(33) Project [codegen id : 12]
-Output [8]: [ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_return_quantity#18]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18]
+(57) ObjectHashAggregate
+Input [1]: [buf#51]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#22, 42), 1417316, 11338528, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#22, 42), 1417316, 11338528, 0, 0)#52]
+Results [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#22, 42), 1417316, 11338528, 0, 0)#52 AS bloomFilter#53]
 
-(34) Exchange
-Input [8]: [ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_return_quantity#18]
-Arguments: hashpartitioning(sr_customer_sk#16, sr_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) Sort [codegen id : 13]
-Input [8]: [ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_return_quantity#18]
-Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST], false, 0
-
-(36) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24, cs_sold_date_sk#25]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#25), dynamicpruningexpression(cs_sold_date_sk#25 IN dynamicpruning#26)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
-ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
-
-(37) ColumnarToRow [codegen id : 15]
-Input [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24, cs_sold_date_sk#25]
-
-(38) Filter [codegen id : 15]
-Input [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24, cs_sold_date_sk#25]
-Condition : (isnotnull(cs_bill_customer_sk#22) AND isnotnull(cs_item_sk#23))
-
-(39) ReusedExchange [Reuses operator id: 64]
-Output [1]: [d_date_sk#27]
-
-(40) BroadcastHashJoin [codegen id : 15]
-Left keys [1]: [cs_sold_date_sk#25]
-Right keys [1]: [d_date_sk#27]
-Join type: Inner
-Join condition: None
-
-(41) Project [codegen id : 15]
-Output [3]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24]
-Input [5]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24, cs_sold_date_sk#25, d_date_sk#27]
-
-(42) Exchange
-Input [3]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24]
-Arguments: hashpartitioning(cs_bill_customer_sk#22, cs_item_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(43) Sort [codegen id : 16]
-Input [3]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24]
-Arguments: [cs_bill_customer_sk#22 ASC NULLS FIRST, cs_item_sk#23 ASC NULLS FIRST], false, 0
-
-(44) SortMergeJoin [codegen id : 17]
-Left keys [2]: [sr_customer_sk#16, sr_item_sk#15]
-Right keys [2]: [cs_bill_customer_sk#22, cs_item_sk#23]
-Join type: Inner
-Join condition: None
-
-(45) Project [codegen id : 17]
-Output [7]: [ss_quantity#5, sr_return_quantity#18, cs_quantity#24, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Input [11]: [ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_return_quantity#18, cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24]
-
-(46) HashAggregate [codegen id : 17]
-Input [7]: [ss_quantity#5, sr_return_quantity#18, cs_quantity#24, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Keys [4]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11]
-Functions [3]: [partial_sum(ss_quantity#5), partial_sum(sr_return_quantity#18), partial_sum(cs_quantity#24)]
-Aggregate Attributes [3]: [sum#28, sum#29, sum#30]
-Results [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#31, sum#32, sum#33]
-
-(47) Exchange
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#31, sum#32, sum#33]
-Arguments: hashpartitioning(i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(48) HashAggregate [codegen id : 18]
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#31, sum#32, sum#33]
-Keys [4]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11]
-Functions [3]: [sum(ss_quantity#5), sum(sr_return_quantity#18), sum(cs_quantity#24)]
-Aggregate Attributes [3]: [sum(ss_quantity#5)#34, sum(sr_return_quantity#18)#35, sum(cs_quantity#24)#36]
-Results [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum(ss_quantity#5)#34 AS store_sales_quantity#37, sum(sr_return_quantity#18)#35 AS store_returns_quantity#38, sum(cs_quantity#24)#36 AS catalog_sales_quantity#39]
-
-(49) TakeOrderedAndProject
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, store_sales_quantity#37, store_returns_quantity#38, catalog_sales_quantity#39]
-Arguments: 100, [i_item_id#13 ASC NULLS FIRST, i_item_desc#14 ASC NULLS FIRST, s_store_id#10 ASC NULLS FIRST, s_store_name#11 ASC NULLS FIRST], [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, store_sales_quantity#37, store_returns_quantity#38, catalog_sales_quantity#39]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
-BroadcastExchange (54)
-+- * Project (53)
-   +- * Filter (52)
-      +- * ColumnarToRow (51)
-         +- Scan parquet spark_catalog.default.date_dim (50)
+Subquery:3 Hosting operator id = 48 Hosting Expression = sr_returned_date_sk#47 IN dynamicpruning#48
+BroadcastExchange (62)
++- * Project (61)
+   +- * Filter (60)
+      +- * ColumnarToRow (59)
+         +- Scan parquet spark_catalog.default.date_dim (58)
 
 
-(50) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#8, d_year#40, d_moy#41]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,9), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
-
-(51) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#40, d_moy#41]
-
-(52) Filter [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#40, d_moy#41]
-Condition : ((((isnotnull(d_moy#41) AND isnotnull(d_year#40)) AND (d_moy#41 = 9)) AND (d_year#40 = 1999)) AND isnotnull(d_date_sk#8))
-
-(53) Project [codegen id : 1]
-Output [1]: [d_date_sk#8]
-Input [3]: [d_date_sk#8, d_year#40, d_moy#41]
-
-(54) BroadcastExchange
-Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
-
-Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#19 IN dynamicpruning#20
-BroadcastExchange (59)
-+- * Project (58)
-   +- * Filter (57)
-      +- * ColumnarToRow (56)
-         +- Scan parquet spark_catalog.default.date_dim (55)
-
-
-(55) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#21, d_year#42, d_moy#43]
+(58) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#49, d_year#54, d_moy#55]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), GreaterThanOrEqual(d_moy,9), LessThanOrEqual(d_moy,12), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(56) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#21, d_year#42, d_moy#43]
+(59) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#49, d_year#54, d_moy#55]
 
-(57) Filter [codegen id : 1]
-Input [3]: [d_date_sk#21, d_year#42, d_moy#43]
-Condition : (((((isnotnull(d_moy#43) AND isnotnull(d_year#42)) AND (d_moy#43 >= 9)) AND (d_moy#43 <= 12)) AND (d_year#42 = 1999)) AND isnotnull(d_date_sk#21))
+(60) Filter [codegen id : 1]
+Input [3]: [d_date_sk#49, d_year#54, d_moy#55]
+Condition : (((((isnotnull(d_moy#55) AND isnotnull(d_year#54)) AND (d_moy#55 >= 9)) AND (d_moy#55 <= 12)) AND (d_year#54 = 1999)) AND isnotnull(d_date_sk#49))
 
-(58) Project [codegen id : 1]
-Output [1]: [d_date_sk#21]
-Input [3]: [d_date_sk#21, d_year#42, d_moy#43]
+(61) Project [codegen id : 1]
+Output [1]: [d_date_sk#49]
+Input [3]: [d_date_sk#49, d_year#54, d_moy#55]
 
-(59) BroadcastExchange
-Input [1]: [d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(62) BroadcastExchange
+Input [1]: [d_date_sk#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#25 IN dynamicpruning#26
-BroadcastExchange (64)
-+- * Project (63)
-   +- * Filter (62)
-      +- * ColumnarToRow (61)
-         +- Scan parquet spark_catalog.default.date_dim (60)
+Subquery:4 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
+ObjectHashAggregate (66)
++- Exchange (65)
+   +- ObjectHashAggregate (64)
+      +- ReusedExchange (63)
 
 
-(60) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#27, d_year#44]
+(63) ReusedExchange [Reuses operator id: 54]
+Output [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24]
+
+(64) ObjectHashAggregate
+Input [4]: [sr_item_sk#21, sr_customer_sk#22, sr_ticket_number#23, sr_return_quantity#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_ticket_number#23, 42), 1417316, 11338528, 0, 0)]
+Aggregate Attributes [1]: [buf#56]
+Results [1]: [buf#57]
+
+(65) Exchange
+Input [1]: [buf#57]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+
+(66) ObjectHashAggregate
+Input [1]: [buf#57]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#23, 42), 1417316, 11338528, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#23, 42), 1417316, 11338528, 0, 0)#58]
+Results [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#23, 42), 1417316, 11338528, 0, 0)#58 AS bloomFilter#59]
+
+Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (71)
++- * Project (70)
+   +- * Filter (69)
+      +- * ColumnarToRow (68)
+         +- Scan parquet spark_catalog.default.date_dim (67)
+
+
+(67) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#14, d_year#60, d_moy#61]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,9), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
+
+(68) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#14, d_year#60, d_moy#61]
+
+(69) Filter [codegen id : 1]
+Input [3]: [d_date_sk#14, d_year#60, d_moy#61]
+Condition : ((((isnotnull(d_moy#61) AND isnotnull(d_year#60)) AND (d_moy#61 = 9)) AND (d_year#60 = 1999)) AND isnotnull(d_date_sk#14))
+
+(70) Project [codegen id : 1]
+Output [1]: [d_date_sk#14]
+Input [3]: [d_date_sk#14, d_year#60, d_moy#61]
+
+(71) BroadcastExchange
+Input [1]: [d_date_sk#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
+
+Subquery:6 Hosting operator id = 27 Hosting Expression = cs_sold_date_sk#28 IN dynamicpruning#29
+BroadcastExchange (76)
++- * Project (75)
+   +- * Filter (74)
+      +- * ColumnarToRow (73)
+         +- Scan parquet spark_catalog.default.date_dim (72)
+
+
+(72) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#30, d_year#62]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(61) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#27, d_year#44]
+(73) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#30, d_year#62]
 
-(62) Filter [codegen id : 1]
-Input [2]: [d_date_sk#27, d_year#44]
-Condition : (d_year#44 IN (1999,2000,2001) AND isnotnull(d_date_sk#27))
+(74) Filter [codegen id : 1]
+Input [2]: [d_date_sk#30, d_year#62]
+Condition : (d_year#62 IN (1999,2000,2001) AND isnotnull(d_date_sk#30))
 
-(63) Project [codegen id : 1]
-Output [1]: [d_date_sk#27]
-Input [2]: [d_date_sk#27, d_year#44]
+(75) Project [codegen id : 1]
+Output [1]: [d_date_sk#30]
+Input [2]: [d_date_sk#30, d_year#62]
 
-(64) BroadcastExchange
-Input [1]: [d_date_sk#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
+(76) BroadcastExchange
+Input [1]: [d_date_sk#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/simplified.txt
@@ -34,6 +34,43 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                                   Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_quantity]
                                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                       Filter [ss_customer_sk,ss_item_sk,ss_ticket_number,ss_store_sk]
+                                                                        Subquery #2
+                                                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                            Exchange #6
+                                                                              ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                Exchange [i_item_sk] #7
+                                                                                  WholeStageCodegen (1)
+                                                                                    Filter [i_item_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
+                                                                        Subquery #3
+                                                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_customer_sk, 42), 1417316, 11338528, 0, 0),bloomFilter,buf]
+                                                                            Exchange #8
+                                                                              ObjectHashAggregate [sr_customer_sk] [buf,buf]
+                                                                                Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #9
+                                                                                  WholeStageCodegen (2)
+                                                                                    Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity]
+                                                                                      BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                                                        Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity,sr_returned_date_sk]
+                                                                                                SubqueryBroadcast [d_date_sk] #4
+                                                                                                  BroadcastExchange #10
+                                                                                                    WholeStageCodegen (1)
+                                                                                                      Project [d_date_sk]
+                                                                                                        Filter [d_moy,d_year,d_date_sk]
+                                                                                                          ColumnarToRow
+                                                                                                            InputAdapter
+                                                                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                                        InputAdapter
+                                                                                          ReusedExchange [d_date_sk] #10
+                                                                        Subquery #5
+                                                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_ticket_number, 42), 1417316, 11338528, 0, 0),bloomFilter,buf]
+                                                                            Exchange #11
+                                                                              ObjectHashAggregate [sr_ticket_number] [buf,buf]
+                                                                                ReusedExchange [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity] #9
                                                                         ColumnarToRow
                                                                           InputAdapter
                                                                             Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_quantity,ss_sold_date_sk]
@@ -48,7 +85,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                                       InputAdapter
                                                                         ReusedExchange [d_date_sk] #5
                                                                   InputAdapter
-                                                                    BroadcastExchange #6
+                                                                    BroadcastExchange #12
                                                                       WholeStageCodegen (2)
                                                                         Filter [s_store_sk]
                                                                           ColumnarToRow
@@ -58,39 +95,17 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                     WholeStageCodegen (6)
                                                       Sort [i_item_sk]
                                                         InputAdapter
-                                                          Exchange [i_item_sk] #7
-                                                            WholeStageCodegen (5)
-                                                              Filter [i_item_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
+                                                          ReusedExchange [i_item_sk,i_item_id,i_item_desc] #7
                                   InputAdapter
                                     WholeStageCodegen (11)
                                       Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
                                         InputAdapter
-                                          Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #8
-                                            WholeStageCodegen (10)
-                                              Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity]
-                                                BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                  Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity,sr_returned_date_sk]
-                                                          SubqueryBroadcast [d_date_sk] #2
-                                                            BroadcastExchange #9
-                                                              WholeStageCodegen (1)
-                                                                Project [d_date_sk]
-                                                                  Filter [d_moy,d_year,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #9
+                                          ReusedExchange [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity] #9
                   InputAdapter
                     WholeStageCodegen (16)
                       Sort [cs_bill_customer_sk,cs_item_sk]
                         InputAdapter
-                          Exchange [cs_bill_customer_sk,cs_item_sk] #10
+                          Exchange [cs_bill_customer_sk,cs_item_sk] #13
                             WholeStageCodegen (15)
                               Project [cs_bill_customer_sk,cs_item_sk,cs_quantity]
                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
@@ -98,8 +113,8 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
-                                          SubqueryBroadcast [d_date_sk] #3
-                                            BroadcastExchange #11
+                                          SubqueryBroadcast [d_date_sk] #6
+                                            BroadcastExchange #14
                                               WholeStageCodegen (1)
                                                 Project [d_date_sk]
                                                   Filter [d_year,d_date_sk]
@@ -107,4 +122,4 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #11
+                                    ReusedExchange [d_date_sk] #14

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31.sf100/explain.txt
@@ -1,17 +1,17 @@
 == Physical Plan ==
-* Sort (110)
-+- Exchange (109)
-   +- * Project (108)
-      +- * BroadcastHashJoin Inner BuildRight (107)
-         :- * Project (54)
-         :  +- * BroadcastHashJoin Inner BuildRight (53)
-         :     :- * Project (36)
-         :     :  +- * BroadcastHashJoin Inner BuildRight (35)
-         :     :     :- * HashAggregate (18)
-         :     :     :  +- Exchange (17)
-         :     :     :     +- * HashAggregate (16)
-         :     :     :        +- * Project (15)
-         :     :     :           +- * SortMergeJoin Inner (14)
+* Sort (107)
++- Exchange (106)
+   +- * Project (105)
+      +- * BroadcastHashJoin Inner BuildRight (104)
+         :- * Project (51)
+         :  +- * BroadcastHashJoin Inner BuildRight (50)
+         :     :- * Project (33)
+         :     :  +- * BroadcastHashJoin Inner BuildRight (32)
+         :     :     :- * HashAggregate (15)
+         :     :     :  +- Exchange (14)
+         :     :     :     +- * HashAggregate (13)
+         :     :     :        +- * Project (12)
+         :     :     :           +- * SortMergeJoin Inner (11)
          :     :     :              :- * Sort (8)
          :     :     :              :  +- Exchange (7)
          :     :     :              :     +- * Project (6)
@@ -20,95 +20,92 @@
          :     :     :              :           :  +- * ColumnarToRow (2)
          :     :     :              :           :     +- Scan parquet spark_catalog.default.store_sales (1)
          :     :     :              :           +- ReusedExchange (4)
-         :     :     :              +- * Sort (13)
-         :     :     :                 +- Exchange (12)
-         :     :     :                    +- * Filter (11)
-         :     :     :                       +- * ColumnarToRow (10)
-         :     :     :                          +- Scan parquet spark_catalog.default.customer_address (9)
-         :     :     +- BroadcastExchange (34)
-         :     :        +- * HashAggregate (33)
-         :     :           +- Exchange (32)
-         :     :              +- * HashAggregate (31)
-         :     :                 +- * Project (30)
-         :     :                    +- * SortMergeJoin Inner (29)
-         :     :                       :- * Sort (26)
-         :     :                       :  +- Exchange (25)
-         :     :                       :     +- * Project (24)
-         :     :                       :        +- * BroadcastHashJoin Inner BuildRight (23)
-         :     :                       :           :- * Filter (21)
-         :     :                       :           :  +- * ColumnarToRow (20)
-         :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (19)
-         :     :                       :           +- ReusedExchange (22)
-         :     :                       +- * Sort (28)
-         :     :                          +- ReusedExchange (27)
-         :     +- BroadcastExchange (52)
-         :        +- * HashAggregate (51)
-         :           +- Exchange (50)
-         :              +- * HashAggregate (49)
-         :                 +- * Project (48)
-         :                    +- * SortMergeJoin Inner (47)
-         :                       :- * Sort (44)
-         :                       :  +- Exchange (43)
-         :                       :     +- * Project (42)
-         :                       :        +- * BroadcastHashJoin Inner BuildRight (41)
-         :                       :           :- * Filter (39)
-         :                       :           :  +- * ColumnarToRow (38)
-         :                       :           :     +- Scan parquet spark_catalog.default.store_sales (37)
-         :                       :           +- ReusedExchange (40)
-         :                       +- * Sort (46)
-         :                          +- ReusedExchange (45)
-         +- BroadcastExchange (106)
-            +- * Project (105)
-               +- * BroadcastHashJoin Inner BuildRight (104)
-                  :- * Project (87)
-                  :  +- * BroadcastHashJoin Inner BuildRight (86)
-                  :     :- * HashAggregate (69)
-                  :     :  +- Exchange (68)
-                  :     :     +- * HashAggregate (67)
-                  :     :        +- * Project (66)
-                  :     :           +- * SortMergeJoin Inner (65)
-                  :     :              :- * Sort (62)
-                  :     :              :  +- Exchange (61)
-                  :     :              :     +- * Project (60)
-                  :     :              :        +- * BroadcastHashJoin Inner BuildRight (59)
-                  :     :              :           :- * Filter (57)
-                  :     :              :           :  +- * ColumnarToRow (56)
-                  :     :              :           :     +- Scan parquet spark_catalog.default.web_sales (55)
-                  :     :              :           +- ReusedExchange (58)
-                  :     :              +- * Sort (64)
-                  :     :                 +- ReusedExchange (63)
-                  :     +- BroadcastExchange (85)
-                  :        +- * HashAggregate (84)
-                  :           +- Exchange (83)
-                  :              +- * HashAggregate (82)
-                  :                 +- * Project (81)
-                  :                    +- * SortMergeJoin Inner (80)
-                  :                       :- * Sort (77)
-                  :                       :  +- Exchange (76)
-                  :                       :     +- * Project (75)
-                  :                       :        +- * BroadcastHashJoin Inner BuildRight (74)
-                  :                       :           :- * Filter (72)
-                  :                       :           :  +- * ColumnarToRow (71)
-                  :                       :           :     +- Scan parquet spark_catalog.default.web_sales (70)
-                  :                       :           +- ReusedExchange (73)
-                  :                       +- * Sort (79)
-                  :                          +- ReusedExchange (78)
-                  +- BroadcastExchange (103)
-                     +- * HashAggregate (102)
-                        +- Exchange (101)
-                           +- * HashAggregate (100)
-                              +- * Project (99)
-                                 +- * SortMergeJoin Inner (98)
-                                    :- * Sort (95)
-                                    :  +- Exchange (94)
-                                    :     +- * Project (93)
-                                    :        +- * BroadcastHashJoin Inner BuildRight (92)
-                                    :           :- * Filter (90)
-                                    :           :  +- * ColumnarToRow (89)
-                                    :           :     +- Scan parquet spark_catalog.default.web_sales (88)
-                                    :           +- ReusedExchange (91)
-                                    +- * Sort (97)
-                                       +- ReusedExchange (96)
+         :     :     :              +- * Sort (10)
+         :     :     :                 +- ReusedExchange (9)
+         :     :     +- BroadcastExchange (31)
+         :     :        +- * HashAggregate (30)
+         :     :           +- Exchange (29)
+         :     :              +- * HashAggregate (28)
+         :     :                 +- * Project (27)
+         :     :                    +- * SortMergeJoin Inner (26)
+         :     :                       :- * Sort (23)
+         :     :                       :  +- Exchange (22)
+         :     :                       :     +- * Project (21)
+         :     :                       :        +- * BroadcastHashJoin Inner BuildRight (20)
+         :     :                       :           :- * Filter (18)
+         :     :                       :           :  +- * ColumnarToRow (17)
+         :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (16)
+         :     :                       :           +- ReusedExchange (19)
+         :     :                       +- * Sort (25)
+         :     :                          +- ReusedExchange (24)
+         :     +- BroadcastExchange (49)
+         :        +- * HashAggregate (48)
+         :           +- Exchange (47)
+         :              +- * HashAggregate (46)
+         :                 +- * Project (45)
+         :                    +- * SortMergeJoin Inner (44)
+         :                       :- * Sort (41)
+         :                       :  +- Exchange (40)
+         :                       :     +- * Project (39)
+         :                       :        +- * BroadcastHashJoin Inner BuildRight (38)
+         :                       :           :- * Filter (36)
+         :                       :           :  +- * ColumnarToRow (35)
+         :                       :           :     +- Scan parquet spark_catalog.default.store_sales (34)
+         :                       :           +- ReusedExchange (37)
+         :                       +- * Sort (43)
+         :                          +- ReusedExchange (42)
+         +- BroadcastExchange (103)
+            +- * Project (102)
+               +- * BroadcastHashJoin Inner BuildRight (101)
+                  :- * Project (84)
+                  :  +- * BroadcastHashJoin Inner BuildRight (83)
+                  :     :- * HashAggregate (66)
+                  :     :  +- Exchange (65)
+                  :     :     +- * HashAggregate (64)
+                  :     :        +- * Project (63)
+                  :     :           +- * SortMergeJoin Inner (62)
+                  :     :              :- * Sort (59)
+                  :     :              :  +- Exchange (58)
+                  :     :              :     +- * Project (57)
+                  :     :              :        +- * BroadcastHashJoin Inner BuildRight (56)
+                  :     :              :           :- * Filter (54)
+                  :     :              :           :  +- * ColumnarToRow (53)
+                  :     :              :           :     +- Scan parquet spark_catalog.default.web_sales (52)
+                  :     :              :           +- ReusedExchange (55)
+                  :     :              +- * Sort (61)
+                  :     :                 +- ReusedExchange (60)
+                  :     +- BroadcastExchange (82)
+                  :        +- * HashAggregate (81)
+                  :           +- Exchange (80)
+                  :              +- * HashAggregate (79)
+                  :                 +- * Project (78)
+                  :                    +- * SortMergeJoin Inner (77)
+                  :                       :- * Sort (74)
+                  :                       :  +- Exchange (73)
+                  :                       :     +- * Project (72)
+                  :                       :        +- * BroadcastHashJoin Inner BuildRight (71)
+                  :                       :           :- * Filter (69)
+                  :                       :           :  +- * ColumnarToRow (68)
+                  :                       :           :     +- Scan parquet spark_catalog.default.web_sales (67)
+                  :                       :           +- ReusedExchange (70)
+                  :                       +- * Sort (76)
+                  :                          +- ReusedExchange (75)
+                  +- BroadcastExchange (100)
+                     +- * HashAggregate (99)
+                        +- Exchange (98)
+                           +- * HashAggregate (97)
+                              +- * Project (96)
+                                 +- * SortMergeJoin Inner (95)
+                                    :- * Sort (92)
+                                    :  +- Exchange (91)
+                                    :     +- * Project (90)
+                                    :        +- * BroadcastHashJoin Inner BuildRight (89)
+                                    :           :- * Filter (87)
+                                    :           :  +- * ColumnarToRow (86)
+                                    :           :     +- Scan parquet spark_catalog.default.web_sales (85)
+                                    :           +- ReusedExchange (88)
+                                    +- * Sort (94)
+                                       +- ReusedExchange (93)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -124,540 +121,546 @@ Input [3]: [ss_addr_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 
 (3) Filter [codegen id : 2]
 Input [3]: [ss_addr_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_addr_sk#1)
+Condition : (isnotnull(ss_addr_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ss_addr_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 114]
-Output [3]: [d_date_sk#5, d_year#6, d_qoy#7]
+(4) ReusedExchange [Reuses operator id: 118]
+Output [3]: [d_date_sk#7, d_year#8, d_qoy#9]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#5]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
-Output [4]: [ss_addr_sk#1, ss_ext_sales_price#2, d_year#6, d_qoy#7]
-Input [6]: [ss_addr_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, d_date_sk#5, d_year#6, d_qoy#7]
+Output [4]: [ss_addr_sk#1, ss_ext_sales_price#2, d_year#8, d_qoy#9]
+Input [6]: [ss_addr_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, d_date_sk#7, d_year#8, d_qoy#9]
 
 (7) Exchange
-Input [4]: [ss_addr_sk#1, ss_ext_sales_price#2, d_year#6, d_qoy#7]
+Input [4]: [ss_addr_sk#1, ss_ext_sales_price#2, d_year#8, d_qoy#9]
 Arguments: hashpartitioning(ss_addr_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (8) Sort [codegen id : 3]
-Input [4]: [ss_addr_sk#1, ss_ext_sales_price#2, d_year#6, d_qoy#7]
+Input [4]: [ss_addr_sk#1, ss_ext_sales_price#2, d_year#8, d_qoy#9]
 Arguments: [ss_addr_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#8, ca_county#9]
+(9) ReusedExchange [Reuses operator id: 111]
+Output [2]: [ca_address_sk#10, ca_county#11]
+
+(10) Sort [codegen id : 5]
+Input [2]: [ca_address_sk#10, ca_county#11]
+Arguments: [ca_address_sk#10 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_addr_sk#1]
+Right keys [1]: [ca_address_sk#10]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [4]: [ss_ext_sales_price#2, d_year#8, d_qoy#9, ca_county#11]
+Input [6]: [ss_addr_sk#1, ss_ext_sales_price#2, d_year#8, d_qoy#9, ca_address_sk#10, ca_county#11]
+
+(13) HashAggregate [codegen id : 6]
+Input [4]: [ss_ext_sales_price#2, d_year#8, d_qoy#9, ca_county#11]
+Keys [3]: [ca_county#11, d_qoy#9, d_year#8]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum#12]
+Results [4]: [ca_county#11, d_qoy#9, d_year#8, sum#13]
+
+(14) Exchange
+Input [4]: [ca_county#11, d_qoy#9, d_year#8, sum#13]
+Arguments: hashpartitioning(ca_county#11, d_qoy#9, d_year#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 42]
+Input [4]: [ca_county#11, d_qoy#9, d_year#8, sum#13]
+Keys [3]: [ca_county#11, d_qoy#9, d_year#8]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#14]
+Results [2]: [ca_county#11, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS store_sales#15]
+
+(16) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_addr_sk#16, ss_ext_sales_price#17, ss_sold_date_sk#18]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#18), dynamicpruningexpression(ss_sold_date_sk#18 IN dynamicpruning#19)]
+PushedFilters: [IsNotNull(ss_addr_sk)]
+ReadSchema: struct<ss_addr_sk:int,ss_ext_sales_price:decimal(7,2)>
+
+(17) ColumnarToRow [codegen id : 8]
+Input [3]: [ss_addr_sk#16, ss_ext_sales_price#17, ss_sold_date_sk#18]
+
+(18) Filter [codegen id : 8]
+Input [3]: [ss_addr_sk#16, ss_ext_sales_price#17, ss_sold_date_sk#18]
+Condition : (isnotnull(ss_addr_sk#16) AND might_contain(Subquery scalar-subquery#20, [id=#21], xxhash64(ss_addr_sk#16, 42), false))
+
+(19) ReusedExchange [Reuses operator id: 129]
+Output [3]: [d_date_sk#22, d_year#23, d_qoy#24]
+
+(20) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [ss_sold_date_sk#18]
+Right keys [1]: [d_date_sk#22]
+Join type: Inner
+Join condition: None
+
+(21) Project [codegen id : 8]
+Output [4]: [ss_addr_sk#16, ss_ext_sales_price#17, d_year#23, d_qoy#24]
+Input [6]: [ss_addr_sk#16, ss_ext_sales_price#17, ss_sold_date_sk#18, d_date_sk#22, d_year#23, d_qoy#24]
+
+(22) Exchange
+Input [4]: [ss_addr_sk#16, ss_ext_sales_price#17, d_year#23, d_qoy#24]
+Arguments: hashpartitioning(ss_addr_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(23) Sort [codegen id : 9]
+Input [4]: [ss_addr_sk#16, ss_ext_sales_price#17, d_year#23, d_qoy#24]
+Arguments: [ss_addr_sk#16 ASC NULLS FIRST], false, 0
+
+(24) ReusedExchange [Reuses operator id: 111]
+Output [2]: [ca_address_sk#25, ca_county#26]
+
+(25) Sort [codegen id : 11]
+Input [2]: [ca_address_sk#25, ca_county#26]
+Arguments: [ca_address_sk#25 ASC NULLS FIRST], false, 0
+
+(26) SortMergeJoin [codegen id : 12]
+Left keys [1]: [ss_addr_sk#16]
+Right keys [1]: [ca_address_sk#25]
+Join type: Inner
+Join condition: None
+
+(27) Project [codegen id : 12]
+Output [4]: [ss_ext_sales_price#17, d_year#23, d_qoy#24, ca_county#26]
+Input [6]: [ss_addr_sk#16, ss_ext_sales_price#17, d_year#23, d_qoy#24, ca_address_sk#25, ca_county#26]
+
+(28) HashAggregate [codegen id : 12]
+Input [4]: [ss_ext_sales_price#17, d_year#23, d_qoy#24, ca_county#26]
+Keys [3]: [ca_county#26, d_qoy#24, d_year#23]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#17))]
+Aggregate Attributes [1]: [sum#27]
+Results [4]: [ca_county#26, d_qoy#24, d_year#23, sum#28]
+
+(29) Exchange
+Input [4]: [ca_county#26, d_qoy#24, d_year#23, sum#28]
+Arguments: hashpartitioning(ca_county#26, d_qoy#24, d_year#23, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(30) HashAggregate [codegen id : 13]
+Input [4]: [ca_county#26, d_qoy#24, d_year#23, sum#28]
+Keys [3]: [ca_county#26, d_qoy#24, d_year#23]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#17))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#17))#14]
+Results [2]: [ca_county#26, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#17))#14,17,2) AS store_sales#29]
+
+(31) BroadcastExchange
+Input [2]: [ca_county#26, store_sales#29]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=5]
+
+(32) BroadcastHashJoin [codegen id : 42]
+Left keys [1]: [ca_county#11]
+Right keys [1]: [ca_county#26]
+Join type: Inner
+Join condition: None
+
+(33) Project [codegen id : 42]
+Output [3]: [ca_county#11, store_sales#15, store_sales#29]
+Input [4]: [ca_county#11, store_sales#15, ca_county#26, store_sales#29]
+
+(34) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_addr_sk#30, ss_ext_sales_price#31, ss_sold_date_sk#32]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#32), dynamicpruningexpression(ss_sold_date_sk#32 IN dynamicpruning#33)]
+PushedFilters: [IsNotNull(ss_addr_sk)]
+ReadSchema: struct<ss_addr_sk:int,ss_ext_sales_price:decimal(7,2)>
+
+(35) ColumnarToRow [codegen id : 15]
+Input [3]: [ss_addr_sk#30, ss_ext_sales_price#31, ss_sold_date_sk#32]
+
+(36) Filter [codegen id : 15]
+Input [3]: [ss_addr_sk#30, ss_ext_sales_price#31, ss_sold_date_sk#32]
+Condition : (isnotnull(ss_addr_sk#30) AND might_contain(ReusedSubquery Subquery scalar-subquery#20, [id=#21], xxhash64(ss_addr_sk#30, 42), false))
+
+(37) ReusedExchange [Reuses operator id: 133]
+Output [3]: [d_date_sk#34, d_year#35, d_qoy#36]
+
+(38) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ss_sold_date_sk#32]
+Right keys [1]: [d_date_sk#34]
+Join type: Inner
+Join condition: None
+
+(39) Project [codegen id : 15]
+Output [4]: [ss_addr_sk#30, ss_ext_sales_price#31, d_year#35, d_qoy#36]
+Input [6]: [ss_addr_sk#30, ss_ext_sales_price#31, ss_sold_date_sk#32, d_date_sk#34, d_year#35, d_qoy#36]
+
+(40) Exchange
+Input [4]: [ss_addr_sk#30, ss_ext_sales_price#31, d_year#35, d_qoy#36]
+Arguments: hashpartitioning(ss_addr_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(41) Sort [codegen id : 16]
+Input [4]: [ss_addr_sk#30, ss_ext_sales_price#31, d_year#35, d_qoy#36]
+Arguments: [ss_addr_sk#30 ASC NULLS FIRST], false, 0
+
+(42) ReusedExchange [Reuses operator id: 111]
+Output [2]: [ca_address_sk#37, ca_county#38]
+
+(43) Sort [codegen id : 18]
+Input [2]: [ca_address_sk#37, ca_county#38]
+Arguments: [ca_address_sk#37 ASC NULLS FIRST], false, 0
+
+(44) SortMergeJoin [codegen id : 19]
+Left keys [1]: [ss_addr_sk#30]
+Right keys [1]: [ca_address_sk#37]
+Join type: Inner
+Join condition: None
+
+(45) Project [codegen id : 19]
+Output [4]: [ss_ext_sales_price#31, d_year#35, d_qoy#36, ca_county#38]
+Input [6]: [ss_addr_sk#30, ss_ext_sales_price#31, d_year#35, d_qoy#36, ca_address_sk#37, ca_county#38]
+
+(46) HashAggregate [codegen id : 19]
+Input [4]: [ss_ext_sales_price#31, d_year#35, d_qoy#36, ca_county#38]
+Keys [3]: [ca_county#38, d_qoy#36, d_year#35]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#31))]
+Aggregate Attributes [1]: [sum#39]
+Results [4]: [ca_county#38, d_qoy#36, d_year#35, sum#40]
+
+(47) Exchange
+Input [4]: [ca_county#38, d_qoy#36, d_year#35, sum#40]
+Arguments: hashpartitioning(ca_county#38, d_qoy#36, d_year#35, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(48) HashAggregate [codegen id : 20]
+Input [4]: [ca_county#38, d_qoy#36, d_year#35, sum#40]
+Keys [3]: [ca_county#38, d_qoy#36, d_year#35]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#31))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#31))#14]
+Results [3]: [ca_county#38, d_year#35, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#31))#14,17,2) AS store_sales#41]
+
+(49) BroadcastExchange
+Input [3]: [ca_county#38, d_year#35, store_sales#41]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=8]
+
+(50) BroadcastHashJoin [codegen id : 42]
+Left keys [1]: [ca_county#11]
+Right keys [1]: [ca_county#38]
+Join type: Inner
+Join condition: None
+
+(51) Project [codegen id : 42]
+Output [5]: [store_sales#15, store_sales#29, ca_county#38, d_year#35, store_sales#41]
+Input [6]: [ca_county#11, store_sales#15, store_sales#29, ca_county#38, d_year#35, store_sales#41]
+
+(52) Scan parquet spark_catalog.default.web_sales
+Output [3]: [ws_bill_addr_sk#42, ws_ext_sales_price#43, ws_sold_date_sk#44]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#44), dynamicpruningexpression(ws_sold_date_sk#44 IN dynamicpruning#33)]
+PushedFilters: [IsNotNull(ws_bill_addr_sk)]
+ReadSchema: struct<ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
+
+(53) ColumnarToRow [codegen id : 22]
+Input [3]: [ws_bill_addr_sk#42, ws_ext_sales_price#43, ws_sold_date_sk#44]
+
+(54) Filter [codegen id : 22]
+Input [3]: [ws_bill_addr_sk#42, ws_ext_sales_price#43, ws_sold_date_sk#44]
+Condition : (isnotnull(ws_bill_addr_sk#42) AND might_contain(ReusedSubquery Subquery scalar-subquery#20, [id=#21], xxhash64(ws_bill_addr_sk#42, 42), false))
+
+(55) ReusedExchange [Reuses operator id: 133]
+Output [3]: [d_date_sk#45, d_year#46, d_qoy#47]
+
+(56) BroadcastHashJoin [codegen id : 22]
+Left keys [1]: [ws_sold_date_sk#44]
+Right keys [1]: [d_date_sk#45]
+Join type: Inner
+Join condition: None
+
+(57) Project [codegen id : 22]
+Output [4]: [ws_bill_addr_sk#42, ws_ext_sales_price#43, d_year#46, d_qoy#47]
+Input [6]: [ws_bill_addr_sk#42, ws_ext_sales_price#43, ws_sold_date_sk#44, d_date_sk#45, d_year#46, d_qoy#47]
+
+(58) Exchange
+Input [4]: [ws_bill_addr_sk#42, ws_ext_sales_price#43, d_year#46, d_qoy#47]
+Arguments: hashpartitioning(ws_bill_addr_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(59) Sort [codegen id : 23]
+Input [4]: [ws_bill_addr_sk#42, ws_ext_sales_price#43, d_year#46, d_qoy#47]
+Arguments: [ws_bill_addr_sk#42 ASC NULLS FIRST], false, 0
+
+(60) ReusedExchange [Reuses operator id: 111]
+Output [2]: [ca_address_sk#48, ca_county#49]
+
+(61) Sort [codegen id : 25]
+Input [2]: [ca_address_sk#48, ca_county#49]
+Arguments: [ca_address_sk#48 ASC NULLS FIRST], false, 0
+
+(62) SortMergeJoin [codegen id : 26]
+Left keys [1]: [ws_bill_addr_sk#42]
+Right keys [1]: [ca_address_sk#48]
+Join type: Inner
+Join condition: None
+
+(63) Project [codegen id : 26]
+Output [4]: [ws_ext_sales_price#43, d_year#46, d_qoy#47, ca_county#49]
+Input [6]: [ws_bill_addr_sk#42, ws_ext_sales_price#43, d_year#46, d_qoy#47, ca_address_sk#48, ca_county#49]
+
+(64) HashAggregate [codegen id : 26]
+Input [4]: [ws_ext_sales_price#43, d_year#46, d_qoy#47, ca_county#49]
+Keys [3]: [ca_county#49, d_qoy#47, d_year#46]
+Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#43))]
+Aggregate Attributes [1]: [sum#50]
+Results [4]: [ca_county#49, d_qoy#47, d_year#46, sum#51]
+
+(65) Exchange
+Input [4]: [ca_county#49, d_qoy#47, d_year#46, sum#51]
+Arguments: hashpartitioning(ca_county#49, d_qoy#47, d_year#46, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(66) HashAggregate [codegen id : 41]
+Input [4]: [ca_county#49, d_qoy#47, d_year#46, sum#51]
+Keys [3]: [ca_county#49, d_qoy#47, d_year#46]
+Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#43))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#43))#52]
+Results [2]: [ca_county#49, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#43))#52,17,2) AS web_sales#53]
+
+(67) Scan parquet spark_catalog.default.web_sales
+Output [3]: [ws_bill_addr_sk#54, ws_ext_sales_price#55, ws_sold_date_sk#56]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#56), dynamicpruningexpression(ws_sold_date_sk#56 IN dynamicpruning#4)]
+PushedFilters: [IsNotNull(ws_bill_addr_sk)]
+ReadSchema: struct<ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
+
+(68) ColumnarToRow [codegen id : 28]
+Input [3]: [ws_bill_addr_sk#54, ws_ext_sales_price#55, ws_sold_date_sk#56]
+
+(69) Filter [codegen id : 28]
+Input [3]: [ws_bill_addr_sk#54, ws_ext_sales_price#55, ws_sold_date_sk#56]
+Condition : (isnotnull(ws_bill_addr_sk#54) AND might_contain(ReusedSubquery Subquery scalar-subquery#20, [id=#21], xxhash64(ws_bill_addr_sk#54, 42), false))
+
+(70) ReusedExchange [Reuses operator id: 118]
+Output [3]: [d_date_sk#57, d_year#58, d_qoy#59]
+
+(71) BroadcastHashJoin [codegen id : 28]
+Left keys [1]: [ws_sold_date_sk#56]
+Right keys [1]: [d_date_sk#57]
+Join type: Inner
+Join condition: None
+
+(72) Project [codegen id : 28]
+Output [4]: [ws_bill_addr_sk#54, ws_ext_sales_price#55, d_year#58, d_qoy#59]
+Input [6]: [ws_bill_addr_sk#54, ws_ext_sales_price#55, ws_sold_date_sk#56, d_date_sk#57, d_year#58, d_qoy#59]
+
+(73) Exchange
+Input [4]: [ws_bill_addr_sk#54, ws_ext_sales_price#55, d_year#58, d_qoy#59]
+Arguments: hashpartitioning(ws_bill_addr_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(74) Sort [codegen id : 29]
+Input [4]: [ws_bill_addr_sk#54, ws_ext_sales_price#55, d_year#58, d_qoy#59]
+Arguments: [ws_bill_addr_sk#54 ASC NULLS FIRST], false, 0
+
+(75) ReusedExchange [Reuses operator id: 111]
+Output [2]: [ca_address_sk#60, ca_county#61]
+
+(76) Sort [codegen id : 31]
+Input [2]: [ca_address_sk#60, ca_county#61]
+Arguments: [ca_address_sk#60 ASC NULLS FIRST], false, 0
+
+(77) SortMergeJoin [codegen id : 32]
+Left keys [1]: [ws_bill_addr_sk#54]
+Right keys [1]: [ca_address_sk#60]
+Join type: Inner
+Join condition: None
+
+(78) Project [codegen id : 32]
+Output [4]: [ws_ext_sales_price#55, d_year#58, d_qoy#59, ca_county#61]
+Input [6]: [ws_bill_addr_sk#54, ws_ext_sales_price#55, d_year#58, d_qoy#59, ca_address_sk#60, ca_county#61]
+
+(79) HashAggregate [codegen id : 32]
+Input [4]: [ws_ext_sales_price#55, d_year#58, d_qoy#59, ca_county#61]
+Keys [3]: [ca_county#61, d_qoy#59, d_year#58]
+Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#55))]
+Aggregate Attributes [1]: [sum#62]
+Results [4]: [ca_county#61, d_qoy#59, d_year#58, sum#63]
+
+(80) Exchange
+Input [4]: [ca_county#61, d_qoy#59, d_year#58, sum#63]
+Arguments: hashpartitioning(ca_county#61, d_qoy#59, d_year#58, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(81) HashAggregate [codegen id : 33]
+Input [4]: [ca_county#61, d_qoy#59, d_year#58, sum#63]
+Keys [3]: [ca_county#61, d_qoy#59, d_year#58]
+Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#55))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#55))#52]
+Results [2]: [ca_county#61, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#55))#52,17,2) AS web_sales#64]
+
+(82) BroadcastExchange
+Input [2]: [ca_county#61, web_sales#64]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=13]
+
+(83) BroadcastHashJoin [codegen id : 41]
+Left keys [1]: [ca_county#49]
+Right keys [1]: [ca_county#61]
+Join type: Inner
+Join condition: None
+
+(84) Project [codegen id : 41]
+Output [3]: [ca_county#49, web_sales#53, web_sales#64]
+Input [4]: [ca_county#49, web_sales#53, ca_county#61, web_sales#64]
+
+(85) Scan parquet spark_catalog.default.web_sales
+Output [3]: [ws_bill_addr_sk#65, ws_ext_sales_price#66, ws_sold_date_sk#67]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#67), dynamicpruningexpression(ws_sold_date_sk#67 IN dynamicpruning#19)]
+PushedFilters: [IsNotNull(ws_bill_addr_sk)]
+ReadSchema: struct<ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
+
+(86) ColumnarToRow [codegen id : 35]
+Input [3]: [ws_bill_addr_sk#65, ws_ext_sales_price#66, ws_sold_date_sk#67]
+
+(87) Filter [codegen id : 35]
+Input [3]: [ws_bill_addr_sk#65, ws_ext_sales_price#66, ws_sold_date_sk#67]
+Condition : (isnotnull(ws_bill_addr_sk#65) AND might_contain(ReusedSubquery Subquery scalar-subquery#20, [id=#21], xxhash64(ws_bill_addr_sk#65, 42), false))
+
+(88) ReusedExchange [Reuses operator id: 129]
+Output [3]: [d_date_sk#68, d_year#69, d_qoy#70]
+
+(89) BroadcastHashJoin [codegen id : 35]
+Left keys [1]: [ws_sold_date_sk#67]
+Right keys [1]: [d_date_sk#68]
+Join type: Inner
+Join condition: None
+
+(90) Project [codegen id : 35]
+Output [4]: [ws_bill_addr_sk#65, ws_ext_sales_price#66, d_year#69, d_qoy#70]
+Input [6]: [ws_bill_addr_sk#65, ws_ext_sales_price#66, ws_sold_date_sk#67, d_date_sk#68, d_year#69, d_qoy#70]
+
+(91) Exchange
+Input [4]: [ws_bill_addr_sk#65, ws_ext_sales_price#66, d_year#69, d_qoy#70]
+Arguments: hashpartitioning(ws_bill_addr_sk#65, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(92) Sort [codegen id : 36]
+Input [4]: [ws_bill_addr_sk#65, ws_ext_sales_price#66, d_year#69, d_qoy#70]
+Arguments: [ws_bill_addr_sk#65 ASC NULLS FIRST], false, 0
+
+(93) ReusedExchange [Reuses operator id: 111]
+Output [2]: [ca_address_sk#71, ca_county#72]
+
+(94) Sort [codegen id : 38]
+Input [2]: [ca_address_sk#71, ca_county#72]
+Arguments: [ca_address_sk#71 ASC NULLS FIRST], false, 0
+
+(95) SortMergeJoin [codegen id : 39]
+Left keys [1]: [ws_bill_addr_sk#65]
+Right keys [1]: [ca_address_sk#71]
+Join type: Inner
+Join condition: None
+
+(96) Project [codegen id : 39]
+Output [4]: [ws_ext_sales_price#66, d_year#69, d_qoy#70, ca_county#72]
+Input [6]: [ws_bill_addr_sk#65, ws_ext_sales_price#66, d_year#69, d_qoy#70, ca_address_sk#71, ca_county#72]
+
+(97) HashAggregate [codegen id : 39]
+Input [4]: [ws_ext_sales_price#66, d_year#69, d_qoy#70, ca_county#72]
+Keys [3]: [ca_county#72, d_qoy#70, d_year#69]
+Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#66))]
+Aggregate Attributes [1]: [sum#73]
+Results [4]: [ca_county#72, d_qoy#70, d_year#69, sum#74]
+
+(98) Exchange
+Input [4]: [ca_county#72, d_qoy#70, d_year#69, sum#74]
+Arguments: hashpartitioning(ca_county#72, d_qoy#70, d_year#69, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(99) HashAggregate [codegen id : 40]
+Input [4]: [ca_county#72, d_qoy#70, d_year#69, sum#74]
+Keys [3]: [ca_county#72, d_qoy#70, d_year#69]
+Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#66))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#66))#52]
+Results [2]: [ca_county#72, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#66))#52,17,2) AS web_sales#75]
+
+(100) BroadcastExchange
+Input [2]: [ca_county#72, web_sales#75]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=16]
+
+(101) BroadcastHashJoin [codegen id : 41]
+Left keys [1]: [ca_county#49]
+Right keys [1]: [ca_county#72]
+Join type: Inner
+Join condition: None
+
+(102) Project [codegen id : 41]
+Output [4]: [ca_county#49, web_sales#53, web_sales#64, web_sales#75]
+Input [5]: [ca_county#49, web_sales#53, web_sales#64, ca_county#72, web_sales#75]
+
+(103) BroadcastExchange
+Input [4]: [ca_county#49, web_sales#53, web_sales#64, web_sales#75]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=17]
+
+(104) BroadcastHashJoin [codegen id : 42]
+Left keys [1]: [ca_county#38]
+Right keys [1]: [ca_county#49]
+Join type: Inner
+Join condition: ((CASE WHEN (web_sales#53 > 0.00) THEN (web_sales#64 / web_sales#53) END > CASE WHEN (store_sales#41 > 0.00) THEN (store_sales#15 / store_sales#41) END) AND (CASE WHEN (web_sales#64 > 0.00) THEN (web_sales#75 / web_sales#64) END > CASE WHEN (store_sales#15 > 0.00) THEN (store_sales#29 / store_sales#15) END))
+
+(105) Project [codegen id : 42]
+Output [6]: [ca_county#38, d_year#35, (web_sales#64 / web_sales#53) AS web_q1_q2_increase#76, (store_sales#15 / store_sales#41) AS store_q1_q2_increase#77, (web_sales#75 / web_sales#64) AS web_q2_q3_increase#78, (store_sales#29 / store_sales#15) AS store_q2_q3_increase#79]
+Input [9]: [store_sales#15, store_sales#29, ca_county#38, d_year#35, store_sales#41, ca_county#49, web_sales#53, web_sales#64, web_sales#75]
+
+(106) Exchange
+Input [6]: [ca_county#38, d_year#35, web_q1_q2_increase#76, store_q1_q2_increase#77, web_q2_q3_increase#78, store_q2_q3_increase#79]
+Arguments: rangepartitioning(ca_county#38 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(107) Sort [codegen id : 43]
+Input [6]: [ca_county#38, d_year#35, web_q1_q2_increase#76, store_q1_q2_increase#77, web_q2_q3_increase#78, store_q2_q3_increase#79]
+Arguments: [ca_county#38 ASC NULLS FIRST], true, 0
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (114)
++- Exchange (113)
+   +- ObjectHashAggregate (112)
+      +- Exchange (111)
+         +- * Filter (110)
+            +- * ColumnarToRow (109)
+               +- Scan parquet spark_catalog.default.customer_address (108)
+
+
+(108) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#10, ca_county#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(10) ColumnarToRow [codegen id : 4]
-Input [2]: [ca_address_sk#8, ca_county#9]
-
-(11) Filter [codegen id : 4]
-Input [2]: [ca_address_sk#8, ca_county#9]
-Condition : (isnotnull(ca_address_sk#8) AND isnotnull(ca_county#9))
-
-(12) Exchange
-Input [2]: [ca_address_sk#8, ca_county#9]
-Arguments: hashpartitioning(ca_address_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(13) Sort [codegen id : 5]
-Input [2]: [ca_address_sk#8, ca_county#9]
-Arguments: [ca_address_sk#8 ASC NULLS FIRST], false, 0
-
-(14) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_addr_sk#1]
-Right keys [1]: [ca_address_sk#8]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [4]: [ss_ext_sales_price#2, d_year#6, d_qoy#7, ca_county#9]
-Input [6]: [ss_addr_sk#1, ss_ext_sales_price#2, d_year#6, d_qoy#7, ca_address_sk#8, ca_county#9]
-
-(16) HashAggregate [codegen id : 6]
-Input [4]: [ss_ext_sales_price#2, d_year#6, d_qoy#7, ca_county#9]
-Keys [3]: [ca_county#9, d_qoy#7, d_year#6]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#10]
-Results [4]: [ca_county#9, d_qoy#7, d_year#6, sum#11]
-
-(17) Exchange
-Input [4]: [ca_county#9, d_qoy#7, d_year#6, sum#11]
-Arguments: hashpartitioning(ca_county#9, d_qoy#7, d_year#6, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 42]
-Input [4]: [ca_county#9, d_qoy#7, d_year#6, sum#11]
-Keys [3]: [ca_county#9, d_qoy#7, d_year#6]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#12]
-Results [2]: [ca_county#9, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#12,17,2) AS store_sales#13]
-
-(19) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_addr_sk#14, ss_ext_sales_price#15, ss_sold_date_sk#16]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#16), dynamicpruningexpression(ss_sold_date_sk#16 IN dynamicpruning#17)]
-PushedFilters: [IsNotNull(ss_addr_sk)]
-ReadSchema: struct<ss_addr_sk:int,ss_ext_sales_price:decimal(7,2)>
-
-(20) ColumnarToRow [codegen id : 8]
-Input [3]: [ss_addr_sk#14, ss_ext_sales_price#15, ss_sold_date_sk#16]
-
-(21) Filter [codegen id : 8]
-Input [3]: [ss_addr_sk#14, ss_ext_sales_price#15, ss_sold_date_sk#16]
-Condition : isnotnull(ss_addr_sk#14)
-
-(22) ReusedExchange [Reuses operator id: 118]
-Output [3]: [d_date_sk#18, d_year#19, d_qoy#20]
-
-(23) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ss_sold_date_sk#16]
-Right keys [1]: [d_date_sk#18]
-Join type: Inner
-Join condition: None
-
-(24) Project [codegen id : 8]
-Output [4]: [ss_addr_sk#14, ss_ext_sales_price#15, d_year#19, d_qoy#20]
-Input [6]: [ss_addr_sk#14, ss_ext_sales_price#15, ss_sold_date_sk#16, d_date_sk#18, d_year#19, d_qoy#20]
-
-(25) Exchange
-Input [4]: [ss_addr_sk#14, ss_ext_sales_price#15, d_year#19, d_qoy#20]
-Arguments: hashpartitioning(ss_addr_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(26) Sort [codegen id : 9]
-Input [4]: [ss_addr_sk#14, ss_ext_sales_price#15, d_year#19, d_qoy#20]
-Arguments: [ss_addr_sk#14 ASC NULLS FIRST], false, 0
-
-(27) ReusedExchange [Reuses operator id: 12]
-Output [2]: [ca_address_sk#21, ca_county#22]
-
-(28) Sort [codegen id : 11]
-Input [2]: [ca_address_sk#21, ca_county#22]
-Arguments: [ca_address_sk#21 ASC NULLS FIRST], false, 0
-
-(29) SortMergeJoin [codegen id : 12]
-Left keys [1]: [ss_addr_sk#14]
-Right keys [1]: [ca_address_sk#21]
-Join type: Inner
-Join condition: None
-
-(30) Project [codegen id : 12]
-Output [4]: [ss_ext_sales_price#15, d_year#19, d_qoy#20, ca_county#22]
-Input [6]: [ss_addr_sk#14, ss_ext_sales_price#15, d_year#19, d_qoy#20, ca_address_sk#21, ca_county#22]
-
-(31) HashAggregate [codegen id : 12]
-Input [4]: [ss_ext_sales_price#15, d_year#19, d_qoy#20, ca_county#22]
-Keys [3]: [ca_county#22, d_qoy#20, d_year#19]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#15))]
-Aggregate Attributes [1]: [sum#23]
-Results [4]: [ca_county#22, d_qoy#20, d_year#19, sum#24]
-
-(32) Exchange
-Input [4]: [ca_county#22, d_qoy#20, d_year#19, sum#24]
-Arguments: hashpartitioning(ca_county#22, d_qoy#20, d_year#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(33) HashAggregate [codegen id : 13]
-Input [4]: [ca_county#22, d_qoy#20, d_year#19, sum#24]
-Keys [3]: [ca_county#22, d_qoy#20, d_year#19]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#15))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#15))#12]
-Results [2]: [ca_county#22, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#15))#12,17,2) AS store_sales#25]
-
-(34) BroadcastExchange
-Input [2]: [ca_county#22, store_sales#25]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=6]
-
-(35) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ca_county#9]
-Right keys [1]: [ca_county#22]
-Join type: Inner
-Join condition: None
-
-(36) Project [codegen id : 42]
-Output [3]: [ca_county#9, store_sales#13, store_sales#25]
-Input [4]: [ca_county#9, store_sales#13, ca_county#22, store_sales#25]
-
-(37) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_addr_sk#26, ss_ext_sales_price#27, ss_sold_date_sk#28]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#28), dynamicpruningexpression(ss_sold_date_sk#28 IN dynamicpruning#29)]
-PushedFilters: [IsNotNull(ss_addr_sk)]
-ReadSchema: struct<ss_addr_sk:int,ss_ext_sales_price:decimal(7,2)>
-
-(38) ColumnarToRow [codegen id : 15]
-Input [3]: [ss_addr_sk#26, ss_ext_sales_price#27, ss_sold_date_sk#28]
-
-(39) Filter [codegen id : 15]
-Input [3]: [ss_addr_sk#26, ss_ext_sales_price#27, ss_sold_date_sk#28]
-Condition : isnotnull(ss_addr_sk#26)
-
-(40) ReusedExchange [Reuses operator id: 122]
-Output [3]: [d_date_sk#30, d_year#31, d_qoy#32]
-
-(41) BroadcastHashJoin [codegen id : 15]
-Left keys [1]: [ss_sold_date_sk#28]
-Right keys [1]: [d_date_sk#30]
-Join type: Inner
-Join condition: None
-
-(42) Project [codegen id : 15]
-Output [4]: [ss_addr_sk#26, ss_ext_sales_price#27, d_year#31, d_qoy#32]
-Input [6]: [ss_addr_sk#26, ss_ext_sales_price#27, ss_sold_date_sk#28, d_date_sk#30, d_year#31, d_qoy#32]
-
-(43) Exchange
-Input [4]: [ss_addr_sk#26, ss_ext_sales_price#27, d_year#31, d_qoy#32]
-Arguments: hashpartitioning(ss_addr_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(44) Sort [codegen id : 16]
-Input [4]: [ss_addr_sk#26, ss_ext_sales_price#27, d_year#31, d_qoy#32]
-Arguments: [ss_addr_sk#26 ASC NULLS FIRST], false, 0
-
-(45) ReusedExchange [Reuses operator id: 12]
-Output [2]: [ca_address_sk#33, ca_county#34]
-
-(46) Sort [codegen id : 18]
-Input [2]: [ca_address_sk#33, ca_county#34]
-Arguments: [ca_address_sk#33 ASC NULLS FIRST], false, 0
-
-(47) SortMergeJoin [codegen id : 19]
-Left keys [1]: [ss_addr_sk#26]
-Right keys [1]: [ca_address_sk#33]
-Join type: Inner
-Join condition: None
-
-(48) Project [codegen id : 19]
-Output [4]: [ss_ext_sales_price#27, d_year#31, d_qoy#32, ca_county#34]
-Input [6]: [ss_addr_sk#26, ss_ext_sales_price#27, d_year#31, d_qoy#32, ca_address_sk#33, ca_county#34]
-
-(49) HashAggregate [codegen id : 19]
-Input [4]: [ss_ext_sales_price#27, d_year#31, d_qoy#32, ca_county#34]
-Keys [3]: [ca_county#34, d_qoy#32, d_year#31]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#27))]
-Aggregate Attributes [1]: [sum#35]
-Results [4]: [ca_county#34, d_qoy#32, d_year#31, sum#36]
-
-(50) Exchange
-Input [4]: [ca_county#34, d_qoy#32, d_year#31, sum#36]
-Arguments: hashpartitioning(ca_county#34, d_qoy#32, d_year#31, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(51) HashAggregate [codegen id : 20]
-Input [4]: [ca_county#34, d_qoy#32, d_year#31, sum#36]
-Keys [3]: [ca_county#34, d_qoy#32, d_year#31]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#27))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#27))#12]
-Results [3]: [ca_county#34, d_year#31, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#27))#12,17,2) AS store_sales#37]
-
-(52) BroadcastExchange
-Input [3]: [ca_county#34, d_year#31, store_sales#37]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=9]
-
-(53) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ca_county#9]
-Right keys [1]: [ca_county#34]
-Join type: Inner
-Join condition: None
-
-(54) Project [codegen id : 42]
-Output [5]: [store_sales#13, store_sales#25, ca_county#34, d_year#31, store_sales#37]
-Input [6]: [ca_county#9, store_sales#13, store_sales#25, ca_county#34, d_year#31, store_sales#37]
-
-(55) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_bill_addr_sk#38, ws_ext_sales_price#39, ws_sold_date_sk#40]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#40), dynamicpruningexpression(ws_sold_date_sk#40 IN dynamicpruning#29)]
-PushedFilters: [IsNotNull(ws_bill_addr_sk)]
-ReadSchema: struct<ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
-
-(56) ColumnarToRow [codegen id : 22]
-Input [3]: [ws_bill_addr_sk#38, ws_ext_sales_price#39, ws_sold_date_sk#40]
-
-(57) Filter [codegen id : 22]
-Input [3]: [ws_bill_addr_sk#38, ws_ext_sales_price#39, ws_sold_date_sk#40]
-Condition : isnotnull(ws_bill_addr_sk#38)
-
-(58) ReusedExchange [Reuses operator id: 122]
-Output [3]: [d_date_sk#41, d_year#42, d_qoy#43]
-
-(59) BroadcastHashJoin [codegen id : 22]
-Left keys [1]: [ws_sold_date_sk#40]
-Right keys [1]: [d_date_sk#41]
-Join type: Inner
-Join condition: None
-
-(60) Project [codegen id : 22]
-Output [4]: [ws_bill_addr_sk#38, ws_ext_sales_price#39, d_year#42, d_qoy#43]
-Input [6]: [ws_bill_addr_sk#38, ws_ext_sales_price#39, ws_sold_date_sk#40, d_date_sk#41, d_year#42, d_qoy#43]
-
-(61) Exchange
-Input [4]: [ws_bill_addr_sk#38, ws_ext_sales_price#39, d_year#42, d_qoy#43]
-Arguments: hashpartitioning(ws_bill_addr_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(62) Sort [codegen id : 23]
-Input [4]: [ws_bill_addr_sk#38, ws_ext_sales_price#39, d_year#42, d_qoy#43]
-Arguments: [ws_bill_addr_sk#38 ASC NULLS FIRST], false, 0
-
-(63) ReusedExchange [Reuses operator id: 12]
-Output [2]: [ca_address_sk#44, ca_county#45]
-
-(64) Sort [codegen id : 25]
-Input [2]: [ca_address_sk#44, ca_county#45]
-Arguments: [ca_address_sk#44 ASC NULLS FIRST], false, 0
-
-(65) SortMergeJoin [codegen id : 26]
-Left keys [1]: [ws_bill_addr_sk#38]
-Right keys [1]: [ca_address_sk#44]
-Join type: Inner
-Join condition: None
-
-(66) Project [codegen id : 26]
-Output [4]: [ws_ext_sales_price#39, d_year#42, d_qoy#43, ca_county#45]
-Input [6]: [ws_bill_addr_sk#38, ws_ext_sales_price#39, d_year#42, d_qoy#43, ca_address_sk#44, ca_county#45]
-
-(67) HashAggregate [codegen id : 26]
-Input [4]: [ws_ext_sales_price#39, d_year#42, d_qoy#43, ca_county#45]
-Keys [3]: [ca_county#45, d_qoy#43, d_year#42]
-Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#39))]
-Aggregate Attributes [1]: [sum#46]
-Results [4]: [ca_county#45, d_qoy#43, d_year#42, sum#47]
-
-(68) Exchange
-Input [4]: [ca_county#45, d_qoy#43, d_year#42, sum#47]
-Arguments: hashpartitioning(ca_county#45, d_qoy#43, d_year#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(69) HashAggregate [codegen id : 41]
-Input [4]: [ca_county#45, d_qoy#43, d_year#42, sum#47]
-Keys [3]: [ca_county#45, d_qoy#43, d_year#42]
-Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#39))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#39))#48]
-Results [2]: [ca_county#45, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#39))#48,17,2) AS web_sales#49]
-
-(70) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_bill_addr_sk#50, ws_ext_sales_price#51, ws_sold_date_sk#52]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#52), dynamicpruningexpression(ws_sold_date_sk#52 IN dynamicpruning#4)]
-PushedFilters: [IsNotNull(ws_bill_addr_sk)]
-ReadSchema: struct<ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
-
-(71) ColumnarToRow [codegen id : 28]
-Input [3]: [ws_bill_addr_sk#50, ws_ext_sales_price#51, ws_sold_date_sk#52]
-
-(72) Filter [codegen id : 28]
-Input [3]: [ws_bill_addr_sk#50, ws_ext_sales_price#51, ws_sold_date_sk#52]
-Condition : isnotnull(ws_bill_addr_sk#50)
-
-(73) ReusedExchange [Reuses operator id: 114]
-Output [3]: [d_date_sk#53, d_year#54, d_qoy#55]
-
-(74) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [ws_sold_date_sk#52]
-Right keys [1]: [d_date_sk#53]
-Join type: Inner
-Join condition: None
-
-(75) Project [codegen id : 28]
-Output [4]: [ws_bill_addr_sk#50, ws_ext_sales_price#51, d_year#54, d_qoy#55]
-Input [6]: [ws_bill_addr_sk#50, ws_ext_sales_price#51, ws_sold_date_sk#52, d_date_sk#53, d_year#54, d_qoy#55]
-
-(76) Exchange
-Input [4]: [ws_bill_addr_sk#50, ws_ext_sales_price#51, d_year#54, d_qoy#55]
-Arguments: hashpartitioning(ws_bill_addr_sk#50, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(77) Sort [codegen id : 29]
-Input [4]: [ws_bill_addr_sk#50, ws_ext_sales_price#51, d_year#54, d_qoy#55]
-Arguments: [ws_bill_addr_sk#50 ASC NULLS FIRST], false, 0
-
-(78) ReusedExchange [Reuses operator id: 12]
-Output [2]: [ca_address_sk#56, ca_county#57]
-
-(79) Sort [codegen id : 31]
-Input [2]: [ca_address_sk#56, ca_county#57]
-Arguments: [ca_address_sk#56 ASC NULLS FIRST], false, 0
-
-(80) SortMergeJoin [codegen id : 32]
-Left keys [1]: [ws_bill_addr_sk#50]
-Right keys [1]: [ca_address_sk#56]
-Join type: Inner
-Join condition: None
-
-(81) Project [codegen id : 32]
-Output [4]: [ws_ext_sales_price#51, d_year#54, d_qoy#55, ca_county#57]
-Input [6]: [ws_bill_addr_sk#50, ws_ext_sales_price#51, d_year#54, d_qoy#55, ca_address_sk#56, ca_county#57]
-
-(82) HashAggregate [codegen id : 32]
-Input [4]: [ws_ext_sales_price#51, d_year#54, d_qoy#55, ca_county#57]
-Keys [3]: [ca_county#57, d_qoy#55, d_year#54]
-Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#51))]
-Aggregate Attributes [1]: [sum#58]
-Results [4]: [ca_county#57, d_qoy#55, d_year#54, sum#59]
-
-(83) Exchange
-Input [4]: [ca_county#57, d_qoy#55, d_year#54, sum#59]
-Arguments: hashpartitioning(ca_county#57, d_qoy#55, d_year#54, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(84) HashAggregate [codegen id : 33]
-Input [4]: [ca_county#57, d_qoy#55, d_year#54, sum#59]
-Keys [3]: [ca_county#57, d_qoy#55, d_year#54]
-Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#51))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#51))#48]
-Results [2]: [ca_county#57, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#51))#48,17,2) AS web_sales#60]
-
-(85) BroadcastExchange
-Input [2]: [ca_county#57, web_sales#60]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=14]
-
-(86) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [ca_county#45]
-Right keys [1]: [ca_county#57]
-Join type: Inner
-Join condition: None
-
-(87) Project [codegen id : 41]
-Output [3]: [ca_county#45, web_sales#49, web_sales#60]
-Input [4]: [ca_county#45, web_sales#49, ca_county#57, web_sales#60]
-
-(88) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_bill_addr_sk#61, ws_ext_sales_price#62, ws_sold_date_sk#63]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#63), dynamicpruningexpression(ws_sold_date_sk#63 IN dynamicpruning#17)]
-PushedFilters: [IsNotNull(ws_bill_addr_sk)]
-ReadSchema: struct<ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
-
-(89) ColumnarToRow [codegen id : 35]
-Input [3]: [ws_bill_addr_sk#61, ws_ext_sales_price#62, ws_sold_date_sk#63]
-
-(90) Filter [codegen id : 35]
-Input [3]: [ws_bill_addr_sk#61, ws_ext_sales_price#62, ws_sold_date_sk#63]
-Condition : isnotnull(ws_bill_addr_sk#61)
-
-(91) ReusedExchange [Reuses operator id: 118]
-Output [3]: [d_date_sk#64, d_year#65, d_qoy#66]
-
-(92) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ws_sold_date_sk#63]
-Right keys [1]: [d_date_sk#64]
-Join type: Inner
-Join condition: None
-
-(93) Project [codegen id : 35]
-Output [4]: [ws_bill_addr_sk#61, ws_ext_sales_price#62, d_year#65, d_qoy#66]
-Input [6]: [ws_bill_addr_sk#61, ws_ext_sales_price#62, ws_sold_date_sk#63, d_date_sk#64, d_year#65, d_qoy#66]
-
-(94) Exchange
-Input [4]: [ws_bill_addr_sk#61, ws_ext_sales_price#62, d_year#65, d_qoy#66]
-Arguments: hashpartitioning(ws_bill_addr_sk#61, 5), ENSURE_REQUIREMENTS, [plan_id=15]
-
-(95) Sort [codegen id : 36]
-Input [4]: [ws_bill_addr_sk#61, ws_ext_sales_price#62, d_year#65, d_qoy#66]
-Arguments: [ws_bill_addr_sk#61 ASC NULLS FIRST], false, 0
-
-(96) ReusedExchange [Reuses operator id: 12]
-Output [2]: [ca_address_sk#67, ca_county#68]
-
-(97) Sort [codegen id : 38]
-Input [2]: [ca_address_sk#67, ca_county#68]
-Arguments: [ca_address_sk#67 ASC NULLS FIRST], false, 0
-
-(98) SortMergeJoin [codegen id : 39]
-Left keys [1]: [ws_bill_addr_sk#61]
-Right keys [1]: [ca_address_sk#67]
-Join type: Inner
-Join condition: None
-
-(99) Project [codegen id : 39]
-Output [4]: [ws_ext_sales_price#62, d_year#65, d_qoy#66, ca_county#68]
-Input [6]: [ws_bill_addr_sk#61, ws_ext_sales_price#62, d_year#65, d_qoy#66, ca_address_sk#67, ca_county#68]
-
-(100) HashAggregate [codegen id : 39]
-Input [4]: [ws_ext_sales_price#62, d_year#65, d_qoy#66, ca_county#68]
-Keys [3]: [ca_county#68, d_qoy#66, d_year#65]
-Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#62))]
-Aggregate Attributes [1]: [sum#69]
-Results [4]: [ca_county#68, d_qoy#66, d_year#65, sum#70]
-
-(101) Exchange
-Input [4]: [ca_county#68, d_qoy#66, d_year#65, sum#70]
-Arguments: hashpartitioning(ca_county#68, d_qoy#66, d_year#65, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(102) HashAggregate [codegen id : 40]
-Input [4]: [ca_county#68, d_qoy#66, d_year#65, sum#70]
-Keys [3]: [ca_county#68, d_qoy#66, d_year#65]
-Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#62))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#62))#48]
-Results [2]: [ca_county#68, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#62))#48,17,2) AS web_sales#71]
-
-(103) BroadcastExchange
-Input [2]: [ca_county#68, web_sales#71]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=17]
-
-(104) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [ca_county#45]
-Right keys [1]: [ca_county#68]
-Join type: Inner
-Join condition: None
-
-(105) Project [codegen id : 41]
-Output [4]: [ca_county#45, web_sales#49, web_sales#60, web_sales#71]
-Input [5]: [ca_county#45, web_sales#49, web_sales#60, ca_county#68, web_sales#71]
-
-(106) BroadcastExchange
-Input [4]: [ca_county#45, web_sales#49, web_sales#60, web_sales#71]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=18]
-
-(107) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ca_county#34]
-Right keys [1]: [ca_county#45]
-Join type: Inner
-Join condition: ((CASE WHEN (web_sales#49 > 0.00) THEN (web_sales#60 / web_sales#49) END > CASE WHEN (store_sales#37 > 0.00) THEN (store_sales#13 / store_sales#37) END) AND (CASE WHEN (web_sales#60 > 0.00) THEN (web_sales#71 / web_sales#60) END > CASE WHEN (store_sales#13 > 0.00) THEN (store_sales#25 / store_sales#13) END))
-
-(108) Project [codegen id : 42]
-Output [6]: [ca_county#34, d_year#31, (web_sales#60 / web_sales#49) AS web_q1_q2_increase#72, (store_sales#13 / store_sales#37) AS store_q1_q2_increase#73, (web_sales#71 / web_sales#60) AS web_q2_q3_increase#74, (store_sales#25 / store_sales#13) AS store_q2_q3_increase#75]
-Input [9]: [store_sales#13, store_sales#25, ca_county#34, d_year#31, store_sales#37, ca_county#45, web_sales#49, web_sales#60, web_sales#71]
-
-(109) Exchange
-Input [6]: [ca_county#34, d_year#31, web_q1_q2_increase#72, store_q1_q2_increase#73, web_q2_q3_increase#74, store_q2_q3_increase#75]
-Arguments: rangepartitioning(ca_county#34 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=19]
-
-(110) Sort [codegen id : 43]
-Input [6]: [ca_county#34, d_year#31, web_q1_q2_increase#72, store_q1_q2_increase#73, web_q2_q3_increase#74, store_q2_q3_increase#75]
-Arguments: [ca_county#34 ASC NULLS FIRST], true, 0
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (114)
-+- * Filter (113)
-   +- * ColumnarToRow (112)
-      +- Scan parquet spark_catalog.default.date_dim (111)
-
-
-(111) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
-
-(112) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-
-(113) Filter [codegen id : 1]
-Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Condition : ((((isnotnull(d_qoy#7) AND isnotnull(d_year#6)) AND (d_qoy#7 = 2)) AND (d_year#6 = 2000)) AND isnotnull(d_date_sk#5))
-
-(114) BroadcastExchange
-Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=20]
-
-Subquery:2 Hosting operator id = 19 Hosting Expression = ss_sold_date_sk#16 IN dynamicpruning#17
+(109) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#10, ca_county#11]
+
+(110) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#10, ca_county#11]
+Condition : (isnotnull(ca_address_sk#10) AND isnotnull(ca_county#11))
+
+(111) Exchange
+Input [2]: [ca_address_sk#10, ca_county#11]
+Arguments: hashpartitioning(ca_address_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+
+(112) ObjectHashAggregate
+Input [2]: [ca_address_sk#10, ca_county#11]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#10, 42), 969973, 7759784, 0, 0)]
+Aggregate Attributes [1]: [buf#80]
+Results [1]: [buf#81]
+
+(113) Exchange
+Input [1]: [buf#81]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+
+(114) ObjectHashAggregate
+Input [1]: [buf#81]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#10, 42), 969973, 7759784, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#10, 42), 969973, 7759784, 0, 0)#82]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#10, 42), 969973, 7759784, 0, 0)#82 AS bloomFilter#83]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
 BroadcastExchange (118)
 +- * Filter (117)
    +- * ColumnarToRow (116)
@@ -665,52 +668,131 @@ BroadcastExchange (118)
 
 
 (115) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#18, d_year#19, d_qoy#20]
+Output [3]: [d_date_sk#7, d_year#8, d_qoy#9]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
+
+(116) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#7, d_year#8, d_qoy#9]
+
+(117) Filter [codegen id : 1]
+Input [3]: [d_date_sk#7, d_year#8, d_qoy#9]
+Condition : ((((isnotnull(d_qoy#9) AND isnotnull(d_year#8)) AND (d_qoy#9 = 2)) AND (d_year#8 = 2000)) AND isnotnull(d_date_sk#7))
+
+(118) BroadcastExchange
+Input [3]: [d_date_sk#7, d_year#8, d_qoy#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=21]
+
+Subquery:3 Hosting operator id = 18 Hosting Expression = Subquery scalar-subquery#20, [id=#21]
+ObjectHashAggregate (125)
++- Exchange (124)
+   +- ObjectHashAggregate (123)
+      +- Exchange (122)
+         +- * Filter (121)
+            +- * ColumnarToRow (120)
+               +- Scan parquet spark_catalog.default.customer_address (119)
+
+
+(119) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#25, ca_county#26]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county)]
+ReadSchema: struct<ca_address_sk:int,ca_county:string>
+
+(120) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#25, ca_county#26]
+
+(121) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#25, ca_county#26]
+Condition : (isnotnull(ca_address_sk#25) AND isnotnull(ca_county#26))
+
+(122) Exchange
+Input [2]: [ca_address_sk#25, ca_county#26]
+Arguments: hashpartitioning(ca_address_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+
+(123) ObjectHashAggregate
+Input [2]: [ca_address_sk#25, ca_county#26]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 969973, 7759784, 0, 0)]
+Aggregate Attributes [1]: [buf#84]
+Results [1]: [buf#85]
+
+(124) Exchange
+Input [1]: [buf#85]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=23]
+
+(125) ObjectHashAggregate
+Input [1]: [buf#85]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 969973, 7759784, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 969973, 7759784, 0, 0)#86]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 969973, 7759784, 0, 0)#86 AS bloomFilter#87]
+
+Subquery:4 Hosting operator id = 16 Hosting Expression = ss_sold_date_sk#18 IN dynamicpruning#19
+BroadcastExchange (129)
++- * Filter (128)
+   +- * ColumnarToRow (127)
+      +- Scan parquet spark_catalog.default.date_dim (126)
+
+
+(126) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#22, d_year#23, d_qoy#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,3), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(116) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#18, d_year#19, d_qoy#20]
+(127) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#22, d_year#23, d_qoy#24]
 
-(117) Filter [codegen id : 1]
-Input [3]: [d_date_sk#18, d_year#19, d_qoy#20]
-Condition : ((((isnotnull(d_qoy#20) AND isnotnull(d_year#19)) AND (d_qoy#20 = 3)) AND (d_year#19 = 2000)) AND isnotnull(d_date_sk#18))
+(128) Filter [codegen id : 1]
+Input [3]: [d_date_sk#22, d_year#23, d_qoy#24]
+Condition : ((((isnotnull(d_qoy#24) AND isnotnull(d_year#23)) AND (d_qoy#24 = 3)) AND (d_year#23 = 2000)) AND isnotnull(d_date_sk#22))
 
-(118) BroadcastExchange
-Input [3]: [d_date_sk#18, d_year#19, d_qoy#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=21]
+(129) BroadcastExchange
+Input [3]: [d_date_sk#22, d_year#23, d_qoy#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=24]
 
-Subquery:3 Hosting operator id = 37 Hosting Expression = ss_sold_date_sk#28 IN dynamicpruning#29
-BroadcastExchange (122)
-+- * Filter (121)
-   +- * ColumnarToRow (120)
-      +- Scan parquet spark_catalog.default.date_dim (119)
+Subquery:5 Hosting operator id = 36 Hosting Expression = ReusedSubquery Subquery scalar-subquery#20, [id=#21]
+
+Subquery:6 Hosting operator id = 34 Hosting Expression = ss_sold_date_sk#32 IN dynamicpruning#33
+BroadcastExchange (133)
++- * Filter (132)
+   +- * ColumnarToRow (131)
+      +- Scan parquet spark_catalog.default.date_dim (130)
 
 
-(119) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#30, d_year#31, d_qoy#32]
+(130) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#34, d_year#35, d_qoy#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,1), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(120) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#30, d_year#31, d_qoy#32]
+(131) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#34, d_year#35, d_qoy#36]
 
-(121) Filter [codegen id : 1]
-Input [3]: [d_date_sk#30, d_year#31, d_qoy#32]
-Condition : ((((isnotnull(d_qoy#32) AND isnotnull(d_year#31)) AND (d_qoy#32 = 1)) AND (d_year#31 = 2000)) AND isnotnull(d_date_sk#30))
+(132) Filter [codegen id : 1]
+Input [3]: [d_date_sk#34, d_year#35, d_qoy#36]
+Condition : ((((isnotnull(d_qoy#36) AND isnotnull(d_year#35)) AND (d_qoy#36 = 1)) AND (d_year#35 = 2000)) AND isnotnull(d_date_sk#34))
 
-(122) BroadcastExchange
-Input [3]: [d_date_sk#30, d_year#31, d_qoy#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=22]
+(133) BroadcastExchange
+Input [3]: [d_date_sk#34, d_year#35, d_qoy#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=25]
 
-Subquery:4 Hosting operator id = 55 Hosting Expression = ws_sold_date_sk#40 IN dynamicpruning#29
+Subquery:7 Hosting operator id = 54 Hosting Expression = ReusedSubquery Subquery scalar-subquery#20, [id=#21]
 
-Subquery:5 Hosting operator id = 70 Hosting Expression = ws_sold_date_sk#52 IN dynamicpruning#4
+Subquery:8 Hosting operator id = 52 Hosting Expression = ws_sold_date_sk#44 IN dynamicpruning#33
 
-Subquery:6 Hosting operator id = 88 Hosting Expression = ws_sold_date_sk#63 IN dynamicpruning#17
+Subquery:9 Hosting operator id = 69 Hosting Expression = ReusedSubquery Subquery scalar-subquery#20, [id=#21]
+
+Subquery:10 Hosting operator id = 67 Hosting Expression = ws_sold_date_sk#56 IN dynamicpruning#4
+
+Subquery:11 Hosting operator id = 87 Hosting Expression = ReusedSubquery Subquery scalar-subquery#20, [id=#21]
+
+Subquery:12 Hosting operator id = 85 Hosting Expression = ws_sold_date_sk#67 IN dynamicpruning#19
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31.sf100/simplified.txt
@@ -25,6 +25,16 @@ WholeStageCodegen (43)
                                                 Project [ss_addr_sk,ss_ext_sales_price,d_year,d_qoy]
                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                     Filter [ss_addr_sk]
+                                                      Subquery #2
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 969973, 7759784, 0, 0),bloomFilter,buf]
+                                                          Exchange #5
+                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                              Exchange [ca_address_sk] #6
+                                                                WholeStageCodegen (1)
+                                                                  Filter [ca_address_sk,ca_county]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.store_sales [ss_addr_sk,ss_ext_sales_price,ss_sold_date_sk]
@@ -41,18 +51,13 @@ WholeStageCodegen (43)
                                       WholeStageCodegen (5)
                                         Sort [ca_address_sk]
                                           InputAdapter
-                                            Exchange [ca_address_sk] #5
-                                              WholeStageCodegen (4)
-                                                Filter [ca_address_sk,ca_county]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                                            ReusedExchange [ca_address_sk,ca_county] #6
                       InputAdapter
-                        BroadcastExchange #6
+                        BroadcastExchange #7
                           WholeStageCodegen (13)
                             HashAggregate [ca_county,d_qoy,d_year,sum] [sum(UnscaledValue(ss_ext_sales_price)),store_sales,sum]
                               InputAdapter
-                                Exchange [ca_county,d_qoy,d_year] #7
+                                Exchange [ca_county,d_qoy,d_year] #8
                                   WholeStageCodegen (12)
                                     HashAggregate [ca_county,d_qoy,d_year,ss_ext_sales_price] [sum,sum]
                                       Project [ss_ext_sales_price,d_year,d_qoy,ca_county]
@@ -61,34 +66,44 @@ WholeStageCodegen (43)
                                             WholeStageCodegen (9)
                                               Sort [ss_addr_sk]
                                                 InputAdapter
-                                                  Exchange [ss_addr_sk] #8
+                                                  Exchange [ss_addr_sk] #9
                                                     WholeStageCodegen (8)
                                                       Project [ss_addr_sk,ss_ext_sales_price,d_year,d_qoy]
                                                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                           Filter [ss_addr_sk]
+                                                            Subquery #4
+                                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 969973, 7759784, 0, 0),bloomFilter,buf]
+                                                                Exchange #11
+                                                                  ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                    Exchange [ca_address_sk] #12
+                                                                      WholeStageCodegen (1)
+                                                                        Filter [ca_address_sk,ca_county]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.store_sales [ss_addr_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #2
-                                                                    BroadcastExchange #9
+                                                                  SubqueryBroadcast [d_date_sk] #3
+                                                                    BroadcastExchange #10
                                                                       WholeStageCodegen (1)
                                                                         Filter [d_qoy,d_year,d_date_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
                                                           InputAdapter
-                                                            ReusedExchange [d_date_sk,d_year,d_qoy] #9
+                                                            ReusedExchange [d_date_sk,d_year,d_qoy] #10
                                           InputAdapter
                                             WholeStageCodegen (11)
                                               Sort [ca_address_sk]
                                                 InputAdapter
-                                                  ReusedExchange [ca_address_sk,ca_county] #5
+                                                  ReusedExchange [ca_address_sk,ca_county] #6
                   InputAdapter
-                    BroadcastExchange #10
+                    BroadcastExchange #13
                       WholeStageCodegen (20)
                         HashAggregate [ca_county,d_qoy,d_year,sum] [sum(UnscaledValue(ss_ext_sales_price)),store_sales,sum]
                           InputAdapter
-                            Exchange [ca_county,d_qoy,d_year] #11
+                            Exchange [ca_county,d_qoy,d_year] #14
                               WholeStageCodegen (19)
                                 HashAggregate [ca_county,d_qoy,d_year,ss_ext_sales_price] [sum,sum]
                                   Project [ss_ext_sales_price,d_year,d_qoy,ca_county]
@@ -97,30 +112,31 @@ WholeStageCodegen (43)
                                         WholeStageCodegen (16)
                                           Sort [ss_addr_sk]
                                             InputAdapter
-                                              Exchange [ss_addr_sk] #12
+                                              Exchange [ss_addr_sk] #15
                                                 WholeStageCodegen (15)
                                                   Project [ss_addr_sk,ss_ext_sales_price,d_year,d_qoy]
                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                       Filter [ss_addr_sk]
+                                                        ReusedSubquery [bloomFilter] #4
                                                         ColumnarToRow
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.store_sales [ss_addr_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #3
-                                                                BroadcastExchange #13
+                                                              SubqueryBroadcast [d_date_sk] #5
+                                                                BroadcastExchange #16
                                                                   WholeStageCodegen (1)
                                                                     Filter [d_qoy,d_year,d_date_sk]
                                                                       ColumnarToRow
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk,d_year,d_qoy] #13
+                                                        ReusedExchange [d_date_sk,d_year,d_qoy] #16
                                       InputAdapter
                                         WholeStageCodegen (18)
                                           Sort [ca_address_sk]
                                             InputAdapter
-                                              ReusedExchange [ca_address_sk,ca_county] #5
+                                              ReusedExchange [ca_address_sk,ca_county] #6
               InputAdapter
-                BroadcastExchange #14
+                BroadcastExchange #17
                   WholeStageCodegen (41)
                     Project [ca_county,web_sales,web_sales,web_sales]
                       BroadcastHashJoin [ca_county,ca_county]
@@ -128,7 +144,7 @@ WholeStageCodegen (43)
                           BroadcastHashJoin [ca_county,ca_county]
                             HashAggregate [ca_county,d_qoy,d_year,sum] [sum(UnscaledValue(ws_ext_sales_price)),web_sales,sum]
                               InputAdapter
-                                Exchange [ca_county,d_qoy,d_year] #15
+                                Exchange [ca_county,d_qoy,d_year] #18
                                   WholeStageCodegen (26)
                                     HashAggregate [ca_county,d_qoy,d_year,ws_ext_sales_price] [sum,sum]
                                       Project [ws_ext_sales_price,d_year,d_qoy,ca_county]
@@ -137,28 +153,29 @@ WholeStageCodegen (43)
                                             WholeStageCodegen (23)
                                               Sort [ws_bill_addr_sk]
                                                 InputAdapter
-                                                  Exchange [ws_bill_addr_sk] #16
+                                                  Exchange [ws_bill_addr_sk] #19
                                                     WholeStageCodegen (22)
                                                       Project [ws_bill_addr_sk,ws_ext_sales_price,d_year,d_qoy]
                                                         BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                           Filter [ws_bill_addr_sk]
+                                                            ReusedSubquery [bloomFilter] #4
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.web_sales [ws_bill_addr_sk,ws_ext_sales_price,ws_sold_date_sk]
-                                                                  ReusedSubquery [d_date_sk] #3
+                                                                  ReusedSubquery [d_date_sk] #5
                                                           InputAdapter
-                                                            ReusedExchange [d_date_sk,d_year,d_qoy] #13
+                                                            ReusedExchange [d_date_sk,d_year,d_qoy] #16
                                           InputAdapter
                                             WholeStageCodegen (25)
                                               Sort [ca_address_sk]
                                                 InputAdapter
-                                                  ReusedExchange [ca_address_sk,ca_county] #5
+                                                  ReusedExchange [ca_address_sk,ca_county] #6
                             InputAdapter
-                              BroadcastExchange #17
+                              BroadcastExchange #20
                                 WholeStageCodegen (33)
                                   HashAggregate [ca_county,d_qoy,d_year,sum] [sum(UnscaledValue(ws_ext_sales_price)),web_sales,sum]
                                     InputAdapter
-                                      Exchange [ca_county,d_qoy,d_year] #18
+                                      Exchange [ca_county,d_qoy,d_year] #21
                                         WholeStageCodegen (32)
                                           HashAggregate [ca_county,d_qoy,d_year,ws_ext_sales_price] [sum,sum]
                                             Project [ws_ext_sales_price,d_year,d_qoy,ca_county]
@@ -167,11 +184,12 @@ WholeStageCodegen (43)
                                                   WholeStageCodegen (29)
                                                     Sort [ws_bill_addr_sk]
                                                       InputAdapter
-                                                        Exchange [ws_bill_addr_sk] #19
+                                                        Exchange [ws_bill_addr_sk] #22
                                                           WholeStageCodegen (28)
                                                             Project [ws_bill_addr_sk,ws_ext_sales_price,d_year,d_qoy]
                                                               BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                 Filter [ws_bill_addr_sk]
+                                                                  ReusedSubquery [bloomFilter] #4
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.web_sales [ws_bill_addr_sk,ws_ext_sales_price,ws_sold_date_sk]
@@ -182,13 +200,13 @@ WholeStageCodegen (43)
                                                   WholeStageCodegen (31)
                                                     Sort [ca_address_sk]
                                                       InputAdapter
-                                                        ReusedExchange [ca_address_sk,ca_county] #5
+                                                        ReusedExchange [ca_address_sk,ca_county] #6
                         InputAdapter
-                          BroadcastExchange #20
+                          BroadcastExchange #23
                             WholeStageCodegen (40)
                               HashAggregate [ca_county,d_qoy,d_year,sum] [sum(UnscaledValue(ws_ext_sales_price)),web_sales,sum]
                                 InputAdapter
-                                  Exchange [ca_county,d_qoy,d_year] #21
+                                  Exchange [ca_county,d_qoy,d_year] #24
                                     WholeStageCodegen (39)
                                       HashAggregate [ca_county,d_qoy,d_year,ws_ext_sales_price] [sum,sum]
                                         Project [ws_ext_sales_price,d_year,d_qoy,ca_county]
@@ -197,19 +215,20 @@ WholeStageCodegen (43)
                                               WholeStageCodegen (36)
                                                 Sort [ws_bill_addr_sk]
                                                   InputAdapter
-                                                    Exchange [ws_bill_addr_sk] #22
+                                                    Exchange [ws_bill_addr_sk] #25
                                                       WholeStageCodegen (35)
                                                         Project [ws_bill_addr_sk,ws_ext_sales_price,d_year,d_qoy]
                                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                             Filter [ws_bill_addr_sk]
+                                                              ReusedSubquery [bloomFilter] #4
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_sales [ws_bill_addr_sk,ws_ext_sales_price,ws_sold_date_sk]
-                                                                    ReusedSubquery [d_date_sk] #2
+                                                                    ReusedSubquery [d_date_sk] #3
                                                             InputAdapter
-                                                              ReusedExchange [d_date_sk,d_year,d_qoy] #9
+                                                              ReusedExchange [d_date_sk,d_year,d_qoy] #10
                                             InputAdapter
                                               WholeStageCodegen (38)
                                                 Sort [ca_address_sk]
                                                   InputAdapter
-                                                    ReusedExchange [ca_address_sk,ca_county] #5
+                                                    ReusedExchange [ca_address_sk,ca_county] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
@@ -65,7 +65,7 @@ Input [3]: [cs_item_sk#3, cs_ext_discount_amt#4, cs_sold_date_sk#5]
 
 (8) Filter [codegen id : 3]
 Input [3]: [cs_item_sk#3, cs_ext_discount_amt#4, cs_sold_date_sk#5]
-Condition : (isnotnull(cs_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(cs_item_sk#3, 42)))
+Condition : (isnotnull(cs_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(cs_item_sk#3, 42), true))
 
 (9) ReusedExchange [Reuses operator id: 41]
 Output [1]: [d_date_sk#9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.sf100/explain.txt
@@ -1,8 +1,8 @@
 == Physical Plan ==
-* Sort (35)
-+- Exchange (34)
-   +- * Project (33)
-      +- * SortMergeJoin Inner (32)
+* Sort (32)
++- Exchange (31)
+   +- * Project (30)
+      +- * SortMergeJoin Inner (29)
          :- * Sort (26)
          :  +- Exchange (25)
          :     +- * Filter (24)
@@ -29,11 +29,8 @@
          :                             +- * Filter (16)
          :                                +- * ColumnarToRow (15)
          :                                   +- Scan parquet spark_catalog.default.household_demographics (14)
-         +- * Sort (31)
-            +- Exchange (30)
-               +- * Filter (29)
-                  +- * ColumnarToRow (28)
-                     +- Scan parquet spark_catalog.default.customer (27)
+         +- * Sort (28)
+            +- ReusedExchange (27)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -49,185 +46,216 @@ Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, 
 
 (3) Filter [codegen id : 4]
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
-Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
+Condition : (((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 40]
-Output [1]: [d_date_sk#7]
+(4) ReusedExchange [Reuses operator id: 44]
+Output [1]: [d_date_sk#9]
 
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
 Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
-Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
+Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#9]
 
 (7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
+Output [2]: [s_store_sk#10, s_county#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_county), EqualTo(s_county,Williamson County), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_county:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
+Input [2]: [s_store_sk#10, s_county#11]
 
 (9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : ((isnotnull(s_county#9) AND (s_county#9 = Williamson County)) AND isnotnull(s_store_sk#8))
+Input [2]: [s_store_sk#10, s_county#11]
+Condition : ((isnotnull(s_county#11) AND (s_county#11 = Williamson County)) AND isnotnull(s_store_sk#10))
 
 (10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
+Output [1]: [s_store_sk#10]
+Input [2]: [s_store_sk#10, s_county#11]
 
 (11) BroadcastExchange
-Input [1]: [s_store_sk#8]
+Input [1]: [s_store_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#10]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#10]
 
 (14) Scan parquet spark_catalog.default.household_demographics
-Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_vehicle_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (16) Filter [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : ((((isnotnull(hd_vehicle_count#13) AND ((hd_buy_potential#11 = >10000         ) OR (hd_buy_potential#11 = unknown        ))) AND (hd_vehicle_count#13 > 0)) AND CASE WHEN (hd_vehicle_count#13 > 0) THEN ((cast(hd_dep_count#12 as double) / cast(hd_vehicle_count#13 as double)) > 1.2) END) AND isnotnull(hd_demo_sk#10))
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
+Condition : ((((isnotnull(hd_vehicle_count#15) AND ((hd_buy_potential#13 = >10000         ) OR (hd_buy_potential#13 = unknown        ))) AND (hd_vehicle_count#15 > 0)) AND CASE WHEN (hd_vehicle_count#15 > 0) THEN ((cast(hd_dep_count#14 as double) / cast(hd_vehicle_count#15 as double)) > 1.2) END) AND isnotnull(hd_demo_sk#12))
 
 (17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [hd_demo_sk#12]
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (18) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [hd_demo_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#12]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#10]
+Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#12]
 
 (21) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#14]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Aggregate Attributes [1]: [count#16]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 
 (22) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Arguments: hashpartitioning(ss_ticket_number#4, ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (23) HashAggregate [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#16]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#16 AS cnt#17]
+Aggregate Attributes [1]: [count(1)#18]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#18 AS cnt#19]
 
 (24) Filter [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
-Condition : ((cnt#17 >= 15) AND (cnt#17 <= 20))
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
+Condition : ((cnt#19 >= 15) AND (cnt#19 <= 20))
 
 (25) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (26) Sort [codegen id : 6]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(27) ReusedExchange [Reuses operator id: 36]
+Output [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+
+(28) Sort [codegen id : 8]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 9]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#20]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 9]
+Output [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19, c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+
+(31) Exchange
+Input [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Arguments: rangepartitioning(c_last_name#23 ASC NULLS FIRST, c_first_name#22 ASC NULLS FIRST, c_salutation#21 ASC NULLS FIRST, c_preferred_cust_flag#24 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(32) Sort [codegen id : 10]
+Input [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Arguments: [c_last_name#23 ASC NULLS FIRST, c_first_name#22 ASC NULLS FIRST, c_salutation#21 ASC NULLS FIRST, c_preferred_cust_flag#24 DESC NULLS LAST], true, 0
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (39)
++- Exchange (38)
+   +- ObjectHashAggregate (37)
+      +- Exchange (36)
+         +- * Filter (35)
+            +- * ColumnarToRow (34)
+               +- Scan parquet spark_catalog.default.customer (33)
+
+
+(33) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string>
 
-(28) ColumnarToRow [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(34) ColumnarToRow [codegen id : 1]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
 
-(29) Filter [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Condition : isnotnull(c_customer_sk#18)
+(35) Filter [codegen id : 1]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Condition : isnotnull(c_customer_sk#20)
 
-(30) Exchange
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(36) Exchange
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(31) Sort [codegen id : 8]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+(37) ObjectHashAggregate
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#25]
+Results [1]: [buf#26]
 
-(32) SortMergeJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
-Join type: Inner
-Join condition: None
+(38) Exchange
+Input [1]: [buf#26]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(33) Project [codegen id : 9]
-Output [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17, c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(39) ObjectHashAggregate
+Input [1]: [buf#26]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)#27]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)#27 AS bloomFilter#28]
 
-(34) Exchange
-Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: rangepartitioning(c_last_name#21 ASC NULLS FIRST, c_first_name#20 ASC NULLS FIRST, c_salutation#19 ASC NULLS FIRST, c_preferred_cust_flag#22 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) Sort [codegen id : 10]
-Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: [c_last_name#21 ASC NULLS FIRST, c_first_name#20 ASC NULLS FIRST, c_salutation#19 ASC NULLS FIRST, c_preferred_cust_flag#22 DESC NULLS LAST], true, 0
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (40)
-+- * Project (39)
-   +- * Filter (38)
-      +- * ColumnarToRow (37)
-         +- Scan parquet spark_catalog.default.date_dim (36)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (44)
++- * Project (43)
+   +- * Filter (42)
+      +- * ColumnarToRow (41)
+         +- Scan parquet spark_catalog.default.date_dim (40)
 
 
-(36) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(40) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#9, d_year#29, d_dom#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(And(GreaterThanOrEqual(d_dom,1),LessThanOrEqual(d_dom,3)),And(GreaterThanOrEqual(d_dom,25),LessThanOrEqual(d_dom,28))), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
-(37) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(41) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
 
-(38) Filter [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
-Condition : (((((d_dom#24 >= 1) AND (d_dom#24 <= 3)) OR ((d_dom#24 >= 25) AND (d_dom#24 <= 28))) AND d_year#23 IN (1999,2000,2001)) AND isnotnull(d_date_sk#7))
+(42) Filter [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
+Condition : (((((d_dom#30 >= 1) AND (d_dom#30 <= 3)) OR ((d_dom#30 >= 25) AND (d_dom#30 <= 28))) AND d_year#29 IN (1999,2000,2001)) AND isnotnull(d_date_sk#9))
 
-(39) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(43) Project [codegen id : 1]
+Output [1]: [d_date_sk#9]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
 
-(40) BroadcastExchange
-Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+(44) BroadcastExchange
+Input [1]: [d_date_sk#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.sf100/simplified.txt
@@ -24,6 +24,16 @@ WholeStageCodegen (10)
                                               Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                   Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                            Exchange [c_customer_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [c_customer_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
@@ -38,7 +48,7 @@ WholeStageCodegen (10)
                                                   InputAdapter
                                                     ReusedExchange [d_date_sk] #4
                                               InputAdapter
-                                                BroadcastExchange #5
+                                                BroadcastExchange #7
                                                   WholeStageCodegen (2)
                                                     Project [s_store_sk]
                                                       Filter [s_county,s_store_sk]
@@ -46,7 +56,7 @@ WholeStageCodegen (10)
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.store [s_store_sk,s_county]
                                           InputAdapter
-                                            BroadcastExchange #6
+                                            BroadcastExchange #8
                                               WholeStageCodegen (3)
                                                 Project [hd_demo_sk]
                                                   Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
@@ -57,9 +67,4 @@ WholeStageCodegen (10)
                 WholeStageCodegen (8)
                   Sort [c_customer_sk]
                     InputAdapter
-                      Exchange [c_customer_sk] #7
-                        WholeStageCodegen (7)
-                          Filter [c_customer_sk]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
+                      ReusedExchange [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35.sf100/explain.txt
@@ -1,57 +1,52 @@
 == Physical Plan ==
-TakeOrderedAndProject (53)
-+- * HashAggregate (52)
-   +- Exchange (51)
-      +- * HashAggregate (50)
-         +- * Project (49)
-            +- * SortMergeJoin Inner (48)
-               :- * Sort (42)
-               :  +- Exchange (41)
-               :     +- * Project (40)
-               :        +- * SortMergeJoin Inner (39)
-               :           :- * Sort (33)
-               :           :  +- Exchange (32)
-               :           :     +- * Project (31)
-               :           :        +- * Filter (30)
-               :           :           +- * SortMergeJoin ExistenceJoin(exists#1) (29)
-               :           :              :- * SortMergeJoin ExistenceJoin(exists#2) (21)
-               :           :              :  :- * SortMergeJoin LeftSemi (13)
+TakeOrderedAndProject (48)
++- * HashAggregate (47)
+   +- Exchange (46)
+      +- * HashAggregate (45)
+         +- * Project (44)
+            +- * SortMergeJoin Inner (43)
+               :- * Sort (40)
+               :  +- Exchange (39)
+               :     +- * Project (38)
+               :        +- * SortMergeJoin Inner (37)
+               :           :- * Sort (34)
+               :           :  +- Exchange (33)
+               :           :     +- * Project (32)
+               :           :        +- * Filter (31)
+               :           :           +- * SortMergeJoin ExistenceJoin(exists#1) (30)
+               :           :              :- * SortMergeJoin ExistenceJoin(exists#2) (22)
+               :           :              :  :- * SortMergeJoin LeftSemi (14)
                :           :              :  :  :- * Sort (5)
                :           :              :  :  :  +- Exchange (4)
                :           :              :  :  :     +- * Filter (3)
                :           :              :  :  :        +- * ColumnarToRow (2)
                :           :              :  :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :           :              :  :  +- * Sort (12)
-               :           :              :  :     +- Exchange (11)
-               :           :              :  :        +- * Project (10)
-               :           :              :  :           +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :              :  :              :- * ColumnarToRow (7)
-               :           :              :  :              :  +- Scan parquet spark_catalog.default.store_sales (6)
-               :           :              :  :              +- ReusedExchange (8)
-               :           :              :  +- * Sort (20)
-               :           :              :     +- Exchange (19)
-               :           :              :        +- * Project (18)
-               :           :              :           +- * BroadcastHashJoin Inner BuildRight (17)
-               :           :              :              :- * ColumnarToRow (15)
-               :           :              :              :  +- Scan parquet spark_catalog.default.web_sales (14)
-               :           :              :              +- ReusedExchange (16)
-               :           :              +- * Sort (28)
-               :           :                 +- Exchange (27)
-               :           :                    +- * Project (26)
-               :           :                       +- * BroadcastHashJoin Inner BuildRight (25)
-               :           :                          :- * ColumnarToRow (23)
-               :           :                          :  +- Scan parquet spark_catalog.default.catalog_sales (22)
-               :           :                          +- ReusedExchange (24)
-               :           +- * Sort (38)
-               :              +- Exchange (37)
-               :                 +- * Filter (36)
-               :                    +- * ColumnarToRow (35)
-               :                       +- Scan parquet spark_catalog.default.customer_address (34)
-               +- * Sort (47)
-                  +- Exchange (46)
-                     +- * Filter (45)
-                        +- * ColumnarToRow (44)
-                           +- Scan parquet spark_catalog.default.customer_demographics (43)
+               :           :              :  :  +- * Sort (13)
+               :           :              :  :     +- Exchange (12)
+               :           :              :  :        +- * Project (11)
+               :           :              :  :           +- * BroadcastHashJoin Inner BuildRight (10)
+               :           :              :  :              :- * Filter (8)
+               :           :              :  :              :  +- * ColumnarToRow (7)
+               :           :              :  :              :     +- Scan parquet spark_catalog.default.store_sales (6)
+               :           :              :  :              +- ReusedExchange (9)
+               :           :              :  +- * Sort (21)
+               :           :              :     +- Exchange (20)
+               :           :              :        +- * Project (19)
+               :           :              :           +- * BroadcastHashJoin Inner BuildRight (18)
+               :           :              :              :- * ColumnarToRow (16)
+               :           :              :              :  +- Scan parquet spark_catalog.default.web_sales (15)
+               :           :              :              +- ReusedExchange (17)
+               :           :              +- * Sort (29)
+               :           :                 +- Exchange (28)
+               :           :                    +- * Project (27)
+               :           :                       +- * BroadcastHashJoin Inner BuildRight (26)
+               :           :                          :- * ColumnarToRow (24)
+               :           :                          :  +- Scan parquet spark_catalog.default.catalog_sales (23)
+               :           :                          +- ReusedExchange (25)
+               :           +- * Sort (36)
+               :              +- ReusedExchange (35)
+               +- * Sort (42)
+                  +- ReusedExchange (41)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -66,7 +61,7 @@ Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
-Condition : (isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4))
+Condition : (((isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(c_current_addr_sk#5, 42), false)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(c_current_cdemo_sk#4, 42), false))
 
 (4) Exchange
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
@@ -77,260 +72,326 @@ Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 Arguments: [c_customer_sk#3 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Output [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#7), dynamicpruningexpression(ss_sold_date_sk#7 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#11), dynamicpruningexpression(ss_sold_date_sk#11 IN dynamicpruning#12)]
 ReadSchema: struct<ss_customer_sk:int>
 
 (7) ColumnarToRow [codegen id : 4]
-Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Input [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
 
-(8) ReusedExchange [Reuses operator id: 58]
-Output [1]: [d_date_sk#9]
+(8) Filter [codegen id : 4]
+Input [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
+Condition : true
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#9]
+(9) ReusedExchange [Reuses operator id: 67]
+Output [1]: [d_date_sk#13]
+
+(10) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [1]: [ss_customer_sk#6]
-Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
+(11) Project [codegen id : 4]
+Output [1]: [ss_customer_sk#10]
+Input [3]: [ss_customer_sk#10, ss_sold_date_sk#11, d_date_sk#13]
 
-(11) Exchange
-Input [1]: [ss_customer_sk#6]
-Arguments: hashpartitioning(ss_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(12) Exchange
+Input [1]: [ss_customer_sk#10]
+Arguments: hashpartitioning(ss_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) Sort [codegen id : 5]
-Input [1]: [ss_customer_sk#6]
-Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [1]: [ss_customer_sk#10]
+Arguments: [ss_customer_sk#10 ASC NULLS FIRST], false, 0
 
-(13) SortMergeJoin [codegen id : 6]
+(14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [ss_customer_sk#6]
+Right keys [1]: [ss_customer_sk#10]
 Join type: LeftSemi
 Join condition: None
 
-(14) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+(15) Scan parquet spark_catalog.default.web_sales
+Output [2]: [ws_bill_customer_sk#14, ws_sold_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#11), dynamicpruningexpression(ws_sold_date_sk#11 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#15), dynamicpruningexpression(ws_sold_date_sk#15 IN dynamicpruning#12)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(15) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+(16) ColumnarToRow [codegen id : 8]
+Input [2]: [ws_bill_customer_sk#14, ws_sold_date_sk#15]
 
-(16) ReusedExchange [Reuses operator id: 58]
-Output [1]: [d_date_sk#12]
+(17) ReusedExchange [Reuses operator id: 67]
+Output [1]: [d_date_sk#16]
 
-(17) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#11]
-Right keys [1]: [d_date_sk#12]
+(18) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [ws_sold_date_sk#15]
+Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 8]
-Output [1]: [ws_bill_customer_sk#10]
-Input [3]: [ws_bill_customer_sk#10, ws_sold_date_sk#11, d_date_sk#12]
+(19) Project [codegen id : 8]
+Output [1]: [ws_bill_customer_sk#14]
+Input [3]: [ws_bill_customer_sk#14, ws_sold_date_sk#15, d_date_sk#16]
 
-(19) Exchange
-Input [1]: [ws_bill_customer_sk#10]
-Arguments: hashpartitioning(ws_bill_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(20) Exchange
+Input [1]: [ws_bill_customer_sk#14]
+Arguments: hashpartitioning(ws_bill_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) Sort [codegen id : 9]
-Input [1]: [ws_bill_customer_sk#10]
-Arguments: [ws_bill_customer_sk#10 ASC NULLS FIRST], false, 0
+(21) Sort [codegen id : 9]
+Input [1]: [ws_bill_customer_sk#14]
+Arguments: [ws_bill_customer_sk#14 ASC NULLS FIRST], false, 0
 
-(21) SortMergeJoin [codegen id : 10]
+(22) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [ws_bill_customer_sk#10]
+Right keys [1]: [ws_bill_customer_sk#14]
 Join type: ExistenceJoin(exists#2)
 Join condition: None
 
-(22) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
+(23) Scan parquet spark_catalog.default.catalog_sales
+Output [2]: [cs_ship_customer_sk#17, cs_sold_date_sk#18]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#14), dynamicpruningexpression(cs_sold_date_sk#14 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#18), dynamicpruningexpression(cs_sold_date_sk#18 IN dynamicpruning#12)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(23) ColumnarToRow [codegen id : 12]
-Input [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
+(24) ColumnarToRow [codegen id : 12]
+Input [2]: [cs_ship_customer_sk#17, cs_sold_date_sk#18]
 
-(24) ReusedExchange [Reuses operator id: 58]
-Output [1]: [d_date_sk#15]
+(25) ReusedExchange [Reuses operator id: 67]
+Output [1]: [d_date_sk#19]
 
-(25) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [cs_sold_date_sk#14]
-Right keys [1]: [d_date_sk#15]
+(26) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [cs_sold_date_sk#18]
+Right keys [1]: [d_date_sk#19]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 12]
-Output [1]: [cs_ship_customer_sk#13]
-Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
+(27) Project [codegen id : 12]
+Output [1]: [cs_ship_customer_sk#17]
+Input [3]: [cs_ship_customer_sk#17, cs_sold_date_sk#18, d_date_sk#19]
 
-(27) Exchange
-Input [1]: [cs_ship_customer_sk#13]
-Arguments: hashpartitioning(cs_ship_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(28) Exchange
+Input [1]: [cs_ship_customer_sk#17]
+Arguments: hashpartitioning(cs_ship_customer_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) Sort [codegen id : 13]
-Input [1]: [cs_ship_customer_sk#13]
-Arguments: [cs_ship_customer_sk#13 ASC NULLS FIRST], false, 0
+(29) Sort [codegen id : 13]
+Input [1]: [cs_ship_customer_sk#17]
+Arguments: [cs_ship_customer_sk#17 ASC NULLS FIRST], false, 0
 
-(29) SortMergeJoin [codegen id : 14]
+(30) SortMergeJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [cs_ship_customer_sk#13]
+Right keys [1]: [cs_ship_customer_sk#17]
 Join type: ExistenceJoin(exists#1)
 Join condition: None
 
-(30) Filter [codegen id : 14]
+(31) Filter [codegen id : 14]
 Input [5]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5, exists#2, exists#1]
 Condition : (exists#2 OR exists#1)
 
-(31) Project [codegen id : 14]
+(32) Project [codegen id : 14]
 Output [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Input [5]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5, exists#2, exists#1]
 
-(32) Exchange
+(33) Exchange
 Input [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Arguments: hashpartitioning(c_current_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(33) Sort [codegen id : 15]
+(34) Sort [codegen id : 15]
 Input [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Arguments: [c_current_addr_sk#5 ASC NULLS FIRST], false, 0
 
-(34) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#16, ca_state#17]
+(35) ReusedExchange [Reuses operator id: 52]
+Output [2]: [ca_address_sk#20, ca_state#21]
+
+(36) Sort [codegen id : 17]
+Input [2]: [ca_address_sk#20, ca_state#21]
+Arguments: [ca_address_sk#20 ASC NULLS FIRST], false, 0
+
+(37) SortMergeJoin [codegen id : 18]
+Left keys [1]: [c_current_addr_sk#5]
+Right keys [1]: [ca_address_sk#20]
+Join type: Inner
+Join condition: None
+
+(38) Project [codegen id : 18]
+Output [2]: [c_current_cdemo_sk#4, ca_state#21]
+Input [4]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#20, ca_state#21]
+
+(39) Exchange
+Input [2]: [c_current_cdemo_sk#4, ca_state#21]
+Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(40) Sort [codegen id : 19]
+Input [2]: [c_current_cdemo_sk#4, ca_state#21]
+Arguments: [c_current_cdemo_sk#4 ASC NULLS FIRST], false, 0
+
+(41) ReusedExchange [Reuses operator id: 59]
+Output [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+
+(42) Sort [codegen id : 21]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: [cd_demo_sk#22 ASC NULLS FIRST], false, 0
+
+(43) SortMergeJoin [codegen id : 22]
+Left keys [1]: [c_current_cdemo_sk#4]
+Right keys [1]: [cd_demo_sk#22]
+Join type: Inner
+Join condition: None
+
+(44) Project [codegen id : 22]
+Output [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Input [8]: [c_current_cdemo_sk#4, ca_state#21, cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+
+(45) HashAggregate [codegen id : 22]
+Input [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Functions [10]: [partial_count(1), partial_min(cd_dep_count#25), partial_max(cd_dep_count#25), partial_avg(cd_dep_count#25), partial_min(cd_dep_employed_count#26), partial_max(cd_dep_employed_count#26), partial_avg(cd_dep_employed_count#26), partial_min(cd_dep_college_count#27), partial_max(cd_dep_college_count#27), partial_avg(cd_dep_college_count#27)]
+Aggregate Attributes [13]: [count#28, min#29, max#30, sum#31, count#32, min#33, max#34, sum#35, count#36, min#37, max#38, sum#39, count#40]
+Results [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, min#42, max#43, sum#44, count#45, min#46, max#47, sum#48, count#49, min#50, max#51, sum#52, count#53]
+
+(46) Exchange
+Input [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, min#42, max#43, sum#44, count#45, min#46, max#47, sum#48, count#49, min#50, max#51, sum#52, count#53]
+Arguments: hashpartitioning(ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(47) HashAggregate [codegen id : 23]
+Input [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, min#42, max#43, sum#44, count#45, min#46, max#47, sum#48, count#49, min#50, max#51, sum#52, count#53]
+Keys [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Functions [10]: [count(1), min(cd_dep_count#25), max(cd_dep_count#25), avg(cd_dep_count#25), min(cd_dep_employed_count#26), max(cd_dep_employed_count#26), avg(cd_dep_employed_count#26), min(cd_dep_college_count#27), max(cd_dep_college_count#27), avg(cd_dep_college_count#27)]
+Aggregate Attributes [10]: [count(1)#54, min(cd_dep_count#25)#55, max(cd_dep_count#25)#56, avg(cd_dep_count#25)#57, min(cd_dep_employed_count#26)#58, max(cd_dep_employed_count#26)#59, avg(cd_dep_employed_count#26)#60, min(cd_dep_college_count#27)#61, max(cd_dep_college_count#27)#62, avg(cd_dep_college_count#27)#63]
+Results [18]: [ca_state#21, cd_gender#23, cd_marital_status#24, count(1)#54 AS cnt1#64, min(cd_dep_count#25)#55 AS min(cd_dep_count)#65, max(cd_dep_count#25)#56 AS max(cd_dep_count)#66, avg(cd_dep_count#25)#57 AS avg(cd_dep_count)#67, cd_dep_employed_count#26, count(1)#54 AS cnt2#68, min(cd_dep_employed_count#26)#58 AS min(cd_dep_employed_count)#69, max(cd_dep_employed_count#26)#59 AS max(cd_dep_employed_count)#70, avg(cd_dep_employed_count#26)#60 AS avg(cd_dep_employed_count)#71, cd_dep_college_count#27, count(1)#54 AS cnt3#72, min(cd_dep_college_count#27)#61 AS min(cd_dep_college_count)#73, max(cd_dep_college_count#27)#62 AS max(cd_dep_college_count)#74, avg(cd_dep_college_count#27)#63 AS avg(cd_dep_college_count)#75, cd_dep_count#25]
+
+(48) TakeOrderedAndProject
+Input [18]: [ca_state#21, cd_gender#23, cd_marital_status#24, cnt1#64, min(cd_dep_count)#65, max(cd_dep_count)#66, avg(cd_dep_count)#67, cd_dep_employed_count#26, cnt2#68, min(cd_dep_employed_count)#69, max(cd_dep_employed_count)#70, avg(cd_dep_employed_count)#71, cd_dep_college_count#27, cnt3#72, min(cd_dep_college_count)#73, max(cd_dep_college_count)#74, avg(cd_dep_college_count)#75, cd_dep_count#25]
+Arguments: 100, [ca_state#21 ASC NULLS FIRST, cd_gender#23 ASC NULLS FIRST, cd_marital_status#24 ASC NULLS FIRST, cd_dep_count#25 ASC NULLS FIRST, cd_dep_employed_count#26 ASC NULLS FIRST, cd_dep_college_count#27 ASC NULLS FIRST], [ca_state#21, cd_gender#23, cd_marital_status#24, cnt1#64, min(cd_dep_count)#65, max(cd_dep_count)#66, avg(cd_dep_count)#67, cd_dep_employed_count#26, cnt2#68, min(cd_dep_employed_count)#69, max(cd_dep_employed_count)#70, avg(cd_dep_employed_count)#71, cd_dep_college_count#27, cnt3#72, min(cd_dep_college_count)#73, max(cd_dep_college_count)#74, avg(cd_dep_college_count)#75]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (55)
++- Exchange (54)
+   +- ObjectHashAggregate (53)
+      +- Exchange (52)
+         +- * Filter (51)
+            +- * ColumnarToRow (50)
+               +- Scan parquet spark_catalog.default.customer_address (49)
+
+
+(49) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#20, ca_state#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(35) ColumnarToRow [codegen id : 16]
-Input [2]: [ca_address_sk#16, ca_state#17]
+(50) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#21]
 
-(36) Filter [codegen id : 16]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Condition : isnotnull(ca_address_sk#16)
+(51) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#21]
+Condition : isnotnull(ca_address_sk#20)
 
-(37) Exchange
-Input [2]: [ca_address_sk#16, ca_state#17]
-Arguments: hashpartitioning(ca_address_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(52) Exchange
+Input [2]: [ca_address_sk#20, ca_state#21]
+Arguments: hashpartitioning(ca_address_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(38) Sort [codegen id : 17]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
+(53) ObjectHashAggregate
+Input [2]: [ca_address_sk#20, ca_state#21]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [buf#76]
+Results [1]: [buf#77]
 
-(39) SortMergeJoin [codegen id : 18]
-Left keys [1]: [c_current_addr_sk#5]
-Right keys [1]: [ca_address_sk#16]
-Join type: Inner
-Join condition: None
+(54) Exchange
+Input [1]: [buf#77]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(40) Project [codegen id : 18]
-Output [2]: [c_current_cdemo_sk#4, ca_state#17]
-Input [4]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#16, ca_state#17]
+(55) ObjectHashAggregate
+Input [1]: [buf#77]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)#78]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)#78 AS bloomFilter#79]
 
-(41) Exchange
-Input [2]: [c_current_cdemo_sk#4, ca_state#17]
-Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (62)
++- Exchange (61)
+   +- ObjectHashAggregate (60)
+      +- Exchange (59)
+         +- * Filter (58)
+            +- * ColumnarToRow (57)
+               +- Scan parquet spark_catalog.default.customer_demographics (56)
 
-(42) Sort [codegen id : 19]
-Input [2]: [c_current_cdemo_sk#4, ca_state#17]
-Arguments: [c_current_cdemo_sk#4 ASC NULLS FIRST], false, 0
 
-(43) Scan parquet spark_catalog.default.customer_demographics
-Output [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(56) Scan parquet spark_catalog.default.customer_demographics
+Output [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(44) ColumnarToRow [codegen id : 20]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(57) ColumnarToRow [codegen id : 1]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(45) Filter [codegen id : 20]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Condition : isnotnull(cd_demo_sk#18)
+(58) Filter [codegen id : 1]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Condition : isnotnull(cd_demo_sk#22)
 
-(46) Exchange
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Arguments: hashpartitioning(cd_demo_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(59) Exchange
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: hashpartitioning(cd_demo_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(47) Sort [codegen id : 21]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Arguments: [cd_demo_sk#18 ASC NULLS FIRST], false, 0
+(60) ObjectHashAggregate
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#80]
+Results [1]: [buf#81]
 
-(48) SortMergeJoin [codegen id : 22]
-Left keys [1]: [c_current_cdemo_sk#4]
-Right keys [1]: [cd_demo_sk#18]
-Join type: Inner
-Join condition: None
+(61) Exchange
+Input [1]: [buf#81]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(49) Project [codegen id : 22]
-Output [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Input [8]: [c_current_cdemo_sk#4, ca_state#17, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(62) ObjectHashAggregate
+Input [1]: [buf#81]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)#82]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)#82 AS bloomFilter#83]
 
-(50) HashAggregate [codegen id : 22]
-Input [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Functions [10]: [partial_count(1), partial_min(cd_dep_count#21), partial_max(cd_dep_count#21), partial_avg(cd_dep_count#21), partial_min(cd_dep_employed_count#22), partial_max(cd_dep_employed_count#22), partial_avg(cd_dep_employed_count#22), partial_min(cd_dep_college_count#23), partial_max(cd_dep_college_count#23), partial_avg(cd_dep_college_count#23)]
-Aggregate Attributes [13]: [count#24, min#25, max#26, sum#27, count#28, min#29, max#30, sum#31, count#32, min#33, max#34, sum#35, count#36]
-Results [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, min#38, max#39, sum#40, count#41, min#42, max#43, sum#44, count#45, min#46, max#47, sum#48, count#49]
-
-(51) Exchange
-Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, min#38, max#39, sum#40, count#41, min#42, max#43, sum#44, count#45, min#46, max#47, sum#48, count#49]
-Arguments: hashpartitioning(ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(52) HashAggregate [codegen id : 23]
-Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, min#38, max#39, sum#40, count#41, min#42, max#43, sum#44, count#45, min#46, max#47, sum#48, count#49]
-Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Functions [10]: [count(1), min(cd_dep_count#21), max(cd_dep_count#21), avg(cd_dep_count#21), min(cd_dep_employed_count#22), max(cd_dep_employed_count#22), avg(cd_dep_employed_count#22), min(cd_dep_college_count#23), max(cd_dep_college_count#23), avg(cd_dep_college_count#23)]
-Aggregate Attributes [10]: [count(1)#50, min(cd_dep_count#21)#51, max(cd_dep_count#21)#52, avg(cd_dep_count#21)#53, min(cd_dep_employed_count#22)#54, max(cd_dep_employed_count#22)#55, avg(cd_dep_employed_count#22)#56, min(cd_dep_college_count#23)#57, max(cd_dep_college_count#23)#58, avg(cd_dep_college_count#23)#59]
-Results [18]: [ca_state#17, cd_gender#19, cd_marital_status#20, count(1)#50 AS cnt1#60, min(cd_dep_count#21)#51 AS min(cd_dep_count)#61, max(cd_dep_count#21)#52 AS max(cd_dep_count)#62, avg(cd_dep_count#21)#53 AS avg(cd_dep_count)#63, cd_dep_employed_count#22, count(1)#50 AS cnt2#64, min(cd_dep_employed_count#22)#54 AS min(cd_dep_employed_count)#65, max(cd_dep_employed_count#22)#55 AS max(cd_dep_employed_count)#66, avg(cd_dep_employed_count#22)#56 AS avg(cd_dep_employed_count)#67, cd_dep_college_count#23, count(1)#50 AS cnt3#68, min(cd_dep_college_count#23)#57 AS min(cd_dep_college_count)#69, max(cd_dep_college_count#23)#58 AS max(cd_dep_college_count)#70, avg(cd_dep_college_count#23)#59 AS avg(cd_dep_college_count)#71, cd_dep_count#21]
-
-(53) TakeOrderedAndProject
-Input [18]: [ca_state#17, cd_gender#19, cd_marital_status#20, cnt1#60, min(cd_dep_count)#61, max(cd_dep_count)#62, avg(cd_dep_count)#63, cd_dep_employed_count#22, cnt2#64, min(cd_dep_employed_count)#65, max(cd_dep_employed_count)#66, avg(cd_dep_employed_count)#67, cd_dep_college_count#23, cnt3#68, min(cd_dep_college_count)#69, max(cd_dep_college_count)#70, avg(cd_dep_college_count)#71, cd_dep_count#21]
-Arguments: 100, [ca_state#17 ASC NULLS FIRST, cd_gender#19 ASC NULLS FIRST, cd_marital_status#20 ASC NULLS FIRST, cd_dep_count#21 ASC NULLS FIRST, cd_dep_employed_count#22 ASC NULLS FIRST, cd_dep_college_count#23 ASC NULLS FIRST], [ca_state#17, cd_gender#19, cd_marital_status#20, cnt1#60, min(cd_dep_count)#61, max(cd_dep_count)#62, avg(cd_dep_count)#63, cd_dep_employed_count#22, cnt2#64, min(cd_dep_employed_count)#65, max(cd_dep_employed_count)#66, avg(cd_dep_employed_count)#67, cd_dep_college_count#23, cnt3#68, min(cd_dep_college_count)#69, max(cd_dep_college_count)#70, avg(cd_dep_college_count)#71]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (58)
-+- * Project (57)
-   +- * Filter (56)
-      +- * ColumnarToRow (55)
-         +- Scan parquet spark_catalog.default.date_dim (54)
+Subquery:3 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
+BroadcastExchange (67)
++- * Project (66)
+   +- * Filter (65)
+      +- * ColumnarToRow (64)
+         +- Scan parquet spark_catalog.default.date_dim (63)
 
 
-(54) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#72, d_qoy#73]
+(63) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#13, d_year#84, d_qoy#85]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_qoy), EqualTo(d_year,2002), LessThan(d_qoy,4), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(55) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#72, d_qoy#73]
+(64) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#13, d_year#84, d_qoy#85]
 
-(56) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#72, d_qoy#73]
-Condition : ((((isnotnull(d_year#72) AND isnotnull(d_qoy#73)) AND (d_year#72 = 2002)) AND (d_qoy#73 < 4)) AND isnotnull(d_date_sk#9))
+(65) Filter [codegen id : 1]
+Input [3]: [d_date_sk#13, d_year#84, d_qoy#85]
+Condition : ((((isnotnull(d_year#84) AND isnotnull(d_qoy#85)) AND (d_year#84 = 2002)) AND (d_qoy#85 < 4)) AND isnotnull(d_date_sk#13))
 
-(57) Project [codegen id : 1]
-Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#72, d_qoy#73]
+(66) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [3]: [d_date_sk#13, d_year#84, d_qoy#85]
 
-(58) BroadcastExchange
-Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(67) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
-Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
+Subquery:4 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#15 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 22 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#8
+Subquery:5 Hosting operator id = 23 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35.sf100/simplified.txt
@@ -37,6 +37,26 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                                         Exchange [c_customer_sk] #4
                                                                           WholeStageCodegen (1)
                                                                             Filter [c_current_addr_sk,c_current_cdemo_sk]
+                                                                              Subquery #1
+                                                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 1000000, 8000000, 0, 0),bloomFilter,buf]
+                                                                                  Exchange #5
+                                                                                    ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                                      Exchange [ca_address_sk] #6
+                                                                                        WholeStageCodegen (1)
+                                                                                          Filter [ca_address_sk]
+                                                                                            ColumnarToRow
+                                                                                              InputAdapter
+                                                                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                                                              Subquery #2
+                                                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
+                                                                                  Exchange #7
+                                                                                    ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                                      Exchange [cd_demo_sk] #8
+                                                                                        WholeStageCodegen (1)
+                                                                                          Filter [cd_demo_sk]
+                                                                                            ColumnarToRow
+                                                                                              InputAdapter
+                                                                                                Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                                                                               ColumnarToRow
                                                                                 InputAdapter
                                                                                   Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
@@ -44,68 +64,59 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                                   WholeStageCodegen (5)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #5
+                                                                        Exchange [ss_customer_sk] #9
                                                                           WholeStageCodegen (4)
                                                                             Project [ss_customer_sk]
                                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                                      SubqueryBroadcast [d_date_sk] #1
-                                                                                        BroadcastExchange #6
-                                                                                          WholeStageCodegen (1)
-                                                                                            Project [d_date_sk]
-                                                                                              Filter [d_year,d_qoy,d_date_sk]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
+                                                                                Filter
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                                        SubqueryBroadcast [d_date_sk] #3
+                                                                                          BroadcastExchange #10
+                                                                                            WholeStageCodegen (1)
+                                                                                              Project [d_date_sk]
+                                                                                                Filter [d_year,d_qoy,d_date_sk]
+                                                                                                  ColumnarToRow
+                                                                                                    InputAdapter
+                                                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
                                                                                 InputAdapter
-                                                                                  ReusedExchange [d_date_sk] #6
+                                                                                  ReusedExchange [d_date_sk] #10
                                                           InputAdapter
                                                             WholeStageCodegen (9)
                                                               Sort [ws_bill_customer_sk]
                                                                 InputAdapter
-                                                                  Exchange [ws_bill_customer_sk] #7
+                                                                  Exchange [ws_bill_customer_sk] #11
                                                                     WholeStageCodegen (8)
                                                                       Project [ws_bill_customer_sk]
                                                                         BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                                ReusedSubquery [d_date_sk] #1
+                                                                                ReusedSubquery [d_date_sk] #3
                                                                           InputAdapter
-                                                                            ReusedExchange [d_date_sk] #6
+                                                                            ReusedExchange [d_date_sk] #10
                                                     InputAdapter
                                                       WholeStageCodegen (13)
                                                         Sort [cs_ship_customer_sk]
                                                           InputAdapter
-                                                            Exchange [cs_ship_customer_sk] #8
+                                                            Exchange [cs_ship_customer_sk] #12
                                                               WholeStageCodegen (12)
                                                                 Project [cs_ship_customer_sk]
                                                                   BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                                          ReusedSubquery [d_date_sk] #1
+                                                                          ReusedSubquery [d_date_sk] #3
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk] #6
+                                                                      ReusedExchange [d_date_sk] #10
                                   InputAdapter
                                     WholeStageCodegen (17)
                                       Sort [ca_address_sk]
                                         InputAdapter
-                                          Exchange [ca_address_sk] #9
-                                            WholeStageCodegen (16)
-                                              Filter [ca_address_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                          ReusedExchange [ca_address_sk,ca_state] #6
                   InputAdapter
                     WholeStageCodegen (21)
                       Sort [cd_demo_sk]
                         InputAdapter
-                          Exchange [cd_demo_sk] #10
-                            WholeStageCodegen (20)
-                              Filter [cd_demo_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
+                          ReusedExchange [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #8

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
-Condition : isnotnull(cs_item_sk#11)
+Condition : (isnotnull(cs_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_item_sk#11, 42), false))
 
 (20) Project [codegen id : 5]
 Output [1]: [cs_item_sk#11]
@@ -170,25 +170,53 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#13]
+Output [2]: [d_date_sk#10, d_date#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-01), LessThanOrEqual(d_date,2000-04-01), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#13]
+Input [2]: [d_date_sk#10, d_date#15]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#13]
-Condition : (((isnotnull(d_date#13) AND (d_date#13 >= 2000-02-01)) AND (d_date#13 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#10, d_date#15]
+Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-02-01)) AND (d_date#15 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#13]
+Input [2]: [d_date_sk#10, d_date#15]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (37)
++- Exchange (36)
+   +- ObjectHashAggregate (35)
+      +- ReusedExchange (34)
+
+
+(34) ReusedExchange [Reuses operator id: 15]
+Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+
+(35) ObjectHashAggregate
+Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 461487, 3691896, 0, 0)]
+Aggregate Attributes [1]: [buf#16]
+Results [1]: [buf#17]
+
+(36) Exchange
+Input [1]: [buf#17]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+
+(37) ObjectHashAggregate
+Input [1]: [buf#17]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 461487, 3691896, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 461487, 3691896, 0, 0)#18]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 461487, 3691896, 0, 0)#18 AS bloomFilter#19]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
@@ -48,6 +48,11 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                             WholeStageCodegen (5)
                               Project [cs_item_sk]
                                 Filter [cs_item_sk]
+                                  Subquery #2
+                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 461487, 3691896, 0, 0),bloomFilter,buf]
+                                      Exchange #6
+                                        ObjectHashAggregate [i_item_sk] [buf,buf]
+                                          ReusedExchange [i_item_sk,i_item_id,i_item_desc,i_current_price] #2
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/explain.txt
@@ -1,17 +1,17 @@
 == Physical Plan ==
-* HashAggregate (60)
-+- Exchange (59)
-   +- * HashAggregate (58)
-      +- * Project (57)
-         +- * SortMergeJoin LeftSemi (56)
-            :- * SortMergeJoin LeftSemi (38)
-            :  :- * Sort (20)
-            :  :  +- Exchange (19)
-            :  :     +- * HashAggregate (18)
-            :  :        +- Exchange (17)
-            :  :           +- * HashAggregate (16)
-            :  :              +- * Project (15)
-            :  :                 +- * SortMergeJoin Inner (14)
+* HashAggregate (57)
++- Exchange (56)
+   +- * HashAggregate (55)
+      +- * Project (54)
+         +- * SortMergeJoin LeftSemi (53)
+            :- * SortMergeJoin LeftSemi (35)
+            :  :- * Sort (17)
+            :  :  +- Exchange (16)
+            :  :     +- * HashAggregate (15)
+            :  :        +- Exchange (14)
+            :  :           +- * HashAggregate (13)
+            :  :              +- * Project (12)
+            :  :                 +- * SortMergeJoin Inner (11)
             :  :                    :- * Sort (8)
             :  :                    :  +- Exchange (7)
             :  :                    :     +- * Project (6)
@@ -20,45 +20,42 @@
             :  :                    :           :  +- * ColumnarToRow (2)
             :  :                    :           :     +- Scan parquet spark_catalog.default.store_sales (1)
             :  :                    :           +- ReusedExchange (4)
-            :  :                    +- * Sort (13)
-            :  :                       +- Exchange (12)
-            :  :                          +- * Filter (11)
-            :  :                             +- * ColumnarToRow (10)
-            :  :                                +- Scan parquet spark_catalog.default.customer (9)
-            :  +- * Sort (37)
-            :     +- Exchange (36)
-            :        +- * HashAggregate (35)
-            :           +- Exchange (34)
-            :              +- * HashAggregate (33)
-            :                 +- * Project (32)
-            :                    +- * SortMergeJoin Inner (31)
-            :                       :- * Sort (28)
-            :                       :  +- Exchange (27)
-            :                       :     +- * Project (26)
-            :                       :        +- * BroadcastHashJoin Inner BuildRight (25)
-            :                       :           :- * Filter (23)
-            :                       :           :  +- * ColumnarToRow (22)
-            :                       :           :     +- Scan parquet spark_catalog.default.catalog_sales (21)
-            :                       :           +- ReusedExchange (24)
-            :                       +- * Sort (30)
-            :                          +- ReusedExchange (29)
-            +- * Sort (55)
-               +- Exchange (54)
-                  +- * HashAggregate (53)
-                     +- Exchange (52)
-                        +- * HashAggregate (51)
-                           +- * Project (50)
-                              +- * SortMergeJoin Inner (49)
-                                 :- * Sort (46)
-                                 :  +- Exchange (45)
-                                 :     +- * Project (44)
-                                 :        +- * BroadcastHashJoin Inner BuildRight (43)
-                                 :           :- * Filter (41)
-                                 :           :  +- * ColumnarToRow (40)
-                                 :           :     +- Scan parquet spark_catalog.default.web_sales (39)
-                                 :           +- ReusedExchange (42)
-                                 +- * Sort (48)
-                                    +- ReusedExchange (47)
+            :  :                    +- * Sort (10)
+            :  :                       +- ReusedExchange (9)
+            :  +- * Sort (34)
+            :     +- Exchange (33)
+            :        +- * HashAggregate (32)
+            :           +- Exchange (31)
+            :              +- * HashAggregate (30)
+            :                 +- * Project (29)
+            :                    +- * SortMergeJoin Inner (28)
+            :                       :- * Sort (25)
+            :                       :  +- Exchange (24)
+            :                       :     +- * Project (23)
+            :                       :        +- * BroadcastHashJoin Inner BuildRight (22)
+            :                       :           :- * Filter (20)
+            :                       :           :  +- * ColumnarToRow (19)
+            :                       :           :     +- Scan parquet spark_catalog.default.catalog_sales (18)
+            :                       :           +- ReusedExchange (21)
+            :                       +- * Sort (27)
+            :                          +- ReusedExchange (26)
+            +- * Sort (52)
+               +- Exchange (51)
+                  +- * HashAggregate (50)
+                     +- Exchange (49)
+                        +- * HashAggregate (48)
+                           +- * Project (47)
+                              +- * SortMergeJoin Inner (46)
+                                 :- * Sort (43)
+                                 :  +- Exchange (42)
+                                 :     +- * Project (41)
+                                 :        +- * BroadcastHashJoin Inner BuildRight (40)
+                                 :           :- * Filter (38)
+                                 :           :  +- * ColumnarToRow (37)
+                                 :           :     +- Scan parquet spark_catalog.default.web_sales (36)
+                                 :           +- ReusedExchange (39)
+                                 +- * Sort (45)
+                                    +- ReusedExchange (44)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -74,313 +71,392 @@ Input [2]: [ss_customer_sk#1, ss_sold_date_sk#2]
 
 (3) Filter [codegen id : 2]
 Input [2]: [ss_customer_sk#1, ss_sold_date_sk#2]
-Condition : isnotnull(ss_customer_sk#1)
+Condition : (isnotnull(ss_customer_sk#1) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 65]
-Output [2]: [d_date_sk#4, d_date#5]
+(4) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#6, d_date#7]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#2]
-Right keys [1]: [d_date_sk#4]
+Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
-Output [2]: [ss_customer_sk#1, d_date#5]
-Input [4]: [ss_customer_sk#1, ss_sold_date_sk#2, d_date_sk#4, d_date#5]
+Output [2]: [ss_customer_sk#1, d_date#7]
+Input [4]: [ss_customer_sk#1, ss_sold_date_sk#2, d_date_sk#6, d_date#7]
 
 (7) Exchange
-Input [2]: [ss_customer_sk#1, d_date#5]
+Input [2]: [ss_customer_sk#1, d_date#7]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (8) Sort [codegen id : 3]
-Input [2]: [ss_customer_sk#1, d_date#5]
+Input [2]: [ss_customer_sk#1, d_date#7]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer
-Output [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
+(9) ReusedExchange [Reuses operator id: 61]
+Output [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
+
+(10) Sort [codegen id : 5]
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
+Arguments: [c_customer_sk#8 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#8]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Input [5]: [ss_customer_sk#1, d_date#7, c_customer_sk#8, c_first_name#9, c_last_name#10]
+
+(13) HashAggregate [codegen id : 6]
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Keys [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#10, c_first_name#9, d_date#7]
+
+(14) Exchange
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Arguments: hashpartitioning(c_last_name#10, c_first_name#9, d_date#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Keys [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#10, c_first_name#9, d_date#7]
+
+(16) Exchange
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Arguments: hashpartitioning(coalesce(c_last_name#10, ), isnull(c_last_name#10), coalesce(c_first_name#9, ), isnull(c_first_name#9), coalesce(d_date#7, 1970-01-01), isnull(d_date#7), 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(17) Sort [codegen id : 8]
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Arguments: [coalesce(c_last_name#10, ) ASC NULLS FIRST, isnull(c_last_name#10) ASC NULLS FIRST, coalesce(c_first_name#9, ) ASC NULLS FIRST, isnull(c_first_name#9) ASC NULLS FIRST, coalesce(d_date#7, 1970-01-01) ASC NULLS FIRST, isnull(d_date#7) ASC NULLS FIRST], false, 0
+
+(18) Scan parquet spark_catalog.default.catalog_sales
+Output [2]: [cs_bill_customer_sk#11, cs_sold_date_sk#12]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#12), dynamicpruningexpression(cs_sold_date_sk#12 IN dynamicpruning#3)]
+PushedFilters: [IsNotNull(cs_bill_customer_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int>
+
+(19) ColumnarToRow [codegen id : 10]
+Input [2]: [cs_bill_customer_sk#11, cs_sold_date_sk#12]
+
+(20) Filter [codegen id : 10]
+Input [2]: [cs_bill_customer_sk#11, cs_sold_date_sk#12]
+Condition : (isnotnull(cs_bill_customer_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_bill_customer_sk#11, 42), false))
+
+(21) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#15, d_date#16]
+
+(22) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [cs_sold_date_sk#12]
+Right keys [1]: [d_date_sk#15]
+Join type: Inner
+Join condition: None
+
+(23) Project [codegen id : 10]
+Output [2]: [cs_bill_customer_sk#11, d_date#16]
+Input [4]: [cs_bill_customer_sk#11, cs_sold_date_sk#12, d_date_sk#15, d_date#16]
+
+(24) Exchange
+Input [2]: [cs_bill_customer_sk#11, d_date#16]
+Arguments: hashpartitioning(cs_bill_customer_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(25) Sort [codegen id : 11]
+Input [2]: [cs_bill_customer_sk#11, d_date#16]
+Arguments: [cs_bill_customer_sk#11 ASC NULLS FIRST], false, 0
+
+(26) ReusedExchange [Reuses operator id: 61]
+Output [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+
+(27) Sort [codegen id : 13]
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Arguments: [c_customer_sk#17 ASC NULLS FIRST], false, 0
+
+(28) SortMergeJoin [codegen id : 14]
+Left keys [1]: [cs_bill_customer_sk#11]
+Right keys [1]: [c_customer_sk#17]
+Join type: Inner
+Join condition: None
+
+(29) Project [codegen id : 14]
+Output [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Input [5]: [cs_bill_customer_sk#11, d_date#16, c_customer_sk#17, c_first_name#18, c_last_name#19]
+
+(30) HashAggregate [codegen id : 14]
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Keys [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#19, c_first_name#18, d_date#16]
+
+(31) Exchange
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Arguments: hashpartitioning(c_last_name#19, c_first_name#18, d_date#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(32) HashAggregate [codegen id : 15]
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Keys [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#19, c_first_name#18, d_date#16]
+
+(33) Exchange
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Arguments: hashpartitioning(coalesce(c_last_name#19, ), isnull(c_last_name#19), coalesce(c_first_name#18, ), isnull(c_first_name#18), coalesce(d_date#16, 1970-01-01), isnull(d_date#16), 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(34) Sort [codegen id : 16]
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Arguments: [coalesce(c_last_name#19, ) ASC NULLS FIRST, isnull(c_last_name#19) ASC NULLS FIRST, coalesce(c_first_name#18, ) ASC NULLS FIRST, isnull(c_first_name#18) ASC NULLS FIRST, coalesce(d_date#16, 1970-01-01) ASC NULLS FIRST, isnull(d_date#16) ASC NULLS FIRST], false, 0
+
+(35) SortMergeJoin [codegen id : 17]
+Left keys [6]: [coalesce(c_last_name#10, ), isnull(c_last_name#10), coalesce(c_first_name#9, ), isnull(c_first_name#9), coalesce(d_date#7, 1970-01-01), isnull(d_date#7)]
+Right keys [6]: [coalesce(c_last_name#19, ), isnull(c_last_name#19), coalesce(c_first_name#18, ), isnull(c_first_name#18), coalesce(d_date#16, 1970-01-01), isnull(d_date#16)]
+Join type: LeftSemi
+Join condition: None
+
+(36) Scan parquet spark_catalog.default.web_sales
+Output [2]: [ws_bill_customer_sk#20, ws_sold_date_sk#21]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#21), dynamicpruningexpression(ws_sold_date_sk#21 IN dynamicpruning#3)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int>
+
+(37) ColumnarToRow [codegen id : 19]
+Input [2]: [ws_bill_customer_sk#20, ws_sold_date_sk#21]
+
+(38) Filter [codegen id : 19]
+Input [2]: [ws_bill_customer_sk#20, ws_sold_date_sk#21]
+Condition : (isnotnull(ws_bill_customer_sk#20) AND might_contain(ReusedSubquery Subquery scalar-subquery#13, [id=#14], xxhash64(ws_bill_customer_sk#20, 42), false))
+
+(39) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#22, d_date#23]
+
+(40) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [ws_sold_date_sk#21]
+Right keys [1]: [d_date_sk#22]
+Join type: Inner
+Join condition: None
+
+(41) Project [codegen id : 19]
+Output [2]: [ws_bill_customer_sk#20, d_date#23]
+Input [4]: [ws_bill_customer_sk#20, ws_sold_date_sk#21, d_date_sk#22, d_date#23]
+
+(42) Exchange
+Input [2]: [ws_bill_customer_sk#20, d_date#23]
+Arguments: hashpartitioning(ws_bill_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(43) Sort [codegen id : 20]
+Input [2]: [ws_bill_customer_sk#20, d_date#23]
+Arguments: [ws_bill_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(44) ReusedExchange [Reuses operator id: 61]
+Output [3]: [c_customer_sk#24, c_first_name#25, c_last_name#26]
+
+(45) Sort [codegen id : 22]
+Input [3]: [c_customer_sk#24, c_first_name#25, c_last_name#26]
+Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+
+(46) SortMergeJoin [codegen id : 23]
+Left keys [1]: [ws_bill_customer_sk#20]
+Right keys [1]: [c_customer_sk#24]
+Join type: Inner
+Join condition: None
+
+(47) Project [codegen id : 23]
+Output [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Input [5]: [ws_bill_customer_sk#20, d_date#23, c_customer_sk#24, c_first_name#25, c_last_name#26]
+
+(48) HashAggregate [codegen id : 23]
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Keys [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
+
+(49) Exchange
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Arguments: hashpartitioning(c_last_name#26, c_first_name#25, d_date#23, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(50) HashAggregate [codegen id : 24]
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Keys [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
+
+(51) Exchange
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Arguments: hashpartitioning(coalesce(c_last_name#26, ), isnull(c_last_name#26), coalesce(c_first_name#25, ), isnull(c_first_name#25), coalesce(d_date#23, 1970-01-01), isnull(d_date#23), 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(52) Sort [codegen id : 25]
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Arguments: [coalesce(c_last_name#26, ) ASC NULLS FIRST, isnull(c_last_name#26) ASC NULLS FIRST, coalesce(c_first_name#25, ) ASC NULLS FIRST, isnull(c_first_name#25) ASC NULLS FIRST, coalesce(d_date#23, 1970-01-01) ASC NULLS FIRST, isnull(d_date#23) ASC NULLS FIRST], false, 0
+
+(53) SortMergeJoin [codegen id : 26]
+Left keys [6]: [coalesce(c_last_name#10, ), isnull(c_last_name#10), coalesce(c_first_name#9, ), isnull(c_first_name#9), coalesce(d_date#7, 1970-01-01), isnull(d_date#7)]
+Right keys [6]: [coalesce(c_last_name#26, ), isnull(c_last_name#26), coalesce(c_first_name#25, ), isnull(c_first_name#25), coalesce(d_date#23, 1970-01-01), isnull(d_date#23)]
+Join type: LeftSemi
+Join condition: None
+
+(54) Project [codegen id : 26]
+Output: []
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+
+(55) HashAggregate [codegen id : 26]
+Input: []
+Keys: []
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#27]
+Results [1]: [count#28]
+
+(56) Exchange
+Input [1]: [count#28]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+
+(57) HashAggregate [codegen id : 27]
+Input [1]: [count#28]
+Keys: []
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#29]
+Results [1]: [count(1)#29 AS count(1)#30]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
+ObjectHashAggregate (64)
++- Exchange (63)
+   +- ObjectHashAggregate (62)
+      +- Exchange (61)
+         +- * Filter (60)
+            +- * ColumnarToRow (59)
+               +- Scan parquet spark_catalog.default.customer (58)
+
+
+(58) Scan parquet spark_catalog.default.customer
+Output [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
-(10) ColumnarToRow [codegen id : 4]
-Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
+(59) ColumnarToRow [codegen id : 1]
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
 
-(11) Filter [codegen id : 4]
-Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
-Condition : isnotnull(c_customer_sk#6)
+(60) Filter [codegen id : 1]
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
+Condition : isnotnull(c_customer_sk#8)
 
-(12) Exchange
-Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
-Arguments: hashpartitioning(c_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(61) Exchange
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
+Arguments: hashpartitioning(c_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(13) Sort [codegen id : 5]
-Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
-Arguments: [c_customer_sk#6 ASC NULLS FIRST], false, 0
-
-(14) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#6]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Input [5]: [ss_customer_sk#1, d_date#5, c_customer_sk#6, c_first_name#7, c_last_name#8]
-
-(16) HashAggregate [codegen id : 6]
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Keys [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#8, c_first_name#7, d_date#5]
-
-(17) Exchange
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Arguments: hashpartitioning(c_last_name#8, c_first_name#7, d_date#5, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Keys [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#8, c_first_name#7, d_date#5]
-
-(19) Exchange
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Arguments: hashpartitioning(coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5), 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(20) Sort [codegen id : 8]
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Arguments: [coalesce(c_last_name#8, ) ASC NULLS FIRST, isnull(c_last_name#8) ASC NULLS FIRST, coalesce(c_first_name#7, ) ASC NULLS FIRST, isnull(c_first_name#7) ASC NULLS FIRST, coalesce(d_date#5, 1970-01-01) ASC NULLS FIRST, isnull(d_date#5) ASC NULLS FIRST], false, 0
-
-(21) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_bill_customer_sk#9, cs_sold_date_sk#10]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#10), dynamicpruningexpression(cs_sold_date_sk#10 IN dynamicpruning#3)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk)]
-ReadSchema: struct<cs_bill_customer_sk:int>
-
-(22) ColumnarToRow [codegen id : 10]
-Input [2]: [cs_bill_customer_sk#9, cs_sold_date_sk#10]
-
-(23) Filter [codegen id : 10]
-Input [2]: [cs_bill_customer_sk#9, cs_sold_date_sk#10]
-Condition : isnotnull(cs_bill_customer_sk#9)
-
-(24) ReusedExchange [Reuses operator id: 65]
-Output [2]: [d_date_sk#11, d_date#12]
-
-(25) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#10]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(26) Project [codegen id : 10]
-Output [2]: [cs_bill_customer_sk#9, d_date#12]
-Input [4]: [cs_bill_customer_sk#9, cs_sold_date_sk#10, d_date_sk#11, d_date#12]
-
-(27) Exchange
-Input [2]: [cs_bill_customer_sk#9, d_date#12]
-Arguments: hashpartitioning(cs_bill_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(28) Sort [codegen id : 11]
-Input [2]: [cs_bill_customer_sk#9, d_date#12]
-Arguments: [cs_bill_customer_sk#9 ASC NULLS FIRST], false, 0
-
-(29) ReusedExchange [Reuses operator id: 12]
-Output [3]: [c_customer_sk#13, c_first_name#14, c_last_name#15]
-
-(30) Sort [codegen id : 13]
-Input [3]: [c_customer_sk#13, c_first_name#14, c_last_name#15]
-Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
-
-(31) SortMergeJoin [codegen id : 14]
-Left keys [1]: [cs_bill_customer_sk#9]
-Right keys [1]: [c_customer_sk#13]
-Join type: Inner
-Join condition: None
-
-(32) Project [codegen id : 14]
-Output [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Input [5]: [cs_bill_customer_sk#9, d_date#12, c_customer_sk#13, c_first_name#14, c_last_name#15]
-
-(33) HashAggregate [codegen id : 14]
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Keys [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#15, c_first_name#14, d_date#12]
-
-(34) Exchange
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, d_date#12, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) HashAggregate [codegen id : 15]
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Keys [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#15, c_first_name#14, d_date#12]
-
-(36) Exchange
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Arguments: hashpartitioning(coalesce(c_last_name#15, ), isnull(c_last_name#15), coalesce(c_first_name#14, ), isnull(c_first_name#14), coalesce(d_date#12, 1970-01-01), isnull(d_date#12), 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(37) Sort [codegen id : 16]
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Arguments: [coalesce(c_last_name#15, ) ASC NULLS FIRST, isnull(c_last_name#15) ASC NULLS FIRST, coalesce(c_first_name#14, ) ASC NULLS FIRST, isnull(c_first_name#14) ASC NULLS FIRST, coalesce(d_date#12, 1970-01-01) ASC NULLS FIRST, isnull(d_date#12) ASC NULLS FIRST], false, 0
-
-(38) SortMergeJoin [codegen id : 17]
-Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
-Right keys [6]: [coalesce(c_last_name#15, ), isnull(c_last_name#15), coalesce(c_first_name#14, ), isnull(c_first_name#14), coalesce(d_date#12, 1970-01-01), isnull(d_date#12)]
-Join type: LeftSemi
-Join condition: None
-
-(39) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#16, ws_sold_date_sk#17]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#17), dynamicpruningexpression(ws_sold_date_sk#17 IN dynamicpruning#3)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int>
-
-(40) ColumnarToRow [codegen id : 19]
-Input [2]: [ws_bill_customer_sk#16, ws_sold_date_sk#17]
-
-(41) Filter [codegen id : 19]
-Input [2]: [ws_bill_customer_sk#16, ws_sold_date_sk#17]
-Condition : isnotnull(ws_bill_customer_sk#16)
-
-(42) ReusedExchange [Reuses operator id: 65]
-Output [2]: [d_date_sk#18, d_date#19]
-
-(43) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_sold_date_sk#17]
-Right keys [1]: [d_date_sk#18]
-Join type: Inner
-Join condition: None
-
-(44) Project [codegen id : 19]
-Output [2]: [ws_bill_customer_sk#16, d_date#19]
-Input [4]: [ws_bill_customer_sk#16, ws_sold_date_sk#17, d_date_sk#18, d_date#19]
-
-(45) Exchange
-Input [2]: [ws_bill_customer_sk#16, d_date#19]
-Arguments: hashpartitioning(ws_bill_customer_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(46) Sort [codegen id : 20]
-Input [2]: [ws_bill_customer_sk#16, d_date#19]
-Arguments: [ws_bill_customer_sk#16 ASC NULLS FIRST], false, 0
-
-(47) ReusedExchange [Reuses operator id: 12]
-Output [3]: [c_customer_sk#20, c_first_name#21, c_last_name#22]
-
-(48) Sort [codegen id : 22]
-Input [3]: [c_customer_sk#20, c_first_name#21, c_last_name#22]
-Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
-
-(49) SortMergeJoin [codegen id : 23]
-Left keys [1]: [ws_bill_customer_sk#16]
-Right keys [1]: [c_customer_sk#20]
-Join type: Inner
-Join condition: None
-
-(50) Project [codegen id : 23]
-Output [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Input [5]: [ws_bill_customer_sk#16, d_date#19, c_customer_sk#20, c_first_name#21, c_last_name#22]
-
-(51) HashAggregate [codegen id : 23]
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Keys [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#22, c_first_name#21, d_date#19]
-
-(52) Exchange
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Arguments: hashpartitioning(c_last_name#22, c_first_name#21, d_date#19, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(53) HashAggregate [codegen id : 24]
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Keys [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#22, c_first_name#21, d_date#19]
-
-(54) Exchange
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Arguments: hashpartitioning(coalesce(c_last_name#22, ), isnull(c_last_name#22), coalesce(c_first_name#21, ), isnull(c_first_name#21), coalesce(d_date#19, 1970-01-01), isnull(d_date#19), 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(55) Sort [codegen id : 25]
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Arguments: [coalesce(c_last_name#22, ) ASC NULLS FIRST, isnull(c_last_name#22) ASC NULLS FIRST, coalesce(c_first_name#21, ) ASC NULLS FIRST, isnull(c_first_name#21) ASC NULLS FIRST, coalesce(d_date#19, 1970-01-01) ASC NULLS FIRST, isnull(d_date#19) ASC NULLS FIRST], false, 0
-
-(56) SortMergeJoin [codegen id : 26]
-Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
-Right keys [6]: [coalesce(c_last_name#22, ), isnull(c_last_name#22), coalesce(c_first_name#21, ), isnull(c_first_name#21), coalesce(d_date#19, 1970-01-01), isnull(d_date#19)]
-Join type: LeftSemi
-Join condition: None
-
-(57) Project [codegen id : 26]
-Output: []
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-
-(58) HashAggregate [codegen id : 26]
-Input: []
+(62) ObjectHashAggregate
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
 Keys: []
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#23]
-Results [1]: [count#24]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#31]
+Results [1]: [buf#32]
 
-(59) Exchange
-Input [1]: [count#24]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+(63) Exchange
+Input [1]: [buf#32]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
-(60) HashAggregate [codegen id : 27]
-Input [1]: [count#24]
+(64) ObjectHashAggregate
+Input [1]: [buf#32]
 Keys: []
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#25]
-Results [1]: [count(1)#25 AS count(1)#26]
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2000000, 16000000, 0, 0)#33]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2000000, 16000000, 0, 0)#33 AS bloomFilter#34]
 
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#2 IN dynamicpruning#3
-BroadcastExchange (65)
-+- * Project (64)
-   +- * Filter (63)
-      +- * ColumnarToRow (62)
-         +- Scan parquet spark_catalog.default.date_dim (61)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#2 IN dynamicpruning#3
+BroadcastExchange (69)
++- * Project (68)
+   +- * Filter (67)
+      +- * ColumnarToRow (66)
+         +- Scan parquet spark_catalog.default.date_dim (65)
 
 
-(61) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#4, d_date#5, d_month_seq#27]
+(65) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#6, d_date#7, d_month_seq#35]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_month_seq:int>
 
-(62) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#4, d_date#5, d_month_seq#27]
+(66) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#6, d_date#7, d_month_seq#35]
 
-(63) Filter [codegen id : 1]
-Input [3]: [d_date_sk#4, d_date#5, d_month_seq#27]
-Condition : (((isnotnull(d_month_seq#27) AND (d_month_seq#27 >= 1200)) AND (d_month_seq#27 <= 1211)) AND isnotnull(d_date_sk#4))
+(67) Filter [codegen id : 1]
+Input [3]: [d_date_sk#6, d_date#7, d_month_seq#35]
+Condition : (((isnotnull(d_month_seq#35) AND (d_month_seq#35 >= 1200)) AND (d_month_seq#35 <= 1211)) AND isnotnull(d_date_sk#6))
 
-(64) Project [codegen id : 1]
-Output [2]: [d_date_sk#4, d_date#5]
-Input [3]: [d_date_sk#4, d_date#5, d_month_seq#27]
+(68) Project [codegen id : 1]
+Output [2]: [d_date_sk#6, d_date#7]
+Input [3]: [d_date_sk#6, d_date#7, d_month_seq#35]
 
-(65) BroadcastExchange
-Input [2]: [d_date_sk#4, d_date#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
+(69) BroadcastExchange
+Input [2]: [d_date_sk#6, d_date#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
 
-Subquery:2 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#10 IN dynamicpruning#3
+Subquery:3 Hosting operator id = 20 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (76)
++- Exchange (75)
+   +- ObjectHashAggregate (74)
+      +- Exchange (73)
+         +- * Filter (72)
+            +- * ColumnarToRow (71)
+               +- Scan parquet spark_catalog.default.customer (70)
 
-Subquery:3 Hosting operator id = 39 Hosting Expression = ws_sold_date_sk#17 IN dynamicpruning#3
+
+(70) Scan parquet spark_catalog.default.customer
+Output [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
+
+(71) ColumnarToRow [codegen id : 1]
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+
+(72) Filter [codegen id : 1]
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Condition : isnotnull(c_customer_sk#17)
+
+(73) Exchange
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Arguments: hashpartitioning(c_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(74) ObjectHashAggregate
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#17, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#36]
+Results [1]: [buf#37]
+
+(75) Exchange
+Input [1]: [buf#37]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
+
+(76) ObjectHashAggregate
+Input [1]: [buf#37]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#17, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#17, 42), 2000000, 16000000, 0, 0)#38]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#17, 42), 2000000, 16000000, 0, 0)#38 AS bloomFilter#39]
+
+Subquery:4 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#12 IN dynamicpruning#3
+
+Subquery:5 Hosting operator id = 38 Hosting Expression = ReusedSubquery Subquery scalar-subquery#13, [id=#14]
+
+Subquery:6 Hosting operator id = 36 Hosting Expression = ws_sold_date_sk#21 IN dynamicpruning#3
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/simplified.txt
@@ -31,6 +31,16 @@ WholeStageCodegen (27)
                                                             Project [ss_customer_sk,d_date]
                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                 Filter [ss_customer_sk]
+                                                                  Subquery #2
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                      Exchange #6
+                                                                        ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                          Exchange [c_customer_sk] #7
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [c_customer_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
@@ -48,21 +58,16 @@ WholeStageCodegen (27)
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #6
-                                                          WholeStageCodegen (4)
-                                                            Filter [c_customer_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
+                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #7
                       InputAdapter
                         WholeStageCodegen (16)
                           Sort [c_last_name,c_first_name,d_date]
                             InputAdapter
-                              Exchange [c_last_name,c_first_name,d_date] #7
+                              Exchange [c_last_name,c_first_name,d_date] #8
                                 WholeStageCodegen (15)
                                   HashAggregate [c_last_name,c_first_name,d_date]
                                     InputAdapter
-                                      Exchange [c_last_name,c_first_name,d_date] #8
+                                      Exchange [c_last_name,c_first_name,d_date] #9
                                         WholeStageCodegen (14)
                                           HashAggregate [c_last_name,c_first_name,d_date]
                                             Project [c_last_name,c_first_name,d_date]
@@ -71,11 +76,21 @@ WholeStageCodegen (27)
                                                   WholeStageCodegen (11)
                                                     Sort [cs_bill_customer_sk]
                                                       InputAdapter
-                                                        Exchange [cs_bill_customer_sk] #9
+                                                        Exchange [cs_bill_customer_sk] #10
                                                           WholeStageCodegen (10)
                                                             Project [cs_bill_customer_sk,d_date]
                                                               BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                 Filter [cs_bill_customer_sk]
+                                                                  Subquery #3
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                      Exchange #11
+                                                                        ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                          Exchange [c_customer_sk] #12
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [c_customer_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_sold_date_sk]
@@ -86,16 +101,16 @@ WholeStageCodegen (27)
                                                   WholeStageCodegen (13)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #6
+                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #7
                 InputAdapter
                   WholeStageCodegen (25)
                     Sort [c_last_name,c_first_name,d_date]
                       InputAdapter
-                        Exchange [c_last_name,c_first_name,d_date] #10
+                        Exchange [c_last_name,c_first_name,d_date] #13
                           WholeStageCodegen (24)
                             HashAggregate [c_last_name,c_first_name,d_date]
                               InputAdapter
-                                Exchange [c_last_name,c_first_name,d_date] #11
+                                Exchange [c_last_name,c_first_name,d_date] #14
                                   WholeStageCodegen (23)
                                     HashAggregate [c_last_name,c_first_name,d_date]
                                       Project [c_last_name,c_first_name,d_date]
@@ -104,11 +119,12 @@ WholeStageCodegen (27)
                                             WholeStageCodegen (20)
                                               Sort [ws_bill_customer_sk]
                                                 InputAdapter
-                                                  Exchange [ws_bill_customer_sk] #12
+                                                  Exchange [ws_bill_customer_sk] #15
                                                     WholeStageCodegen (19)
                                                       Project [ws_bill_customer_sk,d_date]
                                                         BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                           Filter [ws_bill_customer_sk]
+                                                            ReusedSubquery [bloomFilter] #3
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
@@ -119,4 +135,4 @@ WholeStageCodegen (27)
                                             WholeStageCodegen (22)
                                               Sort [c_customer_sk]
                                                 InputAdapter
-                                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #6
+                                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #7

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4.sf100/explain.txt
@@ -1,22 +1,22 @@
 == Physical Plan ==
-TakeOrderedAndProject (118)
-+- * Project (117)
-   +- * SortMergeJoin Inner (116)
-      :- * Project (98)
-      :  +- * SortMergeJoin Inner (97)
-      :     :- * Project (78)
-      :     :  +- * SortMergeJoin Inner (77)
-      :     :     :- * Project (59)
-      :     :     :  +- * SortMergeJoin Inner (58)
-      :     :     :     :- * SortMergeJoin Inner (39)
-      :     :     :     :  :- * Sort (21)
-      :     :     :     :  :  +- Exchange (20)
-      :     :     :     :  :     +- * Filter (19)
-      :     :     :     :  :        +- * HashAggregate (18)
-      :     :     :     :  :           +- Exchange (17)
-      :     :     :     :  :              +- * HashAggregate (16)
-      :     :     :     :  :                 +- * Project (15)
-      :     :     :     :  :                    +- * SortMergeJoin Inner (14)
+TakeOrderedAndProject (115)
++- * Project (114)
+   +- * SortMergeJoin Inner (113)
+      :- * Project (95)
+      :  +- * SortMergeJoin Inner (94)
+      :     :- * Project (75)
+      :     :  +- * SortMergeJoin Inner (74)
+      :     :     :- * Project (56)
+      :     :     :  +- * SortMergeJoin Inner (55)
+      :     :     :     :- * SortMergeJoin Inner (36)
+      :     :     :     :  :- * Sort (18)
+      :     :     :     :  :  +- Exchange (17)
+      :     :     :     :  :     +- * Filter (16)
+      :     :     :     :  :        +- * HashAggregate (15)
+      :     :     :     :  :           +- Exchange (14)
+      :     :     :     :  :              +- * HashAggregate (13)
+      :     :     :     :  :                 +- * Project (12)
+      :     :     :     :  :                    +- * SortMergeJoin Inner (11)
       :     :     :     :  :                       :- * Sort (8)
       :     :     :     :  :                       :  +- Exchange (7)
       :     :     :     :  :                       :     +- * Project (6)
@@ -25,98 +25,95 @@ TakeOrderedAndProject (118)
       :     :     :     :  :                       :           :  +- * ColumnarToRow (2)
       :     :     :     :  :                       :           :     +- Scan parquet spark_catalog.default.store_sales (1)
       :     :     :     :  :                       :           +- ReusedExchange (4)
-      :     :     :     :  :                       +- * Sort (13)
-      :     :     :     :  :                          +- Exchange (12)
-      :     :     :     :  :                             +- * Filter (11)
-      :     :     :     :  :                                +- * ColumnarToRow (10)
-      :     :     :     :  :                                   +- Scan parquet spark_catalog.default.customer (9)
-      :     :     :     :  +- * Sort (38)
-      :     :     :     :     +- Exchange (37)
-      :     :     :     :        +- * HashAggregate (36)
-      :     :     :     :           +- Exchange (35)
-      :     :     :     :              +- * HashAggregate (34)
-      :     :     :     :                 +- * Project (33)
-      :     :     :     :                    +- * SortMergeJoin Inner (32)
-      :     :     :     :                       :- * Sort (29)
-      :     :     :     :                       :  +- Exchange (28)
-      :     :     :     :                       :     +- * Project (27)
-      :     :     :     :                       :        +- * BroadcastHashJoin Inner BuildRight (26)
-      :     :     :     :                       :           :- * Filter (24)
-      :     :     :     :                       :           :  +- * ColumnarToRow (23)
-      :     :     :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (22)
-      :     :     :     :                       :           +- ReusedExchange (25)
-      :     :     :     :                       +- * Sort (31)
-      :     :     :     :                          +- ReusedExchange (30)
-      :     :     :     +- * Sort (57)
-      :     :     :        +- Exchange (56)
-      :     :     :           +- * Filter (55)
-      :     :     :              +- * HashAggregate (54)
-      :     :     :                 +- Exchange (53)
-      :     :     :                    +- * HashAggregate (52)
-      :     :     :                       +- * Project (51)
-      :     :     :                          +- * SortMergeJoin Inner (50)
-      :     :     :                             :- * Sort (47)
-      :     :     :                             :  +- Exchange (46)
-      :     :     :                             :     +- * Project (45)
-      :     :     :                             :        +- * BroadcastHashJoin Inner BuildRight (44)
-      :     :     :                             :           :- * Filter (42)
-      :     :     :                             :           :  +- * ColumnarToRow (41)
-      :     :     :                             :           :     +- Scan parquet spark_catalog.default.catalog_sales (40)
-      :     :     :                             :           +- ReusedExchange (43)
-      :     :     :                             +- * Sort (49)
-      :     :     :                                +- ReusedExchange (48)
-      :     :     +- * Sort (76)
-      :     :        +- Exchange (75)
-      :     :           +- * HashAggregate (74)
-      :     :              +- Exchange (73)
-      :     :                 +- * HashAggregate (72)
-      :     :                    +- * Project (71)
-      :     :                       +- * SortMergeJoin Inner (70)
-      :     :                          :- * Sort (67)
-      :     :                          :  +- Exchange (66)
-      :     :                          :     +- * Project (65)
-      :     :                          :        +- * BroadcastHashJoin Inner BuildRight (64)
-      :     :                          :           :- * Filter (62)
-      :     :                          :           :  +- * ColumnarToRow (61)
-      :     :                          :           :     +- Scan parquet spark_catalog.default.catalog_sales (60)
-      :     :                          :           +- ReusedExchange (63)
-      :     :                          +- * Sort (69)
-      :     :                             +- ReusedExchange (68)
-      :     +- * Sort (96)
-      :        +- Exchange (95)
-      :           +- * Filter (94)
-      :              +- * HashAggregate (93)
-      :                 +- Exchange (92)
-      :                    +- * HashAggregate (91)
-      :                       +- * Project (90)
-      :                          +- * SortMergeJoin Inner (89)
-      :                             :- * Sort (86)
-      :                             :  +- Exchange (85)
-      :                             :     +- * Project (84)
-      :                             :        +- * BroadcastHashJoin Inner BuildRight (83)
-      :                             :           :- * Filter (81)
-      :                             :           :  +- * ColumnarToRow (80)
-      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (79)
-      :                             :           +- ReusedExchange (82)
-      :                             +- * Sort (88)
-      :                                +- ReusedExchange (87)
-      +- * Sort (115)
-         +- Exchange (114)
-            +- * HashAggregate (113)
-               +- Exchange (112)
-                  +- * HashAggregate (111)
-                     +- * Project (110)
-                        +- * SortMergeJoin Inner (109)
-                           :- * Sort (106)
-                           :  +- Exchange (105)
-                           :     +- * Project (104)
-                           :        +- * BroadcastHashJoin Inner BuildRight (103)
-                           :           :- * Filter (101)
-                           :           :  +- * ColumnarToRow (100)
-                           :           :     +- Scan parquet spark_catalog.default.web_sales (99)
-                           :           +- ReusedExchange (102)
-                           +- * Sort (108)
-                              +- ReusedExchange (107)
+      :     :     :     :  :                       +- * Sort (10)
+      :     :     :     :  :                          +- ReusedExchange (9)
+      :     :     :     :  +- * Sort (35)
+      :     :     :     :     +- Exchange (34)
+      :     :     :     :        +- * HashAggregate (33)
+      :     :     :     :           +- Exchange (32)
+      :     :     :     :              +- * HashAggregate (31)
+      :     :     :     :                 +- * Project (30)
+      :     :     :     :                    +- * SortMergeJoin Inner (29)
+      :     :     :     :                       :- * Sort (26)
+      :     :     :     :                       :  +- Exchange (25)
+      :     :     :     :                       :     +- * Project (24)
+      :     :     :     :                       :        +- * BroadcastHashJoin Inner BuildRight (23)
+      :     :     :     :                       :           :- * Filter (21)
+      :     :     :     :                       :           :  +- * ColumnarToRow (20)
+      :     :     :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (19)
+      :     :     :     :                       :           +- ReusedExchange (22)
+      :     :     :     :                       +- * Sort (28)
+      :     :     :     :                          +- ReusedExchange (27)
+      :     :     :     +- * Sort (54)
+      :     :     :        +- Exchange (53)
+      :     :     :           +- * Filter (52)
+      :     :     :              +- * HashAggregate (51)
+      :     :     :                 +- Exchange (50)
+      :     :     :                    +- * HashAggregate (49)
+      :     :     :                       +- * Project (48)
+      :     :     :                          +- * SortMergeJoin Inner (47)
+      :     :     :                             :- * Sort (44)
+      :     :     :                             :  +- Exchange (43)
+      :     :     :                             :     +- * Project (42)
+      :     :     :                             :        +- * BroadcastHashJoin Inner BuildRight (41)
+      :     :     :                             :           :- * Filter (39)
+      :     :     :                             :           :  +- * ColumnarToRow (38)
+      :     :     :                             :           :     +- Scan parquet spark_catalog.default.catalog_sales (37)
+      :     :     :                             :           +- ReusedExchange (40)
+      :     :     :                             +- * Sort (46)
+      :     :     :                                +- ReusedExchange (45)
+      :     :     +- * Sort (73)
+      :     :        +- Exchange (72)
+      :     :           +- * HashAggregate (71)
+      :     :              +- Exchange (70)
+      :     :                 +- * HashAggregate (69)
+      :     :                    +- * Project (68)
+      :     :                       +- * SortMergeJoin Inner (67)
+      :     :                          :- * Sort (64)
+      :     :                          :  +- Exchange (63)
+      :     :                          :     +- * Project (62)
+      :     :                          :        +- * BroadcastHashJoin Inner BuildRight (61)
+      :     :                          :           :- * Filter (59)
+      :     :                          :           :  +- * ColumnarToRow (58)
+      :     :                          :           :     +- Scan parquet spark_catalog.default.catalog_sales (57)
+      :     :                          :           +- ReusedExchange (60)
+      :     :                          +- * Sort (66)
+      :     :                             +- ReusedExchange (65)
+      :     +- * Sort (93)
+      :        +- Exchange (92)
+      :           +- * Filter (91)
+      :              +- * HashAggregate (90)
+      :                 +- Exchange (89)
+      :                    +- * HashAggregate (88)
+      :                       +- * Project (87)
+      :                          +- * SortMergeJoin Inner (86)
+      :                             :- * Sort (83)
+      :                             :  +- Exchange (82)
+      :                             :     +- * Project (81)
+      :                             :        +- * BroadcastHashJoin Inner BuildRight (80)
+      :                             :           :- * Filter (78)
+      :                             :           :  +- * ColumnarToRow (77)
+      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (76)
+      :                             :           +- ReusedExchange (79)
+      :                             +- * Sort (85)
+      :                                +- ReusedExchange (84)
+      +- * Sort (112)
+         +- Exchange (111)
+            +- * HashAggregate (110)
+               +- Exchange (109)
+                  +- * HashAggregate (108)
+                     +- * Project (107)
+                        +- * SortMergeJoin Inner (106)
+                           :- * Sort (103)
+                           :  +- Exchange (102)
+                           :     +- * Project (101)
+                           :        +- * BroadcastHashJoin Inner BuildRight (100)
+                           :           :- * Filter (98)
+                           :           :  +- * ColumnarToRow (97)
+                           :           :     +- Scan parquet spark_catalog.default.web_sales (96)
+                           :           +- ReusedExchange (99)
+                           +- * Sort (105)
+                              +- ReusedExchange (104)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -132,572 +129,578 @@ Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ex
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, ss_sold_date_sk#6]
-Condition : isnotnull(ss_customer_sk#1)
+Condition : (isnotnull(ss_customer_sk#1) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 122]
-Output [2]: [d_date_sk#8, d_year#9]
+(4) ReusedExchange [Reuses operator id: 126]
+Output [2]: [d_date_sk#10, d_year#11]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#6]
-Right keys [1]: [d_date_sk#8]
+Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
-Output [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#9]
-Input [8]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, ss_sold_date_sk#6, d_date_sk#8, d_year#9]
+Output [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#11]
+Input [8]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, ss_sold_date_sk#6, d_date_sk#10, d_year#11]
 
 (7) Exchange
-Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#9]
+Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#11]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (8) Sort [codegen id : 3]
-Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#9]
+Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#11]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer
-Output [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+(9) ReusedExchange [Reuses operator id: 119]
+Output [8]: [c_customer_sk#12, c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19]
+
+(10) Sort [codegen id : 5]
+Input [8]: [c_customer_sk#12, c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19]
+Arguments: [c_customer_sk#12 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#12]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [12]: [c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#11]
+Input [14]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#11, c_customer_sk#12, c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19]
+
+(13) HashAggregate [codegen id : 6]
+Input [12]: [c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#11]
+Keys [8]: [c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19, d_year#11]
+Functions [1]: [partial_sum(((((ss_ext_list_price#5 - ss_ext_wholesale_cost#4) - ss_ext_discount_amt#2) + ss_ext_sales_price#3) / 2))]
+Aggregate Attributes [2]: [sum#20, isEmpty#21]
+Results [10]: [c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19, d_year#11, sum#22, isEmpty#23]
+
+(14) Exchange
+Input [10]: [c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19, d_year#11, sum#22, isEmpty#23]
+Arguments: hashpartitioning(c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19, d_year#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [10]: [c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19, d_year#11, sum#22, isEmpty#23]
+Keys [8]: [c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19, d_year#11]
+Functions [1]: [sum(((((ss_ext_list_price#5 - ss_ext_wholesale_cost#4) - ss_ext_discount_amt#2) + ss_ext_sales_price#3) / 2))]
+Aggregate Attributes [1]: [sum(((((ss_ext_list_price#5 - ss_ext_wholesale_cost#4) - ss_ext_discount_amt#2) + ss_ext_sales_price#3) / 2))#24]
+Results [2]: [c_customer_id#13 AS customer_id#25, sum(((((ss_ext_list_price#5 - ss_ext_wholesale_cost#4) - ss_ext_discount_amt#2) + ss_ext_sales_price#3) / 2))#24 AS year_total#26]
+
+(16) Filter [codegen id : 7]
+Input [2]: [customer_id#25, year_total#26]
+Condition : (isnotnull(year_total#26) AND (year_total#26 > 0.000000))
+
+(17) Exchange
+Input [2]: [customer_id#25, year_total#26]
+Arguments: hashpartitioning(customer_id#25, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(18) Sort [codegen id : 8]
+Input [2]: [customer_id#25, year_total#26]
+Arguments: [customer_id#25 ASC NULLS FIRST], false, 0
+
+(19) Scan parquet spark_catalog.default.store_sales
+Output [6]: [ss_customer_sk#27, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, ss_sold_date_sk#32]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#32), dynamicpruningexpression(ss_sold_date_sk#32 IN dynamicpruning#33)]
+PushedFilters: [IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_customer_sk:int,ss_ext_discount_amt:decimal(7,2),ss_ext_sales_price:decimal(7,2),ss_ext_wholesale_cost:decimal(7,2),ss_ext_list_price:decimal(7,2)>
+
+(20) ColumnarToRow [codegen id : 10]
+Input [6]: [ss_customer_sk#27, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, ss_sold_date_sk#32]
+
+(21) Filter [codegen id : 10]
+Input [6]: [ss_customer_sk#27, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, ss_sold_date_sk#32]
+Condition : (isnotnull(ss_customer_sk#27) AND might_contain(Subquery scalar-subquery#34, [id=#35], xxhash64(ss_customer_sk#27, 42), false))
+
+(22) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#36, d_year#37]
+
+(23) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#32]
+Right keys [1]: [d_date_sk#36]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 10]
+Output [6]: [ss_customer_sk#27, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, d_year#37]
+Input [8]: [ss_customer_sk#27, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, ss_sold_date_sk#32, d_date_sk#36, d_year#37]
+
+(25) Exchange
+Input [6]: [ss_customer_sk#27, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, d_year#37]
+Arguments: hashpartitioning(ss_customer_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) Sort [codegen id : 11]
+Input [6]: [ss_customer_sk#27, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, d_year#37]
+Arguments: [ss_customer_sk#27 ASC NULLS FIRST], false, 0
+
+(27) ReusedExchange [Reuses operator id: 119]
+Output [8]: [c_customer_sk#38, c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45]
+
+(28) Sort [codegen id : 13]
+Input [8]: [c_customer_sk#38, c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45]
+Arguments: [c_customer_sk#38 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 14]
+Left keys [1]: [ss_customer_sk#27]
+Right keys [1]: [c_customer_sk#38]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 14]
+Output [12]: [c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, d_year#37]
+Input [14]: [ss_customer_sk#27, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, d_year#37, c_customer_sk#38, c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45]
+
+(31) HashAggregate [codegen id : 14]
+Input [12]: [c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45, ss_ext_discount_amt#28, ss_ext_sales_price#29, ss_ext_wholesale_cost#30, ss_ext_list_price#31, d_year#37]
+Keys [8]: [c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45, d_year#37]
+Functions [1]: [partial_sum(((((ss_ext_list_price#31 - ss_ext_wholesale_cost#30) - ss_ext_discount_amt#28) + ss_ext_sales_price#29) / 2))]
+Aggregate Attributes [2]: [sum#46, isEmpty#47]
+Results [10]: [c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45, d_year#37, sum#48, isEmpty#49]
+
+(32) Exchange
+Input [10]: [c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45, d_year#37, sum#48, isEmpty#49]
+Arguments: hashpartitioning(c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45, d_year#37, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(33) HashAggregate [codegen id : 15]
+Input [10]: [c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45, d_year#37, sum#48, isEmpty#49]
+Keys [8]: [c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45, d_year#37]
+Functions [1]: [sum(((((ss_ext_list_price#31 - ss_ext_wholesale_cost#30) - ss_ext_discount_amt#28) + ss_ext_sales_price#29) / 2))]
+Aggregate Attributes [1]: [sum(((((ss_ext_list_price#31 - ss_ext_wholesale_cost#30) - ss_ext_discount_amt#28) + ss_ext_sales_price#29) / 2))#24]
+Results [8]: [c_customer_id#39 AS customer_id#50, c_first_name#40 AS customer_first_name#51, c_last_name#41 AS customer_last_name#52, c_preferred_cust_flag#42 AS customer_preferred_cust_flag#53, c_birth_country#43 AS customer_birth_country#54, c_login#44 AS customer_login#55, c_email_address#45 AS customer_email_address#56, sum(((((ss_ext_list_price#31 - ss_ext_wholesale_cost#30) - ss_ext_discount_amt#28) + ss_ext_sales_price#29) / 2))#24 AS year_total#57]
+
+(34) Exchange
+Input [8]: [customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#57]
+Arguments: hashpartitioning(customer_id#50, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(35) Sort [codegen id : 16]
+Input [8]: [customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#57]
+Arguments: [customer_id#50 ASC NULLS FIRST], false, 0
+
+(36) SortMergeJoin [codegen id : 17]
+Left keys [1]: [customer_id#25]
+Right keys [1]: [customer_id#50]
+Join type: Inner
+Join condition: None
+
+(37) Scan parquet spark_catalog.default.catalog_sales
+Output [6]: [cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, cs_sold_date_sk#63]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#63), dynamicpruningexpression(cs_sold_date_sk#63 IN dynamicpruning#7)]
+PushedFilters: [IsNotNull(cs_bill_customer_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int,cs_ext_discount_amt:decimal(7,2),cs_ext_sales_price:decimal(7,2),cs_ext_wholesale_cost:decimal(7,2),cs_ext_list_price:decimal(7,2)>
+
+(38) ColumnarToRow [codegen id : 19]
+Input [6]: [cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, cs_sold_date_sk#63]
+
+(39) Filter [codegen id : 19]
+Input [6]: [cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, cs_sold_date_sk#63]
+Condition : (isnotnull(cs_bill_customer_sk#58) AND might_contain(ReusedSubquery Subquery scalar-subquery#34, [id=#35], xxhash64(cs_bill_customer_sk#58, 42), false))
+
+(40) ReusedExchange [Reuses operator id: 126]
+Output [2]: [d_date_sk#64, d_year#65]
+
+(41) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_sold_date_sk#63]
+Right keys [1]: [d_date_sk#64]
+Join type: Inner
+Join condition: None
+
+(42) Project [codegen id : 19]
+Output [6]: [cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_year#65]
+Input [8]: [cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, cs_sold_date_sk#63, d_date_sk#64, d_year#65]
+
+(43) Exchange
+Input [6]: [cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_year#65]
+Arguments: hashpartitioning(cs_bill_customer_sk#58, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(44) Sort [codegen id : 20]
+Input [6]: [cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_year#65]
+Arguments: [cs_bill_customer_sk#58 ASC NULLS FIRST], false, 0
+
+(45) ReusedExchange [Reuses operator id: 119]
+Output [8]: [c_customer_sk#66, c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73]
+
+(46) Sort [codegen id : 22]
+Input [8]: [c_customer_sk#66, c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73]
+Arguments: [c_customer_sk#66 ASC NULLS FIRST], false, 0
+
+(47) SortMergeJoin [codegen id : 23]
+Left keys [1]: [cs_bill_customer_sk#58]
+Right keys [1]: [c_customer_sk#66]
+Join type: Inner
+Join condition: None
+
+(48) Project [codegen id : 23]
+Output [12]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_year#65]
+Input [14]: [cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_year#65, c_customer_sk#66, c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73]
+
+(49) HashAggregate [codegen id : 23]
+Input [12]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_year#65]
+Keys [8]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65]
+Functions [1]: [partial_sum(((((cs_ext_list_price#62 - cs_ext_wholesale_cost#61) - cs_ext_discount_amt#59) + cs_ext_sales_price#60) / 2))]
+Aggregate Attributes [2]: [sum#74, isEmpty#75]
+Results [10]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65, sum#76, isEmpty#77]
+
+(50) Exchange
+Input [10]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65, sum#76, isEmpty#77]
+Arguments: hashpartitioning(c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(51) HashAggregate [codegen id : 24]
+Input [10]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65, sum#76, isEmpty#77]
+Keys [8]: [c_customer_id#67, c_first_name#68, c_last_name#69, c_preferred_cust_flag#70, c_birth_country#71, c_login#72, c_email_address#73, d_year#65]
+Functions [1]: [sum(((((cs_ext_list_price#62 - cs_ext_wholesale_cost#61) - cs_ext_discount_amt#59) + cs_ext_sales_price#60) / 2))]
+Aggregate Attributes [1]: [sum(((((cs_ext_list_price#62 - cs_ext_wholesale_cost#61) - cs_ext_discount_amt#59) + cs_ext_sales_price#60) / 2))#78]
+Results [2]: [c_customer_id#67 AS customer_id#79, sum(((((cs_ext_list_price#62 - cs_ext_wholesale_cost#61) - cs_ext_discount_amt#59) + cs_ext_sales_price#60) / 2))#78 AS year_total#80]
+
+(52) Filter [codegen id : 24]
+Input [2]: [customer_id#79, year_total#80]
+Condition : (isnotnull(year_total#80) AND (year_total#80 > 0.000000))
+
+(53) Exchange
+Input [2]: [customer_id#79, year_total#80]
+Arguments: hashpartitioning(customer_id#79, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) Sort [codegen id : 25]
+Input [2]: [customer_id#79, year_total#80]
+Arguments: [customer_id#79 ASC NULLS FIRST], false, 0
+
+(55) SortMergeJoin [codegen id : 26]
+Left keys [1]: [customer_id#25]
+Right keys [1]: [customer_id#79]
+Join type: Inner
+Join condition: None
+
+(56) Project [codegen id : 26]
+Output [11]: [customer_id#25, year_total#26, customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#57, year_total#80]
+Input [12]: [customer_id#25, year_total#26, customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#57, customer_id#79, year_total#80]
+
+(57) Scan parquet spark_catalog.default.catalog_sales
+Output [6]: [cs_bill_customer_sk#81, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, cs_sold_date_sk#86]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#86), dynamicpruningexpression(cs_sold_date_sk#86 IN dynamicpruning#33)]
+PushedFilters: [IsNotNull(cs_bill_customer_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int,cs_ext_discount_amt:decimal(7,2),cs_ext_sales_price:decimal(7,2),cs_ext_wholesale_cost:decimal(7,2),cs_ext_list_price:decimal(7,2)>
+
+(58) ColumnarToRow [codegen id : 28]
+Input [6]: [cs_bill_customer_sk#81, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, cs_sold_date_sk#86]
+
+(59) Filter [codegen id : 28]
+Input [6]: [cs_bill_customer_sk#81, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, cs_sold_date_sk#86]
+Condition : (isnotnull(cs_bill_customer_sk#81) AND might_contain(ReusedSubquery Subquery scalar-subquery#34, [id=#35], xxhash64(cs_bill_customer_sk#81, 42), false))
+
+(60) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#87, d_year#88]
+
+(61) BroadcastHashJoin [codegen id : 28]
+Left keys [1]: [cs_sold_date_sk#86]
+Right keys [1]: [d_date_sk#87]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 28]
+Output [6]: [cs_bill_customer_sk#81, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, d_year#88]
+Input [8]: [cs_bill_customer_sk#81, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, cs_sold_date_sk#86, d_date_sk#87, d_year#88]
+
+(63) Exchange
+Input [6]: [cs_bill_customer_sk#81, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, d_year#88]
+Arguments: hashpartitioning(cs_bill_customer_sk#81, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(64) Sort [codegen id : 29]
+Input [6]: [cs_bill_customer_sk#81, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, d_year#88]
+Arguments: [cs_bill_customer_sk#81 ASC NULLS FIRST], false, 0
+
+(65) ReusedExchange [Reuses operator id: 119]
+Output [8]: [c_customer_sk#89, c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96]
+
+(66) Sort [codegen id : 31]
+Input [8]: [c_customer_sk#89, c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96]
+Arguments: [c_customer_sk#89 ASC NULLS FIRST], false, 0
+
+(67) SortMergeJoin [codegen id : 32]
+Left keys [1]: [cs_bill_customer_sk#81]
+Right keys [1]: [c_customer_sk#89]
+Join type: Inner
+Join condition: None
+
+(68) Project [codegen id : 32]
+Output [12]: [c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, d_year#88]
+Input [14]: [cs_bill_customer_sk#81, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, d_year#88, c_customer_sk#89, c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96]
+
+(69) HashAggregate [codegen id : 32]
+Input [12]: [c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96, cs_ext_discount_amt#82, cs_ext_sales_price#83, cs_ext_wholesale_cost#84, cs_ext_list_price#85, d_year#88]
+Keys [8]: [c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96, d_year#88]
+Functions [1]: [partial_sum(((((cs_ext_list_price#85 - cs_ext_wholesale_cost#84) - cs_ext_discount_amt#82) + cs_ext_sales_price#83) / 2))]
+Aggregate Attributes [2]: [sum#97, isEmpty#98]
+Results [10]: [c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96, d_year#88, sum#99, isEmpty#100]
+
+(70) Exchange
+Input [10]: [c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96, d_year#88, sum#99, isEmpty#100]
+Arguments: hashpartitioning(c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96, d_year#88, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(71) HashAggregate [codegen id : 33]
+Input [10]: [c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96, d_year#88, sum#99, isEmpty#100]
+Keys [8]: [c_customer_id#90, c_first_name#91, c_last_name#92, c_preferred_cust_flag#93, c_birth_country#94, c_login#95, c_email_address#96, d_year#88]
+Functions [1]: [sum(((((cs_ext_list_price#85 - cs_ext_wholesale_cost#84) - cs_ext_discount_amt#82) + cs_ext_sales_price#83) / 2))]
+Aggregate Attributes [1]: [sum(((((cs_ext_list_price#85 - cs_ext_wholesale_cost#84) - cs_ext_discount_amt#82) + cs_ext_sales_price#83) / 2))#78]
+Results [2]: [c_customer_id#90 AS customer_id#101, sum(((((cs_ext_list_price#85 - cs_ext_wholesale_cost#84) - cs_ext_discount_amt#82) + cs_ext_sales_price#83) / 2))#78 AS year_total#102]
+
+(72) Exchange
+Input [2]: [customer_id#101, year_total#102]
+Arguments: hashpartitioning(customer_id#101, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(73) Sort [codegen id : 34]
+Input [2]: [customer_id#101, year_total#102]
+Arguments: [customer_id#101 ASC NULLS FIRST], false, 0
+
+(74) SortMergeJoin [codegen id : 35]
+Left keys [1]: [customer_id#25]
+Right keys [1]: [customer_id#101]
+Join type: Inner
+Join condition: (CASE WHEN (year_total#80 > 0.000000) THEN (year_total#102 / year_total#80) END > CASE WHEN (year_total#26 > 0.000000) THEN (year_total#57 / year_total#26) END)
+
+(75) Project [codegen id : 35]
+Output [10]: [customer_id#25, customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#80, year_total#102]
+Input [13]: [customer_id#25, year_total#26, customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#57, year_total#80, customer_id#101, year_total#102]
+
+(76) Scan parquet spark_catalog.default.web_sales
+Output [6]: [ws_bill_customer_sk#103, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, ws_sold_date_sk#108]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#108), dynamicpruningexpression(ws_sold_date_sk#108 IN dynamicpruning#7)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_sales_price:decimal(7,2),ws_ext_wholesale_cost:decimal(7,2),ws_ext_list_price:decimal(7,2)>
+
+(77) ColumnarToRow [codegen id : 37]
+Input [6]: [ws_bill_customer_sk#103, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, ws_sold_date_sk#108]
+
+(78) Filter [codegen id : 37]
+Input [6]: [ws_bill_customer_sk#103, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, ws_sold_date_sk#108]
+Condition : (isnotnull(ws_bill_customer_sk#103) AND might_contain(ReusedSubquery Subquery scalar-subquery#34, [id=#35], xxhash64(ws_bill_customer_sk#103, 42), false))
+
+(79) ReusedExchange [Reuses operator id: 126]
+Output [2]: [d_date_sk#109, d_year#110]
+
+(80) BroadcastHashJoin [codegen id : 37]
+Left keys [1]: [ws_sold_date_sk#108]
+Right keys [1]: [d_date_sk#109]
+Join type: Inner
+Join condition: None
+
+(81) Project [codegen id : 37]
+Output [6]: [ws_bill_customer_sk#103, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, d_year#110]
+Input [8]: [ws_bill_customer_sk#103, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, ws_sold_date_sk#108, d_date_sk#109, d_year#110]
+
+(82) Exchange
+Input [6]: [ws_bill_customer_sk#103, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, d_year#110]
+Arguments: hashpartitioning(ws_bill_customer_sk#103, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(83) Sort [codegen id : 38]
+Input [6]: [ws_bill_customer_sk#103, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, d_year#110]
+Arguments: [ws_bill_customer_sk#103 ASC NULLS FIRST], false, 0
+
+(84) ReusedExchange [Reuses operator id: 119]
+Output [8]: [c_customer_sk#111, c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118]
+
+(85) Sort [codegen id : 40]
+Input [8]: [c_customer_sk#111, c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118]
+Arguments: [c_customer_sk#111 ASC NULLS FIRST], false, 0
+
+(86) SortMergeJoin [codegen id : 41]
+Left keys [1]: [ws_bill_customer_sk#103]
+Right keys [1]: [c_customer_sk#111]
+Join type: Inner
+Join condition: None
+
+(87) Project [codegen id : 41]
+Output [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, d_year#110]
+Input [14]: [ws_bill_customer_sk#103, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, d_year#110, c_customer_sk#111, c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118]
+
+(88) HashAggregate [codegen id : 41]
+Input [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_ext_discount_amt#104, ws_ext_sales_price#105, ws_ext_wholesale_cost#106, ws_ext_list_price#107, d_year#110]
+Keys [8]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#110]
+Functions [1]: [partial_sum(((((ws_ext_list_price#107 - ws_ext_wholesale_cost#106) - ws_ext_discount_amt#104) + ws_ext_sales_price#105) / 2))]
+Aggregate Attributes [2]: [sum#119, isEmpty#120]
+Results [10]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#110, sum#121, isEmpty#122]
+
+(89) Exchange
+Input [10]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#110, sum#121, isEmpty#122]
+Arguments: hashpartitioning(c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#110, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(90) HashAggregate [codegen id : 42]
+Input [10]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#110, sum#121, isEmpty#122]
+Keys [8]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#110]
+Functions [1]: [sum(((((ws_ext_list_price#107 - ws_ext_wholesale_cost#106) - ws_ext_discount_amt#104) + ws_ext_sales_price#105) / 2))]
+Aggregate Attributes [1]: [sum(((((ws_ext_list_price#107 - ws_ext_wholesale_cost#106) - ws_ext_discount_amt#104) + ws_ext_sales_price#105) / 2))#123]
+Results [2]: [c_customer_id#112 AS customer_id#124, sum(((((ws_ext_list_price#107 - ws_ext_wholesale_cost#106) - ws_ext_discount_amt#104) + ws_ext_sales_price#105) / 2))#123 AS year_total#125]
+
+(91) Filter [codegen id : 42]
+Input [2]: [customer_id#124, year_total#125]
+Condition : (isnotnull(year_total#125) AND (year_total#125 > 0.000000))
+
+(92) Exchange
+Input [2]: [customer_id#124, year_total#125]
+Arguments: hashpartitioning(customer_id#124, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(93) Sort [codegen id : 43]
+Input [2]: [customer_id#124, year_total#125]
+Arguments: [customer_id#124 ASC NULLS FIRST], false, 0
+
+(94) SortMergeJoin [codegen id : 44]
+Left keys [1]: [customer_id#25]
+Right keys [1]: [customer_id#124]
+Join type: Inner
+Join condition: None
+
+(95) Project [codegen id : 44]
+Output [11]: [customer_id#25, customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#80, year_total#102, year_total#125]
+Input [12]: [customer_id#25, customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#80, year_total#102, customer_id#124, year_total#125]
+
+(96) Scan parquet spark_catalog.default.web_sales
+Output [6]: [ws_bill_customer_sk#126, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, ws_sold_date_sk#131]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#131), dynamicpruningexpression(ws_sold_date_sk#131 IN dynamicpruning#33)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_sales_price:decimal(7,2),ws_ext_wholesale_cost:decimal(7,2),ws_ext_list_price:decimal(7,2)>
+
+(97) ColumnarToRow [codegen id : 46]
+Input [6]: [ws_bill_customer_sk#126, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, ws_sold_date_sk#131]
+
+(98) Filter [codegen id : 46]
+Input [6]: [ws_bill_customer_sk#126, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, ws_sold_date_sk#131]
+Condition : (isnotnull(ws_bill_customer_sk#126) AND might_contain(ReusedSubquery Subquery scalar-subquery#34, [id=#35], xxhash64(ws_bill_customer_sk#126, 42), false))
+
+(99) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#132, d_year#133]
+
+(100) BroadcastHashJoin [codegen id : 46]
+Left keys [1]: [ws_sold_date_sk#131]
+Right keys [1]: [d_date_sk#132]
+Join type: Inner
+Join condition: None
+
+(101) Project [codegen id : 46]
+Output [6]: [ws_bill_customer_sk#126, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, d_year#133]
+Input [8]: [ws_bill_customer_sk#126, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, ws_sold_date_sk#131, d_date_sk#132, d_year#133]
+
+(102) Exchange
+Input [6]: [ws_bill_customer_sk#126, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, d_year#133]
+Arguments: hashpartitioning(ws_bill_customer_sk#126, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(103) Sort [codegen id : 47]
+Input [6]: [ws_bill_customer_sk#126, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, d_year#133]
+Arguments: [ws_bill_customer_sk#126 ASC NULLS FIRST], false, 0
+
+(104) ReusedExchange [Reuses operator id: 119]
+Output [8]: [c_customer_sk#134, c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141]
+
+(105) Sort [codegen id : 49]
+Input [8]: [c_customer_sk#134, c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141]
+Arguments: [c_customer_sk#134 ASC NULLS FIRST], false, 0
+
+(106) SortMergeJoin [codegen id : 50]
+Left keys [1]: [ws_bill_customer_sk#126]
+Right keys [1]: [c_customer_sk#134]
+Join type: Inner
+Join condition: None
+
+(107) Project [codegen id : 50]
+Output [12]: [c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, d_year#133]
+Input [14]: [ws_bill_customer_sk#126, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, d_year#133, c_customer_sk#134, c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141]
+
+(108) HashAggregate [codegen id : 50]
+Input [12]: [c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141, ws_ext_discount_amt#127, ws_ext_sales_price#128, ws_ext_wholesale_cost#129, ws_ext_list_price#130, d_year#133]
+Keys [8]: [c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141, d_year#133]
+Functions [1]: [partial_sum(((((ws_ext_list_price#130 - ws_ext_wholesale_cost#129) - ws_ext_discount_amt#127) + ws_ext_sales_price#128) / 2))]
+Aggregate Attributes [2]: [sum#142, isEmpty#143]
+Results [10]: [c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141, d_year#133, sum#144, isEmpty#145]
+
+(109) Exchange
+Input [10]: [c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141, d_year#133, sum#144, isEmpty#145]
+Arguments: hashpartitioning(c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141, d_year#133, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+
+(110) HashAggregate [codegen id : 51]
+Input [10]: [c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141, d_year#133, sum#144, isEmpty#145]
+Keys [8]: [c_customer_id#135, c_first_name#136, c_last_name#137, c_preferred_cust_flag#138, c_birth_country#139, c_login#140, c_email_address#141, d_year#133]
+Functions [1]: [sum(((((ws_ext_list_price#130 - ws_ext_wholesale_cost#129) - ws_ext_discount_amt#127) + ws_ext_sales_price#128) / 2))]
+Aggregate Attributes [1]: [sum(((((ws_ext_list_price#130 - ws_ext_wholesale_cost#129) - ws_ext_discount_amt#127) + ws_ext_sales_price#128) / 2))#123]
+Results [2]: [c_customer_id#135 AS customer_id#146, sum(((((ws_ext_list_price#130 - ws_ext_wholesale_cost#129) - ws_ext_discount_amt#127) + ws_ext_sales_price#128) / 2))#123 AS year_total#147]
+
+(111) Exchange
+Input [2]: [customer_id#146, year_total#147]
+Arguments: hashpartitioning(customer_id#146, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(112) Sort [codegen id : 52]
+Input [2]: [customer_id#146, year_total#147]
+Arguments: [customer_id#146 ASC NULLS FIRST], false, 0
+
+(113) SortMergeJoin [codegen id : 53]
+Left keys [1]: [customer_id#25]
+Right keys [1]: [customer_id#146]
+Join type: Inner
+Join condition: (CASE WHEN (year_total#80 > 0.000000) THEN (year_total#102 / year_total#80) END > CASE WHEN (year_total#125 > 0.000000) THEN (year_total#147 / year_total#125) END)
+
+(114) Project [codegen id : 53]
+Output [7]: [customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56]
+Input [13]: [customer_id#25, customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56, year_total#80, year_total#102, year_total#125, customer_id#146, year_total#147]
+
+(115) TakeOrderedAndProject
+Input [7]: [customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56]
+Arguments: 100, [customer_id#50 ASC NULLS FIRST, customer_first_name#51 ASC NULLS FIRST, customer_last_name#52 ASC NULLS FIRST, customer_preferred_cust_flag#53 ASC NULLS FIRST, customer_birth_country#54 ASC NULLS FIRST, customer_login#55 ASC NULLS FIRST, customer_email_address#56 ASC NULLS FIRST], [customer_id#50, customer_first_name#51, customer_last_name#52, customer_preferred_cust_flag#53, customer_birth_country#54, customer_login#55, customer_email_address#56]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (122)
++- Exchange (121)
+   +- ObjectHashAggregate (120)
+      +- Exchange (119)
+         +- * Filter (118)
+            +- * ColumnarToRow (117)
+               +- Scan parquet spark_catalog.default.customer (116)
+
+
+(116) Scan parquet spark_catalog.default.customer
+Output [8]: [c_customer_sk#12, c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(10) ColumnarToRow [codegen id : 4]
-Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
-
-(11) Filter [codegen id : 4]
-Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
-Condition : (isnotnull(c_customer_sk#10) AND isnotnull(c_customer_id#11))
-
-(12) Exchange
-Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
-Arguments: hashpartitioning(c_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(13) Sort [codegen id : 5]
-Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
-Arguments: [c_customer_sk#10 ASC NULLS FIRST], false, 0
-
-(14) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#10]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [12]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#9]
-Input [14]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#9, c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
-
-(16) HashAggregate [codegen id : 6]
-Input [12]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, ss_ext_discount_amt#2, ss_ext_sales_price#3, ss_ext_wholesale_cost#4, ss_ext_list_price#5, d_year#9]
-Keys [8]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, d_year#9]
-Functions [1]: [partial_sum(((((ss_ext_list_price#5 - ss_ext_wholesale_cost#4) - ss_ext_discount_amt#2) + ss_ext_sales_price#3) / 2))]
-Aggregate Attributes [2]: [sum#18, isEmpty#19]
-Results [10]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, d_year#9, sum#20, isEmpty#21]
-
-(17) Exchange
-Input [10]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, d_year#9, sum#20, isEmpty#21]
-Arguments: hashpartitioning(c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, d_year#9, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [10]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, d_year#9, sum#20, isEmpty#21]
-Keys [8]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, d_year#9]
-Functions [1]: [sum(((((ss_ext_list_price#5 - ss_ext_wholesale_cost#4) - ss_ext_discount_amt#2) + ss_ext_sales_price#3) / 2))]
-Aggregate Attributes [1]: [sum(((((ss_ext_list_price#5 - ss_ext_wholesale_cost#4) - ss_ext_discount_amt#2) + ss_ext_sales_price#3) / 2))#22]
-Results [2]: [c_customer_id#11 AS customer_id#23, sum(((((ss_ext_list_price#5 - ss_ext_wholesale_cost#4) - ss_ext_discount_amt#2) + ss_ext_sales_price#3) / 2))#22 AS year_total#24]
-
-(19) Filter [codegen id : 7]
-Input [2]: [customer_id#23, year_total#24]
-Condition : (isnotnull(year_total#24) AND (year_total#24 > 0.000000))
-
-(20) Exchange
-Input [2]: [customer_id#23, year_total#24]
-Arguments: hashpartitioning(customer_id#23, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(21) Sort [codegen id : 8]
-Input [2]: [customer_id#23, year_total#24]
-Arguments: [customer_id#23 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_customer_sk#25, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, ss_sold_date_sk#30]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#30), dynamicpruningexpression(ss_sold_date_sk#30 IN dynamicpruning#31)]
-PushedFilters: [IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_customer_sk:int,ss_ext_discount_amt:decimal(7,2),ss_ext_sales_price:decimal(7,2),ss_ext_wholesale_cost:decimal(7,2),ss_ext_list_price:decimal(7,2)>
-
-(23) ColumnarToRow [codegen id : 10]
-Input [6]: [ss_customer_sk#25, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, ss_sold_date_sk#30]
-
-(24) Filter [codegen id : 10]
-Input [6]: [ss_customer_sk#25, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, ss_sold_date_sk#30]
-Condition : isnotnull(ss_customer_sk#25)
-
-(25) ReusedExchange [Reuses operator id: 126]
-Output [2]: [d_date_sk#32, d_year#33]
-
-(26) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#30]
-Right keys [1]: [d_date_sk#32]
-Join type: Inner
-Join condition: None
-
-(27) Project [codegen id : 10]
-Output [6]: [ss_customer_sk#25, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, d_year#33]
-Input [8]: [ss_customer_sk#25, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, ss_sold_date_sk#30, d_date_sk#32, d_year#33]
-
-(28) Exchange
-Input [6]: [ss_customer_sk#25, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, d_year#33]
-Arguments: hashpartitioning(ss_customer_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(29) Sort [codegen id : 11]
-Input [6]: [ss_customer_sk#25, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, d_year#33]
-Arguments: [ss_customer_sk#25 ASC NULLS FIRST], false, 0
-
-(30) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#34, c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41]
-
-(31) Sort [codegen id : 13]
-Input [8]: [c_customer_sk#34, c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41]
-Arguments: [c_customer_sk#34 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 14]
-Left keys [1]: [ss_customer_sk#25]
-Right keys [1]: [c_customer_sk#34]
-Join type: Inner
-Join condition: None
-
-(33) Project [codegen id : 14]
-Output [12]: [c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, d_year#33]
-Input [14]: [ss_customer_sk#25, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, d_year#33, c_customer_sk#34, c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41]
-
-(34) HashAggregate [codegen id : 14]
-Input [12]: [c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41, ss_ext_discount_amt#26, ss_ext_sales_price#27, ss_ext_wholesale_cost#28, ss_ext_list_price#29, d_year#33]
-Keys [8]: [c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41, d_year#33]
-Functions [1]: [partial_sum(((((ss_ext_list_price#29 - ss_ext_wholesale_cost#28) - ss_ext_discount_amt#26) + ss_ext_sales_price#27) / 2))]
-Aggregate Attributes [2]: [sum#42, isEmpty#43]
-Results [10]: [c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41, d_year#33, sum#44, isEmpty#45]
-
-(35) Exchange
-Input [10]: [c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41, d_year#33, sum#44, isEmpty#45]
-Arguments: hashpartitioning(c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41, d_year#33, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(36) HashAggregate [codegen id : 15]
-Input [10]: [c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41, d_year#33, sum#44, isEmpty#45]
-Keys [8]: [c_customer_id#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_country#39, c_login#40, c_email_address#41, d_year#33]
-Functions [1]: [sum(((((ss_ext_list_price#29 - ss_ext_wholesale_cost#28) - ss_ext_discount_amt#26) + ss_ext_sales_price#27) / 2))]
-Aggregate Attributes [1]: [sum(((((ss_ext_list_price#29 - ss_ext_wholesale_cost#28) - ss_ext_discount_amt#26) + ss_ext_sales_price#27) / 2))#22]
-Results [8]: [c_customer_id#35 AS customer_id#46, c_first_name#36 AS customer_first_name#47, c_last_name#37 AS customer_last_name#48, c_preferred_cust_flag#38 AS customer_preferred_cust_flag#49, c_birth_country#39 AS customer_birth_country#50, c_login#40 AS customer_login#51, c_email_address#41 AS customer_email_address#52, sum(((((ss_ext_list_price#29 - ss_ext_wholesale_cost#28) - ss_ext_discount_amt#26) + ss_ext_sales_price#27) / 2))#22 AS year_total#53]
-
-(37) Exchange
-Input [8]: [customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#53]
-Arguments: hashpartitioning(customer_id#46, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(38) Sort [codegen id : 16]
-Input [8]: [customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#53]
-Arguments: [customer_id#46 ASC NULLS FIRST], false, 0
-
-(39) SortMergeJoin [codegen id : 17]
-Left keys [1]: [customer_id#23]
-Right keys [1]: [customer_id#46]
-Join type: Inner
-Join condition: None
-
-(40) Scan parquet spark_catalog.default.catalog_sales
-Output [6]: [cs_bill_customer_sk#54, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, cs_sold_date_sk#59]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#59), dynamicpruningexpression(cs_sold_date_sk#59 IN dynamicpruning#7)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk)]
-ReadSchema: struct<cs_bill_customer_sk:int,cs_ext_discount_amt:decimal(7,2),cs_ext_sales_price:decimal(7,2),cs_ext_wholesale_cost:decimal(7,2),cs_ext_list_price:decimal(7,2)>
-
-(41) ColumnarToRow [codegen id : 19]
-Input [6]: [cs_bill_customer_sk#54, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, cs_sold_date_sk#59]
-
-(42) Filter [codegen id : 19]
-Input [6]: [cs_bill_customer_sk#54, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, cs_sold_date_sk#59]
-Condition : isnotnull(cs_bill_customer_sk#54)
-
-(43) ReusedExchange [Reuses operator id: 122]
-Output [2]: [d_date_sk#60, d_year#61]
-
-(44) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_sold_date_sk#59]
-Right keys [1]: [d_date_sk#60]
-Join type: Inner
-Join condition: None
-
-(45) Project [codegen id : 19]
-Output [6]: [cs_bill_customer_sk#54, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, d_year#61]
-Input [8]: [cs_bill_customer_sk#54, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, cs_sold_date_sk#59, d_date_sk#60, d_year#61]
-
-(46) Exchange
-Input [6]: [cs_bill_customer_sk#54, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, d_year#61]
-Arguments: hashpartitioning(cs_bill_customer_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(47) Sort [codegen id : 20]
-Input [6]: [cs_bill_customer_sk#54, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, d_year#61]
-Arguments: [cs_bill_customer_sk#54 ASC NULLS FIRST], false, 0
-
-(48) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#62, c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69]
-
-(49) Sort [codegen id : 22]
-Input [8]: [c_customer_sk#62, c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69]
-Arguments: [c_customer_sk#62 ASC NULLS FIRST], false, 0
-
-(50) SortMergeJoin [codegen id : 23]
-Left keys [1]: [cs_bill_customer_sk#54]
-Right keys [1]: [c_customer_sk#62]
-Join type: Inner
-Join condition: None
-
-(51) Project [codegen id : 23]
-Output [12]: [c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, d_year#61]
-Input [14]: [cs_bill_customer_sk#54, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, d_year#61, c_customer_sk#62, c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69]
-
-(52) HashAggregate [codegen id : 23]
-Input [12]: [c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69, cs_ext_discount_amt#55, cs_ext_sales_price#56, cs_ext_wholesale_cost#57, cs_ext_list_price#58, d_year#61]
-Keys [8]: [c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69, d_year#61]
-Functions [1]: [partial_sum(((((cs_ext_list_price#58 - cs_ext_wholesale_cost#57) - cs_ext_discount_amt#55) + cs_ext_sales_price#56) / 2))]
-Aggregate Attributes [2]: [sum#70, isEmpty#71]
-Results [10]: [c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69, d_year#61, sum#72, isEmpty#73]
-
-(53) Exchange
-Input [10]: [c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69, d_year#61, sum#72, isEmpty#73]
-Arguments: hashpartitioning(c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69, d_year#61, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(54) HashAggregate [codegen id : 24]
-Input [10]: [c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69, d_year#61, sum#72, isEmpty#73]
-Keys [8]: [c_customer_id#63, c_first_name#64, c_last_name#65, c_preferred_cust_flag#66, c_birth_country#67, c_login#68, c_email_address#69, d_year#61]
-Functions [1]: [sum(((((cs_ext_list_price#58 - cs_ext_wholesale_cost#57) - cs_ext_discount_amt#55) + cs_ext_sales_price#56) / 2))]
-Aggregate Attributes [1]: [sum(((((cs_ext_list_price#58 - cs_ext_wholesale_cost#57) - cs_ext_discount_amt#55) + cs_ext_sales_price#56) / 2))#74]
-Results [2]: [c_customer_id#63 AS customer_id#75, sum(((((cs_ext_list_price#58 - cs_ext_wholesale_cost#57) - cs_ext_discount_amt#55) + cs_ext_sales_price#56) / 2))#74 AS year_total#76]
-
-(55) Filter [codegen id : 24]
-Input [2]: [customer_id#75, year_total#76]
-Condition : (isnotnull(year_total#76) AND (year_total#76 > 0.000000))
-
-(56) Exchange
-Input [2]: [customer_id#75, year_total#76]
-Arguments: hashpartitioning(customer_id#75, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(57) Sort [codegen id : 25]
-Input [2]: [customer_id#75, year_total#76]
-Arguments: [customer_id#75 ASC NULLS FIRST], false, 0
-
-(58) SortMergeJoin [codegen id : 26]
-Left keys [1]: [customer_id#23]
-Right keys [1]: [customer_id#75]
-Join type: Inner
-Join condition: None
-
-(59) Project [codegen id : 26]
-Output [11]: [customer_id#23, year_total#24, customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#53, year_total#76]
-Input [12]: [customer_id#23, year_total#24, customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#53, customer_id#75, year_total#76]
-
-(60) Scan parquet spark_catalog.default.catalog_sales
-Output [6]: [cs_bill_customer_sk#77, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, cs_sold_date_sk#82]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#82), dynamicpruningexpression(cs_sold_date_sk#82 IN dynamicpruning#31)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk)]
-ReadSchema: struct<cs_bill_customer_sk:int,cs_ext_discount_amt:decimal(7,2),cs_ext_sales_price:decimal(7,2),cs_ext_wholesale_cost:decimal(7,2),cs_ext_list_price:decimal(7,2)>
-
-(61) ColumnarToRow [codegen id : 28]
-Input [6]: [cs_bill_customer_sk#77, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, cs_sold_date_sk#82]
-
-(62) Filter [codegen id : 28]
-Input [6]: [cs_bill_customer_sk#77, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, cs_sold_date_sk#82]
-Condition : isnotnull(cs_bill_customer_sk#77)
-
-(63) ReusedExchange [Reuses operator id: 126]
-Output [2]: [d_date_sk#83, d_year#84]
-
-(64) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_sold_date_sk#82]
-Right keys [1]: [d_date_sk#83]
-Join type: Inner
-Join condition: None
-
-(65) Project [codegen id : 28]
-Output [6]: [cs_bill_customer_sk#77, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, d_year#84]
-Input [8]: [cs_bill_customer_sk#77, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, cs_sold_date_sk#82, d_date_sk#83, d_year#84]
-
-(66) Exchange
-Input [6]: [cs_bill_customer_sk#77, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, d_year#84]
-Arguments: hashpartitioning(cs_bill_customer_sk#77, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(67) Sort [codegen id : 29]
-Input [6]: [cs_bill_customer_sk#77, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, d_year#84]
-Arguments: [cs_bill_customer_sk#77 ASC NULLS FIRST], false, 0
-
-(68) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#85, c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92]
-
-(69) Sort [codegen id : 31]
-Input [8]: [c_customer_sk#85, c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92]
-Arguments: [c_customer_sk#85 ASC NULLS FIRST], false, 0
-
-(70) SortMergeJoin [codegen id : 32]
-Left keys [1]: [cs_bill_customer_sk#77]
-Right keys [1]: [c_customer_sk#85]
-Join type: Inner
-Join condition: None
-
-(71) Project [codegen id : 32]
-Output [12]: [c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, d_year#84]
-Input [14]: [cs_bill_customer_sk#77, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, d_year#84, c_customer_sk#85, c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92]
-
-(72) HashAggregate [codegen id : 32]
-Input [12]: [c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92, cs_ext_discount_amt#78, cs_ext_sales_price#79, cs_ext_wholesale_cost#80, cs_ext_list_price#81, d_year#84]
-Keys [8]: [c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92, d_year#84]
-Functions [1]: [partial_sum(((((cs_ext_list_price#81 - cs_ext_wholesale_cost#80) - cs_ext_discount_amt#78) + cs_ext_sales_price#79) / 2))]
-Aggregate Attributes [2]: [sum#93, isEmpty#94]
-Results [10]: [c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92, d_year#84, sum#95, isEmpty#96]
-
-(73) Exchange
-Input [10]: [c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92, d_year#84, sum#95, isEmpty#96]
-Arguments: hashpartitioning(c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92, d_year#84, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(74) HashAggregate [codegen id : 33]
-Input [10]: [c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92, d_year#84, sum#95, isEmpty#96]
-Keys [8]: [c_customer_id#86, c_first_name#87, c_last_name#88, c_preferred_cust_flag#89, c_birth_country#90, c_login#91, c_email_address#92, d_year#84]
-Functions [1]: [sum(((((cs_ext_list_price#81 - cs_ext_wholesale_cost#80) - cs_ext_discount_amt#78) + cs_ext_sales_price#79) / 2))]
-Aggregate Attributes [1]: [sum(((((cs_ext_list_price#81 - cs_ext_wholesale_cost#80) - cs_ext_discount_amt#78) + cs_ext_sales_price#79) / 2))#74]
-Results [2]: [c_customer_id#86 AS customer_id#97, sum(((((cs_ext_list_price#81 - cs_ext_wholesale_cost#80) - cs_ext_discount_amt#78) + cs_ext_sales_price#79) / 2))#74 AS year_total#98]
-
-(75) Exchange
-Input [2]: [customer_id#97, year_total#98]
-Arguments: hashpartitioning(customer_id#97, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(76) Sort [codegen id : 34]
-Input [2]: [customer_id#97, year_total#98]
-Arguments: [customer_id#97 ASC NULLS FIRST], false, 0
-
-(77) SortMergeJoin [codegen id : 35]
-Left keys [1]: [customer_id#23]
-Right keys [1]: [customer_id#97]
-Join type: Inner
-Join condition: (CASE WHEN (year_total#76 > 0.000000) THEN (year_total#98 / year_total#76) END > CASE WHEN (year_total#24 > 0.000000) THEN (year_total#53 / year_total#24) END)
-
-(78) Project [codegen id : 35]
-Output [10]: [customer_id#23, customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#76, year_total#98]
-Input [13]: [customer_id#23, year_total#24, customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#53, year_total#76, customer_id#97, year_total#98]
-
-(79) Scan parquet spark_catalog.default.web_sales
-Output [6]: [ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, ws_sold_date_sk#104]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#104), dynamicpruningexpression(ws_sold_date_sk#104 IN dynamicpruning#7)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_sales_price:decimal(7,2),ws_ext_wholesale_cost:decimal(7,2),ws_ext_list_price:decimal(7,2)>
-
-(80) ColumnarToRow [codegen id : 37]
-Input [6]: [ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, ws_sold_date_sk#104]
-
-(81) Filter [codegen id : 37]
-Input [6]: [ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, ws_sold_date_sk#104]
-Condition : isnotnull(ws_bill_customer_sk#99)
-
-(82) ReusedExchange [Reuses operator id: 122]
-Output [2]: [d_date_sk#105, d_year#106]
-
-(83) BroadcastHashJoin [codegen id : 37]
-Left keys [1]: [ws_sold_date_sk#104]
-Right keys [1]: [d_date_sk#105]
-Join type: Inner
-Join condition: None
-
-(84) Project [codegen id : 37]
-Output [6]: [ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#106]
-Input [8]: [ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, ws_sold_date_sk#104, d_date_sk#105, d_year#106]
-
-(85) Exchange
-Input [6]: [ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#106]
-Arguments: hashpartitioning(ws_bill_customer_sk#99, 5), ENSURE_REQUIREMENTS, [plan_id=14]
-
-(86) Sort [codegen id : 38]
-Input [6]: [ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#106]
-Arguments: [ws_bill_customer_sk#99 ASC NULLS FIRST], false, 0
-
-(87) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#107, c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114]
-
-(88) Sort [codegen id : 40]
-Input [8]: [c_customer_sk#107, c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114]
-Arguments: [c_customer_sk#107 ASC NULLS FIRST], false, 0
-
-(89) SortMergeJoin [codegen id : 41]
-Left keys [1]: [ws_bill_customer_sk#99]
-Right keys [1]: [c_customer_sk#107]
-Join type: Inner
-Join condition: None
-
-(90) Project [codegen id : 41]
-Output [12]: [c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#106]
-Input [14]: [ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#106, c_customer_sk#107, c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114]
-
-(91) HashAggregate [codegen id : 41]
-Input [12]: [c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#106]
-Keys [8]: [c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114, d_year#106]
-Functions [1]: [partial_sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))]
-Aggregate Attributes [2]: [sum#115, isEmpty#116]
-Results [10]: [c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114, d_year#106, sum#117, isEmpty#118]
-
-(92) Exchange
-Input [10]: [c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114, d_year#106, sum#117, isEmpty#118]
-Arguments: hashpartitioning(c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114, d_year#106, 5), ENSURE_REQUIREMENTS, [plan_id=15]
-
-(93) HashAggregate [codegen id : 42]
-Input [10]: [c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114, d_year#106, sum#117, isEmpty#118]
-Keys [8]: [c_customer_id#108, c_first_name#109, c_last_name#110, c_preferred_cust_flag#111, c_birth_country#112, c_login#113, c_email_address#114, d_year#106]
-Functions [1]: [sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))]
-Aggregate Attributes [1]: [sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))#119]
-Results [2]: [c_customer_id#108 AS customer_id#120, sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))#119 AS year_total#121]
-
-(94) Filter [codegen id : 42]
-Input [2]: [customer_id#120, year_total#121]
-Condition : (isnotnull(year_total#121) AND (year_total#121 > 0.000000))
-
-(95) Exchange
-Input [2]: [customer_id#120, year_total#121]
-Arguments: hashpartitioning(customer_id#120, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(96) Sort [codegen id : 43]
-Input [2]: [customer_id#120, year_total#121]
-Arguments: [customer_id#120 ASC NULLS FIRST], false, 0
-
-(97) SortMergeJoin [codegen id : 44]
-Left keys [1]: [customer_id#23]
-Right keys [1]: [customer_id#120]
-Join type: Inner
-Join condition: None
-
-(98) Project [codegen id : 44]
-Output [11]: [customer_id#23, customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#76, year_total#98, year_total#121]
-Input [12]: [customer_id#23, customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#76, year_total#98, customer_id#120, year_total#121]
-
-(99) Scan parquet spark_catalog.default.web_sales
-Output [6]: [ws_bill_customer_sk#122, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, ws_sold_date_sk#127]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#127), dynamicpruningexpression(ws_sold_date_sk#127 IN dynamicpruning#31)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_sales_price:decimal(7,2),ws_ext_wholesale_cost:decimal(7,2),ws_ext_list_price:decimal(7,2)>
-
-(100) ColumnarToRow [codegen id : 46]
-Input [6]: [ws_bill_customer_sk#122, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, ws_sold_date_sk#127]
-
-(101) Filter [codegen id : 46]
-Input [6]: [ws_bill_customer_sk#122, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, ws_sold_date_sk#127]
-Condition : isnotnull(ws_bill_customer_sk#122)
-
-(102) ReusedExchange [Reuses operator id: 126]
-Output [2]: [d_date_sk#128, d_year#129]
-
-(103) BroadcastHashJoin [codegen id : 46]
-Left keys [1]: [ws_sold_date_sk#127]
-Right keys [1]: [d_date_sk#128]
-Join type: Inner
-Join condition: None
-
-(104) Project [codegen id : 46]
-Output [6]: [ws_bill_customer_sk#122, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, d_year#129]
-Input [8]: [ws_bill_customer_sk#122, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, ws_sold_date_sk#127, d_date_sk#128, d_year#129]
-
-(105) Exchange
-Input [6]: [ws_bill_customer_sk#122, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, d_year#129]
-Arguments: hashpartitioning(ws_bill_customer_sk#122, 5), ENSURE_REQUIREMENTS, [plan_id=17]
-
-(106) Sort [codegen id : 47]
-Input [6]: [ws_bill_customer_sk#122, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, d_year#129]
-Arguments: [ws_bill_customer_sk#122 ASC NULLS FIRST], false, 0
-
-(107) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#130, c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137]
-
-(108) Sort [codegen id : 49]
-Input [8]: [c_customer_sk#130, c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137]
-Arguments: [c_customer_sk#130 ASC NULLS FIRST], false, 0
-
-(109) SortMergeJoin [codegen id : 50]
-Left keys [1]: [ws_bill_customer_sk#122]
-Right keys [1]: [c_customer_sk#130]
-Join type: Inner
-Join condition: None
-
-(110) Project [codegen id : 50]
-Output [12]: [c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, d_year#129]
-Input [14]: [ws_bill_customer_sk#122, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, d_year#129, c_customer_sk#130, c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137]
-
-(111) HashAggregate [codegen id : 50]
-Input [12]: [c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137, ws_ext_discount_amt#123, ws_ext_sales_price#124, ws_ext_wholesale_cost#125, ws_ext_list_price#126, d_year#129]
-Keys [8]: [c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137, d_year#129]
-Functions [1]: [partial_sum(((((ws_ext_list_price#126 - ws_ext_wholesale_cost#125) - ws_ext_discount_amt#123) + ws_ext_sales_price#124) / 2))]
-Aggregate Attributes [2]: [sum#138, isEmpty#139]
-Results [10]: [c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137, d_year#129, sum#140, isEmpty#141]
-
-(112) Exchange
-Input [10]: [c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137, d_year#129, sum#140, isEmpty#141]
-Arguments: hashpartitioning(c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137, d_year#129, 5), ENSURE_REQUIREMENTS, [plan_id=18]
-
-(113) HashAggregate [codegen id : 51]
-Input [10]: [c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137, d_year#129, sum#140, isEmpty#141]
-Keys [8]: [c_customer_id#131, c_first_name#132, c_last_name#133, c_preferred_cust_flag#134, c_birth_country#135, c_login#136, c_email_address#137, d_year#129]
-Functions [1]: [sum(((((ws_ext_list_price#126 - ws_ext_wholesale_cost#125) - ws_ext_discount_amt#123) + ws_ext_sales_price#124) / 2))]
-Aggregate Attributes [1]: [sum(((((ws_ext_list_price#126 - ws_ext_wholesale_cost#125) - ws_ext_discount_amt#123) + ws_ext_sales_price#124) / 2))#119]
-Results [2]: [c_customer_id#131 AS customer_id#142, sum(((((ws_ext_list_price#126 - ws_ext_wholesale_cost#125) - ws_ext_discount_amt#123) + ws_ext_sales_price#124) / 2))#119 AS year_total#143]
-
-(114) Exchange
-Input [2]: [customer_id#142, year_total#143]
-Arguments: hashpartitioning(customer_id#142, 5), ENSURE_REQUIREMENTS, [plan_id=19]
-
-(115) Sort [codegen id : 52]
-Input [2]: [customer_id#142, year_total#143]
-Arguments: [customer_id#142 ASC NULLS FIRST], false, 0
-
-(116) SortMergeJoin [codegen id : 53]
-Left keys [1]: [customer_id#23]
-Right keys [1]: [customer_id#142]
-Join type: Inner
-Join condition: (CASE WHEN (year_total#76 > 0.000000) THEN (year_total#98 / year_total#76) END > CASE WHEN (year_total#121 > 0.000000) THEN (year_total#143 / year_total#121) END)
-
-(117) Project [codegen id : 53]
-Output [7]: [customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52]
-Input [13]: [customer_id#23, customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52, year_total#76, year_total#98, year_total#121, customer_id#142, year_total#143]
-
-(118) TakeOrderedAndProject
-Input [7]: [customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52]
-Arguments: 100, [customer_id#46 ASC NULLS FIRST, customer_first_name#47 ASC NULLS FIRST, customer_last_name#48 ASC NULLS FIRST, customer_preferred_cust_flag#49 ASC NULLS FIRST, customer_birth_country#50 ASC NULLS FIRST, customer_login#51 ASC NULLS FIRST, customer_email_address#52 ASC NULLS FIRST], [customer_id#46, customer_first_name#47, customer_last_name#48, customer_preferred_cust_flag#49, customer_birth_country#50, customer_login#51, customer_email_address#52]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
-BroadcastExchange (122)
-+- * Filter (121)
-   +- * ColumnarToRow (120)
-      +- Scan parquet spark_catalog.default.date_dim (119)
-
-
-(119) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#8, d_year#9]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int>
-
-(120) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#8, d_year#9]
-
-(121) Filter [codegen id : 1]
-Input [2]: [d_date_sk#8, d_year#9]
-Condition : ((isnotnull(d_year#9) AND (d_year#9 = 2001)) AND isnotnull(d_date_sk#8))
-
-(122) BroadcastExchange
-Input [2]: [d_date_sk#8, d_year#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=20]
-
-Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#30 IN dynamicpruning#31
+(117) ColumnarToRow [codegen id : 1]
+Input [8]: [c_customer_sk#12, c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19]
+
+(118) Filter [codegen id : 1]
+Input [8]: [c_customer_sk#12, c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19]
+Condition : (isnotnull(c_customer_sk#12) AND isnotnull(c_customer_id#13))
+
+(119) Exchange
+Input [8]: [c_customer_sk#12, c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19]
+Arguments: hashpartitioning(c_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+
+(120) ObjectHashAggregate
+Input [8]: [c_customer_sk#12, c_customer_id#13, c_first_name#14, c_last_name#15, c_preferred_cust_flag#16, c_birth_country#17, c_login#18, c_email_address#19]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#12, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#148]
+Results [1]: [buf#149]
+
+(121) Exchange
+Input [1]: [buf#149]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+
+(122) ObjectHashAggregate
+Input [1]: [buf#149]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#12, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#12, 42), 2000000, 16000000, 0, 0)#150]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#12, 42), 2000000, 16000000, 0, 0)#150 AS bloomFilter#151]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
 BroadcastExchange (126)
 +- * Filter (125)
    +- * ColumnarToRow (124)
@@ -705,29 +708,108 @@ BroadcastExchange (126)
 
 
 (123) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#32, d_year#33]
+Output [2]: [d_date_sk#10, d_year#11]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int>
+
+(124) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#10, d_year#11]
+
+(125) Filter [codegen id : 1]
+Input [2]: [d_date_sk#10, d_year#11]
+Condition : ((isnotnull(d_year#11) AND (d_year#11 = 2001)) AND isnotnull(d_date_sk#10))
+
+(126) BroadcastExchange
+Input [2]: [d_date_sk#10, d_year#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=21]
+
+Subquery:3 Hosting operator id = 21 Hosting Expression = Subquery scalar-subquery#34, [id=#35]
+ObjectHashAggregate (133)
++- Exchange (132)
+   +- ObjectHashAggregate (131)
+      +- Exchange (130)
+         +- * Filter (129)
+            +- * ColumnarToRow (128)
+               +- Scan parquet spark_catalog.default.customer (127)
+
+
+(127) Scan parquet spark_catalog.default.customer
+Output [8]: [c_customer_sk#38, c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
+ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
+
+(128) ColumnarToRow [codegen id : 1]
+Input [8]: [c_customer_sk#38, c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45]
+
+(129) Filter [codegen id : 1]
+Input [8]: [c_customer_sk#38, c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45]
+Condition : (isnotnull(c_customer_sk#38) AND isnotnull(c_customer_id#39))
+
+(130) Exchange
+Input [8]: [c_customer_sk#38, c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45]
+Arguments: hashpartitioning(c_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+
+(131) ObjectHashAggregate
+Input [8]: [c_customer_sk#38, c_customer_id#39, c_first_name#40, c_last_name#41, c_preferred_cust_flag#42, c_birth_country#43, c_login#44, c_email_address#45]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#38, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#152]
+Results [1]: [buf#153]
+
+(132) Exchange
+Input [1]: [buf#153]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=23]
+
+(133) ObjectHashAggregate
+Input [1]: [buf#153]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#38, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#38, 42), 2000000, 16000000, 0, 0)#154]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#38, 42), 2000000, 16000000, 0, 0)#154 AS bloomFilter#155]
+
+Subquery:4 Hosting operator id = 19 Hosting Expression = ss_sold_date_sk#32 IN dynamicpruning#33
+BroadcastExchange (137)
++- * Filter (136)
+   +- * ColumnarToRow (135)
+      +- Scan parquet spark_catalog.default.date_dim (134)
+
+
+(134) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#36, d_year#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(124) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#32, d_year#33]
+(135) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#36, d_year#37]
 
-(125) Filter [codegen id : 1]
-Input [2]: [d_date_sk#32, d_year#33]
-Condition : ((isnotnull(d_year#33) AND (d_year#33 = 2002)) AND isnotnull(d_date_sk#32))
+(136) Filter [codegen id : 1]
+Input [2]: [d_date_sk#36, d_year#37]
+Condition : ((isnotnull(d_year#37) AND (d_year#37 = 2002)) AND isnotnull(d_date_sk#36))
 
-(126) BroadcastExchange
-Input [2]: [d_date_sk#32, d_year#33]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=21]
+(137) BroadcastExchange
+Input [2]: [d_date_sk#36, d_year#37]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=24]
 
-Subquery:3 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#59 IN dynamicpruning#7
+Subquery:5 Hosting operator id = 39 Hosting Expression = ReusedSubquery Subquery scalar-subquery#34, [id=#35]
 
-Subquery:4 Hosting operator id = 60 Hosting Expression = cs_sold_date_sk#82 IN dynamicpruning#31
+Subquery:6 Hosting operator id = 37 Hosting Expression = cs_sold_date_sk#63 IN dynamicpruning#7
 
-Subquery:5 Hosting operator id = 79 Hosting Expression = ws_sold_date_sk#104 IN dynamicpruning#7
+Subquery:7 Hosting operator id = 59 Hosting Expression = ReusedSubquery Subquery scalar-subquery#34, [id=#35]
 
-Subquery:6 Hosting operator id = 99 Hosting Expression = ws_sold_date_sk#127 IN dynamicpruning#31
+Subquery:8 Hosting operator id = 57 Hosting Expression = cs_sold_date_sk#86 IN dynamicpruning#33
+
+Subquery:9 Hosting operator id = 78 Hosting Expression = ReusedSubquery Subquery scalar-subquery#34, [id=#35]
+
+Subquery:10 Hosting operator id = 76 Hosting Expression = ws_sold_date_sk#108 IN dynamicpruning#7
+
+Subquery:11 Hosting operator id = 98 Hosting Expression = ReusedSubquery Subquery scalar-subquery#34, [id=#35]
+
+Subquery:12 Hosting operator id = 96 Hosting Expression = ws_sold_date_sk#131 IN dynamicpruning#33
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4.sf100/simplified.txt
@@ -40,6 +40,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                                               Project [ss_customer_sk,ss_ext_discount_amt,ss_ext_sales_price,ss_ext_wholesale_cost,ss_ext_list_price,d_year]
                                                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                                   Filter [ss_customer_sk]
+                                                                                    Subquery #2
+                                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                                        Exchange #5
+                                                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                                            Exchange [c_customer_sk] #6
+                                                                                              WholeStageCodegen (1)
+                                                                                                Filter [c_customer_sk,c_customer_id]
+                                                                                                  ColumnarToRow
+                                                                                                    InputAdapter
+                                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
                                                                                     ColumnarToRow
                                                                                       InputAdapter
                                                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_discount_amt,ss_ext_sales_price,ss_ext_wholesale_cost,ss_ext_list_price,ss_sold_date_sk]
@@ -56,21 +66,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                                     WholeStageCodegen (5)
                                                                       Sort [c_customer_sk]
                                                                         InputAdapter
-                                                                          Exchange [c_customer_sk] #5
-                                                                            WholeStageCodegen (4)
-                                                                              Filter [c_customer_sk,c_customer_id]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
+                                                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
                                       InputAdapter
                                         WholeStageCodegen (16)
                                           Sort [customer_id]
                                             InputAdapter
-                                              Exchange [customer_id] #6
+                                              Exchange [customer_id] #7
                                                 WholeStageCodegen (15)
                                                   HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum,isEmpty] [sum(((((ss_ext_list_price - ss_ext_wholesale_cost) - ss_ext_discount_amt) + ss_ext_sales_price) / 2)),customer_id,customer_first_name,customer_last_name,customer_preferred_cust_flag,customer_birth_country,customer_login,customer_email_address,year_total,sum,isEmpty]
                                                     InputAdapter
-                                                      Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #7
+                                                      Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #8
                                                         WholeStageCodegen (14)
                                                           HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,ss_ext_list_price,ss_ext_wholesale_cost,ss_ext_discount_amt,ss_ext_sales_price] [sum,isEmpty,sum,isEmpty]
                                                             Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ss_ext_discount_amt,ss_ext_sales_price,ss_ext_wholesale_cost,ss_ext_list_price,d_year]
@@ -79,38 +84,48 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                                   WholeStageCodegen (11)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #8
+                                                                        Exchange [ss_customer_sk] #9
                                                                           WholeStageCodegen (10)
                                                                             Project [ss_customer_sk,ss_ext_discount_amt,ss_ext_sales_price,ss_ext_wholesale_cost,ss_ext_list_price,d_year]
                                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                                 Filter [ss_customer_sk]
+                                                                                  Subquery #4
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #11
+                                                                                        ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                                          Exchange [c_customer_sk] #12
+                                                                                            WholeStageCodegen (1)
+                                                                                              Filter [c_customer_sk,c_customer_id]
+                                                                                                ColumnarToRow
+                                                                                                  InputAdapter
+                                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_discount_amt,ss_ext_sales_price,ss_ext_wholesale_cost,ss_ext_list_price,ss_sold_date_sk]
-                                                                                        SubqueryBroadcast [d_date_sk] #2
-                                                                                          BroadcastExchange #9
+                                                                                        SubqueryBroadcast [d_date_sk] #3
+                                                                                          BroadcastExchange #10
                                                                                             WholeStageCodegen (1)
                                                                                               Filter [d_year,d_date_sk]
                                                                                                 ColumnarToRow
                                                                                                   InputAdapter
                                                                                                     Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                                 InputAdapter
-                                                                                  ReusedExchange [d_date_sk,d_year] #9
+                                                                                  ReusedExchange [d_date_sk,d_year] #10
                                                                 InputAdapter
                                                                   WholeStageCodegen (13)
                                                                     Sort [c_customer_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                                                        ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
                                 InputAdapter
                                   WholeStageCodegen (25)
                                     Sort [customer_id]
                                       InputAdapter
-                                        Exchange [customer_id] #10
+                                        Exchange [customer_id] #13
                                           WholeStageCodegen (24)
                                             Filter [year_total]
                                               HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum,isEmpty] [sum(((((cs_ext_list_price - cs_ext_wholesale_cost) - cs_ext_discount_amt) + cs_ext_sales_price) / 2)),customer_id,year_total,sum,isEmpty]
                                                 InputAdapter
-                                                  Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #11
+                                                  Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #14
                                                     WholeStageCodegen (23)
                                                       HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,cs_ext_list_price,cs_ext_wholesale_cost,cs_ext_discount_amt,cs_ext_sales_price] [sum,isEmpty,sum,isEmpty]
                                                         Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,cs_ext_discount_amt,cs_ext_sales_price,cs_ext_wholesale_cost,cs_ext_list_price,d_year]
@@ -119,11 +134,12 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                               WholeStageCodegen (20)
                                                                 Sort [cs_bill_customer_sk]
                                                                   InputAdapter
-                                                                    Exchange [cs_bill_customer_sk] #12
+                                                                    Exchange [cs_bill_customer_sk] #15
                                                                       WholeStageCodegen (19)
                                                                         Project [cs_bill_customer_sk,cs_ext_discount_amt,cs_ext_sales_price,cs_ext_wholesale_cost,cs_ext_list_price,d_year]
                                                                           BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                             Filter [cs_bill_customer_sk]
+                                                                              ReusedSubquery [bloomFilter] #4
                                                                               ColumnarToRow
                                                                                 InputAdapter
                                                                                   Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_ext_discount_amt,cs_ext_sales_price,cs_ext_wholesale_cost,cs_ext_list_price,cs_sold_date_sk]
@@ -134,16 +150,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                               WholeStageCodegen (22)
                                                                 Sort [c_customer_sk]
                                                                   InputAdapter
-                                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
                         InputAdapter
                           WholeStageCodegen (34)
                             Sort [customer_id]
                               InputAdapter
-                                Exchange [customer_id] #13
+                                Exchange [customer_id] #16
                                   WholeStageCodegen (33)
                                     HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum,isEmpty] [sum(((((cs_ext_list_price - cs_ext_wholesale_cost) - cs_ext_discount_amt) + cs_ext_sales_price) / 2)),customer_id,year_total,sum,isEmpty]
                                       InputAdapter
-                                        Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #14
+                                        Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #17
                                           WholeStageCodegen (32)
                                             HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,cs_ext_list_price,cs_ext_wholesale_cost,cs_ext_discount_amt,cs_ext_sales_price] [sum,isEmpty,sum,isEmpty]
                                               Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,cs_ext_discount_amt,cs_ext_sales_price,cs_ext_wholesale_cost,cs_ext_list_price,d_year]
@@ -152,32 +168,33 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                     WholeStageCodegen (29)
                                                       Sort [cs_bill_customer_sk]
                                                         InputAdapter
-                                                          Exchange [cs_bill_customer_sk] #15
+                                                          Exchange [cs_bill_customer_sk] #18
                                                             WholeStageCodegen (28)
                                                               Project [cs_bill_customer_sk,cs_ext_discount_amt,cs_ext_sales_price,cs_ext_wholesale_cost,cs_ext_list_price,d_year]
                                                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                   Filter [cs_bill_customer_sk]
+                                                                    ReusedSubquery [bloomFilter] #4
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_ext_discount_amt,cs_ext_sales_price,cs_ext_wholesale_cost,cs_ext_list_price,cs_sold_date_sk]
-                                                                          ReusedSubquery [d_date_sk] #2
+                                                                          ReusedSubquery [d_date_sk] #3
                                                                   InputAdapter
-                                                                    ReusedExchange [d_date_sk,d_year] #9
+                                                                    ReusedExchange [d_date_sk,d_year] #10
                                                   InputAdapter
                                                     WholeStageCodegen (31)
                                                       Sort [c_customer_sk]
                                                         InputAdapter
-                                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
                 InputAdapter
                   WholeStageCodegen (43)
                     Sort [customer_id]
                       InputAdapter
-                        Exchange [customer_id] #16
+                        Exchange [customer_id] #19
                           WholeStageCodegen (42)
                             Filter [year_total]
                               HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum,isEmpty] [sum(((((ws_ext_list_price - ws_ext_wholesale_cost) - ws_ext_discount_amt) + ws_ext_sales_price) / 2)),customer_id,year_total,sum,isEmpty]
                                 InputAdapter
-                                  Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #17
+                                  Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #20
                                     WholeStageCodegen (41)
                                       HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,ws_ext_list_price,ws_ext_wholesale_cost,ws_ext_discount_amt,ws_ext_sales_price] [sum,isEmpty,sum,isEmpty]
                                         Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ws_ext_discount_amt,ws_ext_sales_price,ws_ext_wholesale_cost,ws_ext_list_price,d_year]
@@ -186,11 +203,12 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                               WholeStageCodegen (38)
                                                 Sort [ws_bill_customer_sk]
                                                   InputAdapter
-                                                    Exchange [ws_bill_customer_sk] #18
+                                                    Exchange [ws_bill_customer_sk] #21
                                                       WholeStageCodegen (37)
                                                         Project [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_sales_price,ws_ext_wholesale_cost,ws_ext_list_price,d_year]
                                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                             Filter [ws_bill_customer_sk]
+                                                              ReusedSubquery [bloomFilter] #4
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_sales_price,ws_ext_wholesale_cost,ws_ext_list_price,ws_sold_date_sk]
@@ -201,16 +219,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                               WholeStageCodegen (40)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
         InputAdapter
           WholeStageCodegen (52)
             Sort [customer_id]
               InputAdapter
-                Exchange [customer_id] #19
+                Exchange [customer_id] #22
                   WholeStageCodegen (51)
                     HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum,isEmpty] [sum(((((ws_ext_list_price - ws_ext_wholesale_cost) - ws_ext_discount_amt) + ws_ext_sales_price) / 2)),customer_id,year_total,sum,isEmpty]
                       InputAdapter
-                        Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #20
+                        Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #23
                           WholeStageCodegen (50)
                             HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,ws_ext_list_price,ws_ext_wholesale_cost,ws_ext_discount_amt,ws_ext_sales_price] [sum,isEmpty,sum,isEmpty]
                               Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ws_ext_discount_amt,ws_ext_sales_price,ws_ext_wholesale_cost,ws_ext_list_price,d_year]
@@ -219,19 +237,20 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                     WholeStageCodegen (47)
                                       Sort [ws_bill_customer_sk]
                                         InputAdapter
-                                          Exchange [ws_bill_customer_sk] #21
+                                          Exchange [ws_bill_customer_sk] #24
                                             WholeStageCodegen (46)
                                               Project [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_sales_price,ws_ext_wholesale_cost,ws_ext_list_price,d_year]
                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                   Filter [ws_bill_customer_sk]
+                                                    ReusedSubquery [bloomFilter] #4
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_sales_price,ws_ext_wholesale_cost,ws_ext_list_price,ws_sold_date_sk]
-                                                          ReusedSubquery [d_date_sk] #2
+                                                          ReusedSubquery [d_date_sk] #3
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk,d_year] #9
+                                                    ReusedExchange [d_date_sk,d_year] #10
                                   InputAdapter
                                     WholeStageCodegen (49)
                                       Sort [c_customer_sk]
                                         InputAdapter
-                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
@@ -47,7 +47,7 @@ Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4
 
 (3) Filter [codegen id : 1]
 Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5]
-Condition : ((isnotnull(cs_warehouse_sk#1) AND isnotnull(cs_item_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(cs_item_sk#2, 42)))
+Condition : ((isnotnull(cs_warehouse_sk#1) AND isnotnull(cs_item_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(cs_item_sk#2, 42), true))
 
 (4) Exchange
 Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45.sf100/explain.txt
@@ -1,13 +1,13 @@
 == Physical Plan ==
-TakeOrderedAndProject (42)
-+- * HashAggregate (41)
-   +- Exchange (40)
-      +- * HashAggregate (39)
-         +- * Project (38)
-            +- * Filter (37)
-               +- * BroadcastHashJoin ExistenceJoin(exists#1) BuildRight (36)
-                  :- * Project (30)
-                  :  +- * SortMergeJoin Inner (29)
+TakeOrderedAndProject (30)
++- * HashAggregate (29)
+   +- Exchange (28)
+      +- * HashAggregate (27)
+         +- * Project (26)
+            +- * Filter (25)
+               +- * BroadcastHashJoin ExistenceJoin(exists#1) BuildRight (24)
+                  :- * Project (18)
+                  :  +- * SortMergeJoin Inner (17)
                   :     :- * Sort (14)
                   :     :  +- Exchange (13)
                   :     :     +- * Project (12)
@@ -22,25 +22,13 @@ TakeOrderedAndProject (42)
                   :     :              +- * Filter (9)
                   :     :                 +- * ColumnarToRow (8)
                   :     :                    +- Scan parquet spark_catalog.default.item (7)
-                  :     +- * Sort (28)
-                  :        +- Exchange (27)
-                  :           +- * Project (26)
-                  :              +- * SortMergeJoin Inner (25)
-                  :                 :- * Sort (19)
-                  :                 :  +- Exchange (18)
-                  :                 :     +- * Filter (17)
-                  :                 :        +- * ColumnarToRow (16)
-                  :                 :           +- Scan parquet spark_catalog.default.customer (15)
-                  :                 +- * Sort (24)
-                  :                    +- Exchange (23)
-                  :                       +- * Filter (22)
-                  :                          +- * ColumnarToRow (21)
-                  :                             +- Scan parquet spark_catalog.default.customer_address (20)
-                  +- BroadcastExchange (35)
-                     +- * Project (34)
-                        +- * Filter (33)
-                           +- * ColumnarToRow (32)
-                              +- Scan parquet spark_catalog.default.item (31)
+                  :     +- * Sort (16)
+                  :        +- ReusedExchange (15)
+                  +- BroadcastExchange (23)
+                     +- * Project (22)
+                        +- * Filter (21)
+                           +- * ColumnarToRow (20)
+                              +- Scan parquet spark_catalog.default.item (19)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -56,217 +44,257 @@ Input [4]: [ws_item_sk#2, ws_bill_customer_sk#3, ws_sales_price#4, ws_sold_date_
 
 (3) Filter [codegen id : 3]
 Input [4]: [ws_item_sk#2, ws_bill_customer_sk#3, ws_sales_price#4, ws_sold_date_sk#5]
-Condition : (isnotnull(ws_bill_customer_sk#3) AND isnotnull(ws_item_sk#2))
+Condition : ((isnotnull(ws_bill_customer_sk#3) AND isnotnull(ws_item_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ws_bill_customer_sk#3, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 47]
-Output [1]: [d_date_sk#7]
+(4) ReusedExchange [Reuses operator id: 51]
+Output [1]: [d_date_sk#9]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
 Output [3]: [ws_item_sk#2, ws_bill_customer_sk#3, ws_sales_price#4]
-Input [5]: [ws_item_sk#2, ws_bill_customer_sk#3, ws_sales_price#4, ws_sold_date_sk#5, d_date_sk#7]
+Input [5]: [ws_item_sk#2, ws_bill_customer_sk#3, ws_sales_price#4, ws_sold_date_sk#5, d_date_sk#9]
 
 (7) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#8, i_item_id#9]
+Output [2]: [i_item_sk#10, i_item_id#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [i_item_sk#8, i_item_id#9]
+Input [2]: [i_item_sk#10, i_item_id#11]
 
 (9) Filter [codegen id : 2]
-Input [2]: [i_item_sk#8, i_item_id#9]
-Condition : isnotnull(i_item_sk#8)
+Input [2]: [i_item_sk#10, i_item_id#11]
+Condition : isnotnull(i_item_sk#10)
 
 (10) BroadcastExchange
-Input [2]: [i_item_sk#8, i_item_id#9]
+Input [2]: [i_item_sk#10, i_item_id#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#2]
-Right keys [1]: [i_item_sk#8]
+Right keys [1]: [i_item_sk#10]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [3]: [ws_bill_customer_sk#3, ws_sales_price#4, i_item_id#9]
-Input [5]: [ws_item_sk#2, ws_bill_customer_sk#3, ws_sales_price#4, i_item_sk#8, i_item_id#9]
+Output [3]: [ws_bill_customer_sk#3, ws_sales_price#4, i_item_id#11]
+Input [5]: [ws_item_sk#2, ws_bill_customer_sk#3, ws_sales_price#4, i_item_sk#10, i_item_id#11]
 
 (13) Exchange
-Input [3]: [ws_bill_customer_sk#3, ws_sales_price#4, i_item_id#9]
+Input [3]: [ws_bill_customer_sk#3, ws_sales_price#4, i_item_id#11]
 Arguments: hashpartitioning(ws_bill_customer_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [3]: [ws_bill_customer_sk#3, ws_sales_price#4, i_item_id#9]
+Input [3]: [ws_bill_customer_sk#3, ws_sales_price#4, i_item_id#11]
 Arguments: [ws_bill_customer_sk#3 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#10, c_current_addr_sk#11]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
+(15) ReusedExchange [Reuses operator id: 43]
+Output [3]: [c_customer_sk#12, ca_city#13, ca_zip#14]
 
-(16) ColumnarToRow [codegen id : 5]
-Input [2]: [c_customer_sk#10, c_current_addr_sk#11]
+(16) Sort [codegen id : 10]
+Input [3]: [c_customer_sk#12, ca_city#13, ca_zip#14]
+Arguments: [c_customer_sk#12 ASC NULLS FIRST], false, 0
 
-(17) Filter [codegen id : 5]
-Input [2]: [c_customer_sk#10, c_current_addr_sk#11]
-Condition : (isnotnull(c_customer_sk#10) AND isnotnull(c_current_addr_sk#11))
-
-(18) Exchange
-Input [2]: [c_customer_sk#10, c_current_addr_sk#11]
-Arguments: hashpartitioning(c_current_addr_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(19) Sort [codegen id : 6]
-Input [2]: [c_customer_sk#10, c_current_addr_sk#11]
-Arguments: [c_current_addr_sk#11 ASC NULLS FIRST], false, 0
-
-(20) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#12, ca_city#13, ca_zip#14]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_city:string,ca_zip:string>
-
-(21) ColumnarToRow [codegen id : 7]
-Input [3]: [ca_address_sk#12, ca_city#13, ca_zip#14]
-
-(22) Filter [codegen id : 7]
-Input [3]: [ca_address_sk#12, ca_city#13, ca_zip#14]
-Condition : isnotnull(ca_address_sk#12)
-
-(23) Exchange
-Input [3]: [ca_address_sk#12, ca_city#13, ca_zip#14]
-Arguments: hashpartitioning(ca_address_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(24) Sort [codegen id : 8]
-Input [3]: [ca_address_sk#12, ca_city#13, ca_zip#14]
-Arguments: [ca_address_sk#12 ASC NULLS FIRST], false, 0
-
-(25) SortMergeJoin [codegen id : 9]
-Left keys [1]: [c_current_addr_sk#11]
-Right keys [1]: [ca_address_sk#12]
-Join type: Inner
-Join condition: None
-
-(26) Project [codegen id : 9]
-Output [3]: [c_customer_sk#10, ca_city#13, ca_zip#14]
-Input [5]: [c_customer_sk#10, c_current_addr_sk#11, ca_address_sk#12, ca_city#13, ca_zip#14]
-
-(27) Exchange
-Input [3]: [c_customer_sk#10, ca_city#13, ca_zip#14]
-Arguments: hashpartitioning(c_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(28) Sort [codegen id : 10]
-Input [3]: [c_customer_sk#10, ca_city#13, ca_zip#14]
-Arguments: [c_customer_sk#10 ASC NULLS FIRST], false, 0
-
-(29) SortMergeJoin [codegen id : 12]
+(17) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ws_bill_customer_sk#3]
-Right keys [1]: [c_customer_sk#10]
+Right keys [1]: [c_customer_sk#12]
 Join type: Inner
 Join condition: None
 
-(30) Project [codegen id : 12]
-Output [4]: [ws_sales_price#4, ca_city#13, ca_zip#14, i_item_id#9]
-Input [6]: [ws_bill_customer_sk#3, ws_sales_price#4, i_item_id#9, c_customer_sk#10, ca_city#13, ca_zip#14]
+(18) Project [codegen id : 12]
+Output [4]: [ws_sales_price#4, ca_city#13, ca_zip#14, i_item_id#11]
+Input [6]: [ws_bill_customer_sk#3, ws_sales_price#4, i_item_id#11, c_customer_sk#12, ca_city#13, ca_zip#14]
 
-(31) Scan parquet spark_catalog.default.item
+(19) Scan parquet spark_catalog.default.item
 Output [2]: [i_item_sk#15, i_item_id#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_item_sk, [11,13,17,19,2,23,29,3,5,7])]
 ReadSchema: struct<i_item_sk:int,i_item_id:string>
 
-(32) ColumnarToRow [codegen id : 11]
+(20) ColumnarToRow [codegen id : 11]
 Input [2]: [i_item_sk#15, i_item_id#16]
 
-(33) Filter [codegen id : 11]
+(21) Filter [codegen id : 11]
 Input [2]: [i_item_sk#15, i_item_id#16]
 Condition : i_item_sk#15 IN (2,3,5,7,11,13,17,19,23,29)
 
-(34) Project [codegen id : 11]
+(22) Project [codegen id : 11]
 Output [1]: [i_item_id#16]
 Input [2]: [i_item_sk#15, i_item_id#16]
 
-(35) BroadcastExchange
+(23) BroadcastExchange
 Input [1]: [i_item_id#16]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=6]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=3]
 
-(36) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [i_item_id#9]
+(24) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [i_item_id#11]
 Right keys [1]: [i_item_id#16]
 Join type: ExistenceJoin(exists#1)
 Join condition: None
 
-(37) Filter [codegen id : 12]
-Input [5]: [ws_sales_price#4, ca_city#13, ca_zip#14, i_item_id#9, exists#1]
+(25) Filter [codegen id : 12]
+Input [5]: [ws_sales_price#4, ca_city#13, ca_zip#14, i_item_id#11, exists#1]
 Condition : (substr(ca_zip#14, 1, 5) IN (85669,86197,88274,83405,86475,85392,85460,80348,81792) OR exists#1)
 
-(38) Project [codegen id : 12]
+(26) Project [codegen id : 12]
 Output [3]: [ws_sales_price#4, ca_city#13, ca_zip#14]
-Input [5]: [ws_sales_price#4, ca_city#13, ca_zip#14, i_item_id#9, exists#1]
+Input [5]: [ws_sales_price#4, ca_city#13, ca_zip#14, i_item_id#11, exists#1]
 
-(39) HashAggregate [codegen id : 12]
+(27) HashAggregate [codegen id : 12]
 Input [3]: [ws_sales_price#4, ca_city#13, ca_zip#14]
 Keys [2]: [ca_zip#14, ca_city#13]
 Functions [1]: [partial_sum(UnscaledValue(ws_sales_price#4))]
 Aggregate Attributes [1]: [sum#17]
 Results [3]: [ca_zip#14, ca_city#13, sum#18]
 
-(40) Exchange
+(28) Exchange
 Input [3]: [ca_zip#14, ca_city#13, sum#18]
-Arguments: hashpartitioning(ca_zip#14, ca_city#13, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: hashpartitioning(ca_zip#14, ca_city#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(41) HashAggregate [codegen id : 13]
+(29) HashAggregate [codegen id : 13]
 Input [3]: [ca_zip#14, ca_city#13, sum#18]
 Keys [2]: [ca_zip#14, ca_city#13]
 Functions [1]: [sum(UnscaledValue(ws_sales_price#4))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_sales_price#4))#19]
 Results [3]: [ca_zip#14, ca_city#13, MakeDecimal(sum(UnscaledValue(ws_sales_price#4))#19,17,2) AS sum(ws_sales_price)#20]
 
-(42) TakeOrderedAndProject
+(30) TakeOrderedAndProject
 Input [3]: [ca_zip#14, ca_city#13, sum(ws_sales_price)#20]
 Arguments: 100, [ca_zip#14 ASC NULLS FIRST, ca_city#13 ASC NULLS FIRST], [ca_zip#14, ca_city#13, sum(ws_sales_price)#20]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (47)
-+- * Project (46)
-   +- * Filter (45)
-      +- * ColumnarToRow (44)
-         +- Scan parquet spark_catalog.default.date_dim (43)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (46)
++- Exchange (45)
+   +- ObjectHashAggregate (44)
+      +- Exchange (43)
+         +- * Project (42)
+            +- * SortMergeJoin Inner (41)
+               :- * Sort (35)
+               :  +- Exchange (34)
+               :     +- * Filter (33)
+               :        +- * ColumnarToRow (32)
+               :           +- Scan parquet spark_catalog.default.customer (31)
+               +- * Sort (40)
+                  +- Exchange (39)
+                     +- * Filter (38)
+                        +- * ColumnarToRow (37)
+                           +- Scan parquet spark_catalog.default.customer_address (36)
 
 
-(43) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#7, d_year#21, d_qoy#22]
+(31) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#12, c_current_addr_sk#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
+
+(32) ColumnarToRow [codegen id : 1]
+Input [2]: [c_customer_sk#12, c_current_addr_sk#21]
+
+(33) Filter [codegen id : 1]
+Input [2]: [c_customer_sk#12, c_current_addr_sk#21]
+Condition : (isnotnull(c_customer_sk#12) AND isnotnull(c_current_addr_sk#21))
+
+(34) Exchange
+Input [2]: [c_customer_sk#12, c_current_addr_sk#21]
+Arguments: hashpartitioning(c_current_addr_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(35) Sort [codegen id : 2]
+Input [2]: [c_customer_sk#12, c_current_addr_sk#21]
+Arguments: [c_current_addr_sk#21 ASC NULLS FIRST], false, 0
+
+(36) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#22, ca_city#13, ca_zip#14]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_city:string,ca_zip:string>
+
+(37) ColumnarToRow [codegen id : 3]
+Input [3]: [ca_address_sk#22, ca_city#13, ca_zip#14]
+
+(38) Filter [codegen id : 3]
+Input [3]: [ca_address_sk#22, ca_city#13, ca_zip#14]
+Condition : isnotnull(ca_address_sk#22)
+
+(39) Exchange
+Input [3]: [ca_address_sk#22, ca_city#13, ca_zip#14]
+Arguments: hashpartitioning(ca_address_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(40) Sort [codegen id : 4]
+Input [3]: [ca_address_sk#22, ca_city#13, ca_zip#14]
+Arguments: [ca_address_sk#22 ASC NULLS FIRST], false, 0
+
+(41) SortMergeJoin [codegen id : 5]
+Left keys [1]: [c_current_addr_sk#21]
+Right keys [1]: [ca_address_sk#22]
+Join type: Inner
+Join condition: None
+
+(42) Project [codegen id : 5]
+Output [3]: [c_customer_sk#12, ca_city#13, ca_zip#14]
+Input [5]: [c_customer_sk#12, c_current_addr_sk#21, ca_address_sk#22, ca_city#13, ca_zip#14]
+
+(43) Exchange
+Input [3]: [c_customer_sk#12, ca_city#13, ca_zip#14]
+Arguments: hashpartitioning(c_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(44) ObjectHashAggregate
+Input [3]: [c_customer_sk#12, ca_city#13, ca_zip#14]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#12, 42), 2120804, 16966432, 0, 0)]
+Aggregate Attributes [1]: [buf#23]
+Results [1]: [buf#24]
+
+(45) Exchange
+Input [1]: [buf#24]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+
+(46) ObjectHashAggregate
+Input [1]: [buf#24]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#12, 42), 2120804, 16966432, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#12, 42), 2120804, 16966432, 0, 0)#25]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#12, 42), 2120804, 16966432, 0, 0)#25 AS bloomFilter#26]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (51)
++- * Project (50)
+   +- * Filter (49)
+      +- * ColumnarToRow (48)
+         +- Scan parquet spark_catalog.default.date_dim (47)
+
+
+(47) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#9, d_year#27, d_qoy#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(44) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#21, d_qoy#22]
+(48) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#27, d_qoy#28]
 
-(45) Filter [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#21, d_qoy#22]
-Condition : ((((isnotnull(d_qoy#22) AND isnotnull(d_year#21)) AND (d_qoy#22 = 2)) AND (d_year#21 = 2001)) AND isnotnull(d_date_sk#7))
+(49) Filter [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#27, d_qoy#28]
+Condition : ((((isnotnull(d_qoy#28) AND isnotnull(d_year#27)) AND (d_qoy#28 = 2)) AND (d_year#27 = 2001)) AND isnotnull(d_date_sk#9))
 
-(46) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#21, d_qoy#22]
+(50) Project [codegen id : 1]
+Output [1]: [d_date_sk#9]
+Input [3]: [d_date_sk#9, d_year#27, d_qoy#28]
 
-(47) BroadcastExchange
-Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+(51) BroadcastExchange
+Input [1]: [d_date_sk#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45.sf100/simplified.txt
@@ -21,6 +21,34 @@ TakeOrderedAndProject [ca_zip,ca_city,sum(ws_sales_price)]
                                         Project [ws_item_sk,ws_bill_customer_sk,ws_sales_price]
                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                             Filter [ws_bill_customer_sk,ws_item_sk]
+                                              Subquery #2
+                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2120804, 16966432, 0, 0),bloomFilter,buf]
+                                                  Exchange #4
+                                                    ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                      Exchange [c_customer_sk] #5
+                                                        WholeStageCodegen (5)
+                                                          Project [c_customer_sk,ca_city,ca_zip]
+                                                            SortMergeJoin [c_current_addr_sk,ca_address_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (2)
+                                                                  Sort [c_current_addr_sk]
+                                                                    InputAdapter
+                                                                      Exchange [c_current_addr_sk] #6
+                                                                        WholeStageCodegen (1)
+                                                                          Filter [c_customer_sk,c_current_addr_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (4)
+                                                                  Sort [ca_address_sk]
+                                                                    InputAdapter
+                                                                      Exchange [ca_address_sk] #7
+                                                                        WholeStageCodegen (3)
+                                                                          Filter [ca_address_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city,ca_zip]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sales_price,ws_sold_date_sk]
@@ -35,7 +63,7 @@ TakeOrderedAndProject [ca_zip,ca_city,sum(ws_sales_price)]
                                             InputAdapter
                                               ReusedExchange [d_date_sk] #3
                                         InputAdapter
-                                          BroadcastExchange #4
+                                          BroadcastExchange #8
                                             WholeStageCodegen (2)
                                               Filter [i_item_sk]
                                                 ColumnarToRow
@@ -45,32 +73,9 @@ TakeOrderedAndProject [ca_zip,ca_city,sum(ws_sales_price)]
                           WholeStageCodegen (10)
                             Sort [c_customer_sk]
                               InputAdapter
-                                Exchange [c_customer_sk] #5
-                                  WholeStageCodegen (9)
-                                    Project [c_customer_sk,ca_city,ca_zip]
-                                      SortMergeJoin [c_current_addr_sk,ca_address_sk]
-                                        InputAdapter
-                                          WholeStageCodegen (6)
-                                            Sort [c_current_addr_sk]
-                                              InputAdapter
-                                                Exchange [c_current_addr_sk] #6
-                                                  WholeStageCodegen (5)
-                                                    Filter [c_customer_sk,c_current_addr_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
-                                        InputAdapter
-                                          WholeStageCodegen (8)
-                                            Sort [ca_address_sk]
-                                              InputAdapter
-                                                Exchange [ca_address_sk] #7
-                                                  WholeStageCodegen (7)
-                                                    Filter [ca_address_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city,ca_zip]
+                                ReusedExchange [c_customer_sk,ca_city,ca_zip] #5
                     InputAdapter
-                      BroadcastExchange #8
+                      BroadcastExchange #9
                         WholeStageCodegen (11)
                           Project [i_item_id]
                             Filter [i_item_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/explain.txt
@@ -123,84 +123,84 @@ Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ti
 
 (17) Filter [codegen id : 10]
 Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14]
-Condition : (((isnotnull(ss_store_sk#10) AND isnotnull(ss_hdemo_sk#8)) AND isnotnull(ss_addr_sk#9)) AND isnotnull(ss_customer_sk#7))
+Condition : (((((isnotnull(ss_store_sk#10) AND isnotnull(ss_hdemo_sk#8)) AND isnotnull(ss_addr_sk#9)) AND isnotnull(ss_customer_sk#7)) AND might_contain(Subquery scalar-subquery#16, [id=#17], xxhash64(ss_addr_sk#9, 42), false)) AND might_contain(Subquery scalar-subquery#18, [id=#19], xxhash64(ss_customer_sk#7, 42), false))
 
-(18) ReusedExchange [Reuses operator id: 52]
-Output [1]: [d_date_sk#16]
+(18) ReusedExchange [Reuses operator id: 63]
+Output [1]: [d_date_sk#20]
 
 (19) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#14]
-Right keys [1]: [d_date_sk#16]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 10]
 Output [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
-Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14, d_date_sk#16]
+Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14, d_date_sk#20]
 
 (21) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#17, s_city#18]
+Output [2]: [s_store_sk#21, s_city#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_city:string>
 
 (22) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#17, s_city#18]
+Input [2]: [s_store_sk#21, s_city#22]
 
 (23) Filter [codegen id : 8]
-Input [2]: [s_store_sk#17, s_city#18]
-Condition : (s_city#18 IN (Fairview,Midway) AND isnotnull(s_store_sk#17))
+Input [2]: [s_store_sk#21, s_city#22]
+Condition : (s_city#22 IN (Fairview,Midway) AND isnotnull(s_store_sk#21))
 
 (24) Project [codegen id : 8]
-Output [1]: [s_store_sk#17]
-Input [2]: [s_store_sk#17, s_city#18]
+Output [1]: [s_store_sk#21]
+Input [2]: [s_store_sk#21, s_city#22]
 
 (25) BroadcastExchange
-Input [1]: [s_store_sk#17]
+Input [1]: [s_store_sk#21]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#10]
-Right keys [1]: [s_store_sk#17]
+Right keys [1]: [s_store_sk#21]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
 Output [6]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
-Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, s_store_sk#17]
+Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, s_store_sk#21]
 
 (28) Scan parquet spark_catalog.default.household_demographics
-Output [3]: [hd_demo_sk#19, hd_dep_count#20, hd_vehicle_count#21]
+Output [3]: [hd_demo_sk#23, hd_dep_count#24, hd_vehicle_count#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [Or(EqualTo(hd_dep_count,4),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
 
 (29) ColumnarToRow [codegen id : 9]
-Input [3]: [hd_demo_sk#19, hd_dep_count#20, hd_vehicle_count#21]
+Input [3]: [hd_demo_sk#23, hd_dep_count#24, hd_vehicle_count#25]
 
 (30) Filter [codegen id : 9]
-Input [3]: [hd_demo_sk#19, hd_dep_count#20, hd_vehicle_count#21]
-Condition : (((hd_dep_count#20 = 4) OR (hd_vehicle_count#21 = 3)) AND isnotnull(hd_demo_sk#19))
+Input [3]: [hd_demo_sk#23, hd_dep_count#24, hd_vehicle_count#25]
+Condition : (((hd_dep_count#24 = 4) OR (hd_vehicle_count#25 = 3)) AND isnotnull(hd_demo_sk#23))
 
 (31) Project [codegen id : 9]
-Output [1]: [hd_demo_sk#19]
-Input [3]: [hd_demo_sk#19, hd_dep_count#20, hd_vehicle_count#21]
+Output [1]: [hd_demo_sk#23]
+Input [3]: [hd_demo_sk#23, hd_dep_count#24, hd_vehicle_count#25]
 
 (32) BroadcastExchange
-Input [1]: [hd_demo_sk#19]
+Input [1]: [hd_demo_sk#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_hdemo_sk#8]
-Right keys [1]: [hd_demo_sk#19]
+Right keys [1]: [hd_demo_sk#23]
 Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 10]
 Output [5]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
-Input [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, hd_demo_sk#19]
+Input [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, hd_demo_sk#23]
 
 (35) Exchange
 Input [5]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
@@ -211,88 +211,162 @@ Input [5]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#1
 Arguments: [ss_addr_sk#9 ASC NULLS FIRST], false, 0
 
 (37) ReusedExchange [Reuses operator id: 9]
-Output [2]: [ca_address_sk#22, ca_city#23]
+Output [2]: [ca_address_sk#26, ca_city#27]
 
 (38) Sort [codegen id : 13]
-Input [2]: [ca_address_sk#22, ca_city#23]
-Arguments: [ca_address_sk#22 ASC NULLS FIRST], false, 0
+Input [2]: [ca_address_sk#26, ca_city#27]
+Arguments: [ca_address_sk#26 ASC NULLS FIRST], false, 0
 
 (39) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ss_addr_sk#9]
-Right keys [1]: [ca_address_sk#22]
+Right keys [1]: [ca_address_sk#26]
 Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 14]
-Output [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_city#23]
-Input [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_address_sk#22, ca_city#23]
+Output [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_city#27]
+Input [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_address_sk#26, ca_city#27]
 
 (41) HashAggregate [codegen id : 14]
-Input [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_city#23]
-Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#23]
+Input [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_city#27]
+Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#27]
 Functions [2]: [partial_sum(UnscaledValue(ss_coupon_amt#12)), partial_sum(UnscaledValue(ss_net_profit#13))]
-Aggregate Attributes [2]: [sum#24, sum#25]
-Results [6]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#23, sum#26, sum#27]
+Aggregate Attributes [2]: [sum#28, sum#29]
+Results [6]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#27, sum#30, sum#31]
 
 (42) HashAggregate [codegen id : 14]
-Input [6]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#23, sum#26, sum#27]
-Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#23]
+Input [6]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#27, sum#30, sum#31]
+Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#27]
 Functions [2]: [sum(UnscaledValue(ss_coupon_amt#12)), sum(UnscaledValue(ss_net_profit#13))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ss_coupon_amt#12))#28, sum(UnscaledValue(ss_net_profit#13))#29]
-Results [5]: [ss_ticket_number#11, ss_customer_sk#7, ca_city#23 AS bought_city#30, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#12))#28,17,2) AS amt#31, MakeDecimal(sum(UnscaledValue(ss_net_profit#13))#29,17,2) AS profit#32]
+Aggregate Attributes [2]: [sum(UnscaledValue(ss_coupon_amt#12))#32, sum(UnscaledValue(ss_net_profit#13))#33]
+Results [5]: [ss_ticket_number#11, ss_customer_sk#7, ca_city#27 AS bought_city#34, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#12))#32,17,2) AS amt#35, MakeDecimal(sum(UnscaledValue(ss_net_profit#13))#33,17,2) AS profit#36]
 
 (43) Exchange
-Input [5]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#30, amt#31, profit#32]
+Input [5]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#34, amt#35, profit#36]
 Arguments: hashpartitioning(ss_customer_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (44) Sort [codegen id : 15]
-Input [5]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#30, amt#31, profit#32]
+Input [5]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#34, amt#35, profit#36]
 Arguments: [ss_customer_sk#7 ASC NULLS FIRST], false, 0
 
 (45) SortMergeJoin [codegen id : 16]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#7]
 Join type: Inner
-Join condition: NOT (ca_city#6 = bought_city#30)
+Join condition: NOT (ca_city#6 = bought_city#34)
 
 (46) Project [codegen id : 16]
-Output [7]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#30, ss_ticket_number#11, amt#31, profit#32]
-Input [9]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6, ss_ticket_number#11, ss_customer_sk#7, bought_city#30, amt#31, profit#32]
+Output [7]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, amt#35, profit#36]
+Input [9]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6, ss_ticket_number#11, ss_customer_sk#7, bought_city#34, amt#35, profit#36]
 
 (47) TakeOrderedAndProject
-Input [7]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#30, ss_ticket_number#11, amt#31, profit#32]
-Arguments: 100, [c_last_name#4 ASC NULLS FIRST, c_first_name#3 ASC NULLS FIRST, ca_city#6 ASC NULLS FIRST, bought_city#30 ASC NULLS FIRST, ss_ticket_number#11 ASC NULLS FIRST], [c_last_name#4, c_first_name#3, ca_city#6, bought_city#30, ss_ticket_number#11, amt#31, profit#32]
+Input [7]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, amt#35, profit#36]
+Arguments: 100, [c_last_name#4 ASC NULLS FIRST, c_first_name#3 ASC NULLS FIRST, ca_city#6 ASC NULLS FIRST, bought_city#34 ASC NULLS FIRST, ss_ticket_number#11 ASC NULLS FIRST], [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, amt#35, profit#36]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#15
-BroadcastExchange (52)
-+- * Project (51)
-   +- * Filter (50)
-      +- * ColumnarToRow (49)
-         +- Scan parquet spark_catalog.default.date_dim (48)
+Subquery:1 Hosting operator id = 17 Hosting Expression = Subquery scalar-subquery#16, [id=#17]
+ObjectHashAggregate (54)
++- Exchange (53)
+   +- ObjectHashAggregate (52)
+      +- Exchange (51)
+         +- * Filter (50)
+            +- * ColumnarToRow (49)
+               +- Scan parquet spark_catalog.default.customer_address (48)
 
 
-(48) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#16, d_year#33, d_dow#34]
+(48) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#26, ca_city#27]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
+ReadSchema: struct<ca_address_sk:int,ca_city:string>
+
+(49) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#26, ca_city#27]
+
+(50) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#26, ca_city#27]
+Condition : (isnotnull(ca_address_sk#26) AND isnotnull(ca_city#27))
+
+(51) Exchange
+Input [2]: [ca_address_sk#26, ca_city#27]
+Arguments: hashpartitioning(ca_address_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(52) ObjectHashAggregate
+Input [2]: [ca_address_sk#26, ca_city#27]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#26, 42), 969817, 7758536, 0, 0)]
+Aggregate Attributes [1]: [buf#37]
+Results [1]: [buf#38]
+
+(53) Exchange
+Input [1]: [buf#38]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) ObjectHashAggregate
+Input [1]: [buf#38]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#26, 42), 969817, 7758536, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#26, 42), 969817, 7758536, 0, 0)#39]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#26, 42), 969817, 7758536, 0, 0)#39 AS bloomFilter#40]
+
+Subquery:2 Hosting operator id = 17 Hosting Expression = Subquery scalar-subquery#18, [id=#19]
+ObjectHashAggregate (58)
++- Exchange (57)
+   +- ObjectHashAggregate (56)
+      +- ReusedExchange (55)
+
+
+(55) ReusedExchange [Reuses operator id: 13]
+Output [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+
+(56) ObjectHashAggregate
+Input [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#1, 42), 2120802, 16966416, 0, 0)]
+Aggregate Attributes [1]: [buf#41]
+Results [1]: [buf#42]
+
+(57) Exchange
+Input [1]: [buf#42]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+
+(58) ObjectHashAggregate
+Input [1]: [buf#42]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#1, 42), 2120802, 16966416, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#1, 42), 2120802, 16966416, 0, 0)#43]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#1, 42), 2120802, 16966416, 0, 0)#43 AS bloomFilter#44]
+
+Subquery:3 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#15
+BroadcastExchange (63)
++- * Project (62)
+   +- * Filter (61)
+      +- * ColumnarToRow (60)
+         +- Scan parquet spark_catalog.default.date_dim (59)
+
+
+(59) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#20, d_year#45, d_dow#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_dow, [0,6]), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
-(49) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
+(60) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#20, d_year#45, d_dow#46]
 
-(50) Filter [codegen id : 1]
-Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
-Condition : ((d_dow#34 IN (6,0) AND d_year#33 IN (1999,2000,2001)) AND isnotnull(d_date_sk#16))
+(61) Filter [codegen id : 1]
+Input [3]: [d_date_sk#20, d_year#45, d_dow#46]
+Condition : ((d_dow#46 IN (6,0) AND d_year#45 IN (1999,2000,2001)) AND isnotnull(d_date_sk#20))
 
-(51) Project [codegen id : 1]
-Output [1]: [d_date_sk#16]
-Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
+(62) Project [codegen id : 1]
+Output [1]: [d_date_sk#20]
+Input [3]: [d_date_sk#20, d_year#45, d_dow#46]
 
-(52) BroadcastExchange
-Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+(63) BroadcastExchange
+Input [1]: [d_date_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/simplified.txt
@@ -53,6 +53,21 @@ TakeOrderedAndProject [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_nu
                                                 Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                     Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
+                                                      Subquery #2
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 969817, 7758536, 0, 0),bloomFilter,buf]
+                                                          Exchange #7
+                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                              Exchange [ca_address_sk] #8
+                                                                WholeStageCodegen (1)
+                                                                  Filter [ca_address_sk,ca_city]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
+                                                      Subquery #3
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2120802, 16966416, 0, 0),bloomFilter,buf]
+                                                          Exchange #9
+                                                            ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                              ReusedExchange [c_customer_sk,c_first_name,c_last_name,ca_city] #1
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit,ss_sold_date_sk]
@@ -67,7 +82,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_nu
                                                     InputAdapter
                                                       ReusedExchange [d_date_sk] #6
                                                 InputAdapter
-                                                  BroadcastExchange #7
+                                                  BroadcastExchange #10
                                                     WholeStageCodegen (8)
                                                       Project [s_store_sk]
                                                         Filter [s_city,s_store_sk]
@@ -75,7 +90,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_nu
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.store [s_store_sk,s_city]
                                             InputAdapter
-                                              BroadcastExchange #8
+                                              BroadcastExchange #11
                                                 WholeStageCodegen (9)
                                                   Project [hd_demo_sk]
                                                     Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
-TakeOrderedAndProject (52)
-+- * Project (51)
-   +- * SortMergeJoin Inner (50)
-      :- * Project (43)
-      :  +- * SortMergeJoin Inner (42)
+TakeOrderedAndProject (89)
++- * Project (88)
+   +- * SortMergeJoin Inner (87)
+      :- * Project (62)
+      :  +- * SortMergeJoin Inner (61)
       :     :- * Sort (33)
       :     :  +- Exchange (32)
       :     :     +- * Project (31)
@@ -37,20 +37,57 @@ TakeOrderedAndProject (52)
       :     :                                               +- * Filter (17)
       :     :                                                  +- * ColumnarToRow (16)
       :     :                                                     +- Scan parquet spark_catalog.default.item (15)
-      :     +- * Sort (41)
-      :        +- Exchange (40)
-      :           +- * Project (39)
-      :              +- Window (38)
-      :                 +- * Sort (37)
-      :                    +- Exchange (36)
-      :                       +- * HashAggregate (35)
-      :                          +- ReusedExchange (34)
-      +- * Sort (49)
-         +- Exchange (48)
-            +- * Project (47)
-               +- Window (46)
-                  +- * Sort (45)
-                     +- ReusedExchange (44)
+      :     +- * Sort (60)
+      :        +- Exchange (59)
+      :           +- * Project (58)
+      :              +- Window (57)
+      :                 +- * Sort (56)
+      :                    +- Exchange (55)
+      :                       +- * HashAggregate (54)
+      :                          +- Exchange (53)
+      :                             +- * HashAggregate (52)
+      :                                +- * Project (51)
+      :                                   +- * SortMergeJoin Inner (50)
+      :                                      :- * Sort (47)
+      :                                      :  +- Exchange (46)
+      :                                      :     +- * Project (45)
+      :                                      :        +- * BroadcastHashJoin Inner BuildRight (44)
+      :                                      :           :- * Project (39)
+      :                                      :           :  +- * BroadcastHashJoin Inner BuildRight (38)
+      :                                      :           :     :- * Filter (36)
+      :                                      :           :     :  +- * ColumnarToRow (35)
+      :                                      :           :     :     +- Scan parquet spark_catalog.default.store_sales (34)
+      :                                      :           :     +- ReusedExchange (37)
+      :                                      :           +- BroadcastExchange (43)
+      :                                      :              +- * Filter (42)
+      :                                      :                 +- * ColumnarToRow (41)
+      :                                      :                    +- Scan parquet spark_catalog.default.store (40)
+      :                                      +- * Sort (49)
+      :                                         +- ReusedExchange (48)
+      +- * Sort (86)
+         +- Exchange (85)
+            +- * Project (84)
+               +- Window (83)
+                  +- * Sort (82)
+                     +- Exchange (81)
+                        +- * HashAggregate (80)
+                           +- Exchange (79)
+                              +- * HashAggregate (78)
+                                 +- * Project (77)
+                                    +- * SortMergeJoin Inner (76)
+                                       :- * Sort (73)
+                                       :  +- Exchange (72)
+                                       :     +- * Project (71)
+                                       :        +- * BroadcastHashJoin Inner BuildRight (70)
+                                       :           :- * Project (68)
+                                       :           :  +- * BroadcastHashJoin Inner BuildRight (67)
+                                       :           :     :- * Filter (65)
+                                       :           :     :  +- * ColumnarToRow (64)
+                                       :           :     :     +- Scan parquet spark_catalog.default.store_sales (63)
+                                       :           :     +- ReusedExchange (66)
+                                       :           +- ReusedExchange (69)
+                                       +- * Sort (75)
+                                          +- ReusedExchange (74)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -66,249 +103,521 @@ Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
 (3) Filter [codegen id : 3]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
-Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
+Condition : ((isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(ss_item_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 56]
-Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(4) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#8, d_year#9, d_moy#10]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
-Output [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8]
-Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_year#7, d_moy#8]
+Output [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#9, d_moy#10]
+Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#8, d_year#9, d_moy#10]
 
 (7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
+Output [3]: [s_store_sk#11, s_store_name#12, s_company_name#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_company_name)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
+Input [3]: [s_store_sk#11, s_store_name#12, s_company_name#13]
 
 (9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Condition : ((isnotnull(s_store_sk#9) AND isnotnull(s_store_name#10)) AND isnotnull(s_company_name#11))
+Input [3]: [s_store_sk#11, s_store_name#12, s_company_name#13]
+Condition : ((((isnotnull(s_store_sk#11) AND isnotnull(s_store_name#12)) AND isnotnull(s_company_name#13)) AND true) AND true)
 
 (10) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
+Input [3]: [s_store_sk#11, s_store_name#12, s_company_name#13]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#9]
+Right keys [1]: [s_store_sk#11]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, s_store_sk#9, s_store_name#10, s_company_name#11]
+Output [6]: [ss_item_sk#1, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
+Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#9, d_moy#10, s_store_sk#11, s_store_name#12, s_company_name#13]
 
 (13) Exchange
-Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
+Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
 Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
+Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#12, i_brand#13, i_category#14]
+Output [3]: [i_item_sk#14, i_brand#15, i_category#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
 
 (16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
 
 (17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Condition : ((isnotnull(i_item_sk#12) AND isnotnull(i_category#14)) AND isnotnull(i_brand#13))
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Condition : ((((isnotnull(i_item_sk#14) AND isnotnull(i_category#16)) AND isnotnull(i_brand#15)) AND true) AND true)
 
 (18) Exchange
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Arguments: hashpartitioning(i_item_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Arguments: [i_item_sk#14 ASC NULLS FIRST], false, 0
 
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#14]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
-Output [7]: [i_brand#13, i_category#14, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Input [9]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11, i_item_sk#12, i_brand#13, i_category#14]
+Output [7]: [i_brand#15, i_category#16, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
+Input [9]: [ss_item_sk#1, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13, i_item_sk#14, i_brand#15, i_category#16]
 
 (22) HashAggregate [codegen id : 7]
-Input [7]: [i_brand#13, i_category#14, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Keys [6]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8]
+Input [7]: [i_brand#15, i_category#16, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
+Keys [6]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10]
 Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
-Aggregate Attributes [1]: [sum#15]
-Results [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
+Aggregate Attributes [1]: [sum#17]
+Results [7]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum#18]
 
 (23) Exchange
-Input [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum#18]
+Arguments: hashpartitioning(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) HashAggregate [codegen id : 8]
-Input [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
-Keys [6]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8]
+Input [7]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum#18]
+Keys [6]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#17]
-Results [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#19]
+Results [8]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#19,17,2) AS sum_sales#20, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#19,17,2) AS _w0#21]
 
 (25) Exchange
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [8]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21]
+Arguments: hashpartitioning(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (26) Sort [codegen id : 9]
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#13 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST, s_company_name#11 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], false, 0
+Input [8]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21]
+Arguments: [i_category#16 ASC NULLS FIRST, i_brand#15 ASC NULLS FIRST, s_store_name#12 ASC NULLS FIRST, s_company_name#13 ASC NULLS FIRST, d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST], false, 0
 
 (27) Window
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: [rank(d_year#7, d_moy#8) windowspecdefinition(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#20], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11], [d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST]
+Input [8]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21]
+Arguments: [rank(d_year#9, d_moy#10) windowspecdefinition(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#22], [i_category#16, i_brand#15, s_store_name#12, s_company_name#13], [d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST]
 
 (28) Filter [codegen id : 10]
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
-Condition : (isnotnull(d_year#7) AND (d_year#7 = 1999))
+Input [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21, rn#22]
+Condition : (isnotnull(d_year#9) AND (d_year#9 = 1999))
 
 (29) Window
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
-Arguments: [avg(_w0#19) windowspecdefinition(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#21], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7]
+Input [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21, rn#22]
+Arguments: [avg(_w0#21) windowspecdefinition(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#23], [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9]
 
 (30) Filter [codegen id : 11]
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
-Condition : ((isnotnull(avg_monthly_sales#21) AND (avg_monthly_sales#21 > 0.000000)) AND CASE WHEN (avg_monthly_sales#21 > 0.000000) THEN ((abs((sum_sales#18 - avg_monthly_sales#21)) / avg_monthly_sales#21) > 0.1000000000000000) END)
+Input [10]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21, rn#22, avg_monthly_sales#23]
+Condition : ((isnotnull(avg_monthly_sales#23) AND (avg_monthly_sales#23 > 0.000000)) AND CASE WHEN (avg_monthly_sales#23 > 0.000000) THEN ((abs((sum_sales#20 - avg_monthly_sales#23)) / avg_monthly_sales#23) > 0.1000000000000000) END)
 
 (31) Project [codegen id : 11]
-Output [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
+Output [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22]
+Input [10]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21, rn#22, avg_monthly_sales#23]
 
 (32) Exchange
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22]
+Arguments: hashpartitioning(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, rn#22, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (33) Sort [codegen id : 12]
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#13 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST, s_company_name#11 ASC NULLS FIRST, rn#20 ASC NULLS FIRST], false, 0
+Input [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22]
+Arguments: [i_category#16 ASC NULLS FIRST, i_brand#15 ASC NULLS FIRST, s_store_name#12 ASC NULLS FIRST, s_company_name#13 ASC NULLS FIRST, rn#22 ASC NULLS FIRST], false, 0
 
-(34) ReusedExchange [Reuses operator id: 23]
-Output [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum#28]
+(34) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, ss_sold_date_sk#27]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#27), dynamicpruningexpression(ss_sold_date_sk#27 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(35) HashAggregate [codegen id : 20]
-Input [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum#28]
-Keys [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27]
-Functions [1]: [sum(UnscaledValue(ss_sales_price#29))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#29))#17]
-Results [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, MakeDecimal(sum(UnscaledValue(ss_sales_price#29))#17,17,2) AS sum_sales#18]
+(35) ColumnarToRow [codegen id : 15]
+Input [4]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, ss_sold_date_sk#27]
 
-(36) Exchange
-Input [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum_sales#18]
-Arguments: hashpartitioning(i_category#22, i_brand#23, s_store_name#24, s_company_name#25, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(36) Filter [codegen id : 15]
+Input [4]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, ss_sold_date_sk#27]
+Condition : ((isnotnull(ss_item_sk#24) AND isnotnull(ss_store_sk#25)) AND might_contain(Subquery scalar-subquery#28, [id=#29], xxhash64(ss_item_sk#24, 42), false))
 
-(37) Sort [codegen id : 21]
-Input [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum_sales#18]
-Arguments: [i_category#22 ASC NULLS FIRST, i_brand#23 ASC NULLS FIRST, s_store_name#24 ASC NULLS FIRST, s_company_name#25 ASC NULLS FIRST, d_year#26 ASC NULLS FIRST, d_moy#27 ASC NULLS FIRST], false, 0
+(37) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#30, d_year#31, d_moy#32]
 
-(38) Window
-Input [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum_sales#18]
-Arguments: [rank(d_year#26, d_moy#27) windowspecdefinition(i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26 ASC NULLS FIRST, d_moy#27 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#30], [i_category#22, i_brand#23, s_store_name#24, s_company_name#25], [d_year#26 ASC NULLS FIRST, d_moy#27 ASC NULLS FIRST]
-
-(39) Project [codegen id : 22]
-Output [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#18 AS sum_sales#31, rn#30]
-Input [8]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum_sales#18, rn#30]
-
-(40) Exchange
-Input [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#31, rn#30]
-Arguments: hashpartitioning(i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#30 + 1), 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(41) Sort [codegen id : 23]
-Input [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#31, rn#30]
-Arguments: [i_category#22 ASC NULLS FIRST, i_brand#23 ASC NULLS FIRST, s_store_name#24 ASC NULLS FIRST, s_company_name#25 ASC NULLS FIRST, (rn#30 + 1) ASC NULLS FIRST], false, 0
-
-(42) SortMergeJoin [codegen id : 24]
-Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
-Right keys [5]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#30 + 1)]
+(38) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ss_sold_date_sk#27]
+Right keys [1]: [d_date_sk#30]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 24]
-Output [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#31]
-Input [15]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#31, rn#30]
+(39) Project [codegen id : 15]
+Output [5]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, d_year#31, d_moy#32]
+Input [7]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, ss_sold_date_sk#27, d_date_sk#30, d_year#31, d_moy#32]
 
-(44) ReusedExchange [Reuses operator id: 36]
-Output [7]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#18]
+(40) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#33, s_store_name#34, s_company_name#35]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_company_name)]
+ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
 
-(45) Sort [codegen id : 33]
-Input [7]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#18]
-Arguments: [i_category#32 ASC NULLS FIRST, i_brand#33 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, d_year#36 ASC NULLS FIRST, d_moy#37 ASC NULLS FIRST], false, 0
+(41) ColumnarToRow [codegen id : 14]
+Input [3]: [s_store_sk#33, s_store_name#34, s_company_name#35]
 
-(46) Window
-Input [7]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#18]
-Arguments: [rank(d_year#36, d_moy#37) windowspecdefinition(i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36 ASC NULLS FIRST, d_moy#37 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#38], [i_category#32, i_brand#33, s_store_name#34, s_company_name#35], [d_year#36 ASC NULLS FIRST, d_moy#37 ASC NULLS FIRST]
+(42) Filter [codegen id : 14]
+Input [3]: [s_store_sk#33, s_store_name#34, s_company_name#35]
+Condition : ((isnotnull(s_store_sk#33) AND isnotnull(s_store_name#34)) AND isnotnull(s_company_name#35))
 
-(47) Project [codegen id : 34]
-Output [6]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#18 AS sum_sales#39, rn#38]
-Input [8]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#18, rn#38]
+(43) BroadcastExchange
+Input [3]: [s_store_sk#33, s_store_name#34, s_company_name#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(48) Exchange
-Input [6]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#39, rn#38]
-Arguments: hashpartitioning(i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#38 - 1), 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(49) Sort [codegen id : 35]
-Input [6]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#39, rn#38]
-Arguments: [i_category#32 ASC NULLS FIRST, i_brand#33 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, (rn#38 - 1) ASC NULLS FIRST], false, 0
-
-(50) SortMergeJoin [codegen id : 36]
-Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
-Right keys [5]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#38 - 1)]
+(44) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ss_store_sk#25]
+Right keys [1]: [s_store_sk#33]
 Join type: Inner
 Join condition: None
 
-(51) Project [codegen id : 36]
-Output [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, sum_sales#31 AS psum#40, sum_sales#39 AS nsum#41]
-Input [16]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#31, i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#39, rn#38]
+(45) Project [codegen id : 15]
+Output [6]: [ss_item_sk#24, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Input [8]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, d_year#31, d_moy#32, s_store_sk#33, s_store_name#34, s_company_name#35]
 
-(52) TakeOrderedAndProject
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
-Arguments: 100, [(sum_sales#18 - avg_monthly_sales#21) ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
+(46) Exchange
+Input [6]: [ss_item_sk#24, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Arguments: hashpartitioning(ss_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(47) Sort [codegen id : 16]
+Input [6]: [ss_item_sk#24, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Arguments: [ss_item_sk#24 ASC NULLS FIRST], false, 0
+
+(48) ReusedExchange [Reuses operator id: 104]
+Output [3]: [i_item_sk#36, i_brand#37, i_category#38]
+
+(49) Sort [codegen id : 18]
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Arguments: [i_item_sk#36 ASC NULLS FIRST], false, 0
+
+(50) SortMergeJoin [codegen id : 19]
+Left keys [1]: [ss_item_sk#24]
+Right keys [1]: [i_item_sk#36]
+Join type: Inner
+Join condition: None
+
+(51) Project [codegen id : 19]
+Output [7]: [i_brand#37, i_category#38, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Input [9]: [ss_item_sk#24, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35, i_item_sk#36, i_brand#37, i_category#38]
+
+(52) HashAggregate [codegen id : 19]
+Input [7]: [i_brand#37, i_category#38, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Keys [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#26))]
+Aggregate Attributes [1]: [sum#39]
+Results [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum#40]
+
+(53) Exchange
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum#40]
+Arguments: hashpartitioning(i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) HashAggregate [codegen id : 20]
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum#40]
+Keys [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#26))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#26))#19]
+Results [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, MakeDecimal(sum(UnscaledValue(ss_sales_price#26))#19,17,2) AS sum_sales#20]
+
+(55) Exchange
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum_sales#20]
+Arguments: hashpartitioning(i_category#38, i_brand#37, s_store_name#34, s_company_name#35, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(56) Sort [codegen id : 21]
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum_sales#20]
+Arguments: [i_category#38 ASC NULLS FIRST, i_brand#37 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, d_year#31 ASC NULLS FIRST, d_moy#32 ASC NULLS FIRST], false, 0
+
+(57) Window
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum_sales#20]
+Arguments: [rank(d_year#31, d_moy#32) windowspecdefinition(i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31 ASC NULLS FIRST, d_moy#32 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#41], [i_category#38, i_brand#37, s_store_name#34, s_company_name#35], [d_year#31 ASC NULLS FIRST, d_moy#32 ASC NULLS FIRST]
+
+(58) Project [codegen id : 22]
+Output [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, sum_sales#20 AS sum_sales#42, rn#41]
+Input [8]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum_sales#20, rn#41]
+
+(59) Exchange
+Input [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, sum_sales#42, rn#41]
+Arguments: hashpartitioning(i_category#38, i_brand#37, s_store_name#34, s_company_name#35, (rn#41 + 1), 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(60) Sort [codegen id : 23]
+Input [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, sum_sales#42, rn#41]
+Arguments: [i_category#38 ASC NULLS FIRST, i_brand#37 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, (rn#41 + 1) ASC NULLS FIRST], false, 0
+
+(61) SortMergeJoin [codegen id : 24]
+Left keys [5]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, rn#22]
+Right keys [5]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, (rn#41 + 1)]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 24]
+Output [10]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22, sum_sales#42]
+Input [15]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22, i_category#38, i_brand#37, s_store_name#34, s_company_name#35, sum_sales#42, rn#41]
+
+(63) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, ss_sold_date_sk#46]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#46), dynamicpruningexpression(ss_sold_date_sk#46 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
+
+(64) ColumnarToRow [codegen id : 27]
+Input [4]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, ss_sold_date_sk#46]
+
+(65) Filter [codegen id : 27]
+Input [4]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, ss_sold_date_sk#46]
+Condition : ((isnotnull(ss_item_sk#43) AND isnotnull(ss_store_sk#44)) AND might_contain(ReusedSubquery Subquery scalar-subquery#6, [id=#7], xxhash64(ss_item_sk#43, 42), false))
+
+(66) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#47, d_year#48, d_moy#49]
+
+(67) BroadcastHashJoin [codegen id : 27]
+Left keys [1]: [ss_sold_date_sk#46]
+Right keys [1]: [d_date_sk#47]
+Join type: Inner
+Join condition: None
+
+(68) Project [codegen id : 27]
+Output [5]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, d_year#48, d_moy#49]
+Input [7]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, ss_sold_date_sk#46, d_date_sk#47, d_year#48, d_moy#49]
+
+(69) ReusedExchange [Reuses operator id: 43]
+Output [3]: [s_store_sk#50, s_store_name#51, s_company_name#52]
+
+(70) BroadcastHashJoin [codegen id : 27]
+Left keys [1]: [ss_store_sk#44]
+Right keys [1]: [s_store_sk#50]
+Join type: Inner
+Join condition: None
+
+(71) Project [codegen id : 27]
+Output [6]: [ss_item_sk#43, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Input [8]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, d_year#48, d_moy#49, s_store_sk#50, s_store_name#51, s_company_name#52]
+
+(72) Exchange
+Input [6]: [ss_item_sk#43, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Arguments: hashpartitioning(ss_item_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(73) Sort [codegen id : 28]
+Input [6]: [ss_item_sk#43, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Arguments: [ss_item_sk#43 ASC NULLS FIRST], false, 0
+
+(74) ReusedExchange [Reuses operator id: 104]
+Output [3]: [i_item_sk#53, i_brand#54, i_category#55]
+
+(75) Sort [codegen id : 30]
+Input [3]: [i_item_sk#53, i_brand#54, i_category#55]
+Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
+
+(76) SortMergeJoin [codegen id : 31]
+Left keys [1]: [ss_item_sk#43]
+Right keys [1]: [i_item_sk#53]
+Join type: Inner
+Join condition: None
+
+(77) Project [codegen id : 31]
+Output [7]: [i_brand#54, i_category#55, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Input [9]: [ss_item_sk#43, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52, i_item_sk#53, i_brand#54, i_category#55]
+
+(78) HashAggregate [codegen id : 31]
+Input [7]: [i_brand#54, i_category#55, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Keys [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#45))]
+Aggregate Attributes [1]: [sum#56]
+Results [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum#57]
+
+(79) Exchange
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum#57]
+Arguments: hashpartitioning(i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(80) HashAggregate [codegen id : 32]
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum#57]
+Keys [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#45))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#45))#19]
+Results [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, MakeDecimal(sum(UnscaledValue(ss_sales_price#45))#19,17,2) AS sum_sales#20]
+
+(81) Exchange
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum_sales#20]
+Arguments: hashpartitioning(i_category#55, i_brand#54, s_store_name#51, s_company_name#52, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(82) Sort [codegen id : 33]
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum_sales#20]
+Arguments: [i_category#55 ASC NULLS FIRST, i_brand#54 ASC NULLS FIRST, s_store_name#51 ASC NULLS FIRST, s_company_name#52 ASC NULLS FIRST, d_year#48 ASC NULLS FIRST, d_moy#49 ASC NULLS FIRST], false, 0
+
+(83) Window
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum_sales#20]
+Arguments: [rank(d_year#48, d_moy#49) windowspecdefinition(i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48 ASC NULLS FIRST, d_moy#49 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#58], [i_category#55, i_brand#54, s_store_name#51, s_company_name#52], [d_year#48 ASC NULLS FIRST, d_moy#49 ASC NULLS FIRST]
+
+(84) Project [codegen id : 34]
+Output [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, sum_sales#20 AS sum_sales#59, rn#58]
+Input [8]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum_sales#20, rn#58]
+
+(85) Exchange
+Input [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, sum_sales#59, rn#58]
+Arguments: hashpartitioning(i_category#55, i_brand#54, s_store_name#51, s_company_name#52, (rn#58 - 1), 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(86) Sort [codegen id : 35]
+Input [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, sum_sales#59, rn#58]
+Arguments: [i_category#55 ASC NULLS FIRST, i_brand#54 ASC NULLS FIRST, s_store_name#51 ASC NULLS FIRST, s_company_name#52 ASC NULLS FIRST, (rn#58 - 1) ASC NULLS FIRST], false, 0
+
+(87) SortMergeJoin [codegen id : 36]
+Left keys [5]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, rn#22]
+Right keys [5]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, (rn#58 - 1)]
+Join type: Inner
+Join condition: None
+
+(88) Project [codegen id : 36]
+Output [10]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, avg_monthly_sales#23, sum_sales#20, sum_sales#42 AS psum#60, sum_sales#59 AS nsum#61]
+Input [16]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22, sum_sales#42, i_category#55, i_brand#54, s_store_name#51, s_company_name#52, sum_sales#59, rn#58]
+
+(89) TakeOrderedAndProject
+Input [10]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, avg_monthly_sales#23, sum_sales#20, psum#60, nsum#61]
+Arguments: 100, [(sum_sales#20 - avg_monthly_sales#23) ASC NULLS FIRST, s_store_name#12 ASC NULLS FIRST], [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, avg_monthly_sales#23, sum_sales#20, psum#60, nsum#61]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (56)
-+- * Filter (55)
-   +- * ColumnarToRow (54)
-      +- Scan parquet spark_catalog.default.date_dim (53)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (96)
++- Exchange (95)
+   +- ObjectHashAggregate (94)
+      +- Exchange (93)
+         +- * Filter (92)
+            +- * ColumnarToRow (91)
+               +- Scan parquet spark_catalog.default.item (90)
 
 
-(53) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(90) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
+
+(91) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+
+(92) Filter [codegen id : 1]
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Condition : ((isnotnull(i_item_sk#14) AND isnotnull(i_category#16)) AND isnotnull(i_brand#15))
+
+(93) Exchange
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Arguments: hashpartitioning(i_item_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(94) ObjectHashAggregate
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#14, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [buf#62]
+Results [1]: [buf#63]
+
+(95) Exchange
+Input [1]: [buf#63]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(96) ObjectHashAggregate
+Input [1]: [buf#63]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 203010, 1624080, 0, 0)#64]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 203010, 1624080, 0, 0)#64 AS bloomFilter#65]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
+BroadcastExchange (100)
++- * Filter (99)
+   +- * ColumnarToRow (98)
+      +- Scan parquet spark_catalog.default.date_dim (97)
+
+
+(97) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#8, d_year#9, d_moy#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(Or(EqualTo(d_year,1999),And(EqualTo(d_year,1998),EqualTo(d_moy,12))),And(EqualTo(d_year,2000),EqualTo(d_moy,1))), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(54) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(98) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
 
-(55) Filter [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR ((d_year#7 = 2000) AND (d_moy#8 = 1))) AND isnotnull(d_date_sk#6))
+(99) Filter [codegen id : 1]
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
+Condition : ((((d_year#9 = 1999) OR ((d_year#9 = 1998) AND (d_moy#10 = 12))) OR ((d_year#9 = 2000) AND (d_moy#10 = 1))) AND isnotnull(d_date_sk#8))
 
-(56) BroadcastExchange
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
+(100) BroadcastExchange
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
+
+Subquery:3 Hosting operator id = 36 Hosting Expression = Subquery scalar-subquery#28, [id=#29]
+ObjectHashAggregate (107)
++- Exchange (106)
+   +- ObjectHashAggregate (105)
+      +- Exchange (104)
+         +- * Filter (103)
+            +- * ColumnarToRow (102)
+               +- Scan parquet spark_catalog.default.item (101)
+
+
+(101) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
+
+(102) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+
+(103) Filter [codegen id : 1]
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Condition : ((isnotnull(i_item_sk#36) AND isnotnull(i_category#38)) AND isnotnull(i_brand#37))
+
+(104) Exchange
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Arguments: hashpartitioning(i_item_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+
+(105) ObjectHashAggregate
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#36, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [buf#66]
+Results [1]: [buf#67]
+
+(106) Exchange
+Input [1]: [buf#67]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+
+(107) ObjectHashAggregate
+Input [1]: [buf#67]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#36, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#36, 42), 203010, 1624080, 0, 0)#68]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#36, 42), 203010, 1624080, 0, 0)#68 AS bloomFilter#69]
+
+Subquery:4 Hosting operator id = 34 Hosting Expression = ss_sold_date_sk#27 IN dynamicpruning#5
+
+Subquery:5 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#6, [id=#7]
+
+Subquery:6 Hosting operator id = 63 Hosting Expression = ss_sold_date_sk#46 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/simplified.txt
@@ -43,6 +43,16 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_bra
                                                                                     Project [ss_item_sk,ss_store_sk,ss_sales_price,d_year,d_moy]
                                                                                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                                         Filter [ss_item_sk,ss_store_sk]
+                                                                                          Subquery #2
+                                                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 203010, 1624080, 0, 0),bloomFilter,buf]
+                                                                                              Exchange #6
+                                                                                                ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                                  Exchange [i_item_sk] #7
+                                                                                                    WholeStageCodegen (1)
+                                                                                                      Filter [i_item_sk,i_category,i_brand]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
                                                                                           ColumnarToRow
                                                                                             InputAdapter
                                                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
@@ -56,7 +66,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_bra
                                                                                         InputAdapter
                                                                                           ReusedExchange [d_date_sk,d_year,d_moy] #5
                                                                                     InputAdapter
-                                                                                      BroadcastExchange #6
+                                                                                      BroadcastExchange #8
                                                                                         WholeStageCodegen (2)
                                                                                           Filter [s_store_sk,s_store_name,s_company_name]
                                                                                             ColumnarToRow
@@ -66,7 +76,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_bra
                                                                       WholeStageCodegen (6)
                                                                         Sort [i_item_sk]
                                                                           InputAdapter
-                                                                            Exchange [i_item_sk] #7
+                                                                            Exchange [i_item_sk] #9
                                                                               WholeStageCodegen (5)
                                                                                 Filter [i_item_sk,i_category,i_brand]
                                                                                   ColumnarToRow
@@ -76,7 +86,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_bra
                   WholeStageCodegen (23)
                     Sort [i_category,i_brand,s_store_name,s_company_name,rn]
                       InputAdapter
-                        Exchange [i_category,i_brand,s_store_name,s_company_name,rn] #8
+                        Exchange [i_category,i_brand,s_store_name,s_company_name,rn] #10
                           WholeStageCodegen (22)
                             Project [i_category,i_brand,s_store_name,s_company_name,sum_sales,rn]
                               InputAdapter
@@ -84,16 +94,59 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_bra
                                   WholeStageCodegen (21)
                                     Sort [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy]
                                       InputAdapter
-                                        Exchange [i_category,i_brand,s_store_name,s_company_name] #9
+                                        Exchange [i_category,i_brand,s_store_name,s_company_name] #11
                                           WholeStageCodegen (20)
                                             HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,sum] [sum(UnscaledValue(ss_sales_price)),sum_sales,sum]
                                               InputAdapter
-                                                ReusedExchange [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,sum] #3
+                                                Exchange [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy] #12
+                                                  WholeStageCodegen (19)
+                                                    HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,ss_sales_price] [sum,sum]
+                                                      Project [i_brand,i_category,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
+                                                        SortMergeJoin [ss_item_sk,i_item_sk]
+                                                          InputAdapter
+                                                            WholeStageCodegen (16)
+                                                              Sort [ss_item_sk]
+                                                                InputAdapter
+                                                                  Exchange [ss_item_sk] #13
+                                                                    WholeStageCodegen (15)
+                                                                      Project [ss_item_sk,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
+                                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                          Project [ss_item_sk,ss_store_sk,ss_sales_price,d_year,d_moy]
+                                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                              Filter [ss_item_sk,ss_store_sk]
+                                                                                Subquery #3
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 203010, 1624080, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #14
+                                                                                      ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                        Exchange [i_item_sk] #15
+                                                                                          WholeStageCodegen (1)
+                                                                                            Filter [i_item_sk,i_category,i_brand]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
+                                                                                      ReusedSubquery [d_date_sk] #1
+                                                                              InputAdapter
+                                                                                ReusedExchange [d_date_sk,d_year,d_moy] #5
+                                                                          InputAdapter
+                                                                            BroadcastExchange #16
+                                                                              WholeStageCodegen (14)
+                                                                                Filter [s_store_sk,s_store_name,s_company_name]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_name]
+                                                          InputAdapter
+                                                            WholeStageCodegen (18)
+                                                              Sort [i_item_sk]
+                                                                InputAdapter
+                                                                  ReusedExchange [i_item_sk,i_brand,i_category] #15
         InputAdapter
           WholeStageCodegen (35)
             Sort [i_category,i_brand,s_store_name,s_company_name,rn]
               InputAdapter
-                Exchange [i_category,i_brand,s_store_name,s_company_name,rn] #10
+                Exchange [i_category,i_brand,s_store_name,s_company_name,rn] #17
                   WholeStageCodegen (34)
                     Project [i_category,i_brand,s_store_name,s_company_name,sum_sales,rn]
                       InputAdapter
@@ -101,4 +154,37 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_bra
                           WholeStageCodegen (33)
                             Sort [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy]
                               InputAdapter
-                                ReusedExchange [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,sum_sales] #9
+                                Exchange [i_category,i_brand,s_store_name,s_company_name] #18
+                                  WholeStageCodegen (32)
+                                    HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,sum] [sum(UnscaledValue(ss_sales_price)),sum_sales,sum]
+                                      InputAdapter
+                                        Exchange [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy] #19
+                                          WholeStageCodegen (31)
+                                            HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,ss_sales_price] [sum,sum]
+                                              Project [i_brand,i_category,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
+                                                SortMergeJoin [ss_item_sk,i_item_sk]
+                                                  InputAdapter
+                                                    WholeStageCodegen (28)
+                                                      Sort [ss_item_sk]
+                                                        InputAdapter
+                                                          Exchange [ss_item_sk] #20
+                                                            WholeStageCodegen (27)
+                                                              Project [ss_item_sk,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
+                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                  Project [ss_item_sk,ss_store_sk,ss_sales_price,d_year,d_moy]
+                                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                      Filter [ss_item_sk,ss_store_sk]
+                                                                        ReusedSubquery [bloomFilter] #2
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
+                                                                              ReusedSubquery [d_date_sk] #1
+                                                                      InputAdapter
+                                                                        ReusedExchange [d_date_sk,d_year,d_moy] #5
+                                                                  InputAdapter
+                                                                    ReusedExchange [s_store_sk,s_store_name,s_company_name] #16
+                                                  InputAdapter
+                                                    WholeStageCodegen (30)
+                                                      Sort [i_item_sk]
+                                                        InputAdapter
+                                                          ReusedExchange [i_item_sk,i_brand,i_category] #15

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/explain.txt
@@ -81,7 +81,7 @@ Input [5]: [ss_item_sk#7, ss_customer_sk#8, ss_store_sk#9, ss_ticket_number#10, 
 
 (11) Filter [codegen id : 4]
 Input [5]: [ss_item_sk#7, ss_customer_sk#8, ss_store_sk#9, ss_ticket_number#10, ss_sold_date_sk#11]
-Condition : (((isnotnull(ss_ticket_number#10) AND isnotnull(ss_item_sk#7)) AND isnotnull(ss_customer_sk#8)) AND isnotnull(ss_store_sk#9))
+Condition : ((((((isnotnull(ss_ticket_number#10) AND isnotnull(ss_item_sk#7)) AND isnotnull(ss_customer_sk#8)) AND isnotnull(ss_store_sk#9)) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ss_ticket_number#10, 42), false)) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#7, 42), false)) AND might_contain(Subquery scalar-subquery#16, [id=#17], xxhash64(ss_customer_sk#8, 42), false))
 
 (12) Exchange
 Input [5]: [ss_item_sk#7, ss_customer_sk#8, ss_store_sk#9, ss_ticket_number#10, ss_sold_date_sk#11]
@@ -102,82 +102,82 @@ Output [3]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11]
 Input [9]: [sr_item_sk#1, sr_customer_sk#2, sr_ticket_number#3, sr_returned_date_sk#4, ss_item_sk#7, ss_customer_sk#8, ss_store_sk#9, ss_ticket_number#10, ss_sold_date_sk#11]
 
 (16) Scan parquet spark_catalog.default.date_dim
-Output [1]: [d_date_sk#12]
+Output [1]: [d_date_sk#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int>
 
 (17) ColumnarToRow [codegen id : 6]
-Input [1]: [d_date_sk#12]
+Input [1]: [d_date_sk#18]
 
 (18) Filter [codegen id : 6]
-Input [1]: [d_date_sk#12]
-Condition : isnotnull(d_date_sk#12)
+Input [1]: [d_date_sk#18]
+Condition : isnotnull(d_date_sk#18)
 
 (19) BroadcastExchange
-Input [1]: [d_date_sk#12]
+Input [1]: [d_date_sk#18]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
 (20) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#11]
-Right keys [1]: [d_date_sk#12]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 8]
 Output [3]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11]
-Input [4]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11, d_date_sk#12]
+Input [4]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11, d_date_sk#18]
 
 (22) Scan parquet spark_catalog.default.store
-Output [11]: [s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Output [11]: [s_store_sk#19, s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_id:int,s_street_number:string,s_street_name:string,s_street_type:string,s_suite_number:string,s_city:string,s_county:string,s_state:string,s_zip:string>
 
 (23) ColumnarToRow [codegen id : 7]
-Input [11]: [s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Input [11]: [s_store_sk#19, s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
 
 (24) Filter [codegen id : 7]
-Input [11]: [s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
-Condition : isnotnull(s_store_sk#13)
+Input [11]: [s_store_sk#19, s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
+Condition : isnotnull(s_store_sk#19)
 
 (25) BroadcastExchange
-Input [11]: [s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Input [11]: [s_store_sk#19, s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 (26) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#9]
-Right keys [1]: [s_store_sk#13]
+Right keys [1]: [s_store_sk#19]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 8]
-Output [12]: [ss_sold_date_sk#11, sr_returned_date_sk#4, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
-Input [14]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11, s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Output [12]: [ss_sold_date_sk#11, sr_returned_date_sk#4, s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
+Input [14]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11, s_store_sk#19, s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
 
 (28) HashAggregate [codegen id : 8]
-Input [12]: [ss_sold_date_sk#11, sr_returned_date_sk#4, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
-Keys [10]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Input [12]: [ss_sold_date_sk#11, sr_returned_date_sk#4, s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
+Keys [10]: [s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
 Functions [5]: [partial_sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END), partial_sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END), partial_sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END), partial_sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END), partial_sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)]
-Aggregate Attributes [5]: [sum#24, sum#25, sum#26, sum#27, sum#28]
-Results [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, sum#29, sum#30, sum#31, sum#32, sum#33]
+Aggregate Attributes [5]: [sum#30, sum#31, sum#32, sum#33, sum#34]
+Results [15]: [s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29, sum#35, sum#36, sum#37, sum#38, sum#39]
 
 (29) Exchange
-Input [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, sum#29, sum#30, sum#31, sum#32, sum#33]
-Arguments: hashpartitioning(s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [15]: [s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29, sum#35, sum#36, sum#37, sum#38, sum#39]
+Arguments: hashpartitioning(s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (30) HashAggregate [codegen id : 9]
-Input [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, sum#29, sum#30, sum#31, sum#32, sum#33]
-Keys [10]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Input [15]: [s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29, sum#35, sum#36, sum#37, sum#38, sum#39]
+Keys [10]: [s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29]
 Functions [5]: [sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END), sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END), sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END), sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END), sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)]
-Aggregate Attributes [5]: [sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END)#34, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END)#35, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END)#36, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END)#37, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)#38]
-Results [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END)#34 AS 30 days #39, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END)#35 AS 31 - 60 days #40, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END)#36 AS 61 - 90 days #41, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END)#37 AS 91 - 120 days #42, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)#38 AS >120 days #43]
+Aggregate Attributes [5]: [sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END)#40, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END)#41, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END)#42, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END)#43, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)#44]
+Results [15]: [s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END)#40 AS 30 days #45, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END)#41 AS 31 - 60 days #46, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END)#42 AS 61 - 90 days #47, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END)#43 AS 91 - 120 days #48, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)#44 AS >120 days #49]
 
 (31) TakeOrderedAndProject
-Input [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, 30 days #39, 31 - 60 days #40, 61 - 90 days #41, 91 - 120 days #42, >120 days #43]
-Arguments: 100, [s_store_name#14 ASC NULLS FIRST, s_company_id#15 ASC NULLS FIRST, s_street_number#16 ASC NULLS FIRST, s_street_name#17 ASC NULLS FIRST, s_street_type#18 ASC NULLS FIRST, s_suite_number#19 ASC NULLS FIRST, s_city#20 ASC NULLS FIRST, s_county#21 ASC NULLS FIRST, s_state#22 ASC NULLS FIRST, s_zip#23 ASC NULLS FIRST], [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, 30 days #39, 31 - 60 days #40, 61 - 90 days #41, 91 - 120 days #42, >120 days #43]
+Input [15]: [s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29, 30 days #45, 31 - 60 days #46, 61 - 90 days #47, 91 - 120 days #48, >120 days #49]
+Arguments: 100, [s_store_name#20 ASC NULLS FIRST, s_company_id#21 ASC NULLS FIRST, s_street_number#22 ASC NULLS FIRST, s_street_name#23 ASC NULLS FIRST, s_street_type#24 ASC NULLS FIRST, s_suite_number#25 ASC NULLS FIRST, s_city#26 ASC NULLS FIRST, s_county#27 ASC NULLS FIRST, s_state#28 ASC NULLS FIRST, s_zip#29 ASC NULLS FIRST], [s_store_name#20, s_company_id#21, s_street_number#22, s_street_name#23, s_street_type#24, s_suite_number#25, s_city#26, s_county#27, s_state#28, s_zip#29, 30 days #45, 31 - 60 days #46, 61 - 90 days #47, 91 - 120 days #48, >120 days #49]
 
 ===== Subqueries =====
 
@@ -190,25 +190,109 @@ BroadcastExchange (36)
 
 
 (32) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#6, d_year#44, d_moy#45]
+Output [3]: [d_date_sk#6, d_year#50, d_moy#51]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,8), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (33) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#44, d_moy#45]
+Input [3]: [d_date_sk#6, d_year#50, d_moy#51]
 
 (34) Filter [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#44, d_moy#45]
-Condition : ((((isnotnull(d_year#44) AND isnotnull(d_moy#45)) AND (d_year#44 = 2001)) AND (d_moy#45 = 8)) AND isnotnull(d_date_sk#6))
+Input [3]: [d_date_sk#6, d_year#50, d_moy#51]
+Condition : ((((isnotnull(d_year#50) AND isnotnull(d_moy#51)) AND (d_year#50 = 2001)) AND (d_moy#51 = 8)) AND isnotnull(d_date_sk#6))
 
 (35) Project [codegen id : 1]
 Output [1]: [d_date_sk#6]
-Input [3]: [d_date_sk#6, d_year#44, d_moy#45]
+Input [3]: [d_date_sk#6, d_year#50, d_moy#51]
 
 (36) BroadcastExchange
 Input [1]: [d_date_sk#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+
+Subquery:2 Hosting operator id = 11 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
+ObjectHashAggregate (40)
++- Exchange (39)
+   +- ObjectHashAggregate (38)
+      +- ReusedExchange (37)
+
+
+(37) ReusedExchange [Reuses operator id: 7]
+Output [4]: [sr_item_sk#1, sr_customer_sk#2, sr_ticket_number#3, sr_returned_date_sk#4]
+
+(38) ObjectHashAggregate
+Input [4]: [sr_item_sk#1, sr_customer_sk#2, sr_ticket_number#3, sr_returned_date_sk#4]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_ticket_number#3, 42), 443806, 3550448, 0, 0)]
+Aggregate Attributes [1]: [buf#52]
+Results [1]: [buf#53]
+
+(39) Exchange
+Input [1]: [buf#53]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+
+(40) ObjectHashAggregate
+Input [1]: [buf#53]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#3, 42), 443806, 3550448, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#3, 42), 443806, 3550448, 0, 0)#54]
+Results [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#3, 42), 443806, 3550448, 0, 0)#54 AS bloomFilter#55]
+
+Subquery:3 Hosting operator id = 11 Hosting Expression = Subquery scalar-subquery#14, [id=#15]
+ObjectHashAggregate (44)
++- Exchange (43)
+   +- ObjectHashAggregate (42)
+      +- ReusedExchange (41)
+
+
+(41) ReusedExchange [Reuses operator id: 7]
+Output [4]: [sr_item_sk#1, sr_customer_sk#2, sr_ticket_number#3, sr_returned_date_sk#4]
+
+(42) ObjectHashAggregate
+Input [4]: [sr_item_sk#1, sr_customer_sk#2, sr_ticket_number#3, sr_returned_date_sk#4]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_item_sk#1, 42), 443806, 3550448, 0, 0)]
+Aggregate Attributes [1]: [buf#56]
+Results [1]: [buf#57]
+
+(43) Exchange
+Input [1]: [buf#57]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+
+(44) ObjectHashAggregate
+Input [1]: [buf#57]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_item_sk#1, 42), 443806, 3550448, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_item_sk#1, 42), 443806, 3550448, 0, 0)#58]
+Results [1]: [bloom_filter_agg(xxhash64(sr_item_sk#1, 42), 443806, 3550448, 0, 0)#58 AS bloomFilter#59]
+
+Subquery:4 Hosting operator id = 11 Hosting Expression = Subquery scalar-subquery#16, [id=#17]
+ObjectHashAggregate (48)
++- Exchange (47)
+   +- ObjectHashAggregate (46)
+      +- ReusedExchange (45)
+
+
+(45) ReusedExchange [Reuses operator id: 7]
+Output [4]: [sr_item_sk#1, sr_customer_sk#2, sr_ticket_number#3, sr_returned_date_sk#4]
+
+(46) ObjectHashAggregate
+Input [4]: [sr_item_sk#1, sr_customer_sk#2, sr_ticket_number#3, sr_returned_date_sk#4]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_customer_sk#2, 42), 443806, 3550448, 0, 0)]
+Aggregate Attributes [1]: [buf#60]
+Results [1]: [buf#61]
+
+(47) Exchange
+Input [1]: [buf#61]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+
+(48) ObjectHashAggregate
+Input [1]: [buf#61]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#2, 42), 443806, 3550448, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#2, 42), 443806, 3550448, 0, 0)#62]
+Results [1]: [bloom_filter_agg(xxhash64(sr_customer_sk#2, 42), 443806, 3550448, 0, 0)#62 AS bloomFilter#63]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/simplified.txt
@@ -40,18 +40,33 @@ TakeOrderedAndProject [s_store_name,s_company_id,s_street_number,s_street_name,s
                                   Exchange [ss_ticket_number,ss_item_sk,ss_customer_sk] #4
                                     WholeStageCodegen (4)
                                       Filter [ss_ticket_number,ss_item_sk,ss_customer_sk,ss_store_sk]
+                                        Subquery #2
+                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_ticket_number, 42), 443806, 3550448, 0, 0),bloomFilter,buf]
+                                            Exchange #5
+                                              ObjectHashAggregate [sr_ticket_number] [buf,buf]
+                                                ReusedExchange [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_returned_date_sk] #2
+                                        Subquery #3
+                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_item_sk, 42), 443806, 3550448, 0, 0),bloomFilter,buf]
+                                            Exchange #6
+                                              ObjectHashAggregate [sr_item_sk] [buf,buf]
+                                                ReusedExchange [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_returned_date_sk] #2
+                                        Subquery #4
+                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_customer_sk, 42), 443806, 3550448, 0, 0),bloomFilter,buf]
+                                            Exchange #7
+                                              ObjectHashAggregate [sr_customer_sk] [buf,buf]
+                                                ReusedExchange [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_returned_date_sk] #2
                                         ColumnarToRow
                                           InputAdapter
                                             Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
                       InputAdapter
-                        BroadcastExchange #5
+                        BroadcastExchange #8
                           WholeStageCodegen (6)
                             Filter [d_date_sk]
                               ColumnarToRow
                                 InputAdapter
                                   Scan parquet spark_catalog.default.date_dim [d_date_sk]
                   InputAdapter
-                    BroadcastExchange #6
+                    BroadcastExchange #9
                       WholeStageCodegen (7)
                         Filter [s_store_sk]
                           ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
@@ -1,15 +1,15 @@
 == Physical Plan ==
-TakeOrderedAndProject (59)
-+- * HashAggregate (58)
-   +- Exchange (57)
-      +- * HashAggregate (56)
-         +- * HashAggregate (55)
-            +- * HashAggregate (54)
-               +- * Project (53)
-                  +- * SortMergeJoin Inner (52)
-                     :- * Sort (43)
-                     :  +- * Project (42)
-                     :     +- * BroadcastHashJoin Inner BuildLeft (41)
+TakeOrderedAndProject (56)
++- * HashAggregate (55)
+   +- Exchange (54)
+      +- * HashAggregate (53)
+         +- * HashAggregate (52)
+            +- * HashAggregate (51)
+               +- * Project (50)
+                  +- * SortMergeJoin Inner (49)
+                     :- * Sort (40)
+                     :  +- * Project (39)
+                     :     +- * BroadcastHashJoin Inner BuildLeft (38)
                      :        :- BroadcastExchange (10)
                      :        :  +- * Project (9)
                      :        :     +- * BroadcastHashJoin Inner BuildRight (8)
@@ -20,10 +20,10 @@ TakeOrderedAndProject (59)
                      :        :           +- * Filter (6)
                      :        :              +- * ColumnarToRow (5)
                      :        :                 +- Scan parquet spark_catalog.default.store (4)
-                     :        +- * HashAggregate (40)
-                     :           +- * HashAggregate (39)
-                     :              +- * Project (38)
-                     :                 +- * SortMergeJoin Inner (37)
+                     :        +- * HashAggregate (37)
+                     :           +- * HashAggregate (36)
+                     :              +- * Project (35)
+                     :                 +- * SortMergeJoin Inner (34)
                      :                    :- * Sort (31)
                      :                    :  +- Exchange (30)
                      :                    :     +- * Project (29)
@@ -45,19 +45,16 @@ TakeOrderedAndProject (59)
                      :                    :                 +- * Filter (25)
                      :                    :                    +- * ColumnarToRow (24)
                      :                    :                       +- Scan parquet spark_catalog.default.item (23)
-                     :                    +- * Sort (36)
-                     :                       +- Exchange (35)
-                     :                          +- * Filter (34)
-                     :                             +- * ColumnarToRow (33)
-                     :                                +- Scan parquet spark_catalog.default.customer (32)
-                     +- * Sort (51)
-                        +- Exchange (50)
-                           +- * Project (49)
-                              +- * BroadcastHashJoin Inner BuildRight (48)
-                                 :- * Filter (46)
-                                 :  +- * ColumnarToRow (45)
-                                 :     +- Scan parquet spark_catalog.default.store_sales (44)
-                                 +- ReusedExchange (47)
+                     :                    +- * Sort (33)
+                     :                       +- ReusedExchange (32)
+                     +- * Sort (48)
+                        +- Exchange (47)
+                           +- * Project (46)
+                              +- * BroadcastHashJoin Inner BuildRight (45)
+                                 :- * Filter (43)
+                                 :  +- * ColumnarToRow (42)
+                                 :     +- Scan parquet spark_catalog.default.store_sales (41)
+                                 +- ReusedExchange (44)
 
 
 (1) Scan parquet spark_catalog.default.customer_address
@@ -119,382 +116,415 @@ Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 
 (13) Filter [codegen id : 3]
 Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
-Condition : (isnotnull(cs_item_sk#7) AND isnotnull(cs_bill_customer_sk#6))
+Condition : ((isnotnull(cs_item_sk#7) AND isnotnull(cs_bill_customer_sk#6)) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(cs_bill_customer_sk#6, 42), false))
 
 (14) Project [codegen id : 3]
-Output [3]: [cs_sold_date_sk#8 AS sold_date_sk#10, cs_bill_customer_sk#6 AS customer_sk#11, cs_item_sk#7 AS item_sk#12]
+Output [3]: [cs_sold_date_sk#8 AS sold_date_sk#12, cs_bill_customer_sk#6 AS customer_sk#13, cs_item_sk#7 AS item_sk#14]
 Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 
 (15) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
+Output [3]: [ws_item_sk#15, ws_bill_customer_sk#16, ws_sold_date_sk#17]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#15), dynamicpruningexpression(ws_sold_date_sk#15 IN dynamicpruning#9)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#17), dynamicpruningexpression(ws_sold_date_sk#17 IN dynamicpruning#9)]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int>
 
 (16) ColumnarToRow [codegen id : 4]
-Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
+Input [3]: [ws_item_sk#15, ws_bill_customer_sk#16, ws_sold_date_sk#17]
 
 (17) Filter [codegen id : 4]
-Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
-Condition : (isnotnull(ws_item_sk#13) AND isnotnull(ws_bill_customer_sk#14))
+Input [3]: [ws_item_sk#15, ws_bill_customer_sk#16, ws_sold_date_sk#17]
+Condition : ((isnotnull(ws_item_sk#15) AND isnotnull(ws_bill_customer_sk#16)) AND might_contain(ReusedSubquery Subquery scalar-subquery#10, [id=#11], xxhash64(ws_bill_customer_sk#16, 42), false))
 
 (18) Project [codegen id : 4]
-Output [3]: [ws_sold_date_sk#15 AS sold_date_sk#16, ws_bill_customer_sk#14 AS customer_sk#17, ws_item_sk#13 AS item_sk#18]
-Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
+Output [3]: [ws_sold_date_sk#17 AS sold_date_sk#18, ws_bill_customer_sk#16 AS customer_sk#19, ws_item_sk#15 AS item_sk#20]
+Input [3]: [ws_item_sk#15, ws_bill_customer_sk#16, ws_sold_date_sk#17]
 
 (19) Union
 
-(20) ReusedExchange [Reuses operator id: 64]
-Output [1]: [d_date_sk#19]
+(20) ReusedExchange [Reuses operator id: 68]
+Output [1]: [d_date_sk#21]
 
 (21) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [sold_date_sk#10]
-Right keys [1]: [d_date_sk#19]
+Left keys [1]: [sold_date_sk#12]
+Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 7]
-Output [2]: [customer_sk#11, item_sk#12]
-Input [4]: [sold_date_sk#10, customer_sk#11, item_sk#12, d_date_sk#19]
+Output [2]: [customer_sk#13, item_sk#14]
+Input [4]: [sold_date_sk#12, customer_sk#13, item_sk#14, d_date_sk#21]
 
 (23) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#20, i_class#21, i_category#22]
+Output [3]: [i_item_sk#22, i_class#23, i_category#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_category), IsNotNull(i_class), EqualTo(i_category,Women                                             ), EqualTo(i_class,maternity                                         ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_class:string,i_category:string>
 
 (24) ColumnarToRow [codegen id : 6]
-Input [3]: [i_item_sk#20, i_class#21, i_category#22]
+Input [3]: [i_item_sk#22, i_class#23, i_category#24]
 
 (25) Filter [codegen id : 6]
-Input [3]: [i_item_sk#20, i_class#21, i_category#22]
-Condition : ((((isnotnull(i_category#22) AND isnotnull(i_class#21)) AND (i_category#22 = Women                                             )) AND (i_class#21 = maternity                                         )) AND isnotnull(i_item_sk#20))
+Input [3]: [i_item_sk#22, i_class#23, i_category#24]
+Condition : ((((isnotnull(i_category#24) AND isnotnull(i_class#23)) AND (i_category#24 = Women                                             )) AND (i_class#23 = maternity                                         )) AND isnotnull(i_item_sk#22))
 
 (26) Project [codegen id : 6]
-Output [1]: [i_item_sk#20]
-Input [3]: [i_item_sk#20, i_class#21, i_category#22]
+Output [1]: [i_item_sk#22]
+Input [3]: [i_item_sk#22, i_class#23, i_category#24]
 
 (27) BroadcastExchange
-Input [1]: [i_item_sk#20]
+Input [1]: [i_item_sk#22]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
 (28) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [item_sk#12]
-Right keys [1]: [i_item_sk#20]
+Left keys [1]: [item_sk#14]
+Right keys [1]: [i_item_sk#22]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 7]
-Output [1]: [customer_sk#11]
-Input [3]: [customer_sk#11, item_sk#12, i_item_sk#20]
+Output [1]: [customer_sk#13]
+Input [3]: [customer_sk#13, item_sk#14, i_item_sk#22]
 
 (30) Exchange
-Input [1]: [customer_sk#11]
-Arguments: hashpartitioning(customer_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [1]: [customer_sk#13]
+Arguments: hashpartitioning(customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (31) Sort [codegen id : 8]
-Input [1]: [customer_sk#11]
-Arguments: [customer_sk#11 ASC NULLS FIRST], false, 0
+Input [1]: [customer_sk#13]
+Arguments: [customer_sk#13 ASC NULLS FIRST], false, 0
 
-(32) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#23, c_current_addr_sk#24]
+(32) ReusedExchange [Reuses operator id: 60]
+Output [2]: [c_customer_sk#25, c_current_addr_sk#26]
+
+(33) Sort [codegen id : 10]
+Input [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Arguments: [c_customer_sk#25 ASC NULLS FIRST], false, 0
+
+(34) SortMergeJoin
+Left keys [1]: [customer_sk#13]
+Right keys [1]: [c_customer_sk#25]
+Join type: Inner
+Join condition: None
+
+(35) Project
+Output [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Input [3]: [customer_sk#13, c_customer_sk#25, c_current_addr_sk#26]
+
+(36) HashAggregate
+Input [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Keys [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [c_customer_sk#25, c_current_addr_sk#26]
+
+(37) HashAggregate
+Input [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Keys [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [c_customer_sk#25, c_current_addr_sk#26]
+
+(38) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [ca_address_sk#1]
+Right keys [1]: [c_current_addr_sk#26]
+Join type: Inner
+Join condition: None
+
+(39) Project [codegen id : 11]
+Output [1]: [c_customer_sk#25]
+Input [3]: [ca_address_sk#1, c_customer_sk#25, c_current_addr_sk#26]
+
+(40) Sort [codegen id : 11]
+Input [1]: [c_customer_sk#25]
+Arguments: [c_customer_sk#25 ASC NULLS FIRST], false, 0
+
+(41) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_customer_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#29), dynamicpruningexpression(ss_sold_date_sk#29 IN dynamicpruning#30)]
+PushedFilters: [IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_customer_sk:int,ss_ext_sales_price:decimal(7,2)>
+
+(42) ColumnarToRow [codegen id : 13]
+Input [3]: [ss_customer_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29]
+
+(43) Filter [codegen id : 13]
+Input [3]: [ss_customer_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29]
+Condition : isnotnull(ss_customer_sk#27)
+
+(44) ReusedExchange [Reuses operator id: 73]
+Output [1]: [d_date_sk#31]
+
+(45) BroadcastHashJoin [codegen id : 13]
+Left keys [1]: [ss_sold_date_sk#29]
+Right keys [1]: [d_date_sk#31]
+Join type: Inner
+Join condition: None
+
+(46) Project [codegen id : 13]
+Output [2]: [ss_customer_sk#27, ss_ext_sales_price#28]
+Input [4]: [ss_customer_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29, d_date_sk#31]
+
+(47) Exchange
+Input [2]: [ss_customer_sk#27, ss_ext_sales_price#28]
+Arguments: hashpartitioning(ss_customer_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(48) Sort [codegen id : 14]
+Input [2]: [ss_customer_sk#27, ss_ext_sales_price#28]
+Arguments: [ss_customer_sk#27 ASC NULLS FIRST], false, 0
+
+(49) SortMergeJoin [codegen id : 15]
+Left keys [1]: [c_customer_sk#25]
+Right keys [1]: [ss_customer_sk#27]
+Join type: Inner
+Join condition: None
+
+(50) Project [codegen id : 15]
+Output [2]: [c_customer_sk#25, ss_ext_sales_price#28]
+Input [3]: [c_customer_sk#25, ss_customer_sk#27, ss_ext_sales_price#28]
+
+(51) HashAggregate [codegen id : 15]
+Input [2]: [c_customer_sk#25, ss_ext_sales_price#28]
+Keys [1]: [c_customer_sk#25]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#28))]
+Aggregate Attributes [1]: [sum#32]
+Results [2]: [c_customer_sk#25, sum#33]
+
+(52) HashAggregate [codegen id : 15]
+Input [2]: [c_customer_sk#25, sum#33]
+Keys [1]: [c_customer_sk#25]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#28))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#28))#34]
+Results [1]: [cast((MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#28))#34,17,2) / 50) as int) AS segment#35]
+
+(53) HashAggregate [codegen id : 15]
+Input [1]: [segment#35]
+Keys [1]: [segment#35]
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#36]
+Results [2]: [segment#35, count#37]
+
+(54) Exchange
+Input [2]: [segment#35, count#37]
+Arguments: hashpartitioning(segment#35, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(55) HashAggregate [codegen id : 16]
+Input [2]: [segment#35, count#37]
+Keys [1]: [segment#35]
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#38]
+Results [3]: [segment#35, count(1)#38 AS num_customers#39, (segment#35 * 50) AS segment_base#40]
+
+(56) TakeOrderedAndProject
+Input [3]: [segment#35, num_customers#39, segment_base#40]
+Arguments: 100, [segment#35 ASC NULLS FIRST, num_customers#39 ASC NULLS FIRST], [segment#35, num_customers#39, segment_base#40]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 13 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (63)
++- Exchange (62)
+   +- ObjectHashAggregate (61)
+      +- Exchange (60)
+         +- * Filter (59)
+            +- * ColumnarToRow (58)
+               +- Scan parquet spark_catalog.default.customer (57)
+
+
+(57) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#25, c_current_addr_sk#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(33) ColumnarToRow [codegen id : 9]
-Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
+(58) ColumnarToRow [codegen id : 1]
+Input [2]: [c_customer_sk#25, c_current_addr_sk#26]
 
-(34) Filter [codegen id : 9]
-Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Condition : (isnotnull(c_customer_sk#23) AND isnotnull(c_current_addr_sk#24))
+(59) Filter [codegen id : 1]
+Input [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Condition : (isnotnull(c_customer_sk#25) AND isnotnull(c_current_addr_sk#26))
 
-(35) Exchange
-Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Arguments: hashpartitioning(c_customer_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(60) Exchange
+Input [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Arguments: hashpartitioning(c_customer_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(36) Sort [codegen id : 10]
-Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Arguments: [c_customer_sk#23 ASC NULLS FIRST], false, 0
+(61) ObjectHashAggregate
+Input [2]: [c_customer_sk#25, c_current_addr_sk#26]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#25, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#41]
+Results [1]: [buf#42]
 
-(37) SortMergeJoin
-Left keys [1]: [customer_sk#11]
-Right keys [1]: [c_customer_sk#23]
-Join type: Inner
-Join condition: None
+(62) Exchange
+Input [1]: [buf#42]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(38) Project
-Output [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Input [3]: [customer_sk#11, c_customer_sk#23, c_current_addr_sk#24]
+(63) ObjectHashAggregate
+Input [1]: [buf#42]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#25, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#25, 42), 2000000, 16000000, 0, 0)#43]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#25, 42), 2000000, 16000000, 0, 0)#43 AS bloomFilter#44]
 
-(39) HashAggregate
-Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Keys [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Functions: []
-Aggregate Attributes: []
-Results [2]: [c_customer_sk#23, c_current_addr_sk#24]
-
-(40) HashAggregate
-Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Keys [2]: [c_customer_sk#23, c_current_addr_sk#24]
-Functions: []
-Aggregate Attributes: []
-Results [2]: [c_customer_sk#23, c_current_addr_sk#24]
-
-(41) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ca_address_sk#1]
-Right keys [1]: [c_current_addr_sk#24]
-Join type: Inner
-Join condition: None
-
-(42) Project [codegen id : 11]
-Output [1]: [c_customer_sk#23]
-Input [3]: [ca_address_sk#1, c_customer_sk#23, c_current_addr_sk#24]
-
-(43) Sort [codegen id : 11]
-Input [1]: [c_customer_sk#23]
-Arguments: [c_customer_sk#23 ASC NULLS FIRST], false, 0
-
-(44) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#27), dynamicpruningexpression(ss_sold_date_sk#27 IN dynamicpruning#28)]
-PushedFilters: [IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_customer_sk:int,ss_ext_sales_price:decimal(7,2)>
-
-(45) ColumnarToRow [codegen id : 13]
-Input [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
-
-(46) Filter [codegen id : 13]
-Input [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
-Condition : isnotnull(ss_customer_sk#25)
-
-(47) ReusedExchange [Reuses operator id: 69]
-Output [1]: [d_date_sk#29]
-
-(48) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [ss_sold_date_sk#27]
-Right keys [1]: [d_date_sk#29]
-Join type: Inner
-Join condition: None
-
-(49) Project [codegen id : 13]
-Output [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
-Input [4]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27, d_date_sk#29]
-
-(50) Exchange
-Input [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
-Arguments: hashpartitioning(ss_customer_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(51) Sort [codegen id : 14]
-Input [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
-Arguments: [ss_customer_sk#25 ASC NULLS FIRST], false, 0
-
-(52) SortMergeJoin [codegen id : 15]
-Left keys [1]: [c_customer_sk#23]
-Right keys [1]: [ss_customer_sk#25]
-Join type: Inner
-Join condition: None
-
-(53) Project [codegen id : 15]
-Output [2]: [c_customer_sk#23, ss_ext_sales_price#26]
-Input [3]: [c_customer_sk#23, ss_customer_sk#25, ss_ext_sales_price#26]
-
-(54) HashAggregate [codegen id : 15]
-Input [2]: [c_customer_sk#23, ss_ext_sales_price#26]
-Keys [1]: [c_customer_sk#23]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#26))]
-Aggregate Attributes [1]: [sum#30]
-Results [2]: [c_customer_sk#23, sum#31]
-
-(55) HashAggregate [codegen id : 15]
-Input [2]: [c_customer_sk#23, sum#31]
-Keys [1]: [c_customer_sk#23]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#26))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#26))#32]
-Results [1]: [cast((MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#26))#32,17,2) / 50) as int) AS segment#33]
-
-(56) HashAggregate [codegen id : 15]
-Input [1]: [segment#33]
-Keys [1]: [segment#33]
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#34]
-Results [2]: [segment#33, count#35]
-
-(57) Exchange
-Input [2]: [segment#33, count#35]
-Arguments: hashpartitioning(segment#33, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(58) HashAggregate [codegen id : 16]
-Input [2]: [segment#33, count#35]
-Keys [1]: [segment#33]
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#36]
-Results [3]: [segment#33, count(1)#36 AS num_customers#37, (segment#33 * 50) AS segment_base#38]
-
-(59) TakeOrderedAndProject
-Input [3]: [segment#33, num_customers#37, segment_base#38]
-Arguments: 100, [segment#33 ASC NULLS FIRST, num_customers#37 ASC NULLS FIRST], [segment#33, num_customers#37, segment_base#38]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 11 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (64)
-+- * Project (63)
-   +- * Filter (62)
-      +- * ColumnarToRow (61)
-         +- Scan parquet spark_catalog.default.date_dim (60)
+Subquery:2 Hosting operator id = 11 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
+BroadcastExchange (68)
++- * Project (67)
+   +- * Filter (66)
+      +- * ColumnarToRow (65)
+         +- Scan parquet spark_catalog.default.date_dim (64)
 
 
-(60) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#19, d_year#39, d_moy#40]
+(64) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#21, d_year#45, d_moy#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,12), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(61) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
+(65) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#21, d_year#45, d_moy#46]
 
-(62) Filter [codegen id : 1]
-Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
-Condition : ((((isnotnull(d_moy#40) AND isnotnull(d_year#39)) AND (d_moy#40 = 12)) AND (d_year#39 = 1998)) AND isnotnull(d_date_sk#19))
+(66) Filter [codegen id : 1]
+Input [3]: [d_date_sk#21, d_year#45, d_moy#46]
+Condition : ((((isnotnull(d_moy#46) AND isnotnull(d_year#45)) AND (d_moy#46 = 12)) AND (d_year#45 = 1998)) AND isnotnull(d_date_sk#21))
 
-(63) Project [codegen id : 1]
-Output [1]: [d_date_sk#19]
-Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
+(67) Project [codegen id : 1]
+Output [1]: [d_date_sk#21]
+Input [3]: [d_date_sk#21, d_year#45, d_moy#46]
 
-(64) BroadcastExchange
-Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+(68) BroadcastExchange
+Input [1]: [d_date_sk#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:2 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#15 IN dynamicpruning#9
+Subquery:3 Hosting operator id = 17 Hosting Expression = ReusedSubquery Subquery scalar-subquery#10, [id=#11]
 
-Subquery:3 Hosting operator id = 44 Hosting Expression = ss_sold_date_sk#27 IN dynamicpruning#28
-BroadcastExchange (69)
-+- * Project (68)
-   +- * Filter (67)
-      +- * ColumnarToRow (66)
-         +- Scan parquet spark_catalog.default.date_dim (65)
+Subquery:4 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#17 IN dynamicpruning#9
+
+Subquery:5 Hosting operator id = 41 Hosting Expression = ss_sold_date_sk#29 IN dynamicpruning#30
+BroadcastExchange (73)
++- * Project (72)
+   +- * Filter (71)
+      +- * ColumnarToRow (70)
+         +- Scan parquet spark_catalog.default.date_dim (69)
 
 
-(65) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#29, d_month_seq#41]
+(69) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#31, d_month_seq#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(66) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#29, d_month_seq#41]
+(70) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#31, d_month_seq#47]
 
-(67) Filter [codegen id : 1]
-Input [2]: [d_date_sk#29, d_month_seq#41]
-Condition : (((isnotnull(d_month_seq#41) AND (d_month_seq#41 >= Subquery scalar-subquery#42, [id=#43])) AND (d_month_seq#41 <= Subquery scalar-subquery#44, [id=#45])) AND isnotnull(d_date_sk#29))
+(71) Filter [codegen id : 1]
+Input [2]: [d_date_sk#31, d_month_seq#47]
+Condition : (((isnotnull(d_month_seq#47) AND (d_month_seq#47 >= Subquery scalar-subquery#48, [id=#49])) AND (d_month_seq#47 <= Subquery scalar-subquery#50, [id=#51])) AND isnotnull(d_date_sk#31))
 
-(68) Project [codegen id : 1]
-Output [1]: [d_date_sk#29]
-Input [2]: [d_date_sk#29, d_month_seq#41]
+(72) Project [codegen id : 1]
+Output [1]: [d_date_sk#31]
+Input [2]: [d_date_sk#31, d_month_seq#47]
 
-(69) BroadcastExchange
-Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+(73) BroadcastExchange
+Input [1]: [d_date_sk#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:4 Hosting operator id = 67 Hosting Expression = Subquery scalar-subquery#42, [id=#43]
-* HashAggregate (76)
-+- Exchange (75)
-   +- * HashAggregate (74)
-      +- * Project (73)
-         +- * Filter (72)
-            +- * ColumnarToRow (71)
-               +- Scan parquet spark_catalog.default.date_dim (70)
+Subquery:6 Hosting operator id = 71 Hosting Expression = Subquery scalar-subquery#48, [id=#49]
+* HashAggregate (80)
++- Exchange (79)
+   +- * HashAggregate (78)
+      +- * Project (77)
+         +- * Filter (76)
+            +- * ColumnarToRow (75)
+               +- Scan parquet spark_catalog.default.date_dim (74)
 
 
-(70) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#46, d_year#47, d_moy#48]
+(74) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_month_seq#52, d_year#53, d_moy#54]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(71) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
+(75) ColumnarToRow [codegen id : 1]
+Input [3]: [d_month_seq#52, d_year#53, d_moy#54]
 
-(72) Filter [codegen id : 1]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
-Condition : (((isnotnull(d_year#47) AND isnotnull(d_moy#48)) AND (d_year#47 = 1998)) AND (d_moy#48 = 12))
+(76) Filter [codegen id : 1]
+Input [3]: [d_month_seq#52, d_year#53, d_moy#54]
+Condition : (((isnotnull(d_year#53) AND isnotnull(d_moy#54)) AND (d_year#53 = 1998)) AND (d_moy#54 = 12))
 
-(73) Project [codegen id : 1]
-Output [1]: [(d_month_seq#46 + 1) AS (d_month_seq + 1)#49]
-Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
+(77) Project [codegen id : 1]
+Output [1]: [(d_month_seq#52 + 1) AS (d_month_seq + 1)#55]
+Input [3]: [d_month_seq#52, d_year#53, d_moy#54]
 
-(74) HashAggregate [codegen id : 1]
-Input [1]: [(d_month_seq + 1)#49]
-Keys [1]: [(d_month_seq + 1)#49]
+(78) HashAggregate [codegen id : 1]
+Input [1]: [(d_month_seq + 1)#55]
+Keys [1]: [(d_month_seq + 1)#55]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 1)#49]
+Results [1]: [(d_month_seq + 1)#55]
 
-(75) Exchange
-Input [1]: [(d_month_seq + 1)#49]
-Arguments: hashpartitioning((d_month_seq + 1)#49, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(79) Exchange
+Input [1]: [(d_month_seq + 1)#55]
+Arguments: hashpartitioning((d_month_seq + 1)#55, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(76) HashAggregate [codegen id : 2]
-Input [1]: [(d_month_seq + 1)#49]
-Keys [1]: [(d_month_seq + 1)#49]
+(80) HashAggregate [codegen id : 2]
+Input [1]: [(d_month_seq + 1)#55]
+Keys [1]: [(d_month_seq + 1)#55]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 1)#49]
+Results [1]: [(d_month_seq + 1)#55]
 
-Subquery:5 Hosting operator id = 67 Hosting Expression = Subquery scalar-subquery#44, [id=#45]
-* HashAggregate (83)
-+- Exchange (82)
-   +- * HashAggregate (81)
-      +- * Project (80)
-         +- * Filter (79)
-            +- * ColumnarToRow (78)
-               +- Scan parquet spark_catalog.default.date_dim (77)
+Subquery:7 Hosting operator id = 71 Hosting Expression = Subquery scalar-subquery#50, [id=#51]
+* HashAggregate (87)
++- Exchange (86)
+   +- * HashAggregate (85)
+      +- * Project (84)
+         +- * Filter (83)
+            +- * ColumnarToRow (82)
+               +- Scan parquet spark_catalog.default.date_dim (81)
 
 
-(77) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#50, d_year#51, d_moy#52]
+(81) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_month_seq#56, d_year#57, d_moy#58]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(78) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
+(82) ColumnarToRow [codegen id : 1]
+Input [3]: [d_month_seq#56, d_year#57, d_moy#58]
 
-(79) Filter [codegen id : 1]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
-Condition : (((isnotnull(d_year#51) AND isnotnull(d_moy#52)) AND (d_year#51 = 1998)) AND (d_moy#52 = 12))
+(83) Filter [codegen id : 1]
+Input [3]: [d_month_seq#56, d_year#57, d_moy#58]
+Condition : (((isnotnull(d_year#57) AND isnotnull(d_moy#58)) AND (d_year#57 = 1998)) AND (d_moy#58 = 12))
 
-(80) Project [codegen id : 1]
-Output [1]: [(d_month_seq#50 + 3) AS (d_month_seq + 3)#53]
-Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
+(84) Project [codegen id : 1]
+Output [1]: [(d_month_seq#56 + 3) AS (d_month_seq + 3)#59]
+Input [3]: [d_month_seq#56, d_year#57, d_moy#58]
 
-(81) HashAggregate [codegen id : 1]
-Input [1]: [(d_month_seq + 3)#53]
-Keys [1]: [(d_month_seq + 3)#53]
+(85) HashAggregate [codegen id : 1]
+Input [1]: [(d_month_seq + 3)#59]
+Keys [1]: [(d_month_seq + 3)#59]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 3)#53]
+Results [1]: [(d_month_seq + 3)#59]
 
-(82) Exchange
-Input [1]: [(d_month_seq + 3)#53]
-Arguments: hashpartitioning((d_month_seq + 3)#53, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(86) Exchange
+Input [1]: [(d_month_seq + 3)#59]
+Arguments: hashpartitioning((d_month_seq + 3)#59, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(83) HashAggregate [codegen id : 2]
-Input [1]: [(d_month_seq + 3)#53]
-Keys [1]: [(d_month_seq + 3)#53]
+(87) HashAggregate [codegen id : 2]
+Input [1]: [(d_month_seq + 3)#59]
+Keys [1]: [(d_month_seq + 3)#59]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [(d_month_seq + 3)#53]
+Results [1]: [(d_month_seq + 3)#59]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
@@ -49,6 +49,16 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                                 WholeStageCodegen (3)
                                                                   Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
                                                                     Filter [cs_item_sk,cs_bill_customer_sk]
+                                                                      Subquery #2
+                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                          Exchange #6
+                                                                            ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                              Exchange [c_customer_sk] #7
+                                                                                WholeStageCodegen (1)
+                                                                                  Filter [c_customer_sk,c_current_addr_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
                                                                       ColumnarToRow
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
@@ -63,6 +73,7 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                                 WholeStageCodegen (4)
                                                                   Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
                                                                     Filter [ws_item_sk,ws_bill_customer_sk]
+                                                                      ReusedSubquery [bloomFilter] #2
                                                                       ColumnarToRow
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
@@ -70,7 +81,7 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                             InputAdapter
                                                               ReusedExchange [d_date_sk] #5
                                                         InputAdapter
-                                                          BroadcastExchange #6
+                                                          BroadcastExchange #8
                                                             WholeStageCodegen (6)
                                                               Project [i_item_sk]
                                                                 Filter [i_category,i_class,i_item_sk]
@@ -81,17 +92,12 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                           WholeStageCodegen (10)
                                             Sort [c_customer_sk]
                                               InputAdapter
-                                                Exchange [c_customer_sk] #7
-                                                  WholeStageCodegen (9)
-                                                    Filter [c_customer_sk,c_current_addr_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                                                ReusedExchange [c_customer_sk,c_current_addr_sk] #7
                       InputAdapter
                         WholeStageCodegen (14)
                           Sort [ss_customer_sk]
                             InputAdapter
-                              Exchange [ss_customer_sk] #8
+                              Exchange [ss_customer_sk] #9
                                 WholeStageCodegen (13)
                                   Project [ss_customer_sk,ss_ext_sales_price]
                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -99,16 +105,16 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                         ColumnarToRow
                                           InputAdapter
                                             Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                              SubqueryBroadcast [d_date_sk] #2
-                                                BroadcastExchange #9
+                                              SubqueryBroadcast [d_date_sk] #3
+                                                BroadcastExchange #10
                                                   WholeStageCodegen (1)
                                                     Project [d_date_sk]
                                                       Filter [d_month_seq,d_date_sk]
-                                                        Subquery #3
+                                                        Subquery #4
                                                           WholeStageCodegen (2)
                                                             HashAggregate [(d_month_seq + 1)]
                                                               InputAdapter
-                                                                Exchange [(d_month_seq + 1)] #10
+                                                                Exchange [(d_month_seq + 1)] #11
                                                                   WholeStageCodegen (1)
                                                                     HashAggregate [(d_month_seq + 1)]
                                                                       Project [d_month_seq]
@@ -116,11 +122,11 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
-                                                        Subquery #4
+                                                        Subquery #5
                                                           WholeStageCodegen (2)
                                                             HashAggregate [(d_month_seq + 3)]
                                                               InputAdapter
-                                                                Exchange [(d_month_seq + 3)] #11
+                                                                Exchange [(d_month_seq + 3)] #12
                                                                   WholeStageCodegen (1)
                                                                     HashAggregate [(d_month_seq + 3)]
                                                                       Project [d_month_seq]
@@ -132,4 +138,4 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #9
+                                        ReusedExchange [d_date_sk] #10

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/explain.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
-TakeOrderedAndProject (52)
-+- * Project (51)
-   +- * SortMergeJoin Inner (50)
-      :- * Project (43)
-      :  +- * SortMergeJoin Inner (42)
+TakeOrderedAndProject (89)
++- * Project (88)
+   +- * SortMergeJoin Inner (87)
+      :- * Project (62)
+      :  +- * SortMergeJoin Inner (61)
       :     :- * Sort (33)
       :     :  +- Exchange (32)
       :     :     +- * Project (31)
@@ -37,20 +37,57 @@ TakeOrderedAndProject (52)
       :     :                                               +- * Filter (17)
       :     :                                                  +- * ColumnarToRow (16)
       :     :                                                     +- Scan parquet spark_catalog.default.item (15)
-      :     +- * Sort (41)
-      :        +- Exchange (40)
-      :           +- * Project (39)
-      :              +- Window (38)
-      :                 +- * Sort (37)
-      :                    +- Exchange (36)
-      :                       +- * HashAggregate (35)
-      :                          +- ReusedExchange (34)
-      +- * Sort (49)
-         +- Exchange (48)
-            +- * Project (47)
-               +- Window (46)
-                  +- * Sort (45)
-                     +- ReusedExchange (44)
+      :     +- * Sort (60)
+      :        +- Exchange (59)
+      :           +- * Project (58)
+      :              +- Window (57)
+      :                 +- * Sort (56)
+      :                    +- Exchange (55)
+      :                       +- * HashAggregate (54)
+      :                          +- Exchange (53)
+      :                             +- * HashAggregate (52)
+      :                                +- * Project (51)
+      :                                   +- * SortMergeJoin Inner (50)
+      :                                      :- * Sort (47)
+      :                                      :  +- Exchange (46)
+      :                                      :     +- * Project (45)
+      :                                      :        +- * BroadcastHashJoin Inner BuildRight (44)
+      :                                      :           :- * Project (39)
+      :                                      :           :  +- * BroadcastHashJoin Inner BuildRight (38)
+      :                                      :           :     :- * Filter (36)
+      :                                      :           :     :  +- * ColumnarToRow (35)
+      :                                      :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (34)
+      :                                      :           :     +- ReusedExchange (37)
+      :                                      :           +- BroadcastExchange (43)
+      :                                      :              +- * Filter (42)
+      :                                      :                 +- * ColumnarToRow (41)
+      :                                      :                    +- Scan parquet spark_catalog.default.call_center (40)
+      :                                      +- * Sort (49)
+      :                                         +- ReusedExchange (48)
+      +- * Sort (86)
+         +- Exchange (85)
+            +- * Project (84)
+               +- Window (83)
+                  +- * Sort (82)
+                     +- Exchange (81)
+                        +- * HashAggregate (80)
+                           +- Exchange (79)
+                              +- * HashAggregate (78)
+                                 +- * Project (77)
+                                    +- * SortMergeJoin Inner (76)
+                                       :- * Sort (73)
+                                       :  +- Exchange (72)
+                                       :     +- * Project (71)
+                                       :        +- * BroadcastHashJoin Inner BuildRight (70)
+                                       :           :- * Project (68)
+                                       :           :  +- * BroadcastHashJoin Inner BuildRight (67)
+                                       :           :     :- * Filter (65)
+                                       :           :     :  +- * ColumnarToRow (64)
+                                       :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (63)
+                                       :           :     +- ReusedExchange (66)
+                                       :           +- ReusedExchange (69)
+                                       +- * Sort (75)
+                                          +- ReusedExchange (74)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -66,249 +103,521 @@ Input [4]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, cs_sold_date_sk
 
 (3) Filter [codegen id : 3]
 Input [4]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, cs_sold_date_sk#4]
-Condition : (isnotnull(cs_item_sk#2) AND isnotnull(cs_call_center_sk#1))
+Condition : ((isnotnull(cs_item_sk#2) AND isnotnull(cs_call_center_sk#1)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(cs_item_sk#2, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 56]
-Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(4) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#8, d_year#9, d_moy#10]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
-Output [5]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8]
-Input [7]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, cs_sold_date_sk#4, d_date_sk#6, d_year#7, d_moy#8]
+Output [5]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10]
+Input [7]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, cs_sold_date_sk#4, d_date_sk#8, d_year#9, d_moy#10]
 
 (7) Scan parquet spark_catalog.default.call_center
-Output [2]: [cc_call_center_sk#9, cc_name#10]
+Output [2]: [cc_call_center_sk#11, cc_name#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/call_center]
 PushedFilters: [IsNotNull(cc_call_center_sk), IsNotNull(cc_name)]
 ReadSchema: struct<cc_call_center_sk:int,cc_name:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [cc_call_center_sk#9, cc_name#10]
+Input [2]: [cc_call_center_sk#11, cc_name#12]
 
 (9) Filter [codegen id : 2]
-Input [2]: [cc_call_center_sk#9, cc_name#10]
-Condition : (isnotnull(cc_call_center_sk#9) AND isnotnull(cc_name#10))
+Input [2]: [cc_call_center_sk#11, cc_name#12]
+Condition : ((isnotnull(cc_call_center_sk#11) AND isnotnull(cc_name#12)) AND true)
 
 (10) BroadcastExchange
-Input [2]: [cc_call_center_sk#9, cc_name#10]
+Input [2]: [cc_call_center_sk#11, cc_name#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_call_center_sk#1]
-Right keys [1]: [cc_call_center_sk#9]
+Right keys [1]: [cc_call_center_sk#11]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [5]: [cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
-Input [7]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_call_center_sk#9, cc_name#10]
+Output [5]: [cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
+Input [7]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_call_center_sk#11, cc_name#12]
 
 (13) Exchange
-Input [5]: [cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
+Input [5]: [cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
 Arguments: hashpartitioning(cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [5]: [cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
+Input [5]: [cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
 Arguments: [cs_item_sk#2 ASC NULLS FIRST], false, 0
 
 (15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#11, i_brand#12, i_category#13]
+Output [3]: [i_item_sk#13, i_brand#14, i_category#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
 
 (16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#11, i_brand#12, i_category#13]
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
 
 (17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#11, i_brand#12, i_category#13]
-Condition : ((isnotnull(i_item_sk#11) AND isnotnull(i_category#13)) AND isnotnull(i_brand#12))
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Condition : ((((isnotnull(i_item_sk#13) AND isnotnull(i_category#15)) AND isnotnull(i_brand#14)) AND true) AND true)
 
 (18) Exchange
-Input [3]: [i_item_sk#11, i_brand#12, i_category#13]
-Arguments: hashpartitioning(i_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#11, i_brand#12, i_category#13]
-Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
 
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [i_item_sk#11]
+Right keys [1]: [i_item_sk#13]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
-Output [6]: [i_brand#12, i_category#13, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
-Input [8]: [cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10, i_item_sk#11, i_brand#12, i_category#13]
+Output [6]: [i_brand#14, i_category#15, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
+Input [8]: [cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12, i_item_sk#13, i_brand#14, i_category#15]
 
 (22) HashAggregate [codegen id : 7]
-Input [6]: [i_brand#12, i_category#13, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
-Keys [5]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8]
+Input [6]: [i_brand#14, i_category#15, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
+Keys [5]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10]
 Functions [1]: [partial_sum(UnscaledValue(cs_sales_price#3))]
-Aggregate Attributes [1]: [sum#14]
-Results [6]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum#15]
+Aggregate Attributes [1]: [sum#16]
+Results [6]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum#17]
 
 (23) Exchange
-Input [6]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum#15]
-Arguments: hashpartitioning(i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [6]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum#17]
+Arguments: hashpartitioning(i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) HashAggregate [codegen id : 8]
-Input [6]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum#15]
-Keys [5]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8]
+Input [6]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum#17]
+Keys [5]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10]
 Functions [1]: [sum(UnscaledValue(cs_sales_price#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#3))#16]
-Results [7]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#16,17,2) AS sum_sales#17, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#16,17,2) AS _w0#18]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#3))#18]
+Results [7]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#18,17,2) AS sum_sales#19, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#18,17,2) AS _w0#20]
 
 (25) Exchange
-Input [7]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18]
-Arguments: hashpartitioning(i_category#13, i_brand#12, cc_name#10, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [7]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20]
+Arguments: hashpartitioning(i_category#15, i_brand#14, cc_name#12, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (26) Sort [codegen id : 9]
-Input [7]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18]
-Arguments: [i_category#13 ASC NULLS FIRST, i_brand#12 ASC NULLS FIRST, cc_name#10 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], false, 0
+Input [7]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20]
+Arguments: [i_category#15 ASC NULLS FIRST, i_brand#14 ASC NULLS FIRST, cc_name#12 ASC NULLS FIRST, d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST], false, 0
 
 (27) Window
-Input [7]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18]
-Arguments: [rank(d_year#7, d_moy#8) windowspecdefinition(i_category#13, i_brand#12, cc_name#10, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#19], [i_category#13, i_brand#12, cc_name#10], [d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST]
+Input [7]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20]
+Arguments: [rank(d_year#9, d_moy#10) windowspecdefinition(i_category#15, i_brand#14, cc_name#12, d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#21], [i_category#15, i_brand#14, cc_name#12], [d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST]
 
 (28) Filter [codegen id : 10]
-Input [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18, rn#19]
-Condition : (isnotnull(d_year#7) AND (d_year#7 = 1999))
+Input [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20, rn#21]
+Condition : (isnotnull(d_year#9) AND (d_year#9 = 1999))
 
 (29) Window
-Input [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18, rn#19]
-Arguments: [avg(_w0#18) windowspecdefinition(i_category#13, i_brand#12, cc_name#10, d_year#7, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#20], [i_category#13, i_brand#12, cc_name#10, d_year#7]
+Input [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20, rn#21]
+Arguments: [avg(_w0#20) windowspecdefinition(i_category#15, i_brand#14, cc_name#12, d_year#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#22], [i_category#15, i_brand#14, cc_name#12, d_year#9]
 
 (30) Filter [codegen id : 11]
-Input [9]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18, rn#19, avg_monthly_sales#20]
-Condition : ((isnotnull(avg_monthly_sales#20) AND (avg_monthly_sales#20 > 0.000000)) AND CASE WHEN (avg_monthly_sales#20 > 0.000000) THEN ((abs((sum_sales#17 - avg_monthly_sales#20)) / avg_monthly_sales#20) > 0.1000000000000000) END)
+Input [9]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20, rn#21, avg_monthly_sales#22]
+Condition : ((isnotnull(avg_monthly_sales#22) AND (avg_monthly_sales#22 > 0.000000)) AND CASE WHEN (avg_monthly_sales#22 > 0.000000) THEN ((abs((sum_sales#19 - avg_monthly_sales#22)) / avg_monthly_sales#22) > 0.1000000000000000) END)
 
 (31) Project [codegen id : 11]
-Output [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19]
-Input [9]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18, rn#19, avg_monthly_sales#20]
+Output [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21]
+Input [9]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20, rn#21, avg_monthly_sales#22]
 
 (32) Exchange
-Input [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19]
-Arguments: hashpartitioning(i_category#13, i_brand#12, cc_name#10, rn#19, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21]
+Arguments: hashpartitioning(i_category#15, i_brand#14, cc_name#12, rn#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (33) Sort [codegen id : 12]
-Input [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19]
-Arguments: [i_category#13 ASC NULLS FIRST, i_brand#12 ASC NULLS FIRST, cc_name#10 ASC NULLS FIRST, rn#19 ASC NULLS FIRST], false, 0
+Input [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21]
+Arguments: [i_category#15 ASC NULLS FIRST, i_brand#14 ASC NULLS FIRST, cc_name#12 ASC NULLS FIRST, rn#21 ASC NULLS FIRST], false, 0
 
-(34) ReusedExchange [Reuses operator id: 23]
-Output [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum#26]
+(34) Scan parquet spark_catalog.default.catalog_sales
+Output [4]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, cs_sold_date_sk#26]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#26), dynamicpruningexpression(cs_sold_date_sk#26 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_call_center_sk)]
+ReadSchema: struct<cs_call_center_sk:int,cs_item_sk:int,cs_sales_price:decimal(7,2)>
 
-(35) HashAggregate [codegen id : 20]
-Input [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum#26]
-Keys [5]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25]
-Functions [1]: [sum(UnscaledValue(cs_sales_price#27))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#27))#16]
-Results [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, MakeDecimal(sum(UnscaledValue(cs_sales_price#27))#16,17,2) AS sum_sales#17]
+(35) ColumnarToRow [codegen id : 15]
+Input [4]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, cs_sold_date_sk#26]
 
-(36) Exchange
-Input [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum_sales#17]
-Arguments: hashpartitioning(i_category#21, i_brand#22, cc_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(36) Filter [codegen id : 15]
+Input [4]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, cs_sold_date_sk#26]
+Condition : ((isnotnull(cs_item_sk#24) AND isnotnull(cs_call_center_sk#23)) AND might_contain(Subquery scalar-subquery#27, [id=#28], xxhash64(cs_item_sk#24, 42), false))
 
-(37) Sort [codegen id : 21]
-Input [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum_sales#17]
-Arguments: [i_category#21 ASC NULLS FIRST, i_brand#22 ASC NULLS FIRST, cc_name#23 ASC NULLS FIRST, d_year#24 ASC NULLS FIRST, d_moy#25 ASC NULLS FIRST], false, 0
+(37) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#29, d_year#30, d_moy#31]
 
-(38) Window
-Input [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum_sales#17]
-Arguments: [rank(d_year#24, d_moy#25) windowspecdefinition(i_category#21, i_brand#22, cc_name#23, d_year#24 ASC NULLS FIRST, d_moy#25 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#28], [i_category#21, i_brand#22, cc_name#23], [d_year#24 ASC NULLS FIRST, d_moy#25 ASC NULLS FIRST]
-
-(39) Project [codegen id : 22]
-Output [5]: [i_category#21, i_brand#22, cc_name#23, sum_sales#17 AS sum_sales#29, rn#28]
-Input [7]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum_sales#17, rn#28]
-
-(40) Exchange
-Input [5]: [i_category#21, i_brand#22, cc_name#23, sum_sales#29, rn#28]
-Arguments: hashpartitioning(i_category#21, i_brand#22, cc_name#23, (rn#28 + 1), 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(41) Sort [codegen id : 23]
-Input [5]: [i_category#21, i_brand#22, cc_name#23, sum_sales#29, rn#28]
-Arguments: [i_category#21 ASC NULLS FIRST, i_brand#22 ASC NULLS FIRST, cc_name#23 ASC NULLS FIRST, (rn#28 + 1) ASC NULLS FIRST], false, 0
-
-(42) SortMergeJoin [codegen id : 24]
-Left keys [4]: [i_category#13, i_brand#12, cc_name#10, rn#19]
-Right keys [4]: [i_category#21, i_brand#22, cc_name#23, (rn#28 + 1)]
+(38) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [cs_sold_date_sk#26]
+Right keys [1]: [d_date_sk#29]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 24]
-Output [9]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19, sum_sales#29]
-Input [13]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19, i_category#21, i_brand#22, cc_name#23, sum_sales#29, rn#28]
+(39) Project [codegen id : 15]
+Output [5]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31]
+Input [7]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, cs_sold_date_sk#26, d_date_sk#29, d_year#30, d_moy#31]
 
-(44) ReusedExchange [Reuses operator id: 36]
-Output [6]: [i_category#30, i_brand#31, cc_name#32, d_year#33, d_moy#34, sum_sales#17]
+(40) Scan parquet spark_catalog.default.call_center
+Output [2]: [cc_call_center_sk#32, cc_name#33]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/call_center]
+PushedFilters: [IsNotNull(cc_call_center_sk), IsNotNull(cc_name)]
+ReadSchema: struct<cc_call_center_sk:int,cc_name:string>
 
-(45) Sort [codegen id : 33]
-Input [6]: [i_category#30, i_brand#31, cc_name#32, d_year#33, d_moy#34, sum_sales#17]
-Arguments: [i_category#30 ASC NULLS FIRST, i_brand#31 ASC NULLS FIRST, cc_name#32 ASC NULLS FIRST, d_year#33 ASC NULLS FIRST, d_moy#34 ASC NULLS FIRST], false, 0
+(41) ColumnarToRow [codegen id : 14]
+Input [2]: [cc_call_center_sk#32, cc_name#33]
 
-(46) Window
-Input [6]: [i_category#30, i_brand#31, cc_name#32, d_year#33, d_moy#34, sum_sales#17]
-Arguments: [rank(d_year#33, d_moy#34) windowspecdefinition(i_category#30, i_brand#31, cc_name#32, d_year#33 ASC NULLS FIRST, d_moy#34 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#35], [i_category#30, i_brand#31, cc_name#32], [d_year#33 ASC NULLS FIRST, d_moy#34 ASC NULLS FIRST]
+(42) Filter [codegen id : 14]
+Input [2]: [cc_call_center_sk#32, cc_name#33]
+Condition : (isnotnull(cc_call_center_sk#32) AND isnotnull(cc_name#33))
 
-(47) Project [codegen id : 34]
-Output [5]: [i_category#30, i_brand#31, cc_name#32, sum_sales#17 AS sum_sales#36, rn#35]
-Input [7]: [i_category#30, i_brand#31, cc_name#32, d_year#33, d_moy#34, sum_sales#17, rn#35]
+(43) BroadcastExchange
+Input [2]: [cc_call_center_sk#32, cc_name#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(48) Exchange
-Input [5]: [i_category#30, i_brand#31, cc_name#32, sum_sales#36, rn#35]
-Arguments: hashpartitioning(i_category#30, i_brand#31, cc_name#32, (rn#35 - 1), 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(49) Sort [codegen id : 35]
-Input [5]: [i_category#30, i_brand#31, cc_name#32, sum_sales#36, rn#35]
-Arguments: [i_category#30 ASC NULLS FIRST, i_brand#31 ASC NULLS FIRST, cc_name#32 ASC NULLS FIRST, (rn#35 - 1) ASC NULLS FIRST], false, 0
-
-(50) SortMergeJoin [codegen id : 36]
-Left keys [4]: [i_category#13, i_brand#12, cc_name#10, rn#19]
-Right keys [4]: [i_category#30, i_brand#31, cc_name#32, (rn#35 - 1)]
+(44) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [cs_call_center_sk#23]
+Right keys [1]: [cc_call_center_sk#32]
 Join type: Inner
 Join condition: None
 
-(51) Project [codegen id : 36]
-Output [9]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#20, sum_sales#17, sum_sales#29 AS psum#37, sum_sales#36 AS nsum#38]
-Input [14]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19, sum_sales#29, i_category#30, i_brand#31, cc_name#32, sum_sales#36, rn#35]
+(45) Project [codegen id : 15]
+Output [5]: [cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Input [7]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_call_center_sk#32, cc_name#33]
 
-(52) TakeOrderedAndProject
-Input [9]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#20, sum_sales#17, psum#37, nsum#38]
-Arguments: 100, [(sum_sales#17 - avg_monthly_sales#20) ASC NULLS FIRST, cc_name#10 ASC NULLS FIRST], [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, avg_monthly_sales#20, sum_sales#17, psum#37, nsum#38]
+(46) Exchange
+Input [5]: [cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Arguments: hashpartitioning(cs_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(47) Sort [codegen id : 16]
+Input [5]: [cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Arguments: [cs_item_sk#24 ASC NULLS FIRST], false, 0
+
+(48) ReusedExchange [Reuses operator id: 104]
+Output [3]: [i_item_sk#34, i_brand#35, i_category#36]
+
+(49) Sort [codegen id : 18]
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Arguments: [i_item_sk#34 ASC NULLS FIRST], false, 0
+
+(50) SortMergeJoin [codegen id : 19]
+Left keys [1]: [cs_item_sk#24]
+Right keys [1]: [i_item_sk#34]
+Join type: Inner
+Join condition: None
+
+(51) Project [codegen id : 19]
+Output [6]: [i_brand#35, i_category#36, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Input [8]: [cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33, i_item_sk#34, i_brand#35, i_category#36]
+
+(52) HashAggregate [codegen id : 19]
+Input [6]: [i_brand#35, i_category#36, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Keys [5]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31]
+Functions [1]: [partial_sum(UnscaledValue(cs_sales_price#25))]
+Aggregate Attributes [1]: [sum#37]
+Results [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum#38]
+
+(53) Exchange
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum#38]
+Arguments: hashpartitioning(i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) HashAggregate [codegen id : 20]
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum#38]
+Keys [5]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31]
+Functions [1]: [sum(UnscaledValue(cs_sales_price#25))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#25))#18]
+Results [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, MakeDecimal(sum(UnscaledValue(cs_sales_price#25))#18,17,2) AS sum_sales#19]
+
+(55) Exchange
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum_sales#19]
+Arguments: hashpartitioning(i_category#36, i_brand#35, cc_name#33, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(56) Sort [codegen id : 21]
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum_sales#19]
+Arguments: [i_category#36 ASC NULLS FIRST, i_brand#35 ASC NULLS FIRST, cc_name#33 ASC NULLS FIRST, d_year#30 ASC NULLS FIRST, d_moy#31 ASC NULLS FIRST], false, 0
+
+(57) Window
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum_sales#19]
+Arguments: [rank(d_year#30, d_moy#31) windowspecdefinition(i_category#36, i_brand#35, cc_name#33, d_year#30 ASC NULLS FIRST, d_moy#31 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#39], [i_category#36, i_brand#35, cc_name#33], [d_year#30 ASC NULLS FIRST, d_moy#31 ASC NULLS FIRST]
+
+(58) Project [codegen id : 22]
+Output [5]: [i_category#36, i_brand#35, cc_name#33, sum_sales#19 AS sum_sales#40, rn#39]
+Input [7]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum_sales#19, rn#39]
+
+(59) Exchange
+Input [5]: [i_category#36, i_brand#35, cc_name#33, sum_sales#40, rn#39]
+Arguments: hashpartitioning(i_category#36, i_brand#35, cc_name#33, (rn#39 + 1), 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(60) Sort [codegen id : 23]
+Input [5]: [i_category#36, i_brand#35, cc_name#33, sum_sales#40, rn#39]
+Arguments: [i_category#36 ASC NULLS FIRST, i_brand#35 ASC NULLS FIRST, cc_name#33 ASC NULLS FIRST, (rn#39 + 1) ASC NULLS FIRST], false, 0
+
+(61) SortMergeJoin [codegen id : 24]
+Left keys [4]: [i_category#15, i_brand#14, cc_name#12, rn#21]
+Right keys [4]: [i_category#36, i_brand#35, cc_name#33, (rn#39 + 1)]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 24]
+Output [9]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21, sum_sales#40]
+Input [13]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21, i_category#36, i_brand#35, cc_name#33, sum_sales#40, rn#39]
+
+(63) Scan parquet spark_catalog.default.catalog_sales
+Output [4]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, cs_sold_date_sk#44]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#44), dynamicpruningexpression(cs_sold_date_sk#44 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_call_center_sk)]
+ReadSchema: struct<cs_call_center_sk:int,cs_item_sk:int,cs_sales_price:decimal(7,2)>
+
+(64) ColumnarToRow [codegen id : 27]
+Input [4]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, cs_sold_date_sk#44]
+
+(65) Filter [codegen id : 27]
+Input [4]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, cs_sold_date_sk#44]
+Condition : ((isnotnull(cs_item_sk#42) AND isnotnull(cs_call_center_sk#41)) AND might_contain(ReusedSubquery Subquery scalar-subquery#6, [id=#7], xxhash64(cs_item_sk#42, 42), false))
+
+(66) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#45, d_year#46, d_moy#47]
+
+(67) BroadcastHashJoin [codegen id : 27]
+Left keys [1]: [cs_sold_date_sk#44]
+Right keys [1]: [d_date_sk#45]
+Join type: Inner
+Join condition: None
+
+(68) Project [codegen id : 27]
+Output [5]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47]
+Input [7]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, cs_sold_date_sk#44, d_date_sk#45, d_year#46, d_moy#47]
+
+(69) ReusedExchange [Reuses operator id: 43]
+Output [2]: [cc_call_center_sk#48, cc_name#49]
+
+(70) BroadcastHashJoin [codegen id : 27]
+Left keys [1]: [cs_call_center_sk#41]
+Right keys [1]: [cc_call_center_sk#48]
+Join type: Inner
+Join condition: None
+
+(71) Project [codegen id : 27]
+Output [5]: [cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Input [7]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_call_center_sk#48, cc_name#49]
+
+(72) Exchange
+Input [5]: [cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Arguments: hashpartitioning(cs_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(73) Sort [codegen id : 28]
+Input [5]: [cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Arguments: [cs_item_sk#42 ASC NULLS FIRST], false, 0
+
+(74) ReusedExchange [Reuses operator id: 104]
+Output [3]: [i_item_sk#50, i_brand#51, i_category#52]
+
+(75) Sort [codegen id : 30]
+Input [3]: [i_item_sk#50, i_brand#51, i_category#52]
+Arguments: [i_item_sk#50 ASC NULLS FIRST], false, 0
+
+(76) SortMergeJoin [codegen id : 31]
+Left keys [1]: [cs_item_sk#42]
+Right keys [1]: [i_item_sk#50]
+Join type: Inner
+Join condition: None
+
+(77) Project [codegen id : 31]
+Output [6]: [i_brand#51, i_category#52, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Input [8]: [cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49, i_item_sk#50, i_brand#51, i_category#52]
+
+(78) HashAggregate [codegen id : 31]
+Input [6]: [i_brand#51, i_category#52, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Keys [5]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47]
+Functions [1]: [partial_sum(UnscaledValue(cs_sales_price#43))]
+Aggregate Attributes [1]: [sum#53]
+Results [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum#54]
+
+(79) Exchange
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum#54]
+Arguments: hashpartitioning(i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(80) HashAggregate [codegen id : 32]
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum#54]
+Keys [5]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47]
+Functions [1]: [sum(UnscaledValue(cs_sales_price#43))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#43))#18]
+Results [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, MakeDecimal(sum(UnscaledValue(cs_sales_price#43))#18,17,2) AS sum_sales#19]
+
+(81) Exchange
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum_sales#19]
+Arguments: hashpartitioning(i_category#52, i_brand#51, cc_name#49, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(82) Sort [codegen id : 33]
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum_sales#19]
+Arguments: [i_category#52 ASC NULLS FIRST, i_brand#51 ASC NULLS FIRST, cc_name#49 ASC NULLS FIRST, d_year#46 ASC NULLS FIRST, d_moy#47 ASC NULLS FIRST], false, 0
+
+(83) Window
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum_sales#19]
+Arguments: [rank(d_year#46, d_moy#47) windowspecdefinition(i_category#52, i_brand#51, cc_name#49, d_year#46 ASC NULLS FIRST, d_moy#47 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#55], [i_category#52, i_brand#51, cc_name#49], [d_year#46 ASC NULLS FIRST, d_moy#47 ASC NULLS FIRST]
+
+(84) Project [codegen id : 34]
+Output [5]: [i_category#52, i_brand#51, cc_name#49, sum_sales#19 AS sum_sales#56, rn#55]
+Input [7]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum_sales#19, rn#55]
+
+(85) Exchange
+Input [5]: [i_category#52, i_brand#51, cc_name#49, sum_sales#56, rn#55]
+Arguments: hashpartitioning(i_category#52, i_brand#51, cc_name#49, (rn#55 - 1), 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(86) Sort [codegen id : 35]
+Input [5]: [i_category#52, i_brand#51, cc_name#49, sum_sales#56, rn#55]
+Arguments: [i_category#52 ASC NULLS FIRST, i_brand#51 ASC NULLS FIRST, cc_name#49 ASC NULLS FIRST, (rn#55 - 1) ASC NULLS FIRST], false, 0
+
+(87) SortMergeJoin [codegen id : 36]
+Left keys [4]: [i_category#15, i_brand#14, cc_name#12, rn#21]
+Right keys [4]: [i_category#52, i_brand#51, cc_name#49, (rn#55 - 1)]
+Join type: Inner
+Join condition: None
+
+(88) Project [codegen id : 36]
+Output [9]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, avg_monthly_sales#22, sum_sales#19, sum_sales#40 AS psum#57, sum_sales#56 AS nsum#58]
+Input [14]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21, sum_sales#40, i_category#52, i_brand#51, cc_name#49, sum_sales#56, rn#55]
+
+(89) TakeOrderedAndProject
+Input [9]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, avg_monthly_sales#22, sum_sales#19, psum#57, nsum#58]
+Arguments: 100, [(sum_sales#19 - avg_monthly_sales#22) ASC NULLS FIRST, cc_name#12 ASC NULLS FIRST], [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, avg_monthly_sales#22, sum_sales#19, psum#57, nsum#58]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (56)
-+- * Filter (55)
-   +- * ColumnarToRow (54)
-      +- Scan parquet spark_catalog.default.date_dim (53)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (96)
++- Exchange (95)
+   +- ObjectHashAggregate (94)
+      +- Exchange (93)
+         +- * Filter (92)
+            +- * ColumnarToRow (91)
+               +- Scan parquet spark_catalog.default.item (90)
 
 
-(53) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(90) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
+
+(91) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+
+(92) Filter [codegen id : 1]
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Condition : ((isnotnull(i_item_sk#13) AND isnotnull(i_category#15)) AND isnotnull(i_brand#14))
+
+(93) Exchange
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Arguments: hashpartitioning(i_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(94) ObjectHashAggregate
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#13, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [buf#59]
+Results [1]: [buf#60]
+
+(95) Exchange
+Input [1]: [buf#60]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(96) ObjectHashAggregate
+Input [1]: [buf#60]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 203010, 1624080, 0, 0)#61]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 203010, 1624080, 0, 0)#61 AS bloomFilter#62]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#4 IN dynamicpruning#5
+BroadcastExchange (100)
++- * Filter (99)
+   +- * ColumnarToRow (98)
+      +- Scan parquet spark_catalog.default.date_dim (97)
+
+
+(97) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#8, d_year#9, d_moy#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(Or(EqualTo(d_year,1999),And(EqualTo(d_year,1998),EqualTo(d_moy,12))),And(EqualTo(d_year,2000),EqualTo(d_moy,1))), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(54) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(98) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
 
-(55) Filter [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR ((d_year#7 = 2000) AND (d_moy#8 = 1))) AND isnotnull(d_date_sk#6))
+(99) Filter [codegen id : 1]
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
+Condition : ((((d_year#9 = 1999) OR ((d_year#9 = 1998) AND (d_moy#10 = 12))) OR ((d_year#9 = 2000) AND (d_moy#10 = 1))) AND isnotnull(d_date_sk#8))
 
-(56) BroadcastExchange
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
+(100) BroadcastExchange
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
+
+Subquery:3 Hosting operator id = 36 Hosting Expression = Subquery scalar-subquery#27, [id=#28]
+ObjectHashAggregate (107)
++- Exchange (106)
+   +- ObjectHashAggregate (105)
+      +- Exchange (104)
+         +- * Filter (103)
+            +- * ColumnarToRow (102)
+               +- Scan parquet spark_catalog.default.item (101)
+
+
+(101) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
+
+(102) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+
+(103) Filter [codegen id : 1]
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Condition : ((isnotnull(i_item_sk#34) AND isnotnull(i_category#36)) AND isnotnull(i_brand#35))
+
+(104) Exchange
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Arguments: hashpartitioning(i_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+
+(105) ObjectHashAggregate
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#34, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [buf#63]
+Results [1]: [buf#64]
+
+(106) Exchange
+Input [1]: [buf#64]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+
+(107) ObjectHashAggregate
+Input [1]: [buf#64]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#34, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#34, 42), 203010, 1624080, 0, 0)#65]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#34, 42), 203010, 1624080, 0, 0)#65 AS bloomFilter#66]
+
+Subquery:4 Hosting operator id = 34 Hosting Expression = cs_sold_date_sk#26 IN dynamicpruning#5
+
+Subquery:5 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#6, [id=#7]
+
+Subquery:6 Hosting operator id = 63 Hosting Expression = cs_sold_date_sk#44 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/simplified.txt
@@ -43,6 +43,16 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,cc_name,i_category,i_brand,d_
                                                                                     Project [cs_call_center_sk,cs_item_sk,cs_sales_price,d_year,d_moy]
                                                                                       BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                                         Filter [cs_item_sk,cs_call_center_sk]
+                                                                                          Subquery #2
+                                                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 203010, 1624080, 0, 0),bloomFilter,buf]
+                                                                                              Exchange #6
+                                                                                                ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                                  Exchange [i_item_sk] #7
+                                                                                                    WholeStageCodegen (1)
+                                                                                                      Filter [i_item_sk,i_category,i_brand]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
                                                                                           ColumnarToRow
                                                                                             InputAdapter
                                                                                               Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_item_sk,cs_sales_price,cs_sold_date_sk]
@@ -56,7 +66,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,cc_name,i_category,i_brand,d_
                                                                                         InputAdapter
                                                                                           ReusedExchange [d_date_sk,d_year,d_moy] #5
                                                                                     InputAdapter
-                                                                                      BroadcastExchange #6
+                                                                                      BroadcastExchange #8
                                                                                         WholeStageCodegen (2)
                                                                                           Filter [cc_call_center_sk,cc_name]
                                                                                             ColumnarToRow
@@ -66,7 +76,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,cc_name,i_category,i_brand,d_
                                                                       WholeStageCodegen (6)
                                                                         Sort [i_item_sk]
                                                                           InputAdapter
-                                                                            Exchange [i_item_sk] #7
+                                                                            Exchange [i_item_sk] #9
                                                                               WholeStageCodegen (5)
                                                                                 Filter [i_item_sk,i_category,i_brand]
                                                                                   ColumnarToRow
@@ -76,7 +86,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,cc_name,i_category,i_brand,d_
                   WholeStageCodegen (23)
                     Sort [i_category,i_brand,cc_name,rn]
                       InputAdapter
-                        Exchange [i_category,i_brand,cc_name,rn] #8
+                        Exchange [i_category,i_brand,cc_name,rn] #10
                           WholeStageCodegen (22)
                             Project [i_category,i_brand,cc_name,sum_sales,rn]
                               InputAdapter
@@ -84,16 +94,59 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,cc_name,i_category,i_brand,d_
                                   WholeStageCodegen (21)
                                     Sort [i_category,i_brand,cc_name,d_year,d_moy]
                                       InputAdapter
-                                        Exchange [i_category,i_brand,cc_name] #9
+                                        Exchange [i_category,i_brand,cc_name] #11
                                           WholeStageCodegen (20)
                                             HashAggregate [i_category,i_brand,cc_name,d_year,d_moy,sum] [sum(UnscaledValue(cs_sales_price)),sum_sales,sum]
                                               InputAdapter
-                                                ReusedExchange [i_category,i_brand,cc_name,d_year,d_moy,sum] #3
+                                                Exchange [i_category,i_brand,cc_name,d_year,d_moy] #12
+                                                  WholeStageCodegen (19)
+                                                    HashAggregate [i_category,i_brand,cc_name,d_year,d_moy,cs_sales_price] [sum,sum]
+                                                      Project [i_brand,i_category,cs_sales_price,d_year,d_moy,cc_name]
+                                                        SortMergeJoin [cs_item_sk,i_item_sk]
+                                                          InputAdapter
+                                                            WholeStageCodegen (16)
+                                                              Sort [cs_item_sk]
+                                                                InputAdapter
+                                                                  Exchange [cs_item_sk] #13
+                                                                    WholeStageCodegen (15)
+                                                                      Project [cs_item_sk,cs_sales_price,d_year,d_moy,cc_name]
+                                                                        BroadcastHashJoin [cs_call_center_sk,cc_call_center_sk]
+                                                                          Project [cs_call_center_sk,cs_item_sk,cs_sales_price,d_year,d_moy]
+                                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                              Filter [cs_item_sk,cs_call_center_sk]
+                                                                                Subquery #3
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 203010, 1624080, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #14
+                                                                                      ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                        Exchange [i_item_sk] #15
+                                                                                          WholeStageCodegen (1)
+                                                                                            Filter [i_item_sk,i_category,i_brand]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_item_sk,cs_sales_price,cs_sold_date_sk]
+                                                                                      ReusedSubquery [d_date_sk] #1
+                                                                              InputAdapter
+                                                                                ReusedExchange [d_date_sk,d_year,d_moy] #5
+                                                                          InputAdapter
+                                                                            BroadcastExchange #16
+                                                                              WholeStageCodegen (14)
+                                                                                Filter [cc_call_center_sk,cc_name]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.call_center [cc_call_center_sk,cc_name]
+                                                          InputAdapter
+                                                            WholeStageCodegen (18)
+                                                              Sort [i_item_sk]
+                                                                InputAdapter
+                                                                  ReusedExchange [i_item_sk,i_brand,i_category] #15
         InputAdapter
           WholeStageCodegen (35)
             Sort [i_category,i_brand,cc_name,rn]
               InputAdapter
-                Exchange [i_category,i_brand,cc_name,rn] #10
+                Exchange [i_category,i_brand,cc_name,rn] #17
                   WholeStageCodegen (34)
                     Project [i_category,i_brand,cc_name,sum_sales,rn]
                       InputAdapter
@@ -101,4 +154,37 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,cc_name,i_category,i_brand,d_
                           WholeStageCodegen (33)
                             Sort [i_category,i_brand,cc_name,d_year,d_moy]
                               InputAdapter
-                                ReusedExchange [i_category,i_brand,cc_name,d_year,d_moy,sum_sales] #9
+                                Exchange [i_category,i_brand,cc_name] #18
+                                  WholeStageCodegen (32)
+                                    HashAggregate [i_category,i_brand,cc_name,d_year,d_moy,sum] [sum(UnscaledValue(cs_sales_price)),sum_sales,sum]
+                                      InputAdapter
+                                        Exchange [i_category,i_brand,cc_name,d_year,d_moy] #19
+                                          WholeStageCodegen (31)
+                                            HashAggregate [i_category,i_brand,cc_name,d_year,d_moy,cs_sales_price] [sum,sum]
+                                              Project [i_brand,i_category,cs_sales_price,d_year,d_moy,cc_name]
+                                                SortMergeJoin [cs_item_sk,i_item_sk]
+                                                  InputAdapter
+                                                    WholeStageCodegen (28)
+                                                      Sort [cs_item_sk]
+                                                        InputAdapter
+                                                          Exchange [cs_item_sk] #20
+                                                            WholeStageCodegen (27)
+                                                              Project [cs_item_sk,cs_sales_price,d_year,d_moy,cc_name]
+                                                                BroadcastHashJoin [cs_call_center_sk,cc_call_center_sk]
+                                                                  Project [cs_call_center_sk,cs_item_sk,cs_sales_price,d_year,d_moy]
+                                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                      Filter [cs_item_sk,cs_call_center_sk]
+                                                                        ReusedSubquery [bloomFilter] #2
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_item_sk,cs_sales_price,cs_sold_date_sk]
+                                                                              ReusedSubquery [d_date_sk] #1
+                                                                      InputAdapter
+                                                                        ReusedExchange [d_date_sk,d_year,d_moy] #5
+                                                                  InputAdapter
+                                                                    ReusedExchange [cc_call_center_sk,cc_name] #16
+                                                  InputAdapter
+                                                    WholeStageCodegen (30)
+                                                      Sort [i_item_sk]
+                                                        InputAdapter
+                                                          ReusedExchange [i_item_sk,i_brand,i_category] #15

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
@@ -82,7 +82,7 @@ Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 
 (6) Filter [codegen id : 1]
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(d_week_seq#5, 42)))
+Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(d_week_seq#5, 42), true))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
@@ -203,7 +203,7 @@ Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 
 (31) Filter [codegen id : 5]
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#52, [id=#53], xxhash64(d_week_seq#5, 42)))
+Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#52, [id=#53], xxhash64(d_week_seq#5, 42), true))
 
 (32) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/explain.txt
@@ -1,11 +1,11 @@
 == Physical Plan ==
-TakeOrderedAndProject (45)
-+- * Filter (44)
-   +- * HashAggregate (43)
-      +- Exchange (42)
-         +- * HashAggregate (41)
-            +- * Project (40)
-               +- * SortMergeJoin Inner (39)
+TakeOrderedAndProject (33)
++- * Filter (32)
+   +- * HashAggregate (31)
+      +- Exchange (30)
+         +- * HashAggregate (29)
+            +- * Project (28)
+               +- * SortMergeJoin Inner (27)
                   :- * Sort (24)
                   :  +- Exchange (23)
                   :     +- * Project (22)
@@ -30,20 +30,8 @@ TakeOrderedAndProject (45)
                   :           :        +- * ColumnarToRow (16)
                   :           :           +- Scan parquet spark_catalog.default.store_sales (15)
                   :           +- ReusedExchange (20)
-                  +- * Sort (38)
-                     +- Exchange (37)
-                        +- * Project (36)
-                           +- * SortMergeJoin Inner (35)
-                              :- * Sort (29)
-                              :  +- Exchange (28)
-                              :     +- * Filter (27)
-                              :        +- * ColumnarToRow (26)
-                              :           +- Scan parquet spark_catalog.default.customer_address (25)
-                              +- * Sort (34)
-                                 +- Exchange (33)
-                                    +- * Filter (32)
-                                       +- * ColumnarToRow (31)
-                                          +- Scan parquet spark_catalog.default.customer (30)
+                  +- * Sort (26)
+                     +- ReusedExchange (25)
 
 
 (1) Scan parquet spark_catalog.default.item
@@ -127,7 +115,7 @@ Input [3]: [ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 
 (17) Filter
 Input [3]: [ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
-Condition : (isnotnull(ss_customer_sk#13) AND isnotnull(ss_item_sk#12))
+Condition : ((isnotnull(ss_customer_sk#13) AND isnotnull(ss_item_sk#12)) AND might_contain(Subquery scalar-subquery#16, [id=#17], xxhash64(ss_customer_sk#13, 42), false))
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [i_item_sk#1]
@@ -139,18 +127,18 @@ Join condition: None
 Output [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Input [4]: [i_item_sk#1, ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 
-(20) ReusedExchange [Reuses operator id: 50]
-Output [1]: [d_date_sk#16]
+(20) ReusedExchange [Reuses operator id: 54]
+Output [1]: [d_date_sk#18]
 
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#14]
-Right keys [1]: [d_date_sk#16]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 5]
 Output [1]: [ss_customer_sk#13]
-Input [3]: [ss_customer_sk#13, ss_sold_date_sk#14, d_date_sk#16]
+Input [3]: [ss_customer_sk#13, ss_sold_date_sk#14, d_date_sk#18]
 
 (23) Exchange
 Input [1]: [ss_customer_sk#13]
@@ -160,180 +148,220 @@ Arguments: hashpartitioning(ss_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id
 Input [1]: [ss_customer_sk#13]
 Arguments: [ss_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(25) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#17, ca_state#18]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
+(25) ReusedExchange [Reuses operator id: 46]
+Output [2]: [ca_state#19, c_customer_sk#20]
 
-(26) ColumnarToRow [codegen id : 7]
-Input [2]: [ca_address_sk#17, ca_state#18]
+(26) Sort [codegen id : 12]
+Input [2]: [ca_state#19, c_customer_sk#20]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
 
-(27) Filter [codegen id : 7]
-Input [2]: [ca_address_sk#17, ca_state#18]
-Condition : isnotnull(ca_address_sk#17)
-
-(28) Exchange
-Input [2]: [ca_address_sk#17, ca_state#18]
-Arguments: hashpartitioning(ca_address_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(29) Sort [codegen id : 8]
-Input [2]: [ca_address_sk#17, ca_state#18]
-Arguments: [ca_address_sk#17 ASC NULLS FIRST], false, 0
-
-(30) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_current_addr_sk), IsNotNull(c_customer_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
-
-(31) ColumnarToRow [codegen id : 9]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-
-(32) Filter [codegen id : 9]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Condition : (isnotnull(c_current_addr_sk#20) AND isnotnull(c_customer_sk#19))
-
-(33) Exchange
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: hashpartitioning(c_current_addr_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(34) Sort [codegen id : 10]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: [c_current_addr_sk#20 ASC NULLS FIRST], false, 0
-
-(35) SortMergeJoin [codegen id : 11]
-Left keys [1]: [ca_address_sk#17]
-Right keys [1]: [c_current_addr_sk#20]
-Join type: Inner
-Join condition: None
-
-(36) Project [codegen id : 11]
-Output [2]: [ca_state#18, c_customer_sk#19]
-Input [4]: [ca_address_sk#17, ca_state#18, c_customer_sk#19, c_current_addr_sk#20]
-
-(37) Exchange
-Input [2]: [ca_state#18, c_customer_sk#19]
-Arguments: hashpartitioning(c_customer_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(38) Sort [codegen id : 12]
-Input [2]: [ca_state#18, c_customer_sk#19]
-Arguments: [c_customer_sk#19 ASC NULLS FIRST], false, 0
-
-(39) SortMergeJoin [codegen id : 13]
+(27) SortMergeJoin [codegen id : 13]
 Left keys [1]: [ss_customer_sk#13]
-Right keys [1]: [c_customer_sk#19]
+Right keys [1]: [c_customer_sk#20]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 13]
-Output [1]: [ca_state#18]
-Input [3]: [ss_customer_sk#13, ca_state#18, c_customer_sk#19]
+(28) Project [codegen id : 13]
+Output [1]: [ca_state#19]
+Input [3]: [ss_customer_sk#13, ca_state#19, c_customer_sk#20]
 
-(41) HashAggregate [codegen id : 13]
-Input [1]: [ca_state#18]
-Keys [1]: [ca_state#18]
+(29) HashAggregate [codegen id : 13]
+Input [1]: [ca_state#19]
+Keys [1]: [ca_state#19]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#21]
-Results [2]: [ca_state#18, count#22]
+Results [2]: [ca_state#19, count#22]
 
-(42) Exchange
-Input [2]: [ca_state#18, count#22]
-Arguments: hashpartitioning(ca_state#18, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(30) Exchange
+Input [2]: [ca_state#19, count#22]
+Arguments: hashpartitioning(ca_state#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(43) HashAggregate [codegen id : 14]
-Input [2]: [ca_state#18, count#22]
-Keys [1]: [ca_state#18]
+(31) HashAggregate [codegen id : 14]
+Input [2]: [ca_state#19, count#22]
+Keys [1]: [ca_state#19]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#23]
-Results [2]: [ca_state#18 AS state#24, count(1)#23 AS cnt#25]
+Results [2]: [ca_state#19 AS state#24, count(1)#23 AS cnt#25]
 
-(44) Filter [codegen id : 14]
+(32) Filter [codegen id : 14]
 Input [2]: [state#24, cnt#25]
 Condition : (cnt#25 >= 10)
 
-(45) TakeOrderedAndProject
+(33) TakeOrderedAndProject
 Input [2]: [state#24, cnt#25]
 Arguments: 100, [cnt#25 ASC NULLS FIRST], [state#24, cnt#25]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#15
-BroadcastExchange (50)
-+- * Project (49)
-   +- * Filter (48)
-      +- * ColumnarToRow (47)
-         +- Scan parquet spark_catalog.default.date_dim (46)
+Subquery:1 Hosting operator id = 17 Hosting Expression = Subquery scalar-subquery#16, [id=#17]
+ObjectHashAggregate (49)
++- Exchange (48)
+   +- ObjectHashAggregate (47)
+      +- Exchange (46)
+         +- * Project (45)
+            +- * SortMergeJoin Inner (44)
+               :- * Sort (38)
+               :  +- Exchange (37)
+               :     +- * Filter (36)
+               :        +- * ColumnarToRow (35)
+               :           +- Scan parquet spark_catalog.default.customer_address (34)
+               +- * Sort (43)
+                  +- Exchange (42)
+                     +- * Filter (41)
+                        +- * ColumnarToRow (40)
+                           +- Scan parquet spark_catalog.default.customer (39)
 
 
-(46) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#16, d_month_seq#26]
+(34) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#26, ca_state#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string>
+
+(35) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#26, ca_state#19]
+
+(36) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#26, ca_state#19]
+Condition : isnotnull(ca_address_sk#26)
+
+(37) Exchange
+Input [2]: [ca_address_sk#26, ca_state#19]
+Arguments: hashpartitioning(ca_address_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(38) Sort [codegen id : 2]
+Input [2]: [ca_address_sk#26, ca_state#19]
+Arguments: [ca_address_sk#26 ASC NULLS FIRST], false, 0
+
+(39) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#20, c_current_addr_sk#27]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_current_addr_sk), IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
+
+(40) ColumnarToRow [codegen id : 3]
+Input [2]: [c_customer_sk#20, c_current_addr_sk#27]
+
+(41) Filter [codegen id : 3]
+Input [2]: [c_customer_sk#20, c_current_addr_sk#27]
+Condition : (isnotnull(c_current_addr_sk#27) AND isnotnull(c_customer_sk#20))
+
+(42) Exchange
+Input [2]: [c_customer_sk#20, c_current_addr_sk#27]
+Arguments: hashpartitioning(c_current_addr_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(43) Sort [codegen id : 4]
+Input [2]: [c_customer_sk#20, c_current_addr_sk#27]
+Arguments: [c_current_addr_sk#27 ASC NULLS FIRST], false, 0
+
+(44) SortMergeJoin [codegen id : 5]
+Left keys [1]: [ca_address_sk#26]
+Right keys [1]: [c_current_addr_sk#27]
+Join type: Inner
+Join condition: None
+
+(45) Project [codegen id : 5]
+Output [2]: [ca_state#19, c_customer_sk#20]
+Input [4]: [ca_address_sk#26, ca_state#19, c_customer_sk#20, c_current_addr_sk#27]
+
+(46) Exchange
+Input [2]: [ca_state#19, c_customer_sk#20]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(47) ObjectHashAggregate
+Input [2]: [ca_state#19, c_customer_sk#20]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2120804, 16966432, 0, 0)]
+Aggregate Attributes [1]: [buf#28]
+Results [1]: [buf#29]
+
+(48) Exchange
+Input [1]: [buf#29]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+
+(49) ObjectHashAggregate
+Input [1]: [buf#29]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2120804, 16966432, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2120804, 16966432, 0, 0)#30]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2120804, 16966432, 0, 0)#30 AS bloomFilter#31]
+
+Subquery:2 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#15
+BroadcastExchange (54)
++- * Project (53)
+   +- * Filter (52)
+      +- * ColumnarToRow (51)
+         +- Scan parquet spark_catalog.default.date_dim (50)
+
+
+(50) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#18, d_month_seq#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(47) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#16, d_month_seq#26]
+(51) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#18, d_month_seq#32]
 
-(48) Filter [codegen id : 1]
-Input [2]: [d_date_sk#16, d_month_seq#26]
-Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#16))
+(52) Filter [codegen id : 1]
+Input [2]: [d_date_sk#18, d_month_seq#32]
+Condition : ((isnotnull(d_month_seq#32) AND (d_month_seq#32 = Subquery scalar-subquery#33, [id=#34])) AND isnotnull(d_date_sk#18))
 
-(49) Project [codegen id : 1]
-Output [1]: [d_date_sk#16]
-Input [2]: [d_date_sk#16, d_month_seq#26]
+(53) Project [codegen id : 1]
+Output [1]: [d_date_sk#18]
+Input [2]: [d_date_sk#18, d_month_seq#32]
 
-(50) BroadcastExchange
-Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+(54) BroadcastExchange
+Input [1]: [d_date_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:2 Hosting operator id = 48 Hosting Expression = Subquery scalar-subquery#27, [id=#28]
-* HashAggregate (57)
-+- Exchange (56)
-   +- * HashAggregate (55)
-      +- * Project (54)
-         +- * Filter (53)
-            +- * ColumnarToRow (52)
-               +- Scan parquet spark_catalog.default.date_dim (51)
+Subquery:3 Hosting operator id = 52 Hosting Expression = Subquery scalar-subquery#33, [id=#34]
+* HashAggregate (61)
++- Exchange (60)
+   +- * HashAggregate (59)
+      +- * Project (58)
+         +- * Filter (57)
+            +- * ColumnarToRow (56)
+               +- Scan parquet spark_catalog.default.date_dim (55)
 
 
-(51) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#29, d_year#30, d_moy#31]
+(55) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_month_seq#35, d_year#36, d_moy#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,1)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(52) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+(56) ColumnarToRow [codegen id : 1]
+Input [3]: [d_month_seq#35, d_year#36, d_moy#37]
 
-(53) Filter [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
-Condition : (((isnotnull(d_year#30) AND isnotnull(d_moy#31)) AND (d_year#30 = 2000)) AND (d_moy#31 = 1))
+(57) Filter [codegen id : 1]
+Input [3]: [d_month_seq#35, d_year#36, d_moy#37]
+Condition : (((isnotnull(d_year#36) AND isnotnull(d_moy#37)) AND (d_year#36 = 2000)) AND (d_moy#37 = 1))
 
-(54) Project [codegen id : 1]
-Output [1]: [d_month_seq#29]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+(58) Project [codegen id : 1]
+Output [1]: [d_month_seq#35]
+Input [3]: [d_month_seq#35, d_year#36, d_moy#37]
 
-(55) HashAggregate [codegen id : 1]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+(59) HashAggregate [codegen id : 1]
+Input [1]: [d_month_seq#35]
+Keys [1]: [d_month_seq#35]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#35]
 
-(56) Exchange
-Input [1]: [d_month_seq#29]
-Arguments: hashpartitioning(d_month_seq#29, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(60) Exchange
+Input [1]: [d_month_seq#35]
+Arguments: hashpartitioning(d_month_seq#35, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(57) HashAggregate [codegen id : 2]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+(61) HashAggregate [codegen id : 2]
+Input [1]: [d_month_seq#35]
+Keys [1]: [d_month_seq#35]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/simplified.txt
@@ -41,6 +41,34 @@ TakeOrderedAndProject [cnt,state]
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.item [i_current_price,i_category]
                                         Filter [ss_customer_sk,ss_item_sk]
+                                          Subquery #3
+                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2120804, 16966432, 0, 0),bloomFilter,buf]
+                                              Exchange #8
+                                                ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                  Exchange [c_customer_sk] #9
+                                                    WholeStageCodegen (5)
+                                                      Project [ca_state,c_customer_sk]
+                                                        SortMergeJoin [ca_address_sk,c_current_addr_sk]
+                                                          InputAdapter
+                                                            WholeStageCodegen (2)
+                                                              Sort [ca_address_sk]
+                                                                InputAdapter
+                                                                  Exchange [ca_address_sk] #10
+                                                                    WholeStageCodegen (1)
+                                                                      Filter [ca_address_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                                          InputAdapter
+                                                            WholeStageCodegen (4)
+                                                              Sort [c_current_addr_sk]
+                                                                InputAdapter
+                                                                  Exchange [c_current_addr_sk] #11
+                                                                    WholeStageCodegen (3)
+                                                                      Filter [c_current_addr_sk,c_customer_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_sold_date_sk]
@@ -70,27 +98,4 @@ TakeOrderedAndProject [cnt,state]
                       WholeStageCodegen (12)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #8
-                              WholeStageCodegen (11)
-                                Project [ca_state,c_customer_sk]
-                                  SortMergeJoin [ca_address_sk,c_current_addr_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (8)
-                                        Sort [ca_address_sk]
-                                          InputAdapter
-                                            Exchange [ca_address_sk] #9
-                                              WholeStageCodegen (7)
-                                                Filter [ca_address_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                    InputAdapter
-                                      WholeStageCodegen (10)
-                                        Sort [c_current_addr_sk]
-                                          InputAdapter
-                                            Exchange [c_current_addr_sk] #10
-                                              WholeStageCodegen (9)
-                                                Filter [c_current_addr_sk,c_customer_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                            ReusedExchange [ca_state,c_customer_sk] #9

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64.sf100/explain.txt
@@ -1,39 +1,39 @@
 == Physical Plan ==
-* Sort (209)
-+- Exchange (208)
-   +- * Project (207)
-      +- * SortMergeJoin Inner (206)
-         :- * Sort (128)
-         :  +- Exchange (127)
-         :     +- * HashAggregate (126)
-         :        +- Exchange (125)
-         :           +- * HashAggregate (124)
-         :              +- * Project (123)
-         :                 +- * BroadcastHashJoin Inner BuildRight (122)
-         :                    :- * Project (116)
-         :                    :  +- * BroadcastHashJoin Inner BuildRight (115)
-         :                    :     :- * Project (113)
-         :                    :     :  +- * BroadcastHashJoin Inner BuildRight (112)
-         :                    :     :     :- * Project (107)
-         :                    :     :     :  +- * SortMergeJoin Inner (106)
-         :                    :     :     :     :- * Sort (103)
-         :                    :     :     :     :  +- Exchange (102)
-         :                    :     :     :     :     +- * Project (101)
-         :                    :     :     :     :        +- * SortMergeJoin Inner (100)
-         :                    :     :     :     :           :- * Sort (94)
-         :                    :     :     :     :           :  +- Exchange (93)
-         :                    :     :     :     :           :     +- * Project (92)
-         :                    :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (91)
-         :                    :     :     :     :           :           :- * Project (89)
-         :                    :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (88)
-         :                    :     :     :     :           :           :     :- * Project (83)
-         :                    :     :     :     :           :           :     :  +- * BroadcastHashJoin Inner BuildRight (82)
-         :                    :     :     :     :           :           :     :     :- * Project (77)
-         :                    :     :     :     :           :           :     :     :  +- * SortMergeJoin Inner (76)
-         :                    :     :     :     :           :           :     :     :     :- * Sort (73)
-         :                    :     :     :     :           :           :     :     :     :  +- Exchange (72)
-         :                    :     :     :     :           :           :     :     :     :     +- * Project (71)
-         :                    :     :     :     :           :           :     :     :     :        +- * SortMergeJoin Inner (70)
+* Sort (206)
++- Exchange (205)
+   +- * Project (204)
+      +- * SortMergeJoin Inner (203)
+         :- * Sort (122)
+         :  +- Exchange (121)
+         :     +- * HashAggregate (120)
+         :        +- Exchange (119)
+         :           +- * HashAggregate (118)
+         :              +- * Project (117)
+         :                 +- * BroadcastHashJoin Inner BuildRight (116)
+         :                    :- * Project (110)
+         :                    :  +- * BroadcastHashJoin Inner BuildRight (109)
+         :                    :     :- * Project (107)
+         :                    :     :  +- * BroadcastHashJoin Inner BuildRight (106)
+         :                    :     :     :- * Project (101)
+         :                    :     :     :  +- * SortMergeJoin Inner (100)
+         :                    :     :     :     :- * Sort (97)
+         :                    :     :     :     :  +- Exchange (96)
+         :                    :     :     :     :     +- * Project (95)
+         :                    :     :     :     :        +- * SortMergeJoin Inner (94)
+         :                    :     :     :     :           :- * Sort (91)
+         :                    :     :     :     :           :  +- Exchange (90)
+         :                    :     :     :     :           :     +- * Project (89)
+         :                    :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (88)
+         :                    :     :     :     :           :           :- * Project (86)
+         :                    :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (85)
+         :                    :     :     :     :           :           :     :- * Project (80)
+         :                    :     :     :     :           :           :     :  +- * BroadcastHashJoin Inner BuildRight (79)
+         :                    :     :     :     :           :           :     :     :- * Project (74)
+         :                    :     :     :     :           :           :     :     :  +- * SortMergeJoin Inner (73)
+         :                    :     :     :     :           :           :     :     :     :- * Sort (70)
+         :                    :     :     :     :           :           :     :     :     :  +- Exchange (69)
+         :                    :     :     :     :           :           :     :     :     :     +- * Project (68)
+         :                    :     :     :     :           :           :     :     :     :        +- * SortMergeJoin Inner (67)
          :                    :     :     :     :           :           :     :     :     :           :- * Sort (64)
          :                    :     :     :     :           :           :     :     :     :           :  +- Exchange (63)
          :                    :     :     :     :           :           :     :     :     :           :     +- * Project (62)
@@ -98,116 +98,113 @@
          :                    :     :     :     :           :           :     :     :     :           :           :           +- * ColumnarToRow (55)
          :                    :     :     :     :           :           :     :     :     :           :           :              +- Scan parquet spark_catalog.default.date_dim (54)
          :                    :     :     :     :           :           :     :     :     :           :           +- ReusedExchange (60)
-         :                    :     :     :     :           :           :     :     :     :           +- * Sort (69)
-         :                    :     :     :     :           :           :     :     :     :              +- Exchange (68)
-         :                    :     :     :     :           :           :     :     :     :                 +- * Filter (67)
-         :                    :     :     :     :           :           :     :     :     :                    +- * ColumnarToRow (66)
-         :                    :     :     :     :           :           :     :     :     :                       +- Scan parquet spark_catalog.default.customer_demographics (65)
-         :                    :     :     :     :           :           :     :     :     +- * Sort (75)
-         :                    :     :     :     :           :           :     :     :        +- ReusedExchange (74)
-         :                    :     :     :     :           :           :     :     +- BroadcastExchange (81)
-         :                    :     :     :     :           :           :     :        +- * Filter (80)
-         :                    :     :     :     :           :           :     :           +- * ColumnarToRow (79)
-         :                    :     :     :     :           :           :     :              +- Scan parquet spark_catalog.default.promotion (78)
-         :                    :     :     :     :           :           :     +- BroadcastExchange (87)
-         :                    :     :     :     :           :           :        +- * Filter (86)
-         :                    :     :     :     :           :           :           +- * ColumnarToRow (85)
-         :                    :     :     :     :           :           :              +- Scan parquet spark_catalog.default.household_demographics (84)
-         :                    :     :     :     :           :           +- ReusedExchange (90)
-         :                    :     :     :     :           +- * Sort (99)
-         :                    :     :     :     :              +- Exchange (98)
-         :                    :     :     :     :                 +- * Filter (97)
-         :                    :     :     :     :                    +- * ColumnarToRow (96)
-         :                    :     :     :     :                       +- Scan parquet spark_catalog.default.customer_address (95)
-         :                    :     :     :     +- * Sort (105)
-         :                    :     :     :        +- ReusedExchange (104)
-         :                    :     :     +- BroadcastExchange (111)
-         :                    :     :        +- * Filter (110)
-         :                    :     :           +- * ColumnarToRow (109)
-         :                    :     :              +- Scan parquet spark_catalog.default.income_band (108)
-         :                    :     +- ReusedExchange (114)
-         :                    +- BroadcastExchange (121)
-         :                       +- * Project (120)
-         :                          +- * Filter (119)
-         :                             +- * ColumnarToRow (118)
-         :                                +- Scan parquet spark_catalog.default.item (117)
-         +- * Sort (205)
-            +- Exchange (204)
-               +- * HashAggregate (203)
-                  +- Exchange (202)
-                     +- * HashAggregate (201)
-                        +- * Project (200)
-                           +- * BroadcastHashJoin Inner BuildRight (199)
-                              :- * Project (197)
-                              :  +- * BroadcastHashJoin Inner BuildRight (196)
-                              :     :- * Project (194)
-                              :     :  +- * BroadcastHashJoin Inner BuildRight (193)
-                              :     :     :- * Project (191)
-                              :     :     :  +- * SortMergeJoin Inner (190)
-                              :     :     :     :- * Sort (187)
-                              :     :     :     :  +- Exchange (186)
-                              :     :     :     :     +- * Project (185)
-                              :     :     :     :        +- * SortMergeJoin Inner (184)
-                              :     :     :     :           :- * Sort (181)
-                              :     :     :     :           :  +- Exchange (180)
-                              :     :     :     :           :     +- * Project (179)
-                              :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (178)
-                              :     :     :     :           :           :- * Project (176)
-                              :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (175)
-                              :     :     :     :           :           :     :- * Project (173)
-                              :     :     :     :           :           :     :  +- * BroadcastHashJoin Inner BuildRight (172)
-                              :     :     :     :           :           :     :     :- * Project (170)
-                              :     :     :     :           :           :     :     :  +- * SortMergeJoin Inner (169)
-                              :     :     :     :           :           :     :     :     :- * Sort (166)
-                              :     :     :     :           :           :     :     :     :  +- Exchange (165)
-                              :     :     :     :           :           :     :     :     :     +- * Project (164)
-                              :     :     :     :           :           :     :     :     :        +- * SortMergeJoin Inner (163)
-                              :     :     :     :           :           :     :     :     :           :- * Sort (160)
-                              :     :     :     :           :           :     :     :     :           :  +- Exchange (159)
-                              :     :     :     :           :           :     :     :     :           :     +- * Project (158)
-                              :     :     :     :           :           :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (157)
-                              :     :     :     :           :           :     :     :     :           :           :- * Project (155)
-                              :     :     :     :           :           :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (154)
-                              :     :     :     :           :           :     :     :     :           :           :     :- * Project (152)
-                              :     :     :     :           :           :     :     :     :           :           :     :  +- * SortMergeJoin Inner (151)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :- * Sort (148)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :  +- Exchange (147)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :     +- * Project (146)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :        +- * BroadcastHashJoin Inner BuildRight (145)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :- * Project (143)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :  +- * BroadcastHashJoin Inner BuildRight (142)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :- * Project (140)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (139)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :- * Project (137)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :  +- * SortMergeJoin Inner (136)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :- * Sort (133)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :  +- Exchange (132)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :     +- * Filter (131)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :        +- * ColumnarToRow (130)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :           +- Scan parquet spark_catalog.default.store_sales (129)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     +- * Sort (135)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :        +- ReusedExchange (134)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     +- ReusedExchange (138)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     +- ReusedExchange (141)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           +- ReusedExchange (144)
-                              :     :     :     :           :           :     :     :     :           :           :     :     +- * Sort (150)
-                              :     :     :     :           :           :     :     :     :           :           :     :        +- ReusedExchange (149)
-                              :     :     :     :           :           :     :     :     :           :           :     +- ReusedExchange (153)
-                              :     :     :     :           :           :     :     :     :           :           +- ReusedExchange (156)
-                              :     :     :     :           :           :     :     :     :           +- * Sort (162)
-                              :     :     :     :           :           :     :     :     :              +- ReusedExchange (161)
-                              :     :     :     :           :           :     :     :     +- * Sort (168)
-                              :     :     :     :           :           :     :     :        +- ReusedExchange (167)
-                              :     :     :     :           :           :     :     +- ReusedExchange (171)
-                              :     :     :     :           :           :     +- ReusedExchange (174)
-                              :     :     :     :           :           +- ReusedExchange (177)
-                              :     :     :     :           +- * Sort (183)
-                              :     :     :     :              +- ReusedExchange (182)
-                              :     :     :     +- * Sort (189)
-                              :     :     :        +- ReusedExchange (188)
-                              :     :     +- ReusedExchange (192)
-                              :     +- ReusedExchange (195)
-                              +- ReusedExchange (198)
+         :                    :     :     :     :           :           :     :     :     :           +- * Sort (66)
+         :                    :     :     :     :           :           :     :     :     :              +- ReusedExchange (65)
+         :                    :     :     :     :           :           :     :     :     +- * Sort (72)
+         :                    :     :     :     :           :           :     :     :        +- ReusedExchange (71)
+         :                    :     :     :     :           :           :     :     +- BroadcastExchange (78)
+         :                    :     :     :     :           :           :     :        +- * Filter (77)
+         :                    :     :     :     :           :           :     :           +- * ColumnarToRow (76)
+         :                    :     :     :     :           :           :     :              +- Scan parquet spark_catalog.default.promotion (75)
+         :                    :     :     :     :           :           :     +- BroadcastExchange (84)
+         :                    :     :     :     :           :           :        +- * Filter (83)
+         :                    :     :     :     :           :           :           +- * ColumnarToRow (82)
+         :                    :     :     :     :           :           :              +- Scan parquet spark_catalog.default.household_demographics (81)
+         :                    :     :     :     :           :           +- ReusedExchange (87)
+         :                    :     :     :     :           +- * Sort (93)
+         :                    :     :     :     :              +- ReusedExchange (92)
+         :                    :     :     :     +- * Sort (99)
+         :                    :     :     :        +- ReusedExchange (98)
+         :                    :     :     +- BroadcastExchange (105)
+         :                    :     :        +- * Filter (104)
+         :                    :     :           +- * ColumnarToRow (103)
+         :                    :     :              +- Scan parquet spark_catalog.default.income_band (102)
+         :                    :     +- ReusedExchange (108)
+         :                    +- BroadcastExchange (115)
+         :                       +- * Project (114)
+         :                          +- * Filter (113)
+         :                             +- * ColumnarToRow (112)
+         :                                +- Scan parquet spark_catalog.default.item (111)
+         +- * Sort (202)
+            +- Exchange (201)
+               +- * HashAggregate (200)
+                  +- Exchange (199)
+                     +- * HashAggregate (198)
+                        +- * Project (197)
+                           +- * BroadcastHashJoin Inner BuildRight (196)
+                              :- * Project (194)
+                              :  +- * BroadcastHashJoin Inner BuildRight (193)
+                              :     :- * Project (191)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (190)
+                              :     :     :- * Project (188)
+                              :     :     :  +- * SortMergeJoin Inner (187)
+                              :     :     :     :- * Sort (184)
+                              :     :     :     :  +- Exchange (183)
+                              :     :     :     :     +- * Project (182)
+                              :     :     :     :        +- * SortMergeJoin Inner (181)
+                              :     :     :     :           :- * Sort (178)
+                              :     :     :     :           :  +- Exchange (177)
+                              :     :     :     :           :     +- * Project (176)
+                              :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (175)
+                              :     :     :     :           :           :- * Project (173)
+                              :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (172)
+                              :     :     :     :           :           :     :- * Project (170)
+                              :     :     :     :           :           :     :  +- * BroadcastHashJoin Inner BuildRight (169)
+                              :     :     :     :           :           :     :     :- * Project (167)
+                              :     :     :     :           :           :     :     :  +- * SortMergeJoin Inner (166)
+                              :     :     :     :           :           :     :     :     :- * Sort (163)
+                              :     :     :     :           :           :     :     :     :  +- Exchange (162)
+                              :     :     :     :           :           :     :     :     :     +- * Project (161)
+                              :     :     :     :           :           :     :     :     :        +- * SortMergeJoin Inner (160)
+                              :     :     :     :           :           :     :     :     :           :- * Sort (157)
+                              :     :     :     :           :           :     :     :     :           :  +- Exchange (156)
+                              :     :     :     :           :           :     :     :     :           :     +- * Project (155)
+                              :     :     :     :           :           :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (154)
+                              :     :     :     :           :           :     :     :     :           :           :- * Project (152)
+                              :     :     :     :           :           :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (151)
+                              :     :     :     :           :           :     :     :     :           :           :     :- * Project (149)
+                              :     :     :     :           :           :     :     :     :           :           :     :  +- * SortMergeJoin Inner (148)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :- * Sort (142)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :  +- Exchange (141)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :     +- * Project (140)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :        +- * BroadcastHashJoin Inner BuildRight (139)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :- * Project (137)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :  +- * BroadcastHashJoin Inner BuildRight (136)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :- * Project (134)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (133)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :- * Project (131)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :  +- * SortMergeJoin Inner (130)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :- * Sort (127)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :  +- Exchange (126)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :     +- * Filter (125)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :        +- * ColumnarToRow (124)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :           +- Scan parquet spark_catalog.default.store_sales (123)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     +- * Sort (129)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :        +- ReusedExchange (128)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     +- ReusedExchange (132)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     +- ReusedExchange (135)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           +- ReusedExchange (138)
+                              :     :     :     :           :           :     :     :     :           :           :     :     +- * Sort (147)
+                              :     :     :     :           :           :     :     :     :           :           :     :        +- Exchange (146)
+                              :     :     :     :           :           :     :     :     :           :           :     :           +- * Filter (145)
+                              :     :     :     :           :           :     :     :     :           :           :     :              +- * ColumnarToRow (144)
+                              :     :     :     :           :           :     :     :     :           :           :     :                 +- Scan parquet spark_catalog.default.customer (143)
+                              :     :     :     :           :           :     :     :     :           :           :     +- ReusedExchange (150)
+                              :     :     :     :           :           :     :     :     :           :           +- ReusedExchange (153)
+                              :     :     :     :           :           :     :     :     :           +- * Sort (159)
+                              :     :     :     :           :           :     :     :     :              +- ReusedExchange (158)
+                              :     :     :     :           :           :     :     :     +- * Sort (165)
+                              :     :     :     :           :           :     :     :        +- ReusedExchange (164)
+                              :     :     :     :           :           :     :     +- ReusedExchange (168)
+                              :     :     :     :           :           :     +- ReusedExchange (171)
+                              :     :     :     :           :           +- ReusedExchange (174)
+                              :     :     :     :           +- * Sort (180)
+                              :     :     :     :              +- ReusedExchange (179)
+                              :     :     :     +- * Sort (186)
+                              :     :     :        +- ReusedExchange (185)
+                              :     :     +- ReusedExchange (189)
+                              :     +- ReusedExchange (192)
+                              +- ReusedExchange (195)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -223,7 +220,7 @@ Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_ad
 
 (3) Filter [codegen id : 1]
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#1, 42)))
+Condition : (((((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND true) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_cdemo_sk#3, 42), false)) AND might_contain(Subquery scalar-subquery#16, [id=#17], xxhash64(ss_addr_sk#5, 42), false)) AND might_contain(Subquery scalar-subquery#18, [id=#19], xxhash64(ss_item_sk#1, 42), true))
 
 (4) Exchange
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
@@ -234,1013 +231,1186 @@ Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_ad
 Arguments: [ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#8 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Output [3]: [sr_item_sk#20, sr_ticket_number#21, sr_returned_date_sk#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Input [3]: [sr_item_sk#20, sr_ticket_number#21, sr_returned_date_sk#22]
 
 (8) Filter [codegen id : 3]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
-Condition : (isnotnull(sr_item_sk#16) AND isnotnull(sr_ticket_number#17))
+Input [3]: [sr_item_sk#20, sr_ticket_number#21, sr_returned_date_sk#22]
+Condition : (isnotnull(sr_item_sk#20) AND isnotnull(sr_ticket_number#21))
 
 (9) Project [codegen id : 3]
-Output [2]: [sr_item_sk#16, sr_ticket_number#17]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Output [2]: [sr_item_sk#20, sr_ticket_number#21]
+Input [3]: [sr_item_sk#20, sr_ticket_number#21, sr_returned_date_sk#22]
 
 (10) Exchange
-Input [2]: [sr_item_sk#16, sr_ticket_number#17]
-Arguments: hashpartitioning(sr_item_sk#16, sr_ticket_number#17, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [sr_item_sk#20, sr_ticket_number#21]
+Arguments: hashpartitioning(sr_item_sk#20, sr_ticket_number#21, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (11) Sort [codegen id : 4]
-Input [2]: [sr_item_sk#16, sr_ticket_number#17]
-Arguments: [sr_item_sk#16 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#20, sr_ticket_number#21]
+Arguments: [sr_item_sk#20 ASC NULLS FIRST, sr_ticket_number#21 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#8]
-Right keys [2]: [sr_item_sk#16, sr_ticket_number#17]
+Right keys [2]: [sr_item_sk#20, sr_ticket_number#21]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 13]
 Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, sr_item_sk#16, sr_ticket_number#17]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, sr_item_sk#20, sr_ticket_number#21]
 
 (14) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Output [4]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cs_sold_date_sk#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_order_number)]
 ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_ext_list_price:decimal(7,2)>
 
 (15) ColumnarToRow [codegen id : 5]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Input [4]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cs_sold_date_sk#26]
 
 (16) Filter [codegen id : 5]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
-Condition : (isnotnull(cs_item_sk#19) AND isnotnull(cs_order_number#20))
+Input [4]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cs_sold_date_sk#26]
+Condition : (isnotnull(cs_item_sk#23) AND isnotnull(cs_order_number#24))
 
 (17) Project [codegen id : 5]
-Output [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Output [3]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25]
+Input [4]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cs_sold_date_sk#26]
 
 (18) Exchange
-Input [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Arguments: hashpartitioning(cs_item_sk#19, cs_order_number#20, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25]
+Arguments: hashpartitioning(cs_item_sk#23, cs_order_number#24, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (19) Sort [codegen id : 6]
-Input [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Arguments: [cs_item_sk#19 ASC NULLS FIRST, cs_order_number#20 ASC NULLS FIRST], false, 0
+Input [3]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25]
+Arguments: [cs_item_sk#23 ASC NULLS FIRST, cs_order_number#24 ASC NULLS FIRST], false, 0
 
 (20) Scan parquet spark_catalog.default.catalog_returns
-Output [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Output [6]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31, cr_returned_date_sk#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_refunded_cash:decimal(7,2),cr_reversed_charge:decimal(7,2),cr_store_credit:decimal(7,2)>
 
 (21) ColumnarToRow [codegen id : 7]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Input [6]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31, cr_returned_date_sk#32]
 
 (22) Filter [codegen id : 7]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
-Condition : (isnotnull(cr_item_sk#23) AND isnotnull(cr_order_number#24))
+Input [6]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31, cr_returned_date_sk#32]
+Condition : (isnotnull(cr_item_sk#27) AND isnotnull(cr_order_number#28))
 
 (23) Project [codegen id : 7]
-Output [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Output [5]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Input [6]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31, cr_returned_date_sk#32]
 
 (24) Exchange
-Input [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Arguments: hashpartitioning(cr_item_sk#23, cr_order_number#24, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [5]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Arguments: hashpartitioning(cr_item_sk#27, cr_order_number#28, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (25) Sort [codegen id : 8]
-Input [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Arguments: [cr_item_sk#23 ASC NULLS FIRST, cr_order_number#24 ASC NULLS FIRST], false, 0
+Input [5]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Arguments: [cr_item_sk#27 ASC NULLS FIRST, cr_order_number#28 ASC NULLS FIRST], false, 0
 
 (26) SortMergeJoin [codegen id : 9]
-Left keys [2]: [cs_item_sk#19, cs_order_number#20]
-Right keys [2]: [cr_item_sk#23, cr_order_number#24]
+Left keys [2]: [cs_item_sk#23, cs_order_number#24]
+Right keys [2]: [cr_item_sk#27, cr_order_number#28]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
-Output [5]: [cs_item_sk#19, cs_ext_list_price#21, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Input [8]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
+Output [5]: [cs_item_sk#23, cs_ext_list_price#25, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Input [8]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
 
 (28) HashAggregate [codegen id : 9]
-Input [5]: [cs_item_sk#19, cs_ext_list_price#21, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Keys [1]: [cs_item_sk#19]
-Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#21)), partial_sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))]
-Aggregate Attributes [3]: [sum#29, sum#30, isEmpty#31]
-Results [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
+Input [5]: [cs_item_sk#23, cs_ext_list_price#25, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Keys [1]: [cs_item_sk#23]
+Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#25)), partial_sum(((cr_refunded_cash#29 + cr_reversed_charge#30) + cr_store_credit#31))]
+Aggregate Attributes [3]: [sum#33, sum#34, isEmpty#35]
+Results [4]: [cs_item_sk#23, sum#36, sum#37, isEmpty#38]
 
 (29) Exchange
-Input [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(cs_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [4]: [cs_item_sk#23, sum#36, sum#37, isEmpty#38]
+Arguments: hashpartitioning(cs_item_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (30) HashAggregate [codegen id : 10]
-Input [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
-Keys [1]: [cs_item_sk#19]
-Functions [2]: [sum(UnscaledValue(cs_ext_list_price#21)), sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#21))#35, sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))#36]
-Results [3]: [cs_item_sk#19, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#21))#35,17,2) AS sale#37, sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))#36 AS refund#38]
+Input [4]: [cs_item_sk#23, sum#36, sum#37, isEmpty#38]
+Keys [1]: [cs_item_sk#23]
+Functions [2]: [sum(UnscaledValue(cs_ext_list_price#25)), sum(((cr_refunded_cash#29 + cr_reversed_charge#30) + cr_store_credit#31))]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#25))#39, sum(((cr_refunded_cash#29 + cr_reversed_charge#30) + cr_store_credit#31))#40]
+Results [3]: [cs_item_sk#23, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#25))#39,17,2) AS sale#41, sum(((cr_refunded_cash#29 + cr_reversed_charge#30) + cr_store_credit#31))#40 AS refund#42]
 
 (31) Filter [codegen id : 10]
-Input [3]: [cs_item_sk#19, sale#37, refund#38]
-Condition : ((isnotnull(sale#37) AND isnotnull(refund#38)) AND (cast(sale#37 as decimal(21,2)) > (2 * refund#38)))
+Input [3]: [cs_item_sk#23, sale#41, refund#42]
+Condition : ((isnotnull(sale#41) AND isnotnull(refund#42)) AND (cast(sale#41 as decimal(21,2)) > (2 * refund#42)))
 
 (32) Project [codegen id : 10]
-Output [1]: [cs_item_sk#19]
-Input [3]: [cs_item_sk#19, sale#37, refund#38]
+Output [1]: [cs_item_sk#23]
+Input [3]: [cs_item_sk#23, sale#41, refund#42]
 
 (33) BroadcastExchange
-Input [1]: [cs_item_sk#19]
+Input [1]: [cs_item_sk#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [cs_item_sk#19]
+Right keys [1]: [cs_item_sk#23]
 Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 13]
 Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, cs_item_sk#19]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, cs_item_sk#23]
 
-(36) ReusedExchange [Reuses operator id: 220]
-Output [2]: [d_date_sk#39, d_year#40]
+(36) ReusedExchange [Reuses operator id: 231]
+Output [2]: [d_date_sk#43, d_year#44]
 
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#39]
+Right keys [1]: [d_date_sk#43]
 Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
-Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40]
-Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, d_date_sk#39, d_year#40]
+Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44]
+Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, d_date_sk#43, d_year#44]
 
 (39) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Output [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_zip:string>
 
 (40) ColumnarToRow [codegen id : 12]
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Input [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
 
 (41) Filter [codegen id : 12]
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
-Condition : ((isnotnull(s_store_sk#41) AND isnotnull(s_store_name#42)) AND isnotnull(s_zip#43))
+Input [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
+Condition : ((isnotnull(s_store_sk#45) AND isnotnull(s_store_name#46)) AND isnotnull(s_zip#47))
 
 (42) BroadcastExchange
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Input [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
 (43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#6]
-Right keys [1]: [s_store_sk#41]
+Right keys [1]: [s_store_sk#45]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
-Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_sk#41, s_store_name#42, s_zip#43]
+Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_sk#45, s_store_name#46, s_zip#47]
 
 (45) Exchange
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (46) Sort [codegen id : 14]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (47) Scan parquet spark_catalog.default.customer
-Output [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Output [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_first_sales_date_sk), IsNotNull(c_first_shipto_date_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int,c_first_shipto_date_sk:int,c_first_sales_date_sk:int>
 
 (48) ColumnarToRow [codegen id : 15]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
 
 (49) Filter [codegen id : 15]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Condition : (((((isnotnull(c_customer_sk#44) AND isnotnull(c_first_sales_date_sk#49)) AND isnotnull(c_first_shipto_date_sk#48)) AND isnotnull(c_current_cdemo_sk#45)) AND isnotnull(c_current_hdemo_sk#46)) AND isnotnull(c_current_addr_sk#47))
+Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
+Condition : (((((((isnotnull(c_customer_sk#48) AND isnotnull(c_first_sales_date_sk#53)) AND isnotnull(c_first_shipto_date_sk#52)) AND isnotnull(c_current_cdemo_sk#49)) AND isnotnull(c_current_hdemo_sk#50)) AND isnotnull(c_current_addr_sk#51)) AND might_contain(Subquery scalar-subquery#54, [id=#55], xxhash64(c_current_cdemo_sk#49, 42), false)) AND might_contain(Subquery scalar-subquery#56, [id=#57], xxhash64(c_current_addr_sk#51, 42), false))
 
 (50) Exchange
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Arguments: hashpartitioning(c_customer_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
+Arguments: hashpartitioning(c_customer_sk#48, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (51) Sort [codegen id : 16]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Arguments: [c_customer_sk#44 ASC NULLS FIRST], false, 0
+Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
+Arguments: [c_customer_sk#48 ASC NULLS FIRST], false, 0
 
 (52) SortMergeJoin [codegen id : 19]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#44]
+Right keys [1]: [c_customer_sk#48]
 Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Input [18]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
+Input [18]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
 
 (54) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#50, d_year#51]
+Output [2]: [d_date_sk#58, d_year#59]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (55) ColumnarToRow [codegen id : 17]
-Input [2]: [d_date_sk#50, d_year#51]
+Input [2]: [d_date_sk#58, d_year#59]
 
 (56) Filter [codegen id : 17]
-Input [2]: [d_date_sk#50, d_year#51]
-Condition : isnotnull(d_date_sk#50)
+Input [2]: [d_date_sk#58, d_year#59]
+Condition : isnotnull(d_date_sk#58)
 
 (57) BroadcastExchange
-Input [2]: [d_date_sk#50, d_year#51]
+Input [2]: [d_date_sk#58, d_year#59]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
 
 (58) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [c_first_sales_date_sk#49]
-Right keys [1]: [d_date_sk#50]
+Left keys [1]: [c_first_sales_date_sk#53]
+Right keys [1]: [d_date_sk#58]
 Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, d_year#51]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49, d_date_sk#50, d_year#51]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, d_year#59]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53, d_date_sk#58, d_year#59]
 
 (60) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#52, d_year#53]
+Output [2]: [d_date_sk#60, d_year#61]
 
 (61) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [c_first_shipto_date_sk#48]
-Right keys [1]: [d_date_sk#52]
+Left keys [1]: [c_first_shipto_date_sk#52]
+Right keys [1]: [d_date_sk#60]
 Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, d_year#51, d_date_sk#52, d_year#53]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, d_year#59, d_date_sk#60, d_year#61]
 
 (63) Exchange
-Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
+Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
 Arguments: hashpartitioning(ss_cdemo_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (64) Sort [codegen id : 20]
-Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
+Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
 Arguments: [ss_cdemo_sk#3 ASC NULLS FIRST], false, 0
 
-(65) Scan parquet spark_catalog.default.customer_demographics
-Output [2]: [cd_demo_sk#54, cd_marital_status#55]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
-ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
+(65) ReusedExchange [Reuses operator id: 235]
+Output [2]: [cd_demo_sk#62, cd_marital_status#63]
 
-(66) ColumnarToRow [codegen id : 21]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
+(66) Sort [codegen id : 22]
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+Arguments: [cd_demo_sk#62 ASC NULLS FIRST], false, 0
 
-(67) Filter [codegen id : 21]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Condition : (isnotnull(cd_demo_sk#54) AND isnotnull(cd_marital_status#55))
-
-(68) Exchange
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Arguments: hashpartitioning(cd_demo_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(69) Sort [codegen id : 22]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Arguments: [cd_demo_sk#54 ASC NULLS FIRST], false, 0
-
-(70) SortMergeJoin [codegen id : 23]
+(67) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ss_cdemo_sk#3]
-Right keys [1]: [cd_demo_sk#54]
+Right keys [1]: [cd_demo_sk#62]
 Join type: Inner
 Join condition: None
 
-(71) Project [codegen id : 23]
-Output [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_demo_sk#54, cd_marital_status#55]
+(68) Project [codegen id : 23]
+Output [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_marital_status#63]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_demo_sk#62, cd_marital_status#63]
 
-(72) Exchange
-Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Arguments: hashpartitioning(c_current_cdemo_sk#45, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+(69) Exchange
+Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_marital_status#63]
+Arguments: hashpartitioning(c_current_cdemo_sk#49, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(73) Sort [codegen id : 24]
-Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Arguments: [c_current_cdemo_sk#45 ASC NULLS FIRST], false, 0
+(70) Sort [codegen id : 24]
+Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_marital_status#63]
+Arguments: [c_current_cdemo_sk#49 ASC NULLS FIRST], false, 0
 
-(74) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#56, cd_marital_status#57]
+(71) ReusedExchange [Reuses operator id: 235]
+Output [2]: [cd_demo_sk#64, cd_marital_status#65]
 
-(75) Sort [codegen id : 26]
-Input [2]: [cd_demo_sk#56, cd_marital_status#57]
-Arguments: [cd_demo_sk#56 ASC NULLS FIRST], false, 0
+(72) Sort [codegen id : 26]
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+Arguments: [cd_demo_sk#64 ASC NULLS FIRST], false, 0
 
-(76) SortMergeJoin [codegen id : 30]
-Left keys [1]: [c_current_cdemo_sk#45]
-Right keys [1]: [cd_demo_sk#56]
+(73) SortMergeJoin [codegen id : 30]
+Left keys [1]: [c_current_cdemo_sk#49]
+Right keys [1]: [cd_demo_sk#64]
 Join type: Inner
-Join condition: NOT (cd_marital_status#55 = cd_marital_status#57)
+Join condition: NOT (cd_marital_status#63 = cd_marital_status#65)
 
-(77) Project [codegen id : 30]
-Output [14]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [18]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55, cd_demo_sk#56, cd_marital_status#57]
+(74) Project [codegen id : 30]
+Output [14]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
+Input [18]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_marital_status#63, cd_demo_sk#64, cd_marital_status#65]
 
-(78) Scan parquet spark_catalog.default.promotion
-Output [1]: [p_promo_sk#58]
+(75) Scan parquet spark_catalog.default.promotion
+Output [1]: [p_promo_sk#66]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(79) ColumnarToRow [codegen id : 27]
-Input [1]: [p_promo_sk#58]
+(76) ColumnarToRow [codegen id : 27]
+Input [1]: [p_promo_sk#66]
 
-(80) Filter [codegen id : 27]
-Input [1]: [p_promo_sk#58]
-Condition : isnotnull(p_promo_sk#58)
+(77) Filter [codegen id : 27]
+Input [1]: [p_promo_sk#66]
+Condition : isnotnull(p_promo_sk#66)
 
-(81) BroadcastExchange
-Input [1]: [p_promo_sk#58]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
+(78) BroadcastExchange
+Input [1]: [p_promo_sk#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
 
-(82) BroadcastHashJoin [codegen id : 30]
+(79) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_promo_sk#7]
-Right keys [1]: [p_promo_sk#58]
+Right keys [1]: [p_promo_sk#66]
 Join type: Inner
 Join condition: None
 
-(83) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, p_promo_sk#58]
+(80) Project [codegen id : 30]
+Output [13]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
+Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, p_promo_sk#66]
 
-(84) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#59, hd_income_band_sk#60]
+(81) Scan parquet spark_catalog.default.household_demographics
+Output [2]: [hd_demo_sk#67, hd_income_band_sk#68]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
-(85) ColumnarToRow [codegen id : 28]
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
+(82) ColumnarToRow [codegen id : 28]
+Input [2]: [hd_demo_sk#67, hd_income_band_sk#68]
 
-(86) Filter [codegen id : 28]
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
-Condition : (isnotnull(hd_demo_sk#59) AND isnotnull(hd_income_band_sk#60))
+(83) Filter [codegen id : 28]
+Input [2]: [hd_demo_sk#67, hd_income_band_sk#68]
+Condition : (isnotnull(hd_demo_sk#67) AND isnotnull(hd_income_band_sk#68))
 
-(87) BroadcastExchange
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+(84) BroadcastExchange
+Input [2]: [hd_demo_sk#67, hd_income_band_sk#68]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
+
+(85) BroadcastHashJoin [codegen id : 30]
+Left keys [1]: [ss_hdemo_sk#4]
+Right keys [1]: [hd_demo_sk#67]
+Join type: Inner
+Join condition: None
+
+(86) Project [codegen id : 30]
+Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68]
+Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, hd_demo_sk#67, hd_income_band_sk#68]
+
+(87) ReusedExchange [Reuses operator id: 84]
+Output [2]: [hd_demo_sk#69, hd_income_band_sk#70]
 
 (88) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [ss_hdemo_sk#4]
-Right keys [1]: [hd_demo_sk#59]
+Left keys [1]: [c_current_hdemo_sk#50]
+Right keys [1]: [hd_demo_sk#69]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60]
-Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_demo_sk#59, hd_income_band_sk#60]
+Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70]
+Input [15]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_demo_sk#69, hd_income_band_sk#70]
 
-(90) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#61, hd_income_band_sk#62]
+(90) Exchange
+Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70]
+Arguments: hashpartitioning(ss_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(91) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [c_current_hdemo_sk#46]
-Right keys [1]: [hd_demo_sk#61]
-Join type: Inner
-Join condition: None
-
-(92) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
-Input [15]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_demo_sk#61, hd_income_band_sk#62]
-
-(93) Exchange
-Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
-Arguments: hashpartitioning(ss_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(94) Sort [codegen id : 31]
-Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
+(91) Sort [codegen id : 31]
+Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70]
 Arguments: [ss_addr_sk#5 ASC NULLS FIRST], false, 0
 
-(95) Scan parquet spark_catalog.default.customer_address
-Output [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
+(92) ReusedExchange [Reuses operator id: 242]
+Output [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
 
-(96) ColumnarToRow [codegen id : 32]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+(93) Sort [codegen id : 33]
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Arguments: [ca_address_sk#71 ASC NULLS FIRST], false, 0
 
-(97) Filter [codegen id : 32]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Condition : isnotnull(ca_address_sk#63)
-
-(98) Exchange
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: hashpartitioning(ca_address_sk#63, 5), ENSURE_REQUIREMENTS, [plan_id=17]
-
-(99) Sort [codegen id : 33]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: [ca_address_sk#63 ASC NULLS FIRST], false, 0
-
-(100) SortMergeJoin [codegen id : 34]
+(94) SortMergeJoin [codegen id : 34]
 Left keys [1]: [ss_addr_sk#5]
-Right keys [1]: [ca_address_sk#63]
+Right keys [1]: [ca_address_sk#71]
 Join type: Inner
 Join condition: None
 
-(101) Project [codegen id : 34]
-Output [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Input [18]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+(95) Project [codegen id : 34]
+Output [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Input [18]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
 
-(102) Exchange
-Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: hashpartitioning(c_current_addr_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+(96) Exchange
+Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Arguments: hashpartitioning(c_current_addr_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(103) Sort [codegen id : 35]
-Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: [c_current_addr_sk#47 ASC NULLS FIRST], false, 0
+(97) Sort [codegen id : 35]
+Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Arguments: [c_current_addr_sk#51 ASC NULLS FIRST], false, 0
 
-(104) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
+(98) ReusedExchange [Reuses operator id: 242]
+Output [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
 
-(105) Sort [codegen id : 37]
-Input [5]: [ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Arguments: [ca_address_sk#68 ASC NULLS FIRST], false, 0
+(99) Sort [codegen id : 37]
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Arguments: [ca_address_sk#76 ASC NULLS FIRST], false, 0
 
-(106) SortMergeJoin [codegen id : 41]
-Left keys [1]: [c_current_addr_sk#47]
-Right keys [1]: [ca_address_sk#68]
+(100) SortMergeJoin [codegen id : 41]
+Left keys [1]: [c_current_addr_sk#51]
+Right keys [1]: [ca_address_sk#76]
 Join type: Inner
 Join condition: None
 
-(107) Project [codegen id : 41]
-Output [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [21]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
+(101) Project [codegen id : 41]
+Output [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Input [21]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
 
-(108) Scan parquet spark_catalog.default.income_band
-Output [1]: [ib_income_band_sk#73]
+(102) Scan parquet spark_catalog.default.income_band
+Output [1]: [ib_income_band_sk#81]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/income_band]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
-(109) ColumnarToRow [codegen id : 38]
-Input [1]: [ib_income_band_sk#73]
+(103) ColumnarToRow [codegen id : 38]
+Input [1]: [ib_income_band_sk#81]
 
-(110) Filter [codegen id : 38]
-Input [1]: [ib_income_band_sk#73]
-Condition : isnotnull(ib_income_band_sk#73)
+(104) Filter [codegen id : 38]
+Input [1]: [ib_income_band_sk#81]
+Condition : isnotnull(ib_income_band_sk#81)
 
-(111) BroadcastExchange
-Input [1]: [ib_income_band_sk#73]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=19]
+(105) BroadcastExchange
+Input [1]: [ib_income_band_sk#81]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=17]
 
-(112) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [hd_income_band_sk#60]
-Right keys [1]: [ib_income_band_sk#73]
+(106) BroadcastHashJoin [codegen id : 41]
+Left keys [1]: [hd_income_band_sk#68]
+Right keys [1]: [ib_income_band_sk#81]
 Join type: Inner
 Join condition: None
 
-(113) Project [codegen id : 41]
-Output [18]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [20]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, ib_income_band_sk#73]
+(107) Project [codegen id : 41]
+Output [18]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Input [20]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, ib_income_band_sk#81]
 
-(114) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#74]
+(108) ReusedExchange [Reuses operator id: 105]
+Output [1]: [ib_income_band_sk#82]
 
-(115) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [hd_income_band_sk#62]
-Right keys [1]: [ib_income_band_sk#74]
+(109) BroadcastHashJoin [codegen id : 41]
+Left keys [1]: [hd_income_band_sk#70]
+Right keys [1]: [ib_income_band_sk#82]
 Join type: Inner
 Join condition: None
 
-(116) Project [codegen id : 41]
-Output [17]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, ib_income_band_sk#74]
+(110) Project [codegen id : 41]
+Output [17]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, ib_income_band_sk#82]
 
-(117) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+(111) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#83, i_current_price#84, i_color#85, i_product_name#86]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood           ,floral              ,indian              ,medium              ,purple              ,spring              ]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string,i_product_name:string>
 
-(118) ColumnarToRow [codegen id : 40]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+(112) ColumnarToRow [codegen id : 40]
+Input [4]: [i_item_sk#83, i_current_price#84, i_color#85, i_product_name#86]
 
-(119) Filter [codegen id : 40]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
-Condition : ((((((isnotnull(i_current_price#76) AND i_color#77 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#76 >= 64.00)) AND (i_current_price#76 <= 74.00)) AND (i_current_price#76 >= 65.00)) AND (i_current_price#76 <= 79.00)) AND isnotnull(i_item_sk#75))
+(113) Filter [codegen id : 40]
+Input [4]: [i_item_sk#83, i_current_price#84, i_color#85, i_product_name#86]
+Condition : ((((((isnotnull(i_current_price#84) AND i_color#85 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#84 >= 64.00)) AND (i_current_price#84 <= 74.00)) AND (i_current_price#84 >= 65.00)) AND (i_current_price#84 <= 79.00)) AND isnotnull(i_item_sk#83))
 
-(120) Project [codegen id : 40]
-Output [2]: [i_item_sk#75, i_product_name#78]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+(114) Project [codegen id : 40]
+Output [2]: [i_item_sk#83, i_product_name#86]
+Input [4]: [i_item_sk#83, i_current_price#84, i_color#85, i_product_name#86]
 
-(121) BroadcastExchange
-Input [2]: [i_item_sk#75, i_product_name#78]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
+(115) BroadcastExchange
+Input [2]: [i_item_sk#83, i_product_name#86]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
-(122) BroadcastHashJoin [codegen id : 41]
+(116) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#75]
+Right keys [1]: [i_item_sk#83]
 Join type: Inner
 Join condition: None
 
-(123) Project [codegen id : 41]
-Output [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, d_year#51, d_year#53, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
-Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
+(117) Project [codegen id : 41]
+Output [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, d_year#59, d_year#61, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, i_item_sk#83, i_product_name#86]
+Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, i_item_sk#83, i_product_name#86]
 
-(124) HashAggregate [codegen id : 41]
-Input [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, d_year#51, d_year#53, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
-Keys [15]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53]
+(118) HashAggregate [codegen id : 41]
+Input [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, d_year#59, d_year#61, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, i_item_sk#83, i_product_name#86]
+Keys [15]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61]
 Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#9)), partial_sum(UnscaledValue(ss_list_price#10)), partial_sum(UnscaledValue(ss_coupon_amt#11))]
-Aggregate Attributes [4]: [count#79, sum#80, sum#81, sum#82]
-Results [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
+Aggregate Attributes [4]: [count#87, sum#88, sum#89, sum#90]
+Results [19]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61, count#91, sum#92, sum#93, sum#94]
 
-(125) Exchange
-Input [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
-Arguments: hashpartitioning(i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+(119) Exchange
+Input [19]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61, count#91, sum#92, sum#93, sum#94]
+Arguments: hashpartitioning(i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(126) HashAggregate [codegen id : 42]
-Input [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
-Keys [15]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53]
+(120) HashAggregate [codegen id : 42]
+Input [19]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61, count#91, sum#92, sum#93, sum#94]
+Keys [15]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61]
 Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#9)), sum(UnscaledValue(ss_list_price#10)), sum(UnscaledValue(ss_coupon_amt#11))]
-Aggregate Attributes [4]: [count(1)#87, sum(UnscaledValue(ss_wholesale_cost#9))#88, sum(UnscaledValue(ss_list_price#10))#89, sum(UnscaledValue(ss_coupon_amt#11))#90]
-Results [17]: [i_product_name#78 AS product_name#91, i_item_sk#75 AS item_sk#92, s_store_name#42 AS store_name#93, s_zip#43 AS store_zip#94, ca_street_number#64 AS b_street_number#95, ca_street_name#65 AS b_streen_name#96, ca_city#66 AS b_city#97, ca_zip#67 AS b_zip#98, ca_street_number#69 AS c_street_number#99, ca_street_name#70 AS c_street_name#100, ca_city#71 AS c_city#101, ca_zip#72 AS c_zip#102, d_year#40 AS syear#103, count(1)#87 AS cnt#104, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#9))#88,17,2) AS s1#105, MakeDecimal(sum(UnscaledValue(ss_list_price#10))#89,17,2) AS s2#106, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#11))#90,17,2) AS s3#107]
+Aggregate Attributes [4]: [count(1)#95, sum(UnscaledValue(ss_wholesale_cost#9))#96, sum(UnscaledValue(ss_list_price#10))#97, sum(UnscaledValue(ss_coupon_amt#11))#98]
+Results [17]: [i_product_name#86 AS product_name#99, i_item_sk#83 AS item_sk#100, s_store_name#46 AS store_name#101, s_zip#47 AS store_zip#102, ca_street_number#72 AS b_street_number#103, ca_street_name#73 AS b_streen_name#104, ca_city#74 AS b_city#105, ca_zip#75 AS b_zip#106, ca_street_number#77 AS c_street_number#107, ca_street_name#78 AS c_street_name#108, ca_city#79 AS c_city#109, ca_zip#80 AS c_zip#110, d_year#44 AS syear#111, count(1)#95 AS cnt#112, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#9))#96,17,2) AS s1#113, MakeDecimal(sum(UnscaledValue(ss_list_price#10))#97,17,2) AS s2#114, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#11))#98,17,2) AS s3#115]
 
-(127) Exchange
-Input [17]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107]
-Arguments: hashpartitioning(item_sk#92, store_name#93, store_zip#94, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+(121) Exchange
+Input [17]: [product_name#99, item_sk#100, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115]
+Arguments: hashpartitioning(item_sk#100, store_name#101, store_zip#102, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(128) Sort [codegen id : 43]
-Input [17]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107]
-Arguments: [item_sk#92 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, store_zip#94 ASC NULLS FIRST], false, 0
+(122) Sort [codegen id : 43]
+Input [17]: [product_name#99, item_sk#100, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115]
+Arguments: [item_sk#100 ASC NULLS FIRST, store_name#101 ASC NULLS FIRST, store_zip#102 ASC NULLS FIRST], false, 0
 
-(129) Scan parquet spark_catalog.default.store_sales
-Output [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
+(123) Scan parquet spark_catalog.default.store_sales
+Output [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#119), dynamicpruningexpression(ss_sold_date_sk#119 IN dynamicpruning#120)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#127), dynamicpruningexpression(ss_sold_date_sk#127 IN dynamicpruning#128)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_cdemo_sk), IsNotNull(ss_promo_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_cdemo_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ticket_number:int,ss_wholesale_cost:decimal(7,2),ss_list_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(130) ColumnarToRow [codegen id : 44]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
+(124) ColumnarToRow [codegen id : 44]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
 
-(131) Filter [codegen id : 44]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Condition : ((((((((isnotnull(ss_item_sk#108) AND isnotnull(ss_ticket_number#115)) AND isnotnull(ss_store_sk#113)) AND isnotnull(ss_customer_sk#109)) AND isnotnull(ss_cdemo_sk#110)) AND isnotnull(ss_promo_sk#114)) AND isnotnull(ss_hdemo_sk#111)) AND isnotnull(ss_addr_sk#112)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#108, 42)))
+(125) Filter [codegen id : 44]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Condition : ((((((((((isnotnull(ss_item_sk#116) AND isnotnull(ss_ticket_number#123)) AND isnotnull(ss_store_sk#121)) AND isnotnull(ss_customer_sk#117)) AND isnotnull(ss_cdemo_sk#118)) AND isnotnull(ss_promo_sk#122)) AND isnotnull(ss_hdemo_sk#119)) AND isnotnull(ss_addr_sk#120)) AND true) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(ss_cdemo_sk#118, 42), false)) AND might_contain(ReusedSubquery Subquery scalar-subquery#16, [id=#17], xxhash64(ss_addr_sk#120, 42), false))
 
-(132) Exchange
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Arguments: hashpartitioning(ss_item_sk#108, ss_ticket_number#115, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+(126) Exchange
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Arguments: hashpartitioning(ss_item_sk#116, ss_ticket_number#123, 5), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(133) Sort [codegen id : 45]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Arguments: [ss_item_sk#108 ASC NULLS FIRST, ss_ticket_number#115 ASC NULLS FIRST], false, 0
+(127) Sort [codegen id : 45]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Arguments: [ss_item_sk#116 ASC NULLS FIRST, ss_ticket_number#123 ASC NULLS FIRST], false, 0
 
-(134) ReusedExchange [Reuses operator id: 10]
-Output [2]: [sr_item_sk#121, sr_ticket_number#122]
+(128) ReusedExchange [Reuses operator id: 10]
+Output [2]: [sr_item_sk#129, sr_ticket_number#130]
 
-(135) Sort [codegen id : 47]
-Input [2]: [sr_item_sk#121, sr_ticket_number#122]
-Arguments: [sr_item_sk#121 ASC NULLS FIRST, sr_ticket_number#122 ASC NULLS FIRST], false, 0
+(129) Sort [codegen id : 47]
+Input [2]: [sr_item_sk#129, sr_ticket_number#130]
+Arguments: [sr_item_sk#129 ASC NULLS FIRST, sr_ticket_number#130 ASC NULLS FIRST], false, 0
 
-(136) SortMergeJoin [codegen id : 56]
-Left keys [2]: [ss_item_sk#108, ss_ticket_number#115]
-Right keys [2]: [sr_item_sk#121, sr_ticket_number#122]
+(130) SortMergeJoin [codegen id : 56]
+Left keys [2]: [ss_item_sk#116, ss_ticket_number#123]
+Right keys [2]: [sr_item_sk#129, sr_ticket_number#130]
+Join type: Inner
+Join condition: None
+
+(131) Project [codegen id : 56]
+Output [11]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Input [14]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127, sr_item_sk#129, sr_ticket_number#130]
+
+(132) ReusedExchange [Reuses operator id: 33]
+Output [1]: [cs_item_sk#131]
+
+(133) BroadcastHashJoin [codegen id : 56]
+Left keys [1]: [ss_item_sk#116]
+Right keys [1]: [cs_item_sk#131]
+Join type: Inner
+Join condition: None
+
+(134) Project [codegen id : 56]
+Output [11]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127, cs_item_sk#131]
+
+(135) ReusedExchange [Reuses operator id: 249]
+Output [2]: [d_date_sk#132, d_year#133]
+
+(136) BroadcastHashJoin [codegen id : 56]
+Left keys [1]: [ss_sold_date_sk#127]
+Right keys [1]: [d_date_sk#132]
 Join type: Inner
 Join condition: None
 
 (137) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Input [14]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, sr_item_sk#121, sr_ticket_number#122]
+Output [11]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133]
+Input [13]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127, d_date_sk#132, d_year#133]
 
-(138) ReusedExchange [Reuses operator id: 33]
-Output [1]: [cs_item_sk#123]
+(138) ReusedExchange [Reuses operator id: 42]
+Output [3]: [s_store_sk#134, s_store_name#135, s_zip#136]
 
 (139) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_item_sk#108]
-Right keys [1]: [cs_item_sk#123]
+Left keys [1]: [ss_store_sk#121]
+Right keys [1]: [s_store_sk#134]
 Join type: Inner
 Join condition: None
 
 (140) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, cs_item_sk#123]
+Output [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136]
+Input [14]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_sk#134, s_store_name#135, s_zip#136]
 
-(141) ReusedExchange [Reuses operator id: 224]
-Output [2]: [d_date_sk#124, d_year#125]
+(141) Exchange
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136]
+Arguments: hashpartitioning(ss_customer_sk#117, 5), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(142) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_sold_date_sk#119]
-Right keys [1]: [d_date_sk#124]
+(142) Sort [codegen id : 57]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136]
+Arguments: [ss_customer_sk#117 ASC NULLS FIRST], false, 0
+
+(143) Scan parquet spark_catalog.default.customer
+Output [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_first_sales_date_sk), IsNotNull(c_first_shipto_date_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int,c_first_shipto_date_sk:int,c_first_sales_date_sk:int>
+
+(144) ColumnarToRow [codegen id : 58]
+Input [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+
+(145) Filter [codegen id : 58]
+Input [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Condition : ((((((isnotnull(c_customer_sk#137) AND isnotnull(c_first_sales_date_sk#142)) AND isnotnull(c_first_shipto_date_sk#141)) AND isnotnull(c_current_cdemo_sk#138)) AND isnotnull(c_current_hdemo_sk#139)) AND isnotnull(c_current_addr_sk#140)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(c_current_cdemo_sk#138, 42), false))
+
+(146) Exchange
+Input [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Arguments: hashpartitioning(c_customer_sk#137, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+
+(147) Sort [codegen id : 59]
+Input [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Arguments: [c_customer_sk#137 ASC NULLS FIRST], false, 0
+
+(148) SortMergeJoin [codegen id : 62]
+Left keys [1]: [ss_customer_sk#117]
+Right keys [1]: [c_customer_sk#137]
 Join type: Inner
 Join condition: None
 
-(143) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125]
-Input [13]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, d_date_sk#124, d_year#125]
+(149) Project [codegen id : 62]
+Output [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Input [18]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
 
-(144) ReusedExchange [Reuses operator id: 42]
-Output [3]: [s_store_sk#126, s_store_name#127, s_zip#128]
+(150) ReusedExchange [Reuses operator id: 57]
+Output [2]: [d_date_sk#143, d_year#144]
 
-(145) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_store_sk#113]
-Right keys [1]: [s_store_sk#126]
-Join type: Inner
-Join condition: None
-
-(146) Project [codegen id : 56]
-Output [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Input [14]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_sk#126, s_store_name#127, s_zip#128]
-
-(147) Exchange
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Arguments: hashpartitioning(ss_customer_sk#109, 5), ENSURE_REQUIREMENTS, [plan_id=24]
-
-(148) Sort [codegen id : 57]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Arguments: [ss_customer_sk#109 ASC NULLS FIRST], false, 0
-
-(149) ReusedExchange [Reuses operator id: 50]
-Output [6]: [c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-
-(150) Sort [codegen id : 59]
-Input [6]: [c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-Arguments: [c_customer_sk#129 ASC NULLS FIRST], false, 0
-
-(151) SortMergeJoin [codegen id : 62]
-Left keys [1]: [ss_customer_sk#109]
-Right keys [1]: [c_customer_sk#129]
+(151) BroadcastHashJoin [codegen id : 62]
+Left keys [1]: [c_first_sales_date_sk#142]
+Right keys [1]: [d_date_sk#143]
 Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-Input [18]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
+Output [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, d_year#144]
+Input [18]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142, d_date_sk#143, d_year#144]
 
 (153) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#135, d_year#136]
+Output [2]: [d_date_sk#145, d_year#146]
 
 (154) BroadcastHashJoin [codegen id : 62]
-Left keys [1]: [c_first_sales_date_sk#134]
-Right keys [1]: [d_date_sk#135]
+Left keys [1]: [c_first_shipto_date_sk#141]
+Right keys [1]: [d_date_sk#145]
 Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, d_year#136]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134, d_date_sk#135, d_year#136]
+Output [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Input [18]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, d_year#144, d_date_sk#145, d_year#146]
 
-(156) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#137, d_year#138]
+(156) Exchange
+Input [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Arguments: hashpartitioning(ss_cdemo_sk#118, 5), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(157) BroadcastHashJoin [codegen id : 62]
-Left keys [1]: [c_first_shipto_date_sk#133]
-Right keys [1]: [d_date_sk#137]
+(157) Sort [codegen id : 63]
+Input [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Arguments: [ss_cdemo_sk#118 ASC NULLS FIRST], false, 0
+
+(158) ReusedExchange [Reuses operator id: 235]
+Output [2]: [cd_demo_sk#147, cd_marital_status#148]
+
+(159) Sort [codegen id : 65]
+Input [2]: [cd_demo_sk#147, cd_marital_status#148]
+Arguments: [cd_demo_sk#147 ASC NULLS FIRST], false, 0
+
+(160) SortMergeJoin [codegen id : 66]
+Left keys [1]: [ss_cdemo_sk#118]
+Right keys [1]: [cd_demo_sk#147]
 Join type: Inner
 Join condition: None
 
-(158) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, d_year#136, d_date_sk#137, d_year#138]
+(161) Project [codegen id : 66]
+Output [16]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_marital_status#148]
+Input [18]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_demo_sk#147, cd_marital_status#148]
 
-(159) Exchange
-Input [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Arguments: hashpartitioning(ss_cdemo_sk#110, 5), ENSURE_REQUIREMENTS, [plan_id=25]
+(162) Exchange
+Input [16]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_marital_status#148]
+Arguments: hashpartitioning(c_current_cdemo_sk#138, 5), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(160) Sort [codegen id : 63]
-Input [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Arguments: [ss_cdemo_sk#110 ASC NULLS FIRST], false, 0
+(163) Sort [codegen id : 67]
+Input [16]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_marital_status#148]
+Arguments: [c_current_cdemo_sk#138 ASC NULLS FIRST], false, 0
 
-(161) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#139, cd_marital_status#140]
+(164) ReusedExchange [Reuses operator id: 235]
+Output [2]: [cd_demo_sk#149, cd_marital_status#150]
 
-(162) Sort [codegen id : 65]
-Input [2]: [cd_demo_sk#139, cd_marital_status#140]
-Arguments: [cd_demo_sk#139 ASC NULLS FIRST], false, 0
+(165) Sort [codegen id : 69]
+Input [2]: [cd_demo_sk#149, cd_marital_status#150]
+Arguments: [cd_demo_sk#149 ASC NULLS FIRST], false, 0
 
-(163) SortMergeJoin [codegen id : 66]
-Left keys [1]: [ss_cdemo_sk#110]
-Right keys [1]: [cd_demo_sk#139]
+(166) SortMergeJoin [codegen id : 73]
+Left keys [1]: [c_current_cdemo_sk#138]
+Right keys [1]: [cd_demo_sk#149]
+Join type: Inner
+Join condition: NOT (cd_marital_status#148 = cd_marital_status#150)
+
+(167) Project [codegen id : 73]
+Output [14]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Input [18]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_marital_status#148, cd_demo_sk#149, cd_marital_status#150]
+
+(168) ReusedExchange [Reuses operator id: 78]
+Output [1]: [p_promo_sk#151]
+
+(169) BroadcastHashJoin [codegen id : 73]
+Left keys [1]: [ss_promo_sk#122]
+Right keys [1]: [p_promo_sk#151]
 Join type: Inner
 Join condition: None
-
-(164) Project [codegen id : 66]
-Output [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_demo_sk#139, cd_marital_status#140]
-
-(165) Exchange
-Input [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Arguments: hashpartitioning(c_current_cdemo_sk#130, 5), ENSURE_REQUIREMENTS, [plan_id=26]
-
-(166) Sort [codegen id : 67]
-Input [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Arguments: [c_current_cdemo_sk#130 ASC NULLS FIRST], false, 0
-
-(167) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#141, cd_marital_status#142]
-
-(168) Sort [codegen id : 69]
-Input [2]: [cd_demo_sk#141, cd_marital_status#142]
-Arguments: [cd_demo_sk#141 ASC NULLS FIRST], false, 0
-
-(169) SortMergeJoin [codegen id : 73]
-Left keys [1]: [c_current_cdemo_sk#130]
-Right keys [1]: [cd_demo_sk#141]
-Join type: Inner
-Join condition: NOT (cd_marital_status#140 = cd_marital_status#142)
 
 (170) Project [codegen id : 73]
-Output [14]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [18]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140, cd_demo_sk#141, cd_marital_status#142]
+Output [13]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Input [15]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, p_promo_sk#151]
 
-(171) ReusedExchange [Reuses operator id: 81]
-Output [1]: [p_promo_sk#143]
+(171) ReusedExchange [Reuses operator id: 84]
+Output [2]: [hd_demo_sk#152, hd_income_band_sk#153]
 
 (172) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [ss_promo_sk#114]
-Right keys [1]: [p_promo_sk#143]
+Left keys [1]: [ss_hdemo_sk#119]
+Right keys [1]: [hd_demo_sk#152]
 Join type: Inner
 Join condition: None
 
 (173) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [15]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, p_promo_sk#143]
+Output [13]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153]
+Input [15]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, hd_demo_sk#152, hd_income_band_sk#153]
 
-(174) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#144, hd_income_band_sk#145]
+(174) ReusedExchange [Reuses operator id: 84]
+Output [2]: [hd_demo_sk#154, hd_income_band_sk#155]
 
 (175) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [ss_hdemo_sk#111]
-Right keys [1]: [hd_demo_sk#144]
+Left keys [1]: [c_current_hdemo_sk#139]
+Right keys [1]: [hd_demo_sk#154]
 Join type: Inner
 Join condition: None
 
 (176) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145]
-Input [15]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_demo_sk#144, hd_income_band_sk#145]
+Output [13]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155]
+Input [15]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_demo_sk#154, hd_income_band_sk#155]
 
-(177) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#146, hd_income_band_sk#147]
+(177) Exchange
+Input [13]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155]
+Arguments: hashpartitioning(ss_addr_sk#120, 5), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(178) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [c_current_hdemo_sk#131]
-Right keys [1]: [hd_demo_sk#146]
+(178) Sort [codegen id : 74]
+Input [13]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155]
+Arguments: [ss_addr_sk#120 ASC NULLS FIRST], false, 0
+
+(179) ReusedExchange [Reuses operator id: 242]
+Output [5]: [ca_address_sk#156, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+
+(180) Sort [codegen id : 76]
+Input [5]: [ca_address_sk#156, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+Arguments: [ca_address_sk#156 ASC NULLS FIRST], false, 0
+
+(181) SortMergeJoin [codegen id : 77]
+Left keys [1]: [ss_addr_sk#120]
+Right keys [1]: [ca_address_sk#156]
 Join type: Inner
 Join condition: None
 
-(179) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Input [15]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_demo_sk#146, hd_income_band_sk#147]
+(182) Project [codegen id : 77]
+Output [16]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+Input [18]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_address_sk#156, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
 
-(180) Exchange
-Input [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Arguments: hashpartitioning(ss_addr_sk#112, 5), ENSURE_REQUIREMENTS, [plan_id=27]
+(183) Exchange
+Input [16]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+Arguments: hashpartitioning(c_current_addr_sk#140, 5), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(181) Sort [codegen id : 74]
-Input [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Arguments: [ss_addr_sk#112 ASC NULLS FIRST], false, 0
+(184) Sort [codegen id : 78]
+Input [16]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+Arguments: [c_current_addr_sk#140 ASC NULLS FIRST], false, 0
 
-(182) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
+(185) ReusedExchange [Reuses operator id: 242]
+Output [5]: [ca_address_sk#161, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
 
-(183) Sort [codegen id : 76]
-Input [5]: [ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: [ca_address_sk#148 ASC NULLS FIRST], false, 0
+(186) Sort [codegen id : 80]
+Input [5]: [ca_address_sk#161, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
+Arguments: [ca_address_sk#161 ASC NULLS FIRST], false, 0
 
-(184) SortMergeJoin [codegen id : 77]
-Left keys [1]: [ss_addr_sk#112]
-Right keys [1]: [ca_address_sk#148]
+(187) SortMergeJoin [codegen id : 84]
+Left keys [1]: [c_current_addr_sk#140]
+Right keys [1]: [ca_address_sk#161]
 Join type: Inner
 Join condition: None
 
-(185) Project [codegen id : 77]
-Output [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Input [18]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
+(188) Project [codegen id : 84]
+Output [19]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
+Input [21]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_address_sk#161, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
 
-(186) Exchange
-Input [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: hashpartitioning(c_current_addr_sk#132, 5), ENSURE_REQUIREMENTS, [plan_id=28]
+(189) ReusedExchange [Reuses operator id: 105]
+Output [1]: [ib_income_band_sk#166]
 
-(187) Sort [codegen id : 78]
-Input [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: [c_current_addr_sk#132 ASC NULLS FIRST], false, 0
-
-(188) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-
-(189) Sort [codegen id : 80]
-Input [5]: [ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Arguments: [ca_address_sk#153 ASC NULLS FIRST], false, 0
-
-(190) SortMergeJoin [codegen id : 84]
-Left keys [1]: [c_current_addr_sk#132]
-Right keys [1]: [ca_address_sk#153]
+(190) BroadcastHashJoin [codegen id : 84]
+Left keys [1]: [hd_income_band_sk#153]
+Right keys [1]: [ib_income_band_sk#166]
 Join type: Inner
 Join condition: None
 
 (191) Project [codegen id : 84]
-Output [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [21]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
+Output [18]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
+Input [20]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, ib_income_band_sk#166]
 
-(192) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#158]
+(192) ReusedExchange [Reuses operator id: 105]
+Output [1]: [ib_income_band_sk#167]
 
 (193) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [hd_income_band_sk#145]
-Right keys [1]: [ib_income_band_sk#158]
+Left keys [1]: [hd_income_band_sk#155]
+Right keys [1]: [ib_income_band_sk#167]
 Join type: Inner
 Join condition: None
 
 (194) Project [codegen id : 84]
-Output [18]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [20]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, ib_income_band_sk#158]
+Output [17]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
+Input [19]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, ib_income_band_sk#167]
 
-(195) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#159]
+(195) ReusedExchange [Reuses operator id: 115]
+Output [2]: [i_item_sk#168, i_product_name#169]
 
 (196) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [hd_income_band_sk#147]
-Right keys [1]: [ib_income_band_sk#159]
+Left keys [1]: [ss_item_sk#116]
+Right keys [1]: [i_item_sk#168]
 Join type: Inner
 Join condition: None
 
 (197) Project [codegen id : 84]
-Output [17]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, ib_income_band_sk#159]
+Output [18]: [ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, d_year#144, d_year#146, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, i_item_sk#168, i_product_name#169]
+Input [19]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, i_item_sk#168, i_product_name#169]
 
-(198) ReusedExchange [Reuses operator id: 121]
-Output [2]: [i_item_sk#160, i_product_name#161]
+(198) HashAggregate [codegen id : 84]
+Input [18]: [ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, d_year#144, d_year#146, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, i_item_sk#168, i_product_name#169]
+Keys [15]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146]
+Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#124)), partial_sum(UnscaledValue(ss_list_price#125)), partial_sum(UnscaledValue(ss_coupon_amt#126))]
+Aggregate Attributes [4]: [count#87, sum#170, sum#171, sum#172]
+Results [19]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146, count#91, sum#173, sum#174, sum#175]
 
-(199) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [ss_item_sk#108]
-Right keys [1]: [i_item_sk#160]
+(199) Exchange
+Input [19]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146, count#91, sum#173, sum#174, sum#175]
+Arguments: hashpartitioning(i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146, 5), ENSURE_REQUIREMENTS, [plan_id=28]
+
+(200) HashAggregate [codegen id : 85]
+Input [19]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146, count#91, sum#173, sum#174, sum#175]
+Keys [15]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146]
+Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#124)), sum(UnscaledValue(ss_list_price#125)), sum(UnscaledValue(ss_coupon_amt#126))]
+Aggregate Attributes [4]: [count(1)#95, sum(UnscaledValue(ss_wholesale_cost#124))#96, sum(UnscaledValue(ss_list_price#125))#97, sum(UnscaledValue(ss_coupon_amt#126))#98]
+Results [8]: [i_item_sk#168 AS item_sk#176, s_store_name#135 AS store_name#177, s_zip#136 AS store_zip#178, d_year#133 AS syear#179, count(1)#95 AS cnt#180, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#124))#96,17,2) AS s1#181, MakeDecimal(sum(UnscaledValue(ss_list_price#125))#97,17,2) AS s2#182, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#126))#98,17,2) AS s3#183]
+
+(201) Exchange
+Input [8]: [item_sk#176, store_name#177, store_zip#178, syear#179, cnt#180, s1#181, s2#182, s3#183]
+Arguments: hashpartitioning(item_sk#176, store_name#177, store_zip#178, 5), ENSURE_REQUIREMENTS, [plan_id=29]
+
+(202) Sort [codegen id : 86]
+Input [8]: [item_sk#176, store_name#177, store_zip#178, syear#179, cnt#180, s1#181, s2#182, s3#183]
+Arguments: [item_sk#176 ASC NULLS FIRST, store_name#177 ASC NULLS FIRST, store_zip#178 ASC NULLS FIRST], false, 0
+
+(203) SortMergeJoin [codegen id : 87]
+Left keys [3]: [item_sk#100, store_name#101, store_zip#102]
+Right keys [3]: [item_sk#176, store_name#177, store_zip#178]
 Join type: Inner
-Join condition: None
+Join condition: (cnt#180 <= cnt#112)
 
-(200) Project [codegen id : 84]
-Output [18]: [ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, d_year#136, d_year#138, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
-Input [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
+(204) Project [codegen id : 87]
+Output [21]: [product_name#99, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115, s1#181, s2#182, s3#183, syear#179, cnt#180]
+Input [25]: [product_name#99, item_sk#100, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115, item_sk#176, store_name#177, store_zip#178, syear#179, cnt#180, s1#181, s2#182, s3#183]
 
-(201) HashAggregate [codegen id : 84]
-Input [18]: [ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, d_year#136, d_year#138, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
-Keys [15]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138]
-Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#116)), partial_sum(UnscaledValue(ss_list_price#117)), partial_sum(UnscaledValue(ss_coupon_amt#118))]
-Aggregate Attributes [4]: [count#79, sum#162, sum#163, sum#164]
-Results [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
+(205) Exchange
+Input [21]: [product_name#99, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115, s1#181, s2#182, s3#183, syear#179, cnt#180]
+Arguments: rangepartitioning(product_name#99 ASC NULLS FIRST, store_name#101 ASC NULLS FIRST, cnt#180 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(202) Exchange
-Input [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
-Arguments: hashpartitioning(i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, 5), ENSURE_REQUIREMENTS, [plan_id=29]
-
-(203) HashAggregate [codegen id : 85]
-Input [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
-Keys [15]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138]
-Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#116)), sum(UnscaledValue(ss_list_price#117)), sum(UnscaledValue(ss_coupon_amt#118))]
-Aggregate Attributes [4]: [count(1)#87, sum(UnscaledValue(ss_wholesale_cost#116))#88, sum(UnscaledValue(ss_list_price#117))#89, sum(UnscaledValue(ss_coupon_amt#118))#90]
-Results [8]: [i_item_sk#160 AS item_sk#168, s_store_name#127 AS store_name#169, s_zip#128 AS store_zip#170, d_year#125 AS syear#171, count(1)#87 AS cnt#172, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#116))#88,17,2) AS s1#173, MakeDecimal(sum(UnscaledValue(ss_list_price#117))#89,17,2) AS s2#174, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#118))#90,17,2) AS s3#175]
-
-(204) Exchange
-Input [8]: [item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-Arguments: hashpartitioning(item_sk#168, store_name#169, store_zip#170, 5), ENSURE_REQUIREMENTS, [plan_id=30]
-
-(205) Sort [codegen id : 86]
-Input [8]: [item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-Arguments: [item_sk#168 ASC NULLS FIRST, store_name#169 ASC NULLS FIRST, store_zip#170 ASC NULLS FIRST], false, 0
-
-(206) SortMergeJoin [codegen id : 87]
-Left keys [3]: [item_sk#92, store_name#93, store_zip#94]
-Right keys [3]: [item_sk#168, store_name#169, store_zip#170]
-Join type: Inner
-Join condition: (cnt#172 <= cnt#104)
-
-(207) Project [codegen id : 87]
-Output [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Input [25]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-
-(208) Exchange
-Input [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Arguments: rangepartitioning(product_name#91 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, cnt#172 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=31]
-
-(209) Sort [codegen id : 88]
-Input [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Arguments: [product_name#91 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, cnt#172 ASC NULLS FIRST], true, 0
+(206) Sort [codegen id : 88]
+Input [21]: [product_name#99, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115, s1#181, s2#182, s3#183, syear#179, cnt#180]
+Arguments: [product_name#99 ASC NULLS FIRST, store_name#101 ASC NULLS FIRST, cnt#180 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#14, [id=#15]
-ObjectHashAggregate (216)
-+- Exchange (215)
-   +- ObjectHashAggregate (214)
-      +- * Project (213)
-         +- * Filter (212)
-            +- * ColumnarToRow (211)
-               +- Scan parquet spark_catalog.default.item (210)
+ObjectHashAggregate (213)
++- Exchange (212)
+   +- ObjectHashAggregate (211)
+      +- Exchange (210)
+         +- * Filter (209)
+            +- * ColumnarToRow (208)
+               +- Scan parquet spark_catalog.default.customer_demographics (207)
 
 
-(210) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+(207) Scan parquet spark_catalog.default.customer_demographics
+Output [2]: [cd_demo_sk#62, cd_marital_status#63]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
+
+(208) ColumnarToRow [codegen id : 1]
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+
+(209) Filter [codegen id : 1]
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+Condition : (isnotnull(cd_demo_sk#62) AND isnotnull(cd_marital_status#63))
+
+(210) Exchange
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+Arguments: hashpartitioning(cd_demo_sk#64, 5), ENSURE_REQUIREMENTS, [plan_id=31]
+
+(211) ObjectHashAggregate
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#62, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#184]
+Results [1]: [buf#185]
+
+(212) Exchange
+Input [1]: [buf#185]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=32]
+
+(213) ObjectHashAggregate
+Input [1]: [buf#185]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#62, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#62, 42), 1920800, 15366400, 0, 0)#186]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#62, 42), 1920800, 15366400, 0, 0)#186 AS bloomFilter#187]
+
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#16, [id=#17]
+ObjectHashAggregate (220)
++- Exchange (219)
+   +- ObjectHashAggregate (218)
+      +- Exchange (217)
+         +- * Filter (216)
+            +- * ColumnarToRow (215)
+               +- Scan parquet spark_catalog.default.customer_address (214)
+
+
+(214) Scan parquet spark_catalog.default.customer_address
+Output [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
+
+(215) ColumnarToRow [codegen id : 1]
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+
+(216) Filter [codegen id : 1]
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Condition : isnotnull(ca_address_sk#71)
+
+(217) Exchange
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Arguments: hashpartitioning(ca_address_sk#76, 5), ENSURE_REQUIREMENTS, [plan_id=33]
+
+(218) ObjectHashAggregate
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#71, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [buf#188]
+Results [1]: [buf#189]
+
+(219) Exchange
+Input [1]: [buf#189]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=34]
+
+(220) ObjectHashAggregate
+Input [1]: [buf#189]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#71, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#71, 42), 1000000, 8000000, 0, 0)#190]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#71, 42), 1000000, 8000000, 0, 0)#190 AS bloomFilter#191]
+
+Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#18, [id=#19]
+ObjectHashAggregate (227)
++- Exchange (226)
+   +- ObjectHashAggregate (225)
+      +- * Project (224)
+         +- * Filter (223)
+            +- * ColumnarToRow (222)
+               +- Scan parquet spark_catalog.default.item (221)
+
+
+(221) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#83, i_current_price#84, i_color#85]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood           ,floral              ,indian              ,medium              ,purple              ,spring              ]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string>
 
-(211) ColumnarToRow [codegen id : 1]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+(222) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#83, i_current_price#84, i_color#85]
 
-(212) Filter [codegen id : 1]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
-Condition : ((((((isnotnull(i_current_price#76) AND i_color#77 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#76 >= 64.00)) AND (i_current_price#76 <= 74.00)) AND (i_current_price#76 >= 65.00)) AND (i_current_price#76 <= 79.00)) AND isnotnull(i_item_sk#75))
+(223) Filter [codegen id : 1]
+Input [3]: [i_item_sk#83, i_current_price#84, i_color#85]
+Condition : ((((((isnotnull(i_current_price#84) AND i_color#85 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#84 >= 64.00)) AND (i_current_price#84 <= 74.00)) AND (i_current_price#84 >= 65.00)) AND (i_current_price#84 <= 79.00)) AND isnotnull(i_item_sk#83))
 
-(213) Project [codegen id : 1]
-Output [1]: [i_item_sk#75]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+(224) Project [codegen id : 1]
+Output [1]: [i_item_sk#83]
+Input [3]: [i_item_sk#83, i_current_price#84, i_color#85]
 
-(214) ObjectHashAggregate
-Input [1]: [i_item_sk#75]
+(225) ObjectHashAggregate
+Input [1]: [i_item_sk#83]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 10000, 0, 0)]
-Aggregate Attributes [1]: [buf#176]
-Results [1]: [buf#177]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#83, 42), 1250, 10000, 0, 0)]
+Aggregate Attributes [1]: [buf#192]
+Results [1]: [buf#193]
 
-(215) Exchange
-Input [1]: [buf#177]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=32]
+(226) Exchange
+Input [1]: [buf#193]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=35]
 
-(216) ObjectHashAggregate
-Input [1]: [buf#177]
+(227) ObjectHashAggregate
+Input [1]: [buf#193]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 10000, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 10000, 0, 0)#178]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 10000, 0, 0)#178 AS bloomFilter#179]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#83, 42), 1250, 10000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#83, 42), 1250, 10000, 0, 0)#194]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#83, 42), 1250, 10000, 0, 0)#194 AS bloomFilter#195]
 
-Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
-BroadcastExchange (220)
-+- * Filter (219)
-   +- * ColumnarToRow (218)
-      +- Scan parquet spark_catalog.default.date_dim (217)
+Subquery:4 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
+BroadcastExchange (231)
++- * Filter (230)
+   +- * ColumnarToRow (229)
+      +- Scan parquet spark_catalog.default.date_dim (228)
 
 
-(217) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#39, d_year#40]
+(228) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#43, d_year#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(218) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#39, d_year#40]
+(229) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#43, d_year#44]
 
-(219) Filter [codegen id : 1]
-Input [2]: [d_date_sk#39, d_year#40]
-Condition : ((isnotnull(d_year#40) AND (d_year#40 = 1999)) AND isnotnull(d_date_sk#39))
+(230) Filter [codegen id : 1]
+Input [2]: [d_date_sk#43, d_year#44]
+Condition : ((isnotnull(d_year#44) AND (d_year#44 = 1999)) AND isnotnull(d_date_sk#43))
 
-(220) BroadcastExchange
-Input [2]: [d_date_sk#39, d_year#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=33]
+(231) BroadcastExchange
+Input [2]: [d_date_sk#43, d_year#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=36]
 
-Subquery:3 Hosting operator id = 131 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+Subquery:5 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#54, [id=#55]
+ObjectHashAggregate (238)
++- Exchange (237)
+   +- ObjectHashAggregate (236)
+      +- Exchange (235)
+         +- * Filter (234)
+            +- * ColumnarToRow (233)
+               +- Scan parquet spark_catalog.default.customer_demographics (232)
 
-Subquery:4 Hosting operator id = 129 Hosting Expression = ss_sold_date_sk#119 IN dynamicpruning#120
-BroadcastExchange (224)
-+- * Filter (223)
-   +- * ColumnarToRow (222)
-      +- Scan parquet spark_catalog.default.date_dim (221)
+
+(232) Scan parquet spark_catalog.default.customer_demographics
+Output [2]: [cd_demo_sk#64, cd_marital_status#65]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
+
+(233) ColumnarToRow [codegen id : 1]
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+
+(234) Filter [codegen id : 1]
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+Condition : (isnotnull(cd_demo_sk#64) AND isnotnull(cd_marital_status#65))
+
+(235) Exchange
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+Arguments: hashpartitioning(cd_demo_sk#64, 5), ENSURE_REQUIREMENTS, [plan_id=37]
+
+(236) ObjectHashAggregate
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#64, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#196]
+Results [1]: [buf#197]
+
+(237) Exchange
+Input [1]: [buf#197]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=38]
+
+(238) ObjectHashAggregate
+Input [1]: [buf#197]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#64, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#64, 42), 1920800, 15366400, 0, 0)#198]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#64, 42), 1920800, 15366400, 0, 0)#198 AS bloomFilter#199]
+
+Subquery:6 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#56, [id=#57]
+ObjectHashAggregate (245)
++- Exchange (244)
+   +- ObjectHashAggregate (243)
+      +- Exchange (242)
+         +- * Filter (241)
+            +- * ColumnarToRow (240)
+               +- Scan parquet spark_catalog.default.customer_address (239)
 
 
-(221) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#124, d_year#125]
+(239) Scan parquet spark_catalog.default.customer_address
+Output [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
+
+(240) ColumnarToRow [codegen id : 1]
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+
+(241) Filter [codegen id : 1]
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Condition : isnotnull(ca_address_sk#76)
+
+(242) Exchange
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Arguments: hashpartitioning(ca_address_sk#76, 5), ENSURE_REQUIREMENTS, [plan_id=39]
+
+(243) ObjectHashAggregate
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#76, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [buf#200]
+Results [1]: [buf#201]
+
+(244) Exchange
+Input [1]: [buf#201]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=40]
+
+(245) ObjectHashAggregate
+Input [1]: [buf#201]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#76, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#76, 42), 1000000, 8000000, 0, 0)#202]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#76, 42), 1000000, 8000000, 0, 0)#202 AS bloomFilter#203]
+
+Subquery:7 Hosting operator id = 125 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+
+Subquery:8 Hosting operator id = 125 Hosting Expression = ReusedSubquery Subquery scalar-subquery#16, [id=#17]
+
+Subquery:9 Hosting operator id = 123 Hosting Expression = ss_sold_date_sk#127 IN dynamicpruning#128
+BroadcastExchange (249)
++- * Filter (248)
+   +- * ColumnarToRow (247)
+      +- Scan parquet spark_catalog.default.date_dim (246)
+
+
+(246) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#132, d_year#133]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(222) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#124, d_year#125]
+(247) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#132, d_year#133]
 
-(223) Filter [codegen id : 1]
-Input [2]: [d_date_sk#124, d_year#125]
-Condition : ((isnotnull(d_year#125) AND (d_year#125 = 2000)) AND isnotnull(d_date_sk#124))
+(248) Filter [codegen id : 1]
+Input [2]: [d_date_sk#132, d_year#133]
+Condition : ((isnotnull(d_year#133) AND (d_year#133 = 2000)) AND isnotnull(d_date_sk#132))
 
-(224) BroadcastExchange
-Input [2]: [d_date_sk#124, d_year#125]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=34]
+(249) BroadcastExchange
+Input [2]: [d_date_sk#132, d_year#133]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=41]
+
+Subquery:10 Hosting operator id = 145 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64.sf100/simplified.txt
@@ -88,8 +88,28 @@ WholeStageCodegen (88)
                                                                                                                                                                               WholeStageCodegen (1)
                                                                                                                                                                                 Filter [ss_item_sk,ss_ticket_number,ss_store_sk,ss_customer_sk,ss_cdemo_sk,ss_promo_sk,ss_hdemo_sk,ss_addr_sk]
                                                                                                                                                                                   Subquery #2
-                                                                                                                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 1250, 10000, 0, 0),bloomFilter,buf]
+                                                                                                                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
                                                                                                                                                                                       Exchange #11
+                                                                                                                                                                                        ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                                                                                                                                          Exchange [cd_demo_sk] #12
+                                                                                                                                                                                            WholeStageCodegen (1)
+                                                                                                                                                                                              Filter [cd_demo_sk,cd_marital_status]
+                                                                                                                                                                                                ColumnarToRow
+                                                                                                                                                                                                  InputAdapter
+                                                                                                                                                                                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
+                                                                                                                                                                                  Subquery #3
+                                                                                                                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 1000000, 8000000, 0, 0),bloomFilter,buf]
+                                                                                                                                                                                      Exchange #13
+                                                                                                                                                                                        ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                                                                                                                                          Exchange [ca_address_sk] #14
+                                                                                                                                                                                            WholeStageCodegen (1)
+                                                                                                                                                                                              Filter [ca_address_sk]
+                                                                                                                                                                                                ColumnarToRow
+                                                                                                                                                                                                  InputAdapter
+                                                                                                                                                                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip]
+                                                                                                                                                                                  Subquery #4
+                                                                                                                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 1250, 10000, 0, 0),bloomFilter,buf]
+                                                                                                                                                                                      Exchange #15
                                                                                                                                                                                         ObjectHashAggregate [i_item_sk] [buf,buf]
                                                                                                                                                                                           WholeStageCodegen (1)
                                                                                                                                                                                             Project [i_item_sk]
@@ -111,7 +131,7 @@ WholeStageCodegen (88)
                                                                                                                                                                       WholeStageCodegen (4)
                                                                                                                                                                         Sort [sr_item_sk,sr_ticket_number]
                                                                                                                                                                           InputAdapter
-                                                                                                                                                                            Exchange [sr_item_sk,sr_ticket_number] #12
+                                                                                                                                                                            Exchange [sr_item_sk,sr_ticket_number] #16
                                                                                                                                                                               WholeStageCodegen (3)
                                                                                                                                                                                 Project [sr_item_sk,sr_ticket_number]
                                                                                                                                                                                   Filter [sr_item_sk,sr_ticket_number]
@@ -119,13 +139,13 @@ WholeStageCodegen (88)
                                                                                                                                                                                       InputAdapter
                                                                                                                                                                                         Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                                                                                                                                                                 InputAdapter
-                                                                                                                                                                  BroadcastExchange #13
+                                                                                                                                                                  BroadcastExchange #17
                                                                                                                                                                     WholeStageCodegen (10)
                                                                                                                                                                       Project [cs_item_sk]
                                                                                                                                                                         Filter [sale,refund]
                                                                                                                                                                           HashAggregate [cs_item_sk,sum,sum,isEmpty] [sum(UnscaledValue(cs_ext_list_price)),sum(((cr_refunded_cash + cr_reversed_charge) + cr_store_credit)),sale,refund,sum,sum,isEmpty]
                                                                                                                                                                             InputAdapter
-                                                                                                                                                                              Exchange [cs_item_sk] #14
+                                                                                                                                                                              Exchange [cs_item_sk] #18
                                                                                                                                                                                 WholeStageCodegen (9)
                                                                                                                                                                                   HashAggregate [cs_item_sk,cs_ext_list_price,cr_refunded_cash,cr_reversed_charge,cr_store_credit] [sum,sum,isEmpty,sum,sum,isEmpty]
                                                                                                                                                                                     Project [cs_item_sk,cs_ext_list_price,cr_refunded_cash,cr_reversed_charge,cr_store_credit]
@@ -134,7 +154,7 @@ WholeStageCodegen (88)
                                                                                                                                                                                           WholeStageCodegen (6)
                                                                                                                                                                                             Sort [cs_item_sk,cs_order_number]
                                                                                                                                                                                               InputAdapter
-                                                                                                                                                                                                Exchange [cs_item_sk,cs_order_number] #15
+                                                                                                                                                                                                Exchange [cs_item_sk,cs_order_number] #19
                                                                                                                                                                                                   WholeStageCodegen (5)
                                                                                                                                                                                                     Project [cs_item_sk,cs_order_number,cs_ext_list_price]
                                                                                                                                                                                                       Filter [cs_item_sk,cs_order_number]
@@ -145,7 +165,7 @@ WholeStageCodegen (88)
                                                                                                                                                                                           WholeStageCodegen (8)
                                                                                                                                                                                             Sort [cr_item_sk,cr_order_number]
                                                                                                                                                                                               InputAdapter
-                                                                                                                                                                                                Exchange [cr_item_sk,cr_order_number] #16
+                                                                                                                                                                                                Exchange [cr_item_sk,cr_order_number] #20
                                                                                                                                                                                                   WholeStageCodegen (7)
                                                                                                                                                                                                     Project [cr_item_sk,cr_order_number,cr_refunded_cash,cr_reversed_charge,cr_store_credit]
                                                                                                                                                                                                       Filter [cr_item_sk,cr_order_number]
@@ -155,7 +175,7 @@ WholeStageCodegen (88)
                                                                                                                                                             InputAdapter
                                                                                                                                                               ReusedExchange [d_date_sk,d_year] #10
                                                                                                                                                         InputAdapter
-                                                                                                                                                          BroadcastExchange #17
+                                                                                                                                                          BroadcastExchange #21
                                                                                                                                                             WholeStageCodegen (12)
                                                                                                                                                               Filter [s_store_sk,s_store_name,s_zip]
                                                                                                                                                                 ColumnarToRow
@@ -165,78 +185,88 @@ WholeStageCodegen (88)
                                                                                                                                           WholeStageCodegen (16)
                                                                                                                                             Sort [c_customer_sk]
                                                                                                                                               InputAdapter
-                                                                                                                                                Exchange [c_customer_sk] #18
+                                                                                                                                                Exchange [c_customer_sk] #22
                                                                                                                                                   WholeStageCodegen (15)
                                                                                                                                                     Filter [c_customer_sk,c_first_sales_date_sk,c_first_shipto_date_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk]
+                                                                                                                                                      Subquery #5
+                                                                                                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
+                                                                                                                                                          Exchange #23
+                                                                                                                                                            ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                                                                                                              Exchange [cd_demo_sk] #24
+                                                                                                                                                                WholeStageCodegen (1)
+                                                                                                                                                                  Filter [cd_demo_sk,cd_marital_status]
+                                                                                                                                                                    ColumnarToRow
+                                                                                                                                                                      InputAdapter
+                                                                                                                                                                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
+                                                                                                                                                      Subquery #6
+                                                                                                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 1000000, 8000000, 0, 0),bloomFilter,buf]
+                                                                                                                                                          Exchange #25
+                                                                                                                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                                                                                                              Exchange [ca_address_sk] #26
+                                                                                                                                                                WholeStageCodegen (1)
+                                                                                                                                                                  Filter [ca_address_sk]
+                                                                                                                                                                    ColumnarToRow
+                                                                                                                                                                      InputAdapter
+                                                                                                                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip]
                                                                                                                                                       ColumnarToRow
                                                                                                                                                         InputAdapter
                                                                                                                                                           Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,c_first_shipto_date_sk,c_first_sales_date_sk]
                                                                                                                                     InputAdapter
-                                                                                                                                      BroadcastExchange #19
+                                                                                                                                      BroadcastExchange #27
                                                                                                                                         WholeStageCodegen (17)
                                                                                                                                           Filter [d_date_sk]
                                                                                                                                             ColumnarToRow
                                                                                                                                               InputAdapter
                                                                                                                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                                                                                 InputAdapter
-                                                                                                                                  ReusedExchange [d_date_sk,d_year] #19
+                                                                                                                                  ReusedExchange [d_date_sk,d_year] #27
                                                                                                                 InputAdapter
                                                                                                                   WholeStageCodegen (22)
                                                                                                                     Sort [cd_demo_sk]
                                                                                                                       InputAdapter
-                                                                                                                        Exchange [cd_demo_sk] #20
-                                                                                                                          WholeStageCodegen (21)
-                                                                                                                            Filter [cd_demo_sk,cd_marital_status]
-                                                                                                                              ColumnarToRow
-                                                                                                                                InputAdapter
-                                                                                                                                  Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
+                                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #24
                                                                                                 InputAdapter
                                                                                                   WholeStageCodegen (26)
                                                                                                     Sort [cd_demo_sk]
                                                                                                       InputAdapter
-                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #20
+                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #24
                                                                                             InputAdapter
-                                                                                              BroadcastExchange #21
+                                                                                              BroadcastExchange #28
                                                                                                 WholeStageCodegen (27)
                                                                                                   Filter [p_promo_sk]
                                                                                                     ColumnarToRow
                                                                                                       InputAdapter
                                                                                                         Scan parquet spark_catalog.default.promotion [p_promo_sk]
                                                                                         InputAdapter
-                                                                                          BroadcastExchange #22
+                                                                                          BroadcastExchange #29
                                                                                             WholeStageCodegen (28)
                                                                                               Filter [hd_demo_sk,hd_income_band_sk]
                                                                                                 ColumnarToRow
                                                                                                   InputAdapter
                                                                                                     Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_income_band_sk]
                                                                                     InputAdapter
-                                                                                      ReusedExchange [hd_demo_sk,hd_income_band_sk] #22
+                                                                                      ReusedExchange [hd_demo_sk,hd_income_band_sk] #29
                                                                     InputAdapter
                                                                       WholeStageCodegen (33)
                                                                         Sort [ca_address_sk]
                                                                           InputAdapter
-                                                                            Exchange [ca_address_sk] #23
-                                                                              WholeStageCodegen (32)
-                                                                                Filter [ca_address_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip]
+                                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #26
                                                     InputAdapter
                                                       WholeStageCodegen (37)
                                                         Sort [ca_address_sk]
                                                           InputAdapter
-                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #23
+                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #26
                                                 InputAdapter
-                                                  BroadcastExchange #24
+                                                  BroadcastExchange #30
                                                     WholeStageCodegen (38)
                                                       Filter [ib_income_band_sk]
                                                         ColumnarToRow
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.income_band [ib_income_band_sk]
                                             InputAdapter
-                                              ReusedExchange [ib_income_band_sk] #24
+                                              ReusedExchange [ib_income_band_sk] #30
                                         InputAdapter
-                                          BroadcastExchange #25
+                                          BroadcastExchange #31
                                             WholeStageCodegen (40)
                                               Project [i_item_sk,i_product_name]
                                                 Filter [i_current_price,i_color,i_item_sk]
@@ -247,11 +277,11 @@ WholeStageCodegen (88)
                 WholeStageCodegen (86)
                   Sort [item_sk,store_name,store_zip]
                     InputAdapter
-                      Exchange [item_sk,store_name,store_zip] #26
+                      Exchange [item_sk,store_name,store_zip] #32
                         WholeStageCodegen (85)
                           HashAggregate [i_product_name,i_item_sk,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,d_year,d_year,d_year,count,sum,sum,sum] [count(1),sum(UnscaledValue(ss_wholesale_cost)),sum(UnscaledValue(ss_list_price)),sum(UnscaledValue(ss_coupon_amt)),item_sk,store_name,store_zip,syear,cnt,s1,s2,s3,count,sum,sum,sum]
                             InputAdapter
-                              Exchange [i_product_name,i_item_sk,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,d_year,d_year,d_year] #27
+                              Exchange [i_product_name,i_item_sk,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,d_year,d_year,d_year] #33
                                 WholeStageCodegen (84)
                                   HashAggregate [i_product_name,i_item_sk,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,d_year,d_year,d_year,ss_wholesale_cost,ss_list_price,ss_coupon_amt] [count,sum,sum,sum,count,sum,sum,sum]
                                     Project [ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,d_year,d_year,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,i_item_sk,i_product_name]
@@ -266,7 +296,7 @@ WholeStageCodegen (88)
                                                       WholeStageCodegen (78)
                                                         Sort [c_current_addr_sk]
                                                           InputAdapter
-                                                            Exchange [c_current_addr_sk] #28
+                                                            Exchange [c_current_addr_sk] #34
                                                               WholeStageCodegen (77)
                                                                 Project [ss_item_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip,c_current_addr_sk,d_year,d_year,hd_income_band_sk,hd_income_band_sk,ca_street_number,ca_street_name,ca_city,ca_zip]
                                                                   SortMergeJoin [ss_addr_sk,ca_address_sk]
@@ -274,7 +304,7 @@ WholeStageCodegen (88)
                                                                       WholeStageCodegen (74)
                                                                         Sort [ss_addr_sk]
                                                                           InputAdapter
-                                                                            Exchange [ss_addr_sk] #29
+                                                                            Exchange [ss_addr_sk] #35
                                                                               WholeStageCodegen (73)
                                                                                 Project [ss_item_sk,ss_addr_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip,c_current_addr_sk,d_year,d_year,hd_income_band_sk,hd_income_band_sk]
                                                                                   BroadcastHashJoin [c_current_hdemo_sk,hd_demo_sk]
@@ -288,7 +318,7 @@ WholeStageCodegen (88)
                                                                                                   WholeStageCodegen (67)
                                                                                                     Sort [c_current_cdemo_sk]
                                                                                                       InputAdapter
-                                                                                                        Exchange [c_current_cdemo_sk] #30
+                                                                                                        Exchange [c_current_cdemo_sk] #36
                                                                                                           WholeStageCodegen (66)
                                                                                                             Project [ss_item_sk,ss_hdemo_sk,ss_addr_sk,ss_promo_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,d_year,d_year,cd_marital_status]
                                                                                                               SortMergeJoin [ss_cdemo_sk,cd_demo_sk]
@@ -296,7 +326,7 @@ WholeStageCodegen (88)
                                                                                                                   WholeStageCodegen (63)
                                                                                                                     Sort [ss_cdemo_sk]
                                                                                                                       InputAdapter
-                                                                                                                        Exchange [ss_cdemo_sk] #31
+                                                                                                                        Exchange [ss_cdemo_sk] #37
                                                                                                                           WholeStageCodegen (62)
                                                                                                                             Project [ss_item_sk,ss_cdemo_sk,ss_hdemo_sk,ss_addr_sk,ss_promo_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,d_year,d_year]
                                                                                                                               BroadcastHashJoin [c_first_shipto_date_sk,d_date_sk]
@@ -308,7 +338,7 @@ WholeStageCodegen (88)
                                                                                                                                           WholeStageCodegen (57)
                                                                                                                                             Sort [ss_customer_sk]
                                                                                                                                               InputAdapter
-                                                                                                                                                Exchange [ss_customer_sk] #32
+                                                                                                                                                Exchange [ss_customer_sk] #38
                                                                                                                                                   WholeStageCodegen (56)
                                                                                                                                                     Project [ss_item_sk,ss_customer_sk,ss_cdemo_sk,ss_hdemo_sk,ss_addr_sk,ss_promo_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip]
                                                                                                                                                       BroadcastHashJoin [ss_store_sk,s_store_sk]
@@ -322,15 +352,16 @@ WholeStageCodegen (88)
                                                                                                                                                                       WholeStageCodegen (45)
                                                                                                                                                                         Sort [ss_item_sk,ss_ticket_number]
                                                                                                                                                                           InputAdapter
-                                                                                                                                                                            Exchange [ss_item_sk,ss_ticket_number] #33
+                                                                                                                                                                            Exchange [ss_item_sk,ss_ticket_number] #39
                                                                                                                                                                               WholeStageCodegen (44)
                                                                                                                                                                                 Filter [ss_item_sk,ss_ticket_number,ss_store_sk,ss_customer_sk,ss_cdemo_sk,ss_promo_sk,ss_hdemo_sk,ss_addr_sk]
                                                                                                                                                                                   ReusedSubquery [bloomFilter] #2
+                                                                                                                                                                                  ReusedSubquery [bloomFilter] #3
                                                                                                                                                                                   ColumnarToRow
                                                                                                                                                                                     InputAdapter
                                                                                                                                                                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_cdemo_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_promo_sk,ss_ticket_number,ss_wholesale_cost,ss_list_price,ss_coupon_amt,ss_sold_date_sk]
-                                                                                                                                                                                        SubqueryBroadcast [d_date_sk] #3
-                                                                                                                                                                                          BroadcastExchange #34
+                                                                                                                                                                                        SubqueryBroadcast [d_date_sk] #7
+                                                                                                                                                                                          BroadcastExchange #40
                                                                                                                                                                                             WholeStageCodegen (1)
                                                                                                                                                                                               Filter [d_year,d_date_sk]
                                                                                                                                                                                                 ColumnarToRow
@@ -340,51 +371,57 @@ WholeStageCodegen (88)
                                                                                                                                                                       WholeStageCodegen (47)
                                                                                                                                                                         Sort [sr_item_sk,sr_ticket_number]
                                                                                                                                                                           InputAdapter
-                                                                                                                                                                            ReusedExchange [sr_item_sk,sr_ticket_number] #12
+                                                                                                                                                                            ReusedExchange [sr_item_sk,sr_ticket_number] #16
                                                                                                                                                                 InputAdapter
-                                                                                                                                                                  ReusedExchange [cs_item_sk] #13
+                                                                                                                                                                  ReusedExchange [cs_item_sk] #17
                                                                                                                                                             InputAdapter
-                                                                                                                                                              ReusedExchange [d_date_sk,d_year] #34
+                                                                                                                                                              ReusedExchange [d_date_sk,d_year] #40
                                                                                                                                                         InputAdapter
-                                                                                                                                                          ReusedExchange [s_store_sk,s_store_name,s_zip] #17
+                                                                                                                                                          ReusedExchange [s_store_sk,s_store_name,s_zip] #21
                                                                                                                                         InputAdapter
                                                                                                                                           WholeStageCodegen (59)
                                                                                                                                             Sort [c_customer_sk]
                                                                                                                                               InputAdapter
-                                                                                                                                                ReusedExchange [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,c_first_shipto_date_sk,c_first_sales_date_sk] #18
+                                                                                                                                                Exchange [c_customer_sk] #41
+                                                                                                                                                  WholeStageCodegen (58)
+                                                                                                                                                    Filter [c_customer_sk,c_first_sales_date_sk,c_first_shipto_date_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk]
+                                                                                                                                                      ReusedSubquery [bloomFilter] #2
+                                                                                                                                                      ColumnarToRow
+                                                                                                                                                        InputAdapter
+                                                                                                                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,c_first_shipto_date_sk,c_first_sales_date_sk]
                                                                                                                                     InputAdapter
-                                                                                                                                      ReusedExchange [d_date_sk,d_year] #19
+                                                                                                                                      ReusedExchange [d_date_sk,d_year] #27
                                                                                                                                 InputAdapter
-                                                                                                                                  ReusedExchange [d_date_sk,d_year] #19
+                                                                                                                                  ReusedExchange [d_date_sk,d_year] #27
                                                                                                                 InputAdapter
                                                                                                                   WholeStageCodegen (65)
                                                                                                                     Sort [cd_demo_sk]
                                                                                                                       InputAdapter
-                                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #20
+                                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #24
                                                                                                 InputAdapter
                                                                                                   WholeStageCodegen (69)
                                                                                                     Sort [cd_demo_sk]
                                                                                                       InputAdapter
-                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #20
+                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #24
                                                                                             InputAdapter
-                                                                                              ReusedExchange [p_promo_sk] #21
+                                                                                              ReusedExchange [p_promo_sk] #28
                                                                                         InputAdapter
-                                                                                          ReusedExchange [hd_demo_sk,hd_income_band_sk] #22
+                                                                                          ReusedExchange [hd_demo_sk,hd_income_band_sk] #29
                                                                                     InputAdapter
-                                                                                      ReusedExchange [hd_demo_sk,hd_income_band_sk] #22
+                                                                                      ReusedExchange [hd_demo_sk,hd_income_band_sk] #29
                                                                     InputAdapter
                                                                       WholeStageCodegen (76)
                                                                         Sort [ca_address_sk]
                                                                           InputAdapter
-                                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #23
+                                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #26
                                                     InputAdapter
                                                       WholeStageCodegen (80)
                                                         Sort [ca_address_sk]
                                                           InputAdapter
-                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #23
+                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #26
                                                 InputAdapter
-                                                  ReusedExchange [ib_income_band_sk] #24
+                                                  ReusedExchange [ib_income_band_sk] #30
                                             InputAdapter
-                                              ReusedExchange [ib_income_band_sk] #24
+                                              ReusedExchange [ib_income_band_sk] #30
                                         InputAdapter
-                                          ReusedExchange [i_item_sk,i_product_name] #25
+                                          ReusedExchange [i_item_sk,i_product_name] #31

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/explain.txt
@@ -1,7 +1,7 @@
 == Physical Plan ==
-TakeOrderedAndProject (42)
-+- * Project (41)
-   +- * SortMergeJoin Inner (40)
+TakeOrderedAndProject (39)
++- * Project (38)
+   +- * SortMergeJoin Inner (37)
       :- * Sort (34)
       :  +- Exchange (33)
       :     +- * Project (32)
@@ -36,11 +36,8 @@ TakeOrderedAndProject (42)
       :              +- * Filter (29)
       :                 +- * ColumnarToRow (28)
       :                    +- Scan parquet spark_catalog.default.store (27)
-      +- * Sort (39)
-         +- Exchange (38)
-            +- * Filter (37)
-               +- * ColumnarToRow (36)
-                  +- Scan parquet spark_catalog.default.item (35)
+      +- * Sort (36)
+         +- ReusedExchange (35)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -56,229 +53,260 @@ Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
 (3) Filter [codegen id : 2]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
-Condition : (isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
+Condition : ((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(ss_item_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 47]
-Output [1]: [d_date_sk#6]
+(4) ReusedExchange [Reuses operator id: 51]
+Output [1]: [d_date_sk#8]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
 Output [3]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3]
-Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6]
+Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#8]
 
 (7) HashAggregate [codegen id : 2]
 Input [3]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3]
 Keys [2]: [ss_store_sk#2, ss_item_sk#1]
 Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
-Aggregate Attributes [1]: [sum#7]
-Results [3]: [ss_store_sk#2, ss_item_sk#1, sum#8]
+Aggregate Attributes [1]: [sum#9]
+Results [3]: [ss_store_sk#2, ss_item_sk#1, sum#10]
 
 (8) Exchange
-Input [3]: [ss_store_sk#2, ss_item_sk#1, sum#8]
+Input [3]: [ss_store_sk#2, ss_item_sk#1, sum#10]
 Arguments: hashpartitioning(ss_store_sk#2, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (9) HashAggregate [codegen id : 8]
-Input [3]: [ss_store_sk#2, ss_item_sk#1, sum#8]
+Input [3]: [ss_store_sk#2, ss_item_sk#1, sum#10]
 Keys [2]: [ss_store_sk#2, ss_item_sk#1]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#9]
-Results [3]: [ss_store_sk#2, ss_item_sk#1, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#9,17,2) AS revenue#10]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#11]
+Results [3]: [ss_store_sk#2, ss_item_sk#1, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#11,17,2) AS revenue#12]
 
 (10) Filter [codegen id : 8]
-Input [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
-Condition : isnotnull(revenue#10)
+Input [3]: [ss_store_sk#2, ss_item_sk#1, revenue#12]
+Condition : isnotnull(revenue#12)
 
 (11) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14]
+Output [4]: [ss_item_sk#13, ss_store_sk#14, ss_sales_price#15, ss_sold_date_sk#16]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#14), dynamicpruningexpression(ss_sold_date_sk#14 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#16), dynamicpruningexpression(ss_sold_date_sk#16 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
 (12) ColumnarToRow [codegen id : 4]
-Input [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14]
+Input [4]: [ss_item_sk#13, ss_store_sk#14, ss_sales_price#15, ss_sold_date_sk#16]
 
 (13) Filter [codegen id : 4]
-Input [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14]
-Condition : isnotnull(ss_store_sk#12)
+Input [4]: [ss_item_sk#13, ss_store_sk#14, ss_sales_price#15, ss_sold_date_sk#16]
+Condition : (isnotnull(ss_store_sk#14) AND true)
 
-(14) ReusedExchange [Reuses operator id: 47]
-Output [1]: [d_date_sk#15]
+(14) ReusedExchange [Reuses operator id: 51]
+Output [1]: [d_date_sk#17]
 
 (15) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#14]
-Right keys [1]: [d_date_sk#15]
+Left keys [1]: [ss_sold_date_sk#16]
+Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
-Output [3]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13]
-Input [5]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14, d_date_sk#15]
+Output [3]: [ss_item_sk#13, ss_store_sk#14, ss_sales_price#15]
+Input [5]: [ss_item_sk#13, ss_store_sk#14, ss_sales_price#15, ss_sold_date_sk#16, d_date_sk#17]
 
 (17) HashAggregate [codegen id : 4]
-Input [3]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13]
-Keys [2]: [ss_store_sk#12, ss_item_sk#11]
-Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#13))]
-Aggregate Attributes [1]: [sum#16]
-Results [3]: [ss_store_sk#12, ss_item_sk#11, sum#17]
+Input [3]: [ss_item_sk#13, ss_store_sk#14, ss_sales_price#15]
+Keys [2]: [ss_store_sk#14, ss_item_sk#13]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#15))]
+Aggregate Attributes [1]: [sum#18]
+Results [3]: [ss_store_sk#14, ss_item_sk#13, sum#19]
 
 (18) Exchange
-Input [3]: [ss_store_sk#12, ss_item_sk#11, sum#17]
-Arguments: hashpartitioning(ss_store_sk#12, ss_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [3]: [ss_store_sk#14, ss_item_sk#13, sum#19]
+Arguments: hashpartitioning(ss_store_sk#14, ss_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (19) HashAggregate [codegen id : 5]
-Input [3]: [ss_store_sk#12, ss_item_sk#11, sum#17]
-Keys [2]: [ss_store_sk#12, ss_item_sk#11]
-Functions [1]: [sum(UnscaledValue(ss_sales_price#13))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#13))#18]
-Results [2]: [ss_store_sk#12, MakeDecimal(sum(UnscaledValue(ss_sales_price#13))#18,17,2) AS revenue#19]
+Input [3]: [ss_store_sk#14, ss_item_sk#13, sum#19]
+Keys [2]: [ss_store_sk#14, ss_item_sk#13]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#15))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#15))#20]
+Results [2]: [ss_store_sk#14, MakeDecimal(sum(UnscaledValue(ss_sales_price#15))#20,17,2) AS revenue#21]
 
 (20) HashAggregate [codegen id : 5]
-Input [2]: [ss_store_sk#12, revenue#19]
-Keys [1]: [ss_store_sk#12]
-Functions [1]: [partial_avg(revenue#19)]
-Aggregate Attributes [2]: [sum#20, count#21]
-Results [3]: [ss_store_sk#12, sum#22, count#23]
+Input [2]: [ss_store_sk#14, revenue#21]
+Keys [1]: [ss_store_sk#14]
+Functions [1]: [partial_avg(revenue#21)]
+Aggregate Attributes [2]: [sum#22, count#23]
+Results [3]: [ss_store_sk#14, sum#24, count#25]
 
 (21) Exchange
-Input [3]: [ss_store_sk#12, sum#22, count#23]
-Arguments: hashpartitioning(ss_store_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [ss_store_sk#14, sum#24, count#25]
+Arguments: hashpartitioning(ss_store_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (22) HashAggregate [codegen id : 6]
-Input [3]: [ss_store_sk#12, sum#22, count#23]
-Keys [1]: [ss_store_sk#12]
-Functions [1]: [avg(revenue#19)]
-Aggregate Attributes [1]: [avg(revenue#19)#24]
-Results [2]: [ss_store_sk#12, avg(revenue#19)#24 AS ave#25]
+Input [3]: [ss_store_sk#14, sum#24, count#25]
+Keys [1]: [ss_store_sk#14]
+Functions [1]: [avg(revenue#21)]
+Aggregate Attributes [1]: [avg(revenue#21)#26]
+Results [2]: [ss_store_sk#14, avg(revenue#21)#26 AS ave#27]
 
 (23) Filter [codegen id : 6]
-Input [2]: [ss_store_sk#12, ave#25]
-Condition : isnotnull(ave#25)
+Input [2]: [ss_store_sk#14, ave#27]
+Condition : isnotnull(ave#27)
 
 (24) BroadcastExchange
-Input [2]: [ss_store_sk#12, ave#25]
+Input [2]: [ss_store_sk#14, ave#27]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (25) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [ss_store_sk#12]
+Right keys [1]: [ss_store_sk#14]
 Join type: Inner
-Join condition: (cast(revenue#10 as decimal(23,7)) <= (0.1 * ave#25))
+Join condition: (cast(revenue#12 as decimal(23,7)) <= (0.1 * ave#27))
 
 (26) Project [codegen id : 8]
-Output [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
-Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#10, ss_store_sk#12, ave#25]
+Output [3]: [ss_store_sk#2, ss_item_sk#1, revenue#12]
+Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#12, ss_store_sk#14, ave#27]
 
 (27) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#26, s_store_name#27]
+Output [2]: [s_store_sk#28, s_store_name#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string>
 
 (28) ColumnarToRow [codegen id : 7]
-Input [2]: [s_store_sk#26, s_store_name#27]
+Input [2]: [s_store_sk#28, s_store_name#29]
 
 (29) Filter [codegen id : 7]
-Input [2]: [s_store_sk#26, s_store_name#27]
-Condition : isnotnull(s_store_sk#26)
+Input [2]: [s_store_sk#28, s_store_name#29]
+Condition : isnotnull(s_store_sk#28)
 
 (30) BroadcastExchange
-Input [2]: [s_store_sk#26, s_store_name#27]
+Input [2]: [s_store_sk#28, s_store_name#29]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
 (31) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#26]
+Right keys [1]: [s_store_sk#28]
 Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 8]
-Output [3]: [ss_item_sk#1, revenue#10, s_store_name#27]
-Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#10, s_store_sk#26, s_store_name#27]
+Output [3]: [ss_item_sk#1, revenue#12, s_store_name#29]
+Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#12, s_store_sk#28, s_store_name#29]
 
 (33) Exchange
-Input [3]: [ss_item_sk#1, revenue#10, s_store_name#27]
+Input [3]: [ss_item_sk#1, revenue#12, s_store_name#29]
 Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (34) Sort [codegen id : 9]
-Input [3]: [ss_item_sk#1, revenue#10, s_store_name#27]
+Input [3]: [ss_item_sk#1, revenue#12, s_store_name#29]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(35) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(35) ReusedExchange [Reuses operator id: 43]
+Output [5]: [i_item_sk#30, i_item_desc#31, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+
+(36) Sort [codegen id : 11]
+Input [5]: [i_item_sk#30, i_item_desc#31, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+Arguments: [i_item_sk#30 ASC NULLS FIRST], false, 0
+
+(37) SortMergeJoin [codegen id : 12]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#30]
+Join type: Inner
+Join condition: None
+
+(38) Project [codegen id : 12]
+Output [6]: [s_store_name#29, i_item_desc#31, revenue#12, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+Input [8]: [ss_item_sk#1, revenue#12, s_store_name#29, i_item_sk#30, i_item_desc#31, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+
+(39) TakeOrderedAndProject
+Input [6]: [s_store_name#29, i_item_desc#31, revenue#12, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+Arguments: 100, [s_store_name#29 ASC NULLS FIRST, i_item_desc#31 ASC NULLS FIRST], [s_store_name#29, i_item_desc#31, revenue#12, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (46)
++- Exchange (45)
+   +- ObjectHashAggregate (44)
+      +- Exchange (43)
+         +- * Filter (42)
+            +- * ColumnarToRow (41)
+               +- Scan parquet spark_catalog.default.item (40)
+
+
+(40) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#30, i_item_desc#31, i_current_price#32, i_wholesale_cost#33, i_brand#34]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string,i_current_price:decimal(7,2),i_wholesale_cost:decimal(7,2),i_brand:string>
 
-(36) ColumnarToRow [codegen id : 10]
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(41) ColumnarToRow [codegen id : 1]
+Input [5]: [i_item_sk#30, i_item_desc#31, i_current_price#32, i_wholesale_cost#33, i_brand#34]
 
-(37) Filter [codegen id : 10]
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Condition : isnotnull(i_item_sk#28)
+(42) Filter [codegen id : 1]
+Input [5]: [i_item_sk#30, i_item_desc#31, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+Condition : isnotnull(i_item_sk#30)
 
-(38) Exchange
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Arguments: hashpartitioning(i_item_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(43) Exchange
+Input [5]: [i_item_sk#30, i_item_desc#31, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+Arguments: hashpartitioning(i_item_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(39) Sort [codegen id : 11]
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Arguments: [i_item_sk#28 ASC NULLS FIRST], false, 0
+(44) ObjectHashAggregate
+Input [5]: [i_item_sk#30, i_item_desc#31, i_current_price#32, i_wholesale_cost#33, i_brand#34]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#30, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#35]
+Results [1]: [buf#36]
 
-(40) SortMergeJoin [codegen id : 12]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#28]
-Join type: Inner
-Join condition: None
+(45) Exchange
+Input [1]: [buf#36]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(41) Project [codegen id : 12]
-Output [6]: [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Input [8]: [ss_item_sk#1, revenue#10, s_store_name#27, i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(46) ObjectHashAggregate
+Input [1]: [buf#36]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#30, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#30, 42), 204000, 1632000, 0, 0)#37]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#30, 42), 204000, 1632000, 0, 0)#37 AS bloomFilter#38]
 
-(42) TakeOrderedAndProject
-Input [6]: [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Arguments: 100, [s_store_name#27 ASC NULLS FIRST, i_item_desc#29 ASC NULLS FIRST], [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (47)
-+- * Project (46)
-   +- * Filter (45)
-      +- * ColumnarToRow (44)
-         +- Scan parquet spark_catalog.default.date_dim (43)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
+BroadcastExchange (51)
++- * Project (50)
+   +- * Filter (49)
+      +- * ColumnarToRow (48)
+         +- Scan parquet spark_catalog.default.date_dim (47)
 
 
-(43) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#6, d_month_seq#33]
+(47) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#8, d_month_seq#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1176), LessThanOrEqual(d_month_seq,1187), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(44) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#6, d_month_seq#33]
+(48) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#8, d_month_seq#39]
 
-(45) Filter [codegen id : 1]
-Input [2]: [d_date_sk#6, d_month_seq#33]
-Condition : (((isnotnull(d_month_seq#33) AND (d_month_seq#33 >= 1176)) AND (d_month_seq#33 <= 1187)) AND isnotnull(d_date_sk#6))
+(49) Filter [codegen id : 1]
+Input [2]: [d_date_sk#8, d_month_seq#39]
+Condition : (((isnotnull(d_month_seq#39) AND (d_month_seq#39 >= 1176)) AND (d_month_seq#39 <= 1187)) AND isnotnull(d_date_sk#8))
 
-(46) Project [codegen id : 1]
-Output [1]: [d_date_sk#6]
-Input [2]: [d_date_sk#6, d_month_seq#33]
+(50) Project [codegen id : 1]
+Output [1]: [d_date_sk#8]
+Input [2]: [d_date_sk#8, d_month_seq#39]
 
-(47) BroadcastExchange
-Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+(51) BroadcastExchange
+Input [1]: [d_date_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:2 Hosting operator id = 11 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#5
+Subquery:3 Hosting operator id = 11 Hosting Expression = ss_sold_date_sk#16 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/simplified.txt
@@ -21,6 +21,16 @@ TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholes
                                         Project [ss_item_sk,ss_store_sk,ss_sales_price]
                                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                             Filter [ss_store_sk,ss_item_sk]
+                                              Subquery #2
+                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                  Exchange #4
+                                                    ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                      Exchange [i_item_sk] #5
+                                                        WholeStageCodegen (1)
+                                                          Filter [i_item_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc,i_current_price,i_wholesale_cost,i_brand]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
@@ -35,17 +45,17 @@ TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholes
                                             InputAdapter
                                               ReusedExchange [d_date_sk] #3
                             InputAdapter
-                              BroadcastExchange #4
+                              BroadcastExchange #6
                                 WholeStageCodegen (6)
                                   Filter [ave]
                                     HashAggregate [ss_store_sk,sum,count] [avg(revenue),ave,sum,count]
                                       InputAdapter
-                                        Exchange [ss_store_sk] #5
+                                        Exchange [ss_store_sk] #7
                                           WholeStageCodegen (5)
                                             HashAggregate [ss_store_sk,revenue] [sum,count,sum,count]
                                               HashAggregate [ss_store_sk,ss_item_sk,sum] [sum(UnscaledValue(ss_sales_price)),revenue,sum]
                                                 InputAdapter
-                                                  Exchange [ss_store_sk,ss_item_sk] #6
+                                                  Exchange [ss_store_sk,ss_item_sk] #8
                                                     WholeStageCodegen (4)
                                                       HashAggregate [ss_store_sk,ss_item_sk,ss_sales_price] [sum,sum]
                                                         Project [ss_item_sk,ss_store_sk,ss_sales_price]
@@ -58,7 +68,7 @@ TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholes
                                                             InputAdapter
                                                               ReusedExchange [d_date_sk] #3
                         InputAdapter
-                          BroadcastExchange #7
+                          BroadcastExchange #9
                             WholeStageCodegen (7)
                               Filter [s_store_sk]
                                 ColumnarToRow
@@ -68,9 +78,4 @@ TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholes
           WholeStageCodegen (11)
             Sort [i_item_sk]
               InputAdapter
-                Exchange [i_item_sk] #8
-                  WholeStageCodegen (10)
-                    Filter [i_item_sk]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc,i_current_price,i_wholesale_cost,i_brand]
+                ReusedExchange [i_item_sk,i_item_desc,i_current_price,i_wholesale_cost,i_brand] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/explain.txt
@@ -1,15 +1,15 @@
 == Physical Plan ==
-TakeOrderedAndProject (30)
-+- * Filter (29)
-   +- Window (28)
-      +- * Sort (27)
-         +- Exchange (26)
-            +- * HashAggregate (25)
-               +- Exchange (24)
-                  +- * HashAggregate (23)
-                     +- * Expand (22)
-                        +- * Project (21)
-                           +- * SortMergeJoin Inner (20)
+TakeOrderedAndProject (27)
++- * Filter (26)
+   +- Window (25)
+      +- * Sort (24)
+         +- Exchange (23)
+            +- * HashAggregate (22)
+               +- Exchange (21)
+                  +- * HashAggregate (20)
+                     +- * Expand (19)
+                        +- * Project (18)
+                           +- * SortMergeJoin Inner (17)
                               :- * Sort (14)
                               :  +- Exchange (13)
                               :     +- * Project (12)
@@ -24,11 +24,8 @@ TakeOrderedAndProject (30)
                               :              +- * Filter (9)
                               :                 +- * ColumnarToRow (8)
                               :                    +- Scan parquet spark_catalog.default.store (7)
-                              +- * Sort (19)
-                                 +- Exchange (18)
-                                    +- * Filter (17)
-                                       +- * ColumnarToRow (16)
-                                          +- Scan parquet spark_catalog.default.item (15)
+                              +- * Sort (16)
+                                 +- ReusedExchange (15)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -44,161 +41,192 @@ Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sol
 
 (3) Filter [codegen id : 3]
 Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5]
-Condition : (isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
+Condition : ((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_item_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 35]
-Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
+(4) ReusedExchange [Reuses operator id: 39]
+Output [4]: [d_date_sk#9, d_year#10, d_moy#11, d_qoy#12]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
-Output [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10]
-Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5, d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
+Output [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12]
+Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5, d_date_sk#9, d_year#10, d_moy#11, d_qoy#12]
 
 (7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#11, s_store_id#12]
+Output [2]: [s_store_sk#13, s_store_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#11, s_store_id#12]
+Input [2]: [s_store_sk#13, s_store_id#14]
 
 (9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#11, s_store_id#12]
-Condition : isnotnull(s_store_sk#11)
+Input [2]: [s_store_sk#13, s_store_id#14]
+Condition : isnotnull(s_store_sk#13)
 
 (10) BroadcastExchange
-Input [2]: [s_store_sk#11, s_store_id#12]
+Input [2]: [s_store_sk#13, s_store_id#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#11]
+Right keys [1]: [s_store_sk#13]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
-Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_sk#11, s_store_id#12]
+Output [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14]
+Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_sk#13, s_store_id#14]
 
 (13) Exchange
-Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
+Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14]
 Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
+Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(15) ReusedExchange [Reuses operator id: 31]
+Output [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+
+(16) Sort [codegen id : 6]
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Arguments: [i_item_sk#15 ASC NULLS FIRST], false, 0
+
+(17) SortMergeJoin [codegen id : 7]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#15]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 7]
+Output [10]: [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Input [12]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14, i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+
+(19) Expand [codegen id : 7]
+Input [10]: [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Arguments: [[ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, 0], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, null, 1], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, null, null, 3], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, null, null, null, 7], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, i_brand#16, i_product_name#19, null, null, null, null, 15], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, i_brand#16, null, null, null, null, null, 31], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#17, null, null, null, null, null, null, 63], [ss_quantity#3, ss_sales_price#4, i_category#18, null, null, null, null, null, null, null, 127], [ss_quantity#3, ss_sales_price#4, null, null, null, null, null, null, null, null, 255]], [ss_quantity#3, ss_sales_price#4, i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, spark_grouping_id#28]
+
+(20) HashAggregate [codegen id : 7]
+Input [11]: [ss_quantity#3, ss_sales_price#4, i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, spark_grouping_id#28]
+Keys [9]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, spark_grouping_id#28]
+Functions [1]: [partial_sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [2]: [sum#29, isEmpty#30]
+Results [11]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, spark_grouping_id#28, sum#31, isEmpty#32]
+
+(21) Exchange
+Input [11]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, spark_grouping_id#28, sum#31, isEmpty#32]
+Arguments: hashpartitioning(i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, spark_grouping_id#28, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(22) HashAggregate [codegen id : 8]
+Input [11]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, spark_grouping_id#28, sum#31, isEmpty#32]
+Keys [9]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, spark_grouping_id#28]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#33]
+Results [9]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#33 AS sumsales#34]
+
+(23) Exchange
+Input [9]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, sumsales#34]
+Arguments: hashpartitioning(i_category#20, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(24) Sort [codegen id : 9]
+Input [9]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, sumsales#34]
+Arguments: [i_category#20 ASC NULLS FIRST, sumsales#34 DESC NULLS LAST], false, 0
+
+(25) Window
+Input [9]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, sumsales#34]
+Arguments: [rank(sumsales#34) windowspecdefinition(i_category#20, sumsales#34 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#35], [i_category#20], [sumsales#34 DESC NULLS LAST]
+
+(26) Filter [codegen id : 10]
+Input [10]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, sumsales#34, rk#35]
+Condition : (rk#35 <= 100)
+
+(27) TakeOrderedAndProject
+Input [10]: [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, sumsales#34, rk#35]
+Arguments: 100, [i_category#20 ASC NULLS FIRST, i_class#21 ASC NULLS FIRST, i_brand#22 ASC NULLS FIRST, i_product_name#23 ASC NULLS FIRST, d_year#24 ASC NULLS FIRST, d_qoy#25 ASC NULLS FIRST, d_moy#26 ASC NULLS FIRST, s_store_id#27 ASC NULLS FIRST, sumsales#34 ASC NULLS FIRST, rk#35 ASC NULLS FIRST], [i_category#20, i_class#21, i_brand#22, i_product_name#23, d_year#24, d_qoy#25, d_moy#26, s_store_id#27, sumsales#34, rk#35]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (34)
++- Exchange (33)
+   +- ObjectHashAggregate (32)
+      +- Exchange (31)
+         +- * Filter (30)
+            +- * ColumnarToRow (29)
+               +- Scan parquet spark_catalog.default.item (28)
+
+
+(28) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_product_name:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(29) ColumnarToRow [codegen id : 1]
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
 
-(17) Filter [codegen id : 5]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Condition : isnotnull(i_item_sk#13)
+(30) Filter [codegen id : 1]
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Condition : isnotnull(i_item_sk#15)
 
-(18) Exchange
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(31) Exchange
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Arguments: hashpartitioning(i_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(19) Sort [codegen id : 6]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
+(32) ObjectHashAggregate
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#15, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#36]
+Results [1]: [buf#37]
 
-(20) SortMergeJoin [codegen id : 7]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#13]
-Join type: Inner
-Join condition: None
+(33) Exchange
+Input [1]: [buf#37]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
-(21) Project [codegen id : 7]
-Output [10]: [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Input [12]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12, i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(34) ObjectHashAggregate
+Input [1]: [buf#37]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 204000, 1632000, 0, 0)#38]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 204000, 1632000, 0, 0)#38 AS bloomFilter#39]
 
-(22) Expand [codegen id : 7]
-Input [10]: [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Arguments: [[ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, 0], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, null, 1], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, null, null, 3], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, null, null, null, 7], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, null, null, null, null, 15], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, null, null, null, null, null, 31], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, null, null, null, null, null, null, 63], [ss_quantity#3, ss_sales_price#4, i_category#16, null, null, null, null, null, null, null, 127], [ss_quantity#3, ss_sales_price#4, null, null, null, null, null, null, null, null, 255]], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26]
-
-(23) HashAggregate [codegen id : 7]
-Input [11]: [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26]
-Keys [9]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26]
-Functions [1]: [partial_sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [2]: [sum#27, isEmpty#28]
-Results [11]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26, sum#29, isEmpty#30]
-
-(24) Exchange
-Input [11]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26, sum#29, isEmpty#30]
-Arguments: hashpartitioning(i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(25) HashAggregate [codegen id : 8]
-Input [11]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26, sum#29, isEmpty#30]
-Keys [9]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#31]
-Results [9]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#31 AS sumsales#32]
-
-(26) Exchange
-Input [9]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, sumsales#32]
-Arguments: hashpartitioning(i_category#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(27) Sort [codegen id : 9]
-Input [9]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, sumsales#32]
-Arguments: [i_category#18 ASC NULLS FIRST, sumsales#32 DESC NULLS LAST], false, 0
-
-(28) Window
-Input [9]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, sumsales#32]
-Arguments: [rank(sumsales#32) windowspecdefinition(i_category#18, sumsales#32 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#33], [i_category#18], [sumsales#32 DESC NULLS LAST]
-
-(29) Filter [codegen id : 10]
-Input [10]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, sumsales#32, rk#33]
-Condition : (rk#33 <= 100)
-
-(30) TakeOrderedAndProject
-Input [10]: [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, sumsales#32, rk#33]
-Arguments: 100, [i_category#18 ASC NULLS FIRST, i_class#19 ASC NULLS FIRST, i_brand#20 ASC NULLS FIRST, i_product_name#21 ASC NULLS FIRST, d_year#22 ASC NULLS FIRST, d_qoy#23 ASC NULLS FIRST, d_moy#24 ASC NULLS FIRST, s_store_id#25 ASC NULLS FIRST, sumsales#32 ASC NULLS FIRST, rk#33 ASC NULLS FIRST], [i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, sumsales#32, rk#33]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (35)
-+- * Project (34)
-   +- * Filter (33)
-      +- * ColumnarToRow (32)
-         +- Scan parquet spark_catalog.default.date_dim (31)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (39)
++- * Project (38)
+   +- * Filter (37)
+      +- * ColumnarToRow (36)
+         +- Scan parquet spark_catalog.default.date_dim (35)
 
 
-(31) Scan parquet spark_catalog.default.date_dim
-Output [5]: [d_date_sk#7, d_month_seq#34, d_year#8, d_moy#9, d_qoy#10]
+(35) Scan parquet spark_catalog.default.date_dim
+Output [5]: [d_date_sk#9, d_month_seq#40, d_year#10, d_moy#11, d_qoy#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int,d_year:int,d_moy:int,d_qoy:int>
 
-(32) ColumnarToRow [codegen id : 1]
-Input [5]: [d_date_sk#7, d_month_seq#34, d_year#8, d_moy#9, d_qoy#10]
+(36) ColumnarToRow [codegen id : 1]
+Input [5]: [d_date_sk#9, d_month_seq#40, d_year#10, d_moy#11, d_qoy#12]
 
-(33) Filter [codegen id : 1]
-Input [5]: [d_date_sk#7, d_month_seq#34, d_year#8, d_moy#9, d_qoy#10]
-Condition : (((isnotnull(d_month_seq#34) AND (d_month_seq#34 >= 1200)) AND (d_month_seq#34 <= 1211)) AND isnotnull(d_date_sk#7))
+(37) Filter [codegen id : 1]
+Input [5]: [d_date_sk#9, d_month_seq#40, d_year#10, d_moy#11, d_qoy#12]
+Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1200)) AND (d_month_seq#40 <= 1211)) AND isnotnull(d_date_sk#9))
 
-(34) Project [codegen id : 1]
-Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
-Input [5]: [d_date_sk#7, d_month_seq#34, d_year#8, d_moy#9, d_qoy#10]
+(38) Project [codegen id : 1]
+Output [4]: [d_date_sk#9, d_year#10, d_moy#11, d_qoy#12]
+Input [5]: [d_date_sk#9, d_month_seq#40, d_year#10, d_moy#11, d_qoy#12]
 
-(35) BroadcastExchange
-Input [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+(39) BroadcastExchange
+Input [4]: [d_date_sk#9, d_year#10, d_moy#11, d_qoy#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/simplified.txt
@@ -27,6 +27,16 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                                     Project [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy]
                                                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                         Filter [ss_store_sk,ss_item_sk]
+                                                          Subquery #2
+                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                              Exchange #5
+                                                                ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                  Exchange [i_item_sk] #6
+                                                                    WholeStageCodegen (1)
+                                                                      Filter [i_item_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,ss_sold_date_sk]
@@ -41,7 +51,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                                         InputAdapter
                                                           ReusedExchange [d_date_sk,d_year,d_moy,d_qoy] #4
                                                     InputAdapter
-                                                      BroadcastExchange #5
+                                                      BroadcastExchange #7
                                                         WholeStageCodegen (2)
                                                           Filter [s_store_sk]
                                                             ColumnarToRow
@@ -51,9 +61,4 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                       WholeStageCodegen (6)
                                         Sort [i_item_sk]
                                           InputAdapter
-                                            Exchange [i_item_sk] #6
-                                              WholeStageCodegen (5)
-                                                Filter [i_item_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
+                                            ReusedExchange [i_item_sk,i_brand,i_class,i_category,i_product_name] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/explain.txt
@@ -123,84 +123,84 @@ Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ti
 
 (17) Filter [codegen id : 10]
 Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15]
-Condition : (((isnotnull(ss_store_sk#10) AND isnotnull(ss_hdemo_sk#8)) AND isnotnull(ss_addr_sk#9)) AND isnotnull(ss_customer_sk#7))
+Condition : (((((isnotnull(ss_store_sk#10) AND isnotnull(ss_hdemo_sk#8)) AND isnotnull(ss_addr_sk#9)) AND isnotnull(ss_customer_sk#7)) AND might_contain(Subquery scalar-subquery#17, [id=#18], xxhash64(ss_addr_sk#9, 42), false)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(ss_customer_sk#7, 42), false))
 
-(18) ReusedExchange [Reuses operator id: 52]
-Output [1]: [d_date_sk#17]
+(18) ReusedExchange [Reuses operator id: 63]
+Output [1]: [d_date_sk#21]
 
 (19) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#15]
-Right keys [1]: [d_date_sk#17]
+Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 10]
 Output [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
-Input [10]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15, d_date_sk#17]
+Input [10]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15, d_date_sk#21]
 
 (21) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#18, s_city#19]
+Output [2]: [s_store_sk#22, s_city#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_city:string>
 
 (22) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#18, s_city#19]
+Input [2]: [s_store_sk#22, s_city#23]
 
 (23) Filter [codegen id : 8]
-Input [2]: [s_store_sk#18, s_city#19]
-Condition : (s_city#19 IN (Midway,Fairview) AND isnotnull(s_store_sk#18))
+Input [2]: [s_store_sk#22, s_city#23]
+Condition : (s_city#23 IN (Midway,Fairview) AND isnotnull(s_store_sk#22))
 
 (24) Project [codegen id : 8]
-Output [1]: [s_store_sk#18]
-Input [2]: [s_store_sk#18, s_city#19]
+Output [1]: [s_store_sk#22]
+Input [2]: [s_store_sk#22, s_city#23]
 
 (25) BroadcastExchange
-Input [1]: [s_store_sk#18]
+Input [1]: [s_store_sk#22]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#10]
-Right keys [1]: [s_store_sk#18]
+Right keys [1]: [s_store_sk#22]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
 Output [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
-Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, s_store_sk#18]
+Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, s_store_sk#22]
 
 (28) Scan parquet spark_catalog.default.household_demographics
-Output [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
+Output [3]: [hd_demo_sk#24, hd_dep_count#25, hd_vehicle_count#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [Or(EqualTo(hd_dep_count,4),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
 
 (29) ColumnarToRow [codegen id : 9]
-Input [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
+Input [3]: [hd_demo_sk#24, hd_dep_count#25, hd_vehicle_count#26]
 
 (30) Filter [codegen id : 9]
-Input [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
-Condition : (((hd_dep_count#21 = 4) OR (hd_vehicle_count#22 = 3)) AND isnotnull(hd_demo_sk#20))
+Input [3]: [hd_demo_sk#24, hd_dep_count#25, hd_vehicle_count#26]
+Condition : (((hd_dep_count#25 = 4) OR (hd_vehicle_count#26 = 3)) AND isnotnull(hd_demo_sk#24))
 
 (31) Project [codegen id : 9]
-Output [1]: [hd_demo_sk#20]
-Input [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
+Output [1]: [hd_demo_sk#24]
+Input [3]: [hd_demo_sk#24, hd_dep_count#25, hd_vehicle_count#26]
 
 (32) BroadcastExchange
-Input [1]: [hd_demo_sk#20]
+Input [1]: [hd_demo_sk#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_hdemo_sk#8]
-Right keys [1]: [hd_demo_sk#20]
+Right keys [1]: [hd_demo_sk#24]
 Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 10]
 Output [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
-Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, hd_demo_sk#20]
+Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, hd_demo_sk#24]
 
 (35) Exchange
 Input [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
@@ -211,88 +211,162 @@ Input [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_pr
 Arguments: [ss_addr_sk#9 ASC NULLS FIRST], false, 0
 
 (37) ReusedExchange [Reuses operator id: 9]
-Output [2]: [ca_address_sk#23, ca_city#24]
+Output [2]: [ca_address_sk#27, ca_city#28]
 
 (38) Sort [codegen id : 13]
-Input [2]: [ca_address_sk#23, ca_city#24]
-Arguments: [ca_address_sk#23 ASC NULLS FIRST], false, 0
+Input [2]: [ca_address_sk#27, ca_city#28]
+Arguments: [ca_address_sk#27 ASC NULLS FIRST], false, 0
 
 (39) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ss_addr_sk#9]
-Right keys [1]: [ca_address_sk#23]
+Right keys [1]: [ca_address_sk#27]
 Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 14]
-Output [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_city#24]
-Input [8]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_address_sk#23, ca_city#24]
+Output [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_city#28]
+Input [8]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_address_sk#27, ca_city#28]
 
 (41) HashAggregate [codegen id : 14]
-Input [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_city#24]
-Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#24]
+Input [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_city#28]
+Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#28]
 Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#12)), partial_sum(UnscaledValue(ss_ext_list_price#13)), partial_sum(UnscaledValue(ss_ext_tax#14))]
-Aggregate Attributes [3]: [sum#25, sum#26, sum#27]
-Results [7]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#24, sum#28, sum#29, sum#30]
+Aggregate Attributes [3]: [sum#29, sum#30, sum#31]
+Results [7]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#28, sum#32, sum#33, sum#34]
 
 (42) HashAggregate [codegen id : 14]
-Input [7]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#24, sum#28, sum#29, sum#30]
-Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#24]
+Input [7]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#28, sum#32, sum#33, sum#34]
+Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#28]
 Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#12)), sum(UnscaledValue(ss_ext_list_price#13)), sum(UnscaledValue(ss_ext_tax#14))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#12))#31, sum(UnscaledValue(ss_ext_list_price#13))#32, sum(UnscaledValue(ss_ext_tax#14))#33]
-Results [6]: [ss_ticket_number#11, ss_customer_sk#7, ca_city#24 AS bought_city#34, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#12))#31,17,2) AS extended_price#35, MakeDecimal(sum(UnscaledValue(ss_ext_list_price#13))#32,17,2) AS list_price#36, MakeDecimal(sum(UnscaledValue(ss_ext_tax#14))#33,17,2) AS extended_tax#37]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#12))#35, sum(UnscaledValue(ss_ext_list_price#13))#36, sum(UnscaledValue(ss_ext_tax#14))#37]
+Results [6]: [ss_ticket_number#11, ss_customer_sk#7, ca_city#28 AS bought_city#38, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#12))#35,17,2) AS extended_price#39, MakeDecimal(sum(UnscaledValue(ss_ext_list_price#13))#36,17,2) AS list_price#40, MakeDecimal(sum(UnscaledValue(ss_ext_tax#14))#37,17,2) AS extended_tax#41]
 
 (43) Exchange
-Input [6]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#34, extended_price#35, list_price#36, extended_tax#37]
+Input [6]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#38, extended_price#39, list_price#40, extended_tax#41]
 Arguments: hashpartitioning(ss_customer_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (44) Sort [codegen id : 15]
-Input [6]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#34, extended_price#35, list_price#36, extended_tax#37]
+Input [6]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#38, extended_price#39, list_price#40, extended_tax#41]
 Arguments: [ss_customer_sk#7 ASC NULLS FIRST], false, 0
 
 (45) SortMergeJoin [codegen id : 16]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#7]
 Join type: Inner
-Join condition: NOT (ca_city#6 = bought_city#34)
+Join condition: NOT (ca_city#6 = bought_city#38)
 
 (46) Project [codegen id : 16]
-Output [8]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, extended_price#35, extended_tax#37, list_price#36]
-Input [10]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6, ss_ticket_number#11, ss_customer_sk#7, bought_city#34, extended_price#35, list_price#36, extended_tax#37]
+Output [8]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#38, ss_ticket_number#11, extended_price#39, extended_tax#41, list_price#40]
+Input [10]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6, ss_ticket_number#11, ss_customer_sk#7, bought_city#38, extended_price#39, list_price#40, extended_tax#41]
 
 (47) TakeOrderedAndProject
-Input [8]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, extended_price#35, extended_tax#37, list_price#36]
-Arguments: 100, [c_last_name#4 ASC NULLS FIRST, ss_ticket_number#11 ASC NULLS FIRST], [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, extended_price#35, extended_tax#37, list_price#36]
+Input [8]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#38, ss_ticket_number#11, extended_price#39, extended_tax#41, list_price#40]
+Arguments: 100, [c_last_name#4 ASC NULLS FIRST, ss_ticket_number#11 ASC NULLS FIRST], [c_last_name#4, c_first_name#3, ca_city#6, bought_city#38, ss_ticket_number#11, extended_price#39, extended_tax#41, list_price#40]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#15 IN dynamicpruning#16
-BroadcastExchange (52)
-+- * Project (51)
-   +- * Filter (50)
-      +- * ColumnarToRow (49)
-         +- Scan parquet spark_catalog.default.date_dim (48)
+Subquery:1 Hosting operator id = 17 Hosting Expression = Subquery scalar-subquery#17, [id=#18]
+ObjectHashAggregate (54)
++- Exchange (53)
+   +- ObjectHashAggregate (52)
+      +- Exchange (51)
+         +- * Filter (50)
+            +- * ColumnarToRow (49)
+               +- Scan parquet spark_catalog.default.customer_address (48)
 
 
-(48) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#17, d_year#38, d_dom#39]
+(48) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#27, ca_city#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
+ReadSchema: struct<ca_address_sk:int,ca_city:string>
+
+(49) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#27, ca_city#28]
+
+(50) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#27, ca_city#28]
+Condition : (isnotnull(ca_address_sk#27) AND isnotnull(ca_city#28))
+
+(51) Exchange
+Input [2]: [ca_address_sk#27, ca_city#28]
+Arguments: hashpartitioning(ca_address_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(52) ObjectHashAggregate
+Input [2]: [ca_address_sk#27, ca_city#28]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 969817, 7758536, 0, 0)]
+Aggregate Attributes [1]: [buf#42]
+Results [1]: [buf#43]
+
+(53) Exchange
+Input [1]: [buf#43]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) ObjectHashAggregate
+Input [1]: [buf#43]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 969817, 7758536, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 969817, 7758536, 0, 0)#44]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 969817, 7758536, 0, 0)#44 AS bloomFilter#45]
+
+Subquery:2 Hosting operator id = 17 Hosting Expression = Subquery scalar-subquery#19, [id=#20]
+ObjectHashAggregate (58)
++- Exchange (57)
+   +- ObjectHashAggregate (56)
+      +- ReusedExchange (55)
+
+
+(55) ReusedExchange [Reuses operator id: 13]
+Output [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+
+(56) ObjectHashAggregate
+Input [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#1, 42), 2120802, 16966416, 0, 0)]
+Aggregate Attributes [1]: [buf#46]
+Results [1]: [buf#47]
+
+(57) Exchange
+Input [1]: [buf#47]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+
+(58) ObjectHashAggregate
+Input [1]: [buf#47]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#1, 42), 2120802, 16966416, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#1, 42), 2120802, 16966416, 0, 0)#48]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#1, 42), 2120802, 16966416, 0, 0)#48 AS bloomFilter#49]
+
+Subquery:3 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#15 IN dynamicpruning#16
+BroadcastExchange (63)
++- * Project (62)
+   +- * Filter (61)
+      +- * ColumnarToRow (60)
+         +- Scan parquet spark_catalog.default.date_dim (59)
+
+
+(59) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#21, d_year#50, d_dom#51]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
-(49) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
+(60) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#21, d_year#50, d_dom#51]
 
-(50) Filter [codegen id : 1]
-Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
-Condition : ((((isnotnull(d_dom#39) AND (d_dom#39 >= 1)) AND (d_dom#39 <= 2)) AND d_year#38 IN (1999,2000,2001)) AND isnotnull(d_date_sk#17))
+(61) Filter [codegen id : 1]
+Input [3]: [d_date_sk#21, d_year#50, d_dom#51]
+Condition : ((((isnotnull(d_dom#51) AND (d_dom#51 >= 1)) AND (d_dom#51 <= 2)) AND d_year#50 IN (1999,2000,2001)) AND isnotnull(d_date_sk#21))
 
-(51) Project [codegen id : 1]
-Output [1]: [d_date_sk#17]
-Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
+(62) Project [codegen id : 1]
+Output [1]: [d_date_sk#21]
+Input [3]: [d_date_sk#21, d_year#50, d_dom#51]
 
-(52) BroadcastExchange
-Input [1]: [d_date_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+(63) BroadcastExchange
+Input [1]: [d_date_sk#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/simplified.txt
@@ -53,6 +53,21 @@ TakeOrderedAndProject [c_last_name,ss_ticket_number,c_first_name,ca_city,bought_
                                                 Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                     Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
+                                                      Subquery #2
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 969817, 7758536, 0, 0),bloomFilter,buf]
+                                                          Exchange #7
+                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                              Exchange [ca_address_sk] #8
+                                                                WholeStageCodegen (1)
+                                                                  Filter [ca_address_sk,ca_city]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
+                                                      Subquery #3
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2120802, 16966416, 0, 0),bloomFilter,buf]
+                                                          Exchange #9
+                                                            ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                              ReusedExchange [c_customer_sk,c_first_name,c_last_name,ca_city] #1
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
@@ -67,7 +82,7 @@ TakeOrderedAndProject [c_last_name,ss_ticket_number,c_first_name,ca_city,bought_
                                                     InputAdapter
                                                       ReusedExchange [d_date_sk] #6
                                                 InputAdapter
-                                                  BroadcastExchange #7
+                                                  BroadcastExchange #10
                                                     WholeStageCodegen (8)
                                                       Project [s_store_sk]
                                                         Filter [s_city,s_store_sk]
@@ -75,7 +90,7 @@ TakeOrderedAndProject [c_last_name,ss_ticket_number,c_first_name,ca_city,bought_
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.store [s_store_sk,s_city]
                                             InputAdapter
-                                              BroadcastExchange #8
+                                              BroadcastExchange #11
                                                 WholeStageCodegen (9)
                                                   Project [hd_demo_sk]
                                                     Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
@@ -1,51 +1,52 @@
 == Physical Plan ==
-TakeOrderedAndProject (47)
-+- * HashAggregate (46)
-   +- Exchange (45)
-      +- * HashAggregate (44)
-         +- * Project (43)
-            +- * BroadcastHashJoin Inner BuildLeft (42)
-               :- BroadcastExchange (38)
-               :  +- * Project (37)
-               :     +- * BroadcastHashJoin Inner BuildRight (36)
-               :        :- * Project (30)
-               :        :  +- * SortMergeJoin LeftAnti (29)
-               :        :     :- * SortMergeJoin LeftAnti (21)
-               :        :     :  :- * SortMergeJoin LeftSemi (13)
+TakeOrderedAndProject (48)
++- * HashAggregate (47)
+   +- Exchange (46)
+      +- * HashAggregate (45)
+         +- * Project (44)
+            +- * BroadcastHashJoin Inner BuildLeft (43)
+               :- BroadcastExchange (39)
+               :  +- * Project (38)
+               :     +- * BroadcastHashJoin Inner BuildRight (37)
+               :        :- * Project (31)
+               :        :  +- * SortMergeJoin LeftAnti (30)
+               :        :     :- * SortMergeJoin LeftAnti (22)
+               :        :     :  :- * SortMergeJoin LeftSemi (14)
                :        :     :  :  :- * Sort (5)
                :        :     :  :  :  +- Exchange (4)
                :        :     :  :  :     +- * Filter (3)
                :        :     :  :  :        +- * ColumnarToRow (2)
                :        :     :  :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :        :     :  :  +- * Sort (12)
-               :        :     :  :     +- Exchange (11)
-               :        :     :  :        +- * Project (10)
-               :        :     :  :           +- * BroadcastHashJoin Inner BuildRight (9)
-               :        :     :  :              :- * ColumnarToRow (7)
-               :        :     :  :              :  +- Scan parquet spark_catalog.default.store_sales (6)
-               :        :     :  :              +- ReusedExchange (8)
-               :        :     :  +- * Sort (20)
-               :        :     :     +- Exchange (19)
-               :        :     :        +- * Project (18)
-               :        :     :           +- * BroadcastHashJoin Inner BuildRight (17)
-               :        :     :              :- * ColumnarToRow (15)
-               :        :     :              :  +- Scan parquet spark_catalog.default.web_sales (14)
-               :        :     :              +- ReusedExchange (16)
-               :        :     +- * Sort (28)
-               :        :        +- Exchange (27)
-               :        :           +- * Project (26)
-               :        :              +- * BroadcastHashJoin Inner BuildRight (25)
-               :        :                 :- * ColumnarToRow (23)
-               :        :                 :  +- Scan parquet spark_catalog.default.catalog_sales (22)
-               :        :                 +- ReusedExchange (24)
-               :        +- BroadcastExchange (35)
-               :           +- * Project (34)
-               :              +- * Filter (33)
-               :                 +- * ColumnarToRow (32)
-               :                    +- Scan parquet spark_catalog.default.customer_address (31)
-               +- * Filter (41)
-                  +- * ColumnarToRow (40)
-                     +- Scan parquet spark_catalog.default.customer_demographics (39)
+               :        :     :  :  +- * Sort (13)
+               :        :     :  :     +- Exchange (12)
+               :        :     :  :        +- * Project (11)
+               :        :     :  :           +- * BroadcastHashJoin Inner BuildRight (10)
+               :        :     :  :              :- * Filter (8)
+               :        :     :  :              :  +- * ColumnarToRow (7)
+               :        :     :  :              :     +- Scan parquet spark_catalog.default.store_sales (6)
+               :        :     :  :              +- ReusedExchange (9)
+               :        :     :  +- * Sort (21)
+               :        :     :     +- Exchange (20)
+               :        :     :        +- * Project (19)
+               :        :     :           +- * BroadcastHashJoin Inner BuildRight (18)
+               :        :     :              :- * ColumnarToRow (16)
+               :        :     :              :  +- Scan parquet spark_catalog.default.web_sales (15)
+               :        :     :              +- ReusedExchange (17)
+               :        :     +- * Sort (29)
+               :        :        +- Exchange (28)
+               :        :           +- * Project (27)
+               :        :              +- * BroadcastHashJoin Inner BuildRight (26)
+               :        :                 :- * ColumnarToRow (24)
+               :        :                 :  +- Scan parquet spark_catalog.default.catalog_sales (23)
+               :        :                 +- ReusedExchange (25)
+               :        +- BroadcastExchange (36)
+               :           +- * Project (35)
+               :              +- * Filter (34)
+               :                 +- * ColumnarToRow (33)
+               :                    +- Scan parquet spark_catalog.default.customer_address (32)
+               +- * Filter (42)
+                  +- * ColumnarToRow (41)
+                     +- Scan parquet spark_catalog.default.customer_demographics (40)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -60,7 +61,7 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : (((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42), true)) AND true)
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
@@ -80,235 +81,239 @@ ReadSchema: struct<ss_customer_sk:int>
 (7) ColumnarToRow [codegen id : 4]
 Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
 
-(8) ReusedExchange [Reuses operator id: 59]
+(8) Filter [codegen id : 4]
+Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Condition : true
+
+(9) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#9]
 
-(9) BroadcastHashJoin [codegen id : 4]
+(10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
+(11) Project [codegen id : 4]
 Output [1]: [ss_customer_sk#6]
 Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
 
-(11) Exchange
+(12) Exchange
 Input [1]: [ss_customer_sk#6]
 Arguments: hashpartitioning(ss_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) Sort [codegen id : 5]
+(13) Sort [codegen id : 5]
 Input [1]: [ss_customer_sk#6]
 Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
 
-(13) SortMergeJoin [codegen id : 6]
+(14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#6]
 Join type: LeftSemi
 Join condition: None
 
-(14) Scan parquet spark_catalog.default.web_sales
+(15) Scan parquet spark_catalog.default.web_sales
 Output [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#11), dynamicpruningexpression(ws_sold_date_sk#11 IN dynamicpruning#8)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(15) ColumnarToRow [codegen id : 8]
+(16) ColumnarToRow [codegen id : 8]
 Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
 
-(16) ReusedExchange [Reuses operator id: 59]
+(17) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#12]
 
-(17) BroadcastHashJoin [codegen id : 8]
+(18) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 8]
+(19) Project [codegen id : 8]
 Output [1]: [ws_bill_customer_sk#10]
 Input [3]: [ws_bill_customer_sk#10, ws_sold_date_sk#11, d_date_sk#12]
 
-(19) Exchange
+(20) Exchange
 Input [1]: [ws_bill_customer_sk#10]
 Arguments: hashpartitioning(ws_bill_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) Sort [codegen id : 9]
+(21) Sort [codegen id : 9]
 Input [1]: [ws_bill_customer_sk#10]
 Arguments: [ws_bill_customer_sk#10 ASC NULLS FIRST], false, 0
 
-(21) SortMergeJoin [codegen id : 10]
+(22) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ws_bill_customer_sk#10]
 Join type: LeftAnti
 Join condition: None
 
-(22) Scan parquet spark_catalog.default.catalog_sales
+(23) Scan parquet spark_catalog.default.catalog_sales
 Output [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#14), dynamicpruningexpression(cs_sold_date_sk#14 IN dynamicpruning#8)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(23) ColumnarToRow [codegen id : 12]
+(24) ColumnarToRow [codegen id : 12]
 Input [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
 
-(24) ReusedExchange [Reuses operator id: 59]
+(25) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#15]
 
-(25) BroadcastHashJoin [codegen id : 12]
+(26) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 12]
+(27) Project [codegen id : 12]
 Output [1]: [cs_ship_customer_sk#13]
 Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
 
-(27) Exchange
+(28) Exchange
 Input [1]: [cs_ship_customer_sk#13]
 Arguments: hashpartitioning(cs_ship_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) Sort [codegen id : 13]
+(29) Sort [codegen id : 13]
 Input [1]: [cs_ship_customer_sk#13]
 Arguments: [cs_ship_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(29) SortMergeJoin [codegen id : 15]
+(30) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [cs_ship_customer_sk#13]
 Join type: LeftAnti
 Join condition: None
 
-(30) Project [codegen id : 15]
+(31) Project [codegen id : 15]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(31) Scan parquet spark_catalog.default.customer_address
+(32) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#16, ca_state#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [GA,KY,NM]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(32) ColumnarToRow [codegen id : 14]
+(33) ColumnarToRow [codegen id : 14]
 Input [2]: [ca_address_sk#16, ca_state#17]
 
-(33) Filter [codegen id : 14]
+(34) Filter [codegen id : 14]
 Input [2]: [ca_address_sk#16, ca_state#17]
 Condition : (ca_state#17 IN (KY,GA,NM) AND isnotnull(ca_address_sk#16))
 
-(34) Project [codegen id : 14]
+(35) Project [codegen id : 14]
 Output [1]: [ca_address_sk#16]
 Input [2]: [ca_address_sk#16, ca_state#17]
 
-(35) BroadcastExchange
+(36) BroadcastExchange
 Input [1]: [ca_address_sk#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(36) BroadcastHashJoin [codegen id : 15]
+(37) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
 Join type: Inner
 Join condition: None
 
-(37) Project [codegen id : 15]
+(38) Project [codegen id : 15]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16]
 
-(38) BroadcastExchange
+(39) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
-(39) Scan parquet spark_catalog.default.customer_demographics
+(40) Scan parquet spark_catalog.default.customer_demographics
 Output [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string>
 
-(40) ColumnarToRow
+(41) ColumnarToRow
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 
-(41) Filter
+(42) Filter
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Condition : isnotnull(cd_demo_sk#18)
 
-(42) BroadcastHashJoin [codegen id : 16]
+(43) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 16]
+(44) Project [codegen id : 16]
 Output [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Input [7]: [c_current_cdemo_sk#2, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 
-(44) HashAggregate [codegen id : 16]
+(45) HashAggregate [codegen id : 16]
 Input [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Keys [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#24]
 Results [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
 
-(45) Exchange
+(46) Exchange
 Input [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
 Arguments: hashpartitioning(cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(46) HashAggregate [codegen id : 17]
+(47) HashAggregate [codegen id : 17]
 Input [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
 Keys [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#26]
 Results [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, count(1)#26 AS cnt1#27, cd_purchase_estimate#22, count(1)#26 AS cnt2#28, cd_credit_rating#23, count(1)#26 AS cnt3#29]
 
-(47) TakeOrderedAndProject
+(48) TakeOrderedAndProject
 Input [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cnt1#27, cd_purchase_estimate#22, cnt2#28, cd_credit_rating#23, cnt3#29]
 Arguments: 100, [cd_gender#19 ASC NULLS FIRST, cd_marital_status#20 ASC NULLS FIRST, cd_education_status#21 ASC NULLS FIRST, cd_purchase_estimate#22 ASC NULLS FIRST, cd_credit_rating#23 ASC NULLS FIRST], [cd_gender#19, cd_marital_status#20, cd_education_status#21, cnt1#27, cd_purchase_estimate#22, cnt2#28, cd_credit_rating#23, cnt3#29]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
-ObjectHashAggregate (54)
-+- Exchange (53)
-   +- ObjectHashAggregate (52)
-      +- * Project (51)
-         +- * Filter (50)
-            +- * ColumnarToRow (49)
-               +- Scan parquet spark_catalog.default.customer_address (48)
+ObjectHashAggregate (55)
++- Exchange (54)
+   +- ObjectHashAggregate (53)
+      +- * Project (52)
+         +- * Filter (51)
+            +- * ColumnarToRow (50)
+               +- Scan parquet spark_catalog.default.customer_address (49)
 
 
-(48) Scan parquet spark_catalog.default.customer_address
+(49) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#16, ca_state#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [GA,KY,NM]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(49) ColumnarToRow [codegen id : 1]
+(50) ColumnarToRow [codegen id : 1]
 Input [2]: [ca_address_sk#16, ca_state#17]
 
-(50) Filter [codegen id : 1]
+(51) Filter [codegen id : 1]
 Input [2]: [ca_address_sk#16, ca_state#17]
 Condition : (ca_state#17 IN (KY,GA,NM) AND isnotnull(ca_address_sk#16))
 
-(51) Project [codegen id : 1]
+(52) Project [codegen id : 1]
 Output [1]: [ca_address_sk#16]
 Input [2]: [ca_address_sk#16, ca_state#17]
 
-(52) ObjectHashAggregate
+(53) ObjectHashAggregate
 Input [1]: [ca_address_sk#16]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 444448, 0, 0)]
 Aggregate Attributes [1]: [buf#30]
 Results [1]: [buf#31]
 
-(53) Exchange
+(54) Exchange
 Input [1]: [buf#31]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(54) ObjectHashAggregate
+(55) ObjectHashAggregate
 Input [1]: [buf#31]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 444448, 0, 0)]
@@ -316,37 +321,37 @@ Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 5555
 Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 444448, 0, 0)#32 AS bloomFilter#33]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (59)
-+- * Project (58)
-   +- * Filter (57)
-      +- * ColumnarToRow (56)
-         +- Scan parquet spark_catalog.default.date_dim (55)
+BroadcastExchange (60)
++- * Project (59)
+   +- * Filter (58)
+      +- * ColumnarToRow (57)
+         +- Scan parquet spark_catalog.default.date_dim (56)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
+(56) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#9, d_year#34, d_moy#35]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,6), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(56) ColumnarToRow [codegen id : 1]
+(57) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
 
-(57) Filter [codegen id : 1]
+(58) Filter [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
 Condition : (((((isnotnull(d_year#34) AND isnotnull(d_moy#35)) AND (d_year#34 = 2001)) AND (d_moy#35 >= 4)) AND (d_moy#35 <= 6)) AND isnotnull(d_date_sk#9))
 
-(58) Project [codegen id : 1]
+(59) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
 Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
 
-(59) BroadcastExchange
+(60) BroadcastExchange
 Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
+Subquery:3 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
 
-Subquery:4 Hosting operator id = 22 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#8
+Subquery:4 Hosting operator id = 23 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#8
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/simplified.txt
@@ -48,17 +48,18 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                       WholeStageCodegen (4)
                                                         Project [ss_customer_sk]
                                                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #2
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (1)
-                                                                        Project [d_date_sk]
-                                                                          Filter [d_year,d_moy,d_date_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                            Filter
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                    SubqueryBroadcast [d_date_sk] #2
+                                                                      BroadcastExchange #6
+                                                                        WholeStageCodegen (1)
+                                                                          Project [d_date_sk]
+                                                                            Filter [d_year,d_moy,d_date_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                             InputAdapter
                                                               ReusedExchange [d_date_sk] #6
                                       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
@@ -1,22 +1,22 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * HashAggregate (69)
-   +- Exchange (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin LeftOuter (65)
-               :- * Sort (58)
-               :  +- Exchange (57)
-               :     +- * Project (56)
-               :        +- * BroadcastHashJoin LeftOuter BuildRight (55)
-               :           :- * Project (50)
-               :           :  +- * SortMergeJoin Inner (49)
-               :           :     :- * Sort (37)
-               :           :     :  +- Exchange (36)
-               :           :     :     +- * Project (35)
-               :           :     :        +- * BroadcastHashJoin Inner BuildRight (34)
-               :           :     :           :- * Project (32)
-               :           :     :           :  +- * SortMergeJoin Inner (31)
+TakeOrderedAndProject (67)
++- * HashAggregate (66)
+   +- Exchange (65)
+      +- * HashAggregate (64)
+         +- * Project (63)
+            +- * SortMergeJoin LeftOuter (62)
+               :- * Sort (55)
+               :  +- Exchange (54)
+               :     +- * Project (53)
+               :        +- * BroadcastHashJoin LeftOuter BuildRight (52)
+               :           :- * Project (47)
+               :           :  +- * SortMergeJoin Inner (46)
+               :           :     :- * Sort (34)
+               :           :     :  +- Exchange (33)
+               :           :     :     +- * Project (32)
+               :           :     :        +- * BroadcastHashJoin Inner BuildRight (31)
+               :           :     :           :- * Project (29)
+               :           :     :           :  +- * SortMergeJoin Inner (28)
                :           :     :           :     :- * Sort (25)
                :           :     :           :     :  +- Exchange (24)
                :           :     :           :     :     +- * Project (23)
@@ -42,33 +42,30 @@ TakeOrderedAndProject (70)
                :           :     :           :     :              +- * Filter (20)
                :           :     :           :     :                 +- * ColumnarToRow (19)
                :           :     :           :     :                    +- Scan parquet spark_catalog.default.date_dim (18)
-               :           :     :           :     +- * Sort (30)
-               :           :     :           :        +- Exchange (29)
-               :           :     :           :           +- * Filter (28)
-               :           :     :           :              +- * ColumnarToRow (27)
-               :           :     :           :                 +- Scan parquet spark_catalog.default.item (26)
-               :           :     :           +- ReusedExchange (33)
-               :           :     +- * Sort (48)
-               :           :        +- Exchange (47)
-               :           :           +- * Project (46)
-               :           :              +- * BroadcastHashJoin Inner BuildRight (45)
-               :           :                 :- * Filter (40)
-               :           :                 :  +- * ColumnarToRow (39)
-               :           :                 :     +- Scan parquet spark_catalog.default.inventory (38)
-               :           :                 +- BroadcastExchange (44)
-               :           :                    +- * Filter (43)
-               :           :                       +- * ColumnarToRow (42)
-               :           :                          +- Scan parquet spark_catalog.default.warehouse (41)
-               :           +- BroadcastExchange (54)
-               :              +- * Filter (53)
-               :                 +- * ColumnarToRow (52)
-               :                    +- Scan parquet spark_catalog.default.promotion (51)
-               +- * Sort (64)
-                  +- Exchange (63)
-                     +- * Project (62)
-                        +- * Filter (61)
-                           +- * ColumnarToRow (60)
-                              +- Scan parquet spark_catalog.default.catalog_returns (59)
+               :           :     :           :     +- * Sort (27)
+               :           :     :           :        +- ReusedExchange (26)
+               :           :     :           +- ReusedExchange (30)
+               :           :     +- * Sort (45)
+               :           :        +- Exchange (44)
+               :           :           +- * Project (43)
+               :           :              +- * BroadcastHashJoin Inner BuildRight (42)
+               :           :                 :- * Filter (37)
+               :           :                 :  +- * ColumnarToRow (36)
+               :           :                 :     +- Scan parquet spark_catalog.default.inventory (35)
+               :           :                 +- BroadcastExchange (41)
+               :           :                    +- * Filter (40)
+               :           :                       +- * ColumnarToRow (39)
+               :           :                          +- Scan parquet spark_catalog.default.warehouse (38)
+               :           +- BroadcastExchange (51)
+               :              +- * Filter (50)
+               :                 +- * ColumnarToRow (49)
+               :                    +- Scan parquet spark_catalog.default.promotion (48)
+               +- * Sort (61)
+                  +- Exchange (60)
+                     +- * Project (59)
+                        +- * Filter (58)
+                           +- * ColumnarToRow (57)
+                              +- Scan parquet spark_catalog.default.catalog_returns (56)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -84,380 +81,411 @@ Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_s
 
 (3) Filter [codegen id : 4]
 Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Condition : ((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
+Condition : (((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1)) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(cs_item_sk#4, 42), false))
 
 (4) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [2]: [hd_demo_sk#12, hd_buy_potential#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,>10000         ), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Input [2]: [hd_demo_sk#12, hd_buy_potential#13]
 
 (6) Filter [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
-Condition : ((isnotnull(hd_buy_potential#11) AND (hd_buy_potential#11 = >10000         )) AND isnotnull(hd_demo_sk#10))
+Input [2]: [hd_demo_sk#12, hd_buy_potential#13]
+Condition : ((isnotnull(hd_buy_potential#13) AND (hd_buy_potential#13 = >10000         )) AND isnotnull(hd_demo_sk#12))
 
 (7) Project [codegen id : 1]
-Output [1]: [hd_demo_sk#10]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [1]: [hd_demo_sk#12]
+Input [2]: [hd_demo_sk#12, hd_buy_potential#13]
 
 (8) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [hd_demo_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#12]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
 Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#10]
+Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#12]
 
 (11) Scan parquet spark_catalog.default.customer_demographics
-Output [2]: [cd_demo_sk#12, cd_marital_status#13]
+Output [2]: [cd_demo_sk#14, cd_marital_status#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,D), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (12) ColumnarToRow [codegen id : 2]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
+Input [2]: [cd_demo_sk#14, cd_marital_status#15]
 
 (13) Filter [codegen id : 2]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
-Condition : ((isnotnull(cd_marital_status#13) AND (cd_marital_status#13 = D)) AND isnotnull(cd_demo_sk#12))
+Input [2]: [cd_demo_sk#14, cd_marital_status#15]
+Condition : ((isnotnull(cd_marital_status#15) AND (cd_marital_status#15 = D)) AND isnotnull(cd_demo_sk#14))
 
 (14) Project [codegen id : 2]
-Output [1]: [cd_demo_sk#12]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
+Output [1]: [cd_demo_sk#14]
+Input [2]: [cd_demo_sk#14, cd_marital_status#15]
 
 (15) BroadcastExchange
-Input [1]: [cd_demo_sk#12]
+Input [1]: [cd_demo_sk#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#12]
+Right keys [1]: [cd_demo_sk#14]
 Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
 Output [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#12]
+Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#14]
 
 (18) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#14, d_date#15]
+Output [2]: [d_date_sk#16, d_date#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (19) ColumnarToRow [codegen id : 3]
-Input [2]: [d_date_sk#14, d_date#15]
+Input [2]: [d_date_sk#16, d_date#17]
 
 (20) Filter [codegen id : 3]
-Input [2]: [d_date_sk#14, d_date#15]
-Condition : (isnotnull(d_date#15) AND isnotnull(d_date_sk#14))
+Input [2]: [d_date_sk#16, d_date#17]
+Condition : (isnotnull(d_date#17) AND isnotnull(d_date_sk#16))
 
 (21) BroadcastExchange
-Input [2]: [d_date_sk#14, d_date#15]
+Input [2]: [d_date_sk#16, d_date#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#14]
+Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 4]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
-Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date_sk#14, d_date#15]
+Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
+Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date_sk#16, d_date#17]
 
 (24) Exchange
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
+Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
 Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (25) Sort [codegen id : 5]
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
+Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
 Arguments: [cs_item_sk#4 ASC NULLS FIRST], false, 0
 
-(26) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#16, i_item_desc#17]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_item_desc:string>
+(26) ReusedExchange [Reuses operator id: 71]
+Output [2]: [i_item_sk#18, i_item_desc#19]
 
-(27) ColumnarToRow [codegen id : 6]
-Input [2]: [i_item_sk#16, i_item_desc#17]
+(27) Sort [codegen id : 7]
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Arguments: [i_item_sk#18 ASC NULLS FIRST], false, 0
 
-(28) Filter [codegen id : 6]
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Condition : isnotnull(i_item_sk#16)
-
-(29) Exchange
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Arguments: hashpartitioning(i_item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(30) Sort [codegen id : 7]
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
-
-(31) SortMergeJoin [codegen id : 10]
+(28) SortMergeJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
-(32) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_desc#17]
-Input [8]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_sk#16, i_item_desc#17]
+(29) Project [codegen id : 10]
+Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_desc#19]
+Input [8]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_sk#18, i_item_desc#19]
 
-(33) ReusedExchange [Reuses operator id: 81]
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
+(30) ReusedExchange [Reuses operator id: 85]
+Output [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23]
 
-(34) BroadcastHashJoin [codegen id : 10]
+(31) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#18]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
-Join condition: (d_date#15 > date_add(d_date#19, 5))
+Join condition: (d_date#17 > date_add(d_date#21, 5))
 
-(35) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_desc#17, d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
+(32) Project [codegen id : 10]
+Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#19, d_week_seq#22, d_date_sk#23]
+Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_desc#19, d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23]
 
-(36) Exchange
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(33) Exchange
+Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#19, d_week_seq#22, d_date_sk#23]
+Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(37) Sort [codegen id : 11]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#21 ASC NULLS FIRST], false, 0
+(34) Sort [codegen id : 11]
+Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#19, d_week_seq#22, d_date_sk#23]
+Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#23 ASC NULLS FIRST], false, 0
 
-(38) Scan parquet spark_catalog.default.inventory
-Output [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
+(35) Scan parquet spark_catalog.default.inventory
+Output [4]: [inv_item_sk#24, inv_warehouse_sk#25, inv_quantity_on_hand#26, inv_date_sk#27]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#25), dynamicpruningexpression(true)]
+PartitionFilters: [isnotnull(inv_date_sk#27), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
-(39) ColumnarToRow [codegen id : 13]
-Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
+(36) ColumnarToRow [codegen id : 13]
+Input [4]: [inv_item_sk#24, inv_warehouse_sk#25, inv_quantity_on_hand#26, inv_date_sk#27]
 
-(40) Filter [codegen id : 13]
-Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
-Condition : ((isnotnull(inv_quantity_on_hand#24) AND isnotnull(inv_item_sk#22)) AND isnotnull(inv_warehouse_sk#23))
+(37) Filter [codegen id : 13]
+Input [4]: [inv_item_sk#24, inv_warehouse_sk#25, inv_quantity_on_hand#26, inv_date_sk#27]
+Condition : ((isnotnull(inv_quantity_on_hand#26) AND isnotnull(inv_item_sk#24)) AND isnotnull(inv_warehouse_sk#25))
 
-(41) Scan parquet spark_catalog.default.warehouse
-Output [2]: [w_warehouse_sk#26, w_warehouse_name#27]
+(38) Scan parquet spark_catalog.default.warehouse
+Output [2]: [w_warehouse_sk#28, w_warehouse_name#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
-(42) ColumnarToRow [codegen id : 12]
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
+(39) ColumnarToRow [codegen id : 12]
+Input [2]: [w_warehouse_sk#28, w_warehouse_name#29]
 
-(43) Filter [codegen id : 12]
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
-Condition : isnotnull(w_warehouse_sk#26)
+(40) Filter [codegen id : 12]
+Input [2]: [w_warehouse_sk#28, w_warehouse_name#29]
+Condition : isnotnull(w_warehouse_sk#28)
 
-(44) BroadcastExchange
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+(41) BroadcastExchange
+Input [2]: [w_warehouse_sk#28, w_warehouse_name#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(45) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [inv_warehouse_sk#23]
-Right keys [1]: [w_warehouse_sk#26]
+(42) BroadcastHashJoin [codegen id : 13]
+Left keys [1]: [inv_warehouse_sk#25]
+Right keys [1]: [w_warehouse_sk#28]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 13]
-Output [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Input [6]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_sk#26, w_warehouse_name#27]
+(43) Project [codegen id : 13]
+Output [4]: [inv_item_sk#24, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_name#29]
+Input [6]: [inv_item_sk#24, inv_warehouse_sk#25, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_sk#28, w_warehouse_name#29]
 
-(47) Exchange
-Input [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Arguments: hashpartitioning(inv_item_sk#22, inv_date_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(44) Exchange
+Input [4]: [inv_item_sk#24, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_name#29]
+Arguments: hashpartitioning(inv_item_sk#24, inv_date_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(48) Sort [codegen id : 14]
-Input [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Arguments: [inv_item_sk#22 ASC NULLS FIRST, inv_date_sk#25 ASC NULLS FIRST], false, 0
+(45) Sort [codegen id : 14]
+Input [4]: [inv_item_sk#24, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_name#29]
+Arguments: [inv_item_sk#24 ASC NULLS FIRST, inv_date_sk#27 ASC NULLS FIRST], false, 0
 
-(49) SortMergeJoin [codegen id : 16]
-Left keys [2]: [cs_item_sk#4, d_date_sk#21]
-Right keys [2]: [inv_item_sk#22, inv_date_sk#25]
+(46) SortMergeJoin [codegen id : 16]
+Left keys [2]: [cs_item_sk#4, d_date_sk#23]
+Right keys [2]: [inv_item_sk#24, inv_date_sk#27]
 Join type: Inner
-Join condition: (inv_quantity_on_hand#24 < cs_quantity#7)
+Join condition: (inv_quantity_on_hand#26 < cs_quantity#7)
 
-(50) Project [codegen id : 16]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21, inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
+(47) Project [codegen id : 16]
+Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#19, d_week_seq#22, d_date_sk#23, inv_item_sk#24, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_name#29]
 
-(51) Scan parquet spark_catalog.default.promotion
-Output [1]: [p_promo_sk#28]
+(48) Scan parquet spark_catalog.default.promotion
+Output [1]: [p_promo_sk#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(52) ColumnarToRow [codegen id : 15]
-Input [1]: [p_promo_sk#28]
+(49) ColumnarToRow [codegen id : 15]
+Input [1]: [p_promo_sk#30]
 
-(53) Filter [codegen id : 15]
-Input [1]: [p_promo_sk#28]
-Condition : isnotnull(p_promo_sk#28)
+(50) Filter [codegen id : 15]
+Input [1]: [p_promo_sk#30]
+Condition : isnotnull(p_promo_sk#30)
 
-(54) BroadcastExchange
-Input [1]: [p_promo_sk#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+(51) BroadcastExchange
+Input [1]: [p_promo_sk#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(55) BroadcastHashJoin [codegen id : 16]
+(52) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [cs_promo_sk#5]
-Right keys [1]: [p_promo_sk#28]
+Right keys [1]: [p_promo_sk#30]
 Join type: LeftOuter
 Join condition: None
 
-(56) Project [codegen id : 16]
-Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20, p_promo_sk#28]
+(53) Project [codegen id : 16]
+Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22, p_promo_sk#30]
 
-(57) Exchange
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(54) Exchange
+Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(58) Sort [codegen id : 17]
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
+(55) Sort [codegen id : 17]
+Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
 Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
 
-(59) Scan parquet spark_catalog.default.catalog_returns
-Output [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
+(56) Scan parquet spark_catalog.default.catalog_returns
+Output [3]: [cr_item_sk#31, cr_order_number#32, cr_returned_date_sk#33]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
 
-(60) ColumnarToRow [codegen id : 18]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
+(57) ColumnarToRow [codegen id : 18]
+Input [3]: [cr_item_sk#31, cr_order_number#32, cr_returned_date_sk#33]
 
-(61) Filter [codegen id : 18]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-Condition : (isnotnull(cr_item_sk#29) AND isnotnull(cr_order_number#30))
+(58) Filter [codegen id : 18]
+Input [3]: [cr_item_sk#31, cr_order_number#32, cr_returned_date_sk#33]
+Condition : (isnotnull(cr_item_sk#31) AND isnotnull(cr_order_number#32))
 
-(62) Project [codegen id : 18]
-Output [2]: [cr_item_sk#29, cr_order_number#30]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
+(59) Project [codegen id : 18]
+Output [2]: [cr_item_sk#31, cr_order_number#32]
+Input [3]: [cr_item_sk#31, cr_order_number#32, cr_returned_date_sk#33]
 
-(63) Exchange
-Input [2]: [cr_item_sk#29, cr_order_number#30]
-Arguments: hashpartitioning(cr_item_sk#29, cr_order_number#30, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(60) Exchange
+Input [2]: [cr_item_sk#31, cr_order_number#32]
+Arguments: hashpartitioning(cr_item_sk#31, cr_order_number#32, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(64) Sort [codegen id : 19]
-Input [2]: [cr_item_sk#29, cr_order_number#30]
-Arguments: [cr_item_sk#29 ASC NULLS FIRST, cr_order_number#30 ASC NULLS FIRST], false, 0
+(61) Sort [codegen id : 19]
+Input [2]: [cr_item_sk#31, cr_order_number#32]
+Arguments: [cr_item_sk#31 ASC NULLS FIRST, cr_order_number#32 ASC NULLS FIRST], false, 0
 
-(65) SortMergeJoin [codegen id : 20]
+(62) SortMergeJoin [codegen id : 20]
 Left keys [2]: [cs_item_sk#4, cs_order_number#6]
-Right keys [2]: [cr_item_sk#29, cr_order_number#30]
+Right keys [2]: [cr_item_sk#31, cr_order_number#32]
 Join type: LeftOuter
 Join condition: None
 
-(66) Project [codegen id : 20]
-Output [3]: [w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20, cr_item_sk#29, cr_order_number#30]
+(63) Project [codegen id : 20]
+Output [3]: [w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22, cr_item_sk#31, cr_order_number#32]
 
-(67) HashAggregate [codegen id : 20]
-Input [3]: [w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Keys [3]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20]
+(64) HashAggregate [codegen id : 20]
+Input [3]: [w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Keys [3]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#32]
-Results [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
+Aggregate Attributes [1]: [count#34]
+Results [4]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, count#35]
 
-(68) Exchange
-Input [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-Arguments: hashpartitioning(i_item_desc#17, w_warehouse_name#27, d_week_seq#20, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(65) Exchange
+Input [4]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, count#35]
+Arguments: hashpartitioning(i_item_desc#19, w_warehouse_name#29, d_week_seq#22, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(69) HashAggregate [codegen id : 21]
-Input [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-Keys [3]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20]
+(66) HashAggregate [codegen id : 21]
+Input [4]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, count#35]
+Keys [3]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#34]
-Results [6]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count(1)#34 AS no_promo#35, count(1)#34 AS promo#36, count(1)#34 AS total_cnt#37]
+Aggregate Attributes [1]: [count(1)#36]
+Results [6]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, count(1)#36 AS no_promo#37, count(1)#36 AS promo#38, count(1)#36 AS total_cnt#39]
 
-(70) TakeOrderedAndProject
-Input [6]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, no_promo#35, promo#36, total_cnt#37]
-Arguments: 100, [total_cnt#37 DESC NULLS LAST, i_item_desc#17 ASC NULLS FIRST, w_warehouse_name#27 ASC NULLS FIRST, d_week_seq#20 ASC NULLS FIRST], [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, no_promo#35, promo#36, total_cnt#37]
+(67) TakeOrderedAndProject
+Input [6]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, no_promo#37, promo#38, total_cnt#39]
+Arguments: 100, [total_cnt#39 DESC NULLS LAST, i_item_desc#19 ASC NULLS FIRST, w_warehouse_name#29 ASC NULLS FIRST, d_week_seq#22 ASC NULLS FIRST], [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, no_promo#37, promo#38, total_cnt#39]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (81)
-+- * Project (80)
-   +- * BroadcastHashJoin Inner BuildLeft (79)
-      :- BroadcastExchange (75)
-      :  +- * Project (74)
-      :     +- * Filter (73)
-      :        +- * ColumnarToRow (72)
-      :           +- Scan parquet spark_catalog.default.date_dim (71)
-      +- * Filter (78)
-         +- * ColumnarToRow (77)
-            +- Scan parquet spark_catalog.default.date_dim (76)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (74)
++- Exchange (73)
+   +- ObjectHashAggregate (72)
+      +- Exchange (71)
+         +- * Filter (70)
+            +- * ColumnarToRow (69)
+               +- Scan parquet spark_catalog.default.item (68)
 
 
-(71) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(68) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#18, i_item_desc#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_item_desc:string>
+
+(69) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#18, i_item_desc#19]
+
+(70) Filter [codegen id : 1]
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Condition : isnotnull(i_item_sk#18)
+
+(71) Exchange
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Arguments: hashpartitioning(i_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(72) ObjectHashAggregate
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#40]
+Results [1]: [buf#41]
+
+(73) Exchange
+Input [1]: [buf#41]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
+
+(74) ObjectHashAggregate
+Input [1]: [buf#41]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)#42]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)#42 AS bloomFilter#43]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
+BroadcastExchange (85)
++- * Project (84)
+   +- * BroadcastHashJoin Inner BuildLeft (83)
+      :- BroadcastExchange (79)
+      :  +- * Project (78)
+      :     +- * Filter (77)
+      :        +- * ColumnarToRow (76)
+      :           +- Scan parquet spark_catalog.default.date_dim (75)
+      +- * Filter (82)
+         +- * ColumnarToRow (81)
+            +- Scan parquet spark_catalog.default.date_dim (80)
+
+
+(75) Scan parquet spark_catalog.default.date_dim
+Output [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_year#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(76) ColumnarToRow [codegen id : 1]
+Input [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_year#44]
 
-(73) Filter [codegen id : 1]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
-Condition : ((((isnotnull(d_year#38) AND (d_year#38 = 1999)) AND isnotnull(d_date_sk#18)) AND isnotnull(d_week_seq#20)) AND isnotnull(d_date#19))
+(77) Filter [codegen id : 1]
+Input [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_year#44]
+Condition : ((((isnotnull(d_year#44) AND (d_year#44 = 1999)) AND isnotnull(d_date_sk#20)) AND isnotnull(d_week_seq#22)) AND isnotnull(d_date#21))
 
-(74) Project [codegen id : 1]
-Output [3]: [d_date_sk#18, d_date#19, d_week_seq#20]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(78) Project [codegen id : 1]
+Output [3]: [d_date_sk#20, d_date#21, d_week_seq#22]
+Input [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_year#44]
 
-(75) BroadcastExchange
-Input [3]: [d_date_sk#18, d_date#19, d_week_seq#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=13]
+(79) BroadcastExchange
+Input [3]: [d_date_sk#20, d_date#21, d_week_seq#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=14]
 
-(76) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#21, d_week_seq#39]
+(80) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#23, d_week_seq#45]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(77) ColumnarToRow
-Input [2]: [d_date_sk#21, d_week_seq#39]
+(81) ColumnarToRow
+Input [2]: [d_date_sk#23, d_week_seq#45]
 
-(78) Filter
-Input [2]: [d_date_sk#21, d_week_seq#39]
-Condition : (isnotnull(d_week_seq#39) AND isnotnull(d_date_sk#21))
+(82) Filter
+Input [2]: [d_date_sk#23, d_week_seq#45]
+Condition : (isnotnull(d_week_seq#45) AND isnotnull(d_date_sk#23))
 
-(79) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [d_week_seq#20]
-Right keys [1]: [d_week_seq#39]
+(83) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [d_week_seq#22]
+Right keys [1]: [d_week_seq#45]
 Join type: Inner
 Join condition: None
 
-(80) Project [codegen id : 2]
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-Input [5]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21, d_week_seq#39]
+(84) Project [codegen id : 2]
+Output [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23]
+Input [5]: [d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23, d_week_seq#45]
 
-(81) BroadcastExchange
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+(85) BroadcastExchange
+Input [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/simplified.txt
@@ -40,6 +40,16 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                               Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
                                                                                 BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
                                                                                   Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
+                                                                                    Subquery #2
+                                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                                        Exchange #7
+                                                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                            Exchange [i_item_sk] #8
+                                                                                              WholeStageCodegen (1)
+                                                                                                Filter [i_item_sk]
+                                                                                                  ColumnarToRow
+                                                                                                    InputAdapter
+                                                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
                                                                                     ColumnarToRow
                                                                                       InputAdapter
                                                                                         Scan parquet spark_catalog.default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
@@ -61,7 +71,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                                         InputAdapter
                                                                                                           Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq]
                                                                                   InputAdapter
-                                                                                    BroadcastExchange #7
+                                                                                    BroadcastExchange #9
                                                                                       WholeStageCodegen (1)
                                                                                         Project [hd_demo_sk]
                                                                                           Filter [hd_buy_potential,hd_demo_sk]
@@ -69,7 +79,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                               InputAdapter
                                                                                                 Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential]
                                                                               InputAdapter
-                                                                                BroadcastExchange #8
+                                                                                BroadcastExchange #10
                                                                                   WholeStageCodegen (2)
                                                                                     Project [cd_demo_sk]
                                                                                       Filter [cd_marital_status,cd_demo_sk]
@@ -77,7 +87,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                           InputAdapter
                                                                                             Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
                                                                           InputAdapter
-                                                                            BroadcastExchange #9
+                                                                            BroadcastExchange #11
                                                                               WholeStageCodegen (3)
                                                                                 Filter [d_date,d_date_sk]
                                                                                   ColumnarToRow
@@ -87,19 +97,14 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                             WholeStageCodegen (7)
                                                               Sort [i_item_sk]
                                                                 InputAdapter
-                                                                  Exchange [i_item_sk] #10
-                                                                    WholeStageCodegen (6)
-                                                                      Filter [i_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
+                                                                  ReusedExchange [i_item_sk,i_item_desc] #8
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk,d_date,d_week_seq,d_date_sk] #5
                                       InputAdapter
                                         WholeStageCodegen (14)
                                           Sort [inv_item_sk,inv_date_sk]
                                             InputAdapter
-                                              Exchange [inv_item_sk,inv_date_sk] #11
+                                              Exchange [inv_item_sk,inv_date_sk] #12
                                                 WholeStageCodegen (13)
                                                   Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
                                                     BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
@@ -108,14 +113,14 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
                                                       InputAdapter
-                                                        BroadcastExchange #12
+                                                        BroadcastExchange #13
                                                           WholeStageCodegen (12)
                                                             Filter [w_warehouse_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_warehouse_name]
                                   InputAdapter
-                                    BroadcastExchange #13
+                                    BroadcastExchange #14
                                       WholeStageCodegen (15)
                                         Filter [p_promo_sk]
                                           ColumnarToRow
@@ -125,7 +130,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                     WholeStageCodegen (19)
                       Sort [cr_item_sk,cr_order_number]
                         InputAdapter
-                          Exchange [cr_item_sk,cr_order_number] #14
+                          Exchange [cr_item_sk,cr_order_number] #15
                             WholeStageCodegen (18)
                               Project [cr_item_sk,cr_order_number]
                                 Filter [cr_item_sk,cr_order_number]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/explain.txt
@@ -1,8 +1,8 @@
 == Physical Plan ==
-* Sort (35)
-+- Exchange (34)
-   +- * Project (33)
-      +- * SortMergeJoin Inner (32)
+* Sort (32)
++- Exchange (31)
+   +- * Project (30)
+      +- * SortMergeJoin Inner (29)
          :- * Sort (26)
          :  +- Exchange (25)
          :     +- * Filter (24)
@@ -29,11 +29,8 @@
          :                             +- * Filter (16)
          :                                +- * ColumnarToRow (15)
          :                                   +- Scan parquet spark_catalog.default.household_demographics (14)
-         +- * Sort (31)
-            +- Exchange (30)
-               +- * Filter (29)
-                  +- * ColumnarToRow (28)
-                     +- Scan parquet spark_catalog.default.customer (27)
+         +- * Sort (28)
+            +- ReusedExchange (27)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -49,185 +46,216 @@ Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, 
 
 (3) Filter [codegen id : 4]
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
-Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
+Condition : (((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 40]
-Output [1]: [d_date_sk#7]
+(4) ReusedExchange [Reuses operator id: 44]
+Output [1]: [d_date_sk#9]
 
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
 Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
-Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
+Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#9]
 
 (7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
+Output [2]: [s_store_sk#10, s_county#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_county, [Bronx County,Franklin Parish,Orange County,Williamson County]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_county:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
+Input [2]: [s_store_sk#10, s_county#11]
 
 (9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : (s_county#9 IN (Williamson County,Franklin Parish,Bronx County,Orange County) AND isnotnull(s_store_sk#8))
+Input [2]: [s_store_sk#10, s_county#11]
+Condition : (s_county#11 IN (Williamson County,Franklin Parish,Bronx County,Orange County) AND isnotnull(s_store_sk#10))
 
 (10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
+Output [1]: [s_store_sk#10]
+Input [2]: [s_store_sk#10, s_county#11]
 
 (11) BroadcastExchange
-Input [1]: [s_store_sk#8]
+Input [1]: [s_store_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#10]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#10]
 
 (14) Scan parquet spark_catalog.default.household_demographics
-Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_vehicle_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (16) Filter [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : ((((isnotnull(hd_vehicle_count#13) AND ((hd_buy_potential#11 = >10000         ) OR (hd_buy_potential#11 = unknown        ))) AND (hd_vehicle_count#13 > 0)) AND CASE WHEN (hd_vehicle_count#13 > 0) THEN ((cast(hd_dep_count#12 as double) / cast(hd_vehicle_count#13 as double)) > 1.0) END) AND isnotnull(hd_demo_sk#10))
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
+Condition : ((((isnotnull(hd_vehicle_count#15) AND ((hd_buy_potential#13 = >10000         ) OR (hd_buy_potential#13 = unknown        ))) AND (hd_vehicle_count#15 > 0)) AND CASE WHEN (hd_vehicle_count#15 > 0) THEN ((cast(hd_dep_count#14 as double) / cast(hd_vehicle_count#15 as double)) > 1.0) END) AND isnotnull(hd_demo_sk#12))
 
 (17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [hd_demo_sk#12]
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (18) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [hd_demo_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#12]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#10]
+Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#12]
 
 (21) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#14]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Aggregate Attributes [1]: [count#16]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 
 (22) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Arguments: hashpartitioning(ss_ticket_number#4, ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (23) HashAggregate [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#16]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#16 AS cnt#17]
+Aggregate Attributes [1]: [count(1)#18]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#18 AS cnt#19]
 
 (24) Filter [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
-Condition : ((cnt#17 >= 1) AND (cnt#17 <= 5))
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
+Condition : ((cnt#19 >= 1) AND (cnt#19 <= 5))
 
 (25) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (26) Sort [codegen id : 6]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(27) ReusedExchange [Reuses operator id: 36]
+Output [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+
+(28) Sort [codegen id : 8]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 9]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#20]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 9]
+Output [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19, c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+
+(31) Exchange
+Input [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Arguments: rangepartitioning(cnt#19 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(32) Sort [codegen id : 10]
+Input [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Arguments: [cnt#19 DESC NULLS LAST], true, 0
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (39)
++- Exchange (38)
+   +- ObjectHashAggregate (37)
+      +- Exchange (36)
+         +- * Filter (35)
+            +- * ColumnarToRow (34)
+               +- Scan parquet spark_catalog.default.customer (33)
+
+
+(33) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string>
 
-(28) ColumnarToRow [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(34) ColumnarToRow [codegen id : 1]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
 
-(29) Filter [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Condition : isnotnull(c_customer_sk#18)
+(35) Filter [codegen id : 1]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Condition : isnotnull(c_customer_sk#20)
 
-(30) Exchange
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(36) Exchange
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(31) Sort [codegen id : 8]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+(37) ObjectHashAggregate
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#25]
+Results [1]: [buf#26]
 
-(32) SortMergeJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
-Join type: Inner
-Join condition: None
+(38) Exchange
+Input [1]: [buf#26]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(33) Project [codegen id : 9]
-Output [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17, c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(39) ObjectHashAggregate
+Input [1]: [buf#26]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)#27]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)#27 AS bloomFilter#28]
 
-(34) Exchange
-Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: rangepartitioning(cnt#17 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) Sort [codegen id : 10]
-Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: [cnt#17 DESC NULLS LAST], true, 0
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (40)
-+- * Project (39)
-   +- * Filter (38)
-      +- * ColumnarToRow (37)
-         +- Scan parquet spark_catalog.default.date_dim (36)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (44)
++- * Project (43)
+   +- * Filter (42)
+      +- * ColumnarToRow (41)
+         +- Scan parquet spark_catalog.default.date_dim (40)
 
 
-(36) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(40) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#9, d_year#29, d_dom#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
-(37) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(41) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
 
-(38) Filter [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
-Condition : ((((isnotnull(d_dom#24) AND (d_dom#24 >= 1)) AND (d_dom#24 <= 2)) AND d_year#23 IN (1999,2000,2001)) AND isnotnull(d_date_sk#7))
+(42) Filter [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
+Condition : ((((isnotnull(d_dom#30) AND (d_dom#30 >= 1)) AND (d_dom#30 <= 2)) AND d_year#29 IN (1999,2000,2001)) AND isnotnull(d_date_sk#9))
 
-(39) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(43) Project [codegen id : 1]
+Output [1]: [d_date_sk#9]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
 
-(40) BroadcastExchange
-Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+(44) BroadcastExchange
+Input [1]: [d_date_sk#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/simplified.txt
@@ -24,6 +24,16 @@ WholeStageCodegen (10)
                                               Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                   Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                            Exchange [c_customer_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [c_customer_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
@@ -38,7 +48,7 @@ WholeStageCodegen (10)
                                                   InputAdapter
                                                     ReusedExchange [d_date_sk] #4
                                               InputAdapter
-                                                BroadcastExchange #5
+                                                BroadcastExchange #7
                                                   WholeStageCodegen (2)
                                                     Project [s_store_sk]
                                                       Filter [s_county,s_store_sk]
@@ -46,7 +56,7 @@ WholeStageCodegen (10)
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.store [s_store_sk,s_county]
                                           InputAdapter
-                                            BroadcastExchange #6
+                                            BroadcastExchange #8
                                               WholeStageCodegen (3)
                                                 Project [hd_demo_sk]
                                                   Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
@@ -57,9 +67,4 @@ WholeStageCodegen (10)
                 WholeStageCodegen (8)
                   Sort [c_customer_sk]
                     InputAdapter
-                      Exchange [c_customer_sk] #7
-                        WholeStageCodegen (7)
-                          Filter [c_customer_sk]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
+                      ReusedExchange [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q74.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q74.sf100/explain.txt
@@ -1,18 +1,18 @@
 == Physical Plan ==
-TakeOrderedAndProject (79)
-+- * Project (78)
-   +- * SortMergeJoin Inner (77)
-      :- * Project (59)
-      :  +- * SortMergeJoin Inner (58)
-      :     :- * SortMergeJoin Inner (39)
-      :     :  :- * Sort (21)
-      :     :  :  +- Exchange (20)
-      :     :  :     +- * Filter (19)
-      :     :  :        +- * HashAggregate (18)
-      :     :  :           +- Exchange (17)
-      :     :  :              +- * HashAggregate (16)
-      :     :  :                 +- * Project (15)
-      :     :  :                    +- * SortMergeJoin Inner (14)
+TakeOrderedAndProject (76)
++- * Project (75)
+   +- * SortMergeJoin Inner (74)
+      :- * Project (56)
+      :  +- * SortMergeJoin Inner (55)
+      :     :- * SortMergeJoin Inner (36)
+      :     :  :- * Sort (18)
+      :     :  :  +- Exchange (17)
+      :     :  :     +- * Filter (16)
+      :     :  :        +- * HashAggregate (15)
+      :     :  :           +- Exchange (14)
+      :     :  :              +- * HashAggregate (13)
+      :     :  :                 +- * Project (12)
+      :     :  :                    +- * SortMergeJoin Inner (11)
       :     :  :                       :- * Sort (8)
       :     :  :                       :  +- Exchange (7)
       :     :  :                       :     +- * Project (6)
@@ -21,63 +21,60 @@ TakeOrderedAndProject (79)
       :     :  :                       :           :  +- * ColumnarToRow (2)
       :     :  :                       :           :     +- Scan parquet spark_catalog.default.store_sales (1)
       :     :  :                       :           +- ReusedExchange (4)
-      :     :  :                       +- * Sort (13)
-      :     :  :                          +- Exchange (12)
-      :     :  :                             +- * Filter (11)
-      :     :  :                                +- * ColumnarToRow (10)
-      :     :  :                                   +- Scan parquet spark_catalog.default.customer (9)
-      :     :  +- * Sort (38)
-      :     :     +- Exchange (37)
-      :     :        +- * HashAggregate (36)
-      :     :           +- Exchange (35)
-      :     :              +- * HashAggregate (34)
-      :     :                 +- * Project (33)
-      :     :                    +- * SortMergeJoin Inner (32)
-      :     :                       :- * Sort (29)
-      :     :                       :  +- Exchange (28)
-      :     :                       :     +- * Project (27)
-      :     :                       :        +- * BroadcastHashJoin Inner BuildRight (26)
-      :     :                       :           :- * Filter (24)
-      :     :                       :           :  +- * ColumnarToRow (23)
-      :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (22)
-      :     :                       :           +- ReusedExchange (25)
-      :     :                       +- * Sort (31)
-      :     :                          +- ReusedExchange (30)
-      :     +- * Sort (57)
-      :        +- Exchange (56)
-      :           +- * Filter (55)
-      :              +- * HashAggregate (54)
-      :                 +- Exchange (53)
-      :                    +- * HashAggregate (52)
-      :                       +- * Project (51)
-      :                          +- * SortMergeJoin Inner (50)
-      :                             :- * Sort (47)
-      :                             :  +- Exchange (46)
-      :                             :     +- * Project (45)
-      :                             :        +- * BroadcastHashJoin Inner BuildRight (44)
-      :                             :           :- * Filter (42)
-      :                             :           :  +- * ColumnarToRow (41)
-      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (40)
-      :                             :           +- ReusedExchange (43)
-      :                             +- * Sort (49)
-      :                                +- ReusedExchange (48)
-      +- * Sort (76)
-         +- Exchange (75)
-            +- * HashAggregate (74)
-               +- Exchange (73)
-                  +- * HashAggregate (72)
-                     +- * Project (71)
-                        +- * SortMergeJoin Inner (70)
-                           :- * Sort (67)
-                           :  +- Exchange (66)
-                           :     +- * Project (65)
-                           :        +- * BroadcastHashJoin Inner BuildRight (64)
-                           :           :- * Filter (62)
-                           :           :  +- * ColumnarToRow (61)
-                           :           :     +- Scan parquet spark_catalog.default.web_sales (60)
-                           :           +- ReusedExchange (63)
-                           +- * Sort (69)
-                              +- ReusedExchange (68)
+      :     :  :                       +- * Sort (10)
+      :     :  :                          +- ReusedExchange (9)
+      :     :  +- * Sort (35)
+      :     :     +- Exchange (34)
+      :     :        +- * HashAggregate (33)
+      :     :           +- Exchange (32)
+      :     :              +- * HashAggregate (31)
+      :     :                 +- * Project (30)
+      :     :                    +- * SortMergeJoin Inner (29)
+      :     :                       :- * Sort (26)
+      :     :                       :  +- Exchange (25)
+      :     :                       :     +- * Project (24)
+      :     :                       :        +- * BroadcastHashJoin Inner BuildRight (23)
+      :     :                       :           :- * Filter (21)
+      :     :                       :           :  +- * ColumnarToRow (20)
+      :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (19)
+      :     :                       :           +- ReusedExchange (22)
+      :     :                       +- * Sort (28)
+      :     :                          +- ReusedExchange (27)
+      :     +- * Sort (54)
+      :        +- Exchange (53)
+      :           +- * Filter (52)
+      :              +- * HashAggregate (51)
+      :                 +- Exchange (50)
+      :                    +- * HashAggregate (49)
+      :                       +- * Project (48)
+      :                          +- * SortMergeJoin Inner (47)
+      :                             :- * Sort (44)
+      :                             :  +- Exchange (43)
+      :                             :     +- * Project (42)
+      :                             :        +- * BroadcastHashJoin Inner BuildRight (41)
+      :                             :           :- * Filter (39)
+      :                             :           :  +- * ColumnarToRow (38)
+      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (37)
+      :                             :           +- ReusedExchange (40)
+      :                             +- * Sort (46)
+      :                                +- ReusedExchange (45)
+      +- * Sort (73)
+         +- Exchange (72)
+            +- * HashAggregate (71)
+               +- Exchange (70)
+                  +- * HashAggregate (69)
+                     +- * Project (68)
+                        +- * SortMergeJoin Inner (67)
+                           :- * Sort (64)
+                           :  +- Exchange (63)
+                           :     +- * Project (62)
+                           :        +- * BroadcastHashJoin Inner BuildRight (61)
+                           :           :- * Filter (59)
+                           :           :  +- * ColumnarToRow (58)
+                           :           :     +- Scan parquet spark_catalog.default.web_sales (57)
+                           :           +- ReusedExchange (60)
+                           +- * Sort (66)
+                              +- ReusedExchange (65)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -93,390 +90,396 @@ Input [3]: [ss_customer_sk#1, ss_net_paid#2, ss_sold_date_sk#3]
 
 (3) Filter [codegen id : 2]
 Input [3]: [ss_customer_sk#1, ss_net_paid#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_customer_sk#1)
+Condition : (isnotnull(ss_customer_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 83]
-Output [2]: [d_date_sk#5, d_year#6]
+(4) ReusedExchange [Reuses operator id: 87]
+Output [2]: [d_date_sk#7, d_year#8]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#5]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
-Output [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#6]
-Input [5]: [ss_customer_sk#1, ss_net_paid#2, ss_sold_date_sk#3, d_date_sk#5, d_year#6]
+Output [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#8]
+Input [5]: [ss_customer_sk#1, ss_net_paid#2, ss_sold_date_sk#3, d_date_sk#7, d_year#8]
 
 (7) Exchange
-Input [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#6]
+Input [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#8]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (8) Sort [codegen id : 3]
-Input [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#6]
+Input [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#8]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
+(9) ReusedExchange [Reuses operator id: 80]
+Output [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+
+(10) Sort [codegen id : 5]
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+Arguments: [c_customer_sk#9 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#9]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, ss_net_paid#2, d_year#8]
+Input [7]: [ss_customer_sk#1, ss_net_paid#2, d_year#8, c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+
+(13) HashAggregate [codegen id : 6]
+Input [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, ss_net_paid#2, d_year#8]
+Keys [4]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#2))]
+Aggregate Attributes [1]: [sum#13]
+Results [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8, sum#14]
+
+(14) Exchange
+Input [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8, sum#14]
+Arguments: hashpartitioning(c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8, sum#14]
+Keys [4]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#2))#15]
+Results [2]: [c_customer_id#10 AS customer_id#16, MakeDecimal(sum(UnscaledValue(ss_net_paid#2))#15,17,2) AS year_total#17]
+
+(16) Filter [codegen id : 7]
+Input [2]: [customer_id#16, year_total#17]
+Condition : (isnotnull(year_total#17) AND (year_total#17 > 0.00))
+
+(17) Exchange
+Input [2]: [customer_id#16, year_total#17]
+Arguments: hashpartitioning(customer_id#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(18) Sort [codegen id : 8]
+Input [2]: [customer_id#16, year_total#17]
+Arguments: [customer_id#16 ASC NULLS FIRST], false, 0
+
+(19) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_customer_sk#18, ss_net_paid#19, ss_sold_date_sk#20]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#20), dynamicpruningexpression(ss_sold_date_sk#20 IN dynamicpruning#21)]
+PushedFilters: [IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_customer_sk:int,ss_net_paid:decimal(7,2)>
+
+(20) ColumnarToRow [codegen id : 10]
+Input [3]: [ss_customer_sk#18, ss_net_paid#19, ss_sold_date_sk#20]
+
+(21) Filter [codegen id : 10]
+Input [3]: [ss_customer_sk#18, ss_net_paid#19, ss_sold_date_sk#20]
+Condition : (isnotnull(ss_customer_sk#18) AND might_contain(Subquery scalar-subquery#22, [id=#23], xxhash64(ss_customer_sk#18, 42), false))
+
+(22) ReusedExchange [Reuses operator id: 98]
+Output [2]: [d_date_sk#24, d_year#25]
+
+(23) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#20]
+Right keys [1]: [d_date_sk#24]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 10]
+Output [3]: [ss_customer_sk#18, ss_net_paid#19, d_year#25]
+Input [5]: [ss_customer_sk#18, ss_net_paid#19, ss_sold_date_sk#20, d_date_sk#24, d_year#25]
+
+(25) Exchange
+Input [3]: [ss_customer_sk#18, ss_net_paid#19, d_year#25]
+Arguments: hashpartitioning(ss_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) Sort [codegen id : 11]
+Input [3]: [ss_customer_sk#18, ss_net_paid#19, d_year#25]
+Arguments: [ss_customer_sk#18 ASC NULLS FIRST], false, 0
+
+(27) ReusedExchange [Reuses operator id: 80]
+Output [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+
+(28) Sort [codegen id : 13]
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Arguments: [c_customer_sk#26 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 14]
+Left keys [1]: [ss_customer_sk#18]
+Right keys [1]: [c_customer_sk#26]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 14]
+Output [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, ss_net_paid#19, d_year#25]
+Input [7]: [ss_customer_sk#18, ss_net_paid#19, d_year#25, c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+
+(31) HashAggregate [codegen id : 14]
+Input [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, ss_net_paid#19, d_year#25]
+Keys [4]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#19))]
+Aggregate Attributes [1]: [sum#30]
+Results [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25, sum#31]
+
+(32) Exchange
+Input [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25, sum#31]
+Arguments: hashpartitioning(c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(33) HashAggregate [codegen id : 15]
+Input [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25, sum#31]
+Keys [4]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#19))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#19))#15]
+Results [4]: [c_customer_id#27 AS customer_id#32, c_first_name#28 AS customer_first_name#33, c_last_name#29 AS customer_last_name#34, MakeDecimal(sum(UnscaledValue(ss_net_paid#19))#15,17,2) AS year_total#35]
+
+(34) Exchange
+Input [4]: [customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35]
+Arguments: hashpartitioning(customer_id#32, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(35) Sort [codegen id : 16]
+Input [4]: [customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35]
+Arguments: [customer_id#32 ASC NULLS FIRST], false, 0
+
+(36) SortMergeJoin [codegen id : 17]
+Left keys [1]: [customer_id#16]
+Right keys [1]: [customer_id#32]
+Join type: Inner
+Join condition: None
+
+(37) Scan parquet spark_catalog.default.web_sales
+Output [3]: [ws_bill_customer_sk#36, ws_net_paid#37, ws_sold_date_sk#38]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#38), dynamicpruningexpression(ws_sold_date_sk#38 IN dynamicpruning#4)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_net_paid:decimal(7,2)>
+
+(38) ColumnarToRow [codegen id : 19]
+Input [3]: [ws_bill_customer_sk#36, ws_net_paid#37, ws_sold_date_sk#38]
+
+(39) Filter [codegen id : 19]
+Input [3]: [ws_bill_customer_sk#36, ws_net_paid#37, ws_sold_date_sk#38]
+Condition : (isnotnull(ws_bill_customer_sk#36) AND might_contain(ReusedSubquery Subquery scalar-subquery#22, [id=#23], xxhash64(ws_bill_customer_sk#36, 42), false))
+
+(40) ReusedExchange [Reuses operator id: 87]
+Output [2]: [d_date_sk#39, d_year#40]
+
+(41) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [ws_sold_date_sk#38]
+Right keys [1]: [d_date_sk#39]
+Join type: Inner
+Join condition: None
+
+(42) Project [codegen id : 19]
+Output [3]: [ws_bill_customer_sk#36, ws_net_paid#37, d_year#40]
+Input [5]: [ws_bill_customer_sk#36, ws_net_paid#37, ws_sold_date_sk#38, d_date_sk#39, d_year#40]
+
+(43) Exchange
+Input [3]: [ws_bill_customer_sk#36, ws_net_paid#37, d_year#40]
+Arguments: hashpartitioning(ws_bill_customer_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(44) Sort [codegen id : 20]
+Input [3]: [ws_bill_customer_sk#36, ws_net_paid#37, d_year#40]
+Arguments: [ws_bill_customer_sk#36 ASC NULLS FIRST], false, 0
+
+(45) ReusedExchange [Reuses operator id: 80]
+Output [4]: [c_customer_sk#41, c_customer_id#42, c_first_name#43, c_last_name#44]
+
+(46) Sort [codegen id : 22]
+Input [4]: [c_customer_sk#41, c_customer_id#42, c_first_name#43, c_last_name#44]
+Arguments: [c_customer_sk#41 ASC NULLS FIRST], false, 0
+
+(47) SortMergeJoin [codegen id : 23]
+Left keys [1]: [ws_bill_customer_sk#36]
+Right keys [1]: [c_customer_sk#41]
+Join type: Inner
+Join condition: None
+
+(48) Project [codegen id : 23]
+Output [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, ws_net_paid#37, d_year#40]
+Input [7]: [ws_bill_customer_sk#36, ws_net_paid#37, d_year#40, c_customer_sk#41, c_customer_id#42, c_first_name#43, c_last_name#44]
+
+(49) HashAggregate [codegen id : 23]
+Input [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, ws_net_paid#37, d_year#40]
+Keys [4]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40]
+Functions [1]: [partial_sum(UnscaledValue(ws_net_paid#37))]
+Aggregate Attributes [1]: [sum#45]
+Results [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40, sum#46]
+
+(50) Exchange
+Input [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40, sum#46]
+Arguments: hashpartitioning(c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(51) HashAggregate [codegen id : 24]
+Input [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40, sum#46]
+Keys [4]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40]
+Functions [1]: [sum(UnscaledValue(ws_net_paid#37))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#37))#47]
+Results [2]: [c_customer_id#42 AS customer_id#48, MakeDecimal(sum(UnscaledValue(ws_net_paid#37))#47,17,2) AS year_total#49]
+
+(52) Filter [codegen id : 24]
+Input [2]: [customer_id#48, year_total#49]
+Condition : (isnotnull(year_total#49) AND (year_total#49 > 0.00))
+
+(53) Exchange
+Input [2]: [customer_id#48, year_total#49]
+Arguments: hashpartitioning(customer_id#48, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) Sort [codegen id : 25]
+Input [2]: [customer_id#48, year_total#49]
+Arguments: [customer_id#48 ASC NULLS FIRST], false, 0
+
+(55) SortMergeJoin [codegen id : 26]
+Left keys [1]: [customer_id#16]
+Right keys [1]: [customer_id#48]
+Join type: Inner
+Join condition: None
+
+(56) Project [codegen id : 26]
+Output [7]: [customer_id#16, year_total#17, customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35, year_total#49]
+Input [8]: [customer_id#16, year_total#17, customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35, customer_id#48, year_total#49]
+
+(57) Scan parquet spark_catalog.default.web_sales
+Output [3]: [ws_bill_customer_sk#50, ws_net_paid#51, ws_sold_date_sk#52]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#52), dynamicpruningexpression(ws_sold_date_sk#52 IN dynamicpruning#21)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_net_paid:decimal(7,2)>
+
+(58) ColumnarToRow [codegen id : 28]
+Input [3]: [ws_bill_customer_sk#50, ws_net_paid#51, ws_sold_date_sk#52]
+
+(59) Filter [codegen id : 28]
+Input [3]: [ws_bill_customer_sk#50, ws_net_paid#51, ws_sold_date_sk#52]
+Condition : (isnotnull(ws_bill_customer_sk#50) AND might_contain(ReusedSubquery Subquery scalar-subquery#22, [id=#23], xxhash64(ws_bill_customer_sk#50, 42), false))
+
+(60) ReusedExchange [Reuses operator id: 98]
+Output [2]: [d_date_sk#53, d_year#54]
+
+(61) BroadcastHashJoin [codegen id : 28]
+Left keys [1]: [ws_sold_date_sk#52]
+Right keys [1]: [d_date_sk#53]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 28]
+Output [3]: [ws_bill_customer_sk#50, ws_net_paid#51, d_year#54]
+Input [5]: [ws_bill_customer_sk#50, ws_net_paid#51, ws_sold_date_sk#52, d_date_sk#53, d_year#54]
+
+(63) Exchange
+Input [3]: [ws_bill_customer_sk#50, ws_net_paid#51, d_year#54]
+Arguments: hashpartitioning(ws_bill_customer_sk#50, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(64) Sort [codegen id : 29]
+Input [3]: [ws_bill_customer_sk#50, ws_net_paid#51, d_year#54]
+Arguments: [ws_bill_customer_sk#50 ASC NULLS FIRST], false, 0
+
+(65) ReusedExchange [Reuses operator id: 80]
+Output [4]: [c_customer_sk#55, c_customer_id#56, c_first_name#57, c_last_name#58]
+
+(66) Sort [codegen id : 31]
+Input [4]: [c_customer_sk#55, c_customer_id#56, c_first_name#57, c_last_name#58]
+Arguments: [c_customer_sk#55 ASC NULLS FIRST], false, 0
+
+(67) SortMergeJoin [codegen id : 32]
+Left keys [1]: [ws_bill_customer_sk#50]
+Right keys [1]: [c_customer_sk#55]
+Join type: Inner
+Join condition: None
+
+(68) Project [codegen id : 32]
+Output [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, ws_net_paid#51, d_year#54]
+Input [7]: [ws_bill_customer_sk#50, ws_net_paid#51, d_year#54, c_customer_sk#55, c_customer_id#56, c_first_name#57, c_last_name#58]
+
+(69) HashAggregate [codegen id : 32]
+Input [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, ws_net_paid#51, d_year#54]
+Keys [4]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54]
+Functions [1]: [partial_sum(UnscaledValue(ws_net_paid#51))]
+Aggregate Attributes [1]: [sum#59]
+Results [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54, sum#60]
+
+(70) Exchange
+Input [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54, sum#60]
+Arguments: hashpartitioning(c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(71) HashAggregate [codegen id : 33]
+Input [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54, sum#60]
+Keys [4]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54]
+Functions [1]: [sum(UnscaledValue(ws_net_paid#51))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#51))#47]
+Results [2]: [c_customer_id#56 AS customer_id#61, MakeDecimal(sum(UnscaledValue(ws_net_paid#51))#47,17,2) AS year_total#62]
+
+(72) Exchange
+Input [2]: [customer_id#61, year_total#62]
+Arguments: hashpartitioning(customer_id#61, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(73) Sort [codegen id : 34]
+Input [2]: [customer_id#61, year_total#62]
+Arguments: [customer_id#61 ASC NULLS FIRST], false, 0
+
+(74) SortMergeJoin [codegen id : 35]
+Left keys [1]: [customer_id#16]
+Right keys [1]: [customer_id#61]
+Join type: Inner
+Join condition: (CASE WHEN (year_total#49 > 0.00) THEN (year_total#62 / year_total#49) END > CASE WHEN (year_total#17 > 0.00) THEN (year_total#35 / year_total#17) END)
+
+(75) Project [codegen id : 35]
+Output [3]: [customer_id#32, customer_first_name#33, customer_last_name#34]
+Input [9]: [customer_id#16, year_total#17, customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35, year_total#49, customer_id#61, year_total#62]
+
+(76) TakeOrderedAndProject
+Input [3]: [customer_id#32, customer_first_name#33, customer_last_name#34]
+Arguments: 100, [customer_id#32 ASC NULLS FIRST, customer_id#32 ASC NULLS FIRST, customer_id#32 ASC NULLS FIRST], [customer_id#32, customer_first_name#33, customer_last_name#34]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (83)
++- Exchange (82)
+   +- ObjectHashAggregate (81)
+      +- Exchange (80)
+         +- * Filter (79)
+            +- * ColumnarToRow (78)
+               +- Scan parquet spark_catalog.default.customer (77)
+
+
+(77) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string>
 
-(10) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-
-(11) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-Condition : (isnotnull(c_customer_sk#7) AND isnotnull(c_customer_id#8))
-
-(12) Exchange
-Input [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-Arguments: hashpartitioning(c_customer_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(13) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-Arguments: [c_customer_sk#7 ASC NULLS FIRST], false, 0
-
-(14) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#7]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, ss_net_paid#2, d_year#6]
-Input [7]: [ss_customer_sk#1, ss_net_paid#2, d_year#6, c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-
-(16) HashAggregate [codegen id : 6]
-Input [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, ss_net_paid#2, d_year#6]
-Keys [4]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#2))]
-Aggregate Attributes [1]: [sum#11]
-Results [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6, sum#12]
-
-(17) Exchange
-Input [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6, sum#12]
-Arguments: hashpartitioning(c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6, sum#12]
-Keys [4]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#2))#13]
-Results [2]: [c_customer_id#8 AS customer_id#14, MakeDecimal(sum(UnscaledValue(ss_net_paid#2))#13,17,2) AS year_total#15]
-
-(19) Filter [codegen id : 7]
-Input [2]: [customer_id#14, year_total#15]
-Condition : (isnotnull(year_total#15) AND (year_total#15 > 0.00))
-
-(20) Exchange
-Input [2]: [customer_id#14, year_total#15]
-Arguments: hashpartitioning(customer_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(21) Sort [codegen id : 8]
-Input [2]: [customer_id#14, year_total#15]
-Arguments: [customer_id#14 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_customer_sk#16, ss_net_paid#17, ss_sold_date_sk#18]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#18), dynamicpruningexpression(ss_sold_date_sk#18 IN dynamicpruning#19)]
-PushedFilters: [IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_customer_sk:int,ss_net_paid:decimal(7,2)>
-
-(23) ColumnarToRow [codegen id : 10]
-Input [3]: [ss_customer_sk#16, ss_net_paid#17, ss_sold_date_sk#18]
-
-(24) Filter [codegen id : 10]
-Input [3]: [ss_customer_sk#16, ss_net_paid#17, ss_sold_date_sk#18]
-Condition : isnotnull(ss_customer_sk#16)
-
-(25) ReusedExchange [Reuses operator id: 87]
-Output [2]: [d_date_sk#20, d_year#21]
-
-(26) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#18]
-Right keys [1]: [d_date_sk#20]
-Join type: Inner
-Join condition: None
-
-(27) Project [codegen id : 10]
-Output [3]: [ss_customer_sk#16, ss_net_paid#17, d_year#21]
-Input [5]: [ss_customer_sk#16, ss_net_paid#17, ss_sold_date_sk#18, d_date_sk#20, d_year#21]
-
-(28) Exchange
-Input [3]: [ss_customer_sk#16, ss_net_paid#17, d_year#21]
-Arguments: hashpartitioning(ss_customer_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(29) Sort [codegen id : 11]
-Input [3]: [ss_customer_sk#16, ss_net_paid#17, d_year#21]
-Arguments: [ss_customer_sk#16 ASC NULLS FIRST], false, 0
-
-(30) ReusedExchange [Reuses operator id: 12]
-Output [4]: [c_customer_sk#22, c_customer_id#23, c_first_name#24, c_last_name#25]
-
-(31) Sort [codegen id : 13]
-Input [4]: [c_customer_sk#22, c_customer_id#23, c_first_name#24, c_last_name#25]
-Arguments: [c_customer_sk#22 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 14]
-Left keys [1]: [ss_customer_sk#16]
-Right keys [1]: [c_customer_sk#22]
-Join type: Inner
-Join condition: None
-
-(33) Project [codegen id : 14]
-Output [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, ss_net_paid#17, d_year#21]
-Input [7]: [ss_customer_sk#16, ss_net_paid#17, d_year#21, c_customer_sk#22, c_customer_id#23, c_first_name#24, c_last_name#25]
-
-(34) HashAggregate [codegen id : 14]
-Input [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, ss_net_paid#17, d_year#21]
-Keys [4]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#17))]
-Aggregate Attributes [1]: [sum#26]
-Results [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21, sum#27]
-
-(35) Exchange
-Input [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21, sum#27]
-Arguments: hashpartitioning(c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(36) HashAggregate [codegen id : 15]
-Input [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21, sum#27]
-Keys [4]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#17))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#17))#13]
-Results [4]: [c_customer_id#23 AS customer_id#28, c_first_name#24 AS customer_first_name#29, c_last_name#25 AS customer_last_name#30, MakeDecimal(sum(UnscaledValue(ss_net_paid#17))#13,17,2) AS year_total#31]
-
-(37) Exchange
-Input [4]: [customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31]
-Arguments: hashpartitioning(customer_id#28, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(38) Sort [codegen id : 16]
-Input [4]: [customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31]
-Arguments: [customer_id#28 ASC NULLS FIRST], false, 0
-
-(39) SortMergeJoin [codegen id : 17]
-Left keys [1]: [customer_id#14]
-Right keys [1]: [customer_id#28]
-Join type: Inner
-Join condition: None
-
-(40) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_bill_customer_sk#32, ws_net_paid#33, ws_sold_date_sk#34]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#34), dynamicpruningexpression(ws_sold_date_sk#34 IN dynamicpruning#4)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_net_paid:decimal(7,2)>
-
-(41) ColumnarToRow [codegen id : 19]
-Input [3]: [ws_bill_customer_sk#32, ws_net_paid#33, ws_sold_date_sk#34]
-
-(42) Filter [codegen id : 19]
-Input [3]: [ws_bill_customer_sk#32, ws_net_paid#33, ws_sold_date_sk#34]
-Condition : isnotnull(ws_bill_customer_sk#32)
-
-(43) ReusedExchange [Reuses operator id: 83]
-Output [2]: [d_date_sk#35, d_year#36]
-
-(44) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_sold_date_sk#34]
-Right keys [1]: [d_date_sk#35]
-Join type: Inner
-Join condition: None
-
-(45) Project [codegen id : 19]
-Output [3]: [ws_bill_customer_sk#32, ws_net_paid#33, d_year#36]
-Input [5]: [ws_bill_customer_sk#32, ws_net_paid#33, ws_sold_date_sk#34, d_date_sk#35, d_year#36]
-
-(46) Exchange
-Input [3]: [ws_bill_customer_sk#32, ws_net_paid#33, d_year#36]
-Arguments: hashpartitioning(ws_bill_customer_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(47) Sort [codegen id : 20]
-Input [3]: [ws_bill_customer_sk#32, ws_net_paid#33, d_year#36]
-Arguments: [ws_bill_customer_sk#32 ASC NULLS FIRST], false, 0
-
-(48) ReusedExchange [Reuses operator id: 12]
-Output [4]: [c_customer_sk#37, c_customer_id#38, c_first_name#39, c_last_name#40]
-
-(49) Sort [codegen id : 22]
-Input [4]: [c_customer_sk#37, c_customer_id#38, c_first_name#39, c_last_name#40]
-Arguments: [c_customer_sk#37 ASC NULLS FIRST], false, 0
-
-(50) SortMergeJoin [codegen id : 23]
-Left keys [1]: [ws_bill_customer_sk#32]
-Right keys [1]: [c_customer_sk#37]
-Join type: Inner
-Join condition: None
-
-(51) Project [codegen id : 23]
-Output [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, ws_net_paid#33, d_year#36]
-Input [7]: [ws_bill_customer_sk#32, ws_net_paid#33, d_year#36, c_customer_sk#37, c_customer_id#38, c_first_name#39, c_last_name#40]
-
-(52) HashAggregate [codegen id : 23]
-Input [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, ws_net_paid#33, d_year#36]
-Keys [4]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36]
-Functions [1]: [partial_sum(UnscaledValue(ws_net_paid#33))]
-Aggregate Attributes [1]: [sum#41]
-Results [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36, sum#42]
-
-(53) Exchange
-Input [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36, sum#42]
-Arguments: hashpartitioning(c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(54) HashAggregate [codegen id : 24]
-Input [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36, sum#42]
-Keys [4]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36]
-Functions [1]: [sum(UnscaledValue(ws_net_paid#33))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#33))#43]
-Results [2]: [c_customer_id#38 AS customer_id#44, MakeDecimal(sum(UnscaledValue(ws_net_paid#33))#43,17,2) AS year_total#45]
-
-(55) Filter [codegen id : 24]
-Input [2]: [customer_id#44, year_total#45]
-Condition : (isnotnull(year_total#45) AND (year_total#45 > 0.00))
-
-(56) Exchange
-Input [2]: [customer_id#44, year_total#45]
-Arguments: hashpartitioning(customer_id#44, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(57) Sort [codegen id : 25]
-Input [2]: [customer_id#44, year_total#45]
-Arguments: [customer_id#44 ASC NULLS FIRST], false, 0
-
-(58) SortMergeJoin [codegen id : 26]
-Left keys [1]: [customer_id#14]
-Right keys [1]: [customer_id#44]
-Join type: Inner
-Join condition: None
-
-(59) Project [codegen id : 26]
-Output [7]: [customer_id#14, year_total#15, customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31, year_total#45]
-Input [8]: [customer_id#14, year_total#15, customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31, customer_id#44, year_total#45]
-
-(60) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_bill_customer_sk#46, ws_net_paid#47, ws_sold_date_sk#48]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#48), dynamicpruningexpression(ws_sold_date_sk#48 IN dynamicpruning#19)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_net_paid:decimal(7,2)>
-
-(61) ColumnarToRow [codegen id : 28]
-Input [3]: [ws_bill_customer_sk#46, ws_net_paid#47, ws_sold_date_sk#48]
-
-(62) Filter [codegen id : 28]
-Input [3]: [ws_bill_customer_sk#46, ws_net_paid#47, ws_sold_date_sk#48]
-Condition : isnotnull(ws_bill_customer_sk#46)
-
-(63) ReusedExchange [Reuses operator id: 87]
-Output [2]: [d_date_sk#49, d_year#50]
-
-(64) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [ws_sold_date_sk#48]
-Right keys [1]: [d_date_sk#49]
-Join type: Inner
-Join condition: None
-
-(65) Project [codegen id : 28]
-Output [3]: [ws_bill_customer_sk#46, ws_net_paid#47, d_year#50]
-Input [5]: [ws_bill_customer_sk#46, ws_net_paid#47, ws_sold_date_sk#48, d_date_sk#49, d_year#50]
-
-(66) Exchange
-Input [3]: [ws_bill_customer_sk#46, ws_net_paid#47, d_year#50]
-Arguments: hashpartitioning(ws_bill_customer_sk#46, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(67) Sort [codegen id : 29]
-Input [3]: [ws_bill_customer_sk#46, ws_net_paid#47, d_year#50]
-Arguments: [ws_bill_customer_sk#46 ASC NULLS FIRST], false, 0
-
-(68) ReusedExchange [Reuses operator id: 12]
-Output [4]: [c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54]
-
-(69) Sort [codegen id : 31]
-Input [4]: [c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54]
-Arguments: [c_customer_sk#51 ASC NULLS FIRST], false, 0
-
-(70) SortMergeJoin [codegen id : 32]
-Left keys [1]: [ws_bill_customer_sk#46]
-Right keys [1]: [c_customer_sk#51]
-Join type: Inner
-Join condition: None
-
-(71) Project [codegen id : 32]
-Output [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, ws_net_paid#47, d_year#50]
-Input [7]: [ws_bill_customer_sk#46, ws_net_paid#47, d_year#50, c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54]
-
-(72) HashAggregate [codegen id : 32]
-Input [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, ws_net_paid#47, d_year#50]
-Keys [4]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50]
-Functions [1]: [partial_sum(UnscaledValue(ws_net_paid#47))]
-Aggregate Attributes [1]: [sum#55]
-Results [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50, sum#56]
-
-(73) Exchange
-Input [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50, sum#56]
-Arguments: hashpartitioning(c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(74) HashAggregate [codegen id : 33]
-Input [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50, sum#56]
-Keys [4]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50]
-Functions [1]: [sum(UnscaledValue(ws_net_paid#47))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#47))#43]
-Results [2]: [c_customer_id#52 AS customer_id#57, MakeDecimal(sum(UnscaledValue(ws_net_paid#47))#43,17,2) AS year_total#58]
-
-(75) Exchange
-Input [2]: [customer_id#57, year_total#58]
-Arguments: hashpartitioning(customer_id#57, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(76) Sort [codegen id : 34]
-Input [2]: [customer_id#57, year_total#58]
-Arguments: [customer_id#57 ASC NULLS FIRST], false, 0
-
-(77) SortMergeJoin [codegen id : 35]
-Left keys [1]: [customer_id#14]
-Right keys [1]: [customer_id#57]
-Join type: Inner
-Join condition: (CASE WHEN (year_total#45 > 0.00) THEN (year_total#58 / year_total#45) END > CASE WHEN (year_total#15 > 0.00) THEN (year_total#31 / year_total#15) END)
-
-(78) Project [codegen id : 35]
-Output [3]: [customer_id#28, customer_first_name#29, customer_last_name#30]
-Input [9]: [customer_id#14, year_total#15, customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31, year_total#45, customer_id#57, year_total#58]
-
-(79) TakeOrderedAndProject
-Input [3]: [customer_id#28, customer_first_name#29, customer_last_name#30]
-Arguments: 100, [customer_id#28 ASC NULLS FIRST, customer_id#28 ASC NULLS FIRST, customer_id#28 ASC NULLS FIRST], [customer_id#28, customer_first_name#29, customer_last_name#30]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (83)
-+- * Filter (82)
-   +- * ColumnarToRow (81)
-      +- Scan parquet spark_catalog.default.date_dim (80)
-
-
-(80) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#5, d_year#6]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), In(d_year, [2001,2002]), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int>
-
-(81) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_year#6]
-
-(82) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_year#6]
-Condition : (((isnotnull(d_year#6) AND (d_year#6 = 2001)) AND d_year#6 IN (2001,2002)) AND isnotnull(d_date_sk#5))
-
-(83) BroadcastExchange
-Input [2]: [d_date_sk#5, d_year#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
-
-Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#18 IN dynamicpruning#19
+(78) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+
+(79) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+Condition : (isnotnull(c_customer_sk#9) AND isnotnull(c_customer_id#10))
+
+(80) Exchange
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+Arguments: hashpartitioning(c_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(81) ObjectHashAggregate
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#9, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#63]
+Results [1]: [buf#64]
+
+(82) Exchange
+Input [1]: [buf#64]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(83) ObjectHashAggregate
+Input [1]: [buf#64]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#9, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#9, 42), 2000000, 16000000, 0, 0)#65]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#9, 42), 2000000, 16000000, 0, 0)#65 AS bloomFilter#66]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
 BroadcastExchange (87)
 +- * Filter (86)
    +- * ColumnarToRow (85)
@@ -484,25 +487,100 @@ BroadcastExchange (87)
 
 
 (84) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#20, d_year#21]
+Output [2]: [d_date_sk#7, d_year#8]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), In(d_year, [2001,2002]), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int>
+
+(85) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#7, d_year#8]
+
+(86) Filter [codegen id : 1]
+Input [2]: [d_date_sk#7, d_year#8]
+Condition : (((isnotnull(d_year#8) AND (d_year#8 = 2001)) AND d_year#8 IN (2001,2002)) AND isnotnull(d_date_sk#7))
+
+(87) BroadcastExchange
+Input [2]: [d_date_sk#7, d_year#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+
+Subquery:3 Hosting operator id = 21 Hosting Expression = Subquery scalar-subquery#22, [id=#23]
+ObjectHashAggregate (94)
++- Exchange (93)
+   +- ObjectHashAggregate (92)
+      +- Exchange (91)
+         +- * Filter (90)
+            +- * ColumnarToRow (89)
+               +- Scan parquet spark_catalog.default.customer (88)
+
+
+(88) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
+ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string>
+
+(89) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+
+(90) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Condition : (isnotnull(c_customer_sk#26) AND isnotnull(c_customer_id#27))
+
+(91) Exchange
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Arguments: hashpartitioning(c_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(92) ObjectHashAggregate
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#26, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#67]
+Results [1]: [buf#68]
+
+(93) Exchange
+Input [1]: [buf#68]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(94) ObjectHashAggregate
+Input [1]: [buf#68]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#26, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#26, 42), 2000000, 16000000, 0, 0)#69]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#26, 42), 2000000, 16000000, 0, 0)#69 AS bloomFilter#70]
+
+Subquery:4 Hosting operator id = 19 Hosting Expression = ss_sold_date_sk#20 IN dynamicpruning#21
+BroadcastExchange (98)
++- * Filter (97)
+   +- * ColumnarToRow (96)
+      +- Scan parquet spark_catalog.default.date_dim (95)
+
+
+(95) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#24, d_year#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), In(d_year, [2001,2002]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(85) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#20, d_year#21]
+(96) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#24, d_year#25]
 
-(86) Filter [codegen id : 1]
-Input [2]: [d_date_sk#20, d_year#21]
-Condition : (((isnotnull(d_year#21) AND (d_year#21 = 2002)) AND d_year#21 IN (2001,2002)) AND isnotnull(d_date_sk#20))
+(97) Filter [codegen id : 1]
+Input [2]: [d_date_sk#24, d_year#25]
+Condition : (((isnotnull(d_year#25) AND (d_year#25 = 2002)) AND d_year#25 IN (2001,2002)) AND isnotnull(d_date_sk#24))
 
-(87) BroadcastExchange
-Input [2]: [d_date_sk#20, d_year#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+(98) BroadcastExchange
+Input [2]: [d_date_sk#24, d_year#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
 
-Subquery:3 Hosting operator id = 40 Hosting Expression = ws_sold_date_sk#34 IN dynamicpruning#4
+Subquery:5 Hosting operator id = 39 Hosting Expression = ReusedSubquery Subquery scalar-subquery#22, [id=#23]
 
-Subquery:4 Hosting operator id = 60 Hosting Expression = ws_sold_date_sk#48 IN dynamicpruning#19
+Subquery:6 Hosting operator id = 37 Hosting Expression = ws_sold_date_sk#38 IN dynamicpruning#4
+
+Subquery:7 Hosting operator id = 59 Hosting Expression = ReusedSubquery Subquery scalar-subquery#22, [id=#23]
+
+Subquery:8 Hosting operator id = 57 Hosting Expression = ws_sold_date_sk#52 IN dynamicpruning#21
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q74.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q74.sf100/simplified.txt
@@ -32,6 +32,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name]
                                                               Project [ss_customer_sk,ss_net_paid,d_year]
                                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                   Filter [ss_customer_sk]
+                                                                    Subquery #2
+                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                        Exchange #5
+                                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                            Exchange [c_customer_sk] #6
+                                                                              WholeStageCodegen (1)
+                                                                                Filter [c_customer_sk,c_customer_id]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_net_paid,ss_sold_date_sk]
@@ -48,21 +58,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name]
                                                     WholeStageCodegen (5)
                                                       Sort [c_customer_sk]
                                                         InputAdapter
-                                                          Exchange [c_customer_sk] #5
-                                                            WholeStageCodegen (4)
-                                                              Filter [c_customer_sk,c_customer_id]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name]
+                                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #6
                       InputAdapter
                         WholeStageCodegen (16)
                           Sort [customer_id]
                             InputAdapter
-                              Exchange [customer_id] #6
+                              Exchange [customer_id] #7
                                 WholeStageCodegen (15)
                                   HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,sum] [sum(UnscaledValue(ss_net_paid)),customer_id,customer_first_name,customer_last_name,year_total,sum]
                                     InputAdapter
-                                      Exchange [c_customer_id,c_first_name,c_last_name,d_year] #7
+                                      Exchange [c_customer_id,c_first_name,c_last_name,d_year] #8
                                         WholeStageCodegen (14)
                                           HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,ss_net_paid] [sum,sum]
                                             Project [c_customer_id,c_first_name,c_last_name,ss_net_paid,d_year]
@@ -71,38 +76,48 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name]
                                                   WholeStageCodegen (11)
                                                     Sort [ss_customer_sk]
                                                       InputAdapter
-                                                        Exchange [ss_customer_sk] #8
+                                                        Exchange [ss_customer_sk] #9
                                                           WholeStageCodegen (10)
                                                             Project [ss_customer_sk,ss_net_paid,d_year]
                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                 Filter [ss_customer_sk]
+                                                                  Subquery #4
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                      Exchange #11
+                                                                        ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                          Exchange [c_customer_sk] #12
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [c_customer_sk,c_customer_id]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_net_paid,ss_sold_date_sk]
-                                                                        SubqueryBroadcast [d_date_sk] #2
-                                                                          BroadcastExchange #9
+                                                                        SubqueryBroadcast [d_date_sk] #3
+                                                                          BroadcastExchange #10
                                                                             WholeStageCodegen (1)
                                                                               Filter [d_year,d_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                 InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_year] #9
+                                                                  ReusedExchange [d_date_sk,d_year] #10
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #5
+                                                        ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #6
                 InputAdapter
                   WholeStageCodegen (25)
                     Sort [customer_id]
                       InputAdapter
-                        Exchange [customer_id] #10
+                        Exchange [customer_id] #13
                           WholeStageCodegen (24)
                             Filter [year_total]
                               HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,sum] [sum(UnscaledValue(ws_net_paid)),customer_id,year_total,sum]
                                 InputAdapter
-                                  Exchange [c_customer_id,c_first_name,c_last_name,d_year] #11
+                                  Exchange [c_customer_id,c_first_name,c_last_name,d_year] #14
                                     WholeStageCodegen (23)
                                       HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,ws_net_paid] [sum,sum]
                                         Project [c_customer_id,c_first_name,c_last_name,ws_net_paid,d_year]
@@ -111,11 +126,12 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name]
                                               WholeStageCodegen (20)
                                                 Sort [ws_bill_customer_sk]
                                                   InputAdapter
-                                                    Exchange [ws_bill_customer_sk] #12
+                                                    Exchange [ws_bill_customer_sk] #15
                                                       WholeStageCodegen (19)
                                                         Project [ws_bill_customer_sk,ws_net_paid,d_year]
                                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                             Filter [ws_bill_customer_sk]
+                                                              ReusedSubquery [bloomFilter] #4
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_net_paid,ws_sold_date_sk]
@@ -126,16 +142,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name]
                                               WholeStageCodegen (22)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #5
+                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #6
         InputAdapter
           WholeStageCodegen (34)
             Sort [customer_id]
               InputAdapter
-                Exchange [customer_id] #13
+                Exchange [customer_id] #16
                   WholeStageCodegen (33)
                     HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,sum] [sum(UnscaledValue(ws_net_paid)),customer_id,year_total,sum]
                       InputAdapter
-                        Exchange [c_customer_id,c_first_name,c_last_name,d_year] #14
+                        Exchange [c_customer_id,c_first_name,c_last_name,d_year] #17
                           WholeStageCodegen (32)
                             HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,ws_net_paid] [sum,sum]
                               Project [c_customer_id,c_first_name,c_last_name,ws_net_paid,d_year]
@@ -144,19 +160,20 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name]
                                     WholeStageCodegen (29)
                                       Sort [ws_bill_customer_sk]
                                         InputAdapter
-                                          Exchange [ws_bill_customer_sk] #15
+                                          Exchange [ws_bill_customer_sk] #18
                                             WholeStageCodegen (28)
                                               Project [ws_bill_customer_sk,ws_net_paid,d_year]
                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                   Filter [ws_bill_customer_sk]
+                                                    ReusedSubquery [bloomFilter] #4
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_net_paid,ws_sold_date_sk]
-                                                          ReusedSubquery [d_date_sk] #2
+                                                          ReusedSubquery [d_date_sk] #3
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk,d_year] #9
+                                                    ReusedExchange [d_date_sk,d_year] #10
                                   InputAdapter
                                     WholeStageCodegen (31)
                                       Sort [c_customer_sk]
                                         InputAdapter
-                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #5
+                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/explain.txt
@@ -1,19 +1,19 @@
 == Physical Plan ==
-TakeOrderedAndProject (129)
-+- * Project (128)
-   +- * SortMergeJoin Inner (127)
-      :- * Sort (71)
-      :  +- Exchange (70)
-      :     +- * Filter (69)
-      :        +- * HashAggregate (68)
-      :           +- Exchange (67)
-      :              +- * HashAggregate (66)
-      :                 +- * HashAggregate (65)
-      :                    +- Exchange (64)
-      :                       +- * HashAggregate (63)
-      :                          +- Union (62)
-      :                             :- * Project (23)
-      :                             :  +- * SortMergeJoin LeftOuter (22)
+TakeOrderedAndProject (64)
++- * Project (63)
+   +- * SortMergeJoin Inner (62)
+      :- * Sort (59)
+      :  +- Exchange (58)
+      :     +- * Filter (57)
+      :        +- * HashAggregate (56)
+      :           +- Exchange (55)
+      :              +- * HashAggregate (54)
+      :                 +- * HashAggregate (53)
+      :                    +- Exchange (52)
+      :                       +- * HashAggregate (51)
+      :                          +- Union (50)
+      :                             :- * Project (19)
+      :                             :  +- * SortMergeJoin LeftOuter (18)
       :                             :     :- * Sort (15)
       :                             :     :  +- Exchange (14)
       :                             :     :     +- * Project (13)
@@ -29,105 +29,40 @@ TakeOrderedAndProject (129)
       :                             :     :           :              +- * ColumnarToRow (5)
       :                             :     :           :                 +- Scan parquet spark_catalog.default.item (4)
       :                             :     :           +- ReusedExchange (11)
-      :                             :     +- * Sort (21)
-      :                             :        +- Exchange (20)
-      :                             :           +- * Project (19)
-      :                             :              +- * Filter (18)
-      :                             :                 +- * ColumnarToRow (17)
-      :                             :                    +- Scan parquet spark_catalog.default.catalog_returns (16)
-      :                             :- * Project (42)
-      :                             :  +- * SortMergeJoin LeftOuter (41)
-      :                             :     :- * Sort (34)
-      :                             :     :  +- Exchange (33)
-      :                             :     :     +- * Project (32)
-      :                             :     :        +- * BroadcastHashJoin Inner BuildRight (31)
-      :                             :     :           :- * Project (29)
-      :                             :     :           :  +- * BroadcastHashJoin Inner BuildRight (28)
-      :                             :     :           :     :- * Filter (26)
-      :                             :     :           :     :  +- * ColumnarToRow (25)
-      :                             :     :           :     :     +- Scan parquet spark_catalog.default.store_sales (24)
-      :                             :     :           :     +- ReusedExchange (27)
-      :                             :     :           +- ReusedExchange (30)
-      :                             :     +- * Sort (40)
-      :                             :        +- Exchange (39)
-      :                             :           +- * Project (38)
-      :                             :              +- * Filter (37)
-      :                             :                 +- * ColumnarToRow (36)
-      :                             :                    +- Scan parquet spark_catalog.default.store_returns (35)
-      :                             +- * Project (61)
-      :                                +- * SortMergeJoin LeftOuter (60)
-      :                                   :- * Sort (53)
-      :                                   :  +- Exchange (52)
-      :                                   :     +- * Project (51)
-      :                                   :        +- * BroadcastHashJoin Inner BuildRight (50)
-      :                                   :           :- * Project (48)
-      :                                   :           :  +- * BroadcastHashJoin Inner BuildRight (47)
-      :                                   :           :     :- * Filter (45)
-      :                                   :           :     :  +- * ColumnarToRow (44)
-      :                                   :           :     :     +- Scan parquet spark_catalog.default.web_sales (43)
-      :                                   :           :     +- ReusedExchange (46)
-      :                                   :           +- ReusedExchange (49)
-      :                                   +- * Sort (59)
-      :                                      +- Exchange (58)
-      :                                         +- * Project (57)
-      :                                            +- * Filter (56)
-      :                                               +- * ColumnarToRow (55)
-      :                                                  +- Scan parquet spark_catalog.default.web_returns (54)
-      +- * Sort (126)
-         +- Exchange (125)
-            +- * Filter (124)
-               +- * HashAggregate (123)
-                  +- Exchange (122)
-                     +- * HashAggregate (121)
-                        +- * HashAggregate (120)
-                           +- Exchange (119)
-                              +- * HashAggregate (118)
-                                 +- Union (117)
-                                    :- * Project (86)
-                                    :  +- * SortMergeJoin LeftOuter (85)
-                                    :     :- * Sort (82)
-                                    :     :  +- Exchange (81)
-                                    :     :     +- * Project (80)
-                                    :     :        +- * BroadcastHashJoin Inner BuildRight (79)
-                                    :     :           :- * Project (77)
-                                    :     :           :  +- * BroadcastHashJoin Inner BuildRight (76)
-                                    :     :           :     :- * Filter (74)
-                                    :     :           :     :  +- * ColumnarToRow (73)
-                                    :     :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (72)
-                                    :     :           :     +- ReusedExchange (75)
-                                    :     :           +- ReusedExchange (78)
-                                    :     +- * Sort (84)
-                                    :        +- ReusedExchange (83)
-                                    :- * Project (101)
-                                    :  +- * SortMergeJoin LeftOuter (100)
-                                    :     :- * Sort (97)
-                                    :     :  +- Exchange (96)
-                                    :     :     +- * Project (95)
-                                    :     :        +- * BroadcastHashJoin Inner BuildRight (94)
-                                    :     :           :- * Project (92)
-                                    :     :           :  +- * BroadcastHashJoin Inner BuildRight (91)
-                                    :     :           :     :- * Filter (89)
-                                    :     :           :     :  +- * ColumnarToRow (88)
-                                    :     :           :     :     +- Scan parquet spark_catalog.default.store_sales (87)
-                                    :     :           :     +- ReusedExchange (90)
-                                    :     :           +- ReusedExchange (93)
-                                    :     +- * Sort (99)
-                                    :        +- ReusedExchange (98)
-                                    +- * Project (116)
-                                       +- * SortMergeJoin LeftOuter (115)
-                                          :- * Sort (112)
-                                          :  +- Exchange (111)
-                                          :     +- * Project (110)
-                                          :        +- * BroadcastHashJoin Inner BuildRight (109)
-                                          :           :- * Project (107)
-                                          :           :  +- * BroadcastHashJoin Inner BuildRight (106)
-                                          :           :     :- * Filter (104)
-                                          :           :     :  +- * ColumnarToRow (103)
-                                          :           :     :     +- Scan parquet spark_catalog.default.web_sales (102)
-                                          :           :     +- ReusedExchange (105)
-                                          :           +- ReusedExchange (108)
-                                          +- * Sort (114)
-                                             +- ReusedExchange (113)
+      :                             :     +- * Sort (17)
+      :                             :        +- ReusedExchange (16)
+      :                             :- * Project (34)
+      :                             :  +- * SortMergeJoin LeftOuter (33)
+      :                             :     :- * Sort (30)
+      :                             :     :  +- Exchange (29)
+      :                             :     :     +- * Project (28)
+      :                             :     :        +- * BroadcastHashJoin Inner BuildRight (27)
+      :                             :     :           :- * Project (25)
+      :                             :     :           :  +- * BroadcastHashJoin Inner BuildRight (24)
+      :                             :     :           :     :- * Filter (22)
+      :                             :     :           :     :  +- * ColumnarToRow (21)
+      :                             :     :           :     :     +- Scan parquet spark_catalog.default.store_sales (20)
+      :                             :     :           :     +- ReusedExchange (23)
+      :                             :     :           +- ReusedExchange (26)
+      :                             :     +- * Sort (32)
+      :                             :        +- ReusedExchange (31)
+      :                             +- * Project (49)
+      :                                +- * SortMergeJoin LeftOuter (48)
+      :                                   :- * Sort (45)
+      :                                   :  +- Exchange (44)
+      :                                   :     +- * Project (43)
+      :                                   :        +- * BroadcastHashJoin Inner BuildRight (42)
+      :                                   :           :- * Project (40)
+      :                                   :           :  +- * BroadcastHashJoin Inner BuildRight (39)
+      :                                   :           :     :- * Filter (37)
+      :                                   :           :     :  +- * ColumnarToRow (36)
+      :                                   :           :     :     +- Scan parquet spark_catalog.default.web_sales (35)
+      :                                   :           :     +- ReusedExchange (38)
+      :                                   :           +- ReusedExchange (41)
+      :                                   +- * Sort (47)
+      :                                      +- ReusedExchange (46)
+      +- * Sort (61)
+         +- ReusedExchange (60)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -157,7 +92,7 @@ Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_categor
 
 (6) Filter [codegen id : 1]
 Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
-Condition : ((((((isnotnull(i_category#11) AND (i_category#11 = Books                                             )) AND isnotnull(i_item_sk#7)) AND isnotnull(i_brand_id#8)) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10)) AND isnotnull(i_manufact_id#12))
+Condition : ((((((((((isnotnull(i_category#11) AND (i_category#11 = Books                                             )) AND isnotnull(i_item_sk#7)) AND isnotnull(i_brand_id#8)) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10)) AND isnotnull(i_manufact_id#12)) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(i_brand_id#8, 42), false)) AND might_contain(Subquery scalar-subquery#15, [id=#16], xxhash64(i_class_id#9, 42), false)) AND might_contain(Subquery scalar-subquery#17, [id=#18], xxhash64(i_category_id#10, 42), false)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(i_manufact_id#12, 42), false))
 
 (7) Project [codegen id : 1]
 Output [5]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
@@ -177,603 +112,803 @@ Join condition: None
 Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
 Input [10]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
 
-(11) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#13, d_year#14]
+(11) ReusedExchange [Reuses operator id: 68]
+Output [2]: [d_date_sk#21, d_year#22]
 
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#13]
+Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]
-Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
-Input [11]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_date_sk#13, d_year#14]
+Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#22]
+Input [11]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_date_sk#21, d_year#22]
 
 (14) Exchange
-Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
+Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#22]
 Arguments: hashpartitioning(cs_order_number#2, cs_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) Sort [codegen id : 4]
-Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
+Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#22]
 Arguments: [cs_order_number#2 ASC NULLS FIRST, cs_item_sk#1 ASC NULLS FIRST], false, 0
 
-(16) Scan parquet spark_catalog.default.catalog_returns
-Output [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
-ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_quantity:int,cr_return_amount:decimal(7,2)>
+(16) ReusedExchange [Reuses operator id: 88]
+Output [4]: [cr_item_sk#23, cr_order_number#24, cr_return_quantity#25, cr_return_amount#26]
 
-(17) ColumnarToRow [codegen id : 5]
-Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
+(17) Sort [codegen id : 6]
+Input [4]: [cr_item_sk#23, cr_order_number#24, cr_return_quantity#25, cr_return_amount#26]
+Arguments: [cr_order_number#24 ASC NULLS FIRST, cr_item_sk#23 ASC NULLS FIRST], false, 0
 
-(18) Filter [codegen id : 5]
-Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
-Condition : (isnotnull(cr_order_number#16) AND isnotnull(cr_item_sk#15))
-
-(19) Project [codegen id : 5]
-Output [4]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
-Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
-
-(20) Exchange
-Input [4]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
-Arguments: hashpartitioning(cr_order_number#16, cr_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(21) Sort [codegen id : 6]
-Input [4]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
-Arguments: [cr_order_number#16 ASC NULLS FIRST, cr_item_sk#15 ASC NULLS FIRST], false, 0
-
-(22) SortMergeJoin [codegen id : 7]
+(18) SortMergeJoin [codegen id : 7]
 Left keys [2]: [cs_order_number#2, cs_item_sk#1]
-Right keys [2]: [cr_order_number#16, cr_item_sk#15]
+Right keys [2]: [cr_order_number#24, cr_item_sk#23]
 Join type: LeftOuter
 Join condition: None
 
-(23) Project [codegen id : 7]
-Output [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, (cs_quantity#3 - coalesce(cr_return_quantity#17, 0)) AS sales_cnt#20, (cs_ext_sales_price#4 - coalesce(cr_return_amount#18, 0.00)) AS sales_amt#21]
-Input [13]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14, cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
+(19) Project [codegen id : 7]
+Output [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, (cs_quantity#3 - coalesce(cr_return_quantity#25, 0)) AS sales_cnt#27, (cs_ext_sales_price#4 - coalesce(cr_return_amount#26, 0.00)) AS sales_amt#28]
+Input [13]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#22, cr_item_sk#23, cr_order_number#24, cr_return_quantity#25, cr_return_amount#26]
 
-(24) Scan parquet spark_catalog.default.store_sales
-Output [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
+(20) Scan parquet spark_catalog.default.store_sales
+Output [5]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#26), dynamicpruningexpression(ss_sold_date_sk#26 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#33), dynamicpruningexpression(ss_sold_date_sk#33 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
 
-(25) ColumnarToRow [codegen id : 10]
-Input [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
+(21) ColumnarToRow [codegen id : 10]
+Input [5]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33]
 
-(26) Filter [codegen id : 10]
-Input [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
-Condition : isnotnull(ss_item_sk#22)
+(22) Filter [codegen id : 10]
+Input [5]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33]
+Condition : isnotnull(ss_item_sk#29)
 
-(27) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
+(23) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#34, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38]
 
-(28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_item_sk#22]
-Right keys [1]: [i_item_sk#27]
+(24) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_item_sk#29]
+Right keys [1]: [i_item_sk#34]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 10]
-Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
-Input [10]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
+(25) Project [codegen id : 10]
+Output [9]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38]
+Input [10]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33, i_item_sk#34, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38]
 
-(30) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#32, d_year#33]
+(26) ReusedExchange [Reuses operator id: 68]
+Output [2]: [d_date_sk#39, d_year#40]
 
-(31) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#26]
-Right keys [1]: [d_date_sk#32]
+(27) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#33]
+Right keys [1]: [d_date_sk#39]
 Join type: Inner
 Join condition: None
 
-(32) Project [codegen id : 10]
-Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
-Input [11]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_date_sk#32, d_year#33]
+(28) Project [codegen id : 10]
+Output [9]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_year#40]
+Input [11]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_date_sk#39, d_year#40]
 
-(33) Exchange
-Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
-Arguments: hashpartitioning(ss_ticket_number#23, ss_item_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(29) Exchange
+Input [9]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_year#40]
+Arguments: hashpartitioning(ss_ticket_number#30, ss_item_sk#29, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(34) Sort [codegen id : 11]
-Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
-Arguments: [ss_ticket_number#23 ASC NULLS FIRST, ss_item_sk#22 ASC NULLS FIRST], false, 0
+(30) Sort [codegen id : 11]
+Input [9]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_year#40]
+Arguments: [ss_ticket_number#30 ASC NULLS FIRST, ss_item_sk#29 ASC NULLS FIRST], false, 0
 
-(35) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store_returns]
-PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
-ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_quantity:int,sr_return_amt:decimal(7,2)>
+(31) ReusedExchange [Reuses operator id: 107]
+Output [4]: [sr_item_sk#41, sr_ticket_number#42, sr_return_quantity#43, sr_return_amt#44]
 
-(36) ColumnarToRow [codegen id : 12]
-Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
+(32) Sort [codegen id : 13]
+Input [4]: [sr_item_sk#41, sr_ticket_number#42, sr_return_quantity#43, sr_return_amt#44]
+Arguments: [sr_ticket_number#42 ASC NULLS FIRST, sr_item_sk#41 ASC NULLS FIRST], false, 0
 
-(37) Filter [codegen id : 12]
-Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
-Condition : (isnotnull(sr_ticket_number#35) AND isnotnull(sr_item_sk#34))
-
-(38) Project [codegen id : 12]
-Output [4]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
-Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
-
-(39) Exchange
-Input [4]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
-Arguments: hashpartitioning(sr_ticket_number#35, sr_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(40) Sort [codegen id : 13]
-Input [4]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
-Arguments: [sr_ticket_number#35 ASC NULLS FIRST, sr_item_sk#34 ASC NULLS FIRST], false, 0
-
-(41) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#23, ss_item_sk#22]
-Right keys [2]: [sr_ticket_number#35, sr_item_sk#34]
+(33) SortMergeJoin [codegen id : 14]
+Left keys [2]: [ss_ticket_number#30, ss_item_sk#29]
+Right keys [2]: [sr_ticket_number#42, sr_item_sk#41]
 Join type: LeftOuter
 Join condition: None
 
-(42) Project [codegen id : 14]
-Output [7]: [d_year#33, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, (ss_quantity#24 - coalesce(sr_return_quantity#36, 0)) AS sales_cnt#39, (ss_ext_sales_price#25 - coalesce(sr_return_amt#37, 0.00)) AS sales_amt#40]
-Input [13]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33, sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
+(34) Project [codegen id : 14]
+Output [7]: [d_year#40, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, (ss_quantity#31 - coalesce(sr_return_quantity#43, 0)) AS sales_cnt#45, (ss_ext_sales_price#32 - coalesce(sr_return_amt#44, 0.00)) AS sales_amt#46]
+Input [13]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_year#40, sr_item_sk#41, sr_ticket_number#42, sr_return_quantity#43, sr_return_amt#44]
 
-(43) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
+(35) Scan parquet spark_catalog.default.web_sales
+Output [5]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#45), dynamicpruningexpression(ws_sold_date_sk#45 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#51), dynamicpruningexpression(ws_sold_date_sk#51 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(44) ColumnarToRow [codegen id : 17]
-Input [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
+(36) ColumnarToRow [codegen id : 17]
+Input [5]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51]
 
-(45) Filter [codegen id : 17]
-Input [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
-Condition : isnotnull(ws_item_sk#41)
+(37) Filter [codegen id : 17]
+Input [5]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51]
+Condition : isnotnull(ws_item_sk#47)
 
-(46) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
+(38) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#52, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56]
 
-(47) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_item_sk#41]
-Right keys [1]: [i_item_sk#46]
+(39) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#47]
+Right keys [1]: [i_item_sk#52]
 Join type: Inner
 Join condition: None
 
-(48) Project [codegen id : 17]
-Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
-Input [10]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
+(40) Project [codegen id : 17]
+Output [9]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56]
+Input [10]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51, i_item_sk#52, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56]
 
-(49) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#51, d_year#52]
+(41) ReusedExchange [Reuses operator id: 68]
+Output [2]: [d_date_sk#57, d_year#58]
 
-(50) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_sold_date_sk#45]
-Right keys [1]: [d_date_sk#51]
+(42) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#51]
+Right keys [1]: [d_date_sk#57]
 Join type: Inner
 Join condition: None
 
-(51) Project [codegen id : 17]
-Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
-Input [11]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_date_sk#51, d_year#52]
+(43) Project [codegen id : 17]
+Output [9]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_year#58]
+Input [11]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_date_sk#57, d_year#58]
+
+(44) Exchange
+Input [9]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_year#58]
+Arguments: hashpartitioning(ws_order_number#48, ws_item_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(45) Sort [codegen id : 18]
+Input [9]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_year#58]
+Arguments: [ws_order_number#48 ASC NULLS FIRST, ws_item_sk#47 ASC NULLS FIRST], false, 0
+
+(46) ReusedExchange [Reuses operator id: 126]
+Output [4]: [wr_item_sk#59, wr_order_number#60, wr_return_quantity#61, wr_return_amt#62]
+
+(47) Sort [codegen id : 20]
+Input [4]: [wr_item_sk#59, wr_order_number#60, wr_return_quantity#61, wr_return_amt#62]
+Arguments: [wr_order_number#60 ASC NULLS FIRST, wr_item_sk#59 ASC NULLS FIRST], false, 0
+
+(48) SortMergeJoin [codegen id : 21]
+Left keys [2]: [ws_order_number#48, ws_item_sk#47]
+Right keys [2]: [wr_order_number#60, wr_item_sk#59]
+Join type: LeftOuter
+Join condition: None
+
+(49) Project [codegen id : 21]
+Output [7]: [d_year#58, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, (ws_quantity#49 - coalesce(wr_return_quantity#61, 0)) AS sales_cnt#63, (ws_ext_sales_price#50 - coalesce(wr_return_amt#62, 0.00)) AS sales_amt#64]
+Input [13]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_year#58, wr_item_sk#59, wr_order_number#60, wr_return_quantity#61, wr_return_amt#62]
+
+(50) Union
+
+(51) HashAggregate [codegen id : 22]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Keys [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
 
 (52) Exchange
-Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
-Arguments: hashpartitioning(ws_order_number#42, ws_item_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Arguments: hashpartitioning(d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(53) Sort [codegen id : 18]
-Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
-Arguments: [ws_order_number#42 ASC NULLS FIRST, ws_item_sk#41 ASC NULLS FIRST], false, 0
+(53) HashAggregate [codegen id : 23]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Keys [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
 
-(54) Scan parquet spark_catalog.default.web_returns
-Output [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/web_returns]
-PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
-ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
+(54) HashAggregate [codegen id : 23]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Keys [5]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+Functions [2]: [partial_sum(sales_cnt#27), partial_sum(UnscaledValue(sales_amt#28))]
+Aggregate Attributes [2]: [sum#65, sum#66]
+Results [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#67, sum#68]
 
-(55) ColumnarToRow [codegen id : 19]
-Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
+(55) Exchange
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#67, sum#68]
+Arguments: hashpartitioning(d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(56) Filter [codegen id : 19]
-Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
-Condition : (isnotnull(wr_order_number#54) AND isnotnull(wr_item_sk#53))
+(56) HashAggregate [codegen id : 24]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#67, sum#68]
+Keys [5]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+Functions [2]: [sum(sales_cnt#27), sum(UnscaledValue(sales_amt#28))]
+Aggregate Attributes [2]: [sum(sales_cnt#27)#69, sum(UnscaledValue(sales_amt#28))#70]
+Results [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum(sales_cnt#27)#69 AS sales_cnt#71, MakeDecimal(sum(UnscaledValue(sales_amt#28))#70,18,2) AS sales_amt#72]
 
-(57) Project [codegen id : 19]
-Output [4]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
-Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
+(57) Filter [codegen id : 24]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#71, sales_amt#72]
+Condition : isnotnull(sales_cnt#71)
 
 (58) Exchange
-Input [4]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
-Arguments: hashpartitioning(wr_order_number#54, wr_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#71, sales_amt#72]
+Arguments: hashpartitioning(i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(59) Sort [codegen id : 20]
-Input [4]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
-Arguments: [wr_order_number#54 ASC NULLS FIRST, wr_item_sk#53 ASC NULLS FIRST], false, 0
-
-(60) SortMergeJoin [codegen id : 21]
-Left keys [2]: [ws_order_number#42, ws_item_sk#41]
-Right keys [2]: [wr_order_number#54, wr_item_sk#53]
-Join type: LeftOuter
-Join condition: None
-
-(61) Project [codegen id : 21]
-Output [7]: [d_year#52, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, (ws_quantity#43 - coalesce(wr_return_quantity#55, 0)) AS sales_cnt#58, (ws_ext_sales_price#44 - coalesce(wr_return_amt#56, 0.00)) AS sales_amt#59]
-Input [13]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52, wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
-
-(62) Union
-
-(63) HashAggregate [codegen id : 22]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-
-(64) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Arguments: hashpartitioning(d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(65) HashAggregate [codegen id : 23]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-
-(66) HashAggregate [codegen id : 23]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [5]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Functions [2]: [partial_sum(sales_cnt#20), partial_sum(UnscaledValue(sales_amt#21))]
-Aggregate Attributes [2]: [sum#60, sum#61]
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-
-(67) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-Arguments: hashpartitioning(d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(68) HashAggregate [codegen id : 24]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-Keys [5]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Functions [2]: [sum(sales_cnt#20), sum(UnscaledValue(sales_amt#21))]
-Aggregate Attributes [2]: [sum(sales_cnt#20)#64, sum(UnscaledValue(sales_amt#21))#65]
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum(sales_cnt#20)#64 AS sales_cnt#66, MakeDecimal(sum(UnscaledValue(sales_amt#21))#65,18,2) AS sales_amt#67]
-
-(69) Filter [codegen id : 24]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
-Condition : isnotnull(sales_cnt#66)
-
-(70) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
-Arguments: hashpartitioning(i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(71) Sort [codegen id : 25]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
+(59) Sort [codegen id : 25]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#71, sales_amt#72]
 Arguments: [i_brand_id#8 ASC NULLS FIRST, i_class_id#9 ASC NULLS FIRST, i_category_id#10 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST], false, 0
 
-(72) Scan parquet spark_catalog.default.catalog_sales
-Output [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#72), dynamicpruningexpression(cs_sold_date_sk#72 IN dynamicpruning#73)]
-PushedFilters: [IsNotNull(cs_item_sk)]
-ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_ext_sales_price:decimal(7,2)>
+(60) ReusedExchange [Reuses operator id: 138]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
 
-(73) ColumnarToRow [codegen id : 28]
-Input [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
+(61) Sort [codegen id : 50]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Arguments: [i_brand_id#74 ASC NULLS FIRST, i_class_id#75 ASC NULLS FIRST, i_category_id#76 ASC NULLS FIRST, i_manufact_id#77 ASC NULLS FIRST], false, 0
 
-(74) Filter [codegen id : 28]
-Input [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
-Condition : isnotnull(cs_item_sk#68)
-
-(75) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-
-(76) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_item_sk#68]
-Right keys [1]: [i_item_sk#74]
-Join type: Inner
-Join condition: None
-
-(77) Project [codegen id : 28]
-Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-Input [10]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-
-(78) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#79, d_year#80]
-
-(79) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_sold_date_sk#72]
-Right keys [1]: [d_date_sk#79]
-Join type: Inner
-Join condition: None
-
-(80) Project [codegen id : 28]
-Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
-Input [11]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_date_sk#79, d_year#80]
-
-(81) Exchange
-Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
-Arguments: hashpartitioning(cs_order_number#69, cs_item_sk#68, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(82) Sort [codegen id : 29]
-Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
-Arguments: [cs_order_number#69 ASC NULLS FIRST, cs_item_sk#68 ASC NULLS FIRST], false, 0
-
-(83) ReusedExchange [Reuses operator id: 20]
-Output [4]: [cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
-
-(84) Sort [codegen id : 31]
-Input [4]: [cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
-Arguments: [cr_order_number#82 ASC NULLS FIRST, cr_item_sk#81 ASC NULLS FIRST], false, 0
-
-(85) SortMergeJoin [codegen id : 32]
-Left keys [2]: [cs_order_number#69, cs_item_sk#68]
-Right keys [2]: [cr_order_number#82, cr_item_sk#81]
-Join type: LeftOuter
-Join condition: None
-
-(86) Project [codegen id : 32]
-Output [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, (cs_quantity#70 - coalesce(cr_return_quantity#83, 0)) AS sales_cnt#20, (cs_ext_sales_price#71 - coalesce(cr_return_amount#84, 0.00)) AS sales_amt#21]
-Input [13]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80, cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
-
-(87) Scan parquet spark_catalog.default.store_sales
-Output [5]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#89), dynamicpruningexpression(ss_sold_date_sk#89 IN dynamicpruning#73)]
-PushedFilters: [IsNotNull(ss_item_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
-
-(88) ColumnarToRow [codegen id : 35]
-Input [5]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89]
-
-(89) Filter [codegen id : 35]
-Input [5]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89]
-Condition : isnotnull(ss_item_sk#85)
-
-(90) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#90, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94]
-
-(91) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ss_item_sk#85]
-Right keys [1]: [i_item_sk#90]
-Join type: Inner
-Join condition: None
-
-(92) Project [codegen id : 35]
-Output [9]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94]
-Input [10]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89, i_item_sk#90, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94]
-
-(93) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#95, d_year#96]
-
-(94) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ss_sold_date_sk#89]
-Right keys [1]: [d_date_sk#95]
-Join type: Inner
-Join condition: None
-
-(95) Project [codegen id : 35]
-Output [9]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_year#96]
-Input [11]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_date_sk#95, d_year#96]
-
-(96) Exchange
-Input [9]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_year#96]
-Arguments: hashpartitioning(ss_ticket_number#86, ss_item_sk#85, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(97) Sort [codegen id : 36]
-Input [9]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_year#96]
-Arguments: [ss_ticket_number#86 ASC NULLS FIRST, ss_item_sk#85 ASC NULLS FIRST], false, 0
-
-(98) ReusedExchange [Reuses operator id: 39]
-Output [4]: [sr_item_sk#97, sr_ticket_number#98, sr_return_quantity#99, sr_return_amt#100]
-
-(99) Sort [codegen id : 38]
-Input [4]: [sr_item_sk#97, sr_ticket_number#98, sr_return_quantity#99, sr_return_amt#100]
-Arguments: [sr_ticket_number#98 ASC NULLS FIRST, sr_item_sk#97 ASC NULLS FIRST], false, 0
-
-(100) SortMergeJoin [codegen id : 39]
-Left keys [2]: [ss_ticket_number#86, ss_item_sk#85]
-Right keys [2]: [sr_ticket_number#98, sr_item_sk#97]
-Join type: LeftOuter
-Join condition: None
-
-(101) Project [codegen id : 39]
-Output [7]: [d_year#96, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, (ss_quantity#87 - coalesce(sr_return_quantity#99, 0)) AS sales_cnt#39, (ss_ext_sales_price#88 - coalesce(sr_return_amt#100, 0.00)) AS sales_amt#40]
-Input [13]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_year#96, sr_item_sk#97, sr_ticket_number#98, sr_return_quantity#99, sr_return_amt#100]
-
-(102) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#105), dynamicpruningexpression(ws_sold_date_sk#105 IN dynamicpruning#73)]
-PushedFilters: [IsNotNull(ws_item_sk)]
-ReadSchema: struct<ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
-
-(103) ColumnarToRow [codegen id : 42]
-Input [5]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105]
-
-(104) Filter [codegen id : 42]
-Input [5]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105]
-Condition : isnotnull(ws_item_sk#101)
-
-(105) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#106, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110]
-
-(106) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ws_item_sk#101]
-Right keys [1]: [i_item_sk#106]
-Join type: Inner
-Join condition: None
-
-(107) Project [codegen id : 42]
-Output [9]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110]
-Input [10]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105, i_item_sk#106, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110]
-
-(108) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#111, d_year#112]
-
-(109) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ws_sold_date_sk#105]
-Right keys [1]: [d_date_sk#111]
-Join type: Inner
-Join condition: None
-
-(110) Project [codegen id : 42]
-Output [9]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_year#112]
-Input [11]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_date_sk#111, d_year#112]
-
-(111) Exchange
-Input [9]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_year#112]
-Arguments: hashpartitioning(ws_order_number#102, ws_item_sk#101, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(112) Sort [codegen id : 43]
-Input [9]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_year#112]
-Arguments: [ws_order_number#102 ASC NULLS FIRST, ws_item_sk#101 ASC NULLS FIRST], false, 0
-
-(113) ReusedExchange [Reuses operator id: 58]
-Output [4]: [wr_item_sk#113, wr_order_number#114, wr_return_quantity#115, wr_return_amt#116]
-
-(114) Sort [codegen id : 45]
-Input [4]: [wr_item_sk#113, wr_order_number#114, wr_return_quantity#115, wr_return_amt#116]
-Arguments: [wr_order_number#114 ASC NULLS FIRST, wr_item_sk#113 ASC NULLS FIRST], false, 0
-
-(115) SortMergeJoin [codegen id : 46]
-Left keys [2]: [ws_order_number#102, ws_item_sk#101]
-Right keys [2]: [wr_order_number#114, wr_item_sk#113]
-Join type: LeftOuter
-Join condition: None
-
-(116) Project [codegen id : 46]
-Output [7]: [d_year#112, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, (ws_quantity#103 - coalesce(wr_return_quantity#115, 0)) AS sales_cnt#58, (ws_ext_sales_price#104 - coalesce(wr_return_amt#116, 0.00)) AS sales_amt#59]
-Input [13]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_year#112, wr_item_sk#113, wr_order_number#114, wr_return_quantity#115, wr_return_amt#116]
-
-(117) Union
-
-(118) HashAggregate [codegen id : 47]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-
-(119) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Arguments: hashpartitioning(d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21, 5), ENSURE_REQUIREMENTS, [plan_id=14]
-
-(120) HashAggregate [codegen id : 48]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-
-(121) HashAggregate [codegen id : 48]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Keys [5]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-Functions [2]: [partial_sum(sales_cnt#20), partial_sum(UnscaledValue(sales_amt#21))]
-Aggregate Attributes [2]: [sum#60, sum#117]
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#62, sum#118]
-
-(122) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#62, sum#118]
-Arguments: hashpartitioning(d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=15]
-
-(123) HashAggregate [codegen id : 49]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#62, sum#118]
-Keys [5]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-Functions [2]: [sum(sales_cnt#20), sum(UnscaledValue(sales_amt#21))]
-Aggregate Attributes [2]: [sum(sales_cnt#20)#64, sum(UnscaledValue(sales_amt#21))#65]
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum(sales_cnt#20)#64 AS sales_cnt#119, MakeDecimal(sum(UnscaledValue(sales_amt#21))#65,18,2) AS sales_amt#120]
-
-(124) Filter [codegen id : 49]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#119, sales_amt#120]
-Condition : isnotnull(sales_cnt#119)
-
-(125) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#119, sales_amt#120]
-Arguments: hashpartitioning(i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(126) Sort [codegen id : 50]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#119, sales_amt#120]
-Arguments: [i_brand_id#75 ASC NULLS FIRST, i_class_id#76 ASC NULLS FIRST, i_category_id#77 ASC NULLS FIRST, i_manufact_id#78 ASC NULLS FIRST], false, 0
-
-(127) SortMergeJoin [codegen id : 51]
+(62) SortMergeJoin [codegen id : 51]
 Left keys [4]: [i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Right keys [4]: [i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Right keys [4]: [i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
 Join type: Inner
-Join condition: ((cast(sales_cnt#66 as decimal(17,2)) / cast(sales_cnt#119 as decimal(17,2))) < 0.90000000000000000000)
+Join condition: ((cast(sales_cnt#71 as decimal(17,2)) / cast(sales_cnt#78 as decimal(17,2))) < 0.90000000000000000000)
 
-(128) Project [codegen id : 51]
-Output [10]: [d_year#80 AS prev_year#121, d_year#14 AS year#122, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#119 AS prev_yr_cnt#123, sales_cnt#66 AS curr_yr_cnt#124, (sales_cnt#66 - sales_cnt#119) AS sales_cnt_diff#125, (sales_amt#67 - sales_amt#120) AS sales_amt_diff#126]
-Input [14]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67, d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#119, sales_amt#120]
+(63) Project [codegen id : 51]
+Output [10]: [d_year#73 AS prev_year#80, d_year#22 AS year#81, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#78 AS prev_yr_cnt#82, sales_cnt#71 AS curr_yr_cnt#83, (sales_cnt#71 - sales_cnt#78) AS sales_cnt_diff#84, (sales_amt#72 - sales_amt#79) AS sales_amt_diff#85]
+Input [14]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#71, sales_amt#72, d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
 
-(129) TakeOrderedAndProject
-Input [10]: [prev_year#121, year#122, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#123, curr_yr_cnt#124, sales_cnt_diff#125, sales_amt_diff#126]
-Arguments: 100, [sales_cnt_diff#125 ASC NULLS FIRST], [prev_year#121, year#122, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#123, curr_yr_cnt#124, sales_cnt_diff#125, sales_amt_diff#126]
+(64) TakeOrderedAndProject
+Input [10]: [prev_year#80, year#81, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#82, curr_yr_cnt#83, sales_cnt_diff#84, sales_amt_diff#85]
+Arguments: 100, [sales_cnt_diff#84 ASC NULLS FIRST], [prev_year#80, year#81, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#82, curr_yr_cnt#83, sales_cnt_diff#84, sales_amt_diff#85]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (133)
-+- * Filter (132)
-   +- * ColumnarToRow (131)
-      +- Scan parquet spark_catalog.default.date_dim (130)
+BroadcastExchange (68)
++- * Filter (67)
+   +- * ColumnarToRow (66)
+      +- Scan parquet spark_catalog.default.date_dim (65)
 
 
-(130) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#13, d_year#14]
+(65) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#21, d_year#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(131) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#14]
+(66) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#21, d_year#22]
 
-(132) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#14]
-Condition : ((isnotnull(d_year#14) AND (d_year#14 = 2002)) AND isnotnull(d_date_sk#13))
+(67) Filter [codegen id : 1]
+Input [2]: [d_date_sk#21, d_year#22]
+Condition : ((isnotnull(d_year#22) AND (d_year#22 = 2002)) AND isnotnull(d_date_sk#21))
 
-(133) BroadcastExchange
-Input [2]: [d_date_sk#13, d_year#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=17]
+(68) BroadcastExchange
+Input [2]: [d_date_sk#21, d_year#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-Subquery:2 Hosting operator id = 24 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#6
+Subquery:2 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (141)
++- Exchange (140)
+   +- ObjectHashAggregate (139)
+      +- Exchange (138)
+         +- * Filter (137)
+            +- * HashAggregate (136)
+               +- Exchange (135)
+                  +- * HashAggregate (134)
+                     +- * HashAggregate (133)
+                        +- Exchange (132)
+                           +- * HashAggregate (131)
+                              +- Union (130)
+                                 :- * Project (91)
+                                 :  +- * SortMergeJoin LeftOuter (90)
+                                 :     :- * Sort (83)
+                                 :     :  +- Exchange (82)
+                                 :     :     +- * Project (81)
+                                 :     :        +- * BroadcastHashJoin Inner BuildRight (80)
+                                 :     :           :- * Project (78)
+                                 :     :           :  +- * BroadcastHashJoin Inner BuildRight (77)
+                                 :     :           :     :- * Filter (71)
+                                 :     :           :     :  +- * ColumnarToRow (70)
+                                 :     :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (69)
+                                 :     :           :     +- BroadcastExchange (76)
+                                 :     :           :        +- * Project (75)
+                                 :     :           :           +- * Filter (74)
+                                 :     :           :              +- * ColumnarToRow (73)
+                                 :     :           :                 +- Scan parquet spark_catalog.default.item (72)
+                                 :     :           +- ReusedExchange (79)
+                                 :     +- * Sort (89)
+                                 :        +- Exchange (88)
+                                 :           +- * Project (87)
+                                 :              +- * Filter (86)
+                                 :                 +- * ColumnarToRow (85)
+                                 :                    +- Scan parquet spark_catalog.default.catalog_returns (84)
+                                 :- * Project (110)
+                                 :  +- * SortMergeJoin LeftOuter (109)
+                                 :     :- * Sort (102)
+                                 :     :  +- Exchange (101)
+                                 :     :     +- * Project (100)
+                                 :     :        +- * BroadcastHashJoin Inner BuildRight (99)
+                                 :     :           :- * Project (97)
+                                 :     :           :  +- * BroadcastHashJoin Inner BuildRight (96)
+                                 :     :           :     :- * Filter (94)
+                                 :     :           :     :  +- * ColumnarToRow (93)
+                                 :     :           :     :     +- Scan parquet spark_catalog.default.store_sales (92)
+                                 :     :           :     +- ReusedExchange (95)
+                                 :     :           +- ReusedExchange (98)
+                                 :     +- * Sort (108)
+                                 :        +- Exchange (107)
+                                 :           +- * Project (106)
+                                 :              +- * Filter (105)
+                                 :                 +- * ColumnarToRow (104)
+                                 :                    +- Scan parquet spark_catalog.default.store_returns (103)
+                                 +- * Project (129)
+                                    +- * SortMergeJoin LeftOuter (128)
+                                       :- * Sort (121)
+                                       :  +- Exchange (120)
+                                       :     +- * Project (119)
+                                       :        +- * BroadcastHashJoin Inner BuildRight (118)
+                                       :           :- * Project (116)
+                                       :           :  +- * BroadcastHashJoin Inner BuildRight (115)
+                                       :           :     :- * Filter (113)
+                                       :           :     :  +- * ColumnarToRow (112)
+                                       :           :     :     +- Scan parquet spark_catalog.default.web_sales (111)
+                                       :           :     +- ReusedExchange (114)
+                                       :           +- ReusedExchange (117)
+                                       +- * Sort (127)
+                                          +- Exchange (126)
+                                             +- * Project (125)
+                                                +- * Filter (124)
+                                                   +- * ColumnarToRow (123)
+                                                      +- Scan parquet spark_catalog.default.web_returns (122)
 
-Subquery:3 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#45 IN dynamicpruning#6
 
-Subquery:4 Hosting operator id = 72 Hosting Expression = cs_sold_date_sk#72 IN dynamicpruning#73
-BroadcastExchange (137)
-+- * Filter (136)
-   +- * ColumnarToRow (135)
-      +- Scan parquet spark_catalog.default.date_dim (134)
+(69) Scan parquet spark_catalog.default.catalog_sales
+Output [5]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#90), dynamicpruningexpression(cs_sold_date_sk#90 IN dynamicpruning#91)]
+PushedFilters: [IsNotNull(cs_item_sk)]
+ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_ext_sales_price:decimal(7,2)>
+
+(70) ColumnarToRow [codegen id : 3]
+Input [5]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90]
+
+(71) Filter [codegen id : 3]
+Input [5]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90]
+Condition : isnotnull(cs_item_sk#86)
+
+(72) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_category#93, i_manufact_id#77]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_category), EqualTo(i_category,Books                                             ), IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id), IsNotNull(i_manufact_id)]
+ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int,i_category:string,i_manufact_id:int>
+
+(73) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_category#93, i_manufact_id#77]
+
+(74) Filter [codegen id : 1]
+Input [6]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_category#93, i_manufact_id#77]
+Condition : ((((((isnotnull(i_category#93) AND (i_category#93 = Books                                             )) AND isnotnull(i_item_sk#92)) AND isnotnull(i_brand_id#74)) AND isnotnull(i_class_id#75)) AND isnotnull(i_category_id#76)) AND isnotnull(i_manufact_id#77))
+
+(75) Project [codegen id : 1]
+Output [5]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Input [6]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_category#93, i_manufact_id#77]
+
+(76) BroadcastExchange
+Input [5]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+
+(77) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [cs_item_sk#86]
+Right keys [1]: [i_item_sk#92]
+Join type: Inner
+Join condition: None
+
+(78) Project [codegen id : 3]
+Output [9]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Input [10]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90, i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+
+(79) ReusedExchange [Reuses operator id: 145]
+Output [2]: [d_date_sk#94, d_year#73]
+
+(80) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [cs_sold_date_sk#90]
+Right keys [1]: [d_date_sk#94]
+Join type: Inner
+Join condition: None
+
+(81) Project [codegen id : 3]
+Output [9]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_year#73]
+Input [11]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_date_sk#94, d_year#73]
+
+(82) Exchange
+Input [9]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_year#73]
+Arguments: hashpartitioning(cs_order_number#87, cs_item_sk#86, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(83) Sort [codegen id : 4]
+Input [9]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_year#73]
+Arguments: [cs_order_number#87 ASC NULLS FIRST, cs_item_sk#86 ASC NULLS FIRST], false, 0
+
+(84) Scan parquet spark_catalog.default.catalog_returns
+Output [5]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98, cr_returned_date_sk#99]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/catalog_returns]
+PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
+ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_quantity:int,cr_return_amount:decimal(7,2)>
+
+(85) ColumnarToRow [codegen id : 5]
+Input [5]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98, cr_returned_date_sk#99]
+
+(86) Filter [codegen id : 5]
+Input [5]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98, cr_returned_date_sk#99]
+Condition : (isnotnull(cr_order_number#96) AND isnotnull(cr_item_sk#95))
+
+(87) Project [codegen id : 5]
+Output [4]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98]
+Input [5]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98, cr_returned_date_sk#99]
+
+(88) Exchange
+Input [4]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98]
+Arguments: hashpartitioning(cr_order_number#96, cr_item_sk#95, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(89) Sort [codegen id : 6]
+Input [4]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98]
+Arguments: [cr_order_number#96 ASC NULLS FIRST, cr_item_sk#95 ASC NULLS FIRST], false, 0
+
+(90) SortMergeJoin [codegen id : 7]
+Left keys [2]: [cs_order_number#87, cs_item_sk#86]
+Right keys [2]: [cr_order_number#96, cr_item_sk#95]
+Join type: LeftOuter
+Join condition: None
+
+(91) Project [codegen id : 7]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, (cs_quantity#88 - coalesce(cr_return_quantity#97, 0)) AS sales_cnt#27, (cs_ext_sales_price#89 - coalesce(cr_return_amount#98, 0.00)) AS sales_amt#28]
+Input [13]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_year#73, cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98]
+
+(92) Scan parquet spark_catalog.default.store_sales
+Output [5]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#104), dynamicpruningexpression(ss_sold_date_sk#104 IN dynamicpruning#91)]
+PushedFilters: [IsNotNull(ss_item_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
+
+(93) ColumnarToRow [codegen id : 10]
+Input [5]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104]
+
+(94) Filter [codegen id : 10]
+Input [5]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104]
+Condition : isnotnull(ss_item_sk#100)
+
+(95) ReusedExchange [Reuses operator id: 76]
+Output [5]: [i_item_sk#105, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109]
+
+(96) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_item_sk#100]
+Right keys [1]: [i_item_sk#105]
+Join type: Inner
+Join condition: None
+
+(97) Project [codegen id : 10]
+Output [9]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109]
+Input [10]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104, i_item_sk#105, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109]
+
+(98) ReusedExchange [Reuses operator id: 145]
+Output [2]: [d_date_sk#110, d_year#111]
+
+(99) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#104]
+Right keys [1]: [d_date_sk#110]
+Join type: Inner
+Join condition: None
+
+(100) Project [codegen id : 10]
+Output [9]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_year#111]
+Input [11]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_date_sk#110, d_year#111]
+
+(101) Exchange
+Input [9]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_year#111]
+Arguments: hashpartitioning(ss_ticket_number#101, ss_item_sk#100, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(102) Sort [codegen id : 11]
+Input [9]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_year#111]
+Arguments: [ss_ticket_number#101 ASC NULLS FIRST, ss_item_sk#100 ASC NULLS FIRST], false, 0
+
+(103) Scan parquet spark_catalog.default.store_returns
+Output [5]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115, sr_returned_date_sk#116]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store_returns]
+PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
+ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_quantity:int,sr_return_amt:decimal(7,2)>
+
+(104) ColumnarToRow [codegen id : 12]
+Input [5]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115, sr_returned_date_sk#116]
+
+(105) Filter [codegen id : 12]
+Input [5]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115, sr_returned_date_sk#116]
+Condition : (isnotnull(sr_ticket_number#113) AND isnotnull(sr_item_sk#112))
+
+(106) Project [codegen id : 12]
+Output [4]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115]
+Input [5]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115, sr_returned_date_sk#116]
+
+(107) Exchange
+Input [4]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115]
+Arguments: hashpartitioning(sr_ticket_number#113, sr_item_sk#112, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(108) Sort [codegen id : 13]
+Input [4]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115]
+Arguments: [sr_ticket_number#113 ASC NULLS FIRST, sr_item_sk#112 ASC NULLS FIRST], false, 0
+
+(109) SortMergeJoin [codegen id : 14]
+Left keys [2]: [ss_ticket_number#101, ss_item_sk#100]
+Right keys [2]: [sr_ticket_number#113, sr_item_sk#112]
+Join type: LeftOuter
+Join condition: None
+
+(110) Project [codegen id : 14]
+Output [7]: [d_year#111, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, (ss_quantity#102 - coalesce(sr_return_quantity#114, 0)) AS sales_cnt#45, (ss_ext_sales_price#103 - coalesce(sr_return_amt#115, 0.00)) AS sales_amt#46]
+Input [13]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_year#111, sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115]
+
+(111) Scan parquet spark_catalog.default.web_sales
+Output [5]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#121), dynamicpruningexpression(ws_sold_date_sk#121 IN dynamicpruning#91)]
+PushedFilters: [IsNotNull(ws_item_sk)]
+ReadSchema: struct<ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
+
+(112) ColumnarToRow [codegen id : 17]
+Input [5]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121]
+
+(113) Filter [codegen id : 17]
+Input [5]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121]
+Condition : isnotnull(ws_item_sk#117)
+
+(114) ReusedExchange [Reuses operator id: 76]
+Output [5]: [i_item_sk#122, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126]
+
+(115) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#117]
+Right keys [1]: [i_item_sk#122]
+Join type: Inner
+Join condition: None
+
+(116) Project [codegen id : 17]
+Output [9]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126]
+Input [10]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121, i_item_sk#122, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126]
+
+(117) ReusedExchange [Reuses operator id: 145]
+Output [2]: [d_date_sk#127, d_year#128]
+
+(118) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#121]
+Right keys [1]: [d_date_sk#127]
+Join type: Inner
+Join condition: None
+
+(119) Project [codegen id : 17]
+Output [9]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_year#128]
+Input [11]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_date_sk#127, d_year#128]
+
+(120) Exchange
+Input [9]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_year#128]
+Arguments: hashpartitioning(ws_order_number#118, ws_item_sk#117, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(121) Sort [codegen id : 18]
+Input [9]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_year#128]
+Arguments: [ws_order_number#118 ASC NULLS FIRST, ws_item_sk#117 ASC NULLS FIRST], false, 0
+
+(122) Scan parquet spark_catalog.default.web_returns
+Output [5]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132, wr_returned_date_sk#133]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/web_returns]
+PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
+ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
+
+(123) ColumnarToRow [codegen id : 19]
+Input [5]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132, wr_returned_date_sk#133]
+
+(124) Filter [codegen id : 19]
+Input [5]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132, wr_returned_date_sk#133]
+Condition : (isnotnull(wr_order_number#130) AND isnotnull(wr_item_sk#129))
+
+(125) Project [codegen id : 19]
+Output [4]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132]
+Input [5]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132, wr_returned_date_sk#133]
+
+(126) Exchange
+Input [4]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132]
+Arguments: hashpartitioning(wr_order_number#130, wr_item_sk#129, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(127) Sort [codegen id : 20]
+Input [4]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132]
+Arguments: [wr_order_number#130 ASC NULLS FIRST, wr_item_sk#129 ASC NULLS FIRST], false, 0
+
+(128) SortMergeJoin [codegen id : 21]
+Left keys [2]: [ws_order_number#118, ws_item_sk#117]
+Right keys [2]: [wr_order_number#130, wr_item_sk#129]
+Join type: LeftOuter
+Join condition: None
+
+(129) Project [codegen id : 21]
+Output [7]: [d_year#128, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, (ws_quantity#119 - coalesce(wr_return_quantity#131, 0)) AS sales_cnt#63, (ws_ext_sales_price#120 - coalesce(wr_return_amt#132, 0.00)) AS sales_amt#64]
+Input [13]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_year#128, wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132]
+
+(130) Union
+
+(131) HashAggregate [codegen id : 22]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Keys [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+
+(132) Exchange
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Arguments: hashpartitioning(d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(133) HashAggregate [codegen id : 23]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Keys [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+
+(134) HashAggregate [codegen id : 23]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Keys [5]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Functions [2]: [partial_sum(sales_cnt#27), partial_sum(UnscaledValue(sales_amt#28))]
+Aggregate Attributes [2]: [sum#65, sum#134]
+Results [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sum#67, sum#135]
+
+(135) Exchange
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sum#67, sum#135]
+Arguments: hashpartitioning(d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+
+(136) HashAggregate [codegen id : 24]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sum#67, sum#135]
+Keys [5]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Functions [2]: [sum(sales_cnt#27), sum(UnscaledValue(sales_amt#28))]
+Aggregate Attributes [2]: [sum(sales_cnt#27)#69, sum(UnscaledValue(sales_amt#28))#70]
+Results [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sum(sales_cnt#27)#69 AS sales_cnt#78, MakeDecimal(sum(UnscaledValue(sales_amt#28))#70,18,2) AS sales_amt#79]
+
+(137) Filter [codegen id : 24]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Condition : isnotnull(sales_cnt#78)
+
+(138) Exchange
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Arguments: hashpartitioning(i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(139) ObjectHashAggregate
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_brand_id#74, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#136]
+Results [1]: [buf#137]
+
+(140) Exchange
+Input [1]: [buf#137]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+
+(141) ObjectHashAggregate
+Input [1]: [buf#137]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_brand_id#74, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_brand_id#74, 42), 1000000, 8388608, 0, 0)#138]
+Results [1]: [bloom_filter_agg(xxhash64(i_brand_id#74, 42), 1000000, 8388608, 0, 0)#138 AS bloomFilter#139]
+
+Subquery:3 Hosting operator id = 69 Hosting Expression = cs_sold_date_sk#90 IN dynamicpruning#91
+BroadcastExchange (145)
++- * Filter (144)
+   +- * ColumnarToRow (143)
+      +- Scan parquet spark_catalog.default.date_dim (142)
 
 
-(134) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#79, d_year#80]
+(142) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#94, d_year#73]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(135) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#79, d_year#80]
+(143) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#94, d_year#73]
 
-(136) Filter [codegen id : 1]
-Input [2]: [d_date_sk#79, d_year#80]
-Condition : ((isnotnull(d_year#80) AND (d_year#80 = 2001)) AND isnotnull(d_date_sk#79))
+(144) Filter [codegen id : 1]
+Input [2]: [d_date_sk#94, d_year#73]
+Condition : ((isnotnull(d_year#73) AND (d_year#73 = 2001)) AND isnotnull(d_date_sk#94))
 
-(137) BroadcastExchange
-Input [2]: [d_date_sk#79, d_year#80]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
+(145) BroadcastExchange
+Input [2]: [d_date_sk#94, d_year#73]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=20]
 
-Subquery:5 Hosting operator id = 87 Hosting Expression = ss_sold_date_sk#89 IN dynamicpruning#73
+Subquery:4 Hosting operator id = 92 Hosting Expression = ss_sold_date_sk#104 IN dynamicpruning#91
 
-Subquery:6 Hosting operator id = 102 Hosting Expression = ws_sold_date_sk#105 IN dynamicpruning#73
+Subquery:5 Hosting operator id = 111 Hosting Expression = ws_sold_date_sk#121 IN dynamicpruning#91
+
+Subquery:6 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#15, [id=#16]
+ObjectHashAggregate (149)
++- Exchange (148)
+   +- ObjectHashAggregate (147)
+      +- ReusedExchange (146)
+
+
+(146) ReusedExchange [Reuses operator id: 138]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+
+(147) ObjectHashAggregate
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_class_id#75, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#140]
+Results [1]: [buf#141]
+
+(148) Exchange
+Input [1]: [buf#141]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
+
+(149) ObjectHashAggregate
+Input [1]: [buf#141]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_class_id#75, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_class_id#75, 42), 1000000, 8388608, 0, 0)#142]
+Results [1]: [bloom_filter_agg(xxhash64(i_class_id#75, 42), 1000000, 8388608, 0, 0)#142 AS bloomFilter#143]
+
+Subquery:7 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#17, [id=#18]
+ObjectHashAggregate (153)
++- Exchange (152)
+   +- ObjectHashAggregate (151)
+      +- ReusedExchange (150)
+
+
+(150) ReusedExchange [Reuses operator id: 138]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+
+(151) ObjectHashAggregate
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_category_id#76, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#144]
+Results [1]: [buf#145]
+
+(152) Exchange
+Input [1]: [buf#145]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
+
+(153) ObjectHashAggregate
+Input [1]: [buf#145]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_category_id#76, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_category_id#76, 42), 1000000, 8388608, 0, 0)#146]
+Results [1]: [bloom_filter_agg(xxhash64(i_category_id#76, 42), 1000000, 8388608, 0, 0)#146 AS bloomFilter#147]
+
+Subquery:8 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#19, [id=#20]
+ObjectHashAggregate (157)
++- Exchange (156)
+   +- ObjectHashAggregate (155)
+      +- ReusedExchange (154)
+
+
+(154) ReusedExchange [Reuses operator id: 138]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+
+(155) ObjectHashAggregate
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_manufact_id#77, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#148]
+Results [1]: [buf#149]
+
+(156) Exchange
+Input [1]: [buf#149]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=23]
+
+(157) ObjectHashAggregate
+Input [1]: [buf#149]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_manufact_id#77, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_manufact_id#77, 42), 1000000, 8388608, 0, 0)#150]
+Results [1]: [bloom_filter_agg(xxhash64(i_manufact_id#77, 42), 1000000, 8388608, 0, 0)#150 AS bloomFilter#151]
+
+Subquery:9 Hosting operator id = 20 Hosting Expression = ss_sold_date_sk#33 IN dynamicpruning#6
+
+Subquery:10 Hosting operator id = 35 Hosting Expression = ws_sold_date_sk#51 IN dynamicpruning#6
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/simplified.txt
@@ -50,6 +50,151 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                                             WholeStageCodegen (1)
                                                                               Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
                                                                                 Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                  Subquery #2
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_brand_id, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #7
+                                                                                        ObjectHashAggregate [i_brand_id] [buf,buf]
+                                                                                          Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #8
+                                                                                            WholeStageCodegen (24)
+                                                                                              Filter [sales_cnt]
+                                                                                                HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(sales_cnt),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
+                                                                                                  InputAdapter
+                                                                                                    Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #9
+                                                                                                      WholeStageCodegen (23)
+                                                                                                        HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
+                                                                                                          HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                                                                                            InputAdapter
+                                                                                                              Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #10
+                                                                                                                WholeStageCodegen (22)
+                                                                                                                  HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                                                                                                    InputAdapter
+                                                                                                                      Union
+                                                                                                                        WholeStageCodegen (7)
+                                                                                                                          Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
+                                                                                                                            SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (4)
+                                                                                                                                  Sort [cs_order_number,cs_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [cs_order_number,cs_item_sk] #11
+                                                                                                                                        WholeStageCodegen (3)
+                                                                                                                                          Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                                                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                                                                  Filter [cs_item_sk]
+                                                                                                                                                    ColumnarToRow
+                                                                                                                                                      InputAdapter
+                                                                                                                                                        Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk]
+                                                                                                                                                          SubqueryBroadcast [d_date_sk] #3
+                                                                                                                                                            BroadcastExchange #12
+                                                                                                                                                              WholeStageCodegen (1)
+                                                                                                                                                                Filter [d_year,d_date_sk]
+                                                                                                                                                                  ColumnarToRow
+                                                                                                                                                                    InputAdapter
+                                                                                                                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
+                                                                                                                                                  InputAdapter
+                                                                                                                                                    BroadcastExchange #13
+                                                                                                                                                      WholeStageCodegen (1)
+                                                                                                                                                        Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                          Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                            ColumnarToRow
+                                                                                                                                                              InputAdapter
+                                                                                                                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                                                                                                                              InputAdapter
+                                                                                                                                                ReusedExchange [d_date_sk,d_year] #12
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (6)
+                                                                                                                                  Sort [cr_order_number,cr_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [cr_order_number,cr_item_sk] #14
+                                                                                                                                        WholeStageCodegen (5)
+                                                                                                                                          Project [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
+                                                                                                                                            Filter [cr_order_number,cr_item_sk]
+                                                                                                                                              ColumnarToRow
+                                                                                                                                                InputAdapter
+                                                                                                                                                  Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount,cr_returned_date_sk]
+                                                                                                                        WholeStageCodegen (14)
+                                                                                                                          Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                                                                                                            SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (11)
+                                                                                                                                  Sort [ss_ticket_number,ss_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [ss_ticket_number,ss_item_sk] #15
+                                                                                                                                        WholeStageCodegen (10)
+                                                                                                                                          Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                                                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                                                                                  Filter [ss_item_sk]
+                                                                                                                                                    ColumnarToRow
+                                                                                                                                                      InputAdapter
+                                                                                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk]
+                                                                                                                                                          ReusedSubquery [d_date_sk] #3
+                                                                                                                                                  InputAdapter
+                                                                                                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
+                                                                                                                                              InputAdapter
+                                                                                                                                                ReusedExchange [d_date_sk,d_year] #12
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (13)
+                                                                                                                                  Sort [sr_ticket_number,sr_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [sr_ticket_number,sr_item_sk] #16
+                                                                                                                                        WholeStageCodegen (12)
+                                                                                                                                          Project [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
+                                                                                                                                            Filter [sr_ticket_number,sr_item_sk]
+                                                                                                                                              ColumnarToRow
+                                                                                                                                                InputAdapter
+                                                                                                                                                  Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt,sr_returned_date_sk]
+                                                                                                                        WholeStageCodegen (21)
+                                                                                                                          Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
+                                                                                                                            SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (18)
+                                                                                                                                  Sort [ws_order_number,ws_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [ws_order_number,ws_item_sk] #17
+                                                                                                                                        WholeStageCodegen (17)
+                                                                                                                                          Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                                                                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                                                                              Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                                                                                  Filter [ws_item_sk]
+                                                                                                                                                    ColumnarToRow
+                                                                                                                                                      InputAdapter
+                                                                                                                                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk]
+                                                                                                                                                          ReusedSubquery [d_date_sk] #3
+                                                                                                                                                  InputAdapter
+                                                                                                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
+                                                                                                                                              InputAdapter
+                                                                                                                                                ReusedExchange [d_date_sk,d_year] #12
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (20)
+                                                                                                                                  Sort [wr_order_number,wr_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [wr_order_number,wr_item_sk] #18
+                                                                                                                                        WholeStageCodegen (19)
+                                                                                                                                          Project [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
+                                                                                                                                            Filter [wr_order_number,wr_item_sk]
+                                                                                                                                              ColumnarToRow
+                                                                                                                                                InputAdapter
+                                                                                                                                                  Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt,wr_returned_date_sk]
+                                                                                  Subquery #4
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_class_id, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #19
+                                                                                        ObjectHashAggregate [i_class_id] [buf,buf]
+                                                                                          ReusedExchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #8
+                                                                                  Subquery #5
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_category_id, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #20
+                                                                                        ObjectHashAggregate [i_category_id] [buf,buf]
+                                                                                          ReusedExchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #8
+                                                                                  Subquery #6
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_manufact_id, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #21
+                                                                                        ObjectHashAggregate [i_manufact_id] [buf,buf]
+                                                                                          ReusedExchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #8
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
@@ -59,13 +204,7 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                       WholeStageCodegen (6)
                                                         Sort [cr_order_number,cr_item_sk]
                                                           InputAdapter
-                                                            Exchange [cr_order_number,cr_item_sk] #7
-                                                              WholeStageCodegen (5)
-                                                                Project [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
-                                                                  Filter [cr_order_number,cr_item_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount,cr_returned_date_sk]
+                                                            ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #14
                                               WholeStageCodegen (14)
                                                 Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
                                                   SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
@@ -73,7 +212,7 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                       WholeStageCodegen (11)
                                                         Sort [ss_ticket_number,ss_item_sk]
                                                           InputAdapter
-                                                            Exchange [ss_ticket_number,ss_item_sk] #8
+                                                            Exchange [ss_ticket_number,ss_item_sk] #22
                                                               WholeStageCodegen (10)
                                                                 Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
                                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -92,13 +231,7 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                       WholeStageCodegen (13)
                                                         Sort [sr_ticket_number,sr_item_sk]
                                                           InputAdapter
-                                                            Exchange [sr_ticket_number,sr_item_sk] #9
-                                                              WholeStageCodegen (12)
-                                                                Project [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
-                                                                  Filter [sr_ticket_number,sr_item_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt,sr_returned_date_sk]
+                                                            ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #16
                                               WholeStageCodegen (21)
                                                 Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                                   SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
@@ -106,7 +239,7 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                       WholeStageCodegen (18)
                                                         Sort [ws_order_number,ws_item_sk]
                                                           InputAdapter
-                                                            Exchange [ws_order_number,ws_item_sk] #10
+                                                            Exchange [ws_order_number,ws_item_sk] #23
                                                               WholeStageCodegen (17)
                                                                 Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
                                                                   BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
@@ -125,116 +258,9 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                       WholeStageCodegen (20)
                                                         Sort [wr_order_number,wr_item_sk]
                                                           InputAdapter
-                                                            Exchange [wr_order_number,wr_item_sk] #11
-                                                              WholeStageCodegen (19)
-                                                                Project [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
-                                                                  Filter [wr_order_number,wr_item_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt,wr_returned_date_sk]
+                                                            ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #18
         InputAdapter
           WholeStageCodegen (50)
             Sort [i_brand_id,i_class_id,i_category_id,i_manufact_id]
               InputAdapter
-                Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #12
-                  WholeStageCodegen (49)
-                    Filter [sales_cnt]
-                      HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(sales_cnt),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
-                        InputAdapter
-                          Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
-                            WholeStageCodegen (48)
-                              HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
-                                HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                  InputAdapter
-                                    Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #14
-                                      WholeStageCodegen (47)
-                                        HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                          InputAdapter
-                                            Union
-                                              WholeStageCodegen (32)
-                                                Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                    InputAdapter
-                                                      WholeStageCodegen (29)
-                                                        Sort [cs_order_number,cs_item_sk]
-                                                          InputAdapter
-                                                            Exchange [cs_order_number,cs_item_sk] #15
-                                                              WholeStageCodegen (28)
-                                                                Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                        Filter [cs_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk]
-                                                                                SubqueryBroadcast [d_date_sk] #2
-                                                                                  BroadcastExchange #16
-                                                                                    WholeStageCodegen (1)
-                                                                                      Filter [d_year,d_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
-                                                                        InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                    InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
-                                                    InputAdapter
-                                                      WholeStageCodegen (31)
-                                                        Sort [cr_order_number,cr_item_sk]
-                                                          InputAdapter
-                                                            ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #7
-                                              WholeStageCodegen (39)
-                                                Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                    InputAdapter
-                                                      WholeStageCodegen (36)
-                                                        Sort [ss_ticket_number,ss_item_sk]
-                                                          InputAdapter
-                                                            Exchange [ss_ticket_number,ss_item_sk] #17
-                                                              WholeStageCodegen (35)
-                                                                Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                        Filter [ss_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk]
-                                                                                ReusedSubquery [d_date_sk] #2
-                                                                        InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                    InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
-                                                    InputAdapter
-                                                      WholeStageCodegen (38)
-                                                        Sort [sr_ticket_number,sr_item_sk]
-                                                          InputAdapter
-                                                            ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #9
-                                              WholeStageCodegen (46)
-                                                Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
-                                                  SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
-                                                    InputAdapter
-                                                      WholeStageCodegen (43)
-                                                        Sort [ws_order_number,ws_item_sk]
-                                                          InputAdapter
-                                                            Exchange [ws_order_number,ws_item_sk] #18
-                                                              WholeStageCodegen (42)
-                                                                Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                        Filter [ws_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk]
-                                                                                ReusedSubquery [d_date_sk] #2
-                                                                        InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                    InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
-                                                    InputAdapter
-                                                      WholeStageCodegen (45)
-                                                        Sort [wr_order_number,wr_item_sk]
-                                                          InputAdapter
-                                                            ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #11
+                ReusedExchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #8

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/explain.txt
@@ -1,7 +1,7 @@
 == Physical Plan ==
-TakeOrderedAndProject (33)
-+- * Project (32)
-   +- * SortMergeJoin Inner (31)
+TakeOrderedAndProject (30)
++- * Project (29)
+   +- * SortMergeJoin Inner (28)
       :- * Sort (25)
       :  +- Exchange (24)
       :     +- * HashAggregate (23)
@@ -27,11 +27,8 @@ TakeOrderedAndProject (33)
       :                          +- * Filter (16)
       :                             +- * ColumnarToRow (15)
       :                                +- Scan parquet spark_catalog.default.store (14)
-      +- * Sort (30)
-         +- Exchange (29)
-            +- * Filter (28)
-               +- * ColumnarToRow (27)
-                  +- Scan parquet spark_catalog.default.customer (26)
+      +- * Sort (27)
+         +- ReusedExchange (26)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -47,177 +44,208 @@ Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_tic
 
 (3) Filter [codegen id : 4]
 Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8]
-Condition : ((isnotnull(ss_store_sk#4) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
+Condition : (((isnotnull(ss_store_sk#4) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1)) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 38]
-Output [1]: [d_date_sk#10]
+(4) ReusedExchange [Reuses operator id: 42]
+Output [1]: [d_date_sk#12]
 
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#10]
+Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
 Output [7]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8, d_date_sk#10]
+Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8, d_date_sk#12]
 
 (7) Scan parquet spark_catalog.default.household_demographics
-Output [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [Or(EqualTo(hd_dep_count,6),GreaterThan(hd_vehicle_count,2)), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (9) Filter [codegen id : 2]
-Input [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : (((hd_dep_count#12 = 6) OR (hd_vehicle_count#13 > 2)) AND isnotnull(hd_demo_sk#11))
+Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
+Condition : (((hd_dep_count#14 = 6) OR (hd_vehicle_count#15 > 2)) AND isnotnull(hd_demo_sk#13))
 
 (10) Project [codegen id : 2]
-Output [1]: [hd_demo_sk#11]
-Input [3]: [hd_demo_sk#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [hd_demo_sk#13]
+Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (11) BroadcastExchange
-Input [1]: [hd_demo_sk#11]
+Input [1]: [hd_demo_sk#13]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#11]
+Right keys [1]: [hd_demo_sk#13]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, hd_demo_sk#11]
+Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, hd_demo_sk#13]
 
 (14) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#14, s_number_employees#15, s_city#16]
+Output [3]: [s_store_sk#16, s_number_employees#17, s_city#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_number_employees), GreaterThanOrEqual(s_number_employees,200), LessThanOrEqual(s_number_employees,295), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_number_employees:int,s_city:string>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [3]: [s_store_sk#14, s_number_employees#15, s_city#16]
+Input [3]: [s_store_sk#16, s_number_employees#17, s_city#18]
 
 (16) Filter [codegen id : 3]
-Input [3]: [s_store_sk#14, s_number_employees#15, s_city#16]
-Condition : (((isnotnull(s_number_employees#15) AND (s_number_employees#15 >= 200)) AND (s_number_employees#15 <= 295)) AND isnotnull(s_store_sk#14))
+Input [3]: [s_store_sk#16, s_number_employees#17, s_city#18]
+Condition : (((isnotnull(s_number_employees#17) AND (s_number_employees#17 >= 200)) AND (s_number_employees#17 <= 295)) AND isnotnull(s_store_sk#16))
 
 (17) Project [codegen id : 3]
-Output [2]: [s_store_sk#14, s_city#16]
-Input [3]: [s_store_sk#14, s_number_employees#15, s_city#16]
+Output [2]: [s_store_sk#16, s_city#18]
+Input [3]: [s_store_sk#16, s_number_employees#17, s_city#18]
 
 (18) BroadcastExchange
-Input [2]: [s_store_sk#14, s_city#16]
+Input [2]: [s_store_sk#16, s_city#18]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
-Right keys [1]: [s_store_sk#14]
+Right keys [1]: [s_store_sk#16]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
-Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_city#16]
-Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_store_sk#14, s_city#16]
+Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_city#18]
+Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_store_sk#16, s_city#18]
 
 (21) HashAggregate [codegen id : 4]
-Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_city#16]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16]
+Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_city#18]
+Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18]
 Functions [2]: [partial_sum(UnscaledValue(ss_coupon_amt#6)), partial_sum(UnscaledValue(ss_net_profit#7))]
-Aggregate Attributes [2]: [sum#17, sum#18]
-Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16, sum#19, sum#20]
+Aggregate Attributes [2]: [sum#19, sum#20]
+Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18, sum#21, sum#22]
 
 (22) Exchange
-Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16, sum#19, sum#20]
-Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18, sum#21, sum#22]
+Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (23) HashAggregate [codegen id : 5]
-Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16, sum#19, sum#20]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#16]
+Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18, sum#21, sum#22]
+Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, s_city#18]
 Functions [2]: [sum(UnscaledValue(ss_coupon_amt#6)), sum(UnscaledValue(ss_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ss_coupon_amt#6))#21, sum(UnscaledValue(ss_net_profit#7))#22]
-Results [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#16, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#6))#21,17,2) AS amt#23, MakeDecimal(sum(UnscaledValue(ss_net_profit#7))#22,17,2) AS profit#24]
+Aggregate Attributes [2]: [sum(UnscaledValue(ss_coupon_amt#6))#23, sum(UnscaledValue(ss_net_profit#7))#24]
+Results [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#18, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#6))#23,17,2) AS amt#25, MakeDecimal(sum(UnscaledValue(ss_net_profit#7))#24,17,2) AS profit#26]
 
 (24) Exchange
-Input [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#16, amt#23, profit#24]
+Input [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#18, amt#25, profit#26]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (25) Sort [codegen id : 6]
-Input [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#16, amt#23, profit#24]
+Input [5]: [ss_ticket_number#5, ss_customer_sk#1, s_city#18, amt#25, profit#26]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(26) Scan parquet spark_catalog.default.customer
-Output [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
+(26) ReusedExchange [Reuses operator id: 34]
+Output [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+
+(27) Sort [codegen id : 8]
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+Arguments: [c_customer_sk#27 ASC NULLS FIRST], false, 0
+
+(28) SortMergeJoin [codegen id : 9]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#27]
+Join type: Inner
+Join condition: None
+
+(29) Project [codegen id : 9]
+Output [7]: [c_last_name#29, c_first_name#28, substr(s_city#18, 1, 30) AS substr(s_city, 1, 30)#30, ss_ticket_number#5, amt#25, profit#26, s_city#18]
+Input [8]: [ss_ticket_number#5, ss_customer_sk#1, s_city#18, amt#25, profit#26, c_customer_sk#27, c_first_name#28, c_last_name#29]
+
+(30) TakeOrderedAndProject
+Input [7]: [c_last_name#29, c_first_name#28, substr(s_city, 1, 30)#30, ss_ticket_number#5, amt#25, profit#26, s_city#18]
+Arguments: 100, [c_last_name#29 ASC NULLS FIRST, c_first_name#28 ASC NULLS FIRST, substr(s_city#18, 1, 30) ASC NULLS FIRST, profit#26 ASC NULLS FIRST], [c_last_name#29, c_first_name#28, substr(s_city, 1, 30)#30, ss_ticket_number#5, amt#25, profit#26]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (37)
++- Exchange (36)
+   +- ObjectHashAggregate (35)
+      +- Exchange (34)
+         +- * Filter (33)
+            +- * ColumnarToRow (32)
+               +- Scan parquet spark_catalog.default.customer (31)
+
+
+(31) Scan parquet spark_catalog.default.customer
+Output [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
+(32) ColumnarToRow [codegen id : 1]
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
 
-(28) Filter [codegen id : 7]
-Input [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
-Condition : isnotnull(c_customer_sk#25)
+(33) Filter [codegen id : 1]
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+Condition : isnotnull(c_customer_sk#27)
 
-(29) Exchange
-Input [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
-Arguments: hashpartitioning(c_customer_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(34) Exchange
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+Arguments: hashpartitioning(c_customer_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(30) Sort [codegen id : 8]
-Input [3]: [c_customer_sk#25, c_first_name#26, c_last_name#27]
-Arguments: [c_customer_sk#25 ASC NULLS FIRST], false, 0
+(35) ObjectHashAggregate
+Input [3]: [c_customer_sk#27, c_first_name#28, c_last_name#29]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#27, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#31]
+Results [1]: [buf#32]
 
-(31) SortMergeJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#25]
-Join type: Inner
-Join condition: None
+(36) Exchange
+Input [1]: [buf#32]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
-(32) Project [codegen id : 9]
-Output [7]: [c_last_name#27, c_first_name#26, substr(s_city#16, 1, 30) AS substr(s_city, 1, 30)#28, ss_ticket_number#5, amt#23, profit#24, s_city#16]
-Input [8]: [ss_ticket_number#5, ss_customer_sk#1, s_city#16, amt#23, profit#24, c_customer_sk#25, c_first_name#26, c_last_name#27]
+(37) ObjectHashAggregate
+Input [1]: [buf#32]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#27, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#27, 42), 2000000, 16000000, 0, 0)#33]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#27, 42), 2000000, 16000000, 0, 0)#33 AS bloomFilter#34]
 
-(33) TakeOrderedAndProject
-Input [7]: [c_last_name#27, c_first_name#26, substr(s_city, 1, 30)#28, ss_ticket_number#5, amt#23, profit#24, s_city#16]
-Arguments: 100, [c_last_name#27 ASC NULLS FIRST, c_first_name#26 ASC NULLS FIRST, substr(s_city#16, 1, 30) ASC NULLS FIRST, profit#24 ASC NULLS FIRST], [c_last_name#27, c_first_name#26, substr(s_city, 1, 30)#28, ss_ticket_number#5, amt#23, profit#24]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (38)
-+- * Project (37)
-   +- * Filter (36)
-      +- * ColumnarToRow (35)
-         +- Scan parquet spark_catalog.default.date_dim (34)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
+BroadcastExchange (42)
++- * Project (41)
+   +- * Filter (40)
+      +- * ColumnarToRow (39)
+         +- Scan parquet spark_catalog.default.date_dim (38)
 
 
-(34) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_year#29, d_dow#30]
+(38) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#12, d_year#35, d_dow#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dow), EqualTo(d_dow,1), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
-(35) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#29, d_dow#30]
+(39) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#12, d_year#35, d_dow#36]
 
-(36) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#29, d_dow#30]
-Condition : (((isnotnull(d_dow#30) AND (d_dow#30 = 1)) AND d_year#29 IN (1999,2000,2001)) AND isnotnull(d_date_sk#10))
+(40) Filter [codegen id : 1]
+Input [3]: [d_date_sk#12, d_year#35, d_dow#36]
+Condition : (((isnotnull(d_dow#36) AND (d_dow#36 = 1)) AND d_year#35 IN (1999,2000,2001)) AND isnotnull(d_date_sk#12))
 
-(37) Project [codegen id : 1]
-Output [1]: [d_date_sk#10]
-Input [3]: [d_date_sk#10, d_year#29, d_dow#30]
+(41) Project [codegen id : 1]
+Output [1]: [d_date_sk#12]
+Input [3]: [d_date_sk#12, d_year#35, d_dow#36]
 
-(38) BroadcastExchange
-Input [1]: [d_date_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+(42) BroadcastExchange
+Input [1]: [d_date_sk#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/simplified.txt
@@ -20,6 +20,16 @@ TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 
                                       Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
                                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                           Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
+                                            Subquery #2
+                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                Exchange #4
+                                                  ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                    Exchange [c_customer_sk] #5
+                                                      WholeStageCodegen (1)
+                                                        Filter [c_customer_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit,ss_sold_date_sk]
@@ -34,7 +44,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 
                                           InputAdapter
                                             ReusedExchange [d_date_sk] #3
                                       InputAdapter
-                                        BroadcastExchange #4
+                                        BroadcastExchange #6
                                           WholeStageCodegen (2)
                                             Project [hd_demo_sk]
                                               Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
@@ -42,7 +52,7 @@ TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
                                   InputAdapter
-                                    BroadcastExchange #5
+                                    BroadcastExchange #7
                                       WholeStageCodegen (3)
                                         Project [s_store_sk,s_city]
                                           Filter [s_number_employees,s_store_sk]
@@ -53,9 +63,4 @@ TakeOrderedAndProject [c_last_name,c_first_name,s_city,profit,substr(s_city, 1, 
           WholeStageCodegen (8)
             Sort [c_customer_sk]
               InputAdapter
-                Exchange [c_customer_sk] #6
-                  WholeStageCodegen (7)
-                    Filter [c_customer_sk]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
+                ReusedExchange [c_customer_sk,c_first_name,c_last_name] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/explain.txt
@@ -1,10 +1,10 @@
 == Physical Plan ==
-TakeOrderedAndProject (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * Project (45)
-            +- * SortMergeJoin Inner (44)
+TakeOrderedAndProject (22)
++- * HashAggregate (21)
+   +- Exchange (20)
+      +- * HashAggregate (19)
+         +- * Project (18)
+            +- * SortMergeJoin Inner (17)
                :- * Sort (14)
                :  +- Exchange (13)
                :     +- * Project (12)
@@ -19,35 +19,8 @@ TakeOrderedAndProject (49)
                :              +- * Filter (9)
                :                 +- * ColumnarToRow (8)
                :                    +- Scan parquet spark_catalog.default.store (7)
-               +- * Sort (43)
-                  +- Exchange (42)
-                     +- * HashAggregate (41)
-                        +- Exchange (40)
-                           +- * HashAggregate (39)
-                              +- * Project (38)
-                                 +- * BroadcastHashJoin LeftSemi BuildRight (37)
-                                    :- * Filter (17)
-                                    :  +- * ColumnarToRow (16)
-                                    :     +- Scan parquet spark_catalog.default.customer_address (15)
-                                    +- BroadcastExchange (36)
-                                       +- * Project (35)
-                                          +- * Filter (34)
-                                             +- * HashAggregate (33)
-                                                +- Exchange (32)
-                                                   +- * HashAggregate (31)
-                                                      +- * Project (30)
-                                                         +- * SortMergeJoin Inner (29)
-                                                            :- * Sort (22)
-                                                            :  +- Exchange (21)
-                                                            :     +- * Filter (20)
-                                                            :        +- * ColumnarToRow (19)
-                                                            :           +- Scan parquet spark_catalog.default.customer_address (18)
-                                                            +- * Sort (28)
-                                                               +- Exchange (27)
-                                                                  +- * Project (26)
-                                                                     +- * Filter (25)
-                                                                        +- * ColumnarToRow (24)
-                                                                           +- Scan parquet spark_catalog.default.customer (23)
+               +- * Sort (16)
+                  +- ReusedExchange (15)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -65,7 +38,7 @@ Input [3]: [ss_store_sk#1, ss_net_profit#2, ss_sold_date_sk#3]
 Input [3]: [ss_store_sk#1, ss_net_profit#2, ss_sold_date_sk#3]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 54]
+(4) ReusedExchange [Reuses operator id: 27]
 Output [1]: [d_date_sk#5]
 
 (5) BroadcastHashJoin [codegen id : 3]
@@ -90,7 +63,7 @@ Input [3]: [s_store_sk#6, s_store_name#7, s_zip#8]
 
 (9) Filter [codegen id : 2]
 Input [3]: [s_store_sk#6, s_store_name#7, s_zip#8]
-Condition : (isnotnull(s_store_sk#6) AND isnotnull(s_zip#8))
+Condition : ((isnotnull(s_store_sk#6) AND isnotnull(s_zip#8)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(substr(s_zip#8, 1, 2), 42), false))
 
 (10) BroadcastExchange
 Input [3]: [s_store_sk#6, s_store_name#7, s_zip#8]
@@ -114,205 +87,260 @@ Arguments: hashpartitioning(substr(s_zip#8, 1, 2), 5), ENSURE_REQUIREMENTS, [pla
 Input [3]: [ss_net_profit#2, s_store_name#7, s_zip#8]
 Arguments: [substr(s_zip#8, 1, 2) ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.customer_address
-Output [1]: [ca_zip#9]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-ReadSchema: struct<ca_zip:string>
-
-(16) ColumnarToRow [codegen id : 11]
-Input [1]: [ca_zip#9]
-
-(17) Filter [codegen id : 11]
-Input [1]: [ca_zip#9]
-Condition : (substr(ca_zip#9, 1, 5) INSET 10144, 10336, 10390, 10445, 10516, 10567, 11101, 11356, 11376, 11489, 11634, 11928, 12305, 13354, 13375, 13376, 13394, 13595, 13695, 13955, 14060, 14089, 14171, 14328, 14663, 14867, 14922, 15126, 15146, 15371, 15455, 15559, 15723, 15734, 15765, 15798, 15882, 16021, 16725, 16807, 17043, 17183, 17871, 17879, 17920, 18119, 18270, 18376, 18383, 18426, 18652, 18767, 18799, 18840, 18842, 18845, 18906, 19430, 19505, 19512, 19515, 19736, 19769, 19849, 20004, 20260, 20548, 21076, 21195, 21286, 21309, 21337, 21756, 22152, 22245, 22246, 22351, 22437, 22461, 22685, 22744, 22752, 22927, 23006, 23470, 23932, 23968, 24128, 24206, 24317, 24610, 24671, 24676, 24996, 25003, 25103, 25280, 25486, 25631, 25733, 25782, 25858, 25989, 26065, 26105, 26231, 26233, 26653, 26689, 26859, 27068, 27156, 27385, 27700, 28286, 28488, 28545, 28577, 28587, 28709, 28810, 28898, 28915, 29178, 29741, 29839, 30010, 30122, 30431, 30450, 30469, 30625, 30903, 31016, 31029, 31387, 31671, 31880, 32213, 32754, 33123, 33282, 33515, 33786, 34102, 34322, 34425, 35258, 35458, 35474, 35576, 35850, 35942, 36233, 36420, 36446, 36495, 36634, 37125, 37126, 37930, 38122, 38193, 38415, 38607, 38935, 39127, 39192, 39371, 39516, 39736, 39861, 39972, 40081, 40162, 40558, 40604, 41248, 41367, 41368, 41766, 41918, 42029, 42666, 42961, 43285, 43848, 43933, 44165, 44438, 45200, 45266, 45375, 45549, 45692, 45721, 45748, 46081, 46136, 46820, 47305, 47537, 47770, 48033, 48425, 48583, 49130, 49156, 49448, 50016, 50298, 50308, 50412, 51061, 51103, 51200, 51211, 51622, 51649, 51650, 51798, 51949, 52867, 53179, 53268, 53535, 53672, 54364, 54601, 54917, 55253, 55307, 55565, 56240, 56458, 56529, 56571, 56575, 56616, 56691, 56910, 57047, 57647, 57665, 57834, 57855, 58048, 58058, 58078, 58263, 58470, 58943, 59166, 59402, 60099, 60279, 60576, 61265, 61547, 61810, 61860, 62377, 62496, 62878, 62971, 63089, 63193, 63435, 63792, 63837, 63981, 64034, 64147, 64457, 64528, 64544, 65084, 65164, 66162, 66708, 66864, 67030, 67301, 67467, 67473, 67853, 67875, 67897, 68014, 68100, 68101, 68309, 68341, 68621, 68786, 68806, 68880, 68893, 68908, 69035, 69399, 69913, 69952, 70372, 70466, 70738, 71256, 71286, 71791, 71954, 72013, 72151, 72175, 72305, 72325, 72425, 72550, 72823, 73134, 73171, 73241, 73273, 73520, 73650, 74351, 75691, 76107, 76231, 76232, 76614, 76638, 76698, 77191, 77556, 77610, 77721, 78451, 78567, 78668, 78890, 79077, 79777, 79994, 81019, 81096, 81312, 81426, 82136, 82276, 82636, 83041, 83144, 83444, 83849, 83921, 83926, 83933, 84093, 84935, 85816, 86057, 86198, 86284, 86379, 87343, 87501, 87816, 88086, 88190, 88424, 88885, 89091, 89360, 90225, 90257, 90578, 91068, 91110, 91137, 91393, 92712, 94167, 94627, 94898, 94945, 94983, 96451, 96576, 96765, 96888, 96976, 97189, 97789, 98025, 98235, 98294, 98359, 98569, 99076, 99543 AND isnotnull(substr(ca_zip#9, 1, 5)))
-
-(18) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#10, ca_zip#11]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_zip:string>
-
-(19) ColumnarToRow [codegen id : 5]
-Input [2]: [ca_address_sk#10, ca_zip#11]
-
-(20) Filter [codegen id : 5]
-Input [2]: [ca_address_sk#10, ca_zip#11]
-Condition : isnotnull(ca_address_sk#10)
-
-(21) Exchange
-Input [2]: [ca_address_sk#10, ca_zip#11]
-Arguments: hashpartitioning(ca_address_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(22) Sort [codegen id : 6]
-Input [2]: [ca_address_sk#10, ca_zip#11]
-Arguments: [ca_address_sk#10 ASC NULLS FIRST], false, 0
-
-(23) Scan parquet spark_catalog.default.customer
-Output [2]: [c_current_addr_sk#12, c_preferred_cust_flag#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_preferred_cust_flag), EqualTo(c_preferred_cust_flag,Y), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_current_addr_sk:int,c_preferred_cust_flag:string>
-
-(24) ColumnarToRow [codegen id : 7]
-Input [2]: [c_current_addr_sk#12, c_preferred_cust_flag#13]
-
-(25) Filter [codegen id : 7]
-Input [2]: [c_current_addr_sk#12, c_preferred_cust_flag#13]
-Condition : ((isnotnull(c_preferred_cust_flag#13) AND (c_preferred_cust_flag#13 = Y)) AND isnotnull(c_current_addr_sk#12))
-
-(26) Project [codegen id : 7]
-Output [1]: [c_current_addr_sk#12]
-Input [2]: [c_current_addr_sk#12, c_preferred_cust_flag#13]
-
-(27) Exchange
-Input [1]: [c_current_addr_sk#12]
-Arguments: hashpartitioning(c_current_addr_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(28) Sort [codegen id : 8]
-Input [1]: [c_current_addr_sk#12]
-Arguments: [c_current_addr_sk#12 ASC NULLS FIRST], false, 0
-
-(29) SortMergeJoin [codegen id : 9]
-Left keys [1]: [ca_address_sk#10]
-Right keys [1]: [c_current_addr_sk#12]
-Join type: Inner
-Join condition: None
-
-(30) Project [codegen id : 9]
+(15) ReusedExchange [Reuses operator id: 55]
 Output [1]: [ca_zip#11]
-Input [3]: [ca_address_sk#10, ca_zip#11, c_current_addr_sk#12]
 
-(31) HashAggregate [codegen id : 9]
+(16) Sort [codegen id : 13]
 Input [1]: [ca_zip#11]
-Keys [1]: [ca_zip#11]
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#14]
-Results [2]: [ca_zip#11, count#15]
+Arguments: [substr(ca_zip#11, 1, 2) ASC NULLS FIRST], false, 0
 
-(32) Exchange
-Input [2]: [ca_zip#11, count#15]
-Arguments: hashpartitioning(ca_zip#11, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(33) HashAggregate [codegen id : 10]
-Input [2]: [ca_zip#11, count#15]
-Keys [1]: [ca_zip#11]
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#16]
-Results [2]: [substr(ca_zip#11, 1, 5) AS ca_zip#17, count(1)#16 AS cnt#18]
-
-(34) Filter [codegen id : 10]
-Input [2]: [ca_zip#17, cnt#18]
-Condition : (cnt#18 > 10)
-
-(35) Project [codegen id : 10]
-Output [1]: [ca_zip#17]
-Input [2]: [ca_zip#17, cnt#18]
-
-(36) BroadcastExchange
-Input [1]: [ca_zip#17]
-Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true])),false), [plan_id=6]
-
-(37) BroadcastHashJoin [codegen id : 11]
-Left keys [2]: [coalesce(substr(ca_zip#9, 1, 5), ), isnull(substr(ca_zip#9, 1, 5))]
-Right keys [2]: [coalesce(ca_zip#17, ), isnull(ca_zip#17)]
-Join type: LeftSemi
-Join condition: None
-
-(38) Project [codegen id : 11]
-Output [1]: [substr(ca_zip#9, 1, 5) AS ca_zip#19]
-Input [1]: [ca_zip#9]
-
-(39) HashAggregate [codegen id : 11]
-Input [1]: [ca_zip#19]
-Keys [1]: [ca_zip#19]
-Functions: []
-Aggregate Attributes: []
-Results [1]: [ca_zip#19]
-
-(40) Exchange
-Input [1]: [ca_zip#19]
-Arguments: hashpartitioning(ca_zip#19, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(41) HashAggregate [codegen id : 12]
-Input [1]: [ca_zip#19]
-Keys [1]: [ca_zip#19]
-Functions: []
-Aggregate Attributes: []
-Results [1]: [ca_zip#19]
-
-(42) Exchange
-Input [1]: [ca_zip#19]
-Arguments: hashpartitioning(substr(ca_zip#19, 1, 2), 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(43) Sort [codegen id : 13]
-Input [1]: [ca_zip#19]
-Arguments: [substr(ca_zip#19, 1, 2) ASC NULLS FIRST], false, 0
-
-(44) SortMergeJoin [codegen id : 14]
+(17) SortMergeJoin [codegen id : 14]
 Left keys [1]: [substr(s_zip#8, 1, 2)]
-Right keys [1]: [substr(ca_zip#19, 1, 2)]
+Right keys [1]: [substr(ca_zip#11, 1, 2)]
 Join type: Inner
 Join condition: None
 
-(45) Project [codegen id : 14]
+(18) Project [codegen id : 14]
 Output [2]: [ss_net_profit#2, s_store_name#7]
-Input [4]: [ss_net_profit#2, s_store_name#7, s_zip#8, ca_zip#19]
+Input [4]: [ss_net_profit#2, s_store_name#7, s_zip#8, ca_zip#11]
 
-(46) HashAggregate [codegen id : 14]
+(19) HashAggregate [codegen id : 14]
 Input [2]: [ss_net_profit#2, s_store_name#7]
 Keys [1]: [s_store_name#7]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_profit#2))]
-Aggregate Attributes [1]: [sum#20]
-Results [2]: [s_store_name#7, sum#21]
+Aggregate Attributes [1]: [sum#12]
+Results [2]: [s_store_name#7, sum#13]
 
-(47) Exchange
-Input [2]: [s_store_name#7, sum#21]
-Arguments: hashpartitioning(s_store_name#7, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+(20) Exchange
+Input [2]: [s_store_name#7, sum#13]
+Arguments: hashpartitioning(s_store_name#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(48) HashAggregate [codegen id : 15]
-Input [2]: [s_store_name#7, sum#21]
+(21) HashAggregate [codegen id : 15]
+Input [2]: [s_store_name#7, sum#13]
 Keys [1]: [s_store_name#7]
 Functions [1]: [sum(UnscaledValue(ss_net_profit#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#2))#22]
-Results [2]: [s_store_name#7, MakeDecimal(sum(UnscaledValue(ss_net_profit#2))#22,17,2) AS sum(ss_net_profit)#23]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_profit#2))#14]
+Results [2]: [s_store_name#7, MakeDecimal(sum(UnscaledValue(ss_net_profit#2))#14,17,2) AS sum(ss_net_profit)#15]
 
-(49) TakeOrderedAndProject
-Input [2]: [s_store_name#7, sum(ss_net_profit)#23]
-Arguments: 100, [s_store_name#7 ASC NULLS FIRST], [s_store_name#7, sum(ss_net_profit)#23]
+(22) TakeOrderedAndProject
+Input [2]: [s_store_name#7, sum(ss_net_profit)#15]
+Arguments: 100, [s_store_name#7 ASC NULLS FIRST], [s_store_name#7, sum(ss_net_profit)#15]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (54)
-+- * Project (53)
-   +- * Filter (52)
-      +- * ColumnarToRow (51)
-         +- Scan parquet spark_catalog.default.date_dim (50)
+BroadcastExchange (27)
++- * Project (26)
+   +- * Filter (25)
+      +- * ColumnarToRow (24)
+         +- Scan parquet spark_catalog.default.date_dim (23)
 
 
-(50) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#5, d_year#24, d_qoy#25]
+(23) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#5, d_year#16, d_qoy#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(51) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#5, d_year#24, d_qoy#25]
+(24) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#5, d_year#16, d_qoy#17]
 
-(52) Filter [codegen id : 1]
-Input [3]: [d_date_sk#5, d_year#24, d_qoy#25]
-Condition : ((((isnotnull(d_qoy#25) AND isnotnull(d_year#24)) AND (d_qoy#25 = 2)) AND (d_year#24 = 1998)) AND isnotnull(d_date_sk#5))
+(25) Filter [codegen id : 1]
+Input [3]: [d_date_sk#5, d_year#16, d_qoy#17]
+Condition : ((((isnotnull(d_qoy#17) AND isnotnull(d_year#16)) AND (d_qoy#17 = 2)) AND (d_year#16 = 1998)) AND isnotnull(d_date_sk#5))
 
-(53) Project [codegen id : 1]
+(26) Project [codegen id : 1]
 Output [1]: [d_date_sk#5]
-Input [3]: [d_date_sk#5, d_year#24, d_qoy#25]
+Input [3]: [d_date_sk#5, d_year#16, d_qoy#17]
 
-(54) BroadcastExchange
+(27) BroadcastExchange
 Input [1]: [d_date_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+
+Subquery:2 Hosting operator id = 9 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
+ObjectHashAggregate (58)
++- Exchange (57)
+   +- ObjectHashAggregate (56)
+      +- Exchange (55)
+         +- * HashAggregate (54)
+            +- Exchange (53)
+               +- * HashAggregate (52)
+                  +- * Project (51)
+                     +- * BroadcastHashJoin LeftSemi BuildRight (50)
+                        :- * Filter (30)
+                        :  +- * ColumnarToRow (29)
+                        :     +- Scan parquet spark_catalog.default.customer_address (28)
+                        +- BroadcastExchange (49)
+                           +- * Project (48)
+                              +- * Filter (47)
+                                 +- * HashAggregate (46)
+                                    +- Exchange (45)
+                                       +- * HashAggregate (44)
+                                          +- * Project (43)
+                                             +- * SortMergeJoin Inner (42)
+                                                :- * Sort (35)
+                                                :  +- Exchange (34)
+                                                :     +- * Filter (33)
+                                                :        +- * ColumnarToRow (32)
+                                                :           +- Scan parquet spark_catalog.default.customer_address (31)
+                                                +- * Sort (41)
+                                                   +- Exchange (40)
+                                                      +- * Project (39)
+                                                         +- * Filter (38)
+                                                            +- * ColumnarToRow (37)
+                                                               +- Scan parquet spark_catalog.default.customer (36)
+
+
+(28) Scan parquet spark_catalog.default.customer_address
+Output [1]: [ca_zip#18]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+ReadSchema: struct<ca_zip:string>
+
+(29) ColumnarToRow [codegen id : 7]
+Input [1]: [ca_zip#18]
+
+(30) Filter [codegen id : 7]
+Input [1]: [ca_zip#18]
+Condition : (substr(ca_zip#18, 1, 5) INSET 10144, 10336, 10390, 10445, 10516, 10567, 11101, 11356, 11376, 11489, 11634, 11928, 12305, 13354, 13375, 13376, 13394, 13595, 13695, 13955, 14060, 14089, 14171, 14328, 14663, 14867, 14922, 15126, 15146, 15371, 15455, 15559, 15723, 15734, 15765, 15798, 15882, 16021, 16725, 16807, 17043, 17183, 17871, 17879, 17920, 18119, 18270, 18376, 18383, 18426, 18652, 18767, 18799, 18840, 18842, 18845, 18906, 19430, 19505, 19512, 19515, 19736, 19769, 19849, 20004, 20260, 20548, 21076, 21195, 21286, 21309, 21337, 21756, 22152, 22245, 22246, 22351, 22437, 22461, 22685, 22744, 22752, 22927, 23006, 23470, 23932, 23968, 24128, 24206, 24317, 24610, 24671, 24676, 24996, 25003, 25103, 25280, 25486, 25631, 25733, 25782, 25858, 25989, 26065, 26105, 26231, 26233, 26653, 26689, 26859, 27068, 27156, 27385, 27700, 28286, 28488, 28545, 28577, 28587, 28709, 28810, 28898, 28915, 29178, 29741, 29839, 30010, 30122, 30431, 30450, 30469, 30625, 30903, 31016, 31029, 31387, 31671, 31880, 32213, 32754, 33123, 33282, 33515, 33786, 34102, 34322, 34425, 35258, 35458, 35474, 35576, 35850, 35942, 36233, 36420, 36446, 36495, 36634, 37125, 37126, 37930, 38122, 38193, 38415, 38607, 38935, 39127, 39192, 39371, 39516, 39736, 39861, 39972, 40081, 40162, 40558, 40604, 41248, 41367, 41368, 41766, 41918, 42029, 42666, 42961, 43285, 43848, 43933, 44165, 44438, 45200, 45266, 45375, 45549, 45692, 45721, 45748, 46081, 46136, 46820, 47305, 47537, 47770, 48033, 48425, 48583, 49130, 49156, 49448, 50016, 50298, 50308, 50412, 51061, 51103, 51200, 51211, 51622, 51649, 51650, 51798, 51949, 52867, 53179, 53268, 53535, 53672, 54364, 54601, 54917, 55253, 55307, 55565, 56240, 56458, 56529, 56571, 56575, 56616, 56691, 56910, 57047, 57647, 57665, 57834, 57855, 58048, 58058, 58078, 58263, 58470, 58943, 59166, 59402, 60099, 60279, 60576, 61265, 61547, 61810, 61860, 62377, 62496, 62878, 62971, 63089, 63193, 63435, 63792, 63837, 63981, 64034, 64147, 64457, 64528, 64544, 65084, 65164, 66162, 66708, 66864, 67030, 67301, 67467, 67473, 67853, 67875, 67897, 68014, 68100, 68101, 68309, 68341, 68621, 68786, 68806, 68880, 68893, 68908, 69035, 69399, 69913, 69952, 70372, 70466, 70738, 71256, 71286, 71791, 71954, 72013, 72151, 72175, 72305, 72325, 72425, 72550, 72823, 73134, 73171, 73241, 73273, 73520, 73650, 74351, 75691, 76107, 76231, 76232, 76614, 76638, 76698, 77191, 77556, 77610, 77721, 78451, 78567, 78668, 78890, 79077, 79777, 79994, 81019, 81096, 81312, 81426, 82136, 82276, 82636, 83041, 83144, 83444, 83849, 83921, 83926, 83933, 84093, 84935, 85816, 86057, 86198, 86284, 86379, 87343, 87501, 87816, 88086, 88190, 88424, 88885, 89091, 89360, 90225, 90257, 90578, 91068, 91110, 91137, 91393, 92712, 94167, 94627, 94898, 94945, 94983, 96451, 96576, 96765, 96888, 96976, 97189, 97789, 98025, 98235, 98294, 98359, 98569, 99076, 99543 AND isnotnull(substr(ca_zip#18, 1, 5)))
+
+(31) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#19, ca_zip#20]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_zip:string>
+
+(32) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#19, ca_zip#20]
+
+(33) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#19, ca_zip#20]
+Condition : isnotnull(ca_address_sk#19)
+
+(34) Exchange
+Input [2]: [ca_address_sk#19, ca_zip#20]
+Arguments: hashpartitioning(ca_address_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(35) Sort [codegen id : 2]
+Input [2]: [ca_address_sk#19, ca_zip#20]
+Arguments: [ca_address_sk#19 ASC NULLS FIRST], false, 0
+
+(36) Scan parquet spark_catalog.default.customer
+Output [2]: [c_current_addr_sk#21, c_preferred_cust_flag#22]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_preferred_cust_flag), EqualTo(c_preferred_cust_flag,Y), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_current_addr_sk:int,c_preferred_cust_flag:string>
+
+(37) ColumnarToRow [codegen id : 3]
+Input [2]: [c_current_addr_sk#21, c_preferred_cust_flag#22]
+
+(38) Filter [codegen id : 3]
+Input [2]: [c_current_addr_sk#21, c_preferred_cust_flag#22]
+Condition : ((isnotnull(c_preferred_cust_flag#22) AND (c_preferred_cust_flag#22 = Y)) AND isnotnull(c_current_addr_sk#21))
+
+(39) Project [codegen id : 3]
+Output [1]: [c_current_addr_sk#21]
+Input [2]: [c_current_addr_sk#21, c_preferred_cust_flag#22]
+
+(40) Exchange
+Input [1]: [c_current_addr_sk#21]
+Arguments: hashpartitioning(c_current_addr_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(41) Sort [codegen id : 4]
+Input [1]: [c_current_addr_sk#21]
+Arguments: [c_current_addr_sk#21 ASC NULLS FIRST], false, 0
+
+(42) SortMergeJoin [codegen id : 5]
+Left keys [1]: [ca_address_sk#19]
+Right keys [1]: [c_current_addr_sk#21]
+Join type: Inner
+Join condition: None
+
+(43) Project [codegen id : 5]
+Output [1]: [ca_zip#20]
+Input [3]: [ca_address_sk#19, ca_zip#20, c_current_addr_sk#21]
+
+(44) HashAggregate [codegen id : 5]
+Input [1]: [ca_zip#20]
+Keys [1]: [ca_zip#20]
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#23]
+Results [2]: [ca_zip#20, count#24]
+
+(45) Exchange
+Input [2]: [ca_zip#20, count#24]
+Arguments: hashpartitioning(ca_zip#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(46) HashAggregate [codegen id : 6]
+Input [2]: [ca_zip#20, count#24]
+Keys [1]: [ca_zip#20]
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#25]
+Results [2]: [substr(ca_zip#20, 1, 5) AS ca_zip#26, count(1)#25 AS cnt#27]
+
+(47) Filter [codegen id : 6]
+Input [2]: [ca_zip#26, cnt#27]
+Condition : (cnt#27 > 10)
+
+(48) Project [codegen id : 6]
+Output [1]: [ca_zip#26]
+Input [2]: [ca_zip#26, cnt#27]
+
+(49) BroadcastExchange
+Input [1]: [ca_zip#26]
+Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), isnull(input[0, string, true])),false), [plan_id=8]
+
+(50) BroadcastHashJoin [codegen id : 7]
+Left keys [2]: [coalesce(substr(ca_zip#18, 1, 5), ), isnull(substr(ca_zip#18, 1, 5))]
+Right keys [2]: [coalesce(ca_zip#26, ), isnull(ca_zip#26)]
+Join type: LeftSemi
+Join condition: None
+
+(51) Project [codegen id : 7]
+Output [1]: [substr(ca_zip#18, 1, 5) AS ca_zip#11]
+Input [1]: [ca_zip#18]
+
+(52) HashAggregate [codegen id : 7]
+Input [1]: [ca_zip#11]
+Keys [1]: [ca_zip#11]
+Functions: []
+Aggregate Attributes: []
+Results [1]: [ca_zip#11]
+
+(53) Exchange
+Input [1]: [ca_zip#11]
+Arguments: hashpartitioning(ca_zip#11, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) HashAggregate [codegen id : 8]
+Input [1]: [ca_zip#11]
+Keys [1]: [ca_zip#11]
+Functions: []
+Aggregate Attributes: []
+Results [1]: [ca_zip#11]
+
+(55) Exchange
+Input [1]: [ca_zip#11]
+Arguments: hashpartitioning(substr(ca_zip#11, 1, 2), 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(56) ObjectHashAggregate
+Input [1]: [ca_zip#11]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(substr(ca_zip#11, 1, 2), 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#28]
+Results [1]: [buf#29]
+
+(57) Exchange
+Input [1]: [buf#29]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+
+(58) ObjectHashAggregate
+Input [1]: [buf#29]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(substr(ca_zip#11, 1, 2), 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(substr(ca_zip#11, 1, 2), 42), 1000000, 8388608, 0, 0)#30]
+Results [1]: [bloom_filter_agg(xxhash64(substr(ca_zip#11, 1, 2), 42), 1000000, 8388608, 0, 0)#30 AS bloomFilter#31]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/simplified.txt
@@ -35,6 +35,56 @@ TakeOrderedAndProject [s_store_name,sum(ss_net_profit)]
                                     BroadcastExchange #4
                                       WholeStageCodegen (2)
                                         Filter [s_store_sk,s_zip]
+                                          Subquery #2
+                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(substr(ca_zip, 1, 2), 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                              Exchange #5
+                                                ObjectHashAggregate [ca_zip] [buf,buf]
+                                                  Exchange [ca_zip] #6
+                                                    WholeStageCodegen (8)
+                                                      HashAggregate [ca_zip]
+                                                        InputAdapter
+                                                          Exchange [ca_zip] #7
+                                                            WholeStageCodegen (7)
+                                                              HashAggregate [ca_zip]
+                                                                Project [ca_zip]
+                                                                  BroadcastHashJoin [ca_zip,ca_zip]
+                                                                    Filter [ca_zip]
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet spark_catalog.default.customer_address [ca_zip]
+                                                                    InputAdapter
+                                                                      BroadcastExchange #8
+                                                                        WholeStageCodegen (6)
+                                                                          Project [ca_zip]
+                                                                            Filter [cnt]
+                                                                              HashAggregate [ca_zip,count] [count(1),ca_zip,cnt,count]
+                                                                                InputAdapter
+                                                                                  Exchange [ca_zip] #9
+                                                                                    WholeStageCodegen (5)
+                                                                                      HashAggregate [ca_zip] [count,count]
+                                                                                        Project [ca_zip]
+                                                                                          SortMergeJoin [ca_address_sk,c_current_addr_sk]
+                                                                                            InputAdapter
+                                                                                              WholeStageCodegen (2)
+                                                                                                Sort [ca_address_sk]
+                                                                                                  InputAdapter
+                                                                                                    Exchange [ca_address_sk] #10
+                                                                                                      WholeStageCodegen (1)
+                                                                                                        Filter [ca_address_sk]
+                                                                                                          ColumnarToRow
+                                                                                                            InputAdapter
+                                                                                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_zip]
+                                                                                            InputAdapter
+                                                                                              WholeStageCodegen (4)
+                                                                                                Sort [c_current_addr_sk]
+                                                                                                  InputAdapter
+                                                                                                    Exchange [c_current_addr_sk] #11
+                                                                                                      WholeStageCodegen (3)
+                                                                                                        Project [c_current_addr_sk]
+                                                                                                          Filter [c_preferred_cust_flag,c_current_addr_sk]
+                                                                                                            ColumnarToRow
+                                                                                                              InputAdapter
+                                                                                                                Scan parquet spark_catalog.default.customer [c_current_addr_sk,c_preferred_cust_flag]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_zip]
@@ -42,49 +92,4 @@ TakeOrderedAndProject [s_store_name,sum(ss_net_profit)]
                     WholeStageCodegen (13)
                       Sort [ca_zip]
                         InputAdapter
-                          Exchange [ca_zip] #5
-                            WholeStageCodegen (12)
-                              HashAggregate [ca_zip]
-                                InputAdapter
-                                  Exchange [ca_zip] #6
-                                    WholeStageCodegen (11)
-                                      HashAggregate [ca_zip]
-                                        Project [ca_zip]
-                                          BroadcastHashJoin [ca_zip,ca_zip]
-                                            Filter [ca_zip]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.customer_address [ca_zip]
-                                            InputAdapter
-                                              BroadcastExchange #7
-                                                WholeStageCodegen (10)
-                                                  Project [ca_zip]
-                                                    Filter [cnt]
-                                                      HashAggregate [ca_zip,count] [count(1),ca_zip,cnt,count]
-                                                        InputAdapter
-                                                          Exchange [ca_zip] #8
-                                                            WholeStageCodegen (9)
-                                                              HashAggregate [ca_zip] [count,count]
-                                                                Project [ca_zip]
-                                                                  SortMergeJoin [ca_address_sk,c_current_addr_sk]
-                                                                    InputAdapter
-                                                                      WholeStageCodegen (6)
-                                                                        Sort [ca_address_sk]
-                                                                          InputAdapter
-                                                                            Exchange [ca_address_sk] #9
-                                                                              WholeStageCodegen (5)
-                                                                                Filter [ca_address_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_zip]
-                                                                    InputAdapter
-                                                                      WholeStageCodegen (8)
-                                                                        Sort [c_current_addr_sk]
-                                                                          InputAdapter
-                                                                            Exchange [c_current_addr_sk] #10
-                                                                              WholeStageCodegen (7)
-                                                                                Project [c_current_addr_sk]
-                                                                                  Filter [c_preferred_cust_flag,c_current_addr_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet spark_catalog.default.customer [c_current_addr_sk,c_preferred_cust_flag]
+                          ReusedExchange [ca_zip] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
@@ -121,7 +121,7 @@ Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_e
 
 (3) Filter [codegen id : 1]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
-Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ss_item_sk#1, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ss_promo_sk#3, 42)))
+Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ss_item_sk#1, 42), true)) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ss_promo_sk#3, 42), true))
 
 (4) Exchange
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
@@ -303,7 +303,7 @@ Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_numbe
 
 (42) Filter [codegen id : 11]
 Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42)))
+Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42), true)) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42), true))
 
 (43) Exchange
 Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
@@ -447,7 +447,7 @@ Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81
 
 (73) Filter [codegen id : 21]
 Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42)))
+Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42), true)) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42), true))
 
 (74) Exchange
 Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+Condition : (isnotnull(ss_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ss_item_sk#11, 42), false))
 
 (20) Project [codegen id : 5]
 Output [1]: [ss_item_sk#11]
@@ -170,25 +170,53 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#13]
+Output [2]: [d_date_sk#10, d_date#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-05-25), LessThanOrEqual(d_date,2000-07-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#13]
+Input [2]: [d_date_sk#10, d_date#15]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#13]
-Condition : (((isnotnull(d_date#13) AND (d_date#13 >= 2000-05-25)) AND (d_date#13 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#10, d_date#15]
+Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-05-25)) AND (d_date#15 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#13]
+Input [2]: [d_date_sk#10, d_date#15]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (37)
++- Exchange (36)
+   +- ObjectHashAggregate (35)
+      +- ReusedExchange (34)
+
+
+(34) ReusedExchange [Reuses operator id: 15]
+Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+
+(35) ObjectHashAggregate
+Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 461487, 3691896, 0, 0)]
+Aggregate Attributes [1]: [buf#16]
+Results [1]: [buf#17]
+
+(36) Exchange
+Input [1]: [buf#17]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+
+(37) ObjectHashAggregate
+Input [1]: [buf#17]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 461487, 3691896, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 461487, 3691896, 0, 0)#18]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 461487, 3691896, 0, 0)#18 AS bloomFilter#19]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
@@ -48,6 +48,11 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                             WholeStageCodegen (5)
                               Project [ss_item_sk]
                                 Filter [ss_item_sk]
+                                  Subquery #2
+                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 461487, 3691896, 0, 0),bloomFilter,buf]
+                                      Exchange #6
+                                        ObjectHashAggregate [i_item_sk] [buf,buf]
+                                          ReusedExchange [i_item_sk,i_item_id,i_item_desc,i_current_price] #2
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
@@ -1,16 +1,16 @@
 == Physical Plan ==
-TakeOrderedAndProject (54)
-+- * HashAggregate (53)
-   +- Exchange (52)
-      +- * HashAggregate (51)
-         +- * Project (50)
-            +- * BroadcastHashJoin Inner BuildRight (49)
-               :- * Project (44)
-               :  +- * BroadcastHashJoin Inner BuildRight (43)
-               :     :- * Project (41)
-               :     :  +- * BroadcastHashJoin Inner BuildRight (40)
-               :     :     :- * Project (34)
-               :     :     :  +- * SortMergeJoin Inner (33)
+TakeOrderedAndProject (51)
++- * HashAggregate (50)
+   +- Exchange (49)
+      +- * HashAggregate (48)
+         +- * Project (47)
+            +- * BroadcastHashJoin Inner BuildRight (46)
+               :- * Project (41)
+               :  +- * BroadcastHashJoin Inner BuildRight (40)
+               :     :- * Project (38)
+               :     :  +- * BroadcastHashJoin Inner BuildRight (37)
+               :     :     :- * Project (31)
+               :     :     :  +- * SortMergeJoin Inner (30)
                :     :     :     :- * Sort (27)
                :     :     :     :  +- Exchange (26)
                :     :     :     :     +- * Project (25)
@@ -38,21 +38,18 @@ TakeOrderedAndProject (54)
                :     :     :     :              +- * Filter (22)
                :     :     :     :                 +- * ColumnarToRow (21)
                :     :     :     :                    +- Scan parquet spark_catalog.default.customer_demographics (20)
-               :     :     :     +- * Sort (32)
-               :     :     :        +- Exchange (31)
-               :     :     :           +- * Filter (30)
-               :     :     :              +- * ColumnarToRow (29)
-               :     :     :                 +- Scan parquet spark_catalog.default.customer_demographics (28)
-               :     :     +- BroadcastExchange (39)
-               :     :        +- * Project (38)
-               :     :           +- * Filter (37)
-               :     :              +- * ColumnarToRow (36)
-               :     :                 +- Scan parquet spark_catalog.default.customer_address (35)
-               :     +- ReusedExchange (42)
-               +- BroadcastExchange (48)
-                  +- * Filter (47)
-                     +- * ColumnarToRow (46)
-                        +- Scan parquet spark_catalog.default.reason (45)
+               :     :     :     +- * Sort (29)
+               :     :     :        +- ReusedExchange (28)
+               :     :     +- BroadcastExchange (36)
+               :     :        +- * Project (35)
+               :     :           +- * Filter (34)
+               :     :              +- * ColumnarToRow (33)
+               :     :                 +- Scan parquet spark_catalog.default.customer_address (32)
+               :     +- ReusedExchange (39)
+               +- BroadcastExchange (45)
+                  +- * Filter (44)
+                     +- * ColumnarToRow (43)
+                        +- Scan parquet spark_catalog.default.reason (42)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -118,7 +115,7 @@ Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_r
 
 (14) Filter [codegen id : 4]
 Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17, wr_returned_date_sk#18]
-Condition : (((((((isnotnull(wr_item_sk#10) AND isnotnull(wr_order_number#15)) AND isnotnull(wr_refunded_cdemo_sk#11)) AND isnotnull(wr_returning_cdemo_sk#13)) AND isnotnull(wr_refunded_addr_sk#12)) AND isnotnull(wr_reason_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(wr_refunded_cdemo_sk#11, 42))) AND might_contain(Subquery scalar-subquery#21, [id=#22], xxhash64(wr_refunded_addr_sk#12, 42)))
+Condition : ((((((((isnotnull(wr_item_sk#10) AND isnotnull(wr_order_number#15)) AND isnotnull(wr_refunded_cdemo_sk#11)) AND isnotnull(wr_returning_cdemo_sk#13)) AND isnotnull(wr_refunded_addr_sk#12)) AND isnotnull(wr_reason_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(wr_refunded_cdemo_sk#11, 42), true)) AND might_contain(Subquery scalar-subquery#21, [id=#22], xxhash64(wr_returning_cdemo_sk#13, 42), false)) AND might_contain(Subquery scalar-subquery#23, [id=#24], xxhash64(wr_refunded_addr_sk#12, 42), true))
 
 (15) Project [codegen id : 4]
 Output [8]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
@@ -143,290 +140,377 @@ Output [10]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#
 Input [14]: [ws_item_sk#1, ws_order_number#3, ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
 
 (20) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Output [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
 (21) ColumnarToRow [codegen id : 6]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Input [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
 
 (22) Filter [codegen id : 6]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Condition : (((isnotnull(cd_demo_sk#23) AND isnotnull(cd_marital_status#24)) AND isnotnull(cd_education_status#25)) AND ((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) OR ((cd_marital_status#24 = S) AND (cd_education_status#25 = College             ))) OR ((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         ))))
+Input [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
+Condition : (((((isnotnull(cd_demo_sk#25) AND isnotnull(cd_marital_status#26)) AND isnotnull(cd_education_status#27)) AND ((((cd_marital_status#26 = M) AND (cd_education_status#27 = Advanced Degree     )) OR ((cd_marital_status#26 = S) AND (cd_education_status#27 = College             ))) OR ((cd_marital_status#26 = W) AND (cd_education_status#27 = 2 yr Degree         )))) AND might_contain(Subquery scalar-subquery#28, [id=#29], xxhash64(cd_marital_status#26, 42), false)) AND might_contain(Subquery scalar-subquery#30, [id=#31], xxhash64(cd_education_status#27, 42), false))
 
 (23) BroadcastExchange
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Input [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 (24) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [wr_refunded_cdemo_sk#11]
-Right keys [1]: [cd_demo_sk#23]
+Right keys [1]: [cd_demo_sk#25]
 Join type: Inner
-Join condition: ((((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) AND (ws_sales_price#5 >= 100.00)) AND (ws_sales_price#5 <= 150.00)) OR ((((cd_marital_status#24 = S) AND (cd_education_status#25 = College             )) AND (ws_sales_price#5 >= 50.00)) AND (ws_sales_price#5 <= 100.00))) OR ((((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         )) AND (ws_sales_price#5 >= 150.00)) AND (ws_sales_price#5 <= 200.00)))
+Join condition: ((((((cd_marital_status#26 = M) AND (cd_education_status#27 = Advanced Degree     )) AND (ws_sales_price#5 >= 100.00)) AND (ws_sales_price#5 <= 150.00)) OR ((((cd_marital_status#26 = S) AND (cd_education_status#27 = College             )) AND (ws_sales_price#5 >= 50.00)) AND (ws_sales_price#5 <= 100.00))) OR ((((cd_marital_status#26 = W) AND (cd_education_status#27 = 2 yr Degree         )) AND (ws_sales_price#5 >= 150.00)) AND (ws_sales_price#5 <= 200.00)))
 
 (25) Project [codegen id : 7]
-Output [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Input [13]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Output [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#26, cd_education_status#27]
+Input [13]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
 
 (26) Exchange
-Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Arguments: hashpartitioning(wr_returning_cdemo_sk#13, cd_marital_status#24, cd_education_status#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#26, cd_education_status#27]
+Arguments: hashpartitioning(wr_returning_cdemo_sk#13, cd_marital_status#26, cd_education_status#27, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (27) Sort [codegen id : 8]
-Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Arguments: [wr_returning_cdemo_sk#13 ASC NULLS FIRST, cd_marital_status#24 ASC NULLS FIRST, cd_education_status#25 ASC NULLS FIRST], false, 0
+Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#26, cd_education_status#27]
+Arguments: [wr_returning_cdemo_sk#13 ASC NULLS FIRST, cd_marital_status#26 ASC NULLS FIRST, cd_education_status#27 ASC NULLS FIRST], false, 0
 
-(28) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status)]
-ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
+(28) ReusedExchange [Reuses operator id: 67]
+Output [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
 
-(29) ColumnarToRow [codegen id : 9]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+(29) Sort [codegen id : 10]
+Input [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+Arguments: [cd_demo_sk#32 ASC NULLS FIRST, cd_marital_status#33 ASC NULLS FIRST, cd_education_status#34 ASC NULLS FIRST], false, 0
 
-(30) Filter [codegen id : 9]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Condition : ((isnotnull(cd_demo_sk#26) AND isnotnull(cd_marital_status#27)) AND isnotnull(cd_education_status#28))
-
-(31) Exchange
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Arguments: hashpartitioning(cd_demo_sk#26, cd_marital_status#27, cd_education_status#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(32) Sort [codegen id : 10]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Arguments: [cd_demo_sk#26 ASC NULLS FIRST, cd_marital_status#27 ASC NULLS FIRST, cd_education_status#28 ASC NULLS FIRST], false, 0
-
-(33) SortMergeJoin [codegen id : 14]
-Left keys [3]: [wr_returning_cdemo_sk#13, cd_marital_status#24, cd_education_status#25]
-Right keys [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+(30) SortMergeJoin [codegen id : 14]
+Left keys [3]: [wr_returning_cdemo_sk#13, cd_marital_status#26, cd_education_status#27]
+Right keys [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 14]
+(31) Project [codegen id : 14]
 Output [7]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [13]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25, cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+Input [13]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#26, cd_education_status#27, cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
 
-(35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(32) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#35, ca_state#36, ca_country#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(36) ColumnarToRow [codegen id : 11]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(33) ColumnarToRow [codegen id : 11]
+Input [3]: [ca_address_sk#35, ca_state#36, ca_country#37]
 
-(37) Filter [codegen id : 11]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
-Condition : (((isnotnull(ca_country#31) AND (ca_country#31 = United States)) AND isnotnull(ca_address_sk#29)) AND ((ca_state#30 IN (IN,OH,NJ) OR ca_state#30 IN (WI,CT,KY)) OR ca_state#30 IN (LA,IA,AR)))
+(34) Filter [codegen id : 11]
+Input [3]: [ca_address_sk#35, ca_state#36, ca_country#37]
+Condition : (((isnotnull(ca_country#37) AND (ca_country#37 = United States)) AND isnotnull(ca_address_sk#35)) AND ((ca_state#36 IN (IN,OH,NJ) OR ca_state#36 IN (WI,CT,KY)) OR ca_state#36 IN (LA,IA,AR)))
 
-(38) Project [codegen id : 11]
-Output [2]: [ca_address_sk#29, ca_state#30]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(35) Project [codegen id : 11]
+Output [2]: [ca_address_sk#35, ca_state#36]
+Input [3]: [ca_address_sk#35, ca_state#36, ca_country#37]
 
-(39) BroadcastExchange
-Input [2]: [ca_address_sk#29, ca_state#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+(36) BroadcastExchange
+Input [2]: [ca_address_sk#35, ca_state#36]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+
+(37) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [wr_refunded_addr_sk#12]
+Right keys [1]: [ca_address_sk#35]
+Join type: Inner
+Join condition: ((((ca_state#36 IN (IN,OH,NJ) AND (ws_net_profit#6 >= 100.00)) AND (ws_net_profit#6 <= 200.00)) OR ((ca_state#36 IN (WI,CT,KY) AND (ws_net_profit#6 >= 150.00)) AND (ws_net_profit#6 <= 300.00))) OR ((ca_state#36 IN (LA,IA,AR) AND (ws_net_profit#6 >= 50.00)) AND (ws_net_profit#6 <= 250.00)))
+
+(38) Project [codegen id : 14]
+Output [5]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
+Input [9]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, ca_address_sk#35, ca_state#36]
+
+(39) ReusedExchange [Reuses operator id: 56]
+Output [1]: [d_date_sk#38]
 
 (40) BroadcastHashJoin [codegen id : 14]
-Left keys [1]: [wr_refunded_addr_sk#12]
-Right keys [1]: [ca_address_sk#29]
-Join type: Inner
-Join condition: ((((ca_state#30 IN (IN,OH,NJ) AND (ws_net_profit#6 >= 100.00)) AND (ws_net_profit#6 <= 200.00)) OR ((ca_state#30 IN (WI,CT,KY) AND (ws_net_profit#6 >= 150.00)) AND (ws_net_profit#6 <= 300.00))) OR ((ca_state#30 IN (LA,IA,AR) AND (ws_net_profit#6 >= 50.00)) AND (ws_net_profit#6 <= 250.00)))
-
-(41) Project [codegen id : 14]
-Output [5]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [9]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, ca_address_sk#29, ca_state#30]
-
-(42) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#32]
-
-(43) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ws_sold_date_sk#7]
-Right keys [1]: [d_date_sk#32]
+Right keys [1]: [d_date_sk#38]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 14]
+(41) Project [codegen id : 14]
 Output [4]: [ws_quantity#4, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [6]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, d_date_sk#32]
+Input [6]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, d_date_sk#38]
 
-(45) Scan parquet spark_catalog.default.reason
-Output [2]: [r_reason_sk#33, r_reason_desc#34]
+(42) Scan parquet spark_catalog.default.reason
+Output [2]: [r_reason_sk#39, r_reason_desc#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/reason]
 PushedFilters: [IsNotNull(r_reason_sk)]
 ReadSchema: struct<r_reason_sk:int,r_reason_desc:string>
 
-(46) ColumnarToRow [codegen id : 13]
-Input [2]: [r_reason_sk#33, r_reason_desc#34]
+(43) ColumnarToRow [codegen id : 13]
+Input [2]: [r_reason_sk#39, r_reason_desc#40]
 
-(47) Filter [codegen id : 13]
-Input [2]: [r_reason_sk#33, r_reason_desc#34]
-Condition : isnotnull(r_reason_sk#33)
+(44) Filter [codegen id : 13]
+Input [2]: [r_reason_sk#39, r_reason_desc#40]
+Condition : isnotnull(r_reason_sk#39)
 
-(48) BroadcastExchange
-Input [2]: [r_reason_sk#33, r_reason_desc#34]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
+(45) BroadcastExchange
+Input [2]: [r_reason_sk#39, r_reason_desc#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(49) BroadcastHashJoin [codegen id : 14]
+(46) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [wr_reason_sk#14]
-Right keys [1]: [r_reason_sk#33]
+Right keys [1]: [r_reason_sk#39]
 Join type: Inner
 Join condition: None
 
-(50) Project [codegen id : 14]
-Output [4]: [ws_quantity#4, wr_fee#16, wr_refunded_cash#17, r_reason_desc#34]
-Input [6]: [ws_quantity#4, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, r_reason_sk#33, r_reason_desc#34]
+(47) Project [codegen id : 14]
+Output [4]: [ws_quantity#4, wr_fee#16, wr_refunded_cash#17, r_reason_desc#40]
+Input [6]: [ws_quantity#4, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, r_reason_sk#39, r_reason_desc#40]
 
-(51) HashAggregate [codegen id : 14]
-Input [4]: [ws_quantity#4, wr_fee#16, wr_refunded_cash#17, r_reason_desc#34]
-Keys [1]: [r_reason_desc#34]
+(48) HashAggregate [codegen id : 14]
+Input [4]: [ws_quantity#4, wr_fee#16, wr_refunded_cash#17, r_reason_desc#40]
+Keys [1]: [r_reason_desc#40]
 Functions [3]: [partial_avg(ws_quantity#4), partial_avg(UnscaledValue(wr_refunded_cash#17)), partial_avg(UnscaledValue(wr_fee#16))]
-Aggregate Attributes [6]: [sum#35, count#36, sum#37, count#38, sum#39, count#40]
-Results [7]: [r_reason_desc#34, sum#41, count#42, sum#43, count#44, sum#45, count#46]
+Aggregate Attributes [6]: [sum#41, count#42, sum#43, count#44, sum#45, count#46]
+Results [7]: [r_reason_desc#40, sum#47, count#48, sum#49, count#50, sum#51, count#52]
 
-(52) Exchange
-Input [7]: [r_reason_desc#34, sum#41, count#42, sum#43, count#44, sum#45, count#46]
-Arguments: hashpartitioning(r_reason_desc#34, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+(49) Exchange
+Input [7]: [r_reason_desc#40, sum#47, count#48, sum#49, count#50, sum#51, count#52]
+Arguments: hashpartitioning(r_reason_desc#40, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(53) HashAggregate [codegen id : 15]
-Input [7]: [r_reason_desc#34, sum#41, count#42, sum#43, count#44, sum#45, count#46]
-Keys [1]: [r_reason_desc#34]
+(50) HashAggregate [codegen id : 15]
+Input [7]: [r_reason_desc#40, sum#47, count#48, sum#49, count#50, sum#51, count#52]
+Keys [1]: [r_reason_desc#40]
 Functions [3]: [avg(ws_quantity#4), avg(UnscaledValue(wr_refunded_cash#17)), avg(UnscaledValue(wr_fee#16))]
-Aggregate Attributes [3]: [avg(ws_quantity#4)#47, avg(UnscaledValue(wr_refunded_cash#17))#48, avg(UnscaledValue(wr_fee#16))#49]
-Results [4]: [substr(r_reason_desc#34, 1, 20) AS substr(r_reason_desc, 1, 20)#50, avg(ws_quantity#4)#47 AS avg(ws_quantity)#51, cast((avg(UnscaledValue(wr_refunded_cash#17))#48 / 100.0) as decimal(11,6)) AS avg(wr_refunded_cash)#52, cast((avg(UnscaledValue(wr_fee#16))#49 / 100.0) as decimal(11,6)) AS avg(wr_fee)#53]
+Aggregate Attributes [3]: [avg(ws_quantity#4)#53, avg(UnscaledValue(wr_refunded_cash#17))#54, avg(UnscaledValue(wr_fee#16))#55]
+Results [4]: [substr(r_reason_desc#40, 1, 20) AS substr(r_reason_desc, 1, 20)#56, avg(ws_quantity#4)#53 AS avg(ws_quantity)#57, cast((avg(UnscaledValue(wr_refunded_cash#17))#54 / 100.0) as decimal(11,6)) AS avg(wr_refunded_cash)#58, cast((avg(UnscaledValue(wr_fee#16))#55 / 100.0) as decimal(11,6)) AS avg(wr_fee)#59]
 
-(54) TakeOrderedAndProject
-Input [4]: [substr(r_reason_desc, 1, 20)#50, avg(ws_quantity)#51, avg(wr_refunded_cash)#52, avg(wr_fee)#53]
-Arguments: 100, [substr(r_reason_desc, 1, 20)#50 ASC NULLS FIRST, avg(ws_quantity)#51 ASC NULLS FIRST, avg(wr_refunded_cash)#52 ASC NULLS FIRST, avg(wr_fee)#53 ASC NULLS FIRST], [substr(r_reason_desc, 1, 20)#50, avg(ws_quantity)#51, avg(wr_refunded_cash)#52, avg(wr_fee)#53]
+(51) TakeOrderedAndProject
+Input [4]: [substr(r_reason_desc, 1, 20)#56, avg(ws_quantity)#57, avg(wr_refunded_cash)#58, avg(wr_fee)#59]
+Arguments: 100, [substr(r_reason_desc, 1, 20)#56 ASC NULLS FIRST, avg(ws_quantity)#57 ASC NULLS FIRST, avg(wr_refunded_cash)#58 ASC NULLS FIRST, avg(wr_fee)#59 ASC NULLS FIRST], [substr(r_reason_desc, 1, 20)#56, avg(ws_quantity)#57, avg(wr_refunded_cash)#58, avg(wr_fee)#59]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (59)
-+- * Project (58)
-   +- * Filter (57)
-      +- * ColumnarToRow (56)
-         +- Scan parquet spark_catalog.default.date_dim (55)
+BroadcastExchange (56)
++- * Project (55)
+   +- * Filter (54)
+      +- * ColumnarToRow (53)
+         +- Scan parquet spark_catalog.default.date_dim (52)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#32, d_year#54]
+(52) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#38, d_year#60]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#32, d_year#54]
+(53) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#38, d_year#60]
 
-(57) Filter [codegen id : 1]
-Input [2]: [d_date_sk#32, d_year#54]
-Condition : ((isnotnull(d_year#54) AND (d_year#54 = 2000)) AND isnotnull(d_date_sk#32))
+(54) Filter [codegen id : 1]
+Input [2]: [d_date_sk#38, d_year#60]
+Condition : ((isnotnull(d_year#60) AND (d_year#60 = 2000)) AND isnotnull(d_date_sk#38))
 
-(58) Project [codegen id : 1]
-Output [1]: [d_date_sk#32]
-Input [2]: [d_date_sk#32, d_year#54]
+(55) Project [codegen id : 1]
+Output [1]: [d_date_sk#38]
+Input [2]: [d_date_sk#38, d_year#60]
 
-(59) BroadcastExchange
-Input [1]: [d_date_sk#32]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(56) BroadcastExchange
+Input [1]: [d_date_sk#38]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 Subquery:2 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#19, [id=#20]
-ObjectHashAggregate (66)
-+- Exchange (65)
-   +- ObjectHashAggregate (64)
-      +- * Project (63)
-         +- * Filter (62)
-            +- * ColumnarToRow (61)
-               +- Scan parquet spark_catalog.default.customer_demographics (60)
+ObjectHashAggregate (63)
++- Exchange (62)
+   +- ObjectHashAggregate (61)
+      +- * Project (60)
+         +- * Filter (59)
+            +- * ColumnarToRow (58)
+               +- Scan parquet spark_catalog.default.customer_demographics (57)
 
 
-(60) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+(57) Scan parquet spark_catalog.default.customer_demographics
+Output [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
-(61) ColumnarToRow [codegen id : 1]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+(58) ColumnarToRow [codegen id : 1]
+Input [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
 
-(62) Filter [codegen id : 1]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Condition : (((isnotnull(cd_demo_sk#23) AND isnotnull(cd_marital_status#24)) AND isnotnull(cd_education_status#25)) AND ((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) OR ((cd_marital_status#24 = S) AND (cd_education_status#25 = College             ))) OR ((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         ))))
+(59) Filter [codegen id : 1]
+Input [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
+Condition : (((isnotnull(cd_demo_sk#25) AND isnotnull(cd_marital_status#26)) AND isnotnull(cd_education_status#27)) AND ((((cd_marital_status#26 = M) AND (cd_education_status#27 = Advanced Degree     )) OR ((cd_marital_status#26 = S) AND (cd_education_status#27 = College             ))) OR ((cd_marital_status#26 = W) AND (cd_education_status#27 = 2 yr Degree         ))))
 
-(63) Project [codegen id : 1]
-Output [1]: [cd_demo_sk#23]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+(60) Project [codegen id : 1]
+Output [1]: [cd_demo_sk#25]
+Input [3]: [cd_demo_sk#25, cd_marital_status#26, cd_education_status#27]
 
-(64) ObjectHashAggregate
-Input [1]: [cd_demo_sk#23]
+(61) ObjectHashAggregate
+Input [1]: [cd_demo_sk#25]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 1279848, 0, 0)]
-Aggregate Attributes [1]: [buf#55]
-Results [1]: [buf#56]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#25, 42), 159981, 1279848, 0, 0)]
+Aggregate Attributes [1]: [buf#61]
+Results [1]: [buf#62]
 
-(65) Exchange
-Input [1]: [buf#56]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+(62) Exchange
+Input [1]: [buf#62]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(66) ObjectHashAggregate
-Input [1]: [buf#56]
+(63) ObjectHashAggregate
+Input [1]: [buf#62]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 1279848, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 1279848, 0, 0)#57]
-Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 1279848, 0, 0)#57 AS bloomFilter#58]
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#25, 42), 159981, 1279848, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#25, 42), 159981, 1279848, 0, 0)#63]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#25, 42), 159981, 1279848, 0, 0)#63 AS bloomFilter#64]
 
 Subquery:3 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#21, [id=#22]
-ObjectHashAggregate (73)
-+- Exchange (72)
-   +- ObjectHashAggregate (71)
-      +- * Project (70)
-         +- * Filter (69)
-            +- * ColumnarToRow (68)
-               +- Scan parquet spark_catalog.default.customer_address (67)
+ObjectHashAggregate (70)
++- Exchange (69)
+   +- ObjectHashAggregate (68)
+      +- Exchange (67)
+         +- * Filter (66)
+            +- * ColumnarToRow (65)
+               +- Scan parquet spark_catalog.default.customer_demographics (64)
 
 
-(67) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(64) Scan parquet spark_catalog.default.customer_demographics
+Output [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status)]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
+
+(65) ColumnarToRow [codegen id : 1]
+Input [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+
+(66) Filter [codegen id : 1]
+Input [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+Condition : ((isnotnull(cd_demo_sk#32) AND isnotnull(cd_marital_status#33)) AND isnotnull(cd_education_status#34))
+
+(67) Exchange
+Input [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+Arguments: hashpartitioning(cd_demo_sk#32, cd_marital_status#33, cd_education_status#34, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(68) ObjectHashAggregate
+Input [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#32, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#65]
+Results [1]: [buf#66]
+
+(69) Exchange
+Input [1]: [buf#66]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+
+(70) ObjectHashAggregate
+Input [1]: [buf#66]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#32, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#32, 42), 1920800, 15366400, 0, 0)#67]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#32, 42), 1920800, 15366400, 0, 0)#67 AS bloomFilter#68]
+
+Subquery:4 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#23, [id=#24]
+ObjectHashAggregate (77)
++- Exchange (76)
+   +- ObjectHashAggregate (75)
+      +- * Project (74)
+         +- * Filter (73)
+            +- * ColumnarToRow (72)
+               +- Scan parquet spark_catalog.default.customer_address (71)
+
+
+(71) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#35, ca_state#36, ca_country#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(68) ColumnarToRow [codegen id : 1]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(72) ColumnarToRow [codegen id : 1]
+Input [3]: [ca_address_sk#35, ca_state#36, ca_country#37]
 
-(69) Filter [codegen id : 1]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
-Condition : (((isnotnull(ca_country#31) AND (ca_country#31 = United States)) AND isnotnull(ca_address_sk#29)) AND ((ca_state#30 IN (IN,OH,NJ) OR ca_state#30 IN (WI,CT,KY)) OR ca_state#30 IN (LA,IA,AR)))
+(73) Filter [codegen id : 1]
+Input [3]: [ca_address_sk#35, ca_state#36, ca_country#37]
+Condition : (((isnotnull(ca_country#37) AND (ca_country#37 = United States)) AND isnotnull(ca_address_sk#35)) AND ((ca_state#36 IN (IN,OH,NJ) OR ca_state#36 IN (WI,CT,KY)) OR ca_state#36 IN (LA,IA,AR)))
 
-(70) Project [codegen id : 1]
-Output [1]: [ca_address_sk#29]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(74) Project [codegen id : 1]
+Output [1]: [ca_address_sk#35]
+Input [3]: [ca_address_sk#35, ca_state#36, ca_country#37]
 
-(71) ObjectHashAggregate
-Input [1]: [ca_address_sk#29]
+(75) ObjectHashAggregate
+Input [1]: [ca_address_sk#35]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 1222696, 0, 0)]
-Aggregate Attributes [1]: [buf#59]
-Results [1]: [buf#60]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#35, 42), 152837, 1222696, 0, 0)]
+Aggregate Attributes [1]: [buf#69]
+Results [1]: [buf#70]
 
-(72) Exchange
-Input [1]: [buf#60]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+(76) Exchange
+Input [1]: [buf#70]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
-(73) ObjectHashAggregate
-Input [1]: [buf#60]
+(77) ObjectHashAggregate
+Input [1]: [buf#70]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 1222696, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 1222696, 0, 0)#61]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 1222696, 0, 0)#61 AS bloomFilter#62]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#35, 42), 152837, 1222696, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#35, 42), 152837, 1222696, 0, 0)#71]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#35, 42), 152837, 1222696, 0, 0)#71 AS bloomFilter#72]
+
+Subquery:5 Hosting operator id = 22 Hosting Expression = Subquery scalar-subquery#28, [id=#29]
+ObjectHashAggregate (81)
++- Exchange (80)
+   +- ObjectHashAggregate (79)
+      +- ReusedExchange (78)
+
+
+(78) ReusedExchange [Reuses operator id: 67]
+Output [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+
+(79) ObjectHashAggregate
+Input [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_marital_status#33, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#73]
+Results [1]: [buf#74]
+
+(80) Exchange
+Input [1]: [buf#74]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(81) ObjectHashAggregate
+Input [1]: [buf#74]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_marital_status#33, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_marital_status#33, 42), 1920800, 15366400, 0, 0)#75]
+Results [1]: [bloom_filter_agg(xxhash64(cd_marital_status#33, 42), 1920800, 15366400, 0, 0)#75 AS bloomFilter#76]
+
+Subquery:6 Hosting operator id = 22 Hosting Expression = Subquery scalar-subquery#30, [id=#31]
+ObjectHashAggregate (85)
++- Exchange (84)
+   +- ObjectHashAggregate (83)
+      +- ReusedExchange (82)
+
+
+(82) ReusedExchange [Reuses operator id: 67]
+Output [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+
+(83) ObjectHashAggregate
+Input [3]: [cd_demo_sk#32, cd_marital_status#33, cd_education_status#34]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_education_status#34, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#77]
+Results [1]: [buf#78]
+
+(84) Exchange
+Input [1]: [buf#78]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
+
+(85) ObjectHashAggregate
+Input [1]: [buf#78]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_education_status#34, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_education_status#34, 42), 1920800, 15366400, 0, 0)#79]
+Results [1]: [bloom_filter_agg(xxhash64(cd_education_status#34, 42), 1920800, 15366400, 0, 0)#79 AS bloomFilter#80]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/simplified.txt
@@ -69,8 +69,18 @@ TakeOrderedAndProject [substr(r_reason_desc, 1, 20),avg(ws_quantity),avg(wr_refu
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
                                                                   Subquery #3
-                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 152837, 1222696, 0, 0),bloomFilter,buf]
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
                                                                       Exchange #8
+                                                                        ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                          Exchange [cd_demo_sk,cd_marital_status,cd_education_status] #9
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [cd_demo_sk,cd_marital_status,cd_education_status]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
+                                                                  Subquery #4
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 152837, 1222696, 0, 0),bloomFilter,buf]
+                                                                      Exchange #10
                                                                         ObjectHashAggregate [ca_address_sk] [buf,buf]
                                                                           WholeStageCodegen (1)
                                                                             Project [ca_address_sk]
@@ -82,9 +92,19 @@ TakeOrderedAndProject [substr(r_reason_desc, 1, 20),avg(ws_quantity),avg(wr_refu
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_refunded_cdemo_sk,wr_refunded_addr_sk,wr_returning_cdemo_sk,wr_reason_sk,wr_order_number,wr_fee,wr_refunded_cash,wr_returned_date_sk]
                                               InputAdapter
-                                                BroadcastExchange #9
+                                                BroadcastExchange #11
                                                   WholeStageCodegen (6)
                                                     Filter [cd_demo_sk,cd_marital_status,cd_education_status]
+                                                      Subquery #5
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_marital_status, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
+                                                          Exchange #12
+                                                            ObjectHashAggregate [cd_marital_status] [buf,buf]
+                                                              ReusedExchange [cd_demo_sk,cd_marital_status,cd_education_status] #9
+                                                      Subquery #6
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_education_status, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
+                                                          Exchange #13
+                                                            ObjectHashAggregate [cd_education_status] [buf,buf]
+                                                              ReusedExchange [cd_demo_sk,cd_marital_status,cd_education_status] #9
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
@@ -92,14 +112,9 @@ TakeOrderedAndProject [substr(r_reason_desc, 1, 20),avg(ws_quantity),avg(wr_refu
                                 WholeStageCodegen (10)
                                   Sort [cd_demo_sk,cd_marital_status,cd_education_status]
                                     InputAdapter
-                                      Exchange [cd_demo_sk,cd_marital_status,cd_education_status] #10
-                                        WholeStageCodegen (9)
-                                          Filter [cd_demo_sk,cd_marital_status,cd_education_status]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
+                                      ReusedExchange [cd_demo_sk,cd_marital_status,cd_education_status] #9
                           InputAdapter
-                            BroadcastExchange #11
+                            BroadcastExchange #14
                               WholeStageCodegen (11)
                                 Project [ca_address_sk,ca_state]
                                   Filter [ca_country,ca_address_sk,ca_state]
@@ -109,7 +124,7 @@ TakeOrderedAndProject [substr(r_reason_desc, 1, 20),avg(ws_quantity),avg(wr_refu
                       InputAdapter
                         ReusedExchange [d_date_sk] #4
                   InputAdapter
-                    BroadcastExchange #12
+                    BroadcastExchange #15
                       WholeStageCodegen (13)
                         Filter [r_reason_sk]
                           ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/explain.txt
@@ -1,17 +1,17 @@
 == Physical Plan ==
-* HashAggregate (60)
-+- Exchange (59)
-   +- * HashAggregate (58)
-      +- * Project (57)
-         +- * SortMergeJoin LeftAnti (56)
-            :- * SortMergeJoin LeftAnti (38)
-            :  :- * Sort (20)
-            :  :  +- Exchange (19)
-            :  :     +- * HashAggregate (18)
-            :  :        +- Exchange (17)
-            :  :           +- * HashAggregate (16)
-            :  :              +- * Project (15)
-            :  :                 +- * SortMergeJoin Inner (14)
+* HashAggregate (57)
++- Exchange (56)
+   +- * HashAggregate (55)
+      +- * Project (54)
+         +- * SortMergeJoin LeftAnti (53)
+            :- * SortMergeJoin LeftAnti (35)
+            :  :- * Sort (17)
+            :  :  +- Exchange (16)
+            :  :     +- * HashAggregate (15)
+            :  :        +- Exchange (14)
+            :  :           +- * HashAggregate (13)
+            :  :              +- * Project (12)
+            :  :                 +- * SortMergeJoin Inner (11)
             :  :                    :- * Sort (8)
             :  :                    :  +- Exchange (7)
             :  :                    :     +- * Project (6)
@@ -20,45 +20,42 @@
             :  :                    :           :  +- * ColumnarToRow (2)
             :  :                    :           :     +- Scan parquet spark_catalog.default.store_sales (1)
             :  :                    :           +- ReusedExchange (4)
-            :  :                    +- * Sort (13)
-            :  :                       +- Exchange (12)
-            :  :                          +- * Filter (11)
-            :  :                             +- * ColumnarToRow (10)
-            :  :                                +- Scan parquet spark_catalog.default.customer (9)
-            :  +- * Sort (37)
-            :     +- Exchange (36)
-            :        +- * HashAggregate (35)
-            :           +- Exchange (34)
-            :              +- * HashAggregate (33)
-            :                 +- * Project (32)
-            :                    +- * SortMergeJoin Inner (31)
-            :                       :- * Sort (28)
-            :                       :  +- Exchange (27)
-            :                       :     +- * Project (26)
-            :                       :        +- * BroadcastHashJoin Inner BuildRight (25)
-            :                       :           :- * Filter (23)
-            :                       :           :  +- * ColumnarToRow (22)
-            :                       :           :     +- Scan parquet spark_catalog.default.catalog_sales (21)
-            :                       :           +- ReusedExchange (24)
-            :                       +- * Sort (30)
-            :                          +- ReusedExchange (29)
-            +- * Sort (55)
-               +- Exchange (54)
-                  +- * HashAggregate (53)
-                     +- Exchange (52)
-                        +- * HashAggregate (51)
-                           +- * Project (50)
-                              +- * SortMergeJoin Inner (49)
-                                 :- * Sort (46)
-                                 :  +- Exchange (45)
-                                 :     +- * Project (44)
-                                 :        +- * BroadcastHashJoin Inner BuildRight (43)
-                                 :           :- * Filter (41)
-                                 :           :  +- * ColumnarToRow (40)
-                                 :           :     +- Scan parquet spark_catalog.default.web_sales (39)
-                                 :           +- ReusedExchange (42)
-                                 +- * Sort (48)
-                                    +- ReusedExchange (47)
+            :  :                    +- * Sort (10)
+            :  :                       +- ReusedExchange (9)
+            :  +- * Sort (34)
+            :     +- Exchange (33)
+            :        +- * HashAggregate (32)
+            :           +- Exchange (31)
+            :              +- * HashAggregate (30)
+            :                 +- * Project (29)
+            :                    +- * SortMergeJoin Inner (28)
+            :                       :- * Sort (25)
+            :                       :  +- Exchange (24)
+            :                       :     +- * Project (23)
+            :                       :        +- * BroadcastHashJoin Inner BuildRight (22)
+            :                       :           :- * Filter (20)
+            :                       :           :  +- * ColumnarToRow (19)
+            :                       :           :     +- Scan parquet spark_catalog.default.catalog_sales (18)
+            :                       :           +- ReusedExchange (21)
+            :                       +- * Sort (27)
+            :                          +- ReusedExchange (26)
+            +- * Sort (52)
+               +- Exchange (51)
+                  +- * HashAggregate (50)
+                     +- Exchange (49)
+                        +- * HashAggregate (48)
+                           +- * Project (47)
+                              +- * SortMergeJoin Inner (46)
+                                 :- * Sort (43)
+                                 :  +- Exchange (42)
+                                 :     +- * Project (41)
+                                 :        +- * BroadcastHashJoin Inner BuildRight (40)
+                                 :           :- * Filter (38)
+                                 :           :  +- * ColumnarToRow (37)
+                                 :           :     +- Scan parquet spark_catalog.default.web_sales (36)
+                                 :           +- ReusedExchange (39)
+                                 +- * Sort (45)
+                                    +- ReusedExchange (44)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -74,313 +71,392 @@ Input [2]: [ss_customer_sk#1, ss_sold_date_sk#2]
 
 (3) Filter [codegen id : 2]
 Input [2]: [ss_customer_sk#1, ss_sold_date_sk#2]
-Condition : isnotnull(ss_customer_sk#1)
+Condition : (isnotnull(ss_customer_sk#1) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 65]
-Output [2]: [d_date_sk#4, d_date#5]
+(4) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#6, d_date#7]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#2]
-Right keys [1]: [d_date_sk#4]
+Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
-Output [2]: [ss_customer_sk#1, d_date#5]
-Input [4]: [ss_customer_sk#1, ss_sold_date_sk#2, d_date_sk#4, d_date#5]
+Output [2]: [ss_customer_sk#1, d_date#7]
+Input [4]: [ss_customer_sk#1, ss_sold_date_sk#2, d_date_sk#6, d_date#7]
 
 (7) Exchange
-Input [2]: [ss_customer_sk#1, d_date#5]
+Input [2]: [ss_customer_sk#1, d_date#7]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (8) Sort [codegen id : 3]
-Input [2]: [ss_customer_sk#1, d_date#5]
+Input [2]: [ss_customer_sk#1, d_date#7]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer
-Output [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
+(9) ReusedExchange [Reuses operator id: 61]
+Output [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
+
+(10) Sort [codegen id : 5]
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
+Arguments: [c_customer_sk#8 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#8]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Input [5]: [ss_customer_sk#1, d_date#7, c_customer_sk#8, c_first_name#9, c_last_name#10]
+
+(13) HashAggregate [codegen id : 6]
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Keys [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#10, c_first_name#9, d_date#7]
+
+(14) Exchange
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Arguments: hashpartitioning(c_last_name#10, c_first_name#9, d_date#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Keys [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#10, c_first_name#9, d_date#7]
+
+(16) Exchange
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Arguments: hashpartitioning(coalesce(c_last_name#10, ), isnull(c_last_name#10), coalesce(c_first_name#9, ), isnull(c_first_name#9), coalesce(d_date#7, 1970-01-01), isnull(d_date#7), 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(17) Sort [codegen id : 8]
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+Arguments: [coalesce(c_last_name#10, ) ASC NULLS FIRST, isnull(c_last_name#10) ASC NULLS FIRST, coalesce(c_first_name#9, ) ASC NULLS FIRST, isnull(c_first_name#9) ASC NULLS FIRST, coalesce(d_date#7, 1970-01-01) ASC NULLS FIRST, isnull(d_date#7) ASC NULLS FIRST], false, 0
+
+(18) Scan parquet spark_catalog.default.catalog_sales
+Output [2]: [cs_bill_customer_sk#11, cs_sold_date_sk#12]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#12), dynamicpruningexpression(cs_sold_date_sk#12 IN dynamicpruning#3)]
+PushedFilters: [IsNotNull(cs_bill_customer_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int>
+
+(19) ColumnarToRow [codegen id : 10]
+Input [2]: [cs_bill_customer_sk#11, cs_sold_date_sk#12]
+
+(20) Filter [codegen id : 10]
+Input [2]: [cs_bill_customer_sk#11, cs_sold_date_sk#12]
+Condition : (isnotnull(cs_bill_customer_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_bill_customer_sk#11, 42), false))
+
+(21) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#15, d_date#16]
+
+(22) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [cs_sold_date_sk#12]
+Right keys [1]: [d_date_sk#15]
+Join type: Inner
+Join condition: None
+
+(23) Project [codegen id : 10]
+Output [2]: [cs_bill_customer_sk#11, d_date#16]
+Input [4]: [cs_bill_customer_sk#11, cs_sold_date_sk#12, d_date_sk#15, d_date#16]
+
+(24) Exchange
+Input [2]: [cs_bill_customer_sk#11, d_date#16]
+Arguments: hashpartitioning(cs_bill_customer_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(25) Sort [codegen id : 11]
+Input [2]: [cs_bill_customer_sk#11, d_date#16]
+Arguments: [cs_bill_customer_sk#11 ASC NULLS FIRST], false, 0
+
+(26) ReusedExchange [Reuses operator id: 61]
+Output [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+
+(27) Sort [codegen id : 13]
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Arguments: [c_customer_sk#17 ASC NULLS FIRST], false, 0
+
+(28) SortMergeJoin [codegen id : 14]
+Left keys [1]: [cs_bill_customer_sk#11]
+Right keys [1]: [c_customer_sk#17]
+Join type: Inner
+Join condition: None
+
+(29) Project [codegen id : 14]
+Output [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Input [5]: [cs_bill_customer_sk#11, d_date#16, c_customer_sk#17, c_first_name#18, c_last_name#19]
+
+(30) HashAggregate [codegen id : 14]
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Keys [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#19, c_first_name#18, d_date#16]
+
+(31) Exchange
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Arguments: hashpartitioning(c_last_name#19, c_first_name#18, d_date#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(32) HashAggregate [codegen id : 15]
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Keys [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#19, c_first_name#18, d_date#16]
+
+(33) Exchange
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Arguments: hashpartitioning(coalesce(c_last_name#19, ), isnull(c_last_name#19), coalesce(c_first_name#18, ), isnull(c_first_name#18), coalesce(d_date#16, 1970-01-01), isnull(d_date#16), 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(34) Sort [codegen id : 16]
+Input [3]: [c_last_name#19, c_first_name#18, d_date#16]
+Arguments: [coalesce(c_last_name#19, ) ASC NULLS FIRST, isnull(c_last_name#19) ASC NULLS FIRST, coalesce(c_first_name#18, ) ASC NULLS FIRST, isnull(c_first_name#18) ASC NULLS FIRST, coalesce(d_date#16, 1970-01-01) ASC NULLS FIRST, isnull(d_date#16) ASC NULLS FIRST], false, 0
+
+(35) SortMergeJoin [codegen id : 17]
+Left keys [6]: [coalesce(c_last_name#10, ), isnull(c_last_name#10), coalesce(c_first_name#9, ), isnull(c_first_name#9), coalesce(d_date#7, 1970-01-01), isnull(d_date#7)]
+Right keys [6]: [coalesce(c_last_name#19, ), isnull(c_last_name#19), coalesce(c_first_name#18, ), isnull(c_first_name#18), coalesce(d_date#16, 1970-01-01), isnull(d_date#16)]
+Join type: LeftAnti
+Join condition: None
+
+(36) Scan parquet spark_catalog.default.web_sales
+Output [2]: [ws_bill_customer_sk#20, ws_sold_date_sk#21]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#21), dynamicpruningexpression(ws_sold_date_sk#21 IN dynamicpruning#3)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int>
+
+(37) ColumnarToRow [codegen id : 19]
+Input [2]: [ws_bill_customer_sk#20, ws_sold_date_sk#21]
+
+(38) Filter [codegen id : 19]
+Input [2]: [ws_bill_customer_sk#20, ws_sold_date_sk#21]
+Condition : (isnotnull(ws_bill_customer_sk#20) AND might_contain(ReusedSubquery Subquery scalar-subquery#13, [id=#14], xxhash64(ws_bill_customer_sk#20, 42), false))
+
+(39) ReusedExchange [Reuses operator id: 69]
+Output [2]: [d_date_sk#22, d_date#23]
+
+(40) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [ws_sold_date_sk#21]
+Right keys [1]: [d_date_sk#22]
+Join type: Inner
+Join condition: None
+
+(41) Project [codegen id : 19]
+Output [2]: [ws_bill_customer_sk#20, d_date#23]
+Input [4]: [ws_bill_customer_sk#20, ws_sold_date_sk#21, d_date_sk#22, d_date#23]
+
+(42) Exchange
+Input [2]: [ws_bill_customer_sk#20, d_date#23]
+Arguments: hashpartitioning(ws_bill_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(43) Sort [codegen id : 20]
+Input [2]: [ws_bill_customer_sk#20, d_date#23]
+Arguments: [ws_bill_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(44) ReusedExchange [Reuses operator id: 61]
+Output [3]: [c_customer_sk#24, c_first_name#25, c_last_name#26]
+
+(45) Sort [codegen id : 22]
+Input [3]: [c_customer_sk#24, c_first_name#25, c_last_name#26]
+Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
+
+(46) SortMergeJoin [codegen id : 23]
+Left keys [1]: [ws_bill_customer_sk#20]
+Right keys [1]: [c_customer_sk#24]
+Join type: Inner
+Join condition: None
+
+(47) Project [codegen id : 23]
+Output [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Input [5]: [ws_bill_customer_sk#20, d_date#23, c_customer_sk#24, c_first_name#25, c_last_name#26]
+
+(48) HashAggregate [codegen id : 23]
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Keys [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
+
+(49) Exchange
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Arguments: hashpartitioning(c_last_name#26, c_first_name#25, d_date#23, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(50) HashAggregate [codegen id : 24]
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Keys [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#26, c_first_name#25, d_date#23]
+
+(51) Exchange
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Arguments: hashpartitioning(coalesce(c_last_name#26, ), isnull(c_last_name#26), coalesce(c_first_name#25, ), isnull(c_first_name#25), coalesce(d_date#23, 1970-01-01), isnull(d_date#23), 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(52) Sort [codegen id : 25]
+Input [3]: [c_last_name#26, c_first_name#25, d_date#23]
+Arguments: [coalesce(c_last_name#26, ) ASC NULLS FIRST, isnull(c_last_name#26) ASC NULLS FIRST, coalesce(c_first_name#25, ) ASC NULLS FIRST, isnull(c_first_name#25) ASC NULLS FIRST, coalesce(d_date#23, 1970-01-01) ASC NULLS FIRST, isnull(d_date#23) ASC NULLS FIRST], false, 0
+
+(53) SortMergeJoin [codegen id : 26]
+Left keys [6]: [coalesce(c_last_name#10, ), isnull(c_last_name#10), coalesce(c_first_name#9, ), isnull(c_first_name#9), coalesce(d_date#7, 1970-01-01), isnull(d_date#7)]
+Right keys [6]: [coalesce(c_last_name#26, ), isnull(c_last_name#26), coalesce(c_first_name#25, ), isnull(c_first_name#25), coalesce(d_date#23, 1970-01-01), isnull(d_date#23)]
+Join type: LeftAnti
+Join condition: None
+
+(54) Project [codegen id : 26]
+Output: []
+Input [3]: [c_last_name#10, c_first_name#9, d_date#7]
+
+(55) HashAggregate [codegen id : 26]
+Input: []
+Keys: []
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#27]
+Results [1]: [count#28]
+
+(56) Exchange
+Input [1]: [count#28]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+
+(57) HashAggregate [codegen id : 27]
+Input [1]: [count#28]
+Keys: []
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#29]
+Results [1]: [count(1)#29 AS count(1)#30]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
+ObjectHashAggregate (64)
++- Exchange (63)
+   +- ObjectHashAggregate (62)
+      +- Exchange (61)
+         +- * Filter (60)
+            +- * ColumnarToRow (59)
+               +- Scan parquet spark_catalog.default.customer (58)
+
+
+(58) Scan parquet spark_catalog.default.customer
+Output [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
-(10) ColumnarToRow [codegen id : 4]
-Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
+(59) ColumnarToRow [codegen id : 1]
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
 
-(11) Filter [codegen id : 4]
-Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
-Condition : isnotnull(c_customer_sk#6)
+(60) Filter [codegen id : 1]
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
+Condition : isnotnull(c_customer_sk#8)
 
-(12) Exchange
-Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
-Arguments: hashpartitioning(c_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(61) Exchange
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
+Arguments: hashpartitioning(c_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(13) Sort [codegen id : 5]
-Input [3]: [c_customer_sk#6, c_first_name#7, c_last_name#8]
-Arguments: [c_customer_sk#6 ASC NULLS FIRST], false, 0
-
-(14) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#6]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Input [5]: [ss_customer_sk#1, d_date#5, c_customer_sk#6, c_first_name#7, c_last_name#8]
-
-(16) HashAggregate [codegen id : 6]
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Keys [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#8, c_first_name#7, d_date#5]
-
-(17) Exchange
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Arguments: hashpartitioning(c_last_name#8, c_first_name#7, d_date#5, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Keys [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#8, c_first_name#7, d_date#5]
-
-(19) Exchange
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Arguments: hashpartitioning(coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5), 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(20) Sort [codegen id : 8]
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-Arguments: [coalesce(c_last_name#8, ) ASC NULLS FIRST, isnull(c_last_name#8) ASC NULLS FIRST, coalesce(c_first_name#7, ) ASC NULLS FIRST, isnull(c_first_name#7) ASC NULLS FIRST, coalesce(d_date#5, 1970-01-01) ASC NULLS FIRST, isnull(d_date#5) ASC NULLS FIRST], false, 0
-
-(21) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_bill_customer_sk#9, cs_sold_date_sk#10]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#10), dynamicpruningexpression(cs_sold_date_sk#10 IN dynamicpruning#3)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk)]
-ReadSchema: struct<cs_bill_customer_sk:int>
-
-(22) ColumnarToRow [codegen id : 10]
-Input [2]: [cs_bill_customer_sk#9, cs_sold_date_sk#10]
-
-(23) Filter [codegen id : 10]
-Input [2]: [cs_bill_customer_sk#9, cs_sold_date_sk#10]
-Condition : isnotnull(cs_bill_customer_sk#9)
-
-(24) ReusedExchange [Reuses operator id: 65]
-Output [2]: [d_date_sk#11, d_date#12]
-
-(25) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#10]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(26) Project [codegen id : 10]
-Output [2]: [cs_bill_customer_sk#9, d_date#12]
-Input [4]: [cs_bill_customer_sk#9, cs_sold_date_sk#10, d_date_sk#11, d_date#12]
-
-(27) Exchange
-Input [2]: [cs_bill_customer_sk#9, d_date#12]
-Arguments: hashpartitioning(cs_bill_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(28) Sort [codegen id : 11]
-Input [2]: [cs_bill_customer_sk#9, d_date#12]
-Arguments: [cs_bill_customer_sk#9 ASC NULLS FIRST], false, 0
-
-(29) ReusedExchange [Reuses operator id: 12]
-Output [3]: [c_customer_sk#13, c_first_name#14, c_last_name#15]
-
-(30) Sort [codegen id : 13]
-Input [3]: [c_customer_sk#13, c_first_name#14, c_last_name#15]
-Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
-
-(31) SortMergeJoin [codegen id : 14]
-Left keys [1]: [cs_bill_customer_sk#9]
-Right keys [1]: [c_customer_sk#13]
-Join type: Inner
-Join condition: None
-
-(32) Project [codegen id : 14]
-Output [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Input [5]: [cs_bill_customer_sk#9, d_date#12, c_customer_sk#13, c_first_name#14, c_last_name#15]
-
-(33) HashAggregate [codegen id : 14]
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Keys [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#15, c_first_name#14, d_date#12]
-
-(34) Exchange
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, d_date#12, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) HashAggregate [codegen id : 15]
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Keys [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#15, c_first_name#14, d_date#12]
-
-(36) Exchange
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Arguments: hashpartitioning(coalesce(c_last_name#15, ), isnull(c_last_name#15), coalesce(c_first_name#14, ), isnull(c_first_name#14), coalesce(d_date#12, 1970-01-01), isnull(d_date#12), 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(37) Sort [codegen id : 16]
-Input [3]: [c_last_name#15, c_first_name#14, d_date#12]
-Arguments: [coalesce(c_last_name#15, ) ASC NULLS FIRST, isnull(c_last_name#15) ASC NULLS FIRST, coalesce(c_first_name#14, ) ASC NULLS FIRST, isnull(c_first_name#14) ASC NULLS FIRST, coalesce(d_date#12, 1970-01-01) ASC NULLS FIRST, isnull(d_date#12) ASC NULLS FIRST], false, 0
-
-(38) SortMergeJoin [codegen id : 17]
-Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
-Right keys [6]: [coalesce(c_last_name#15, ), isnull(c_last_name#15), coalesce(c_first_name#14, ), isnull(c_first_name#14), coalesce(d_date#12, 1970-01-01), isnull(d_date#12)]
-Join type: LeftAnti
-Join condition: None
-
-(39) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#16, ws_sold_date_sk#17]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#17), dynamicpruningexpression(ws_sold_date_sk#17 IN dynamicpruning#3)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int>
-
-(40) ColumnarToRow [codegen id : 19]
-Input [2]: [ws_bill_customer_sk#16, ws_sold_date_sk#17]
-
-(41) Filter [codegen id : 19]
-Input [2]: [ws_bill_customer_sk#16, ws_sold_date_sk#17]
-Condition : isnotnull(ws_bill_customer_sk#16)
-
-(42) ReusedExchange [Reuses operator id: 65]
-Output [2]: [d_date_sk#18, d_date#19]
-
-(43) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_sold_date_sk#17]
-Right keys [1]: [d_date_sk#18]
-Join type: Inner
-Join condition: None
-
-(44) Project [codegen id : 19]
-Output [2]: [ws_bill_customer_sk#16, d_date#19]
-Input [4]: [ws_bill_customer_sk#16, ws_sold_date_sk#17, d_date_sk#18, d_date#19]
-
-(45) Exchange
-Input [2]: [ws_bill_customer_sk#16, d_date#19]
-Arguments: hashpartitioning(ws_bill_customer_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(46) Sort [codegen id : 20]
-Input [2]: [ws_bill_customer_sk#16, d_date#19]
-Arguments: [ws_bill_customer_sk#16 ASC NULLS FIRST], false, 0
-
-(47) ReusedExchange [Reuses operator id: 12]
-Output [3]: [c_customer_sk#20, c_first_name#21, c_last_name#22]
-
-(48) Sort [codegen id : 22]
-Input [3]: [c_customer_sk#20, c_first_name#21, c_last_name#22]
-Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
-
-(49) SortMergeJoin [codegen id : 23]
-Left keys [1]: [ws_bill_customer_sk#16]
-Right keys [1]: [c_customer_sk#20]
-Join type: Inner
-Join condition: None
-
-(50) Project [codegen id : 23]
-Output [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Input [5]: [ws_bill_customer_sk#16, d_date#19, c_customer_sk#20, c_first_name#21, c_last_name#22]
-
-(51) HashAggregate [codegen id : 23]
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Keys [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#22, c_first_name#21, d_date#19]
-
-(52) Exchange
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Arguments: hashpartitioning(c_last_name#22, c_first_name#21, d_date#19, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(53) HashAggregate [codegen id : 24]
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Keys [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#22, c_first_name#21, d_date#19]
-
-(54) Exchange
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Arguments: hashpartitioning(coalesce(c_last_name#22, ), isnull(c_last_name#22), coalesce(c_first_name#21, ), isnull(c_first_name#21), coalesce(d_date#19, 1970-01-01), isnull(d_date#19), 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(55) Sort [codegen id : 25]
-Input [3]: [c_last_name#22, c_first_name#21, d_date#19]
-Arguments: [coalesce(c_last_name#22, ) ASC NULLS FIRST, isnull(c_last_name#22) ASC NULLS FIRST, coalesce(c_first_name#21, ) ASC NULLS FIRST, isnull(c_first_name#21) ASC NULLS FIRST, coalesce(d_date#19, 1970-01-01) ASC NULLS FIRST, isnull(d_date#19) ASC NULLS FIRST], false, 0
-
-(56) SortMergeJoin [codegen id : 26]
-Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
-Right keys [6]: [coalesce(c_last_name#22, ), isnull(c_last_name#22), coalesce(c_first_name#21, ), isnull(c_first_name#21), coalesce(d_date#19, 1970-01-01), isnull(d_date#19)]
-Join type: LeftAnti
-Join condition: None
-
-(57) Project [codegen id : 26]
-Output: []
-Input [3]: [c_last_name#8, c_first_name#7, d_date#5]
-
-(58) HashAggregate [codegen id : 26]
-Input: []
+(62) ObjectHashAggregate
+Input [3]: [c_customer_sk#8, c_first_name#9, c_last_name#10]
 Keys: []
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#23]
-Results [1]: [count#24]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#31]
+Results [1]: [buf#32]
 
-(59) Exchange
-Input [1]: [count#24]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+(63) Exchange
+Input [1]: [buf#32]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
-(60) HashAggregate [codegen id : 27]
-Input [1]: [count#24]
+(64) ObjectHashAggregate
+Input [1]: [buf#32]
 Keys: []
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#25]
-Results [1]: [count(1)#25 AS count(1)#26]
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2000000, 16000000, 0, 0)#33]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#8, 42), 2000000, 16000000, 0, 0)#33 AS bloomFilter#34]
 
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#2 IN dynamicpruning#3
-BroadcastExchange (65)
-+- * Project (64)
-   +- * Filter (63)
-      +- * ColumnarToRow (62)
-         +- Scan parquet spark_catalog.default.date_dim (61)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#2 IN dynamicpruning#3
+BroadcastExchange (69)
++- * Project (68)
+   +- * Filter (67)
+      +- * ColumnarToRow (66)
+         +- Scan parquet spark_catalog.default.date_dim (65)
 
 
-(61) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#4, d_date#5, d_month_seq#27]
+(65) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#6, d_date#7, d_month_seq#35]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_month_seq:int>
 
-(62) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#4, d_date#5, d_month_seq#27]
+(66) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#6, d_date#7, d_month_seq#35]
 
-(63) Filter [codegen id : 1]
-Input [3]: [d_date_sk#4, d_date#5, d_month_seq#27]
-Condition : (((isnotnull(d_month_seq#27) AND (d_month_seq#27 >= 1200)) AND (d_month_seq#27 <= 1211)) AND isnotnull(d_date_sk#4))
+(67) Filter [codegen id : 1]
+Input [3]: [d_date_sk#6, d_date#7, d_month_seq#35]
+Condition : (((isnotnull(d_month_seq#35) AND (d_month_seq#35 >= 1200)) AND (d_month_seq#35 <= 1211)) AND isnotnull(d_date_sk#6))
 
-(64) Project [codegen id : 1]
-Output [2]: [d_date_sk#4, d_date#5]
-Input [3]: [d_date_sk#4, d_date#5, d_month_seq#27]
+(68) Project [codegen id : 1]
+Output [2]: [d_date_sk#6, d_date#7]
+Input [3]: [d_date_sk#6, d_date#7, d_month_seq#35]
 
-(65) BroadcastExchange
-Input [2]: [d_date_sk#4, d_date#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
+(69) BroadcastExchange
+Input [2]: [d_date_sk#6, d_date#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
 
-Subquery:2 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#10 IN dynamicpruning#3
+Subquery:3 Hosting operator id = 20 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (76)
++- Exchange (75)
+   +- ObjectHashAggregate (74)
+      +- Exchange (73)
+         +- * Filter (72)
+            +- * ColumnarToRow (71)
+               +- Scan parquet spark_catalog.default.customer (70)
 
-Subquery:3 Hosting operator id = 39 Hosting Expression = ws_sold_date_sk#17 IN dynamicpruning#3
+
+(70) Scan parquet spark_catalog.default.customer
+Output [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk)]
+ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
+
+(71) ColumnarToRow [codegen id : 1]
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+
+(72) Filter [codegen id : 1]
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Condition : isnotnull(c_customer_sk#17)
+
+(73) Exchange
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Arguments: hashpartitioning(c_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(74) ObjectHashAggregate
+Input [3]: [c_customer_sk#17, c_first_name#18, c_last_name#19]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#17, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#36]
+Results [1]: [buf#37]
+
+(75) Exchange
+Input [1]: [buf#37]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
+
+(76) ObjectHashAggregate
+Input [1]: [buf#37]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#17, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#17, 42), 2000000, 16000000, 0, 0)#38]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#17, 42), 2000000, 16000000, 0, 0)#38 AS bloomFilter#39]
+
+Subquery:4 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#12 IN dynamicpruning#3
+
+Subquery:5 Hosting operator id = 38 Hosting Expression = ReusedSubquery Subquery scalar-subquery#13, [id=#14]
+
+Subquery:6 Hosting operator id = 36 Hosting Expression = ws_sold_date_sk#21 IN dynamicpruning#3
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/simplified.txt
@@ -31,6 +31,16 @@ WholeStageCodegen (27)
                                                             Project [ss_customer_sk,d_date]
                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                 Filter [ss_customer_sk]
+                                                                  Subquery #2
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                      Exchange #6
+                                                                        ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                          Exchange [c_customer_sk] #7
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [c_customer_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
@@ -48,21 +58,16 @@ WholeStageCodegen (27)
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #6
-                                                          WholeStageCodegen (4)
-                                                            Filter [c_customer_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
+                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #7
                       InputAdapter
                         WholeStageCodegen (16)
                           Sort [c_last_name,c_first_name,d_date]
                             InputAdapter
-                              Exchange [c_last_name,c_first_name,d_date] #7
+                              Exchange [c_last_name,c_first_name,d_date] #8
                                 WholeStageCodegen (15)
                                   HashAggregate [c_last_name,c_first_name,d_date]
                                     InputAdapter
-                                      Exchange [c_last_name,c_first_name,d_date] #8
+                                      Exchange [c_last_name,c_first_name,d_date] #9
                                         WholeStageCodegen (14)
                                           HashAggregate [c_last_name,c_first_name,d_date]
                                             Project [c_last_name,c_first_name,d_date]
@@ -71,11 +76,21 @@ WholeStageCodegen (27)
                                                   WholeStageCodegen (11)
                                                     Sort [cs_bill_customer_sk]
                                                       InputAdapter
-                                                        Exchange [cs_bill_customer_sk] #9
+                                                        Exchange [cs_bill_customer_sk] #10
                                                           WholeStageCodegen (10)
                                                             Project [cs_bill_customer_sk,d_date]
                                                               BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                 Filter [cs_bill_customer_sk]
+                                                                  Subquery #3
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                      Exchange #11
+                                                                        ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                          Exchange [c_customer_sk] #12
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [c_customer_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_sold_date_sk]
@@ -86,16 +101,16 @@ WholeStageCodegen (27)
                                                   WholeStageCodegen (13)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #6
+                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #7
                 InputAdapter
                   WholeStageCodegen (25)
                     Sort [c_last_name,c_first_name,d_date]
                       InputAdapter
-                        Exchange [c_last_name,c_first_name,d_date] #10
+                        Exchange [c_last_name,c_first_name,d_date] #13
                           WholeStageCodegen (24)
                             HashAggregate [c_last_name,c_first_name,d_date]
                               InputAdapter
-                                Exchange [c_last_name,c_first_name,d_date] #11
+                                Exchange [c_last_name,c_first_name,d_date] #14
                                   WholeStageCodegen (23)
                                     HashAggregate [c_last_name,c_first_name,d_date]
                                       Project [c_last_name,c_first_name,d_date]
@@ -104,11 +119,12 @@ WholeStageCodegen (27)
                                             WholeStageCodegen (20)
                                               Sort [ws_bill_customer_sk]
                                                 InputAdapter
-                                                  Exchange [ws_bill_customer_sk] #12
+                                                  Exchange [ws_bill_customer_sk] #15
                                                     WholeStageCodegen (19)
                                                       Project [ws_bill_customer_sk,d_date]
                                                         BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                           Filter [ws_bill_customer_sk]
+                                                            ReusedSubquery [bloomFilter] #3
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
@@ -119,4 +135,4 @@ WholeStageCodegen (27)
                                             WholeStageCodegen (22)
                                               Sort [c_customer_sk]
                                                 InputAdapter
-                                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #6
+                                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #7

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
@@ -65,7 +65,7 @@ Input [3]: [ws_item_sk#3, ws_ext_discount_amt#4, ws_sold_date_sk#5]
 
 (8) Filter [codegen id : 3]
 Input [3]: [ws_item_sk#3, ws_ext_discount_amt#4, ws_sold_date_sk#5]
-Condition : (isnotnull(ws_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ws_item_sk#3, 42)))
+Condition : (isnotnull(ws_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ws_item_sk#3, 42), true))
 
 (9) ReusedExchange [Reuses operator id: 41]
 Output [1]: [d_date_sk#9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93.sf100/explain.txt
@@ -1,10 +1,10 @@
 == Physical Plan ==
-TakeOrderedAndProject (24)
-+- * HashAggregate (23)
-   +- Exchange (22)
-      +- * HashAggregate (21)
-         +- * Project (20)
-            +- * SortMergeJoin Inner (19)
+TakeOrderedAndProject (25)
++- * HashAggregate (24)
+   +- Exchange (23)
+      +- * HashAggregate (22)
+         +- * Project (21)
+            +- * SortMergeJoin Inner (20)
                :- * Sort (13)
                :  +- Exchange (12)
                :     +- * Project (11)
@@ -18,11 +18,12 @@ TakeOrderedAndProject (24)
                :                 +- * Filter (7)
                :                    +- * ColumnarToRow (6)
                :                       +- Scan parquet spark_catalog.default.reason (5)
-               +- * Sort (18)
-                  +- Exchange (17)
-                     +- * Project (16)
-                        +- * ColumnarToRow (15)
-                           +- Scan parquet spark_catalog.default.store_sales (14)
+               +- * Sort (19)
+                  +- Exchange (18)
+                     +- * Project (17)
+                        +- * Filter (16)
+                           +- * ColumnarToRow (15)
+                              +- Scan parquet spark_catalog.default.store_sales (14)
 
 
 (1) Scan parquet spark_catalog.default.store_returns
@@ -92,47 +93,110 @@ ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_ticket_number:int,ss_qua
 (15) ColumnarToRow [codegen id : 4]
 Input [6]: [ss_item_sk#8, ss_customer_sk#9, ss_ticket_number#10, ss_quantity#11, ss_sales_price#12, ss_sold_date_sk#13]
 
-(16) Project [codegen id : 4]
+(16) Filter [codegen id : 4]
+Input [6]: [ss_item_sk#8, ss_customer_sk#9, ss_ticket_number#10, ss_quantity#11, ss_sales_price#12, ss_sold_date_sk#13]
+Condition : (might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#8, 42), false) AND might_contain(Subquery scalar-subquery#16, [id=#17], xxhash64(ss_ticket_number#10, 42), false))
+
+(17) Project [codegen id : 4]
 Output [5]: [ss_item_sk#8, ss_customer_sk#9, ss_ticket_number#10, ss_quantity#11, ss_sales_price#12]
 Input [6]: [ss_item_sk#8, ss_customer_sk#9, ss_ticket_number#10, ss_quantity#11, ss_sales_price#12, ss_sold_date_sk#13]
 
-(17) Exchange
+(18) Exchange
 Input [5]: [ss_item_sk#8, ss_customer_sk#9, ss_ticket_number#10, ss_quantity#11, ss_sales_price#12]
 Arguments: hashpartitioning(ss_item_sk#8, ss_ticket_number#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(18) Sort [codegen id : 5]
+(19) Sort [codegen id : 5]
 Input [5]: [ss_item_sk#8, ss_customer_sk#9, ss_ticket_number#10, ss_quantity#11, ss_sales_price#12]
 Arguments: [ss_item_sk#8 ASC NULLS FIRST, ss_ticket_number#10 ASC NULLS FIRST], false, 0
 
-(19) SortMergeJoin [codegen id : 6]
+(20) SortMergeJoin [codegen id : 6]
 Left keys [2]: [sr_item_sk#1, sr_ticket_number#3]
 Right keys [2]: [ss_item_sk#8, ss_ticket_number#10]
 Join type: Inner
 Join condition: None
 
-(20) Project [codegen id : 6]
-Output [2]: [ss_customer_sk#9, CASE WHEN isnotnull(sr_return_quantity#4) THEN (cast((ss_quantity#11 - sr_return_quantity#4) as decimal(10,0)) * ss_sales_price#12) ELSE (cast(ss_quantity#11 as decimal(10,0)) * ss_sales_price#12) END AS act_sales#14]
+(21) Project [codegen id : 6]
+Output [2]: [ss_customer_sk#9, CASE WHEN isnotnull(sr_return_quantity#4) THEN (cast((ss_quantity#11 - sr_return_quantity#4) as decimal(10,0)) * ss_sales_price#12) ELSE (cast(ss_quantity#11 as decimal(10,0)) * ss_sales_price#12) END AS act_sales#18]
 Input [8]: [sr_item_sk#1, sr_ticket_number#3, sr_return_quantity#4, ss_item_sk#8, ss_customer_sk#9, ss_ticket_number#10, ss_quantity#11, ss_sales_price#12]
 
-(21) HashAggregate [codegen id : 6]
-Input [2]: [ss_customer_sk#9, act_sales#14]
+(22) HashAggregate [codegen id : 6]
+Input [2]: [ss_customer_sk#9, act_sales#18]
 Keys [1]: [ss_customer_sk#9]
-Functions [1]: [partial_sum(act_sales#14)]
-Aggregate Attributes [2]: [sum#15, isEmpty#16]
-Results [3]: [ss_customer_sk#9, sum#17, isEmpty#18]
+Functions [1]: [partial_sum(act_sales#18)]
+Aggregate Attributes [2]: [sum#19, isEmpty#20]
+Results [3]: [ss_customer_sk#9, sum#21, isEmpty#22]
 
-(22) Exchange
-Input [3]: [ss_customer_sk#9, sum#17, isEmpty#18]
+(23) Exchange
+Input [3]: [ss_customer_sk#9, sum#21, isEmpty#22]
 Arguments: hashpartitioning(ss_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(23) HashAggregate [codegen id : 7]
-Input [3]: [ss_customer_sk#9, sum#17, isEmpty#18]
+(24) HashAggregate [codegen id : 7]
+Input [3]: [ss_customer_sk#9, sum#21, isEmpty#22]
 Keys [1]: [ss_customer_sk#9]
-Functions [1]: [sum(act_sales#14)]
-Aggregate Attributes [1]: [sum(act_sales#14)#19]
-Results [2]: [ss_customer_sk#9, sum(act_sales#14)#19 AS sumsales#20]
+Functions [1]: [sum(act_sales#18)]
+Aggregate Attributes [1]: [sum(act_sales#18)#23]
+Results [2]: [ss_customer_sk#9, sum(act_sales#18)#23 AS sumsales#24]
 
-(24) TakeOrderedAndProject
-Input [2]: [ss_customer_sk#9, sumsales#20]
-Arguments: 100, [sumsales#20 ASC NULLS FIRST, ss_customer_sk#9 ASC NULLS FIRST], [ss_customer_sk#9, sumsales#20]
+(25) TakeOrderedAndProject
+Input [2]: [ss_customer_sk#9, sumsales#24]
+Arguments: 100, [sumsales#24 ASC NULLS FIRST, ss_customer_sk#9 ASC NULLS FIRST], [ss_customer_sk#9, sumsales#24]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 16 Hosting Expression = Subquery scalar-subquery#14, [id=#15]
+ObjectHashAggregate (29)
++- Exchange (28)
+   +- ObjectHashAggregate (27)
+      +- ReusedExchange (26)
+
+
+(26) ReusedExchange [Reuses operator id: 12]
+Output [3]: [sr_item_sk#1, sr_ticket_number#3, sr_return_quantity#4]
+
+(27) ObjectHashAggregate
+Input [3]: [sr_item_sk#1, sr_ticket_number#3, sr_return_quantity#4]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_item_sk#1, 42), 496193, 3969544, 0, 0)]
+Aggregate Attributes [1]: [buf#25]
+Results [1]: [buf#26]
+
+(28) Exchange
+Input [1]: [buf#26]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+
+(29) ObjectHashAggregate
+Input [1]: [buf#26]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_item_sk#1, 42), 496193, 3969544, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_item_sk#1, 42), 496193, 3969544, 0, 0)#27]
+Results [1]: [bloom_filter_agg(xxhash64(sr_item_sk#1, 42), 496193, 3969544, 0, 0)#27 AS bloomFilter#28]
+
+Subquery:2 Hosting operator id = 16 Hosting Expression = Subquery scalar-subquery#16, [id=#17]
+ObjectHashAggregate (33)
++- Exchange (32)
+   +- ObjectHashAggregate (31)
+      +- ReusedExchange (30)
+
+
+(30) ReusedExchange [Reuses operator id: 12]
+Output [3]: [sr_item_sk#1, sr_ticket_number#3, sr_return_quantity#4]
+
+(31) ObjectHashAggregate
+Input [3]: [sr_item_sk#1, sr_ticket_number#3, sr_return_quantity#4]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_ticket_number#3, 42), 496193, 3969544, 0, 0)]
+Aggregate Attributes [1]: [buf#29]
+Results [1]: [buf#30]
+
+(32) Exchange
+Input [1]: [buf#30]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+
+(33) ObjectHashAggregate
+Input [1]: [buf#30]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#3, 42), 496193, 3969544, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#3, 42), 496193, 3969544, 0, 0)#31]
+Results [1]: [bloom_filter_agg(xxhash64(sr_ticket_number#3, 42), 496193, 3969544, 0, 0)#31 AS bloomFilter#32]
+
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93.sf100/simplified.txt
@@ -35,6 +35,17 @@ TakeOrderedAndProject [sumsales,ss_customer_sk]
                           Exchange [ss_item_sk,ss_ticket_number] #4
                             WholeStageCodegen (4)
                               Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,ss_sales_price]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,ss_sales_price,ss_sold_date_sk]
+                                Filter [ss_item_sk,ss_ticket_number]
+                                  Subquery #1
+                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_item_sk, 42), 496193, 3969544, 0, 0),bloomFilter,buf]
+                                      Exchange #5
+                                        ObjectHashAggregate [sr_item_sk] [buf,buf]
+                                          ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity] #2
+                                  Subquery #2
+                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_ticket_number, 42), 496193, 3969544, 0, 0),bloomFilter,buf]
+                                      Exchange #6
+                                        ObjectHashAggregate [sr_ticket_number] [buf,buf]
+                                          ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity] #2
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,ss_sales_price,ss_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
@@ -58,7 +58,7 @@ Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse
 
 (3) Filter [codegen id : 1]
 Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ws_sold_date_sk#8]
-Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ws_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ws_ship_addr_sk#2, 42), true)) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ws_web_site_sk#3, 42), true)) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ws_ship_date_sk#1, 42), true))
 
 (4) Project [codegen id : 1]
 Output [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
@@ -70,7 +70,7 @@ Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_num
 
 (3) Filter [codegen id : 1]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ws_sold_date_sk#7]
-Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ws_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ws_ship_addr_sk#2, 42), true)) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ws_web_site_sk#3, 42), true)) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ws_ship_date_sk#1, 42), true))
 
 (4) Project [codegen id : 1]
 Output [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/explain.txt
@@ -1,29 +1,26 @@
 == Physical Plan ==
-* Project (25)
-+- * Sort (24)
-   +- Exchange (23)
-      +- * Project (22)
-         +- Window (21)
-            +- * Sort (20)
-               +- Exchange (19)
-                  +- * HashAggregate (18)
-                     +- Exchange (17)
-                        +- * HashAggregate (16)
-                           +- * Project (15)
-                              +- * BroadcastHashJoin Inner BuildRight (14)
-                                 :- * Project (12)
-                                 :  +- * SortMergeJoin Inner (11)
+* Project (22)
++- * Sort (21)
+   +- Exchange (20)
+      +- * Project (19)
+         +- Window (18)
+            +- * Sort (17)
+               +- Exchange (16)
+                  +- * HashAggregate (15)
+                     +- Exchange (14)
+                        +- * HashAggregate (13)
+                           +- * Project (12)
+                              +- * BroadcastHashJoin Inner BuildRight (11)
+                                 :- * Project (9)
+                                 :  +- * SortMergeJoin Inner (8)
                                  :     :- * Sort (5)
                                  :     :  +- Exchange (4)
                                  :     :     +- * Filter (3)
                                  :     :        +- * ColumnarToRow (2)
                                  :     :           +- Scan parquet spark_catalog.default.store_sales (1)
-                                 :     +- * Sort (10)
-                                 :        +- Exchange (9)
-                                 :           +- * Filter (8)
-                                 :              +- * ColumnarToRow (7)
-                                 :                 +- Scan parquet spark_catalog.default.item (6)
-                                 +- ReusedExchange (13)
+                                 :     +- * Sort (7)
+                                 :        +- ReusedExchange (6)
+                                 +- ReusedExchange (10)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -39,7 +36,7 @@ Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_item_sk#1)
+Condition : (isnotnull(ss_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ss_item_sk#1, 42), false))
 
 (4) Exchange
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
@@ -49,127 +46,158 @@ Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(6) ReusedExchange [Reuses operator id: 26]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(7) Sort [codegen id : 4]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
+
+(8) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#7]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 6]
+Output [7]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(10) ReusedExchange [Reuses operator id: 34]
+Output [1]: [d_date_sk#13]
+
+(11) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_sold_date_sk#3]
+Right keys [1]: [d_date_sk#13]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [6]: [ss_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
+
+(13) HashAggregate [codegen id : 6]
+Input [6]: [ss_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+
+(14) Exchange
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#16]
+Results [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS _w0#18, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS _w1#19, i_item_id#8]
+
+(16) Exchange
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(17) Sort [codegen id : 8]
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
+
+(18) Window
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8]
+Arguments: [sum(_w1#19) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#20], [i_class#11]
+
+(19) Project [codegen id : 9]
+Output [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#20) AS revenueratio#21, i_item_id#8]
+Input [9]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, i_item_id#8, _we0#20]
+
+(20) Exchange
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21, i_item_id#8]
+Arguments: rangepartitioning(i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#21 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(21) Sort [codegen id : 10]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21, i_item_id#8]
+Arguments: [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#21 ASC NULLS FIRST], true, 0
+
+(22) Project [codegen id : 10]
+Output [6]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21, i_item_id#8]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (29)
++- Exchange (28)
+   +- ObjectHashAggregate (27)
+      +- Exchange (26)
+         +- * Filter (25)
+            +- * ColumnarToRow (24)
+               +- Scan parquet spark_catalog.default.item (23)
+
+
+(23) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
-(7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(24) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+(25) Filter [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
-(9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(26) Exchange
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+(27) ObjectHashAggregate
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [buf#22]
+Results [1]: [buf#23]
 
-(11) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
+(28) Exchange
+Input [1]: [buf#23]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
-(12) Project [codegen id : 6]
-Output [7]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(29) ObjectHashAggregate
+Input [1]: [buf#23]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24 AS bloomFilter#25]
 
-(13) ReusedExchange [Reuses operator id: 30]
-Output [1]: [d_date_sk#11]
-
-(14) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [6]: [ss_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
-
-(16) HashAggregate [codegen id : 6]
-Input [6]: [ss_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-
-(17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#14]
-Results [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS _w0#16, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS _w1#17, i_item_id#6]
-
-(19) Exchange
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(20) Sort [codegen id : 8]
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
-
-(21) Window
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6]
-Arguments: [sum(_w1#17) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#18], [i_class#9]
-
-(22) Project [codegen id : 9]
-Output [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#18) AS revenueratio#19, i_item_id#6]
-Input [9]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, i_item_id#6, _we0#18]
-
-(23) Exchange
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19, i_item_id#6]
-Arguments: rangepartitioning(i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#19 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(24) Sort [codegen id : 10]
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19, i_item_id#6]
-Arguments: [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#19 ASC NULLS FIRST], true, 0
-
-(25) Project [codegen id : 10]
-Output [6]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19, i_item_id#6]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (30)
-+- * Project (29)
-   +- * Filter (28)
-      +- * ColumnarToRow (27)
-         +- Scan parquet spark_catalog.default.date_dim (26)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (34)
++- * Project (33)
+   +- * Filter (32)
+      +- * ColumnarToRow (31)
+         +- Scan parquet spark_catalog.default.date_dim (30)
 
 
-(26) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#20]
+(30) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(27) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
+(31) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(28) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
-Condition : (((isnotnull(d_date#20) AND (d_date#20 >= 1999-02-22)) AND (d_date#20 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(32) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
+Condition : (((isnotnull(d_date#26) AND (d_date#26 >= 1999-02-22)) AND (d_date#26 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(29) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#20]
+(33) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(30) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+(34) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/simplified.txt
@@ -28,6 +28,16 @@ WholeStageCodegen (10)
                                                       Exchange [ss_item_sk] #4
                                                         WholeStageCodegen (1)
                                                           Filter [ss_item_sk]
+                                                            Subquery #2
+                                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 489600, 0, 0),bloomFilter,buf]
+                                                                Exchange #6
+                                                                  ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                    Exchange [i_item_sk] #7
+                                                                      WholeStageCodegen (1)
+                                                                        Filter [i_category,i_item_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
@@ -43,11 +53,6 @@ WholeStageCodegen (10)
                                                 WholeStageCodegen (4)
                                                   Sort [i_item_sk]
                                                     InputAdapter
-                                                      Exchange [i_item_sk] #6
-                                                        WholeStageCodegen (3)
-                                                          Filter [i_category,i_item_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
+                                                      ReusedExchange [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category] #7
                                           InputAdapter
                                             ReusedExchange [d_date_sk] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
@@ -1,49 +1,52 @@
 == Physical Plan ==
-TakeOrderedAndProject (45)
-+- * HashAggregate (44)
-   +- Exchange (43)
-      +- * HashAggregate (42)
-         +- * Project (41)
-            +- * BroadcastHashJoin Inner BuildLeft (40)
-               :- BroadcastExchange (36)
-               :  +- * Project (35)
-               :     +- * BroadcastHashJoin Inner BuildRight (34)
-               :        :- * Project (28)
-               :        :  +- * SortMergeJoin LeftSemi (27)
-               :        :     :- * SortMergeJoin LeftSemi (13)
+TakeOrderedAndProject (48)
++- * HashAggregate (47)
+   +- Exchange (46)
+      +- * HashAggregate (45)
+         +- * Project (44)
+            +- * BroadcastHashJoin Inner BuildLeft (43)
+               :- BroadcastExchange (39)
+               :  +- * Project (38)
+               :     +- * BroadcastHashJoin Inner BuildRight (37)
+               :        :- * Project (31)
+               :        :  +- * SortMergeJoin LeftSemi (30)
+               :        :     :- * SortMergeJoin LeftSemi (14)
                :        :     :  :- * Sort (5)
                :        :     :  :  +- Exchange (4)
                :        :     :  :     +- * Filter (3)
                :        :     :  :        +- * ColumnarToRow (2)
                :        :     :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :        :     :  +- * Sort (12)
-               :        :     :     +- Exchange (11)
-               :        :     :        +- * Project (10)
-               :        :     :           +- * BroadcastHashJoin Inner BuildRight (9)
-               :        :     :              :- * ColumnarToRow (7)
-               :        :     :              :  +- Scan parquet spark_catalog.default.store_sales (6)
-               :        :     :              +- ReusedExchange (8)
-               :        :     +- * Sort (26)
-               :        :        +- Exchange (25)
-               :        :           +- Union (24)
-               :        :              :- * Project (18)
-               :        :              :  +- * BroadcastHashJoin Inner BuildRight (17)
-               :        :              :     :- * ColumnarToRow (15)
-               :        :              :     :  +- Scan parquet spark_catalog.default.web_sales (14)
-               :        :              :     +- ReusedExchange (16)
-               :        :              +- * Project (23)
-               :        :                 +- * BroadcastHashJoin Inner BuildRight (22)
-               :        :                    :- * ColumnarToRow (20)
-               :        :                    :  +- Scan parquet spark_catalog.default.catalog_sales (19)
-               :        :                    +- ReusedExchange (21)
-               :        +- BroadcastExchange (33)
-               :           +- * Project (32)
-               :              +- * Filter (31)
-               :                 +- * ColumnarToRow (30)
-               :                    +- Scan parquet spark_catalog.default.customer_address (29)
-               +- * Filter (39)
-                  +- * ColumnarToRow (38)
-                     +- Scan parquet spark_catalog.default.customer_demographics (37)
+               :        :     :  +- * Sort (13)
+               :        :     :     +- Exchange (12)
+               :        :     :        +- * Project (11)
+               :        :     :           +- * BroadcastHashJoin Inner BuildRight (10)
+               :        :     :              :- * Filter (8)
+               :        :     :              :  +- * ColumnarToRow (7)
+               :        :     :              :     +- Scan parquet spark_catalog.default.store_sales (6)
+               :        :     :              +- ReusedExchange (9)
+               :        :     +- * Sort (29)
+               :        :        +- Exchange (28)
+               :        :           +- Union (27)
+               :        :              :- * Project (20)
+               :        :              :  +- * BroadcastHashJoin Inner BuildRight (19)
+               :        :              :     :- * Filter (17)
+               :        :              :     :  +- * ColumnarToRow (16)
+               :        :              :     :     +- Scan parquet spark_catalog.default.web_sales (15)
+               :        :              :     +- ReusedExchange (18)
+               :        :              +- * Project (26)
+               :        :                 +- * BroadcastHashJoin Inner BuildRight (25)
+               :        :                    :- * Filter (23)
+               :        :                    :  +- * ColumnarToRow (22)
+               :        :                    :     +- Scan parquet spark_catalog.default.catalog_sales (21)
+               :        :                    +- ReusedExchange (24)
+               :        +- BroadcastExchange (36)
+               :           +- * Project (35)
+               :              +- * Filter (34)
+               :                 +- * ColumnarToRow (33)
+               :                    +- Scan parquet spark_catalog.default.customer_address (32)
+               +- * Filter (42)
+                  +- * ColumnarToRow (41)
+                     +- Scan parquet spark_catalog.default.customer_demographics (40)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -58,7 +61,7 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : (((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42), true)) AND true)
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
@@ -78,223 +81,235 @@ ReadSchema: struct<ss_customer_sk:int>
 (7) ColumnarToRow [codegen id : 4]
 Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
 
-(8) ReusedExchange [Reuses operator id: 57]
+(8) Filter [codegen id : 4]
+Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Condition : true
+
+(9) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#9]
 
-(9) BroadcastHashJoin [codegen id : 4]
+(10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
+(11) Project [codegen id : 4]
 Output [1]: [ss_customer_sk#6]
 Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
 
-(11) Exchange
+(12) Exchange
 Input [1]: [ss_customer_sk#6]
 Arguments: hashpartitioning(ss_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) Sort [codegen id : 5]
+(13) Sort [codegen id : 5]
 Input [1]: [ss_customer_sk#6]
 Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
 
-(13) SortMergeJoin [codegen id : 6]
+(14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#6]
 Join type: LeftSemi
 Join condition: None
 
-(14) Scan parquet spark_catalog.default.web_sales
+(15) Scan parquet spark_catalog.default.web_sales
 Output [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#11), dynamicpruningexpression(ws_sold_date_sk#11 IN dynamicpruning#8)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(15) ColumnarToRow [codegen id : 8]
+(16) ColumnarToRow [codegen id : 8]
 Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
 
-(16) ReusedExchange [Reuses operator id: 57]
+(17) Filter [codegen id : 8]
+Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+Condition : true
+
+(18) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#12]
 
-(17) BroadcastHashJoin [codegen id : 8]
+(19) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 8]
+(20) Project [codegen id : 8]
 Output [1]: [ws_bill_customer_sk#10 AS customer_sk#13]
 Input [3]: [ws_bill_customer_sk#10, ws_sold_date_sk#11, d_date_sk#12]
 
-(19) Scan parquet spark_catalog.default.catalog_sales
+(21) Scan parquet spark_catalog.default.catalog_sales
 Output [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#15), dynamicpruningexpression(cs_sold_date_sk#15 IN dynamicpruning#8)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(20) ColumnarToRow [codegen id : 10]
+(22) ColumnarToRow [codegen id : 10]
 Input [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
 
-(21) ReusedExchange [Reuses operator id: 57]
+(23) Filter [codegen id : 10]
+Input [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
+Condition : true
+
+(24) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#16]
 
-(22) BroadcastHashJoin [codegen id : 10]
+(25) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#15]
 Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 10]
+(26) Project [codegen id : 10]
 Output [1]: [cs_ship_customer_sk#14 AS customer_sk#17]
 Input [3]: [cs_ship_customer_sk#14, cs_sold_date_sk#15, d_date_sk#16]
 
-(24) Union
+(27) Union
 
-(25) Exchange
+(28) Exchange
 Input [1]: [customer_sk#13]
 Arguments: hashpartitioning(customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(26) Sort [codegen id : 11]
+(29) Sort [codegen id : 11]
 Input [1]: [customer_sk#13]
 Arguments: [customer_sk#13 ASC NULLS FIRST], false, 0
 
-(27) SortMergeJoin [codegen id : 13]
+(30) SortMergeJoin [codegen id : 13]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#13]
 Join type: LeftSemi
 Join condition: None
 
-(28) Project [codegen id : 13]
+(31) Project [codegen id : 13]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(29) Scan parquet spark_catalog.default.customer_address
+(32) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#18, ca_county#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(30) ColumnarToRow [codegen id : 12]
+(33) ColumnarToRow [codegen id : 12]
 Input [2]: [ca_address_sk#18, ca_county#19]
 
-(31) Filter [codegen id : 12]
+(34) Filter [codegen id : 12]
 Input [2]: [ca_address_sk#18, ca_county#19]
 Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
 
-(32) Project [codegen id : 12]
+(35) Project [codegen id : 12]
 Output [1]: [ca_address_sk#18]
 Input [2]: [ca_address_sk#18, ca_county#19]
 
-(33) BroadcastExchange
+(36) BroadcastExchange
 Input [1]: [ca_address_sk#18]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(34) BroadcastHashJoin [codegen id : 13]
+(37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#18]
 Join type: Inner
 Join condition: None
 
-(35) Project [codegen id : 13]
+(38) Project [codegen id : 13]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#18]
 
-(36) BroadcastExchange
+(39) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(37) Scan parquet spark_catalog.default.customer_demographics
+(40) Scan parquet spark_catalog.default.customer_demographics
 Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(38) ColumnarToRow
+(41) ColumnarToRow
 Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
-(39) Filter
+(42) Filter
 Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Condition : isnotnull(cd_demo_sk#20)
 
-(40) BroadcastHashJoin [codegen id : 14]
+(43) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#20]
 Join type: Inner
 Join condition: None
 
-(41) Project [codegen id : 14]
+(44) Project [codegen id : 14]
 Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
-(42) HashAggregate [codegen id : 14]
+(45) HashAggregate [codegen id : 14]
 Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#29]
 Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 
-(43) Exchange
+(46) Exchange
 Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(44) HashAggregate [codegen id : 15]
+(47) HashAggregate [codegen id : 15]
 Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#31]
 Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
 
-(45) TakeOrderedAndProject
+(48) TakeOrderedAndProject
 Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
 Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
-ObjectHashAggregate (52)
-+- Exchange (51)
-   +- ObjectHashAggregate (50)
-      +- * Project (49)
-         +- * Filter (48)
-            +- * ColumnarToRow (47)
-               +- Scan parquet spark_catalog.default.customer_address (46)
+ObjectHashAggregate (55)
++- Exchange (54)
+   +- ObjectHashAggregate (53)
+      +- * Project (52)
+         +- * Filter (51)
+            +- * ColumnarToRow (50)
+               +- Scan parquet spark_catalog.default.customer_address (49)
 
 
-(46) Scan parquet spark_catalog.default.customer_address
+(49) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#18, ca_county#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(47) ColumnarToRow [codegen id : 1]
+(50) ColumnarToRow [codegen id : 1]
 Input [2]: [ca_address_sk#18, ca_county#19]
 
-(48) Filter [codegen id : 1]
+(51) Filter [codegen id : 1]
 Input [2]: [ca_address_sk#18, ca_county#19]
 Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
 
-(49) Project [codegen id : 1]
+(52) Project [codegen id : 1]
 Output [1]: [ca_address_sk#18]
 Input [2]: [ca_address_sk#18, ca_county#19]
 
-(50) ObjectHashAggregate
+(53) ObjectHashAggregate
 Input [1]: [ca_address_sk#18]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 20440, 0, 0)]
 Aggregate Attributes [1]: [buf#38]
 Results [1]: [buf#39]
 
-(51) Exchange
+(54) Exchange
 Input [1]: [buf#39]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(52) ObjectHashAggregate
+(55) ObjectHashAggregate
 Input [1]: [buf#39]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 20440, 0, 0)]
@@ -302,37 +317,37 @@ Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555
 Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 20440, 0, 0)#40 AS bloomFilter#41]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (57)
-+- * Project (56)
-   +- * Filter (55)
-      +- * ColumnarToRow (54)
-         +- Scan parquet spark_catalog.default.date_dim (53)
+BroadcastExchange (60)
++- * Project (59)
+   +- * Filter (58)
+      +- * ColumnarToRow (57)
+         +- Scan parquet spark_catalog.default.date_dim (56)
 
 
-(53) Scan parquet spark_catalog.default.date_dim
+(56) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#9, d_year#42, d_moy#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,7), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(54) ColumnarToRow [codegen id : 1]
+(57) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
 
-(55) Filter [codegen id : 1]
+(58) Filter [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
 Condition : (((((isnotnull(d_year#42) AND isnotnull(d_moy#43)) AND (d_year#42 = 2002)) AND (d_moy#43 >= 4)) AND (d_moy#43 <= 7)) AND isnotnull(d_date_sk#9))
 
-(56) Project [codegen id : 1]
+(59) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
 Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
 
-(57) BroadcastExchange
+(60) BroadcastExchange
 Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
-Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
+Subquery:3 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
 
-Subquery:4 Hosting operator id = 19 Hosting Expression = cs_sold_date_sk#15 IN dynamicpruning#8
+Subquery:4 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#15 IN dynamicpruning#8
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/simplified.txt
@@ -45,17 +45,18 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                 WholeStageCodegen (4)
                                                   Project [ss_customer_sk]
                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                            SubqueryBroadcast [d_date_sk] #2
-                                                              BroadcastExchange #6
-                                                                WholeStageCodegen (1)
-                                                                  Project [d_date_sk]
-                                                                    Filter [d_year,d_moy,d_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                      Filter
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                              SubqueryBroadcast [d_date_sk] #2
+                                                                BroadcastExchange #6
+                                                                  WholeStageCodegen (1)
+                                                                    Project [d_date_sk]
+                                                                      Filter [d_year,d_moy,d_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #6
                                 InputAdapter
@@ -67,19 +68,21 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                             WholeStageCodegen (8)
                                               Project [ws_bill_customer_sk]
                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
+                                                  Filter
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
+                                                          ReusedSubquery [d_date_sk] #2
                                                   InputAdapter
                                                     ReusedExchange [d_date_sk] #6
                                             WholeStageCodegen (10)
                                               Project [cs_ship_customer_sk]
                                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
+                                                  Filter
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
+                                                          ReusedSubquery [d_date_sk] #2
                                                   InputAdapter
                                                     ReusedExchange [d_date_sk] #6
                             InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11.sf100/explain.txt
@@ -1,18 +1,18 @@
 == Physical Plan ==
-TakeOrderedAndProject (79)
-+- * Project (78)
-   +- * SortMergeJoin Inner (77)
-      :- * Project (59)
-      :  +- * SortMergeJoin Inner (58)
-      :     :- * SortMergeJoin Inner (39)
-      :     :  :- * Sort (21)
-      :     :  :  +- Exchange (20)
-      :     :  :     +- * Filter (19)
-      :     :  :        +- * HashAggregate (18)
-      :     :  :           +- Exchange (17)
-      :     :  :              +- * HashAggregate (16)
-      :     :  :                 +- * Project (15)
-      :     :  :                    +- * SortMergeJoin Inner (14)
+TakeOrderedAndProject (76)
++- * Project (75)
+   +- * SortMergeJoin Inner (74)
+      :- * Project (56)
+      :  +- * SortMergeJoin Inner (55)
+      :     :- * SortMergeJoin Inner (36)
+      :     :  :- * Sort (18)
+      :     :  :  +- Exchange (17)
+      :     :  :     +- * Filter (16)
+      :     :  :        +- * HashAggregate (15)
+      :     :  :           +- Exchange (14)
+      :     :  :              +- * HashAggregate (13)
+      :     :  :                 +- * Project (12)
+      :     :  :                    +- * SortMergeJoin Inner (11)
       :     :  :                       :- * Sort (8)
       :     :  :                       :  +- Exchange (7)
       :     :  :                       :     +- * Project (6)
@@ -21,63 +21,60 @@ TakeOrderedAndProject (79)
       :     :  :                       :           :  +- * ColumnarToRow (2)
       :     :  :                       :           :     +- Scan parquet spark_catalog.default.store_sales (1)
       :     :  :                       :           +- ReusedExchange (4)
-      :     :  :                       +- * Sort (13)
-      :     :  :                          +- Exchange (12)
-      :     :  :                             +- * Filter (11)
-      :     :  :                                +- * ColumnarToRow (10)
-      :     :  :                                   +- Scan parquet spark_catalog.default.customer (9)
-      :     :  +- * Sort (38)
-      :     :     +- Exchange (37)
-      :     :        +- * HashAggregate (36)
-      :     :           +- Exchange (35)
-      :     :              +- * HashAggregate (34)
-      :     :                 +- * Project (33)
-      :     :                    +- * SortMergeJoin Inner (32)
-      :     :                       :- * Sort (29)
-      :     :                       :  +- Exchange (28)
-      :     :                       :     +- * Project (27)
-      :     :                       :        +- * BroadcastHashJoin Inner BuildRight (26)
-      :     :                       :           :- * Filter (24)
-      :     :                       :           :  +- * ColumnarToRow (23)
-      :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (22)
-      :     :                       :           +- ReusedExchange (25)
-      :     :                       +- * Sort (31)
-      :     :                          +- ReusedExchange (30)
-      :     +- * Sort (57)
-      :        +- Exchange (56)
-      :           +- * Filter (55)
-      :              +- * HashAggregate (54)
-      :                 +- Exchange (53)
-      :                    +- * HashAggregate (52)
-      :                       +- * Project (51)
-      :                          +- * SortMergeJoin Inner (50)
-      :                             :- * Sort (47)
-      :                             :  +- Exchange (46)
-      :                             :     +- * Project (45)
-      :                             :        +- * BroadcastHashJoin Inner BuildRight (44)
-      :                             :           :- * Filter (42)
-      :                             :           :  +- * ColumnarToRow (41)
-      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (40)
-      :                             :           +- ReusedExchange (43)
-      :                             +- * Sort (49)
-      :                                +- ReusedExchange (48)
-      +- * Sort (76)
-         +- Exchange (75)
-            +- * HashAggregate (74)
-               +- Exchange (73)
-                  +- * HashAggregate (72)
-                     +- * Project (71)
-                        +- * SortMergeJoin Inner (70)
-                           :- * Sort (67)
-                           :  +- Exchange (66)
-                           :     +- * Project (65)
-                           :        +- * BroadcastHashJoin Inner BuildRight (64)
-                           :           :- * Filter (62)
-                           :           :  +- * ColumnarToRow (61)
-                           :           :     +- Scan parquet spark_catalog.default.web_sales (60)
-                           :           +- ReusedExchange (63)
-                           +- * Sort (69)
-                              +- ReusedExchange (68)
+      :     :  :                       +- * Sort (10)
+      :     :  :                          +- ReusedExchange (9)
+      :     :  +- * Sort (35)
+      :     :     +- Exchange (34)
+      :     :        +- * HashAggregate (33)
+      :     :           +- Exchange (32)
+      :     :              +- * HashAggregate (31)
+      :     :                 +- * Project (30)
+      :     :                    +- * SortMergeJoin Inner (29)
+      :     :                       :- * Sort (26)
+      :     :                       :  +- Exchange (25)
+      :     :                       :     +- * Project (24)
+      :     :                       :        +- * BroadcastHashJoin Inner BuildRight (23)
+      :     :                       :           :- * Filter (21)
+      :     :                       :           :  +- * ColumnarToRow (20)
+      :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (19)
+      :     :                       :           +- ReusedExchange (22)
+      :     :                       +- * Sort (28)
+      :     :                          +- ReusedExchange (27)
+      :     +- * Sort (54)
+      :        +- Exchange (53)
+      :           +- * Filter (52)
+      :              +- * HashAggregate (51)
+      :                 +- Exchange (50)
+      :                    +- * HashAggregate (49)
+      :                       +- * Project (48)
+      :                          +- * SortMergeJoin Inner (47)
+      :                             :- * Sort (44)
+      :                             :  +- Exchange (43)
+      :                             :     +- * Project (42)
+      :                             :        +- * BroadcastHashJoin Inner BuildRight (41)
+      :                             :           :- * Filter (39)
+      :                             :           :  +- * ColumnarToRow (38)
+      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (37)
+      :                             :           +- ReusedExchange (40)
+      :                             +- * Sort (46)
+      :                                +- ReusedExchange (45)
+      +- * Sort (73)
+         +- Exchange (72)
+            +- * HashAggregate (71)
+               +- Exchange (70)
+                  +- * HashAggregate (69)
+                     +- * Project (68)
+                        +- * SortMergeJoin Inner (67)
+                           :- * Sort (64)
+                           :  +- Exchange (63)
+                           :     +- * Project (62)
+                           :        +- * BroadcastHashJoin Inner BuildRight (61)
+                           :           :- * Filter (59)
+                           :           :  +- * ColumnarToRow (58)
+                           :           :     +- Scan parquet spark_catalog.default.web_sales (57)
+                           :           +- ReusedExchange (60)
+                           +- * Sort (66)
+                              +- ReusedExchange (65)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -93,390 +90,396 @@ Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, ss_sol
 
 (3) Filter [codegen id : 2]
 Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, ss_sold_date_sk#4]
-Condition : isnotnull(ss_customer_sk#1)
+Condition : (isnotnull(ss_customer_sk#1) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 83]
-Output [2]: [d_date_sk#6, d_year#7]
+(4) ReusedExchange [Reuses operator id: 87]
+Output [2]: [d_date_sk#8, d_year#9]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
-Output [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
-Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, ss_sold_date_sk#4, d_date_sk#6, d_year#7]
+Output [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
+Input [6]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, ss_sold_date_sk#4, d_date_sk#8, d_year#9]
 
 (7) Exchange
-Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
+Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (8) Sort [codegen id : 3]
-Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
+Input [4]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer
-Output [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
+(9) ReusedExchange [Reuses operator id: 80]
+Output [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+
+(10) Sort [codegen id : 5]
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Arguments: [c_customer_sk#10 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#10]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [10]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
+Input [12]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9, c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+
+(13) HashAggregate [codegen id : 6]
+Input [10]: [c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#9]
+Keys [8]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Functions [1]: [partial_sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))]
+Aggregate Attributes [1]: [sum#18]
+Results [9]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, sum#19]
+
+(14) Exchange
+Input [9]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, sum#19]
+Arguments: hashpartitioning(c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [9]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17, sum#19]
+Keys [8]: [c_customer_id#11, c_first_name#12, c_last_name#13, d_year#9, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Functions [1]: [sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))]
+Aggregate Attributes [1]: [sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))#20]
+Results [2]: [c_customer_id#11 AS customer_id#21, MakeDecimal(sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))#20,18,2) AS year_total#22]
+
+(16) Filter [codegen id : 7]
+Input [2]: [customer_id#21, year_total#22]
+Condition : (isnotnull(year_total#22) AND (year_total#22 > 0.00))
+
+(17) Exchange
+Input [2]: [customer_id#21, year_total#22]
+Arguments: hashpartitioning(customer_id#21, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(18) Sort [codegen id : 8]
+Input [2]: [customer_id#21, year_total#22]
+Arguments: [customer_id#21 ASC NULLS FIRST], false, 0
+
+(19) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, ss_sold_date_sk#26]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#26), dynamicpruningexpression(ss_sold_date_sk#26 IN dynamicpruning#27)]
+PushedFilters: [IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_customer_sk:int,ss_ext_discount_amt:decimal(7,2),ss_ext_list_price:decimal(7,2)>
+
+(20) ColumnarToRow [codegen id : 10]
+Input [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, ss_sold_date_sk#26]
+
+(21) Filter [codegen id : 10]
+Input [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, ss_sold_date_sk#26]
+Condition : (isnotnull(ss_customer_sk#23) AND might_contain(Subquery scalar-subquery#28, [id=#29], xxhash64(ss_customer_sk#23, 42), false))
+
+(22) ReusedExchange [Reuses operator id: 98]
+Output [2]: [d_date_sk#30, d_year#31]
+
+(23) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#26]
+Right keys [1]: [d_date_sk#30]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 10]
+Output [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Input [6]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, ss_sold_date_sk#26, d_date_sk#30, d_year#31]
+
+(25) Exchange
+Input [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Arguments: hashpartitioning(ss_customer_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) Sort [codegen id : 11]
+Input [4]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Arguments: [ss_customer_sk#23 ASC NULLS FIRST], false, 0
+
+(27) ReusedExchange [Reuses operator id: 80]
+Output [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+
+(28) Sort [codegen id : 13]
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Arguments: [c_customer_sk#32 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 14]
+Left keys [1]: [ss_customer_sk#23]
+Right keys [1]: [c_customer_sk#32]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 14]
+Output [10]: [c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Input [12]: [ss_customer_sk#23, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31, c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+
+(31) HashAggregate [codegen id : 14]
+Input [10]: [c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, ss_ext_discount_amt#24, ss_ext_list_price#25, d_year#31]
+Keys [8]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Functions [1]: [partial_sum(UnscaledValue((ss_ext_list_price#25 - ss_ext_discount_amt#24)))]
+Aggregate Attributes [1]: [sum#40]
+Results [9]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, sum#41]
+
+(32) Exchange
+Input [9]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, sum#41]
+Arguments: hashpartitioning(c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(33) HashAggregate [codegen id : 15]
+Input [9]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39, sum#41]
+Keys [8]: [c_customer_id#33, c_first_name#34, c_last_name#35, d_year#31, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Functions [1]: [sum(UnscaledValue((ss_ext_list_price#25 - ss_ext_discount_amt#24)))]
+Aggregate Attributes [1]: [sum(UnscaledValue((ss_ext_list_price#25 - ss_ext_discount_amt#24)))#20]
+Results [5]: [c_customer_id#33 AS customer_id#42, c_first_name#34 AS customer_first_name#43, c_last_name#35 AS customer_last_name#44, c_email_address#39 AS customer_email_address#45, MakeDecimal(sum(UnscaledValue((ss_ext_list_price#25 - ss_ext_discount_amt#24)))#20,18,2) AS year_total#46]
+
+(34) Exchange
+Input [5]: [customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45, year_total#46]
+Arguments: hashpartitioning(customer_id#42, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(35) Sort [codegen id : 16]
+Input [5]: [customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45, year_total#46]
+Arguments: [customer_id#42 ASC NULLS FIRST], false, 0
+
+(36) SortMergeJoin [codegen id : 17]
+Left keys [1]: [customer_id#21]
+Right keys [1]: [customer_id#42]
+Join type: Inner
+Join condition: None
+
+(37) Scan parquet spark_catalog.default.web_sales
+Output [4]: [ws_bill_customer_sk#47, ws_ext_discount_amt#48, ws_ext_list_price#49, ws_sold_date_sk#50]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#50), dynamicpruningexpression(ws_sold_date_sk#50 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_list_price:decimal(7,2)>
+
+(38) ColumnarToRow [codegen id : 19]
+Input [4]: [ws_bill_customer_sk#47, ws_ext_discount_amt#48, ws_ext_list_price#49, ws_sold_date_sk#50]
+
+(39) Filter [codegen id : 19]
+Input [4]: [ws_bill_customer_sk#47, ws_ext_discount_amt#48, ws_ext_list_price#49, ws_sold_date_sk#50]
+Condition : (isnotnull(ws_bill_customer_sk#47) AND might_contain(ReusedSubquery Subquery scalar-subquery#28, [id=#29], xxhash64(ws_bill_customer_sk#47, 42), false))
+
+(40) ReusedExchange [Reuses operator id: 87]
+Output [2]: [d_date_sk#51, d_year#52]
+
+(41) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [ws_sold_date_sk#50]
+Right keys [1]: [d_date_sk#51]
+Join type: Inner
+Join condition: None
+
+(42) Project [codegen id : 19]
+Output [4]: [ws_bill_customer_sk#47, ws_ext_discount_amt#48, ws_ext_list_price#49, d_year#52]
+Input [6]: [ws_bill_customer_sk#47, ws_ext_discount_amt#48, ws_ext_list_price#49, ws_sold_date_sk#50, d_date_sk#51, d_year#52]
+
+(43) Exchange
+Input [4]: [ws_bill_customer_sk#47, ws_ext_discount_amt#48, ws_ext_list_price#49, d_year#52]
+Arguments: hashpartitioning(ws_bill_customer_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(44) Sort [codegen id : 20]
+Input [4]: [ws_bill_customer_sk#47, ws_ext_discount_amt#48, ws_ext_list_price#49, d_year#52]
+Arguments: [ws_bill_customer_sk#47 ASC NULLS FIRST], false, 0
+
+(45) ReusedExchange [Reuses operator id: 80]
+Output [8]: [c_customer_sk#53, c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60]
+
+(46) Sort [codegen id : 22]
+Input [8]: [c_customer_sk#53, c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60]
+Arguments: [c_customer_sk#53 ASC NULLS FIRST], false, 0
+
+(47) SortMergeJoin [codegen id : 23]
+Left keys [1]: [ws_bill_customer_sk#47]
+Right keys [1]: [c_customer_sk#53]
+Join type: Inner
+Join condition: None
+
+(48) Project [codegen id : 23]
+Output [10]: [c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60, ws_ext_discount_amt#48, ws_ext_list_price#49, d_year#52]
+Input [12]: [ws_bill_customer_sk#47, ws_ext_discount_amt#48, ws_ext_list_price#49, d_year#52, c_customer_sk#53, c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60]
+
+(49) HashAggregate [codegen id : 23]
+Input [10]: [c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60, ws_ext_discount_amt#48, ws_ext_list_price#49, d_year#52]
+Keys [8]: [c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60, d_year#52]
+Functions [1]: [partial_sum(UnscaledValue((ws_ext_list_price#49 - ws_ext_discount_amt#48)))]
+Aggregate Attributes [1]: [sum#61]
+Results [9]: [c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60, d_year#52, sum#62]
+
+(50) Exchange
+Input [9]: [c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60, d_year#52, sum#62]
+Arguments: hashpartitioning(c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60, d_year#52, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(51) HashAggregate [codegen id : 24]
+Input [9]: [c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60, d_year#52, sum#62]
+Keys [8]: [c_customer_id#54, c_first_name#55, c_last_name#56, c_preferred_cust_flag#57, c_birth_country#58, c_login#59, c_email_address#60, d_year#52]
+Functions [1]: [sum(UnscaledValue((ws_ext_list_price#49 - ws_ext_discount_amt#48)))]
+Aggregate Attributes [1]: [sum(UnscaledValue((ws_ext_list_price#49 - ws_ext_discount_amt#48)))#63]
+Results [2]: [c_customer_id#54 AS customer_id#64, MakeDecimal(sum(UnscaledValue((ws_ext_list_price#49 - ws_ext_discount_amt#48)))#63,18,2) AS year_total#65]
+
+(52) Filter [codegen id : 24]
+Input [2]: [customer_id#64, year_total#65]
+Condition : (isnotnull(year_total#65) AND (year_total#65 > 0.00))
+
+(53) Exchange
+Input [2]: [customer_id#64, year_total#65]
+Arguments: hashpartitioning(customer_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) Sort [codegen id : 25]
+Input [2]: [customer_id#64, year_total#65]
+Arguments: [customer_id#64 ASC NULLS FIRST], false, 0
+
+(55) SortMergeJoin [codegen id : 26]
+Left keys [1]: [customer_id#21]
+Right keys [1]: [customer_id#64]
+Join type: Inner
+Join condition: None
+
+(56) Project [codegen id : 26]
+Output [8]: [customer_id#21, year_total#22, customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45, year_total#46, year_total#65]
+Input [9]: [customer_id#21, year_total#22, customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45, year_total#46, customer_id#64, year_total#65]
+
+(57) Scan parquet spark_catalog.default.web_sales
+Output [4]: [ws_bill_customer_sk#66, ws_ext_discount_amt#67, ws_ext_list_price#68, ws_sold_date_sk#69]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#69), dynamicpruningexpression(ws_sold_date_sk#69 IN dynamicpruning#27)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_list_price:decimal(7,2)>
+
+(58) ColumnarToRow [codegen id : 28]
+Input [4]: [ws_bill_customer_sk#66, ws_ext_discount_amt#67, ws_ext_list_price#68, ws_sold_date_sk#69]
+
+(59) Filter [codegen id : 28]
+Input [4]: [ws_bill_customer_sk#66, ws_ext_discount_amt#67, ws_ext_list_price#68, ws_sold_date_sk#69]
+Condition : (isnotnull(ws_bill_customer_sk#66) AND might_contain(ReusedSubquery Subquery scalar-subquery#28, [id=#29], xxhash64(ws_bill_customer_sk#66, 42), false))
+
+(60) ReusedExchange [Reuses operator id: 98]
+Output [2]: [d_date_sk#70, d_year#71]
+
+(61) BroadcastHashJoin [codegen id : 28]
+Left keys [1]: [ws_sold_date_sk#69]
+Right keys [1]: [d_date_sk#70]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 28]
+Output [4]: [ws_bill_customer_sk#66, ws_ext_discount_amt#67, ws_ext_list_price#68, d_year#71]
+Input [6]: [ws_bill_customer_sk#66, ws_ext_discount_amt#67, ws_ext_list_price#68, ws_sold_date_sk#69, d_date_sk#70, d_year#71]
+
+(63) Exchange
+Input [4]: [ws_bill_customer_sk#66, ws_ext_discount_amt#67, ws_ext_list_price#68, d_year#71]
+Arguments: hashpartitioning(ws_bill_customer_sk#66, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(64) Sort [codegen id : 29]
+Input [4]: [ws_bill_customer_sk#66, ws_ext_discount_amt#67, ws_ext_list_price#68, d_year#71]
+Arguments: [ws_bill_customer_sk#66 ASC NULLS FIRST], false, 0
+
+(65) ReusedExchange [Reuses operator id: 80]
+Output [8]: [c_customer_sk#72, c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79]
+
+(66) Sort [codegen id : 31]
+Input [8]: [c_customer_sk#72, c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79]
+Arguments: [c_customer_sk#72 ASC NULLS FIRST], false, 0
+
+(67) SortMergeJoin [codegen id : 32]
+Left keys [1]: [ws_bill_customer_sk#66]
+Right keys [1]: [c_customer_sk#72]
+Join type: Inner
+Join condition: None
+
+(68) Project [codegen id : 32]
+Output [10]: [c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79, ws_ext_discount_amt#67, ws_ext_list_price#68, d_year#71]
+Input [12]: [ws_bill_customer_sk#66, ws_ext_discount_amt#67, ws_ext_list_price#68, d_year#71, c_customer_sk#72, c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79]
+
+(69) HashAggregate [codegen id : 32]
+Input [10]: [c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79, ws_ext_discount_amt#67, ws_ext_list_price#68, d_year#71]
+Keys [8]: [c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79, d_year#71]
+Functions [1]: [partial_sum(UnscaledValue((ws_ext_list_price#68 - ws_ext_discount_amt#67)))]
+Aggregate Attributes [1]: [sum#80]
+Results [9]: [c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79, d_year#71, sum#81]
+
+(70) Exchange
+Input [9]: [c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79, d_year#71, sum#81]
+Arguments: hashpartitioning(c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79, d_year#71, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(71) HashAggregate [codegen id : 33]
+Input [9]: [c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79, d_year#71, sum#81]
+Keys [8]: [c_customer_id#73, c_first_name#74, c_last_name#75, c_preferred_cust_flag#76, c_birth_country#77, c_login#78, c_email_address#79, d_year#71]
+Functions [1]: [sum(UnscaledValue((ws_ext_list_price#68 - ws_ext_discount_amt#67)))]
+Aggregate Attributes [1]: [sum(UnscaledValue((ws_ext_list_price#68 - ws_ext_discount_amt#67)))#63]
+Results [2]: [c_customer_id#73 AS customer_id#82, MakeDecimal(sum(UnscaledValue((ws_ext_list_price#68 - ws_ext_discount_amt#67)))#63,18,2) AS year_total#83]
+
+(72) Exchange
+Input [2]: [customer_id#82, year_total#83]
+Arguments: hashpartitioning(customer_id#82, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(73) Sort [codegen id : 34]
+Input [2]: [customer_id#82, year_total#83]
+Arguments: [customer_id#82 ASC NULLS FIRST], false, 0
+
+(74) SortMergeJoin [codegen id : 35]
+Left keys [1]: [customer_id#21]
+Right keys [1]: [customer_id#82]
+Join type: Inner
+Join condition: (CASE WHEN (year_total#65 > 0.00) THEN (year_total#83 / year_total#65) ELSE 0E-20 END > CASE WHEN (year_total#22 > 0.00) THEN (year_total#46 / year_total#22) ELSE 0E-20 END)
+
+(75) Project [codegen id : 35]
+Output [4]: [customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45]
+Input [10]: [customer_id#21, year_total#22, customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45, year_total#46, year_total#65, customer_id#82, year_total#83]
+
+(76) TakeOrderedAndProject
+Input [4]: [customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45]
+Arguments: 100, [customer_id#42 ASC NULLS FIRST, customer_first_name#43 ASC NULLS FIRST, customer_last_name#44 ASC NULLS FIRST, customer_email_address#45 ASC NULLS FIRST], [customer_id#42, customer_first_name#43, customer_last_name#44, customer_email_address#45]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (83)
++- Exchange (82)
+   +- ObjectHashAggregate (81)
+      +- Exchange (80)
+         +- * Filter (79)
+            +- * ColumnarToRow (78)
+               +- Scan parquet spark_catalog.default.customer (77)
+
+
+(77) Scan parquet spark_catalog.default.customer
+Output [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(10) ColumnarToRow [codegen id : 4]
-Input [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-
-(11) Filter [codegen id : 4]
-Input [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Condition : (isnotnull(c_customer_sk#8) AND isnotnull(c_customer_id#9))
-
-(12) Exchange
-Input [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Arguments: hashpartitioning(c_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(13) Sort [codegen id : 5]
-Input [8]: [c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Arguments: [c_customer_sk#8 ASC NULLS FIRST], false, 0
-
-(14) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#8]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [10]: [c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
-Input [12]: [ss_customer_sk#1, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7, c_customer_sk#8, c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-
-(16) HashAggregate [codegen id : 6]
-Input [10]: [c_customer_id#9, c_first_name#10, c_last_name#11, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, ss_ext_discount_amt#2, ss_ext_list_price#3, d_year#7]
-Keys [8]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Functions [1]: [partial_sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))]
-Aggregate Attributes [1]: [sum#16]
-Results [9]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, sum#17]
-
-(17) Exchange
-Input [9]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, sum#17]
-Arguments: hashpartitioning(c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [9]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15, sum#17]
-Keys [8]: [c_customer_id#9, c_first_name#10, c_last_name#11, d_year#7, c_preferred_cust_flag#12, c_birth_country#13, c_login#14, c_email_address#15]
-Functions [1]: [sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))]
-Aggregate Attributes [1]: [sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))#18]
-Results [2]: [c_customer_id#9 AS customer_id#19, MakeDecimal(sum(UnscaledValue((ss_ext_list_price#3 - ss_ext_discount_amt#2)))#18,18,2) AS year_total#20]
-
-(19) Filter [codegen id : 7]
-Input [2]: [customer_id#19, year_total#20]
-Condition : (isnotnull(year_total#20) AND (year_total#20 > 0.00))
-
-(20) Exchange
-Input [2]: [customer_id#19, year_total#20]
-Arguments: hashpartitioning(customer_id#19, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(21) Sort [codegen id : 8]
-Input [2]: [customer_id#19, year_total#20]
-Arguments: [customer_id#19 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, ss_sold_date_sk#24]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#24), dynamicpruningexpression(ss_sold_date_sk#24 IN dynamicpruning#25)]
-PushedFilters: [IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_customer_sk:int,ss_ext_discount_amt:decimal(7,2),ss_ext_list_price:decimal(7,2)>
-
-(23) ColumnarToRow [codegen id : 10]
-Input [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, ss_sold_date_sk#24]
-
-(24) Filter [codegen id : 10]
-Input [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, ss_sold_date_sk#24]
-Condition : isnotnull(ss_customer_sk#21)
-
-(25) ReusedExchange [Reuses operator id: 87]
-Output [2]: [d_date_sk#26, d_year#27]
-
-(26) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#24]
-Right keys [1]: [d_date_sk#26]
-Join type: Inner
-Join condition: None
-
-(27) Project [codegen id : 10]
-Output [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Input [6]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, ss_sold_date_sk#24, d_date_sk#26, d_year#27]
-
-(28) Exchange
-Input [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Arguments: hashpartitioning(ss_customer_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(29) Sort [codegen id : 11]
-Input [4]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Arguments: [ss_customer_sk#21 ASC NULLS FIRST], false, 0
-
-(30) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#28, c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-
-(31) Sort [codegen id : 13]
-Input [8]: [c_customer_sk#28, c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 14]
-Left keys [1]: [ss_customer_sk#21]
-Right keys [1]: [c_customer_sk#28]
-Join type: Inner
-Join condition: None
-
-(33) Project [codegen id : 14]
-Output [10]: [c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Input [12]: [ss_customer_sk#21, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27, c_customer_sk#28, c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-
-(34) HashAggregate [codegen id : 14]
-Input [10]: [c_customer_id#29, c_first_name#30, c_last_name#31, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, ss_ext_discount_amt#22, ss_ext_list_price#23, d_year#27]
-Keys [8]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-Functions [1]: [partial_sum(UnscaledValue((ss_ext_list_price#23 - ss_ext_discount_amt#22)))]
-Aggregate Attributes [1]: [sum#36]
-Results [9]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, sum#37]
-
-(35) Exchange
-Input [9]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, sum#37]
-Arguments: hashpartitioning(c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(36) HashAggregate [codegen id : 15]
-Input [9]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35, sum#37]
-Keys [8]: [c_customer_id#29, c_first_name#30, c_last_name#31, d_year#27, c_preferred_cust_flag#32, c_birth_country#33, c_login#34, c_email_address#35]
-Functions [1]: [sum(UnscaledValue((ss_ext_list_price#23 - ss_ext_discount_amt#22)))]
-Aggregate Attributes [1]: [sum(UnscaledValue((ss_ext_list_price#23 - ss_ext_discount_amt#22)))#18]
-Results [5]: [c_customer_id#29 AS customer_id#38, c_first_name#30 AS customer_first_name#39, c_last_name#31 AS customer_last_name#40, c_email_address#35 AS customer_email_address#41, MakeDecimal(sum(UnscaledValue((ss_ext_list_price#23 - ss_ext_discount_amt#22)))#18,18,2) AS year_total#42]
-
-(37) Exchange
-Input [5]: [customer_id#38, customer_first_name#39, customer_last_name#40, customer_email_address#41, year_total#42]
-Arguments: hashpartitioning(customer_id#38, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(38) Sort [codegen id : 16]
-Input [5]: [customer_id#38, customer_first_name#39, customer_last_name#40, customer_email_address#41, year_total#42]
-Arguments: [customer_id#38 ASC NULLS FIRST], false, 0
-
-(39) SortMergeJoin [codegen id : 17]
-Left keys [1]: [customer_id#19]
-Right keys [1]: [customer_id#38]
-Join type: Inner
-Join condition: None
-
-(40) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_bill_customer_sk#43, ws_ext_discount_amt#44, ws_ext_list_price#45, ws_sold_date_sk#46]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#46), dynamicpruningexpression(ws_sold_date_sk#46 IN dynamicpruning#5)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_list_price:decimal(7,2)>
-
-(41) ColumnarToRow [codegen id : 19]
-Input [4]: [ws_bill_customer_sk#43, ws_ext_discount_amt#44, ws_ext_list_price#45, ws_sold_date_sk#46]
-
-(42) Filter [codegen id : 19]
-Input [4]: [ws_bill_customer_sk#43, ws_ext_discount_amt#44, ws_ext_list_price#45, ws_sold_date_sk#46]
-Condition : isnotnull(ws_bill_customer_sk#43)
-
-(43) ReusedExchange [Reuses operator id: 83]
-Output [2]: [d_date_sk#47, d_year#48]
-
-(44) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_sold_date_sk#46]
-Right keys [1]: [d_date_sk#47]
-Join type: Inner
-Join condition: None
-
-(45) Project [codegen id : 19]
-Output [4]: [ws_bill_customer_sk#43, ws_ext_discount_amt#44, ws_ext_list_price#45, d_year#48]
-Input [6]: [ws_bill_customer_sk#43, ws_ext_discount_amt#44, ws_ext_list_price#45, ws_sold_date_sk#46, d_date_sk#47, d_year#48]
-
-(46) Exchange
-Input [4]: [ws_bill_customer_sk#43, ws_ext_discount_amt#44, ws_ext_list_price#45, d_year#48]
-Arguments: hashpartitioning(ws_bill_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(47) Sort [codegen id : 20]
-Input [4]: [ws_bill_customer_sk#43, ws_ext_discount_amt#44, ws_ext_list_price#45, d_year#48]
-Arguments: [ws_bill_customer_sk#43 ASC NULLS FIRST], false, 0
-
-(48) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#49, c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56]
-
-(49) Sort [codegen id : 22]
-Input [8]: [c_customer_sk#49, c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56]
-Arguments: [c_customer_sk#49 ASC NULLS FIRST], false, 0
-
-(50) SortMergeJoin [codegen id : 23]
-Left keys [1]: [ws_bill_customer_sk#43]
-Right keys [1]: [c_customer_sk#49]
-Join type: Inner
-Join condition: None
-
-(51) Project [codegen id : 23]
-Output [10]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, ws_ext_discount_amt#44, ws_ext_list_price#45, d_year#48]
-Input [12]: [ws_bill_customer_sk#43, ws_ext_discount_amt#44, ws_ext_list_price#45, d_year#48, c_customer_sk#49, c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56]
-
-(52) HashAggregate [codegen id : 23]
-Input [10]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, ws_ext_discount_amt#44, ws_ext_list_price#45, d_year#48]
-Keys [8]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#48]
-Functions [1]: [partial_sum(UnscaledValue((ws_ext_list_price#45 - ws_ext_discount_amt#44)))]
-Aggregate Attributes [1]: [sum#57]
-Results [9]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#48, sum#58]
-
-(53) Exchange
-Input [9]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#48, sum#58]
-Arguments: hashpartitioning(c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#48, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(54) HashAggregate [codegen id : 24]
-Input [9]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#48, sum#58]
-Keys [8]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#48]
-Functions [1]: [sum(UnscaledValue((ws_ext_list_price#45 - ws_ext_discount_amt#44)))]
-Aggregate Attributes [1]: [sum(UnscaledValue((ws_ext_list_price#45 - ws_ext_discount_amt#44)))#59]
-Results [2]: [c_customer_id#50 AS customer_id#60, MakeDecimal(sum(UnscaledValue((ws_ext_list_price#45 - ws_ext_discount_amt#44)))#59,18,2) AS year_total#61]
-
-(55) Filter [codegen id : 24]
-Input [2]: [customer_id#60, year_total#61]
-Condition : (isnotnull(year_total#61) AND (year_total#61 > 0.00))
-
-(56) Exchange
-Input [2]: [customer_id#60, year_total#61]
-Arguments: hashpartitioning(customer_id#60, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(57) Sort [codegen id : 25]
-Input [2]: [customer_id#60, year_total#61]
-Arguments: [customer_id#60 ASC NULLS FIRST], false, 0
-
-(58) SortMergeJoin [codegen id : 26]
-Left keys [1]: [customer_id#19]
-Right keys [1]: [customer_id#60]
-Join type: Inner
-Join condition: None
-
-(59) Project [codegen id : 26]
-Output [8]: [customer_id#19, year_total#20, customer_id#38, customer_first_name#39, customer_last_name#40, customer_email_address#41, year_total#42, year_total#61]
-Input [9]: [customer_id#19, year_total#20, customer_id#38, customer_first_name#39, customer_last_name#40, customer_email_address#41, year_total#42, customer_id#60, year_total#61]
-
-(60) Scan parquet spark_catalog.default.web_sales
-Output [4]: [ws_bill_customer_sk#62, ws_ext_discount_amt#63, ws_ext_list_price#64, ws_sold_date_sk#65]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#65), dynamicpruningexpression(ws_sold_date_sk#65 IN dynamicpruning#25)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_list_price:decimal(7,2)>
-
-(61) ColumnarToRow [codegen id : 28]
-Input [4]: [ws_bill_customer_sk#62, ws_ext_discount_amt#63, ws_ext_list_price#64, ws_sold_date_sk#65]
-
-(62) Filter [codegen id : 28]
-Input [4]: [ws_bill_customer_sk#62, ws_ext_discount_amt#63, ws_ext_list_price#64, ws_sold_date_sk#65]
-Condition : isnotnull(ws_bill_customer_sk#62)
-
-(63) ReusedExchange [Reuses operator id: 87]
-Output [2]: [d_date_sk#66, d_year#67]
-
-(64) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [ws_sold_date_sk#65]
-Right keys [1]: [d_date_sk#66]
-Join type: Inner
-Join condition: None
-
-(65) Project [codegen id : 28]
-Output [4]: [ws_bill_customer_sk#62, ws_ext_discount_amt#63, ws_ext_list_price#64, d_year#67]
-Input [6]: [ws_bill_customer_sk#62, ws_ext_discount_amt#63, ws_ext_list_price#64, ws_sold_date_sk#65, d_date_sk#66, d_year#67]
-
-(66) Exchange
-Input [4]: [ws_bill_customer_sk#62, ws_ext_discount_amt#63, ws_ext_list_price#64, d_year#67]
-Arguments: hashpartitioning(ws_bill_customer_sk#62, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(67) Sort [codegen id : 29]
-Input [4]: [ws_bill_customer_sk#62, ws_ext_discount_amt#63, ws_ext_list_price#64, d_year#67]
-Arguments: [ws_bill_customer_sk#62 ASC NULLS FIRST], false, 0
-
-(68) ReusedExchange [Reuses operator id: 12]
-Output [8]: [c_customer_sk#68, c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75]
-
-(69) Sort [codegen id : 31]
-Input [8]: [c_customer_sk#68, c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75]
-Arguments: [c_customer_sk#68 ASC NULLS FIRST], false, 0
-
-(70) SortMergeJoin [codegen id : 32]
-Left keys [1]: [ws_bill_customer_sk#62]
-Right keys [1]: [c_customer_sk#68]
-Join type: Inner
-Join condition: None
-
-(71) Project [codegen id : 32]
-Output [10]: [c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75, ws_ext_discount_amt#63, ws_ext_list_price#64, d_year#67]
-Input [12]: [ws_bill_customer_sk#62, ws_ext_discount_amt#63, ws_ext_list_price#64, d_year#67, c_customer_sk#68, c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75]
-
-(72) HashAggregate [codegen id : 32]
-Input [10]: [c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75, ws_ext_discount_amt#63, ws_ext_list_price#64, d_year#67]
-Keys [8]: [c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75, d_year#67]
-Functions [1]: [partial_sum(UnscaledValue((ws_ext_list_price#64 - ws_ext_discount_amt#63)))]
-Aggregate Attributes [1]: [sum#76]
-Results [9]: [c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75, d_year#67, sum#77]
-
-(73) Exchange
-Input [9]: [c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75, d_year#67, sum#77]
-Arguments: hashpartitioning(c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75, d_year#67, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(74) HashAggregate [codegen id : 33]
-Input [9]: [c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75, d_year#67, sum#77]
-Keys [8]: [c_customer_id#69, c_first_name#70, c_last_name#71, c_preferred_cust_flag#72, c_birth_country#73, c_login#74, c_email_address#75, d_year#67]
-Functions [1]: [sum(UnscaledValue((ws_ext_list_price#64 - ws_ext_discount_amt#63)))]
-Aggregate Attributes [1]: [sum(UnscaledValue((ws_ext_list_price#64 - ws_ext_discount_amt#63)))#59]
-Results [2]: [c_customer_id#69 AS customer_id#78, MakeDecimal(sum(UnscaledValue((ws_ext_list_price#64 - ws_ext_discount_amt#63)))#59,18,2) AS year_total#79]
-
-(75) Exchange
-Input [2]: [customer_id#78, year_total#79]
-Arguments: hashpartitioning(customer_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(76) Sort [codegen id : 34]
-Input [2]: [customer_id#78, year_total#79]
-Arguments: [customer_id#78 ASC NULLS FIRST], false, 0
-
-(77) SortMergeJoin [codegen id : 35]
-Left keys [1]: [customer_id#19]
-Right keys [1]: [customer_id#78]
-Join type: Inner
-Join condition: (CASE WHEN (year_total#61 > 0.00) THEN (year_total#79 / year_total#61) ELSE 0E-20 END > CASE WHEN (year_total#20 > 0.00) THEN (year_total#42 / year_total#20) ELSE 0E-20 END)
-
-(78) Project [codegen id : 35]
-Output [4]: [customer_id#38, customer_first_name#39, customer_last_name#40, customer_email_address#41]
-Input [10]: [customer_id#19, year_total#20, customer_id#38, customer_first_name#39, customer_last_name#40, customer_email_address#41, year_total#42, year_total#61, customer_id#78, year_total#79]
-
-(79) TakeOrderedAndProject
-Input [4]: [customer_id#38, customer_first_name#39, customer_last_name#40, customer_email_address#41]
-Arguments: 100, [customer_id#38 ASC NULLS FIRST, customer_first_name#39 ASC NULLS FIRST, customer_last_name#40 ASC NULLS FIRST, customer_email_address#41 ASC NULLS FIRST], [customer_id#38, customer_first_name#39, customer_last_name#40, customer_email_address#41]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (83)
-+- * Filter (82)
-   +- * ColumnarToRow (81)
-      +- Scan parquet spark_catalog.default.date_dim (80)
-
-
-(80) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#6, d_year#7]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int>
-
-(81) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#6, d_year#7]
-
-(82) Filter [codegen id : 1]
-Input [2]: [d_date_sk#6, d_year#7]
-Condition : ((isnotnull(d_year#7) AND (d_year#7 = 2001)) AND isnotnull(d_date_sk#6))
-
-(83) BroadcastExchange
-Input [2]: [d_date_sk#6, d_year#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
-
-Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#24 IN dynamicpruning#25
+(78) ColumnarToRow [codegen id : 1]
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+
+(79) Filter [codegen id : 1]
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Condition : (isnotnull(c_customer_sk#10) AND isnotnull(c_customer_id#11))
+
+(80) Exchange
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Arguments: hashpartitioning(c_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(81) ObjectHashAggregate
+Input [8]: [c_customer_sk#10, c_customer_id#11, c_first_name#12, c_last_name#13, c_preferred_cust_flag#14, c_birth_country#15, c_login#16, c_email_address#17]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#10, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#84]
+Results [1]: [buf#85]
+
+(82) Exchange
+Input [1]: [buf#85]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(83) ObjectHashAggregate
+Input [1]: [buf#85]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#10, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#10, 42), 2000000, 16000000, 0, 0)#86]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#10, 42), 2000000, 16000000, 0, 0)#86 AS bloomFilter#87]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (87)
 +- * Filter (86)
    +- * ColumnarToRow (85)
@@ -484,25 +487,100 @@ BroadcastExchange (87)
 
 
 (84) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#26, d_year#27]
+Output [2]: [d_date_sk#8, d_year#9]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int>
+
+(85) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#8, d_year#9]
+
+(86) Filter [codegen id : 1]
+Input [2]: [d_date_sk#8, d_year#9]
+Condition : ((isnotnull(d_year#9) AND (d_year#9 = 2001)) AND isnotnull(d_date_sk#8))
+
+(87) BroadcastExchange
+Input [2]: [d_date_sk#8, d_year#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+
+Subquery:3 Hosting operator id = 21 Hosting Expression = Subquery scalar-subquery#28, [id=#29]
+ObjectHashAggregate (94)
++- Exchange (93)
+   +- ObjectHashAggregate (92)
+      +- Exchange (91)
+         +- * Filter (90)
+            +- * ColumnarToRow (89)
+               +- Scan parquet spark_catalog.default.customer (88)
+
+
+(88) Scan parquet spark_catalog.default.customer
+Output [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
+ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
+
+(89) ColumnarToRow [codegen id : 1]
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+
+(90) Filter [codegen id : 1]
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_customer_id#33))
+
+(91) Exchange
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Arguments: hashpartitioning(c_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(92) ObjectHashAggregate
+Input [8]: [c_customer_sk#32, c_customer_id#33, c_first_name#34, c_last_name#35, c_preferred_cust_flag#36, c_birth_country#37, c_login#38, c_email_address#39]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#32, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#88]
+Results [1]: [buf#89]
+
+(93) Exchange
+Input [1]: [buf#89]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(94) ObjectHashAggregate
+Input [1]: [buf#89]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#32, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#32, 42), 2000000, 16000000, 0, 0)#90]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#32, 42), 2000000, 16000000, 0, 0)#90 AS bloomFilter#91]
+
+Subquery:4 Hosting operator id = 19 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#27
+BroadcastExchange (98)
++- * Filter (97)
+   +- * ColumnarToRow (96)
+      +- Scan parquet spark_catalog.default.date_dim (95)
+
+
+(95) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#30, d_year#31]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(85) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#26, d_year#27]
+(96) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#30, d_year#31]
 
-(86) Filter [codegen id : 1]
-Input [2]: [d_date_sk#26, d_year#27]
-Condition : ((isnotnull(d_year#27) AND (d_year#27 = 2002)) AND isnotnull(d_date_sk#26))
+(97) Filter [codegen id : 1]
+Input [2]: [d_date_sk#30, d_year#31]
+Condition : ((isnotnull(d_year#31) AND (d_year#31 = 2002)) AND isnotnull(d_date_sk#30))
 
-(87) BroadcastExchange
-Input [2]: [d_date_sk#26, d_year#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+(98) BroadcastExchange
+Input [2]: [d_date_sk#30, d_year#31]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
 
-Subquery:3 Hosting operator id = 40 Hosting Expression = ws_sold_date_sk#46 IN dynamicpruning#5
+Subquery:5 Hosting operator id = 39 Hosting Expression = ReusedSubquery Subquery scalar-subquery#28, [id=#29]
 
-Subquery:4 Hosting operator id = 60 Hosting Expression = ws_sold_date_sk#65 IN dynamicpruning#25
+Subquery:6 Hosting operator id = 37 Hosting Expression = ws_sold_date_sk#50 IN dynamicpruning#5
+
+Subquery:7 Hosting operator id = 59 Hosting Expression = ReusedSubquery Subquery scalar-subquery#28, [id=#29]
+
+Subquery:8 Hosting operator id = 57 Hosting Expression = ws_sold_date_sk#69 IN dynamicpruning#27
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11.sf100/simplified.txt
@@ -32,6 +32,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                               Project [ss_customer_sk,ss_ext_discount_amt,ss_ext_list_price,d_year]
                                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                   Filter [ss_customer_sk]
+                                                                    Subquery #2
+                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                        Exchange #5
+                                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                            Exchange [c_customer_sk] #6
+                                                                              WholeStageCodegen (1)
+                                                                                Filter [c_customer_sk,c_customer_id]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_discount_amt,ss_ext_list_price,ss_sold_date_sk]
@@ -48,21 +58,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                     WholeStageCodegen (5)
                                                       Sort [c_customer_sk]
                                                         InputAdapter
-                                                          Exchange [c_customer_sk] #5
-                                                            WholeStageCodegen (4)
-                                                              Filter [c_customer_sk,c_customer_id]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
+                                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
                       InputAdapter
                         WholeStageCodegen (16)
                           Sort [customer_id]
                             InputAdapter
-                              Exchange [customer_id] #6
+                              Exchange [customer_id] #7
                                 WholeStageCodegen (15)
                                   HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,sum] [sum(UnscaledValue((ss_ext_list_price - ss_ext_discount_amt))),customer_id,customer_first_name,customer_last_name,customer_email_address,year_total,sum]
                                     InputAdapter
-                                      Exchange [c_customer_id,c_first_name,c_last_name,d_year,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #7
+                                      Exchange [c_customer_id,c_first_name,c_last_name,d_year,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #8
                                         WholeStageCodegen (14)
                                           HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ss_ext_list_price,ss_ext_discount_amt] [sum,sum]
                                             Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ss_ext_discount_amt,ss_ext_list_price,d_year]
@@ -71,38 +76,48 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                                   WholeStageCodegen (11)
                                                     Sort [ss_customer_sk]
                                                       InputAdapter
-                                                        Exchange [ss_customer_sk] #8
+                                                        Exchange [ss_customer_sk] #9
                                                           WholeStageCodegen (10)
                                                             Project [ss_customer_sk,ss_ext_discount_amt,ss_ext_list_price,d_year]
                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                 Filter [ss_customer_sk]
+                                                                  Subquery #4
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                      Exchange #11
+                                                                        ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                          Exchange [c_customer_sk] #12
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [c_customer_sk,c_customer_id]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_discount_amt,ss_ext_list_price,ss_sold_date_sk]
-                                                                        SubqueryBroadcast [d_date_sk] #2
-                                                                          BroadcastExchange #9
+                                                                        SubqueryBroadcast [d_date_sk] #3
+                                                                          BroadcastExchange #10
                                                                             WholeStageCodegen (1)
                                                                               Filter [d_year,d_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                 InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_year] #9
+                                                                  ReusedExchange [d_date_sk,d_year] #10
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                                        ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
                 InputAdapter
                   WholeStageCodegen (25)
                     Sort [customer_id]
                       InputAdapter
-                        Exchange [customer_id] #10
+                        Exchange [customer_id] #13
                           WholeStageCodegen (24)
                             Filter [year_total]
                               HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum] [sum(UnscaledValue((ws_ext_list_price - ws_ext_discount_amt))),customer_id,year_total,sum]
                                 InputAdapter
-                                  Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #11
+                                  Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #14
                                     WholeStageCodegen (23)
                                       HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,ws_ext_list_price,ws_ext_discount_amt] [sum,sum]
                                         Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ws_ext_discount_amt,ws_ext_list_price,d_year]
@@ -111,11 +126,12 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                               WholeStageCodegen (20)
                                                 Sort [ws_bill_customer_sk]
                                                   InputAdapter
-                                                    Exchange [ws_bill_customer_sk] #12
+                                                    Exchange [ws_bill_customer_sk] #15
                                                       WholeStageCodegen (19)
                                                         Project [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_list_price,d_year]
                                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                             Filter [ws_bill_customer_sk]
+                                                              ReusedSubquery [bloomFilter] #4
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_list_price,ws_sold_date_sk]
@@ -126,16 +142,16 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                               WholeStageCodegen (22)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6
         InputAdapter
           WholeStageCodegen (34)
             Sort [customer_id]
               InputAdapter
-                Exchange [customer_id] #13
+                Exchange [customer_id] #16
                   WholeStageCodegen (33)
                     HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,sum] [sum(UnscaledValue((ws_ext_list_price - ws_ext_discount_amt))),customer_id,year_total,sum]
                       InputAdapter
-                        Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #14
+                        Exchange [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year] #17
                           WholeStageCodegen (32)
                             HashAggregate [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,d_year,ws_ext_list_price,ws_ext_discount_amt] [sum,sum]
                               Project [c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address,ws_ext_discount_amt,ws_ext_list_price,d_year]
@@ -144,19 +160,20 @@ TakeOrderedAndProject [customer_id,customer_first_name,customer_last_name,custom
                                     WholeStageCodegen (29)
                                       Sort [ws_bill_customer_sk]
                                         InputAdapter
-                                          Exchange [ws_bill_customer_sk] #15
+                                          Exchange [ws_bill_customer_sk] #18
                                             WholeStageCodegen (28)
                                               Project [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_list_price,d_year]
                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                   Filter [ws_bill_customer_sk]
+                                                    ReusedSubquery [bloomFilter] #4
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_ext_discount_amt,ws_ext_list_price,ws_sold_date_sk]
-                                                          ReusedSubquery [d_date_sk] #2
+                                                          ReusedSubquery [d_date_sk] #3
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk,d_year] #9
+                                                    ReusedExchange [d_date_sk,d_year] #10
                                   InputAdapter
                                     WholeStageCodegen (31)
                                       Sort [c_customer_sk]
                                         InputAdapter
-                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #5
+                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_country,c_login,c_email_address] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/explain.txt
@@ -1,27 +1,24 @@
 == Physical Plan ==
-TakeOrderedAndProject (23)
-+- * Project (22)
-   +- Window (21)
-      +- * Sort (20)
-         +- Exchange (19)
-            +- * HashAggregate (18)
-               +- Exchange (17)
-                  +- * HashAggregate (16)
-                     +- * Project (15)
-                        +- * BroadcastHashJoin Inner BuildRight (14)
-                           :- * Project (12)
-                           :  +- * SortMergeJoin Inner (11)
+TakeOrderedAndProject (20)
++- * Project (19)
+   +- Window (18)
+      +- * Sort (17)
+         +- Exchange (16)
+            +- * HashAggregate (15)
+               +- Exchange (14)
+                  +- * HashAggregate (13)
+                     +- * Project (12)
+                        +- * BroadcastHashJoin Inner BuildRight (11)
+                           :- * Project (9)
+                           :  +- * SortMergeJoin Inner (8)
                            :     :- * Sort (5)
                            :     :  +- Exchange (4)
                            :     :     +- * Filter (3)
                            :     :        +- * ColumnarToRow (2)
                            :     :           +- Scan parquet spark_catalog.default.web_sales (1)
-                           :     +- * Sort (10)
-                           :        +- Exchange (9)
-                           :           +- * Filter (8)
-                           :              +- * ColumnarToRow (7)
-                           :                 +- Scan parquet spark_catalog.default.item (6)
-                           +- ReusedExchange (13)
+                           :     +- * Sort (7)
+                           :        +- ReusedExchange (6)
+                           +- ReusedExchange (10)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -37,7 +34,7 @@ Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
-Condition : isnotnull(ws_item_sk#1)
+Condition : (isnotnull(ws_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ws_item_sk#1, 42), false))
 
 (4) Exchange
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
@@ -47,119 +44,150 @@ Arguments: hashpartitioning(ws_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
 Arguments: [ws_item_sk#1 ASC NULLS FIRST], false, 0
 
-(6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(6) ReusedExchange [Reuses operator id: 24]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(7) Sort [codegen id : 4]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
+
+(8) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ws_item_sk#1]
+Right keys [1]: [i_item_sk#7]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 6]
+Output [7]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(10) ReusedExchange [Reuses operator id: 32]
+Output [1]: [d_date_sk#13]
+
+(11) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#3]
+Right keys [1]: [d_date_sk#13]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [6]: [ws_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
+
+(13) HashAggregate [codegen id : 6]
+Input [6]: [ws_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+
+(14) Exchange
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#2))#16]
+Results [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS _w0#18, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS _w1#19]
+
+(16) Exchange
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(17) Sort [codegen id : 8]
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
+
+(18) Window
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: [sum(_w1#19) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#20], [i_class#11]
+
+(19) Project [codegen id : 9]
+Output [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#20) AS revenueratio#21]
+Input [9]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, _we0#20]
+
+(20) TakeOrderedAndProject
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+Arguments: 100, [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#21 ASC NULLS FIRST], [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (27)
++- Exchange (26)
+   +- ObjectHashAggregate (25)
+      +- Exchange (24)
+         +- * Filter (23)
+            +- * ColumnarToRow (22)
+               +- Scan parquet spark_catalog.default.item (21)
+
+
+(21) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
-(7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(22) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+(23) Filter [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
-(9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(24) Exchange
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+(25) ObjectHashAggregate
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [buf#22]
+Results [1]: [buf#23]
 
-(11) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ws_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
+(26) Exchange
+Input [1]: [buf#23]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
-(12) Project [codegen id : 6]
-Output [7]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(27) ObjectHashAggregate
+Input [1]: [buf#23]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24 AS bloomFilter#25]
 
-(13) ReusedExchange [Reuses operator id: 28]
-Output [1]: [d_date_sk#11]
-
-(14) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [6]: [ws_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
-
-(16) HashAggregate [codegen id : 6]
-Input [6]: [ws_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-
-(17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#2))#14]
-Results [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS _w0#16, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS _w1#17]
-
-(19) Exchange
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(20) Sort [codegen id : 8]
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
-
-(21) Window
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: [sum(_w1#17) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#18], [i_class#9]
-
-(22) Project [codegen id : 9]
-Output [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#18) AS revenueratio#19]
-Input [9]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, _we0#18]
-
-(23) TakeOrderedAndProject
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-Arguments: 100, [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#19 ASC NULLS FIRST], [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (28)
-+- * Project (27)
-   +- * Filter (26)
-      +- * ColumnarToRow (25)
-         +- Scan parquet spark_catalog.default.date_dim (24)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (32)
++- * Project (31)
+   +- * Filter (30)
+      +- * ColumnarToRow (29)
+         +- Scan parquet spark_catalog.default.date_dim (28)
 
 
-(24) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#20]
+(28) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(25) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
+(29) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(26) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
-Condition : (((isnotnull(d_date#20) AND (d_date#20 >= 1999-02-22)) AND (d_date#20 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(30) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
+Condition : (((isnotnull(d_date#26) AND (d_date#26 >= 1999-02-22)) AND (d_date#26 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(27) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#20]
+(31) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(28) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(32) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/simplified.txt
@@ -24,6 +24,16 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                               Exchange [ws_item_sk] #3
                                                 WholeStageCodegen (1)
                                                   Filter [ws_item_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 489600, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                            Exchange [i_item_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [i_category,i_item_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
@@ -39,11 +49,6 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                         WholeStageCodegen (4)
                                           Sort [i_item_sk]
                                             InputAdapter
-                                              Exchange [i_item_sk] #5
-                                                WholeStageCodegen (3)
-                                                  Filter [i_category,i_item_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
+                                              ReusedExchange [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category] #6
                                   InputAdapter
                                     ReusedExchange [d_date_sk] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
@@ -1,13 +1,13 @@
 == Physical Plan ==
-TakeOrderedAndProject (143)
-+- * HashAggregate (142)
-   +- Exchange (141)
-      +- * HashAggregate (140)
-         +- Union (139)
-            :- * HashAggregate (118)
-            :  +- Exchange (117)
-            :     +- * HashAggregate (116)
-            :        +- Union (115)
+TakeOrderedAndProject (151)
++- * HashAggregate (150)
+   +- Exchange (149)
+      +- * HashAggregate (148)
+         +- Union (147)
+            :- * HashAggregate (126)
+            :  +- Exchange (125)
+            :     +- * HashAggregate (124)
+            :        +- Union (123)
             :           :- * Filter (78)
             :           :  +- * HashAggregate (77)
             :           :     +- Exchange (76)
@@ -86,12 +86,12 @@ TakeOrderedAndProject (143)
             :           :                       :           +- Scan parquet spark_catalog.default.item (64)
             :           :                       +- * Sort (70)
             :           :                          +- ReusedExchange (69)
-            :           :- * Filter (96)
-            :           :  +- * HashAggregate (95)
-            :           :     +- Exchange (94)
-            :           :        +- * HashAggregate (93)
-            :           :           +- * Project (92)
-            :           :              +- * BroadcastHashJoin Inner BuildRight (91)
+            :           :- * Filter (104)
+            :           :  +- * HashAggregate (103)
+            :           :     +- Exchange (102)
+            :           :        +- * HashAggregate (101)
+            :           :           +- * Project (100)
+            :           :              +- * BroadcastHashJoin Inner BuildRight (99)
             :           :                 :- * Project (89)
             :           :                 :  +- * BroadcastHashJoin Inner BuildRight (88)
             :           :                 :     :- * SortMergeJoin LeftSemi (86)
@@ -103,45 +103,53 @@ TakeOrderedAndProject (143)
             :           :                 :     :  +- * Sort (85)
             :           :                 :     :     +- ReusedExchange (84)
             :           :                 :     +- ReusedExchange (87)
-            :           :                 +- ReusedExchange (90)
-            :           +- * Filter (114)
-            :              +- * HashAggregate (113)
-            :                 +- Exchange (112)
-            :                    +- * HashAggregate (111)
-            :                       +- * Project (110)
-            :                          +- * BroadcastHashJoin Inner BuildRight (109)
-            :                             :- * Project (107)
-            :                             :  +- * BroadcastHashJoin Inner BuildRight (106)
-            :                             :     :- * SortMergeJoin LeftSemi (104)
-            :                             :     :  :- * Sort (101)
-            :                             :     :  :  +- Exchange (100)
-            :                             :     :  :     +- * Filter (99)
-            :                             :     :  :        +- * ColumnarToRow (98)
-            :                             :     :  :           +- Scan parquet spark_catalog.default.web_sales (97)
-            :                             :     :  +- * Sort (103)
-            :                             :     :     +- ReusedExchange (102)
-            :                             :     +- ReusedExchange (105)
-            :                             +- ReusedExchange (108)
-            :- * HashAggregate (123)
-            :  +- Exchange (122)
-            :     +- * HashAggregate (121)
-            :        +- * HashAggregate (120)
-            :           +- ReusedExchange (119)
-            :- * HashAggregate (128)
-            :  +- Exchange (127)
-            :     +- * HashAggregate (126)
-            :        +- * HashAggregate (125)
-            :           +- ReusedExchange (124)
-            :- * HashAggregate (133)
-            :  +- Exchange (132)
-            :     +- * HashAggregate (131)
-            :        +- * HashAggregate (130)
-            :           +- ReusedExchange (129)
-            +- * HashAggregate (138)
-               +- Exchange (137)
-                  +- * HashAggregate (136)
-                     +- * HashAggregate (135)
-                        +- ReusedExchange (134)
+            :           :                 +- BroadcastExchange (98)
+            :           :                    +- * SortMergeJoin LeftSemi (97)
+            :           :                       :- * Sort (94)
+            :           :                       :  +- Exchange (93)
+            :           :                       :     +- * Filter (92)
+            :           :                       :        +- * ColumnarToRow (91)
+            :           :                       :           +- Scan parquet spark_catalog.default.item (90)
+            :           :                       +- * Sort (96)
+            :           :                          +- ReusedExchange (95)
+            :           +- * Filter (122)
+            :              +- * HashAggregate (121)
+            :                 +- Exchange (120)
+            :                    +- * HashAggregate (119)
+            :                       +- * Project (118)
+            :                          +- * BroadcastHashJoin Inner BuildRight (117)
+            :                             :- * Project (115)
+            :                             :  +- * BroadcastHashJoin Inner BuildRight (114)
+            :                             :     :- * SortMergeJoin LeftSemi (112)
+            :                             :     :  :- * Sort (109)
+            :                             :     :  :  +- Exchange (108)
+            :                             :     :  :     +- * Filter (107)
+            :                             :     :  :        +- * ColumnarToRow (106)
+            :                             :     :  :           +- Scan parquet spark_catalog.default.web_sales (105)
+            :                             :     :  +- * Sort (111)
+            :                             :     :     +- ReusedExchange (110)
+            :                             :     +- ReusedExchange (113)
+            :                             +- ReusedExchange (116)
+            :- * HashAggregate (131)
+            :  +- Exchange (130)
+            :     +- * HashAggregate (129)
+            :        +- * HashAggregate (128)
+            :           +- ReusedExchange (127)
+            :- * HashAggregate (136)
+            :  +- Exchange (135)
+            :     +- * HashAggregate (134)
+            :        +- * HashAggregate (133)
+            :           +- ReusedExchange (132)
+            :- * HashAggregate (141)
+            :  +- Exchange (140)
+            :     +- * HashAggregate (139)
+            :        +- * HashAggregate (138)
+            :           +- ReusedExchange (137)
+            +- * HashAggregate (146)
+               +- Exchange (145)
+                  +- * HashAggregate (144)
+                     +- * HashAggregate (143)
+                        +- ReusedExchange (142)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -196,7 +204,7 @@ Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 Condition : isnotnull(ss_item_sk#10)
 
-(12) ReusedExchange [Reuses operator id: 177]
+(12) ReusedExchange [Reuses operator id: 185]
 Output [1]: [d_date_sk#13]
 
 (13) BroadcastHashJoin [codegen id : 11]
@@ -246,7 +254,7 @@ Input [2]: [cs_item_sk#18, cs_sold_date_sk#19]
 Input [2]: [cs_item_sk#18, cs_sold_date_sk#19]
 Condition : isnotnull(cs_item_sk#18)
 
-(23) ReusedExchange [Reuses operator id: 177]
+(23) ReusedExchange [Reuses operator id: 185]
 Output [1]: [d_date_sk#20]
 
 (24) BroadcastHashJoin [codegen id : 8]
@@ -356,7 +364,7 @@ Input [2]: [ws_item_sk#28, ws_sold_date_sk#29]
 Input [2]: [ws_item_sk#28, ws_sold_date_sk#29]
 Condition : isnotnull(ws_item_sk#28)
 
-(46) ReusedExchange [Reuses operator id: 177]
+(46) ReusedExchange [Reuses operator id: 185]
 Output [1]: [d_date_sk#30]
 
 (47) BroadcastHashJoin [codegen id : 16]
@@ -424,7 +432,7 @@ Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(61) ReusedExchange [Reuses operator id: 172]
+(61) ReusedExchange [Reuses operator id: 180]
 Output [1]: [d_date_sk#36]
 
 (62) BroadcastHashJoin [codegen id : 43]
@@ -544,7 +552,7 @@ Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(87) ReusedExchange [Reuses operator id: 172]
+(87) ReusedExchange [Reuses operator id: 180]
 Output [1]: [d_date_sk#58]
 
 (88) BroadcastHashJoin [codegen id : 87]
@@ -557,42 +565,78 @@ Join condition: None
 Output [3]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56]
 Input [5]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, d_date_sk#58]
 
-(90) ReusedExchange [Reuses operator id: 72]
+(90) Scan parquet spark_catalog.default.item
 Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(91) BroadcastHashJoin [codegen id : 87]
+(91) ColumnarToRow [codegen id : 66]
+Input [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+
+(92) Filter [codegen id : 66]
+Input [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Condition : (isnotnull(i_item_sk#59) AND true)
+
+(93) Exchange
+Input [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Arguments: hashpartitioning(i_item_sk#59, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(94) Sort [codegen id : 67]
+Input [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Arguments: [i_item_sk#59 ASC NULLS FIRST], false, 0
+
+(95) ReusedExchange [Reuses operator id: 58]
+Output [1]: [ss_item_sk#35]
+
+(96) Sort [codegen id : 85]
+Input [1]: [ss_item_sk#35]
+Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
+
+(97) SortMergeJoin [codegen id : 86]
+Left keys [1]: [i_item_sk#59]
+Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
+Join condition: None
+
+(98) BroadcastExchange
+Input [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=16]
+
+(99) BroadcastHashJoin [codegen id : 87]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [i_item_sk#59]
 Join type: Inner
 Join condition: None
 
-(92) Project [codegen id : 87]
+(100) Project [codegen id : 87]
 Output [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#60, i_class_id#61, i_category_id#62]
 Input [7]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 
-(93) HashAggregate [codegen id : 87]
+(101) HashAggregate [codegen id : 87]
 Input [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#60, i_class_id#61, i_category_id#62]
 Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
 Functions [2]: [partial_sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56)), partial_count(1)]
 Aggregate Attributes [3]: [sum#63, isEmpty#64, count#65]
 Results [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
 
-(94) Exchange
+(102) Exchange
 Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
-Arguments: hashpartitioning(i_brand_id#60, i_class_id#61, i_category_id#62, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Arguments: hashpartitioning(i_brand_id#60, i_class_id#61, i_category_id#62, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(95) HashAggregate [codegen id : 88]
+(103) HashAggregate [codegen id : 88]
 Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
 Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
 Functions [2]: [sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56)), count(1)]
 Aggregate Attributes [2]: [sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56))#69, count(1)#70]
 Results [6]: [catalog AS channel#71, i_brand_id#60, i_class_id#61, i_category_id#62, sum((cast(cs_quantity#55 as decimal(10,0)) * cs_list_price#56))#69 AS sales#72, count(1)#70 AS number_sales#73]
 
-(96) Filter [codegen id : 88]
+(104) Filter [codegen id : 88]
 Input [6]: [channel#71, i_brand_id#60, i_class_id#61, i_category_id#62, sales#72, number_sales#73]
 Condition : (isnotnull(sales#72) AND (cast(sales#72 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
 
-(97) Scan parquet spark_catalog.default.web_sales
+(105) Scan parquet spark_catalog.default.web_sales
 Output [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
 Batched: true
 Location: InMemoryFileIndex []
@@ -600,455 +644,455 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#77), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(98) ColumnarToRow [codegen id : 89]
+(106) ColumnarToRow [codegen id : 89]
 Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
 
-(99) Filter [codegen id : 89]
+(107) Filter [codegen id : 89]
 Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
 Condition : isnotnull(ws_item_sk#74)
 
-(100) Exchange
+(108) Exchange
 Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
-Arguments: hashpartitioning(ws_item_sk#74, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Arguments: hashpartitioning(ws_item_sk#74, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(101) Sort [codegen id : 90]
+(109) Sort [codegen id : 90]
 Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
 Arguments: [ws_item_sk#74 ASC NULLS FIRST], false, 0
 
-(102) ReusedExchange [Reuses operator id: 58]
+(110) ReusedExchange [Reuses operator id: 58]
 Output [1]: [ss_item_sk#35]
 
-(103) Sort [codegen id : 108]
+(111) Sort [codegen id : 108]
 Input [1]: [ss_item_sk#35]
 Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 
-(104) SortMergeJoin [codegen id : 131]
+(112) SortMergeJoin [codegen id : 131]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(105) ReusedExchange [Reuses operator id: 172]
+(113) ReusedExchange [Reuses operator id: 180]
 Output [1]: [d_date_sk#78]
 
-(106) BroadcastHashJoin [codegen id : 131]
+(114) BroadcastHashJoin [codegen id : 131]
 Left keys [1]: [ws_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
 Join type: Inner
 Join condition: None
 
-(107) Project [codegen id : 131]
+(115) Project [codegen id : 131]
 Output [3]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76]
 Input [5]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, d_date_sk#78]
 
-(108) ReusedExchange [Reuses operator id: 72]
+(116) ReusedExchange [Reuses operator id: 98]
 Output [4]: [i_item_sk#79, i_brand_id#80, i_class_id#81, i_category_id#82]
 
-(109) BroadcastHashJoin [codegen id : 131]
+(117) BroadcastHashJoin [codegen id : 131]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [i_item_sk#79]
 Join type: Inner
 Join condition: None
 
-(110) Project [codegen id : 131]
+(118) Project [codegen id : 131]
 Output [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#80, i_class_id#81, i_category_id#82]
 Input [7]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, i_item_sk#79, i_brand_id#80, i_class_id#81, i_category_id#82]
 
-(111) HashAggregate [codegen id : 131]
+(119) HashAggregate [codegen id : 131]
 Input [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#80, i_class_id#81, i_category_id#82]
 Keys [3]: [i_brand_id#80, i_class_id#81, i_category_id#82]
 Functions [2]: [partial_sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76)), partial_count(1)]
 Aggregate Attributes [3]: [sum#83, isEmpty#84, count#85]
 Results [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#86, isEmpty#87, count#88]
 
-(112) Exchange
+(120) Exchange
 Input [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#86, isEmpty#87, count#88]
-Arguments: hashpartitioning(i_brand_id#80, i_class_id#81, i_category_id#82, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Arguments: hashpartitioning(i_brand_id#80, i_class_id#81, i_category_id#82, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(113) HashAggregate [codegen id : 132]
+(121) HashAggregate [codegen id : 132]
 Input [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#86, isEmpty#87, count#88]
 Keys [3]: [i_brand_id#80, i_class_id#81, i_category_id#82]
 Functions [2]: [sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76)), count(1)]
 Aggregate Attributes [2]: [sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76))#89, count(1)#90]
 Results [6]: [web AS channel#91, i_brand_id#80, i_class_id#81, i_category_id#82, sum((cast(ws_quantity#75 as decimal(10,0)) * ws_list_price#76))#89 AS sales#92, count(1)#90 AS number_sales#93]
 
-(114) Filter [codegen id : 132]
+(122) Filter [codegen id : 132]
 Input [6]: [channel#91, i_brand_id#80, i_class_id#81, i_category_id#82, sales#92, number_sales#93]
 Condition : (isnotnull(sales#92) AND (cast(sales#92 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
 
-(115) Union
+(123) Union
 
-(116) HashAggregate [codegen id : 133]
+(124) HashAggregate [codegen id : 133]
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51]
 Keys [4]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40]
 Functions [2]: [partial_sum(sales#50), partial_sum(number_sales#51)]
 Aggregate Attributes [3]: [sum#94, isEmpty#95, sum#96]
 Results [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 
-(117) Exchange
+(125) Exchange
 Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
-Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(118) HashAggregate [codegen id : 134]
+(126) HashAggregate [codegen id : 134]
 Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 Keys [4]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40]
 Functions [2]: [sum(sales#50), sum(number_sales#51)]
 Aggregate Attributes [2]: [sum(sales#50)#100, sum(number_sales#51)#101]
 Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum(sales#50)#100 AS sum_sales#102, sum(number_sales#51)#101 AS number_sales#103]
 
-(119) ReusedExchange [Reuses operator id: 117]
+(127) ReusedExchange [Reuses operator id: 125]
 Output [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 
-(120) HashAggregate [codegen id : 268]
+(128) HashAggregate [codegen id : 268]
 Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 Keys [4]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40]
 Functions [2]: [sum(sales#50), sum(number_sales#51)]
 Aggregate Attributes [2]: [sum(sales#50)#100, sum(number_sales#51)#101]
 Results [5]: [channel#49, i_brand_id#38, i_class_id#39, sum(sales#50)#100 AS sum_sales#102, sum(number_sales#51)#101 AS number_sales#103]
 
-(121) HashAggregate [codegen id : 268]
+(129) HashAggregate [codegen id : 268]
 Input [5]: [channel#49, i_brand_id#38, i_class_id#39, sum_sales#102, number_sales#103]
 Keys [3]: [channel#49, i_brand_id#38, i_class_id#39]
 Functions [2]: [partial_sum(sum_sales#102), partial_sum(number_sales#103)]
 Aggregate Attributes [3]: [sum#104, isEmpty#105, sum#106]
 Results [6]: [channel#49, i_brand_id#38, i_class_id#39, sum#107, isEmpty#108, sum#109]
 
-(122) Exchange
+(130) Exchange
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, sum#107, isEmpty#108, sum#109]
-Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, 5), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(123) HashAggregate [codegen id : 269]
+(131) HashAggregate [codegen id : 269]
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, sum#107, isEmpty#108, sum#109]
 Keys [3]: [channel#49, i_brand_id#38, i_class_id#39]
 Functions [2]: [sum(sum_sales#102), sum(number_sales#103)]
 Aggregate Attributes [2]: [sum(sum_sales#102)#110, sum(number_sales#103)#111]
 Results [6]: [channel#49, i_brand_id#38, i_class_id#39, null AS i_category_id#112, sum(sum_sales#102)#110 AS sum(sum_sales)#113, sum(number_sales#103)#111 AS sum(number_sales)#114]
 
-(124) ReusedExchange [Reuses operator id: 117]
+(132) ReusedExchange [Reuses operator id: 125]
 Output [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 
-(125) HashAggregate [codegen id : 403]
+(133) HashAggregate [codegen id : 403]
 Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 Keys [4]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40]
 Functions [2]: [sum(sales#50), sum(number_sales#51)]
 Aggregate Attributes [2]: [sum(sales#50)#100, sum(number_sales#51)#101]
 Results [4]: [channel#49, i_brand_id#38, sum(sales#50)#100 AS sum_sales#102, sum(number_sales#51)#101 AS number_sales#103]
 
-(126) HashAggregate [codegen id : 403]
+(134) HashAggregate [codegen id : 403]
 Input [4]: [channel#49, i_brand_id#38, sum_sales#102, number_sales#103]
 Keys [2]: [channel#49, i_brand_id#38]
 Functions [2]: [partial_sum(sum_sales#102), partial_sum(number_sales#103)]
 Aggregate Attributes [3]: [sum#115, isEmpty#116, sum#117]
 Results [5]: [channel#49, i_brand_id#38, sum#118, isEmpty#119, sum#120]
 
-(127) Exchange
+(135) Exchange
 Input [5]: [channel#49, i_brand_id#38, sum#118, isEmpty#119, sum#120]
-Arguments: hashpartitioning(channel#49, i_brand_id#38, 5), ENSURE_REQUIREMENTS, [plan_id=20]
+Arguments: hashpartitioning(channel#49, i_brand_id#38, 5), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(128) HashAggregate [codegen id : 404]
+(136) HashAggregate [codegen id : 404]
 Input [5]: [channel#49, i_brand_id#38, sum#118, isEmpty#119, sum#120]
 Keys [2]: [channel#49, i_brand_id#38]
 Functions [2]: [sum(sum_sales#102), sum(number_sales#103)]
 Aggregate Attributes [2]: [sum(sum_sales#102)#121, sum(number_sales#103)#122]
 Results [6]: [channel#49, i_brand_id#38, null AS i_class_id#123, null AS i_category_id#124, sum(sum_sales#102)#121 AS sum(sum_sales)#125, sum(number_sales#103)#122 AS sum(number_sales)#126]
 
-(129) ReusedExchange [Reuses operator id: 117]
+(137) ReusedExchange [Reuses operator id: 125]
 Output [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 
-(130) HashAggregate [codegen id : 538]
+(138) HashAggregate [codegen id : 538]
 Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 Keys [4]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40]
 Functions [2]: [sum(sales#50), sum(number_sales#51)]
 Aggregate Attributes [2]: [sum(sales#50)#100, sum(number_sales#51)#101]
 Results [3]: [channel#49, sum(sales#50)#100 AS sum_sales#102, sum(number_sales#51)#101 AS number_sales#103]
 
-(131) HashAggregate [codegen id : 538]
+(139) HashAggregate [codegen id : 538]
 Input [3]: [channel#49, sum_sales#102, number_sales#103]
 Keys [1]: [channel#49]
 Functions [2]: [partial_sum(sum_sales#102), partial_sum(number_sales#103)]
 Aggregate Attributes [3]: [sum#127, isEmpty#128, sum#129]
 Results [4]: [channel#49, sum#130, isEmpty#131, sum#132]
 
-(132) Exchange
+(140) Exchange
 Input [4]: [channel#49, sum#130, isEmpty#131, sum#132]
-Arguments: hashpartitioning(channel#49, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+Arguments: hashpartitioning(channel#49, 5), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(133) HashAggregate [codegen id : 539]
+(141) HashAggregate [codegen id : 539]
 Input [4]: [channel#49, sum#130, isEmpty#131, sum#132]
 Keys [1]: [channel#49]
 Functions [2]: [sum(sum_sales#102), sum(number_sales#103)]
 Aggregate Attributes [2]: [sum(sum_sales#102)#133, sum(number_sales#103)#134]
 Results [6]: [channel#49, null AS i_brand_id#135, null AS i_class_id#136, null AS i_category_id#137, sum(sum_sales#102)#133 AS sum(sum_sales)#138, sum(number_sales#103)#134 AS sum(number_sales)#139]
 
-(134) ReusedExchange [Reuses operator id: 117]
+(142) ReusedExchange [Reuses operator id: 125]
 Output [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 
-(135) HashAggregate [codegen id : 673]
+(143) HashAggregate [codegen id : 673]
 Input [7]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum#97, isEmpty#98, sum#99]
 Keys [4]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40]
 Functions [2]: [sum(sales#50), sum(number_sales#51)]
 Aggregate Attributes [2]: [sum(sales#50)#100, sum(number_sales#51)#101]
 Results [2]: [sum(sales#50)#100 AS sum_sales#102, sum(number_sales#51)#101 AS number_sales#103]
 
-(136) HashAggregate [codegen id : 673]
+(144) HashAggregate [codegen id : 673]
 Input [2]: [sum_sales#102, number_sales#103]
 Keys: []
 Functions [2]: [partial_sum(sum_sales#102), partial_sum(number_sales#103)]
 Aggregate Attributes [3]: [sum#140, isEmpty#141, sum#142]
 Results [3]: [sum#143, isEmpty#144, sum#145]
 
-(137) Exchange
+(145) Exchange
 Input [3]: [sum#143, isEmpty#144, sum#145]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=24]
 
-(138) HashAggregate [codegen id : 674]
+(146) HashAggregate [codegen id : 674]
 Input [3]: [sum#143, isEmpty#144, sum#145]
 Keys: []
 Functions [2]: [sum(sum_sales#102), sum(number_sales#103)]
 Aggregate Attributes [2]: [sum(sum_sales#102)#146, sum(number_sales#103)#147]
 Results [6]: [null AS channel#148, null AS i_brand_id#149, null AS i_class_id#150, null AS i_category_id#151, sum(sum_sales#102)#146 AS sum(sum_sales)#152, sum(number_sales#103)#147 AS sum(number_sales)#153]
 
-(139) Union
+(147) Union
 
-(140) HashAggregate [codegen id : 675]
+(148) HashAggregate [codegen id : 675]
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
 Keys [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
 
-(141) Exchange
+(149) Exchange
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
-Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+Arguments: hashpartitioning(channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103, 5), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(142) HashAggregate [codegen id : 676]
+(150) HashAggregate [codegen id : 676]
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
 Keys [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
 Functions: []
 Aggregate Attributes: []
 Results [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
 
-(143) TakeOrderedAndProject
+(151) TakeOrderedAndProject
 Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
 Arguments: 100, [channel#49 ASC NULLS FIRST, i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum_sales#102, number_sales#103]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 78 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
-* HashAggregate (162)
-+- Exchange (161)
-   +- * HashAggregate (160)
-      +- Union (159)
-         :- * Project (148)
-         :  +- * BroadcastHashJoin Inner BuildRight (147)
-         :     :- * ColumnarToRow (145)
-         :     :  +- Scan parquet spark_catalog.default.store_sales (144)
-         :     +- ReusedExchange (146)
-         :- * Project (153)
-         :  +- * BroadcastHashJoin Inner BuildRight (152)
-         :     :- * ColumnarToRow (150)
-         :     :  +- Scan parquet spark_catalog.default.catalog_sales (149)
-         :     +- ReusedExchange (151)
-         +- * Project (158)
-            +- * BroadcastHashJoin Inner BuildRight (157)
-               :- * ColumnarToRow (155)
-               :  +- Scan parquet spark_catalog.default.web_sales (154)
-               +- ReusedExchange (156)
+* HashAggregate (170)
++- Exchange (169)
+   +- * HashAggregate (168)
+      +- Union (167)
+         :- * Project (156)
+         :  +- * BroadcastHashJoin Inner BuildRight (155)
+         :     :- * ColumnarToRow (153)
+         :     :  +- Scan parquet spark_catalog.default.store_sales (152)
+         :     +- ReusedExchange (154)
+         :- * Project (161)
+         :  +- * BroadcastHashJoin Inner BuildRight (160)
+         :     :- * ColumnarToRow (158)
+         :     :  +- Scan parquet spark_catalog.default.catalog_sales (157)
+         :     +- ReusedExchange (159)
+         +- * Project (166)
+            +- * BroadcastHashJoin Inner BuildRight (165)
+               :- * ColumnarToRow (163)
+               :  +- Scan parquet spark_catalog.default.web_sales (162)
+               +- ReusedExchange (164)
 
 
-(144) Scan parquet spark_catalog.default.store_sales
+(152) Scan parquet spark_catalog.default.store_sales
 Output [3]: [ss_quantity#154, ss_list_price#155, ss_sold_date_sk#156]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ss_sold_date_sk#156), dynamicpruningexpression(ss_sold_date_sk#156 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(145) ColumnarToRow [codegen id : 2]
+(153) ColumnarToRow [codegen id : 2]
 Input [3]: [ss_quantity#154, ss_list_price#155, ss_sold_date_sk#156]
 
-(146) ReusedExchange [Reuses operator id: 177]
+(154) ReusedExchange [Reuses operator id: 185]
 Output [1]: [d_date_sk#157]
 
-(147) BroadcastHashJoin [codegen id : 2]
+(155) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#156]
 Right keys [1]: [d_date_sk#157]
 Join type: Inner
 Join condition: None
 
-(148) Project [codegen id : 2]
+(156) Project [codegen id : 2]
 Output [2]: [ss_quantity#154 AS quantity#158, ss_list_price#155 AS list_price#159]
 Input [4]: [ss_quantity#154, ss_list_price#155, ss_sold_date_sk#156, d_date_sk#157]
 
-(149) Scan parquet spark_catalog.default.catalog_sales
+(157) Scan parquet spark_catalog.default.catalog_sales
 Output [3]: [cs_quantity#160, cs_list_price#161, cs_sold_date_sk#162]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#162), dynamicpruningexpression(cs_sold_date_sk#162 IN dynamicpruning#163)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(150) ColumnarToRow [codegen id : 4]
+(158) ColumnarToRow [codegen id : 4]
 Input [3]: [cs_quantity#160, cs_list_price#161, cs_sold_date_sk#162]
 
-(151) ReusedExchange [Reuses operator id: 167]
+(159) ReusedExchange [Reuses operator id: 175]
 Output [1]: [d_date_sk#164]
 
-(152) BroadcastHashJoin [codegen id : 4]
+(160) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#162]
 Right keys [1]: [d_date_sk#164]
 Join type: Inner
 Join condition: None
 
-(153) Project [codegen id : 4]
+(161) Project [codegen id : 4]
 Output [2]: [cs_quantity#160 AS quantity#165, cs_list_price#161 AS list_price#166]
 Input [4]: [cs_quantity#160, cs_list_price#161, cs_sold_date_sk#162, d_date_sk#164]
 
-(154) Scan parquet spark_catalog.default.web_sales
+(162) Scan parquet spark_catalog.default.web_sales
 Output [3]: [ws_quantity#167, ws_list_price#168, ws_sold_date_sk#169]
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(ws_sold_date_sk#169), dynamicpruningexpression(ws_sold_date_sk#169 IN dynamicpruning#163)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(155) ColumnarToRow [codegen id : 6]
+(163) ColumnarToRow [codegen id : 6]
 Input [3]: [ws_quantity#167, ws_list_price#168, ws_sold_date_sk#169]
 
-(156) ReusedExchange [Reuses operator id: 167]
+(164) ReusedExchange [Reuses operator id: 175]
 Output [1]: [d_date_sk#170]
 
-(157) BroadcastHashJoin [codegen id : 6]
+(165) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#169]
 Right keys [1]: [d_date_sk#170]
 Join type: Inner
 Join condition: None
 
-(158) Project [codegen id : 6]
+(166) Project [codegen id : 6]
 Output [2]: [ws_quantity#167 AS quantity#171, ws_list_price#168 AS list_price#172]
 Input [4]: [ws_quantity#167, ws_list_price#168, ws_sold_date_sk#169, d_date_sk#170]
 
-(159) Union
+(167) Union
 
-(160) HashAggregate [codegen id : 7]
+(168) HashAggregate [codegen id : 7]
 Input [2]: [quantity#158, list_price#159]
 Keys: []
 Functions [1]: [partial_avg((cast(quantity#158 as decimal(10,0)) * list_price#159))]
 Aggregate Attributes [2]: [sum#173, count#174]
 Results [2]: [sum#175, count#176]
 
-(161) Exchange
+(169) Exchange
 Input [2]: [sum#175, count#176]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=24]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=26]
 
-(162) HashAggregate [codegen id : 8]
+(170) HashAggregate [codegen id : 8]
 Input [2]: [sum#175, count#176]
 Keys: []
 Functions [1]: [avg((cast(quantity#158 as decimal(10,0)) * list_price#159))]
 Aggregate Attributes [1]: [avg((cast(quantity#158 as decimal(10,0)) * list_price#159))#177]
 Results [1]: [avg((cast(quantity#158 as decimal(10,0)) * list_price#159))#177 AS average_sales#178]
 
-Subquery:2 Hosting operator id = 144 Hosting Expression = ss_sold_date_sk#156 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 152 Hosting Expression = ss_sold_date_sk#156 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 149 Hosting Expression = cs_sold_date_sk#162 IN dynamicpruning#163
-BroadcastExchange (167)
-+- * Project (166)
-   +- * Filter (165)
-      +- * ColumnarToRow (164)
-         +- Scan parquet spark_catalog.default.date_dim (163)
+Subquery:3 Hosting operator id = 157 Hosting Expression = cs_sold_date_sk#162 IN dynamicpruning#163
+BroadcastExchange (175)
++- * Project (174)
+   +- * Filter (173)
+      +- * ColumnarToRow (172)
+         +- Scan parquet spark_catalog.default.date_dim (171)
 
 
-(163) Scan parquet spark_catalog.default.date_dim
+(171) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#164, d_year#179]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(164) ColumnarToRow [codegen id : 1]
+(172) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#164, d_year#179]
 
-(165) Filter [codegen id : 1]
+(173) Filter [codegen id : 1]
 Input [2]: [d_date_sk#164, d_year#179]
 Condition : (((isnotnull(d_year#179) AND (d_year#179 >= 1998)) AND (d_year#179 <= 2000)) AND isnotnull(d_date_sk#164))
 
-(166) Project [codegen id : 1]
+(174) Project [codegen id : 1]
 Output [1]: [d_date_sk#164]
 Input [2]: [d_date_sk#164, d_year#179]
 
-(167) BroadcastExchange
+(175) BroadcastExchange
 Input [1]: [d_date_sk#164]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=27]
 
-Subquery:4 Hosting operator id = 154 Hosting Expression = ws_sold_date_sk#169 IN dynamicpruning#163
+Subquery:4 Hosting operator id = 162 Hosting Expression = ws_sold_date_sk#169 IN dynamicpruning#163
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (172)
-+- * Project (171)
-   +- * Filter (170)
-      +- * ColumnarToRow (169)
-         +- Scan parquet spark_catalog.default.date_dim (168)
+BroadcastExchange (180)
++- * Project (179)
+   +- * Filter (178)
+      +- * ColumnarToRow (177)
+         +- Scan parquet spark_catalog.default.date_dim (176)
 
 
-(168) Scan parquet spark_catalog.default.date_dim
+(176) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#36, d_year#180, d_moy#181]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(169) ColumnarToRow [codegen id : 1]
+(177) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#36, d_year#180, d_moy#181]
 
-(170) Filter [codegen id : 1]
+(178) Filter [codegen id : 1]
 Input [3]: [d_date_sk#36, d_year#180, d_moy#181]
 Condition : ((((isnotnull(d_year#180) AND isnotnull(d_moy#181)) AND (d_year#180 = 2000)) AND (d_moy#181 = 11)) AND isnotnull(d_date_sk#36))
 
-(171) Project [codegen id : 1]
+(179) Project [codegen id : 1]
 Output [1]: [d_date_sk#36]
 Input [3]: [d_date_sk#36, d_year#180, d_moy#181]
 
-(172) BroadcastExchange
+(180) BroadcastExchange
 Input [1]: [d_date_sk#36]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=28]
 
 Subquery:6 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
-BroadcastExchange (177)
-+- * Project (176)
-   +- * Filter (175)
-      +- * ColumnarToRow (174)
-         +- Scan parquet spark_catalog.default.date_dim (173)
+BroadcastExchange (185)
++- * Project (184)
+   +- * Filter (183)
+      +- * ColumnarToRow (182)
+         +- Scan parquet spark_catalog.default.date_dim (181)
 
 
-(173) Scan parquet spark_catalog.default.date_dim
+(181) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#13, d_year#182]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(174) ColumnarToRow [codegen id : 1]
+(182) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#13, d_year#182]
 
-(175) Filter [codegen id : 1]
+(183) Filter [codegen id : 1]
 Input [2]: [d_date_sk#13, d_year#182]
 Condition : (((isnotnull(d_year#182) AND (d_year#182 >= 1999)) AND (d_year#182 <= 2001)) AND isnotnull(d_date_sk#13))
 
-(176) Project [codegen id : 1]
+(184) Project [codegen id : 1]
 Output [1]: [d_date_sk#13]
 Input [2]: [d_date_sk#13, d_year#182]
 
-(177) BroadcastExchange
+(185) BroadcastExchange
 Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=29]
 
 Subquery:7 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#19 IN dynamicpruning#12
 
 Subquery:8 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#29 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 96 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:9 Hosting operator id = 104 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
 
 Subquery:10 Hosting operator id = 79 Hosting Expression = cs_sold_date_sk#57 IN dynamicpruning#5
 
-Subquery:11 Hosting operator id = 114 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
+Subquery:11 Hosting operator id = 122 Hosting Expression = ReusedSubquery Subquery scalar-subquery#52, [id=#53]
 
-Subquery:12 Hosting operator id = 97 Hosting Expression = ws_sold_date_sk#77 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 105 Hosting Expression = ws_sold_date_sk#77 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
@@ -243,13 +243,30 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                         InputAdapter
                                                           ReusedExchange [d_date_sk] #5
                                                     InputAdapter
-                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #16
+                                                      BroadcastExchange #22
+                                                        WholeStageCodegen (86)
+                                                          SortMergeJoin [i_item_sk,ss_item_sk]
+                                                            InputAdapter
+                                                              WholeStageCodegen (67)
+                                                                Sort [i_item_sk]
+                                                                  InputAdapter
+                                                                    Exchange [i_item_sk] #23
+                                                                      WholeStageCodegen (66)
+                                                                        Filter [i_item_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                            InputAdapter
+                                                              WholeStageCodegen (85)
+                                                                Sort [ss_item_sk]
+                                                                  InputAdapter
+                                                                    ReusedExchange [ss_item_sk] #6
                                   WholeStageCodegen (132)
                                     Filter [sales]
                                       ReusedSubquery [average_sales] #3
                                       HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum((cast(ws_quantity as decimal(10,0)) * ws_list_price)),count(1),channel,sales,number_sales,sum,isEmpty,count]
                                         InputAdapter
-                                          Exchange [i_brand_id,i_class_id,i_category_id] #22
+                                          Exchange [i_brand_id,i_class_id,i_category_id] #24
                                             WholeStageCodegen (131)
                                               HashAggregate [i_brand_id,i_class_id,i_category_id,ws_quantity,ws_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                                                 Project [ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
@@ -261,7 +278,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                             WholeStageCodegen (90)
                                                               Sort [ws_item_sk]
                                                                 InputAdapter
-                                                                  Exchange [ws_item_sk] #23
+                                                                  Exchange [ws_item_sk] #25
                                                                     WholeStageCodegen (89)
                                                                       Filter [ws_item_sk]
                                                                         ColumnarToRow
@@ -276,11 +293,11 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                         InputAdapter
                                                           ReusedExchange [d_date_sk] #5
                                                     InputAdapter
-                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #16
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #22
                   WholeStageCodegen (269)
                     HashAggregate [channel,i_brand_id,i_class_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange [channel,i_brand_id,i_class_id] #24
+                        Exchange [channel,i_brand_id,i_class_id] #26
                           WholeStageCodegen (268)
                             HashAggregate [channel,i_brand_id,i_class_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
@@ -289,7 +306,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                   WholeStageCodegen (404)
                     HashAggregate [channel,i_brand_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange [channel,i_brand_id] #25
+                        Exchange [channel,i_brand_id] #27
                           WholeStageCodegen (403)
                             HashAggregate [channel,i_brand_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
@@ -298,7 +315,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                   WholeStageCodegen (539)
                     HashAggregate [channel,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange [channel] #26
+                        Exchange [channel] #28
                           WholeStageCodegen (538)
                             HashAggregate [channel,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
@@ -307,7 +324,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                   WholeStageCodegen (674)
                     HashAggregate [sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),channel,i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange #27
+                        Exchange #29
                           WholeStageCodegen (673)
                             HashAggregate [sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
@@ -1,11 +1,11 @@
 == Physical Plan ==
-TakeOrderedAndProject (156)
-+- Union (155)
-   :- * HashAggregate (47)
-   :  +- Exchange (46)
-   :     +- * HashAggregate (45)
-   :        +- * Project (44)
-   :           +- * SortMergeJoin Inner (43)
+TakeOrderedAndProject (128)
++- Union (127)
+   :- * HashAggregate (28)
+   :  +- Exchange (27)
+   :     +- * HashAggregate (26)
+   :        +- * Project (25)
+   :           +- * SortMergeJoin Inner (24)
    :              :- * Sort (21)
    :              :  +- Exchange (20)
    :              :     +- * Project (19)
@@ -27,134 +27,106 @@ TakeOrderedAndProject (156)
    :              :              +- * Filter (16)
    :              :                 +- * ColumnarToRow (15)
    :              :                    +- Scan parquet spark_catalog.default.item (14)
-   :              +- * Sort (42)
-   :                 +- Exchange (41)
-   :                    +- * Project (40)
-   :                       +- * SortMergeJoin Inner (39)
-   :                          :- * Sort (33)
-   :                          :  +- Exchange (32)
-   :                          :     +- * Project (31)
-   :                          :        +- * BroadcastHashJoin Inner BuildRight (30)
-   :                          :           :- * Project (25)
-   :                          :           :  +- * Filter (24)
-   :                          :           :     +- * ColumnarToRow (23)
-   :                          :           :        +- Scan parquet spark_catalog.default.customer (22)
-   :                          :           +- BroadcastExchange (29)
-   :                          :              +- * Filter (28)
-   :                          :                 +- * ColumnarToRow (27)
-   :                          :                    +- Scan parquet spark_catalog.default.customer_address (26)
-   :                          +- * Sort (38)
-   :                             +- Exchange (37)
-   :                                +- * Filter (36)
-   :                                   +- * ColumnarToRow (35)
-   :                                      +- Scan parquet spark_catalog.default.customer_demographics (34)
-   :- * HashAggregate (72)
-   :  +- Exchange (71)
-   :     +- * HashAggregate (70)
-   :        +- * Project (69)
-   :           +- * SortMergeJoin Inner (68)
-   :              :- * Sort (49)
-   :              :  +- ReusedExchange (48)
-   :              +- * Sort (67)
-   :                 +- Exchange (66)
-   :                    +- * Project (65)
-   :                       +- * SortMergeJoin Inner (64)
-   :                          :- * Sort (61)
-   :                          :  +- Exchange (60)
-   :                          :     +- * Project (59)
-   :                          :        +- * BroadcastHashJoin Inner BuildRight (58)
-   :                          :           :- * Project (53)
-   :                          :           :  +- * Filter (52)
-   :                          :           :     +- * ColumnarToRow (51)
-   :                          :           :        +- Scan parquet spark_catalog.default.customer (50)
-   :                          :           +- BroadcastExchange (57)
-   :                          :              +- * Filter (56)
-   :                          :                 +- * ColumnarToRow (55)
-   :                          :                    +- Scan parquet spark_catalog.default.customer_address (54)
-   :                          +- * Sort (63)
-   :                             +- ReusedExchange (62)
-   :- * HashAggregate (98)
-   :  +- Exchange (97)
-   :     +- * HashAggregate (96)
-   :        +- * Project (95)
-   :           +- * SortMergeJoin Inner (94)
-   :              :- * Sort (74)
-   :              :  +- ReusedExchange (73)
-   :              +- * Sort (93)
-   :                 +- Exchange (92)
-   :                    +- * Project (91)
-   :                       +- * SortMergeJoin Inner (90)
-   :                          :- * Sort (87)
-   :                          :  +- Exchange (86)
-   :                          :     +- * Project (85)
-   :                          :        +- * BroadcastHashJoin Inner BuildRight (84)
-   :                          :           :- * Project (78)
-   :                          :           :  +- * Filter (77)
-   :                          :           :     +- * ColumnarToRow (76)
-   :                          :           :        +- Scan parquet spark_catalog.default.customer (75)
-   :                          :           +- BroadcastExchange (83)
-   :                          :              +- * Project (82)
-   :                          :                 +- * Filter (81)
-   :                          :                    +- * ColumnarToRow (80)
-   :                          :                       +- Scan parquet spark_catalog.default.customer_address (79)
-   :                          +- * Sort (89)
-   :                             +- ReusedExchange (88)
-   :- * HashAggregate (133)
-   :  +- Exchange (132)
-   :     +- * HashAggregate (131)
-   :        +- * Project (130)
-   :           +- * BroadcastHashJoin Inner BuildRight (129)
-   :              :- * Project (127)
-   :              :  +- * BroadcastHashJoin Inner BuildRight (126)
-   :              :     :- * Project (107)
-   :              :     :  +- * BroadcastHashJoin Inner BuildRight (106)
-   :              :     :     :- * Project (104)
-   :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (103)
-   :              :     :     :     :- * Filter (101)
-   :              :     :     :     :  +- * ColumnarToRow (100)
-   :              :     :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (99)
-   :              :     :     :     +- ReusedExchange (102)
-   :              :     :     +- ReusedExchange (105)
-   :              :     +- BroadcastExchange (125)
-   :              :        +- * Project (124)
-   :              :           +- * BroadcastHashJoin Inner BuildLeft (123)
-   :              :              :- BroadcastExchange (119)
-   :              :              :  +- * Project (118)
-   :              :              :     +- * BroadcastHashJoin Inner BuildRight (117)
-   :              :              :        :- * Project (111)
-   :              :              :        :  +- * Filter (110)
-   :              :              :        :     +- * ColumnarToRow (109)
-   :              :              :        :        +- Scan parquet spark_catalog.default.customer (108)
-   :              :              :        +- BroadcastExchange (116)
-   :              :              :           +- * Project (115)
-   :              :              :              +- * Filter (114)
-   :              :              :                 +- * ColumnarToRow (113)
-   :              :              :                    +- Scan parquet spark_catalog.default.customer_address (112)
-   :              :              +- * Filter (122)
-   :              :                 +- * ColumnarToRow (121)
-   :              :                    +- Scan parquet spark_catalog.default.customer_demographics (120)
-   :              +- ReusedExchange (128)
-   +- * HashAggregate (154)
-      +- Exchange (153)
-         +- * HashAggregate (152)
-            +- * Project (151)
-               +- * BroadcastHashJoin Inner BuildRight (150)
-                  :- * Project (148)
-                  :  +- * BroadcastHashJoin Inner BuildRight (147)
-                  :     :- * Project (142)
-                  :     :  +- * BroadcastHashJoin Inner BuildRight (141)
-                  :     :     :- * Project (139)
-                  :     :     :  +- * BroadcastHashJoin Inner BuildRight (138)
-                  :     :     :     :- * Filter (136)
-                  :     :     :     :  +- * ColumnarToRow (135)
-                  :     :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (134)
-                  :     :     :     +- ReusedExchange (137)
-                  :     :     +- ReusedExchange (140)
-                  :     +- BroadcastExchange (146)
-                  :        +- * Filter (145)
-                  :           +- * ColumnarToRow (144)
-                  :              +- Scan parquet spark_catalog.default.item (143)
-                  +- ReusedExchange (149)
+   :              +- * Sort (23)
+   :                 +- ReusedExchange (22)
+   :- * HashAggregate (49)
+   :  +- Exchange (48)
+   :     +- * HashAggregate (47)
+   :        +- * Project (46)
+   :           +- * SortMergeJoin Inner (45)
+   :              :- * Sort (42)
+   :              :  +- Exchange (41)
+   :              :     +- * Project (40)
+   :              :        +- * BroadcastHashJoin Inner BuildRight (39)
+   :              :           :- * Project (37)
+   :              :           :  +- * BroadcastHashJoin Inner BuildRight (36)
+   :              :           :     :- * Project (34)
+   :              :           :     :  +- * BroadcastHashJoin Inner BuildRight (33)
+   :              :           :     :     :- * Filter (31)
+   :              :           :     :     :  +- * ColumnarToRow (30)
+   :              :           :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (29)
+   :              :           :     :     +- ReusedExchange (32)
+   :              :           :     +- ReusedExchange (35)
+   :              :           +- ReusedExchange (38)
+   :              +- * Sort (44)
+   :                 +- ReusedExchange (43)
+   :- * HashAggregate (70)
+   :  +- Exchange (69)
+   :     +- * HashAggregate (68)
+   :        +- * Project (67)
+   :           +- * SortMergeJoin Inner (66)
+   :              :- * Sort (63)
+   :              :  +- Exchange (62)
+   :              :     +- * Project (61)
+   :              :        +- * BroadcastHashJoin Inner BuildRight (60)
+   :              :           :- * Project (58)
+   :              :           :  +- * BroadcastHashJoin Inner BuildRight (57)
+   :              :           :     :- * Project (55)
+   :              :           :     :  +- * BroadcastHashJoin Inner BuildRight (54)
+   :              :           :     :     :- * Filter (52)
+   :              :           :     :     :  +- * ColumnarToRow (51)
+   :              :           :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (50)
+   :              :           :     :     +- ReusedExchange (53)
+   :              :           :     +- ReusedExchange (56)
+   :              :           +- ReusedExchange (59)
+   :              +- * Sort (65)
+   :                 +- ReusedExchange (64)
+   :- * HashAggregate (105)
+   :  +- Exchange (104)
+   :     +- * HashAggregate (103)
+   :        +- * Project (102)
+   :           +- * BroadcastHashJoin Inner BuildRight (101)
+   :              :- * Project (99)
+   :              :  +- * BroadcastHashJoin Inner BuildRight (98)
+   :              :     :- * Project (79)
+   :              :     :  +- * BroadcastHashJoin Inner BuildRight (78)
+   :              :     :     :- * Project (76)
+   :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (75)
+   :              :     :     :     :- * Filter (73)
+   :              :     :     :     :  +- * ColumnarToRow (72)
+   :              :     :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (71)
+   :              :     :     :     +- ReusedExchange (74)
+   :              :     :     +- ReusedExchange (77)
+   :              :     +- BroadcastExchange (97)
+   :              :        +- * Project (96)
+   :              :           +- * BroadcastHashJoin Inner BuildLeft (95)
+   :              :              :- BroadcastExchange (91)
+   :              :              :  +- * Project (90)
+   :              :              :     +- * BroadcastHashJoin Inner BuildRight (89)
+   :              :              :        :- * Project (83)
+   :              :              :        :  +- * Filter (82)
+   :              :              :        :     +- * ColumnarToRow (81)
+   :              :              :        :        +- Scan parquet spark_catalog.default.customer (80)
+   :              :              :        +- BroadcastExchange (88)
+   :              :              :           +- * Project (87)
+   :              :              :              +- * Filter (86)
+   :              :              :                 +- * ColumnarToRow (85)
+   :              :              :                    +- Scan parquet spark_catalog.default.customer_address (84)
+   :              :              +- * Filter (94)
+   :              :                 +- * ColumnarToRow (93)
+   :              :                    +- Scan parquet spark_catalog.default.customer_demographics (92)
+   :              +- ReusedExchange (100)
+   +- * HashAggregate (126)
+      +- Exchange (125)
+         +- * HashAggregate (124)
+            +- * Project (123)
+               +- * BroadcastHashJoin Inner BuildRight (122)
+                  :- * Project (120)
+                  :  +- * BroadcastHashJoin Inner BuildRight (119)
+                  :     :- * Project (114)
+                  :     :  +- * BroadcastHashJoin Inner BuildRight (113)
+                  :     :     :- * Project (111)
+                  :     :     :  +- * BroadcastHashJoin Inner BuildRight (110)
+                  :     :     :     :- * Filter (108)
+                  :     :     :     :  +- * ColumnarToRow (107)
+                  :     :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (106)
+                  :     :     :     +- ReusedExchange (109)
+                  :     :     +- ReusedExchange (112)
+                  :     +- BroadcastExchange (118)
+                  :        +- * Filter (117)
+                  :           +- * ColumnarToRow (116)
+                  :              +- Scan parquet spark_catalog.default.item (115)
+                  +- ReusedExchange (121)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -170,444 +142,125 @@ Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity
 
 (3) Filter [codegen id : 4]
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
-Condition : ((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3))
+Condition : (((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3)) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_bill_customer_sk#1, 42), false))
 
 (4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Output [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_education_status), EqualTo(cd_gender,M), EqualTo(cd_education_status,College             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_education_status:string,cd_dep_count:int>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 
 (6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
-Condition : ((((isnotnull(cd_gender#12) AND isnotnull(cd_education_status#13)) AND (cd_gender#12 = M)) AND (cd_education_status#13 = College             )) AND isnotnull(cd_demo_sk#11))
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
+Condition : ((((isnotnull(cd_gender#14) AND isnotnull(cd_education_status#15)) AND (cd_gender#14 = M)) AND (cd_education_status#15 = College             )) AND isnotnull(cd_demo_sk#13))
 
 (7) Project [codegen id : 1]
-Output [2]: [cd_demo_sk#11, cd_dep_count#14]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Output [2]: [cd_demo_sk#13, cd_dep_count#16]
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 
 (8) BroadcastExchange
-Input [2]: [cd_demo_sk#11, cd_dep_count#14]
+Input [2]: [cd_demo_sk#13, cd_dep_count#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#11]
+Right keys [1]: [cd_demo_sk#13]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14]
-Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#11, cd_dep_count#14]
+Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16]
+Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#13, cd_dep_count#16]
 
-(11) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#15]
+(11) ReusedExchange [Reuses operator id: 156]
+Output [1]: [d_date_sk#17]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#9]
-Right keys [1]: [d_date_sk#15]
+Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14, d_date_sk#15]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16, d_date_sk#17]
 
 (14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#16, i_item_id#17]
+Output [2]: [i_item_sk#18, i_item_id#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [2]: [i_item_sk#16, i_item_id#17]
+Input [2]: [i_item_sk#18, i_item_id#19]
 
 (16) Filter [codegen id : 3]
-Input [2]: [i_item_sk#16, i_item_id#17]
-Condition : isnotnull(i_item_sk#16)
+Input [2]: [i_item_sk#18, i_item_id#19]
+Condition : isnotnull(i_item_sk#18)
 
 (17) BroadcastExchange
-Input [2]: [i_item_sk#16, i_item_id#17]
+Input [2]: [i_item_sk#18, i_item_id#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_item_sk#3]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_sk#16, i_item_id#17]
+Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_sk#18, i_item_id#19]
 
 (20) Exchange
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
 Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) Sort [codegen id : 5]
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(22) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
+(22) ReusedExchange [Reuses operator id: 148]
+Output [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
 
-(23) ColumnarToRow [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+(23) Sort [codegen id : 12]
+Input [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
 
-(24) Filter [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Condition : (((c_birth_month#21 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#18)) AND isnotnull(c_current_cdemo_sk#19)) AND isnotnull(c_current_addr_sk#20))
-
-(25) Project [codegen id : 7]
-Output [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-
-(26) Scan parquet spark_catalog.default.customer_address
-Output [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_county:string,ca_state:string,ca_country:string>
-
-(27) ColumnarToRow [codegen id : 6]
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-
-(28) Filter [codegen id : 6]
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-Condition : (ca_state#25 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#23))
-
-(29) BroadcastExchange
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
-
-(30) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [c_current_addr_sk#20]
-Right keys [1]: [ca_address_sk#23]
-Join type: Inner
-Join condition: None
-
-(31) Project [codegen id : 7]
-Output [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Input [8]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22, ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-
-(32) Exchange
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_current_cdemo_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(33) Sort [codegen id : 8]
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: [c_current_cdemo_sk#19 ASC NULLS FIRST], false, 0
-
-(34) Scan parquet spark_catalog.default.customer_demographics
-Output [1]: [cd_demo_sk#27]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk)]
-ReadSchema: struct<cd_demo_sk:int>
-
-(35) ColumnarToRow [codegen id : 9]
-Input [1]: [cd_demo_sk#27]
-
-(36) Filter [codegen id : 9]
-Input [1]: [cd_demo_sk#27]
-Condition : isnotnull(cd_demo_sk#27)
-
-(37) Exchange
-Input [1]: [cd_demo_sk#27]
-Arguments: hashpartitioning(cd_demo_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(38) Sort [codegen id : 10]
-Input [1]: [cd_demo_sk#27]
-Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
-
-(39) SortMergeJoin [codegen id : 11]
-Left keys [1]: [c_current_cdemo_sk#19]
-Right keys [1]: [cd_demo_sk#27]
-Join type: Inner
-Join condition: None
-
-(40) Project [codegen id : 11]
-Output [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Input [7]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26, cd_demo_sk#27]
-
-(41) Exchange
-Input [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(42) Sort [codegen id : 12]
-Input [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
-
-(43) SortMergeJoin [codegen id : 13]
+(24) SortMergeJoin [codegen id : 13]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
+Right keys [1]: [c_customer_sk#20]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 13]
-Output [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, cast(cs_quantity#4 as decimal(12,2)) AS agg1#28, cast(cs_list_price#5 as decimal(12,2)) AS agg2#29, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#30, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#31, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#32, cast(c_birth_year#22 as decimal(12,2)) AS agg6#33, cast(cd_dep_count#14 as decimal(12,2)) AS agg7#34]
-Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
+(25) Project [codegen id : 13]
+Output [11]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22, cast(cs_quantity#4 as decimal(12,2)) AS agg1#25, cast(cs_list_price#5 as decimal(12,2)) AS agg2#26, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#27, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#28, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#29, cast(c_birth_year#21 as decimal(12,2)) AS agg6#30, cast(cd_dep_count#16 as decimal(12,2)) AS agg7#31]
+Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19, c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
 
-(45) HashAggregate [codegen id : 13]
-Input [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#28, agg2#29, agg3#30, agg4#31, agg5#32, agg6#33, agg7#34]
-Keys [4]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Functions [7]: [partial_avg(agg1#28), partial_avg(agg2#29), partial_avg(agg3#30), partial_avg(agg4#31), partial_avg(agg5#32), partial_avg(agg6#33), partial_avg(agg7#34)]
-Aggregate Attributes [14]: [sum#35, count#36, sum#37, count#38, sum#39, count#40, sum#41, count#42, sum#43, count#44, sum#45, count#46, sum#47, count#48]
-Results [18]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
+(26) HashAggregate [codegen id : 13]
+Input [11]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22, agg1#25, agg2#26, agg3#27, agg4#28, agg5#29, agg6#30, agg7#31]
+Keys [4]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22]
+Functions [7]: [partial_avg(agg1#25), partial_avg(agg2#26), partial_avg(agg3#27), partial_avg(agg4#28), partial_avg(agg5#29), partial_avg(agg6#30), partial_avg(agg7#31)]
+Aggregate Attributes [14]: [sum#32, count#33, sum#34, count#35, sum#36, count#37, sum#38, count#39, sum#40, count#41, sum#42, count#43, sum#44, count#45]
+Results [18]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22, sum#46, count#47, sum#48, count#49, sum#50, count#51, sum#52, count#53, sum#54, count#55, sum#56, count#57, sum#58, count#59]
 
-(46) Exchange
-Input [18]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
-Arguments: hashpartitioning(i_item_id#17, ca_country#26, ca_state#25, ca_county#24, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(27) Exchange
+Input [18]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22, sum#46, count#47, sum#48, count#49, sum#50, count#51, sum#52, count#53, sum#54, count#55, sum#56, count#57, sum#58, count#59]
+Arguments: hashpartitioning(i_item_id#19, ca_country#24, ca_state#23, ca_county#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(47) HashAggregate [codegen id : 14]
-Input [18]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
-Keys [4]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Functions [7]: [avg(agg1#28), avg(agg2#29), avg(agg3#30), avg(agg4#31), avg(agg5#32), avg(agg6#33), avg(agg7#34)]
-Aggregate Attributes [7]: [avg(agg1#28)#63, avg(agg2#29)#64, avg(agg3#30)#65, avg(agg4#31)#66, avg(agg5#32)#67, avg(agg6#33)#68, avg(agg7#34)#69]
-Results [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, avg(agg1#28)#63 AS agg1#70, avg(agg2#29)#64 AS agg2#71, avg(agg3#30)#65 AS agg3#72, avg(agg4#31)#66 AS agg4#73, avg(agg5#32)#67 AS agg5#74, avg(agg6#33)#68 AS agg6#75, avg(agg7#34)#69 AS agg7#76]
+(28) HashAggregate [codegen id : 14]
+Input [18]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22, sum#46, count#47, sum#48, count#49, sum#50, count#51, sum#52, count#53, sum#54, count#55, sum#56, count#57, sum#58, count#59]
+Keys [4]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22]
+Functions [7]: [avg(agg1#25), avg(agg2#26), avg(agg3#27), avg(agg4#28), avg(agg5#29), avg(agg6#30), avg(agg7#31)]
+Aggregate Attributes [7]: [avg(agg1#25)#60, avg(agg2#26)#61, avg(agg3#27)#62, avg(agg4#28)#63, avg(agg5#29)#64, avg(agg6#30)#65, avg(agg7#31)#66]
+Results [11]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22, avg(agg1#25)#60 AS agg1#67, avg(agg2#26)#61 AS agg2#68, avg(agg3#27)#62 AS agg3#69, avg(agg4#28)#63 AS agg4#70, avg(agg5#29)#64 AS agg5#71, avg(agg6#30)#65 AS agg6#72, avg(agg7#31)#66 AS agg7#73]
 
-(48) ReusedExchange [Reuses operator id: 20]
-Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-
-(49) Sort [codegen id : 19]
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
-
-(50) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
-
-(51) ColumnarToRow [codegen id : 21]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-
-(52) Filter [codegen id : 21]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Condition : (((c_birth_month#21 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#18)) AND isnotnull(c_current_cdemo_sk#19)) AND isnotnull(c_current_addr_sk#20))
-
-(53) Project [codegen id : 21]
-Output [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-
-(54) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#23, ca_state#25, ca_country#26]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
-
-(55) ColumnarToRow [codegen id : 20]
-Input [3]: [ca_address_sk#23, ca_state#25, ca_country#26]
-
-(56) Filter [codegen id : 20]
-Input [3]: [ca_address_sk#23, ca_state#25, ca_country#26]
-Condition : (ca_state#25 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#23))
-
-(57) BroadcastExchange
-Input [3]: [ca_address_sk#23, ca_state#25, ca_country#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
-
-(58) BroadcastHashJoin [codegen id : 21]
-Left keys [1]: [c_current_addr_sk#20]
-Right keys [1]: [ca_address_sk#23]
-Join type: Inner
-Join condition: None
-
-(59) Project [codegen id : 21]
-Output [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_state#25, ca_country#26]
-Input [7]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22, ca_address_sk#23, ca_state#25, ca_country#26]
-
-(60) Exchange
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_current_cdemo_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(61) Sort [codegen id : 22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_state#25, ca_country#26]
-Arguments: [c_current_cdemo_sk#19 ASC NULLS FIRST], false, 0
-
-(62) ReusedExchange [Reuses operator id: 37]
-Output [1]: [cd_demo_sk#27]
-
-(63) Sort [codegen id : 24]
-Input [1]: [cd_demo_sk#27]
-Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
-
-(64) SortMergeJoin [codegen id : 25]
-Left keys [1]: [c_current_cdemo_sk#19]
-Right keys [1]: [cd_demo_sk#27]
-Join type: Inner
-Join condition: None
-
-(65) Project [codegen id : 25]
-Output [4]: [c_customer_sk#18, c_birth_year#22, ca_state#25, ca_country#26]
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_state#25, ca_country#26, cd_demo_sk#27]
-
-(66) Exchange
-Input [4]: [c_customer_sk#18, c_birth_year#22, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(67) Sort [codegen id : 26]
-Input [4]: [c_customer_sk#18, c_birth_year#22, ca_state#25, ca_country#26]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
-
-(68) SortMergeJoin [codegen id : 27]
-Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
-Join type: Inner
-Join condition: None
-
-(69) Project [codegen id : 27]
-Output [10]: [i_item_id#17, ca_country#26, ca_state#25, cast(cs_quantity#4 as decimal(12,2)) AS agg1#28, cast(cs_list_price#5 as decimal(12,2)) AS agg2#29, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#30, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#31, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#32, cast(c_birth_year#22 as decimal(12,2)) AS agg6#33, cast(cd_dep_count#14 as decimal(12,2)) AS agg7#34]
-Input [12]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_state#25, ca_country#26]
-
-(70) HashAggregate [codegen id : 27]
-Input [10]: [i_item_id#17, ca_country#26, ca_state#25, agg1#28, agg2#29, agg3#30, agg4#31, agg5#32, agg6#33, agg7#34]
-Keys [3]: [i_item_id#17, ca_country#26, ca_state#25]
-Functions [7]: [partial_avg(agg1#28), partial_avg(agg2#29), partial_avg(agg3#30), partial_avg(agg4#31), partial_avg(agg5#32), partial_avg(agg6#33), partial_avg(agg7#34)]
-Aggregate Attributes [14]: [sum#77, count#78, sum#79, count#80, sum#81, count#82, sum#83, count#84, sum#85, count#86, sum#87, count#88, sum#89, count#90]
-Results [17]: [i_item_id#17, ca_country#26, ca_state#25, sum#91, count#92, sum#93, count#94, sum#95, count#96, sum#97, count#98, sum#99, count#100, sum#101, count#102, sum#103, count#104]
-
-(71) Exchange
-Input [17]: [i_item_id#17, ca_country#26, ca_state#25, sum#91, count#92, sum#93, count#94, sum#95, count#96, sum#97, count#98, sum#99, count#100, sum#101, count#102, sum#103, count#104]
-Arguments: hashpartitioning(i_item_id#17, ca_country#26, ca_state#25, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(72) HashAggregate [codegen id : 28]
-Input [17]: [i_item_id#17, ca_country#26, ca_state#25, sum#91, count#92, sum#93, count#94, sum#95, count#96, sum#97, count#98, sum#99, count#100, sum#101, count#102, sum#103, count#104]
-Keys [3]: [i_item_id#17, ca_country#26, ca_state#25]
-Functions [7]: [avg(agg1#28), avg(agg2#29), avg(agg3#30), avg(agg4#31), avg(agg5#32), avg(agg6#33), avg(agg7#34)]
-Aggregate Attributes [7]: [avg(agg1#28)#105, avg(agg2#29)#106, avg(agg3#30)#107, avg(agg4#31)#108, avg(agg5#32)#109, avg(agg6#33)#110, avg(agg7#34)#111]
-Results [11]: [i_item_id#17, ca_country#26, ca_state#25, null AS county#112, avg(agg1#28)#105 AS agg1#113, avg(agg2#29)#106 AS agg2#114, avg(agg3#30)#107 AS agg3#115, avg(agg4#31)#108 AS agg4#116, avg(agg5#32)#109 AS agg5#117, avg(agg6#33)#110 AS agg6#118, avg(agg7#34)#111 AS agg7#119]
-
-(73) ReusedExchange [Reuses operator id: 20]
-Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-
-(74) Sort [codegen id : 33]
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
-
-(75) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
-
-(76) ColumnarToRow [codegen id : 35]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-
-(77) Filter [codegen id : 35]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Condition : (((c_birth_month#21 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#18)) AND isnotnull(c_current_cdemo_sk#19)) AND isnotnull(c_current_addr_sk#20))
-
-(78) Project [codegen id : 35]
-Output [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-
-(79) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#23, ca_state#25, ca_country#26]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
-
-(80) ColumnarToRow [codegen id : 34]
-Input [3]: [ca_address_sk#23, ca_state#25, ca_country#26]
-
-(81) Filter [codegen id : 34]
-Input [3]: [ca_address_sk#23, ca_state#25, ca_country#26]
-Condition : (ca_state#25 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#23))
-
-(82) Project [codegen id : 34]
-Output [2]: [ca_address_sk#23, ca_country#26]
-Input [3]: [ca_address_sk#23, ca_state#25, ca_country#26]
-
-(83) BroadcastExchange
-Input [2]: [ca_address_sk#23, ca_country#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
-
-(84) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [c_current_addr_sk#20]
-Right keys [1]: [ca_address_sk#23]
-Join type: Inner
-Join condition: None
-
-(85) Project [codegen id : 35]
-Output [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_country#26]
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22, ca_address_sk#23, ca_country#26]
-
-(86) Exchange
-Input [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_country#26]
-Arguments: hashpartitioning(c_current_cdemo_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=14]
-
-(87) Sort [codegen id : 36]
-Input [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_country#26]
-Arguments: [c_current_cdemo_sk#19 ASC NULLS FIRST], false, 0
-
-(88) ReusedExchange [Reuses operator id: 37]
-Output [1]: [cd_demo_sk#27]
-
-(89) Sort [codegen id : 38]
-Input [1]: [cd_demo_sk#27]
-Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
-
-(90) SortMergeJoin [codegen id : 39]
-Left keys [1]: [c_current_cdemo_sk#19]
-Right keys [1]: [cd_demo_sk#27]
-Join type: Inner
-Join condition: None
-
-(91) Project [codegen id : 39]
-Output [3]: [c_customer_sk#18, c_birth_year#22, ca_country#26]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_country#26, cd_demo_sk#27]
-
-(92) Exchange
-Input [3]: [c_customer_sk#18, c_birth_year#22, ca_country#26]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=15]
-
-(93) Sort [codegen id : 40]
-Input [3]: [c_customer_sk#18, c_birth_year#22, ca_country#26]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
-
-(94) SortMergeJoin [codegen id : 41]
-Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
-Join type: Inner
-Join condition: None
-
-(95) Project [codegen id : 41]
-Output [9]: [i_item_id#17, ca_country#26, cast(cs_quantity#4 as decimal(12,2)) AS agg1#28, cast(cs_list_price#5 as decimal(12,2)) AS agg2#29, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#30, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#31, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#32, cast(c_birth_year#22 as decimal(12,2)) AS agg6#33, cast(cd_dep_count#14 as decimal(12,2)) AS agg7#34]
-Input [11]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_country#26]
-
-(96) HashAggregate [codegen id : 41]
-Input [9]: [i_item_id#17, ca_country#26, agg1#28, agg2#29, agg3#30, agg4#31, agg5#32, agg6#33, agg7#34]
-Keys [2]: [i_item_id#17, ca_country#26]
-Functions [7]: [partial_avg(agg1#28), partial_avg(agg2#29), partial_avg(agg3#30), partial_avg(agg4#31), partial_avg(agg5#32), partial_avg(agg6#33), partial_avg(agg7#34)]
-Aggregate Attributes [14]: [sum#120, count#121, sum#122, count#123, sum#124, count#125, sum#126, count#127, sum#128, count#129, sum#130, count#131, sum#132, count#133]
-Results [16]: [i_item_id#17, ca_country#26, sum#134, count#135, sum#136, count#137, sum#138, count#139, sum#140, count#141, sum#142, count#143, sum#144, count#145, sum#146, count#147]
-
-(97) Exchange
-Input [16]: [i_item_id#17, ca_country#26, sum#134, count#135, sum#136, count#137, sum#138, count#139, sum#140, count#141, sum#142, count#143, sum#144, count#145, sum#146, count#147]
-Arguments: hashpartitioning(i_item_id#17, ca_country#26, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(98) HashAggregate [codegen id : 42]
-Input [16]: [i_item_id#17, ca_country#26, sum#134, count#135, sum#136, count#137, sum#138, count#139, sum#140, count#141, sum#142, count#143, sum#144, count#145, sum#146, count#147]
-Keys [2]: [i_item_id#17, ca_country#26]
-Functions [7]: [avg(agg1#28), avg(agg2#29), avg(agg3#30), avg(agg4#31), avg(agg5#32), avg(agg6#33), avg(agg7#34)]
-Aggregate Attributes [7]: [avg(agg1#28)#148, avg(agg2#29)#149, avg(agg3#30)#150, avg(agg4#31)#151, avg(agg5#32)#152, avg(agg6#33)#153, avg(agg7#34)#154]
-Results [11]: [i_item_id#17, ca_country#26, null AS ca_state#155, null AS county#156, avg(agg1#28)#148 AS agg1#157, avg(agg2#29)#149 AS agg2#158, avg(agg3#30)#150 AS agg3#159, avg(agg4#31)#151 AS agg4#160, avg(agg5#32)#152 AS agg5#161, avg(agg6#33)#153 AS agg6#162, avg(agg7#34)#154 AS agg7#163]
-
-(99) Scan parquet spark_catalog.default.catalog_sales
+(29) Scan parquet spark_catalog.default.catalog_sales
 Output [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
 Batched: true
 Location: InMemoryFileIndex []
@@ -615,163 +268,357 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#9), dynamicpruningexpression(cs_sol
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(100) ColumnarToRow [codegen id : 49]
+(30) ColumnarToRow [codegen id : 18]
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
 
-(101) Filter [codegen id : 49]
+(31) Filter [codegen id : 18]
+Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
+Condition : (((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3)) AND might_contain(Subquery scalar-subquery#74, [id=#75], xxhash64(cs_bill_customer_sk#1, 42), false))
+
+(32) ReusedExchange [Reuses operator id: 8]
+Output [2]: [cd_demo_sk#13, cd_dep_count#16]
+
+(33) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [cs_bill_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#13]
+Join type: Inner
+Join condition: None
+
+(34) Project [codegen id : 18]
+Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16]
+Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#13, cd_dep_count#16]
+
+(35) ReusedExchange [Reuses operator id: 156]
+Output [1]: [d_date_sk#17]
+
+(36) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [cs_sold_date_sk#9]
+Right keys [1]: [d_date_sk#17]
+Join type: Inner
+Join condition: None
+
+(37) Project [codegen id : 18]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16, d_date_sk#17]
+
+(38) ReusedExchange [Reuses operator id: 17]
+Output [2]: [i_item_sk#18, i_item_id#19]
+
+(39) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [cs_item_sk#3]
+Right keys [1]: [i_item_sk#18]
+Join type: Inner
+Join condition: None
+
+(40) Project [codegen id : 18]
+Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_sk#18, i_item_id#19]
+
+(41) Exchange
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(42) Sort [codegen id : 19]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
+
+(43) ReusedExchange [Reuses operator id: 173]
+Output [4]: [c_customer_sk#20, c_birth_year#21, ca_state#23, ca_country#24]
+
+(44) Sort [codegen id : 26]
+Input [4]: [c_customer_sk#20, c_birth_year#21, ca_state#23, ca_country#24]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(45) SortMergeJoin [codegen id : 27]
+Left keys [1]: [cs_bill_customer_sk#1]
+Right keys [1]: [c_customer_sk#20]
+Join type: Inner
+Join condition: None
+
+(46) Project [codegen id : 27]
+Output [10]: [i_item_id#19, ca_country#24, ca_state#23, cast(cs_quantity#4 as decimal(12,2)) AS agg1#25, cast(cs_list_price#5 as decimal(12,2)) AS agg2#26, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#27, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#28, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#29, cast(c_birth_year#21 as decimal(12,2)) AS agg6#30, cast(cd_dep_count#16 as decimal(12,2)) AS agg7#31]
+Input [12]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19, c_customer_sk#20, c_birth_year#21, ca_state#23, ca_country#24]
+
+(47) HashAggregate [codegen id : 27]
+Input [10]: [i_item_id#19, ca_country#24, ca_state#23, agg1#25, agg2#26, agg3#27, agg4#28, agg5#29, agg6#30, agg7#31]
+Keys [3]: [i_item_id#19, ca_country#24, ca_state#23]
+Functions [7]: [partial_avg(agg1#25), partial_avg(agg2#26), partial_avg(agg3#27), partial_avg(agg4#28), partial_avg(agg5#29), partial_avg(agg6#30), partial_avg(agg7#31)]
+Aggregate Attributes [14]: [sum#76, count#77, sum#78, count#79, sum#80, count#81, sum#82, count#83, sum#84, count#85, sum#86, count#87, sum#88, count#89]
+Results [17]: [i_item_id#19, ca_country#24, ca_state#23, sum#90, count#91, sum#92, count#93, sum#94, count#95, sum#96, count#97, sum#98, count#99, sum#100, count#101, sum#102, count#103]
+
+(48) Exchange
+Input [17]: [i_item_id#19, ca_country#24, ca_state#23, sum#90, count#91, sum#92, count#93, sum#94, count#95, sum#96, count#97, sum#98, count#99, sum#100, count#101, sum#102, count#103]
+Arguments: hashpartitioning(i_item_id#19, ca_country#24, ca_state#23, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(49) HashAggregate [codegen id : 28]
+Input [17]: [i_item_id#19, ca_country#24, ca_state#23, sum#90, count#91, sum#92, count#93, sum#94, count#95, sum#96, count#97, sum#98, count#99, sum#100, count#101, sum#102, count#103]
+Keys [3]: [i_item_id#19, ca_country#24, ca_state#23]
+Functions [7]: [avg(agg1#25), avg(agg2#26), avg(agg3#27), avg(agg4#28), avg(agg5#29), avg(agg6#30), avg(agg7#31)]
+Aggregate Attributes [7]: [avg(agg1#25)#104, avg(agg2#26)#105, avg(agg3#27)#106, avg(agg4#28)#107, avg(agg5#29)#108, avg(agg6#30)#109, avg(agg7#31)#110]
+Results [11]: [i_item_id#19, ca_country#24, ca_state#23, null AS county#111, avg(agg1#25)#104 AS agg1#112, avg(agg2#26)#105 AS agg2#113, avg(agg3#27)#106 AS agg3#114, avg(agg4#28)#107 AS agg4#115, avg(agg5#29)#108 AS agg5#116, avg(agg6#30)#109 AS agg6#117, avg(agg7#31)#110 AS agg7#118]
+
+(50) Scan parquet spark_catalog.default.catalog_sales
+Output [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#9), dynamicpruningexpression(cs_sold_date_sk#9 IN dynamicpruning#10)]
+PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
+
+(51) ColumnarToRow [codegen id : 32]
+Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
+
+(52) Filter [codegen id : 32]
+Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
+Condition : (((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3)) AND might_contain(Subquery scalar-subquery#119, [id=#120], xxhash64(cs_bill_customer_sk#1, 42), false))
+
+(53) ReusedExchange [Reuses operator id: 8]
+Output [2]: [cd_demo_sk#13, cd_dep_count#16]
+
+(54) BroadcastHashJoin [codegen id : 32]
+Left keys [1]: [cs_bill_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#13]
+Join type: Inner
+Join condition: None
+
+(55) Project [codegen id : 32]
+Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16]
+Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#13, cd_dep_count#16]
+
+(56) ReusedExchange [Reuses operator id: 156]
+Output [1]: [d_date_sk#17]
+
+(57) BroadcastHashJoin [codegen id : 32]
+Left keys [1]: [cs_sold_date_sk#9]
+Right keys [1]: [d_date_sk#17]
+Join type: Inner
+Join condition: None
+
+(58) Project [codegen id : 32]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16, d_date_sk#17]
+
+(59) ReusedExchange [Reuses operator id: 17]
+Output [2]: [i_item_sk#18, i_item_id#19]
+
+(60) BroadcastHashJoin [codegen id : 32]
+Left keys [1]: [cs_item_sk#3]
+Right keys [1]: [i_item_sk#18]
+Join type: Inner
+Join condition: None
+
+(61) Project [codegen id : 32]
+Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_sk#18, i_item_id#19]
+
+(62) Exchange
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(63) Sort [codegen id : 33]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
+
+(64) ReusedExchange [Reuses operator id: 194]
+Output [3]: [c_customer_sk#20, c_birth_year#21, ca_country#24]
+
+(65) Sort [codegen id : 40]
+Input [3]: [c_customer_sk#20, c_birth_year#21, ca_country#24]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(66) SortMergeJoin [codegen id : 41]
+Left keys [1]: [cs_bill_customer_sk#1]
+Right keys [1]: [c_customer_sk#20]
+Join type: Inner
+Join condition: None
+
+(67) Project [codegen id : 41]
+Output [9]: [i_item_id#19, ca_country#24, cast(cs_quantity#4 as decimal(12,2)) AS agg1#25, cast(cs_list_price#5 as decimal(12,2)) AS agg2#26, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#27, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#28, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#29, cast(c_birth_year#21 as decimal(12,2)) AS agg6#30, cast(cd_dep_count#16 as decimal(12,2)) AS agg7#31]
+Input [11]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19, c_customer_sk#20, c_birth_year#21, ca_country#24]
+
+(68) HashAggregate [codegen id : 41]
+Input [9]: [i_item_id#19, ca_country#24, agg1#25, agg2#26, agg3#27, agg4#28, agg5#29, agg6#30, agg7#31]
+Keys [2]: [i_item_id#19, ca_country#24]
+Functions [7]: [partial_avg(agg1#25), partial_avg(agg2#26), partial_avg(agg3#27), partial_avg(agg4#28), partial_avg(agg5#29), partial_avg(agg6#30), partial_avg(agg7#31)]
+Aggregate Attributes [14]: [sum#121, count#122, sum#123, count#124, sum#125, count#126, sum#127, count#128, sum#129, count#130, sum#131, count#132, sum#133, count#134]
+Results [16]: [i_item_id#19, ca_country#24, sum#135, count#136, sum#137, count#138, sum#139, count#140, sum#141, count#142, sum#143, count#144, sum#145, count#146, sum#147, count#148]
+
+(69) Exchange
+Input [16]: [i_item_id#19, ca_country#24, sum#135, count#136, sum#137, count#138, sum#139, count#140, sum#141, count#142, sum#143, count#144, sum#145, count#146, sum#147, count#148]
+Arguments: hashpartitioning(i_item_id#19, ca_country#24, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(70) HashAggregate [codegen id : 42]
+Input [16]: [i_item_id#19, ca_country#24, sum#135, count#136, sum#137, count#138, sum#139, count#140, sum#141, count#142, sum#143, count#144, sum#145, count#146, sum#147, count#148]
+Keys [2]: [i_item_id#19, ca_country#24]
+Functions [7]: [avg(agg1#25), avg(agg2#26), avg(agg3#27), avg(agg4#28), avg(agg5#29), avg(agg6#30), avg(agg7#31)]
+Aggregate Attributes [7]: [avg(agg1#25)#149, avg(agg2#26)#150, avg(agg3#27)#151, avg(agg4#28)#152, avg(agg5#29)#153, avg(agg6#30)#154, avg(agg7#31)#155]
+Results [11]: [i_item_id#19, ca_country#24, null AS ca_state#156, null AS county#157, avg(agg1#25)#149 AS agg1#158, avg(agg2#26)#150 AS agg2#159, avg(agg3#27)#151 AS agg3#160, avg(agg4#28)#152 AS agg4#161, avg(agg5#29)#153 AS agg5#162, avg(agg6#30)#154 AS agg6#163, avg(agg7#31)#155 AS agg7#164]
+
+(71) Scan parquet spark_catalog.default.catalog_sales
+Output [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#9), dynamicpruningexpression(cs_sold_date_sk#9 IN dynamicpruning#10)]
+PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
+
+(72) ColumnarToRow [codegen id : 49]
+Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
+
+(73) Filter [codegen id : 49]
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
 Condition : ((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3))
 
-(102) ReusedExchange [Reuses operator id: 8]
-Output [2]: [cd_demo_sk#11, cd_dep_count#14]
+(74) ReusedExchange [Reuses operator id: 8]
+Output [2]: [cd_demo_sk#13, cd_dep_count#16]
 
-(103) BroadcastHashJoin [codegen id : 49]
+(75) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#11]
+Right keys [1]: [cd_demo_sk#13]
 Join type: Inner
 Join condition: None
 
-(104) Project [codegen id : 49]
-Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14]
-Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#11, cd_dep_count#14]
+(76) Project [codegen id : 49]
+Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16]
+Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#13, cd_dep_count#16]
 
-(105) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#15]
+(77) ReusedExchange [Reuses operator id: 156]
+Output [1]: [d_date_sk#17]
 
-(106) BroadcastHashJoin [codegen id : 49]
+(78) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_sold_date_sk#9]
-Right keys [1]: [d_date_sk#15]
+Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
-(107) Project [codegen id : 49]
-Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14, d_date_sk#15]
+(79) Project [codegen id : 49]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16, d_date_sk#17]
 
-(108) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+(80) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
 
-(109) ColumnarToRow [codegen id : 46]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+(81) ColumnarToRow [codegen id : 46]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
 
-(110) Filter [codegen id : 46]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Condition : (((c_birth_month#21 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#18)) AND isnotnull(c_current_cdemo_sk#19)) AND isnotnull(c_current_addr_sk#20))
+(82) Filter [codegen id : 46]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+Condition : (((c_birth_month#167 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#165)) AND isnotnull(c_current_addr_sk#166))
 
-(111) Project [codegen id : 46]
-Output [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+(83) Project [codegen id : 46]
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_year#21]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
 
-(112) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#23, ca_state#25]
+(84) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#168, ca_state#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(113) ColumnarToRow [codegen id : 45]
-Input [2]: [ca_address_sk#23, ca_state#25]
+(85) ColumnarToRow [codegen id : 45]
+Input [2]: [ca_address_sk#168, ca_state#23]
 
-(114) Filter [codegen id : 45]
-Input [2]: [ca_address_sk#23, ca_state#25]
-Condition : (ca_state#25 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#23))
+(86) Filter [codegen id : 45]
+Input [2]: [ca_address_sk#168, ca_state#23]
+Condition : (ca_state#23 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#168))
 
-(115) Project [codegen id : 45]
-Output [1]: [ca_address_sk#23]
-Input [2]: [ca_address_sk#23, ca_state#25]
+(87) Project [codegen id : 45]
+Output [1]: [ca_address_sk#168]
+Input [2]: [ca_address_sk#168, ca_state#23]
 
-(116) BroadcastExchange
-Input [1]: [ca_address_sk#23]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
+(88) BroadcastExchange
+Input [1]: [ca_address_sk#168]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-(117) BroadcastHashJoin [codegen id : 46]
-Left keys [1]: [c_current_addr_sk#20]
-Right keys [1]: [ca_address_sk#23]
+(89) BroadcastHashJoin [codegen id : 46]
+Left keys [1]: [c_current_addr_sk#166]
+Right keys [1]: [ca_address_sk#168]
 Join type: Inner
 Join condition: None
 
-(118) Project [codegen id : 46]
-Output [3]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22, ca_address_sk#23]
+(90) Project [codegen id : 46]
+Output [3]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_year#21, ca_address_sk#168]
 
-(119) BroadcastExchange
-Input [3]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=18]
+(91) BroadcastExchange
+Input [3]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=10]
 
-(120) Scan parquet spark_catalog.default.customer_demographics
-Output [1]: [cd_demo_sk#27]
+(92) Scan parquet spark_catalog.default.customer_demographics
+Output [1]: [cd_demo_sk#169]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int>
 
-(121) ColumnarToRow
-Input [1]: [cd_demo_sk#27]
+(93) ColumnarToRow
+Input [1]: [cd_demo_sk#169]
 
-(122) Filter
-Input [1]: [cd_demo_sk#27]
-Condition : isnotnull(cd_demo_sk#27)
+(94) Filter
+Input [1]: [cd_demo_sk#169]
+Condition : isnotnull(cd_demo_sk#169)
 
-(123) BroadcastHashJoin [codegen id : 47]
-Left keys [1]: [c_current_cdemo_sk#19]
-Right keys [1]: [cd_demo_sk#27]
+(95) BroadcastHashJoin [codegen id : 47]
+Left keys [1]: [c_current_cdemo_sk#165]
+Right keys [1]: [cd_demo_sk#169]
 Join type: Inner
 Join condition: None
 
-(124) Project [codegen id : 47]
-Output [2]: [c_customer_sk#18, c_birth_year#22]
-Input [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, cd_demo_sk#27]
+(96) Project [codegen id : 47]
+Output [2]: [c_customer_sk#20, c_birth_year#21]
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, cd_demo_sk#169]
 
-(125) BroadcastExchange
-Input [2]: [c_customer_sk#18, c_birth_year#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=19]
+(97) BroadcastExchange
+Input [2]: [c_customer_sk#20, c_birth_year#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-(126) BroadcastHashJoin [codegen id : 49]
+(98) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
+Right keys [1]: [c_customer_sk#20]
 Join type: Inner
 Join condition: None
 
-(127) Project [codegen id : 49]
-Output [8]: [cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_customer_sk#18, c_birth_year#22]
+(99) Project [codegen id : 49]
+Output [8]: [cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_customer_sk#20, c_birth_year#21]
 
-(128) ReusedExchange [Reuses operator id: 17]
-Output [2]: [i_item_sk#16, i_item_id#17]
+(100) ReusedExchange [Reuses operator id: 17]
+Output [2]: [i_item_sk#18, i_item_id#19]
 
-(129) BroadcastHashJoin [codegen id : 49]
+(101) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_item_sk#3]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
-(130) Project [codegen id : 49]
-Output [8]: [i_item_id#17, cast(cs_quantity#4 as decimal(12,2)) AS agg1#28, cast(cs_list_price#5 as decimal(12,2)) AS agg2#29, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#30, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#31, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#32, cast(c_birth_year#22 as decimal(12,2)) AS agg6#33, cast(cd_dep_count#14 as decimal(12,2)) AS agg7#34]
-Input [10]: [cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_sk#16, i_item_id#17]
+(102) Project [codegen id : 49]
+Output [8]: [i_item_id#19, cast(cs_quantity#4 as decimal(12,2)) AS agg1#25, cast(cs_list_price#5 as decimal(12,2)) AS agg2#26, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#27, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#28, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#29, cast(c_birth_year#21 as decimal(12,2)) AS agg6#30, cast(cd_dep_count#16 as decimal(12,2)) AS agg7#31]
+Input [10]: [cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#21, i_item_sk#18, i_item_id#19]
 
-(131) HashAggregate [codegen id : 49]
-Input [8]: [i_item_id#17, agg1#28, agg2#29, agg3#30, agg4#31, agg5#32, agg6#33, agg7#34]
-Keys [1]: [i_item_id#17]
-Functions [7]: [partial_avg(agg1#28), partial_avg(agg2#29), partial_avg(agg3#30), partial_avg(agg4#31), partial_avg(agg5#32), partial_avg(agg6#33), partial_avg(agg7#34)]
-Aggregate Attributes [14]: [sum#164, count#165, sum#166, count#167, sum#168, count#169, sum#170, count#171, sum#172, count#173, sum#174, count#175, sum#176, count#177]
-Results [15]: [i_item_id#17, sum#178, count#179, sum#180, count#181, sum#182, count#183, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191]
+(103) HashAggregate [codegen id : 49]
+Input [8]: [i_item_id#19, agg1#25, agg2#26, agg3#27, agg4#28, agg5#29, agg6#30, agg7#31]
+Keys [1]: [i_item_id#19]
+Functions [7]: [partial_avg(agg1#25), partial_avg(agg2#26), partial_avg(agg3#27), partial_avg(agg4#28), partial_avg(agg5#29), partial_avg(agg6#30), partial_avg(agg7#31)]
+Aggregate Attributes [14]: [sum#170, count#171, sum#172, count#173, sum#174, count#175, sum#176, count#177, sum#178, count#179, sum#180, count#181, sum#182, count#183]
+Results [15]: [i_item_id#19, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195, sum#196, count#197]
 
-(132) Exchange
-Input [15]: [i_item_id#17, sum#178, count#179, sum#180, count#181, sum#182, count#183, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191]
-Arguments: hashpartitioning(i_item_id#17, 5), ENSURE_REQUIREMENTS, [plan_id=20]
+(104) Exchange
+Input [15]: [i_item_id#19, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195, sum#196, count#197]
+Arguments: hashpartitioning(i_item_id#19, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(133) HashAggregate [codegen id : 50]
-Input [15]: [i_item_id#17, sum#178, count#179, sum#180, count#181, sum#182, count#183, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191]
-Keys [1]: [i_item_id#17]
-Functions [7]: [avg(agg1#28), avg(agg2#29), avg(agg3#30), avg(agg4#31), avg(agg5#32), avg(agg6#33), avg(agg7#34)]
-Aggregate Attributes [7]: [avg(agg1#28)#192, avg(agg2#29)#193, avg(agg3#30)#194, avg(agg4#31)#195, avg(agg5#32)#196, avg(agg6#33)#197, avg(agg7#34)#198]
-Results [11]: [i_item_id#17, null AS ca_country#199, null AS ca_state#200, null AS county#201, avg(agg1#28)#192 AS agg1#202, avg(agg2#29)#193 AS agg2#203, avg(agg3#30)#194 AS agg3#204, avg(agg4#31)#195 AS agg4#205, avg(agg5#32)#196 AS agg5#206, avg(agg6#33)#197 AS agg6#207, avg(agg7#34)#198 AS agg7#208]
+(105) HashAggregate [codegen id : 50]
+Input [15]: [i_item_id#19, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195, sum#196, count#197]
+Keys [1]: [i_item_id#19]
+Functions [7]: [avg(agg1#25), avg(agg2#26), avg(agg3#27), avg(agg4#28), avg(agg5#29), avg(agg6#30), avg(agg7#31)]
+Aggregate Attributes [7]: [avg(agg1#25)#198, avg(agg2#26)#199, avg(agg3#27)#200, avg(agg4#28)#201, avg(agg5#29)#202, avg(agg6#30)#203, avg(agg7#31)#204]
+Results [11]: [i_item_id#19, null AS ca_country#205, null AS ca_state#206, null AS county#207, avg(agg1#25)#198 AS agg1#208, avg(agg2#26)#199 AS agg2#209, avg(agg3#27)#200 AS agg3#210, avg(agg4#28)#201 AS agg4#211, avg(agg5#29)#202 AS agg5#212, avg(agg6#30)#203 AS agg6#213, avg(agg7#31)#204 AS agg7#214]
 
-(134) Scan parquet spark_catalog.default.catalog_sales
+(106) Scan parquet spark_catalog.default.catalog_sales
 Output [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
 Batched: true
 Location: InMemoryFileIndex []
@@ -779,138 +626,513 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#9), dynamicpruningexpression(cs_sol
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(135) ColumnarToRow [codegen id : 57]
+(107) ColumnarToRow [codegen id : 57]
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
 
-(136) Filter [codegen id : 57]
+(108) Filter [codegen id : 57]
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
 Condition : ((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3))
 
-(137) ReusedExchange [Reuses operator id: 8]
-Output [2]: [cd_demo_sk#11, cd_dep_count#14]
+(109) ReusedExchange [Reuses operator id: 8]
+Output [2]: [cd_demo_sk#13, cd_dep_count#16]
 
-(138) BroadcastHashJoin [codegen id : 57]
+(110) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#11]
+Right keys [1]: [cd_demo_sk#13]
 Join type: Inner
 Join condition: None
 
-(139) Project [codegen id : 57]
-Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14]
-Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#11, cd_dep_count#14]
+(111) Project [codegen id : 57]
+Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16]
+Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#13, cd_dep_count#16]
 
-(140) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#15]
+(112) ReusedExchange [Reuses operator id: 156]
+Output [1]: [d_date_sk#17]
 
-(141) BroadcastHashJoin [codegen id : 57]
+(113) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_sold_date_sk#9]
-Right keys [1]: [d_date_sk#15]
+Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
-(142) Project [codegen id : 57]
-Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14, d_date_sk#15]
+(114) Project [codegen id : 57]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16, d_date_sk#17]
 
-(143) Scan parquet spark_catalog.default.item
-Output [1]: [i_item_sk#16]
+(115) Scan parquet spark_catalog.default.item
+Output [1]: [i_item_sk#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int>
 
-(144) ColumnarToRow [codegen id : 53]
-Input [1]: [i_item_sk#16]
+(116) ColumnarToRow [codegen id : 53]
+Input [1]: [i_item_sk#18]
 
-(145) Filter [codegen id : 53]
-Input [1]: [i_item_sk#16]
-Condition : isnotnull(i_item_sk#16)
+(117) Filter [codegen id : 53]
+Input [1]: [i_item_sk#18]
+Condition : isnotnull(i_item_sk#18)
 
-(146) BroadcastExchange
-Input [1]: [i_item_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=21]
+(118) BroadcastExchange
+Input [1]: [i_item_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
 
-(147) BroadcastHashJoin [codegen id : 57]
+(119) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_item_sk#3]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
-(148) Project [codegen id : 57]
-Output [7]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_sk#16]
+(120) Project [codegen id : 57]
+Output [7]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_sk#18]
 
-(149) ReusedExchange [Reuses operator id: 125]
-Output [2]: [c_customer_sk#18, c_birth_year#22]
+(121) ReusedExchange [Reuses operator id: 97]
+Output [2]: [c_customer_sk#20, c_birth_year#21]
 
-(150) BroadcastHashJoin [codegen id : 57]
+(122) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
+Right keys [1]: [c_customer_sk#20]
 Join type: Inner
 Join condition: None
 
-(151) Project [codegen id : 57]
-Output [7]: [cast(cs_quantity#4 as decimal(12,2)) AS agg1#28, cast(cs_list_price#5 as decimal(12,2)) AS agg2#29, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#30, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#31, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#32, cast(c_birth_year#22 as decimal(12,2)) AS agg6#33, cast(cd_dep_count#14 as decimal(12,2)) AS agg7#34]
-Input [9]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_customer_sk#18, c_birth_year#22]
+(123) Project [codegen id : 57]
+Output [7]: [cast(cs_quantity#4 as decimal(12,2)) AS agg1#25, cast(cs_list_price#5 as decimal(12,2)) AS agg2#26, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#27, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#28, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#29, cast(c_birth_year#21 as decimal(12,2)) AS agg6#30, cast(cd_dep_count#16 as decimal(12,2)) AS agg7#31]
+Input [9]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_customer_sk#20, c_birth_year#21]
 
-(152) HashAggregate [codegen id : 57]
-Input [7]: [agg1#28, agg2#29, agg3#30, agg4#31, agg5#32, agg6#33, agg7#34]
+(124) HashAggregate [codegen id : 57]
+Input [7]: [agg1#25, agg2#26, agg3#27, agg4#28, agg5#29, agg6#30, agg7#31]
 Keys: []
-Functions [7]: [partial_avg(agg1#28), partial_avg(agg2#29), partial_avg(agg3#30), partial_avg(agg4#31), partial_avg(agg5#32), partial_avg(agg6#33), partial_avg(agg7#34)]
-Aggregate Attributes [14]: [sum#209, count#210, sum#211, count#212, sum#213, count#214, sum#215, count#216, sum#217, count#218, sum#219, count#220, sum#221, count#222]
-Results [14]: [sum#223, count#224, sum#225, count#226, sum#227, count#228, sum#229, count#230, sum#231, count#232, sum#233, count#234, sum#235, count#236]
+Functions [7]: [partial_avg(agg1#25), partial_avg(agg2#26), partial_avg(agg3#27), partial_avg(agg4#28), partial_avg(agg5#29), partial_avg(agg6#30), partial_avg(agg7#31)]
+Aggregate Attributes [14]: [sum#215, count#216, sum#217, count#218, sum#219, count#220, sum#221, count#222, sum#223, count#224, sum#225, count#226, sum#227, count#228]
+Results [14]: [sum#229, count#230, sum#231, count#232, sum#233, count#234, sum#235, count#236, sum#237, count#238, sum#239, count#240, sum#241, count#242]
 
-(153) Exchange
-Input [14]: [sum#223, count#224, sum#225, count#226, sum#227, count#228, sum#229, count#230, sum#231, count#232, sum#233, count#234, sum#235, count#236]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
+(125) Exchange
+Input [14]: [sum#229, count#230, sum#231, count#232, sum#233, count#234, sum#235, count#236, sum#237, count#238, sum#239, count#240, sum#241, count#242]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
-(154) HashAggregate [codegen id : 58]
-Input [14]: [sum#223, count#224, sum#225, count#226, sum#227, count#228, sum#229, count#230, sum#231, count#232, sum#233, count#234, sum#235, count#236]
+(126) HashAggregate [codegen id : 58]
+Input [14]: [sum#229, count#230, sum#231, count#232, sum#233, count#234, sum#235, count#236, sum#237, count#238, sum#239, count#240, sum#241, count#242]
 Keys: []
-Functions [7]: [avg(agg1#28), avg(agg2#29), avg(agg3#30), avg(agg4#31), avg(agg5#32), avg(agg6#33), avg(agg7#34)]
-Aggregate Attributes [7]: [avg(agg1#28)#237, avg(agg2#29)#238, avg(agg3#30)#239, avg(agg4#31)#240, avg(agg5#32)#241, avg(agg6#33)#242, avg(agg7#34)#243]
-Results [11]: [null AS i_item_id#244, null AS ca_country#245, null AS ca_state#246, null AS county#247, avg(agg1#28)#237 AS agg1#248, avg(agg2#29)#238 AS agg2#249, avg(agg3#30)#239 AS agg3#250, avg(agg4#31)#240 AS agg4#251, avg(agg5#32)#241 AS agg5#252, avg(agg6#33)#242 AS agg6#253, avg(agg7#34)#243 AS agg7#254]
+Functions [7]: [avg(agg1#25), avg(agg2#26), avg(agg3#27), avg(agg4#28), avg(agg5#29), avg(agg6#30), avg(agg7#31)]
+Aggregate Attributes [7]: [avg(agg1#25)#243, avg(agg2#26)#244, avg(agg3#27)#245, avg(agg4#28)#246, avg(agg5#29)#247, avg(agg6#30)#248, avg(agg7#31)#249]
+Results [11]: [null AS i_item_id#250, null AS ca_country#251, null AS ca_state#252, null AS county#253, avg(agg1#25)#243 AS agg1#254, avg(agg2#26)#244 AS agg2#255, avg(agg3#27)#245 AS agg3#256, avg(agg4#28)#246 AS agg4#257, avg(agg5#29)#247 AS agg5#258, avg(agg6#30)#248 AS agg6#259, avg(agg7#31)#249 AS agg7#260]
 
-(155) Union
+(127) Union
 
-(156) TakeOrderedAndProject
-Input [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]
-Arguments: 100, [ca_country#26 ASC NULLS FIRST, ca_state#25 ASC NULLS FIRST, ca_county#24 ASC NULLS FIRST, i_item_id#17 ASC NULLS FIRST], [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]
+(128) TakeOrderedAndProject
+Input [11]: [i_item_id#19, ca_country#24, ca_state#23, ca_county#22, agg1#67, agg2#68, agg3#69, agg4#70, agg5#71, agg6#72, agg7#73]
+Arguments: 100, [ca_country#24 ASC NULLS FIRST, ca_state#23 ASC NULLS FIRST, ca_county#22 ASC NULLS FIRST, i_item_id#19 ASC NULLS FIRST], [i_item_id#19, ca_country#24, ca_state#23, ca_county#22, agg1#67, agg2#68, agg3#69, agg4#70, agg5#71, agg6#72, agg7#73]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (161)
-+- * Project (160)
-   +- * Filter (159)
-      +- * ColumnarToRow (158)
-         +- Scan parquet spark_catalog.default.date_dim (157)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+ObjectHashAggregate (151)
++- Exchange (150)
+   +- ObjectHashAggregate (149)
+      +- Exchange (148)
+         +- * Project (147)
+            +- * SortMergeJoin Inner (146)
+               :- * Sort (140)
+               :  +- Exchange (139)
+               :     +- * Project (138)
+               :        +- * BroadcastHashJoin Inner BuildRight (137)
+               :           :- * Project (132)
+               :           :  +- * Filter (131)
+               :           :     +- * ColumnarToRow (130)
+               :           :        +- Scan parquet spark_catalog.default.customer (129)
+               :           +- BroadcastExchange (136)
+               :              +- * Filter (135)
+               :                 +- * ColumnarToRow (134)
+               :                    +- Scan parquet spark_catalog.default.customer_address (133)
+               +- * Sort (145)
+                  +- Exchange (144)
+                     +- * Filter (143)
+                        +- * ColumnarToRow (142)
+                           +- Scan parquet spark_catalog.default.customer_demographics (141)
 
 
-(157) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#15, d_year#255]
+(129) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
+
+(130) ColumnarToRow [codegen id : 2]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+
+(131) Filter [codegen id : 2]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+Condition : (((c_birth_month#167 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#165)) AND isnotnull(c_current_addr_sk#166))
+
+(132) Project [codegen id : 2]
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_year#21]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+
+(133) Scan parquet spark_catalog.default.customer_address
+Output [4]: [ca_address_sk#168, ca_county#22, ca_state#23, ca_country#24]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_county:string,ca_state:string,ca_country:string>
+
+(134) ColumnarToRow [codegen id : 1]
+Input [4]: [ca_address_sk#168, ca_county#22, ca_state#23, ca_country#24]
+
+(135) Filter [codegen id : 1]
+Input [4]: [ca_address_sk#168, ca_county#22, ca_state#23, ca_country#24]
+Condition : (ca_state#23 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#168))
+
+(136) BroadcastExchange
+Input [4]: [ca_address_sk#168, ca_county#22, ca_state#23, ca_country#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+
+(137) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [c_current_addr_sk#166]
+Right keys [1]: [ca_address_sk#168]
+Join type: Inner
+Join condition: None
+
+(138) Project [codegen id : 2]
+Output [6]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Input [8]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_year#21, ca_address_sk#168, ca_county#22, ca_state#23, ca_country#24]
+
+(139) Exchange
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Arguments: hashpartitioning(c_current_cdemo_sk#165, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(140) Sort [codegen id : 3]
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Arguments: [c_current_cdemo_sk#165 ASC NULLS FIRST], false, 0
+
+(141) Scan parquet spark_catalog.default.customer_demographics
+Output [1]: [cd_demo_sk#169]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk)]
+ReadSchema: struct<cd_demo_sk:int>
+
+(142) ColumnarToRow [codegen id : 4]
+Input [1]: [cd_demo_sk#169]
+
+(143) Filter [codegen id : 4]
+Input [1]: [cd_demo_sk#169]
+Condition : isnotnull(cd_demo_sk#169)
+
+(144) Exchange
+Input [1]: [cd_demo_sk#169]
+Arguments: hashpartitioning(cd_demo_sk#169, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+
+(145) Sort [codegen id : 5]
+Input [1]: [cd_demo_sk#169]
+Arguments: [cd_demo_sk#169 ASC NULLS FIRST], false, 0
+
+(146) SortMergeJoin [codegen id : 6]
+Left keys [1]: [c_current_cdemo_sk#165]
+Right keys [1]: [cd_demo_sk#169]
+Join type: Inner
+Join condition: None
+
+(147) Project [codegen id : 6]
+Output [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Input [7]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24, cd_demo_sk#169]
+
+(148) Exchange
+Input [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(149) ObjectHashAggregate
+Input [5]: [c_customer_sk#20, c_birth_year#21, ca_county#22, ca_state#23, ca_country#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)]
+Aggregate Attributes [1]: [buf#261]
+Results [1]: [buf#262]
+
+(150) Exchange
+Input [1]: [buf#262]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+
+(151) ObjectHashAggregate
+Input [1]: [buf#262]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)#263]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)#263 AS bloomFilter#264]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+BroadcastExchange (156)
++- * Project (155)
+   +- * Filter (154)
+      +- * ColumnarToRow (153)
+         +- Scan parquet spark_catalog.default.date_dim (152)
+
+
+(152) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#17, d_year#265]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(158) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#255]
+(153) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#17, d_year#265]
 
-(159) Filter [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#255]
-Condition : ((isnotnull(d_year#255) AND (d_year#255 = 2001)) AND isnotnull(d_date_sk#15))
+(154) Filter [codegen id : 1]
+Input [2]: [d_date_sk#17, d_year#265]
+Condition : ((isnotnull(d_year#265) AND (d_year#265 = 2001)) AND isnotnull(d_date_sk#17))
 
-(160) Project [codegen id : 1]
-Output [1]: [d_date_sk#15]
-Input [2]: [d_date_sk#15, d_year#255]
+(155) Project [codegen id : 1]
+Output [1]: [d_date_sk#17]
+Input [2]: [d_date_sk#17, d_year#265]
 
-(161) BroadcastExchange
-Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=23]
+(156) BroadcastExchange
+Input [1]: [d_date_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
 
-Subquery:2 Hosting operator id = 99 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+Subquery:3 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#74, [id=#75]
+ObjectHashAggregate (176)
++- Exchange (175)
+   +- ObjectHashAggregate (174)
+      +- Exchange (173)
+         +- * Project (172)
+            +- * SortMergeJoin Inner (171)
+               :- * Sort (168)
+               :  +- Exchange (167)
+               :     +- * Project (166)
+               :        +- * BroadcastHashJoin Inner BuildRight (165)
+               :           :- * Project (160)
+               :           :  +- * Filter (159)
+               :           :     +- * ColumnarToRow (158)
+               :           :        +- Scan parquet spark_catalog.default.customer (157)
+               :           +- BroadcastExchange (164)
+               :              +- * Filter (163)
+               :                 +- * ColumnarToRow (162)
+               :                    +- Scan parquet spark_catalog.default.customer_address (161)
+               +- * Sort (170)
+                  +- ReusedExchange (169)
 
-Subquery:3 Hosting operator id = 134 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+
+(157) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
+
+(158) ColumnarToRow [codegen id : 2]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+
+(159) Filter [codegen id : 2]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+Condition : (((c_birth_month#167 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#165)) AND isnotnull(c_current_addr_sk#166))
+
+(160) Project [codegen id : 2]
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_year#21]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+
+(161) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#168, ca_state#23, ca_country#24]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
+
+(162) ColumnarToRow [codegen id : 1]
+Input [3]: [ca_address_sk#168, ca_state#23, ca_country#24]
+
+(163) Filter [codegen id : 1]
+Input [3]: [ca_address_sk#168, ca_state#23, ca_country#24]
+Condition : (ca_state#23 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#168))
+
+(164) BroadcastExchange
+Input [3]: [ca_address_sk#168, ca_state#23, ca_country#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=21]
+
+(165) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [c_current_addr_sk#166]
+Right keys [1]: [ca_address_sk#168]
+Join type: Inner
+Join condition: None
+
+(166) Project [codegen id : 2]
+Output [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_state#23, ca_country#24]
+Input [7]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_year#21, ca_address_sk#168, ca_state#23, ca_country#24]
+
+(167) Exchange
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_state#23, ca_country#24]
+Arguments: hashpartitioning(c_current_cdemo_sk#165, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+
+(168) Sort [codegen id : 3]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_state#23, ca_country#24]
+Arguments: [c_current_cdemo_sk#165 ASC NULLS FIRST], false, 0
+
+(169) ReusedExchange [Reuses operator id: 144]
+Output [1]: [cd_demo_sk#169]
+
+(170) Sort [codegen id : 5]
+Input [1]: [cd_demo_sk#169]
+Arguments: [cd_demo_sk#169 ASC NULLS FIRST], false, 0
+
+(171) SortMergeJoin [codegen id : 6]
+Left keys [1]: [c_current_cdemo_sk#165]
+Right keys [1]: [cd_demo_sk#169]
+Join type: Inner
+Join condition: None
+
+(172) Project [codegen id : 6]
+Output [4]: [c_customer_sk#20, c_birth_year#21, ca_state#23, ca_country#24]
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_state#23, ca_country#24, cd_demo_sk#169]
+
+(173) Exchange
+Input [4]: [c_customer_sk#20, c_birth_year#21, ca_state#23, ca_country#24]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+
+(174) ObjectHashAggregate
+Input [4]: [c_customer_sk#20, c_birth_year#21, ca_state#23, ca_country#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)]
+Aggregate Attributes [1]: [buf#266]
+Results [1]: [buf#267]
+
+(175) Exchange
+Input [1]: [buf#267]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=24]
+
+(176) ObjectHashAggregate
+Input [1]: [buf#267]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)#268]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)#268 AS bloomFilter#269]
+
+Subquery:4 Hosting operator id = 29 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+
+Subquery:5 Hosting operator id = 52 Hosting Expression = Subquery scalar-subquery#119, [id=#120]
+ObjectHashAggregate (197)
++- Exchange (196)
+   +- ObjectHashAggregate (195)
+      +- Exchange (194)
+         +- * Project (193)
+            +- * SortMergeJoin Inner (192)
+               :- * Sort (189)
+               :  +- Exchange (188)
+               :     +- * Project (187)
+               :        +- * BroadcastHashJoin Inner BuildRight (186)
+               :           :- * Project (180)
+               :           :  +- * Filter (179)
+               :           :     +- * ColumnarToRow (178)
+               :           :        +- Scan parquet spark_catalog.default.customer (177)
+               :           +- BroadcastExchange (185)
+               :              +- * Project (184)
+               :                 +- * Filter (183)
+               :                    +- * ColumnarToRow (182)
+               :                       +- Scan parquet spark_catalog.default.customer_address (181)
+               +- * Sort (191)
+                  +- ReusedExchange (190)
+
+
+(177) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
+
+(178) ColumnarToRow [codegen id : 2]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+
+(179) Filter [codegen id : 2]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+Condition : (((c_birth_month#167 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#165)) AND isnotnull(c_current_addr_sk#166))
+
+(180) Project [codegen id : 2]
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_year#21]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_month#167, c_birth_year#21]
+
+(181) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#168, ca_state#23, ca_country#24]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
+
+(182) ColumnarToRow [codegen id : 1]
+Input [3]: [ca_address_sk#168, ca_state#23, ca_country#24]
+
+(183) Filter [codegen id : 1]
+Input [3]: [ca_address_sk#168, ca_state#23, ca_country#24]
+Condition : (ca_state#23 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#168))
+
+(184) Project [codegen id : 1]
+Output [2]: [ca_address_sk#168, ca_country#24]
+Input [3]: [ca_address_sk#168, ca_state#23, ca_country#24]
+
+(185) BroadcastExchange
+Input [2]: [ca_address_sk#168, ca_country#24]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=25]
+
+(186) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [c_current_addr_sk#166]
+Right keys [1]: [ca_address_sk#168]
+Join type: Inner
+Join condition: None
+
+(187) Project [codegen id : 2]
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_country#24]
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#165, c_current_addr_sk#166, c_birth_year#21, ca_address_sk#168, ca_country#24]
+
+(188) Exchange
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_country#24]
+Arguments: hashpartitioning(c_current_cdemo_sk#165, 5), ENSURE_REQUIREMENTS, [plan_id=26]
+
+(189) Sort [codegen id : 3]
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_country#24]
+Arguments: [c_current_cdemo_sk#165 ASC NULLS FIRST], false, 0
+
+(190) ReusedExchange [Reuses operator id: 144]
+Output [1]: [cd_demo_sk#169]
+
+(191) Sort [codegen id : 5]
+Input [1]: [cd_demo_sk#169]
+Arguments: [cd_demo_sk#169 ASC NULLS FIRST], false, 0
+
+(192) SortMergeJoin [codegen id : 6]
+Left keys [1]: [c_current_cdemo_sk#165]
+Right keys [1]: [cd_demo_sk#169]
+Join type: Inner
+Join condition: None
+
+(193) Project [codegen id : 6]
+Output [3]: [c_customer_sk#20, c_birth_year#21, ca_country#24]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#165, c_birth_year#21, ca_country#24, cd_demo_sk#169]
+
+(194) Exchange
+Input [3]: [c_customer_sk#20, c_birth_year#21, ca_country#24]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=27]
+
+(195) ObjectHashAggregate
+Input [3]: [c_customer_sk#20, c_birth_year#21, ca_country#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)]
+Aggregate Attributes [1]: [buf#270]
+Results [1]: [buf#271]
+
+(196) Exchange
+Input [1]: [buf#271]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=28]
+
+(197) ObjectHashAggregate
+Input [1]: [buf#271]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)#272]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 327043, 2616344, 0, 0)#272 AS bloomFilter#273]
+
+Subquery:6 Hosting operator id = 50 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+
+Subquery:7 Hosting operator id = 71 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+
+Subquery:8 Hosting operator id = 106 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/simplified.txt
@@ -21,6 +21,44 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
                                           BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
                                             Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
+                                              Subquery #2
+                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 327043, 2616344, 0, 0),bloomFilter,buf]
+                                                  Exchange #4
+                                                    ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                      Exchange [c_customer_sk] #5
+                                                        WholeStageCodegen (6)
+                                                          Project [c_customer_sk,c_birth_year,ca_county,ca_state,ca_country]
+                                                            SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (3)
+                                                                  Sort [c_current_cdemo_sk]
+                                                                    InputAdapter
+                                                                      Exchange [c_current_cdemo_sk] #6
+                                                                        WholeStageCodegen (2)
+                                                                          Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_county,ca_state,ca_country]
+                                                                            BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                                                              Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
+                                                                                Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
+                                                                              InputAdapter
+                                                                                BroadcastExchange #7
+                                                                                  WholeStageCodegen (1)
+                                                                                    Filter [ca_state,ca_address_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state,ca_country]
+                                                              InputAdapter
+                                                                WholeStageCodegen (5)
+                                                                  Sort [cd_demo_sk]
+                                                                    InputAdapter
+                                                                      Exchange [cd_demo_sk] #8
+                                                                        WholeStageCodegen (4)
+                                                                          Filter [cd_demo_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
@@ -33,7 +71,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                             InputAdapter
-                                              BroadcastExchange #4
+                                              BroadcastExchange #9
                                                 WholeStageCodegen (1)
                                                   Project [cd_demo_sk,cd_dep_count]
                                                     Filter [cd_gender,cd_education_status,cd_demo_sk]
@@ -43,7 +81,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
-                                      BroadcastExchange #5
+                                      BroadcastExchange #10
                                         WholeStageCodegen (3)
                                           Filter [i_item_sk]
                                             ColumnarToRow
@@ -53,44 +91,11 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                       WholeStageCodegen (12)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #6
-                              WholeStageCodegen (11)
-                                Project [c_customer_sk,c_birth_year,ca_county,ca_state,ca_country]
-                                  SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (8)
-                                        Sort [c_current_cdemo_sk]
-                                          InputAdapter
-                                            Exchange [c_current_cdemo_sk] #7
-                                              WholeStageCodegen (7)
-                                                Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_county,ca_state,ca_country]
-                                                  BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                                                    Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
-                                                      Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
-                                                    InputAdapter
-                                                      BroadcastExchange #8
-                                                        WholeStageCodegen (6)
-                                                          Filter [ca_state,ca_address_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state,ca_country]
-                                    InputAdapter
-                                      WholeStageCodegen (10)
-                                        Sort [cd_demo_sk]
-                                          InputAdapter
-                                            Exchange [cd_demo_sk] #9
-                                              WholeStageCodegen (9)
-                                                Filter [cd_demo_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
+                            ReusedExchange [c_customer_sk,c_birth_year,ca_county,ca_state,ca_country] #5
     WholeStageCodegen (28)
       HashAggregate [i_item_id,ca_country,ca_state,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
-          Exchange [i_item_id,ca_country,ca_state] #10
+          Exchange [i_item_id,ca_country,ca_state] #11
             WholeStageCodegen (27)
               HashAggregate [i_item_id,ca_country,ca_state,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ca_country,ca_state,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
@@ -99,44 +104,67 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                       WholeStageCodegen (19)
                         Sort [cs_bill_customer_sk]
                           InputAdapter
-                            ReusedExchange [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count,i_item_id] #2
+                            Exchange [cs_bill_customer_sk] #12
+                              WholeStageCodegen (18)
+                                Project [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count,i_item_id]
+                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                    Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count]
+                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                        Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
+                                          BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                            Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
+                                              Subquery #3
+                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 327043, 2616344, 0, 0),bloomFilter,buf]
+                                                  Exchange #13
+                                                    ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                      Exchange [c_customer_sk] #14
+                                                        WholeStageCodegen (6)
+                                                          Project [c_customer_sk,c_birth_year,ca_state,ca_country]
+                                                            SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (3)
+                                                                  Sort [c_current_cdemo_sk]
+                                                                    InputAdapter
+                                                                      Exchange [c_current_cdemo_sk] #15
+                                                                        WholeStageCodegen (2)
+                                                                          Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_state,ca_country]
+                                                                            BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                                                              Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
+                                                                                Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
+                                                                              InputAdapter
+                                                                                BroadcastExchange #16
+                                                                                  WholeStageCodegen (1)
+                                                                                    Filter [ca_state,ca_address_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
+                                                              InputAdapter
+                                                                WholeStageCodegen (5)
+                                                                  Sort [cd_demo_sk]
+                                                                    InputAdapter
+                                                                      ReusedExchange [cd_demo_sk] #8
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
+                                            InputAdapter
+                                              ReusedExchange [cd_demo_sk,cd_dep_count] #9
+                                        InputAdapter
+                                          ReusedExchange [d_date_sk] #3
+                                    InputAdapter
+                                      ReusedExchange [i_item_sk,i_item_id] #10
                     InputAdapter
                       WholeStageCodegen (26)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #11
-                              WholeStageCodegen (25)
-                                Project [c_customer_sk,c_birth_year,ca_state,ca_country]
-                                  SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (22)
-                                        Sort [c_current_cdemo_sk]
-                                          InputAdapter
-                                            Exchange [c_current_cdemo_sk] #12
-                                              WholeStageCodegen (21)
-                                                Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_state,ca_country]
-                                                  BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                                                    Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
-                                                      Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
-                                                    InputAdapter
-                                                      BroadcastExchange #13
-                                                        WholeStageCodegen (20)
-                                                          Filter [ca_state,ca_address_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
-                                    InputAdapter
-                                      WholeStageCodegen (24)
-                                        Sort [cd_demo_sk]
-                                          InputAdapter
-                                            ReusedExchange [cd_demo_sk] #9
+                            ReusedExchange [c_customer_sk,c_birth_year,ca_state,ca_country] #14
     WholeStageCodegen (42)
       HashAggregate [i_item_id,ca_country,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
-          Exchange [i_item_id,ca_country] #14
+          Exchange [i_item_id,ca_country] #17
             WholeStageCodegen (41)
               HashAggregate [i_item_id,ca_country,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ca_country,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
@@ -145,45 +173,68 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                       WholeStageCodegen (33)
                         Sort [cs_bill_customer_sk]
                           InputAdapter
-                            ReusedExchange [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count,i_item_id] #2
+                            Exchange [cs_bill_customer_sk] #18
+                              WholeStageCodegen (32)
+                                Project [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count,i_item_id]
+                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                    Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count]
+                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                        Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
+                                          BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                            Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
+                                              Subquery #4
+                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 327043, 2616344, 0, 0),bloomFilter,buf]
+                                                  Exchange #19
+                                                    ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                      Exchange [c_customer_sk] #20
+                                                        WholeStageCodegen (6)
+                                                          Project [c_customer_sk,c_birth_year,ca_country]
+                                                            SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (3)
+                                                                  Sort [c_current_cdemo_sk]
+                                                                    InputAdapter
+                                                                      Exchange [c_current_cdemo_sk] #21
+                                                                        WholeStageCodegen (2)
+                                                                          Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_country]
+                                                                            BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                                                              Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
+                                                                                Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
+                                                                              InputAdapter
+                                                                                BroadcastExchange #22
+                                                                                  WholeStageCodegen (1)
+                                                                                    Project [ca_address_sk,ca_country]
+                                                                                      Filter [ca_state,ca_address_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
+                                                              InputAdapter
+                                                                WholeStageCodegen (5)
+                                                                  Sort [cd_demo_sk]
+                                                                    InputAdapter
+                                                                      ReusedExchange [cd_demo_sk] #8
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
+                                            InputAdapter
+                                              ReusedExchange [cd_demo_sk,cd_dep_count] #9
+                                        InputAdapter
+                                          ReusedExchange [d_date_sk] #3
+                                    InputAdapter
+                                      ReusedExchange [i_item_sk,i_item_id] #10
                     InputAdapter
                       WholeStageCodegen (40)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #15
-                              WholeStageCodegen (39)
-                                Project [c_customer_sk,c_birth_year,ca_country]
-                                  SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (36)
-                                        Sort [c_current_cdemo_sk]
-                                          InputAdapter
-                                            Exchange [c_current_cdemo_sk] #16
-                                              WholeStageCodegen (35)
-                                                Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_country]
-                                                  BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                                                    Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
-                                                      Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
-                                                    InputAdapter
-                                                      BroadcastExchange #17
-                                                        WholeStageCodegen (34)
-                                                          Project [ca_address_sk,ca_country]
-                                                            Filter [ca_state,ca_address_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
-                                    InputAdapter
-                                      WholeStageCodegen (38)
-                                        Sort [cd_demo_sk]
-                                          InputAdapter
-                                            ReusedExchange [cd_demo_sk] #9
+                            ReusedExchange [c_customer_sk,c_birth_year,ca_country] #20
     WholeStageCodegen (50)
       HashAggregate [i_item_id,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),ca_country,ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
-          Exchange [i_item_id] #18
+          Exchange [i_item_id] #23
             WholeStageCodegen (49)
               HashAggregate [i_item_id,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
@@ -200,16 +251,16 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
                                         ReusedSubquery [d_date_sk] #1
                                 InputAdapter
-                                  ReusedExchange [cd_demo_sk,cd_dep_count] #4
+                                  ReusedExchange [cd_demo_sk,cd_dep_count] #9
                             InputAdapter
                               ReusedExchange [d_date_sk] #3
                         InputAdapter
-                          BroadcastExchange #19
+                          BroadcastExchange #24
                             WholeStageCodegen (47)
                               Project [c_customer_sk,c_birth_year]
                                 BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
                                   InputAdapter
-                                    BroadcastExchange #20
+                                    BroadcastExchange #25
                                       WholeStageCodegen (46)
                                         Project [c_customer_sk,c_current_cdemo_sk,c_birth_year]
                                           BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
@@ -219,7 +270,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
                                             InputAdapter
-                                              BroadcastExchange #21
+                                              BroadcastExchange #26
                                                 WholeStageCodegen (45)
                                                   Project [ca_address_sk]
                                                     Filter [ca_state,ca_address_sk]
@@ -231,11 +282,11 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       InputAdapter
                                         Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
                     InputAdapter
-                      ReusedExchange [i_item_sk,i_item_id] #5
+                      ReusedExchange [i_item_sk,i_item_id] #10
     WholeStageCodegen (58)
       HashAggregate [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),i_item_id,ca_country,ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
-          Exchange #22
+          Exchange #27
             WholeStageCodegen (57)
               HashAggregate [agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
@@ -252,15 +303,15 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
                                         ReusedSubquery [d_date_sk] #1
                                 InputAdapter
-                                  ReusedExchange [cd_demo_sk,cd_dep_count] #4
+                                  ReusedExchange [cd_demo_sk,cd_dep_count] #9
                             InputAdapter
                               ReusedExchange [d_date_sk] #3
                         InputAdapter
-                          BroadcastExchange #23
+                          BroadcastExchange #28
                             WholeStageCodegen (53)
                               Filter [i_item_sk]
                                 ColumnarToRow
                                   InputAdapter
                                     Scan parquet spark_catalog.default.item [i_item_sk]
                     InputAdapter
-                      ReusedExchange [c_customer_sk,c_birth_year] #19
+                      ReusedExchange [c_customer_sk,c_birth_year] #24

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/explain.txt
@@ -1,27 +1,24 @@
 == Physical Plan ==
-TakeOrderedAndProject (23)
-+- * Project (22)
-   +- Window (21)
-      +- * Sort (20)
-         +- Exchange (19)
-            +- * HashAggregate (18)
-               +- Exchange (17)
-                  +- * HashAggregate (16)
-                     +- * Project (15)
-                        +- * BroadcastHashJoin Inner BuildRight (14)
-                           :- * Project (12)
-                           :  +- * SortMergeJoin Inner (11)
+TakeOrderedAndProject (20)
++- * Project (19)
+   +- Window (18)
+      +- * Sort (17)
+         +- Exchange (16)
+            +- * HashAggregate (15)
+               +- Exchange (14)
+                  +- * HashAggregate (13)
+                     +- * Project (12)
+                        +- * BroadcastHashJoin Inner BuildRight (11)
+                           :- * Project (9)
+                           :  +- * SortMergeJoin Inner (8)
                            :     :- * Sort (5)
                            :     :  +- Exchange (4)
                            :     :     +- * Filter (3)
                            :     :        +- * ColumnarToRow (2)
                            :     :           +- Scan parquet spark_catalog.default.catalog_sales (1)
-                           :     +- * Sort (10)
-                           :        +- Exchange (9)
-                           :           +- * Filter (8)
-                           :              +- * ColumnarToRow (7)
-                           :                 +- Scan parquet spark_catalog.default.item (6)
-                           +- ReusedExchange (13)
+                           :     +- * Sort (7)
+                           :        +- ReusedExchange (6)
+                           +- ReusedExchange (10)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -37,7 +34,7 @@ Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
-Condition : isnotnull(cs_item_sk#1)
+Condition : (isnotnull(cs_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(cs_item_sk#1, 42), false))
 
 (4) Exchange
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
@@ -47,119 +44,150 @@ Arguments: hashpartitioning(cs_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
 Arguments: [cs_item_sk#1 ASC NULLS FIRST], false, 0
 
-(6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(6) ReusedExchange [Reuses operator id: 24]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(7) Sort [codegen id : 4]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
+
+(8) SortMergeJoin [codegen id : 6]
+Left keys [1]: [cs_item_sk#1]
+Right keys [1]: [i_item_sk#7]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 6]
+Output [7]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(10) ReusedExchange [Reuses operator id: 32]
+Output [1]: [d_date_sk#13]
+
+(11) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#3]
+Right keys [1]: [d_date_sk#13]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [6]: [cs_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
+
+(13) HashAggregate [codegen id : 6]
+Input [6]: [cs_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [partial_sum(UnscaledValue(cs_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+
+(14) Exchange
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [sum(UnscaledValue(cs_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#2))#16]
+Results [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS _w0#18, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS _w1#19]
+
+(16) Exchange
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(17) Sort [codegen id : 8]
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
+
+(18) Window
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: [sum(_w1#19) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#20], [i_class#11]
+
+(19) Project [codegen id : 9]
+Output [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#20) AS revenueratio#21]
+Input [9]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, _we0#20]
+
+(20) TakeOrderedAndProject
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+Arguments: 100, [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#21 ASC NULLS FIRST], [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (27)
++- Exchange (26)
+   +- ObjectHashAggregate (25)
+      +- Exchange (24)
+         +- * Filter (23)
+            +- * ColumnarToRow (22)
+               +- Scan parquet spark_catalog.default.item (21)
+
+
+(21) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
-(7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(22) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+(23) Filter [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
-(9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(24) Exchange
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+(25) ObjectHashAggregate
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [buf#22]
+Results [1]: [buf#23]
 
-(11) SortMergeJoin [codegen id : 6]
-Left keys [1]: [cs_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
+(26) Exchange
+Input [1]: [buf#23]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
-(12) Project [codegen id : 6]
-Output [7]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(27) ObjectHashAggregate
+Input [1]: [buf#23]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24 AS bloomFilter#25]
 
-(13) ReusedExchange [Reuses operator id: 28]
-Output [1]: [d_date_sk#11]
-
-(14) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [cs_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [6]: [cs_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
-
-(16) HashAggregate [codegen id : 6]
-Input [6]: [cs_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [partial_sum(UnscaledValue(cs_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-
-(17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [sum(UnscaledValue(cs_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#2))#14]
-Results [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS _w0#16, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS _w1#17]
-
-(19) Exchange
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(20) Sort [codegen id : 8]
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
-
-(21) Window
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: [sum(_w1#17) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#18], [i_class#9]
-
-(22) Project [codegen id : 9]
-Output [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#18) AS revenueratio#19]
-Input [9]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, _we0#18]
-
-(23) TakeOrderedAndProject
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-Arguments: 100, [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#19 ASC NULLS FIRST], [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (28)
-+- * Project (27)
-   +- * Filter (26)
-      +- * ColumnarToRow (25)
-         +- Scan parquet spark_catalog.default.date_dim (24)
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (32)
++- * Project (31)
+   +- * Filter (30)
+      +- * ColumnarToRow (29)
+         +- Scan parquet spark_catalog.default.date_dim (28)
 
 
-(24) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#20]
+(28) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(25) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
+(29) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(26) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
-Condition : (((isnotnull(d_date#20) AND (d_date#20 >= 1999-02-22)) AND (d_date#20 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(30) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
+Condition : (((isnotnull(d_date#26) AND (d_date#26 >= 1999-02-22)) AND (d_date#26 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(27) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#20]
+(31) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(28) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(32) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/simplified.txt
@@ -24,6 +24,16 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                               Exchange [cs_item_sk] #3
                                                 WholeStageCodegen (1)
                                                   Filter [cs_item_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 489600, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                            Exchange [i_item_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [i_category,i_item_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
@@ -39,11 +49,6 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                         WholeStageCodegen (4)
                                           Sort [i_item_sk]
                                             InputAdapter
-                                              Exchange [i_item_sk] #5
-                                                WholeStageCodegen (3)
-                                                  Filter [i_category,i_item_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
+                                              ReusedExchange [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category] #6
                                   InputAdapter
                                     ReusedExchange [d_date_sk] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
@@ -278,18 +278,18 @@ Arguments: [c_last_name#13 ASC NULLS FIRST, c_first_name#12 ASC NULLS FIRST, s_s
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
-* HashAggregate (76)
-+- Exchange (75)
-   +- * HashAggregate (74)
-      +- * HashAggregate (73)
-         +- Exchange (72)
-            +- * HashAggregate (71)
-               +- * Project (70)
-                  +- * SortMergeJoin Inner (69)
-                     :- * Sort (66)
-                     :  +- Exchange (65)
-                     :     +- * Project (64)
-                     :        +- * SortMergeJoin Inner (63)
+* HashAggregate (73)
++- Exchange (72)
+   +- * HashAggregate (71)
+      +- * HashAggregate (70)
+         +- Exchange (69)
+            +- * HashAggregate (68)
+               +- * Project (67)
+                  +- * SortMergeJoin Inner (66)
+                     :- * Sort (63)
+                     :  +- Exchange (62)
+                     :     +- * Project (61)
+                     :        +- * SortMergeJoin Inner (60)
                      :           :- * Sort (57)
                      :           :  +- Exchange (56)
                      :           :     +- * Project (55)
@@ -299,13 +299,10 @@ Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquer
                      :           :              +- * Filter (52)
                      :           :                 +- * ColumnarToRow (51)
                      :           :                    +- Scan parquet spark_catalog.default.store_sales (50)
-                     :           +- * Sort (62)
-                     :              +- Exchange (61)
-                     :                 +- * Filter (60)
-                     :                    +- * ColumnarToRow (59)
-                     :                       +- Scan parquet spark_catalog.default.item (58)
-                     +- * Sort (68)
-                        +- ReusedExchange (67)
+                     :           +- * Sort (59)
+                     :              +- ReusedExchange (58)
+                     +- * Sort (65)
+                        +- ReusedExchange (64)
 
 
 (49) ReusedExchange [Reuses operator id: 17]
@@ -323,7 +320,7 @@ Input [6]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#1
 
 (52) Filter
 Input [6]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#18, ss_net_paid#19, ss_sold_date_sk#20]
-Condition : (((isnotnull(ss_ticket_number#18) AND isnotnull(ss_item_sk#15)) AND isnotnull(ss_store_sk#17)) AND isnotnull(ss_customer_sk#16))
+Condition : ((((isnotnull(ss_ticket_number#18) AND isnotnull(ss_item_sk#15)) AND isnotnull(ss_store_sk#17)) AND isnotnull(ss_customer_sk#16)) AND might_contain(Subquery scalar-subquery#42, [id=#43], xxhash64(ss_item_sk#15, 42), false))
 
 (53) Project
 Output [5]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#18, ss_net_paid#19]
@@ -347,97 +344,128 @@ Arguments: hashpartitioning(ss_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 Input [8]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19]
 Arguments: [ss_item_sk#15 ASC NULLS FIRST], false, 0
 
-(58) Scan parquet spark_catalog.default.item
+(58) ReusedExchange [Reuses operator id: 77]
+Output [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+
+(59) Sort [codegen id : 7]
+Input [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+Arguments: [i_item_sk#21 ASC NULLS FIRST], false, 0
+
+(60) SortMergeJoin [codegen id : 8]
+Left keys [1]: [ss_item_sk#15]
+Right keys [1]: [i_item_sk#21]
+Join type: Inner
+Join condition: None
+
+(61) Project [codegen id : 8]
+Output [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+Input [14]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+
+(62) Exchange
+Input [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+Arguments: hashpartitioning(ss_ticket_number#18, ss_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(63) Sort [codegen id : 9]
+Input [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+Arguments: [ss_ticket_number#18 ASC NULLS FIRST, ss_item_sk#15 ASC NULLS FIRST], false, 0
+
+(64) ReusedExchange [Reuses operator id: 36]
+Output [2]: [sr_item_sk#27, sr_ticket_number#28]
+
+(65) Sort [codegen id : 11]
+Input [2]: [sr_item_sk#27, sr_ticket_number#28]
+Arguments: [sr_ticket_number#28 ASC NULLS FIRST, sr_item_sk#27 ASC NULLS FIRST], false, 0
+
+(66) SortMergeJoin [codegen id : 12]
+Left keys [2]: [ss_ticket_number#18, ss_item_sk#15]
+Right keys [2]: [sr_ticket_number#28, sr_item_sk#27]
+Join type: Inner
+Join condition: None
+
+(67) Project [codegen id : 12]
+Output [11]: [ss_net_paid#19, s_store_name#2, s_state#4, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, c_first_name#12, c_last_name#13, ca_state#7]
+Input [15]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, sr_item_sk#27, sr_ticket_number#28]
+
+(68) HashAggregate [codegen id : 12]
+Input [11]: [ss_net_paid#19, s_store_name#2, s_state#4, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, c_first_name#12, c_last_name#13, ca_state#7]
+Keys [10]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#19))]
+Aggregate Attributes [1]: [sum#44]
+Results [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#45]
+
+(69) Exchange
+Input [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#45]
+Arguments: hashpartitioning(c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(70) HashAggregate [codegen id : 13]
+Input [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#45]
+Keys [10]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#19))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#19))#32]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#19))#32,17,2) AS netpaid#33]
+
+(71) HashAggregate [codegen id : 13]
+Input [1]: [netpaid#33]
+Keys: []
+Functions [1]: [partial_avg(netpaid#33)]
+Aggregate Attributes [2]: [sum#46, count#47]
+Results [2]: [sum#48, count#49]
+
+(72) Exchange
+Input [2]: [sum#48, count#49]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
+
+(73) HashAggregate [codegen id : 14]
+Input [2]: [sum#48, count#49]
+Keys: []
+Functions [1]: [avg(netpaid#33)]
+Aggregate Attributes [1]: [avg(netpaid#33)#50]
+Results [1]: [(0.05 * avg(netpaid#33)#50) AS (0.05 * avg(netpaid))#51]
+
+Subquery:2 Hosting operator id = 52 Hosting Expression = Subquery scalar-subquery#42, [id=#43]
+ObjectHashAggregate (80)
++- Exchange (79)
+   +- ObjectHashAggregate (78)
+      +- Exchange (77)
+         +- * Filter (76)
+            +- * ColumnarToRow (75)
+               +- Scan parquet spark_catalog.default.item (74)
+
+
+(74) Scan parquet spark_catalog.default.item
 Output [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
-(59) ColumnarToRow [codegen id : 6]
+(75) ColumnarToRow [codegen id : 1]
 Input [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
 
-(60) Filter [codegen id : 6]
+(76) Filter [codegen id : 1]
 Input [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
 Condition : isnotnull(i_item_sk#21)
 
-(61) Exchange
+(77) Exchange
 Input [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Arguments: hashpartitioning(i_item_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Arguments: hashpartitioning(i_item_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(62) Sort [codegen id : 7]
+(78) ObjectHashAggregate
 Input [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Arguments: [i_item_sk#21 ASC NULLS FIRST], false, 0
-
-(63) SortMergeJoin [codegen id : 8]
-Left keys [1]: [ss_item_sk#15]
-Right keys [1]: [i_item_sk#21]
-Join type: Inner
-Join condition: None
-
-(64) Project [codegen id : 8]
-Output [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Input [14]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-
-(65) Exchange
-Input [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Arguments: hashpartitioning(ss_ticket_number#18, ss_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(66) Sort [codegen id : 9]
-Input [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Arguments: [ss_ticket_number#18 ASC NULLS FIRST, ss_item_sk#15 ASC NULLS FIRST], false, 0
-
-(67) ReusedExchange [Reuses operator id: 36]
-Output [2]: [sr_item_sk#27, sr_ticket_number#28]
-
-(68) Sort [codegen id : 11]
-Input [2]: [sr_item_sk#27, sr_ticket_number#28]
-Arguments: [sr_ticket_number#28 ASC NULLS FIRST, sr_item_sk#27 ASC NULLS FIRST], false, 0
-
-(69) SortMergeJoin [codegen id : 12]
-Left keys [2]: [ss_ticket_number#18, ss_item_sk#15]
-Right keys [2]: [sr_ticket_number#28, sr_item_sk#27]
-Join type: Inner
-Join condition: None
-
-(70) Project [codegen id : 12]
-Output [11]: [ss_net_paid#19, s_store_name#2, s_state#4, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, c_first_name#12, c_last_name#13, ca_state#7]
-Input [15]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, sr_item_sk#27, sr_ticket_number#28]
-
-(71) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#19, s_store_name#2, s_state#4, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, c_first_name#12, c_last_name#13, ca_state#7]
-Keys [10]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#19))]
-Aggregate Attributes [1]: [sum#42]
-Results [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#43]
-
-(72) Exchange
-Input [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#43]
-Arguments: hashpartitioning(c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(73) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#43]
-Keys [10]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#19))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#19))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#19))#32,17,2) AS netpaid#33]
-
-(74) HashAggregate [codegen id : 13]
-Input [1]: [netpaid#33]
 Keys: []
-Functions [1]: [partial_avg(netpaid#33)]
-Aggregate Attributes [2]: [sum#44, count#45]
-Results [2]: [sum#46, count#47]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#21, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#52]
+Results [1]: [buf#53]
 
-(75) Exchange
-Input [2]: [sum#46, count#47]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+(79) Exchange
+Input [1]: [buf#53]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
-(76) HashAggregate [codegen id : 14]
-Input [2]: [sum#46, count#47]
+(80) ObjectHashAggregate
+Input [1]: [buf#53]
 Keys: []
-Functions [1]: [avg(netpaid#33)]
-Aggregate Attributes [1]: [avg(netpaid#33)#48]
-Results [1]: [(0.05 * avg(netpaid#33)#48) AS (0.05 * avg(netpaid))#49]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#21, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#21, 42), 204000, 1632000, 0, 0)#54]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#21, 42), 204000, 1632000, 0, 0)#54 AS bloomFilter#55]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/simplified.txt
@@ -38,6 +38,16 @@ WholeStageCodegen (12)
                                                                           ReusedExchange [s_store_sk,s_store_name,s_state,ca_state,c_customer_sk,c_first_name,c_last_name] #5
                                                                         Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                           Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                            Subquery #2
+                                                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                                Exchange #14
+                                                                                  ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                    Exchange [i_item_sk] #15
+                                                                                      WholeStageCodegen (1)
+                                                                                        Filter [i_item_sk]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                             ColumnarToRow
                                                                               InputAdapter
                                                                                 Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
@@ -45,12 +55,7 @@ WholeStageCodegen (12)
                                                           WholeStageCodegen (7)
                                                             Sort [i_item_sk]
                                                               InputAdapter
-                                                                Exchange [i_item_sk] #14
-                                                                  WholeStageCodegen (6)
-                                                                    Filter [i_item_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                ReusedExchange [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id] #15
                                         InputAdapter
                                           WholeStageCodegen (11)
                                             Sort [sr_ticket_number,sr_item_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/explain.txt
@@ -1,8 +1,8 @@
 == Physical Plan ==
-* Sort (35)
-+- Exchange (34)
-   +- * Project (33)
-      +- * SortMergeJoin Inner (32)
+* Sort (32)
++- Exchange (31)
+   +- * Project (30)
+      +- * SortMergeJoin Inner (29)
          :- * Sort (26)
          :  +- Exchange (25)
          :     +- * Filter (24)
@@ -29,11 +29,8 @@
          :                             +- * Filter (16)
          :                                +- * ColumnarToRow (15)
          :                                   +- Scan parquet spark_catalog.default.household_demographics (14)
-         +- * Sort (31)
-            +- Exchange (30)
-               +- * Filter (29)
-                  +- * ColumnarToRow (28)
-                     +- Scan parquet spark_catalog.default.customer (27)
+         +- * Sort (28)
+            +- ReusedExchange (27)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -49,185 +46,216 @@ Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, 
 
 (3) Filter [codegen id : 4]
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
-Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
+Condition : (((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 40]
-Output [1]: [d_date_sk#7]
+(4) ReusedExchange [Reuses operator id: 44]
+Output [1]: [d_date_sk#9]
 
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
 Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
-Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
+Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#9]
 
 (7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
+Output [2]: [s_store_sk#10, s_county#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_county), EqualTo(s_county,Williamson County), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_county:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
+Input [2]: [s_store_sk#10, s_county#11]
 
 (9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : ((isnotnull(s_county#9) AND (s_county#9 = Williamson County)) AND isnotnull(s_store_sk#8))
+Input [2]: [s_store_sk#10, s_county#11]
+Condition : ((isnotnull(s_county#11) AND (s_county#11 = Williamson County)) AND isnotnull(s_store_sk#10))
 
 (10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
+Output [1]: [s_store_sk#10]
+Input [2]: [s_store_sk#10, s_county#11]
 
 (11) BroadcastExchange
-Input [1]: [s_store_sk#8]
+Input [1]: [s_store_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#10]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#10]
 
 (14) Scan parquet spark_catalog.default.household_demographics
-Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_vehicle_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (16) Filter [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : ((((isnotnull(hd_vehicle_count#13) AND ((hd_buy_potential#11 = >10000         ) OR (hd_buy_potential#11 = unknown        ))) AND (hd_vehicle_count#13 > 0)) AND CASE WHEN (hd_vehicle_count#13 > 0) THEN ((cast(hd_dep_count#12 as double) / cast(hd_vehicle_count#13 as double)) > 1.2) END) AND isnotnull(hd_demo_sk#10))
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
+Condition : ((((isnotnull(hd_vehicle_count#15) AND ((hd_buy_potential#13 = >10000         ) OR (hd_buy_potential#13 = unknown        ))) AND (hd_vehicle_count#15 > 0)) AND CASE WHEN (hd_vehicle_count#15 > 0) THEN ((cast(hd_dep_count#14 as double) / cast(hd_vehicle_count#15 as double)) > 1.2) END) AND isnotnull(hd_demo_sk#12))
 
 (17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [hd_demo_sk#12]
+Input [4]: [hd_demo_sk#12, hd_buy_potential#13, hd_dep_count#14, hd_vehicle_count#15]
 
 (18) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [hd_demo_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#12]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#10]
+Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#12]
 
 (21) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#14]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Aggregate Attributes [1]: [count#16]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 
 (22) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Arguments: hashpartitioning(ss_ticket_number#4, ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (23) HashAggregate [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#15]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, count#17]
 Keys [2]: [ss_ticket_number#4, ss_customer_sk#1]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#16]
-Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#16 AS cnt#17]
+Aggregate Attributes [1]: [count(1)#18]
+Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#18 AS cnt#19]
 
 (24) Filter [codegen id : 5]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
-Condition : ((cnt#17 >= 15) AND (cnt#17 <= 20))
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
+Condition : ((cnt#19 >= 15) AND (cnt#19 <= 20))
 
 (25) Exchange
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (26) Sort [codegen id : 6]
-Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(27) ReusedExchange [Reuses operator id: 36]
+Output [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+
+(28) Sort [codegen id : 8]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 9]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#20]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 9]
+Output [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#19, c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+
+(31) Exchange
+Input [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Arguments: rangepartitioning(c_last_name#23 ASC NULLS FIRST, c_first_name#22 ASC NULLS FIRST, c_salutation#21 ASC NULLS FIRST, c_preferred_cust_flag#24 DESC NULLS LAST, ss_ticket_number#4 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(32) Sort [codegen id : 10]
+Input [6]: [c_last_name#23, c_first_name#22, c_salutation#21, c_preferred_cust_flag#24, ss_ticket_number#4, cnt#19]
+Arguments: [c_last_name#23 ASC NULLS FIRST, c_first_name#22 ASC NULLS FIRST, c_salutation#21 ASC NULLS FIRST, c_preferred_cust_flag#24 DESC NULLS LAST, ss_ticket_number#4 ASC NULLS FIRST], true, 0
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (39)
++- Exchange (38)
+   +- ObjectHashAggregate (37)
+      +- Exchange (36)
+         +- * Filter (35)
+            +- * ColumnarToRow (34)
+               +- Scan parquet spark_catalog.default.customer (33)
+
+
+(33) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string>
 
-(28) ColumnarToRow [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(34) ColumnarToRow [codegen id : 1]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
 
-(29) Filter [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Condition : isnotnull(c_customer_sk#18)
+(35) Filter [codegen id : 1]
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Condition : isnotnull(c_customer_sk#20)
 
-(30) Exchange
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(36) Exchange
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(31) Sort [codegen id : 8]
-Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+(37) ObjectHashAggregate
+Input [5]: [c_customer_sk#20, c_salutation#21, c_first_name#22, c_last_name#23, c_preferred_cust_flag#24]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#25]
+Results [1]: [buf#26]
 
-(32) SortMergeJoin [codegen id : 9]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
-Join type: Inner
-Join condition: None
+(38) Exchange
+Input [1]: [buf#26]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(33) Project [codegen id : 9]
-Output [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17, c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+(39) ObjectHashAggregate
+Input [1]: [buf#26]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)#27]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2000000, 16000000, 0, 0)#27 AS bloomFilter#28]
 
-(34) Exchange
-Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: rangepartitioning(c_last_name#21 ASC NULLS FIRST, c_first_name#20 ASC NULLS FIRST, c_salutation#19 ASC NULLS FIRST, c_preferred_cust_flag#22 DESC NULLS LAST, ss_ticket_number#4 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(35) Sort [codegen id : 10]
-Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: [c_last_name#21 ASC NULLS FIRST, c_first_name#20 ASC NULLS FIRST, c_salutation#19 ASC NULLS FIRST, c_preferred_cust_flag#22 DESC NULLS LAST, ss_ticket_number#4 ASC NULLS FIRST], true, 0
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (40)
-+- * Project (39)
-   +- * Filter (38)
-      +- * ColumnarToRow (37)
-         +- Scan parquet spark_catalog.default.date_dim (36)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (44)
++- * Project (43)
+   +- * Filter (42)
+      +- * ColumnarToRow (41)
+         +- Scan parquet spark_catalog.default.date_dim (40)
 
 
-(36) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(40) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#9, d_year#29, d_dom#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(And(GreaterThanOrEqual(d_dom,1),LessThanOrEqual(d_dom,3)),And(GreaterThanOrEqual(d_dom,25),LessThanOrEqual(d_dom,28))), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
-(37) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(41) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
 
-(38) Filter [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
-Condition : (((((d_dom#24 >= 1) AND (d_dom#24 <= 3)) OR ((d_dom#24 >= 25) AND (d_dom#24 <= 28))) AND d_year#23 IN (1999,2000,2001)) AND isnotnull(d_date_sk#7))
+(42) Filter [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
+Condition : (((((d_dom#30 >= 1) AND (d_dom#30 <= 3)) OR ((d_dom#30 >= 25) AND (d_dom#30 <= 28))) AND d_year#29 IN (1999,2000,2001)) AND isnotnull(d_date_sk#9))
 
-(39) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+(43) Project [codegen id : 1]
+Output [1]: [d_date_sk#9]
+Input [3]: [d_date_sk#9, d_year#29, d_dom#30]
 
-(40) BroadcastExchange
-Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+(44) BroadcastExchange
+Input [1]: [d_date_sk#9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/simplified.txt
@@ -24,6 +24,16 @@ WholeStageCodegen (10)
                                               Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                   Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                            Exchange [c_customer_sk] #6
+                                                              WholeStageCodegen (1)
+                                                                Filter [c_customer_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
@@ -38,7 +48,7 @@ WholeStageCodegen (10)
                                                   InputAdapter
                                                     ReusedExchange [d_date_sk] #4
                                               InputAdapter
-                                                BroadcastExchange #5
+                                                BroadcastExchange #7
                                                   WholeStageCodegen (2)
                                                     Project [s_store_sk]
                                                       Filter [s_county,s_store_sk]
@@ -46,7 +56,7 @@ WholeStageCodegen (10)
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.store [s_store_sk,s_county]
                                           InputAdapter
-                                            BroadcastExchange #6
+                                            BroadcastExchange #8
                                               WholeStageCodegen (3)
                                                 Project [hd_demo_sk]
                                                   Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
@@ -57,9 +67,4 @@ WholeStageCodegen (10)
                 WholeStageCodegen (8)
                   Sort [c_customer_sk]
                     InputAdapter
-                      Exchange [c_customer_sk] #7
-                        WholeStageCodegen (7)
-                          Filter [c_customer_sk]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
+                      ReusedExchange [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35.sf100/explain.txt
@@ -1,57 +1,52 @@
 == Physical Plan ==
-TakeOrderedAndProject (53)
-+- * HashAggregate (52)
-   +- Exchange (51)
-      +- * HashAggregate (50)
-         +- * Project (49)
-            +- * SortMergeJoin Inner (48)
-               :- * Sort (42)
-               :  +- Exchange (41)
-               :     +- * Project (40)
-               :        +- * SortMergeJoin Inner (39)
-               :           :- * Sort (33)
-               :           :  +- Exchange (32)
-               :           :     +- * Project (31)
-               :           :        +- * Filter (30)
-               :           :           +- * SortMergeJoin ExistenceJoin(exists#1) (29)
-               :           :              :- * SortMergeJoin ExistenceJoin(exists#2) (21)
-               :           :              :  :- * SortMergeJoin LeftSemi (13)
+TakeOrderedAndProject (48)
++- * HashAggregate (47)
+   +- Exchange (46)
+      +- * HashAggregate (45)
+         +- * Project (44)
+            +- * SortMergeJoin Inner (43)
+               :- * Sort (40)
+               :  +- Exchange (39)
+               :     +- * Project (38)
+               :        +- * SortMergeJoin Inner (37)
+               :           :- * Sort (34)
+               :           :  +- Exchange (33)
+               :           :     +- * Project (32)
+               :           :        +- * Filter (31)
+               :           :           +- * SortMergeJoin ExistenceJoin(exists#1) (30)
+               :           :              :- * SortMergeJoin ExistenceJoin(exists#2) (22)
+               :           :              :  :- * SortMergeJoin LeftSemi (14)
                :           :              :  :  :- * Sort (5)
                :           :              :  :  :  +- Exchange (4)
                :           :              :  :  :     +- * Filter (3)
                :           :              :  :  :        +- * ColumnarToRow (2)
                :           :              :  :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :           :              :  :  +- * Sort (12)
-               :           :              :  :     +- Exchange (11)
-               :           :              :  :        +- * Project (10)
-               :           :              :  :           +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :              :  :              :- * ColumnarToRow (7)
-               :           :              :  :              :  +- Scan parquet spark_catalog.default.store_sales (6)
-               :           :              :  :              +- ReusedExchange (8)
-               :           :              :  +- * Sort (20)
-               :           :              :     +- Exchange (19)
-               :           :              :        +- * Project (18)
-               :           :              :           +- * BroadcastHashJoin Inner BuildRight (17)
-               :           :              :              :- * ColumnarToRow (15)
-               :           :              :              :  +- Scan parquet spark_catalog.default.web_sales (14)
-               :           :              :              +- ReusedExchange (16)
-               :           :              +- * Sort (28)
-               :           :                 +- Exchange (27)
-               :           :                    +- * Project (26)
-               :           :                       +- * BroadcastHashJoin Inner BuildRight (25)
-               :           :                          :- * ColumnarToRow (23)
-               :           :                          :  +- Scan parquet spark_catalog.default.catalog_sales (22)
-               :           :                          +- ReusedExchange (24)
-               :           +- * Sort (38)
-               :              +- Exchange (37)
-               :                 +- * Filter (36)
-               :                    +- * ColumnarToRow (35)
-               :                       +- Scan parquet spark_catalog.default.customer_address (34)
-               +- * Sort (47)
-                  +- Exchange (46)
-                     +- * Filter (45)
-                        +- * ColumnarToRow (44)
-                           +- Scan parquet spark_catalog.default.customer_demographics (43)
+               :           :              :  :  +- * Sort (13)
+               :           :              :  :     +- Exchange (12)
+               :           :              :  :        +- * Project (11)
+               :           :              :  :           +- * BroadcastHashJoin Inner BuildRight (10)
+               :           :              :  :              :- * Filter (8)
+               :           :              :  :              :  +- * ColumnarToRow (7)
+               :           :              :  :              :     +- Scan parquet spark_catalog.default.store_sales (6)
+               :           :              :  :              +- ReusedExchange (9)
+               :           :              :  +- * Sort (21)
+               :           :              :     +- Exchange (20)
+               :           :              :        +- * Project (19)
+               :           :              :           +- * BroadcastHashJoin Inner BuildRight (18)
+               :           :              :              :- * ColumnarToRow (16)
+               :           :              :              :  +- Scan parquet spark_catalog.default.web_sales (15)
+               :           :              :              +- ReusedExchange (17)
+               :           :              +- * Sort (29)
+               :           :                 +- Exchange (28)
+               :           :                    +- * Project (27)
+               :           :                       +- * BroadcastHashJoin Inner BuildRight (26)
+               :           :                          :- * ColumnarToRow (24)
+               :           :                          :  +- Scan parquet spark_catalog.default.catalog_sales (23)
+               :           :                          +- ReusedExchange (25)
+               :           +- * Sort (36)
+               :              +- ReusedExchange (35)
+               +- * Sort (42)
+                  +- ReusedExchange (41)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -66,7 +61,7 @@ Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
-Condition : (isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4))
+Condition : (((isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(c_current_addr_sk#5, 42), false)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(c_current_cdemo_sk#4, 42), false))
 
 (4) Exchange
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
@@ -77,260 +72,326 @@ Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 Arguments: [c_customer_sk#3 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Output [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#7), dynamicpruningexpression(ss_sold_date_sk#7 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#11), dynamicpruningexpression(ss_sold_date_sk#11 IN dynamicpruning#12)]
 ReadSchema: struct<ss_customer_sk:int>
 
 (7) ColumnarToRow [codegen id : 4]
-Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
+Input [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
 
-(8) ReusedExchange [Reuses operator id: 58]
-Output [1]: [d_date_sk#9]
+(8) Filter [codegen id : 4]
+Input [2]: [ss_customer_sk#10, ss_sold_date_sk#11]
+Condition : true
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#9]
+(9) ReusedExchange [Reuses operator id: 67]
+Output [1]: [d_date_sk#13]
+
+(10) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [1]: [ss_customer_sk#6]
-Input [3]: [ss_customer_sk#6, ss_sold_date_sk#7, d_date_sk#9]
+(11) Project [codegen id : 4]
+Output [1]: [ss_customer_sk#10]
+Input [3]: [ss_customer_sk#10, ss_sold_date_sk#11, d_date_sk#13]
 
-(11) Exchange
-Input [1]: [ss_customer_sk#6]
-Arguments: hashpartitioning(ss_customer_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(12) Exchange
+Input [1]: [ss_customer_sk#10]
+Arguments: hashpartitioning(ss_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) Sort [codegen id : 5]
-Input [1]: [ss_customer_sk#6]
-Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [1]: [ss_customer_sk#10]
+Arguments: [ss_customer_sk#10 ASC NULLS FIRST], false, 0
 
-(13) SortMergeJoin [codegen id : 6]
+(14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [ss_customer_sk#6]
+Right keys [1]: [ss_customer_sk#10]
 Join type: LeftSemi
 Join condition: None
 
-(14) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+(15) Scan parquet spark_catalog.default.web_sales
+Output [2]: [ws_bill_customer_sk#14, ws_sold_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#11), dynamicpruningexpression(ws_sold_date_sk#11 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#15), dynamicpruningexpression(ws_sold_date_sk#15 IN dynamicpruning#12)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(15) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
+(16) ColumnarToRow [codegen id : 8]
+Input [2]: [ws_bill_customer_sk#14, ws_sold_date_sk#15]
 
-(16) ReusedExchange [Reuses operator id: 58]
-Output [1]: [d_date_sk#12]
+(17) ReusedExchange [Reuses operator id: 67]
+Output [1]: [d_date_sk#16]
 
-(17) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#11]
-Right keys [1]: [d_date_sk#12]
+(18) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [ws_sold_date_sk#15]
+Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 8]
-Output [1]: [ws_bill_customer_sk#10]
-Input [3]: [ws_bill_customer_sk#10, ws_sold_date_sk#11, d_date_sk#12]
+(19) Project [codegen id : 8]
+Output [1]: [ws_bill_customer_sk#14]
+Input [3]: [ws_bill_customer_sk#14, ws_sold_date_sk#15, d_date_sk#16]
 
-(19) Exchange
-Input [1]: [ws_bill_customer_sk#10]
-Arguments: hashpartitioning(ws_bill_customer_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(20) Exchange
+Input [1]: [ws_bill_customer_sk#14]
+Arguments: hashpartitioning(ws_bill_customer_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) Sort [codegen id : 9]
-Input [1]: [ws_bill_customer_sk#10]
-Arguments: [ws_bill_customer_sk#10 ASC NULLS FIRST], false, 0
+(21) Sort [codegen id : 9]
+Input [1]: [ws_bill_customer_sk#14]
+Arguments: [ws_bill_customer_sk#14 ASC NULLS FIRST], false, 0
 
-(21) SortMergeJoin [codegen id : 10]
+(22) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [ws_bill_customer_sk#10]
+Right keys [1]: [ws_bill_customer_sk#14]
 Join type: ExistenceJoin(exists#2)
 Join condition: None
 
-(22) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
+(23) Scan parquet spark_catalog.default.catalog_sales
+Output [2]: [cs_ship_customer_sk#17, cs_sold_date_sk#18]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#14), dynamicpruningexpression(cs_sold_date_sk#14 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#18), dynamicpruningexpression(cs_sold_date_sk#18 IN dynamicpruning#12)]
 ReadSchema: struct<cs_ship_customer_sk:int>
 
-(23) ColumnarToRow [codegen id : 12]
-Input [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
+(24) ColumnarToRow [codegen id : 12]
+Input [2]: [cs_ship_customer_sk#17, cs_sold_date_sk#18]
 
-(24) ReusedExchange [Reuses operator id: 58]
-Output [1]: [d_date_sk#15]
+(25) ReusedExchange [Reuses operator id: 67]
+Output [1]: [d_date_sk#19]
 
-(25) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [cs_sold_date_sk#14]
-Right keys [1]: [d_date_sk#15]
+(26) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [cs_sold_date_sk#18]
+Right keys [1]: [d_date_sk#19]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 12]
-Output [1]: [cs_ship_customer_sk#13]
-Input [3]: [cs_ship_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15]
+(27) Project [codegen id : 12]
+Output [1]: [cs_ship_customer_sk#17]
+Input [3]: [cs_ship_customer_sk#17, cs_sold_date_sk#18, d_date_sk#19]
 
-(27) Exchange
-Input [1]: [cs_ship_customer_sk#13]
-Arguments: hashpartitioning(cs_ship_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(28) Exchange
+Input [1]: [cs_ship_customer_sk#17]
+Arguments: hashpartitioning(cs_ship_customer_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(28) Sort [codegen id : 13]
-Input [1]: [cs_ship_customer_sk#13]
-Arguments: [cs_ship_customer_sk#13 ASC NULLS FIRST], false, 0
+(29) Sort [codegen id : 13]
+Input [1]: [cs_ship_customer_sk#17]
+Arguments: [cs_ship_customer_sk#17 ASC NULLS FIRST], false, 0
 
-(29) SortMergeJoin [codegen id : 14]
+(30) SortMergeJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#3]
-Right keys [1]: [cs_ship_customer_sk#13]
+Right keys [1]: [cs_ship_customer_sk#17]
 Join type: ExistenceJoin(exists#1)
 Join condition: None
 
-(30) Filter [codegen id : 14]
+(31) Filter [codegen id : 14]
 Input [5]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5, exists#2, exists#1]
 Condition : (exists#2 OR exists#1)
 
-(31) Project [codegen id : 14]
+(32) Project [codegen id : 14]
 Output [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Input [5]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5, exists#2, exists#1]
 
-(32) Exchange
+(33) Exchange
 Input [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Arguments: hashpartitioning(c_current_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(33) Sort [codegen id : 15]
+(34) Sort [codegen id : 15]
 Input [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Arguments: [c_current_addr_sk#5 ASC NULLS FIRST], false, 0
 
-(34) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#16, ca_state#17]
+(35) ReusedExchange [Reuses operator id: 52]
+Output [2]: [ca_address_sk#20, ca_state#21]
+
+(36) Sort [codegen id : 17]
+Input [2]: [ca_address_sk#20, ca_state#21]
+Arguments: [ca_address_sk#20 ASC NULLS FIRST], false, 0
+
+(37) SortMergeJoin [codegen id : 18]
+Left keys [1]: [c_current_addr_sk#5]
+Right keys [1]: [ca_address_sk#20]
+Join type: Inner
+Join condition: None
+
+(38) Project [codegen id : 18]
+Output [2]: [c_current_cdemo_sk#4, ca_state#21]
+Input [4]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#20, ca_state#21]
+
+(39) Exchange
+Input [2]: [c_current_cdemo_sk#4, ca_state#21]
+Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(40) Sort [codegen id : 19]
+Input [2]: [c_current_cdemo_sk#4, ca_state#21]
+Arguments: [c_current_cdemo_sk#4 ASC NULLS FIRST], false, 0
+
+(41) ReusedExchange [Reuses operator id: 59]
+Output [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+
+(42) Sort [codegen id : 21]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: [cd_demo_sk#22 ASC NULLS FIRST], false, 0
+
+(43) SortMergeJoin [codegen id : 22]
+Left keys [1]: [c_current_cdemo_sk#4]
+Right keys [1]: [cd_demo_sk#22]
+Join type: Inner
+Join condition: None
+
+(44) Project [codegen id : 22]
+Output [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Input [8]: [c_current_cdemo_sk#4, ca_state#21, cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+
+(45) HashAggregate [codegen id : 22]
+Input [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Functions [10]: [partial_count(1), partial_avg(cd_dep_count#25), partial_max(cd_dep_count#25), partial_sum(cd_dep_count#25), partial_avg(cd_dep_employed_count#26), partial_max(cd_dep_employed_count#26), partial_sum(cd_dep_employed_count#26), partial_avg(cd_dep_college_count#27), partial_max(cd_dep_college_count#27), partial_sum(cd_dep_college_count#27)]
+Aggregate Attributes [13]: [count#28, sum#29, count#30, max#31, sum#32, sum#33, count#34, max#35, sum#36, sum#37, count#38, max#39, sum#40]
+Results [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49, sum#50, count#51, max#52, sum#53]
+
+(46) Exchange
+Input [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49, sum#50, count#51, max#52, sum#53]
+Arguments: hashpartitioning(ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(47) HashAggregate [codegen id : 23]
+Input [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49, sum#50, count#51, max#52, sum#53]
+Keys [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Functions [10]: [count(1), avg(cd_dep_count#25), max(cd_dep_count#25), sum(cd_dep_count#25), avg(cd_dep_employed_count#26), max(cd_dep_employed_count#26), sum(cd_dep_employed_count#26), avg(cd_dep_college_count#27), max(cd_dep_college_count#27), sum(cd_dep_college_count#27)]
+Aggregate Attributes [10]: [count(1)#54, avg(cd_dep_count#25)#55, max(cd_dep_count#25)#56, sum(cd_dep_count#25)#57, avg(cd_dep_employed_count#26)#58, max(cd_dep_employed_count#26)#59, sum(cd_dep_employed_count#26)#60, avg(cd_dep_college_count#27)#61, max(cd_dep_college_count#27)#62, sum(cd_dep_college_count#27)#63]
+Results [18]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, count(1)#54 AS cnt1#64, avg(cd_dep_count#25)#55 AS avg(cd_dep_count)#65, max(cd_dep_count#25)#56 AS max(cd_dep_count)#66, sum(cd_dep_count#25)#57 AS sum(cd_dep_count)#67, cd_dep_employed_count#26, count(1)#54 AS cnt2#68, avg(cd_dep_employed_count#26)#58 AS avg(cd_dep_employed_count)#69, max(cd_dep_employed_count#26)#59 AS max(cd_dep_employed_count)#70, sum(cd_dep_employed_count#26)#60 AS sum(cd_dep_employed_count)#71, cd_dep_college_count#27, count(1)#54 AS cnt3#72, avg(cd_dep_college_count#27)#61 AS avg(cd_dep_college_count)#73, max(cd_dep_college_count#27)#62 AS max(cd_dep_college_count)#74, sum(cd_dep_college_count#27)#63 AS sum(cd_dep_college_count)#75]
+
+(48) TakeOrderedAndProject
+Input [18]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cnt1#64, avg(cd_dep_count)#65, max(cd_dep_count)#66, sum(cd_dep_count)#67, cd_dep_employed_count#26, cnt2#68, avg(cd_dep_employed_count)#69, max(cd_dep_employed_count)#70, sum(cd_dep_employed_count)#71, cd_dep_college_count#27, cnt3#72, avg(cd_dep_college_count)#73, max(cd_dep_college_count)#74, sum(cd_dep_college_count)#75]
+Arguments: 100, [ca_state#21 ASC NULLS FIRST, cd_gender#23 ASC NULLS FIRST, cd_marital_status#24 ASC NULLS FIRST, cd_dep_count#25 ASC NULLS FIRST, cd_dep_employed_count#26 ASC NULLS FIRST, cd_dep_college_count#27 ASC NULLS FIRST], [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cnt1#64, avg(cd_dep_count)#65, max(cd_dep_count)#66, sum(cd_dep_count)#67, cd_dep_employed_count#26, cnt2#68, avg(cd_dep_employed_count)#69, max(cd_dep_employed_count)#70, sum(cd_dep_employed_count)#71, cd_dep_college_count#27, cnt3#72, avg(cd_dep_college_count)#73, max(cd_dep_college_count)#74, sum(cd_dep_college_count)#75]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (55)
++- Exchange (54)
+   +- ObjectHashAggregate (53)
+      +- Exchange (52)
+         +- * Filter (51)
+            +- * ColumnarToRow (50)
+               +- Scan parquet spark_catalog.default.customer_address (49)
+
+
+(49) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#20, ca_state#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(35) ColumnarToRow [codegen id : 16]
-Input [2]: [ca_address_sk#16, ca_state#17]
+(50) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#21]
 
-(36) Filter [codegen id : 16]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Condition : isnotnull(ca_address_sk#16)
+(51) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#21]
+Condition : isnotnull(ca_address_sk#20)
 
-(37) Exchange
-Input [2]: [ca_address_sk#16, ca_state#17]
-Arguments: hashpartitioning(ca_address_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(52) Exchange
+Input [2]: [ca_address_sk#20, ca_state#21]
+Arguments: hashpartitioning(ca_address_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(38) Sort [codegen id : 17]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
+(53) ObjectHashAggregate
+Input [2]: [ca_address_sk#20, ca_state#21]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [buf#76]
+Results [1]: [buf#77]
 
-(39) SortMergeJoin [codegen id : 18]
-Left keys [1]: [c_current_addr_sk#5]
-Right keys [1]: [ca_address_sk#16]
-Join type: Inner
-Join condition: None
+(54) Exchange
+Input [1]: [buf#77]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(40) Project [codegen id : 18]
-Output [2]: [c_current_cdemo_sk#4, ca_state#17]
-Input [4]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#16, ca_state#17]
+(55) ObjectHashAggregate
+Input [1]: [buf#77]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)#78]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)#78 AS bloomFilter#79]
 
-(41) Exchange
-Input [2]: [c_current_cdemo_sk#4, ca_state#17]
-Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (62)
++- Exchange (61)
+   +- ObjectHashAggregate (60)
+      +- Exchange (59)
+         +- * Filter (58)
+            +- * ColumnarToRow (57)
+               +- Scan parquet spark_catalog.default.customer_demographics (56)
 
-(42) Sort [codegen id : 19]
-Input [2]: [c_current_cdemo_sk#4, ca_state#17]
-Arguments: [c_current_cdemo_sk#4 ASC NULLS FIRST], false, 0
 
-(43) Scan parquet spark_catalog.default.customer_demographics
-Output [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(56) Scan parquet spark_catalog.default.customer_demographics
+Output [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(44) ColumnarToRow [codegen id : 20]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(57) ColumnarToRow [codegen id : 1]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(45) Filter [codegen id : 20]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Condition : isnotnull(cd_demo_sk#18)
+(58) Filter [codegen id : 1]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Condition : isnotnull(cd_demo_sk#22)
 
-(46) Exchange
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Arguments: hashpartitioning(cd_demo_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(59) Exchange
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: hashpartitioning(cd_demo_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(47) Sort [codegen id : 21]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Arguments: [cd_demo_sk#18 ASC NULLS FIRST], false, 0
+(60) ObjectHashAggregate
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#80]
+Results [1]: [buf#81]
 
-(48) SortMergeJoin [codegen id : 22]
-Left keys [1]: [c_current_cdemo_sk#4]
-Right keys [1]: [cd_demo_sk#18]
-Join type: Inner
-Join condition: None
+(61) Exchange
+Input [1]: [buf#81]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(49) Project [codegen id : 22]
-Output [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Input [8]: [c_current_cdemo_sk#4, ca_state#17, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(62) ObjectHashAggregate
+Input [1]: [buf#81]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)#82]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)#82 AS bloomFilter#83]
 
-(50) HashAggregate [codegen id : 22]
-Input [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Functions [10]: [partial_count(1), partial_avg(cd_dep_count#21), partial_max(cd_dep_count#21), partial_sum(cd_dep_count#21), partial_avg(cd_dep_employed_count#22), partial_max(cd_dep_employed_count#22), partial_sum(cd_dep_employed_count#22), partial_avg(cd_dep_college_count#23), partial_max(cd_dep_college_count#23), partial_sum(cd_dep_college_count#23)]
-Aggregate Attributes [13]: [count#24, sum#25, count#26, max#27, sum#28, sum#29, count#30, max#31, sum#32, sum#33, count#34, max#35, sum#36]
-Results [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
-
-(51) Exchange
-Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
-Arguments: hashpartitioning(ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(52) HashAggregate [codegen id : 23]
-Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
-Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Functions [10]: [count(1), avg(cd_dep_count#21), max(cd_dep_count#21), sum(cd_dep_count#21), avg(cd_dep_employed_count#22), max(cd_dep_employed_count#22), sum(cd_dep_employed_count#22), avg(cd_dep_college_count#23), max(cd_dep_college_count#23), sum(cd_dep_college_count#23)]
-Aggregate Attributes [10]: [count(1)#50, avg(cd_dep_count#21)#51, max(cd_dep_count#21)#52, sum(cd_dep_count#21)#53, avg(cd_dep_employed_count#22)#54, max(cd_dep_employed_count#22)#55, sum(cd_dep_employed_count#22)#56, avg(cd_dep_college_count#23)#57, max(cd_dep_college_count#23)#58, sum(cd_dep_college_count#23)#59]
-Results [18]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, count(1)#50 AS cnt1#60, avg(cd_dep_count#21)#51 AS avg(cd_dep_count)#61, max(cd_dep_count#21)#52 AS max(cd_dep_count)#62, sum(cd_dep_count#21)#53 AS sum(cd_dep_count)#63, cd_dep_employed_count#22, count(1)#50 AS cnt2#64, avg(cd_dep_employed_count#22)#54 AS avg(cd_dep_employed_count)#65, max(cd_dep_employed_count#22)#55 AS max(cd_dep_employed_count)#66, sum(cd_dep_employed_count#22)#56 AS sum(cd_dep_employed_count)#67, cd_dep_college_count#23, count(1)#50 AS cnt3#68, avg(cd_dep_college_count#23)#57 AS avg(cd_dep_college_count)#69, max(cd_dep_college_count#23)#58 AS max(cd_dep_college_count)#70, sum(cd_dep_college_count#23)#59 AS sum(cd_dep_college_count)#71]
-
-(53) TakeOrderedAndProject
-Input [18]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cnt1#60, avg(cd_dep_count)#61, max(cd_dep_count)#62, sum(cd_dep_count)#63, cd_dep_employed_count#22, cnt2#64, avg(cd_dep_employed_count)#65, max(cd_dep_employed_count)#66, sum(cd_dep_employed_count)#67, cd_dep_college_count#23, cnt3#68, avg(cd_dep_college_count)#69, max(cd_dep_college_count)#70, sum(cd_dep_college_count)#71]
-Arguments: 100, [ca_state#17 ASC NULLS FIRST, cd_gender#19 ASC NULLS FIRST, cd_marital_status#20 ASC NULLS FIRST, cd_dep_count#21 ASC NULLS FIRST, cd_dep_employed_count#22 ASC NULLS FIRST, cd_dep_college_count#23 ASC NULLS FIRST], [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cnt1#60, avg(cd_dep_count)#61, max(cd_dep_count)#62, sum(cd_dep_count)#63, cd_dep_employed_count#22, cnt2#64, avg(cd_dep_employed_count)#65, max(cd_dep_employed_count)#66, sum(cd_dep_employed_count)#67, cd_dep_college_count#23, cnt3#68, avg(cd_dep_college_count)#69, max(cd_dep_college_count)#70, sum(cd_dep_college_count)#71]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (58)
-+- * Project (57)
-   +- * Filter (56)
-      +- * ColumnarToRow (55)
-         +- Scan parquet spark_catalog.default.date_dim (54)
+Subquery:3 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
+BroadcastExchange (67)
++- * Project (66)
+   +- * Filter (65)
+      +- * ColumnarToRow (64)
+         +- Scan parquet spark_catalog.default.date_dim (63)
 
 
-(54) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#72, d_qoy#73]
+(63) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#13, d_year#84, d_qoy#85]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_qoy), EqualTo(d_year,2002), LessThan(d_qoy,4), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(55) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#72, d_qoy#73]
+(64) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#13, d_year#84, d_qoy#85]
 
-(56) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#72, d_qoy#73]
-Condition : ((((isnotnull(d_year#72) AND isnotnull(d_qoy#73)) AND (d_year#72 = 2002)) AND (d_qoy#73 < 4)) AND isnotnull(d_date_sk#9))
+(65) Filter [codegen id : 1]
+Input [3]: [d_date_sk#13, d_year#84, d_qoy#85]
+Condition : ((((isnotnull(d_year#84) AND isnotnull(d_qoy#85)) AND (d_year#84 = 2002)) AND (d_qoy#85 < 4)) AND isnotnull(d_date_sk#13))
 
-(57) Project [codegen id : 1]
-Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#72, d_qoy#73]
+(66) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [3]: [d_date_sk#13, d_year#84, d_qoy#85]
 
-(58) BroadcastExchange
-Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(67) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
-Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
+Subquery:4 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#15 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 22 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#8
+Subquery:5 Hosting operator id = 23 Hosting Expression = cs_sold_date_sk#18 IN dynamicpruning#12
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35.sf100/simplified.txt
@@ -37,6 +37,26 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                                         Exchange [c_customer_sk] #4
                                                                           WholeStageCodegen (1)
                                                                             Filter [c_current_addr_sk,c_current_cdemo_sk]
+                                                                              Subquery #1
+                                                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 1000000, 8000000, 0, 0),bloomFilter,buf]
+                                                                                  Exchange #5
+                                                                                    ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                                      Exchange [ca_address_sk] #6
+                                                                                        WholeStageCodegen (1)
+                                                                                          Filter [ca_address_sk]
+                                                                                            ColumnarToRow
+                                                                                              InputAdapter
+                                                                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                                                              Subquery #2
+                                                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
+                                                                                  Exchange #7
+                                                                                    ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                                      Exchange [cd_demo_sk] #8
+                                                                                        WholeStageCodegen (1)
+                                                                                          Filter [cd_demo_sk]
+                                                                                            ColumnarToRow
+                                                                                              InputAdapter
+                                                                                                Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                                                                               ColumnarToRow
                                                                                 InputAdapter
                                                                                   Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
@@ -44,68 +64,59 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                                   WholeStageCodegen (5)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #5
+                                                                        Exchange [ss_customer_sk] #9
                                                                           WholeStageCodegen (4)
                                                                             Project [ss_customer_sk]
                                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                                      SubqueryBroadcast [d_date_sk] #1
-                                                                                        BroadcastExchange #6
-                                                                                          WholeStageCodegen (1)
-                                                                                            Project [d_date_sk]
-                                                                                              Filter [d_year,d_qoy,d_date_sk]
-                                                                                                ColumnarToRow
-                                                                                                  InputAdapter
-                                                                                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
+                                                                                Filter
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                                        SubqueryBroadcast [d_date_sk] #3
+                                                                                          BroadcastExchange #10
+                                                                                            WholeStageCodegen (1)
+                                                                                              Project [d_date_sk]
+                                                                                                Filter [d_year,d_qoy,d_date_sk]
+                                                                                                  ColumnarToRow
+                                                                                                    InputAdapter
+                                                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
                                                                                 InputAdapter
-                                                                                  ReusedExchange [d_date_sk] #6
+                                                                                  ReusedExchange [d_date_sk] #10
                                                           InputAdapter
                                                             WholeStageCodegen (9)
                                                               Sort [ws_bill_customer_sk]
                                                                 InputAdapter
-                                                                  Exchange [ws_bill_customer_sk] #7
+                                                                  Exchange [ws_bill_customer_sk] #11
                                                                     WholeStageCodegen (8)
                                                                       Project [ws_bill_customer_sk]
                                                                         BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                                ReusedSubquery [d_date_sk] #1
+                                                                                ReusedSubquery [d_date_sk] #3
                                                                           InputAdapter
-                                                                            ReusedExchange [d_date_sk] #6
+                                                                            ReusedExchange [d_date_sk] #10
                                                     InputAdapter
                                                       WholeStageCodegen (13)
                                                         Sort [cs_ship_customer_sk]
                                                           InputAdapter
-                                                            Exchange [cs_ship_customer_sk] #8
+                                                            Exchange [cs_ship_customer_sk] #12
                                                               WholeStageCodegen (12)
                                                                 Project [cs_ship_customer_sk]
                                                                   BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                                          ReusedSubquery [d_date_sk] #1
+                                                                          ReusedSubquery [d_date_sk] #3
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk] #6
+                                                                      ReusedExchange [d_date_sk] #10
                                   InputAdapter
                                     WholeStageCodegen (17)
                                       Sort [ca_address_sk]
                                         InputAdapter
-                                          Exchange [ca_address_sk] #9
-                                            WholeStageCodegen (16)
-                                              Filter [ca_address_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                          ReusedExchange [ca_address_sk,ca_state] #6
                   InputAdapter
                     WholeStageCodegen (21)
                       Sort [cd_demo_sk]
                         InputAdapter
-                          Exchange [cd_demo_sk] #10
-                            WholeStageCodegen (20)
-                              Filter [cd_demo_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
+                          ReusedExchange [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #8

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/explain.txt
@@ -1,54 +1,51 @@
 == Physical Plan ==
-TakeOrderedAndProject (50)
-+- * HashAggregate (49)
-   +- Exchange (48)
-      +- * HashAggregate (47)
-         +- * Project (46)
-            +- * SortMergeJoin Inner (45)
+TakeOrderedAndProject (47)
++- * HashAggregate (46)
+   +- Exchange (45)
+      +- * HashAggregate (44)
+         +- * Project (43)
+            +- * SortMergeJoin Inner (42)
                :- * Sort (39)
                :  +- Exchange (38)
                :     +- * Project (37)
                :        +- * SortMergeJoin Inner (36)
-               :           :- * Sort (30)
-               :           :  +- Exchange (29)
-               :           :     +- * Project (28)
-               :           :        +- * SortMergeJoin LeftSemi (27)
-               :           :           :- * SortMergeJoin LeftSemi (13)
+               :           :- * Sort (33)
+               :           :  +- Exchange (32)
+               :           :     +- * Project (31)
+               :           :        +- * SortMergeJoin LeftSemi (30)
+               :           :           :- * SortMergeJoin LeftSemi (14)
                :           :           :  :- * Sort (5)
                :           :           :  :  +- Exchange (4)
                :           :           :  :     +- * Filter (3)
                :           :           :  :        +- * ColumnarToRow (2)
                :           :           :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :           :           :  +- * Sort (12)
-               :           :           :     +- Exchange (11)
-               :           :           :        +- * Project (10)
-               :           :           :           +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :           :              :- * ColumnarToRow (7)
-               :           :           :              :  +- Scan parquet spark_catalog.default.store_sales (6)
-               :           :           :              +- ReusedExchange (8)
-               :           :           +- * Sort (26)
-               :           :              +- Exchange (25)
-               :           :                 +- Union (24)
-               :           :                    :- * Project (18)
-               :           :                    :  +- * BroadcastHashJoin Inner BuildRight (17)
-               :           :                    :     :- * ColumnarToRow (15)
-               :           :                    :     :  +- Scan parquet spark_catalog.default.web_sales (14)
-               :           :                    :     +- ReusedExchange (16)
-               :           :                    +- * Project (23)
-               :           :                       +- * BroadcastHashJoin Inner BuildRight (22)
-               :           :                          :- * ColumnarToRow (20)
-               :           :                          :  +- Scan parquet spark_catalog.default.catalog_sales (19)
-               :           :                          +- ReusedExchange (21)
+               :           :           :  +- * Sort (13)
+               :           :           :     +- Exchange (12)
+               :           :           :        +- * Project (11)
+               :           :           :           +- * BroadcastHashJoin Inner BuildRight (10)
+               :           :           :              :- * Filter (8)
+               :           :           :              :  +- * ColumnarToRow (7)
+               :           :           :              :     +- Scan parquet spark_catalog.default.store_sales (6)
+               :           :           :              +- ReusedExchange (9)
+               :           :           +- * Sort (29)
+               :           :              +- Exchange (28)
+               :           :                 +- Union (27)
+               :           :                    :- * Project (20)
+               :           :                    :  +- * BroadcastHashJoin Inner BuildRight (19)
+               :           :                    :     :- * Filter (17)
+               :           :                    :     :  +- * ColumnarToRow (16)
+               :           :                    :     :     +- Scan parquet spark_catalog.default.web_sales (15)
+               :           :                    :     +- ReusedExchange (18)
+               :           :                    +- * Project (26)
+               :           :                       +- * BroadcastHashJoin Inner BuildRight (25)
+               :           :                          :- * Filter (23)
+               :           :                          :  +- * ColumnarToRow (22)
+               :           :                          :     +- Scan parquet spark_catalog.default.catalog_sales (21)
+               :           :                          +- ReusedExchange (24)
                :           +- * Sort (35)
-               :              +- Exchange (34)
-               :                 +- * Filter (33)
-               :                    +- * ColumnarToRow (32)
-               :                       +- Scan parquet spark_catalog.default.customer_address (31)
-               +- * Sort (44)
-                  +- Exchange (43)
-                     +- * Filter (42)
-                        +- * ColumnarToRow (41)
-                           +- Scan parquet spark_catalog.default.customer_demographics (40)
+               :              +- ReusedExchange (34)
+               +- * Sort (41)
+                  +- ReusedExchange (40)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -63,7 +60,7 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : (isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2))
+Condition : (((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42), false)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(c_current_cdemo_sk#2, 42), false))
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
@@ -74,244 +71,318 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_customer_sk#4, ss_sold_date_sk#5]
+Output [2]: [ss_customer_sk#8, ss_sold_date_sk#9]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#5), dynamicpruningexpression(ss_sold_date_sk#5 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#9), dynamicpruningexpression(ss_sold_date_sk#9 IN dynamicpruning#10)]
 ReadSchema: struct<ss_customer_sk:int>
 
 (7) ColumnarToRow [codegen id : 4]
-Input [2]: [ss_customer_sk#4, ss_sold_date_sk#5]
+Input [2]: [ss_customer_sk#8, ss_sold_date_sk#9]
 
-(8) ReusedExchange [Reuses operator id: 55]
-Output [1]: [d_date_sk#7]
+(8) Filter [codegen id : 4]
+Input [2]: [ss_customer_sk#8, ss_sold_date_sk#9]
+Condition : true
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+(9) ReusedExchange [Reuses operator id: 66]
+Output [1]: [d_date_sk#11]
+
+(10) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#9]
+Right keys [1]: [d_date_sk#11]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [1]: [ss_customer_sk#4]
-Input [3]: [ss_customer_sk#4, ss_sold_date_sk#5, d_date_sk#7]
+(11) Project [codegen id : 4]
+Output [1]: [ss_customer_sk#8]
+Input [3]: [ss_customer_sk#8, ss_sold_date_sk#9, d_date_sk#11]
 
-(11) Exchange
-Input [1]: [ss_customer_sk#4]
-Arguments: hashpartitioning(ss_customer_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(12) Exchange
+Input [1]: [ss_customer_sk#8]
+Arguments: hashpartitioning(ss_customer_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) Sort [codegen id : 5]
-Input [1]: [ss_customer_sk#4]
-Arguments: [ss_customer_sk#4 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [1]: [ss_customer_sk#8]
+Arguments: [ss_customer_sk#8 ASC NULLS FIRST], false, 0
 
-(13) SortMergeJoin [codegen id : 6]
+(14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [ss_customer_sk#4]
+Right keys [1]: [ss_customer_sk#8]
 Join type: LeftSemi
 Join condition: None
 
-(14) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_bill_customer_sk#8, ws_sold_date_sk#9]
+(15) Scan parquet spark_catalog.default.web_sales
+Output [2]: [ws_bill_customer_sk#12, ws_sold_date_sk#13]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#9), dynamicpruningexpression(ws_sold_date_sk#9 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#13), dynamicpruningexpression(ws_sold_date_sk#13 IN dynamicpruning#10)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(15) ColumnarToRow [codegen id : 8]
-Input [2]: [ws_bill_customer_sk#8, ws_sold_date_sk#9]
+(16) ColumnarToRow [codegen id : 8]
+Input [2]: [ws_bill_customer_sk#12, ws_sold_date_sk#13]
 
-(16) ReusedExchange [Reuses operator id: 55]
-Output [1]: [d_date_sk#10]
+(17) Filter [codegen id : 8]
+Input [2]: [ws_bill_customer_sk#12, ws_sold_date_sk#13]
+Condition : true
 
-(17) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ws_sold_date_sk#9]
-Right keys [1]: [d_date_sk#10]
-Join type: Inner
-Join condition: None
-
-(18) Project [codegen id : 8]
-Output [1]: [ws_bill_customer_sk#8 AS customsk#11]
-Input [3]: [ws_bill_customer_sk#8, ws_sold_date_sk#9, d_date_sk#10]
-
-(19) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ship_customer_sk#12, cs_sold_date_sk#13]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#13), dynamicpruningexpression(cs_sold_date_sk#13 IN dynamicpruning#6)]
-ReadSchema: struct<cs_ship_customer_sk:int>
-
-(20) ColumnarToRow [codegen id : 10]
-Input [2]: [cs_ship_customer_sk#12, cs_sold_date_sk#13]
-
-(21) ReusedExchange [Reuses operator id: 55]
+(18) ReusedExchange [Reuses operator id: 66]
 Output [1]: [d_date_sk#14]
 
-(22) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#13]
+(19) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [ws_sold_date_sk#13]
 Right keys [1]: [d_date_sk#14]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 10]
-Output [1]: [cs_ship_customer_sk#12 AS customsk#15]
-Input [3]: [cs_ship_customer_sk#12, cs_sold_date_sk#13, d_date_sk#14]
+(20) Project [codegen id : 8]
+Output [1]: [ws_bill_customer_sk#12 AS customsk#15]
+Input [3]: [ws_bill_customer_sk#12, ws_sold_date_sk#13, d_date_sk#14]
 
-(24) Union
+(21) Scan parquet spark_catalog.default.catalog_sales
+Output [2]: [cs_ship_customer_sk#16, cs_sold_date_sk#17]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#17), dynamicpruningexpression(cs_sold_date_sk#17 IN dynamicpruning#10)]
+ReadSchema: struct<cs_ship_customer_sk:int>
 
-(25) Exchange
-Input [1]: [customsk#11]
-Arguments: hashpartitioning(customsk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(22) ColumnarToRow [codegen id : 10]
+Input [2]: [cs_ship_customer_sk#16, cs_sold_date_sk#17]
 
-(26) Sort [codegen id : 11]
-Input [1]: [customsk#11]
-Arguments: [customsk#11 ASC NULLS FIRST], false, 0
+(23) Filter [codegen id : 10]
+Input [2]: [cs_ship_customer_sk#16, cs_sold_date_sk#17]
+Condition : true
 
-(27) SortMergeJoin [codegen id : 12]
+(24) ReusedExchange [Reuses operator id: 66]
+Output [1]: [d_date_sk#18]
+
+(25) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [cs_sold_date_sk#17]
+Right keys [1]: [d_date_sk#18]
+Join type: Inner
+Join condition: None
+
+(26) Project [codegen id : 10]
+Output [1]: [cs_ship_customer_sk#16 AS customsk#19]
+Input [3]: [cs_ship_customer_sk#16, cs_sold_date_sk#17, d_date_sk#18]
+
+(27) Union
+
+(28) Exchange
+Input [1]: [customsk#15]
+Arguments: hashpartitioning(customsk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(29) Sort [codegen id : 11]
+Input [1]: [customsk#15]
+Arguments: [customsk#15 ASC NULLS FIRST], false, 0
+
+(30) SortMergeJoin [codegen id : 12]
 Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [customsk#11]
+Right keys [1]: [customsk#15]
 Join type: LeftSemi
 Join condition: None
 
-(28) Project [codegen id : 12]
+(31) Project [codegen id : 12]
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(29) Exchange
+(32) Exchange
 Input [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Arguments: hashpartitioning(c_current_addr_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(30) Sort [codegen id : 13]
+(33) Sort [codegen id : 13]
 Input [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Arguments: [c_current_addr_sk#3 ASC NULLS FIRST], false, 0
 
-(31) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#16, ca_state#17]
+(34) ReusedExchange [Reuses operator id: 51]
+Output [2]: [ca_address_sk#20, ca_state#21]
+
+(35) Sort [codegen id : 15]
+Input [2]: [ca_address_sk#20, ca_state#21]
+Arguments: [ca_address_sk#20 ASC NULLS FIRST], false, 0
+
+(36) SortMergeJoin [codegen id : 16]
+Left keys [1]: [c_current_addr_sk#3]
+Right keys [1]: [ca_address_sk#20]
+Join type: Inner
+Join condition: None
+
+(37) Project [codegen id : 16]
+Output [2]: [c_current_cdemo_sk#2, ca_state#21]
+Input [4]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#20, ca_state#21]
+
+(38) Exchange
+Input [2]: [c_current_cdemo_sk#2, ca_state#21]
+Arguments: hashpartitioning(c_current_cdemo_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(39) Sort [codegen id : 17]
+Input [2]: [c_current_cdemo_sk#2, ca_state#21]
+Arguments: [c_current_cdemo_sk#2 ASC NULLS FIRST], false, 0
+
+(40) ReusedExchange [Reuses operator id: 58]
+Output [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+
+(41) Sort [codegen id : 19]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: [cd_demo_sk#22 ASC NULLS FIRST], false, 0
+
+(42) SortMergeJoin [codegen id : 20]
+Left keys [1]: [c_current_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#22]
+Join type: Inner
+Join condition: None
+
+(43) Project [codegen id : 20]
+Output [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Input [8]: [c_current_cdemo_sk#2, ca_state#21, cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+
+(44) HashAggregate [codegen id : 20]
+Input [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Functions [10]: [partial_count(1), partial_avg(cd_dep_count#25), partial_max(cd_dep_count#25), partial_sum(cd_dep_count#25), partial_avg(cd_dep_employed_count#26), partial_max(cd_dep_employed_count#26), partial_sum(cd_dep_employed_count#26), partial_avg(cd_dep_college_count#27), partial_max(cd_dep_college_count#27), partial_sum(cd_dep_college_count#27)]
+Aggregate Attributes [13]: [count#28, sum#29, count#30, max#31, sum#32, sum#33, count#34, max#35, sum#36, sum#37, count#38, max#39, sum#40]
+Results [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49, sum#50, count#51, max#52, sum#53]
+
+(45) Exchange
+Input [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49, sum#50, count#51, max#52, sum#53]
+Arguments: hashpartitioning(ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(46) HashAggregate [codegen id : 21]
+Input [19]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49, sum#50, count#51, max#52, sum#53]
+Keys [6]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Functions [10]: [count(1), avg(cd_dep_count#25), max(cd_dep_count#25), sum(cd_dep_count#25), avg(cd_dep_employed_count#26), max(cd_dep_employed_count#26), sum(cd_dep_employed_count#26), avg(cd_dep_college_count#27), max(cd_dep_college_count#27), sum(cd_dep_college_count#27)]
+Aggregate Attributes [10]: [count(1)#54, avg(cd_dep_count#25)#55, max(cd_dep_count#25)#56, sum(cd_dep_count#25)#57, avg(cd_dep_employed_count#26)#58, max(cd_dep_employed_count#26)#59, sum(cd_dep_employed_count#26)#60, avg(cd_dep_college_count#27)#61, max(cd_dep_college_count#27)#62, sum(cd_dep_college_count#27)#63]
+Results [18]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, count(1)#54 AS cnt1#64, avg(cd_dep_count#25)#55 AS avg(cd_dep_count)#65, max(cd_dep_count#25)#56 AS max(cd_dep_count)#66, sum(cd_dep_count#25)#57 AS sum(cd_dep_count)#67, cd_dep_employed_count#26, count(1)#54 AS cnt2#68, avg(cd_dep_employed_count#26)#58 AS avg(cd_dep_employed_count)#69, max(cd_dep_employed_count#26)#59 AS max(cd_dep_employed_count)#70, sum(cd_dep_employed_count#26)#60 AS sum(cd_dep_employed_count)#71, cd_dep_college_count#27, count(1)#54 AS cnt3#72, avg(cd_dep_college_count#27)#61 AS avg(cd_dep_college_count)#73, max(cd_dep_college_count#27)#62 AS max(cd_dep_college_count)#74, sum(cd_dep_college_count#27)#63 AS sum(cd_dep_college_count)#75]
+
+(47) TakeOrderedAndProject
+Input [18]: [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cnt1#64, avg(cd_dep_count)#65, max(cd_dep_count)#66, sum(cd_dep_count)#67, cd_dep_employed_count#26, cnt2#68, avg(cd_dep_employed_count)#69, max(cd_dep_employed_count)#70, sum(cd_dep_employed_count)#71, cd_dep_college_count#27, cnt3#72, avg(cd_dep_college_count)#73, max(cd_dep_college_count)#74, sum(cd_dep_college_count)#75]
+Arguments: 100, [ca_state#21 ASC NULLS FIRST, cd_gender#23 ASC NULLS FIRST, cd_marital_status#24 ASC NULLS FIRST, cd_dep_count#25 ASC NULLS FIRST, cd_dep_employed_count#26 ASC NULLS FIRST, cd_dep_college_count#27 ASC NULLS FIRST], [ca_state#21, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cnt1#64, avg(cd_dep_count)#65, max(cd_dep_count)#66, sum(cd_dep_count)#67, cd_dep_employed_count#26, cnt2#68, avg(cd_dep_employed_count)#69, max(cd_dep_employed_count)#70, sum(cd_dep_employed_count)#71, cd_dep_college_count#27, cnt3#72, avg(cd_dep_college_count)#73, max(cd_dep_college_count)#74, sum(cd_dep_college_count)#75]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
+ObjectHashAggregate (54)
++- Exchange (53)
+   +- ObjectHashAggregate (52)
+      +- Exchange (51)
+         +- * Filter (50)
+            +- * ColumnarToRow (49)
+               +- Scan parquet spark_catalog.default.customer_address (48)
+
+
+(48) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#20, ca_state#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(32) ColumnarToRow [codegen id : 14]
-Input [2]: [ca_address_sk#16, ca_state#17]
+(49) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#21]
 
-(33) Filter [codegen id : 14]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Condition : isnotnull(ca_address_sk#16)
+(50) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#21]
+Condition : isnotnull(ca_address_sk#20)
 
-(34) Exchange
-Input [2]: [ca_address_sk#16, ca_state#17]
-Arguments: hashpartitioning(ca_address_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(51) Exchange
+Input [2]: [ca_address_sk#20, ca_state#21]
+Arguments: hashpartitioning(ca_address_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(35) Sort [codegen id : 15]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
+(52) ObjectHashAggregate
+Input [2]: [ca_address_sk#20, ca_state#21]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [buf#76]
+Results [1]: [buf#77]
 
-(36) SortMergeJoin [codegen id : 16]
-Left keys [1]: [c_current_addr_sk#3]
-Right keys [1]: [ca_address_sk#16]
-Join type: Inner
-Join condition: None
+(53) Exchange
+Input [1]: [buf#77]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(37) Project [codegen id : 16]
-Output [2]: [c_current_cdemo_sk#2, ca_state#17]
-Input [4]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16, ca_state#17]
+(54) ObjectHashAggregate
+Input [1]: [buf#77]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)#78]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1000000, 8000000, 0, 0)#78 AS bloomFilter#79]
 
-(38) Exchange
-Input [2]: [c_current_cdemo_sk#2, ca_state#17]
-Arguments: hashpartitioning(c_current_cdemo_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (61)
++- Exchange (60)
+   +- ObjectHashAggregate (59)
+      +- Exchange (58)
+         +- * Filter (57)
+            +- * ColumnarToRow (56)
+               +- Scan parquet spark_catalog.default.customer_demographics (55)
 
-(39) Sort [codegen id : 17]
-Input [2]: [c_current_cdemo_sk#2, ca_state#17]
-Arguments: [c_current_cdemo_sk#2 ASC NULLS FIRST], false, 0
 
-(40) Scan parquet spark_catalog.default.customer_demographics
-Output [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(55) Scan parquet spark_catalog.default.customer_demographics
+Output [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(41) ColumnarToRow [codegen id : 18]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(56) ColumnarToRow [codegen id : 1]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(42) Filter [codegen id : 18]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Condition : isnotnull(cd_demo_sk#18)
+(57) Filter [codegen id : 1]
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Condition : isnotnull(cd_demo_sk#22)
 
-(43) Exchange
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Arguments: hashpartitioning(cd_demo_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(58) Exchange
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: hashpartitioning(cd_demo_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(44) Sort [codegen id : 19]
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Arguments: [cd_demo_sk#18 ASC NULLS FIRST], false, 0
+(59) ObjectHashAggregate
+Input [6]: [cd_demo_sk#22, cd_gender#23, cd_marital_status#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#80]
+Results [1]: [buf#81]
 
-(45) SortMergeJoin [codegen id : 20]
-Left keys [1]: [c_current_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#18]
-Join type: Inner
-Join condition: None
+(60) Exchange
+Input [1]: [buf#81]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(46) Project [codegen id : 20]
-Output [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Input [8]: [c_current_cdemo_sk#2, ca_state#17, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
+(61) ObjectHashAggregate
+Input [1]: [buf#81]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)#82]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#22, 42), 1920800, 15366400, 0, 0)#82 AS bloomFilter#83]
 
-(47) HashAggregate [codegen id : 20]
-Input [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Functions [10]: [partial_count(1), partial_avg(cd_dep_count#21), partial_max(cd_dep_count#21), partial_sum(cd_dep_count#21), partial_avg(cd_dep_employed_count#22), partial_max(cd_dep_employed_count#22), partial_sum(cd_dep_employed_count#22), partial_avg(cd_dep_college_count#23), partial_max(cd_dep_college_count#23), partial_sum(cd_dep_college_count#23)]
-Aggregate Attributes [13]: [count#24, sum#25, count#26, max#27, sum#28, sum#29, count#30, max#31, sum#32, sum#33, count#34, max#35, sum#36]
-Results [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
-
-(48) Exchange
-Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
-Arguments: hashpartitioning(ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(49) HashAggregate [codegen id : 21]
-Input [19]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23, count#37, sum#38, count#39, max#40, sum#41, sum#42, count#43, max#44, sum#45, sum#46, count#47, max#48, sum#49]
-Keys [6]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cd_dep_employed_count#22, cd_dep_college_count#23]
-Functions [10]: [count(1), avg(cd_dep_count#21), max(cd_dep_count#21), sum(cd_dep_count#21), avg(cd_dep_employed_count#22), max(cd_dep_employed_count#22), sum(cd_dep_employed_count#22), avg(cd_dep_college_count#23), max(cd_dep_college_count#23), sum(cd_dep_college_count#23)]
-Aggregate Attributes [10]: [count(1)#50, avg(cd_dep_count#21)#51, max(cd_dep_count#21)#52, sum(cd_dep_count#21)#53, avg(cd_dep_employed_count#22)#54, max(cd_dep_employed_count#22)#55, sum(cd_dep_employed_count#22)#56, avg(cd_dep_college_count#23)#57, max(cd_dep_college_count#23)#58, sum(cd_dep_college_count#23)#59]
-Results [18]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, count(1)#50 AS cnt1#60, avg(cd_dep_count#21)#51 AS avg(cd_dep_count)#61, max(cd_dep_count#21)#52 AS max(cd_dep_count)#62, sum(cd_dep_count#21)#53 AS sum(cd_dep_count)#63, cd_dep_employed_count#22, count(1)#50 AS cnt2#64, avg(cd_dep_employed_count#22)#54 AS avg(cd_dep_employed_count)#65, max(cd_dep_employed_count#22)#55 AS max(cd_dep_employed_count)#66, sum(cd_dep_employed_count#22)#56 AS sum(cd_dep_employed_count)#67, cd_dep_college_count#23, count(1)#50 AS cnt3#68, avg(cd_dep_college_count#23)#57 AS avg(cd_dep_college_count)#69, max(cd_dep_college_count#23)#58 AS max(cd_dep_college_count)#70, sum(cd_dep_college_count#23)#59 AS sum(cd_dep_college_count)#71]
-
-(50) TakeOrderedAndProject
-Input [18]: [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cnt1#60, avg(cd_dep_count)#61, max(cd_dep_count)#62, sum(cd_dep_count)#63, cd_dep_employed_count#22, cnt2#64, avg(cd_dep_employed_count)#65, max(cd_dep_employed_count)#66, sum(cd_dep_employed_count)#67, cd_dep_college_count#23, cnt3#68, avg(cd_dep_college_count)#69, max(cd_dep_college_count)#70, sum(cd_dep_college_count)#71]
-Arguments: 100, [ca_state#17 ASC NULLS FIRST, cd_gender#19 ASC NULLS FIRST, cd_marital_status#20 ASC NULLS FIRST, cd_dep_count#21 ASC NULLS FIRST, cd_dep_employed_count#22 ASC NULLS FIRST, cd_dep_college_count#23 ASC NULLS FIRST], [ca_state#17, cd_gender#19, cd_marital_status#20, cd_dep_count#21, cnt1#60, avg(cd_dep_count)#61, max(cd_dep_count)#62, sum(cd_dep_count)#63, cd_dep_employed_count#22, cnt2#64, avg(cd_dep_employed_count)#65, max(cd_dep_employed_count)#66, sum(cd_dep_employed_count)#67, cd_dep_college_count#23, cnt3#68, avg(cd_dep_college_count)#69, max(cd_dep_college_count)#70, sum(cd_dep_college_count)#71]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (55)
-+- * Project (54)
-   +- * Filter (53)
-      +- * ColumnarToRow (52)
-         +- Scan parquet spark_catalog.default.date_dim (51)
+Subquery:3 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
+BroadcastExchange (66)
++- * Project (65)
+   +- * Filter (64)
+      +- * ColumnarToRow (63)
+         +- Scan parquet spark_catalog.default.date_dim (62)
 
 
-(51) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#7, d_year#72, d_qoy#73]
+(62) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#11, d_year#84, d_qoy#85]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_qoy), EqualTo(d_year,1999), LessThan(d_qoy,4), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(52) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#72, d_qoy#73]
+(63) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#11, d_year#84, d_qoy#85]
 
-(53) Filter [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#72, d_qoy#73]
-Condition : ((((isnotnull(d_year#72) AND isnotnull(d_qoy#73)) AND (d_year#72 = 1999)) AND (d_qoy#73 < 4)) AND isnotnull(d_date_sk#7))
+(64) Filter [codegen id : 1]
+Input [3]: [d_date_sk#11, d_year#84, d_qoy#85]
+Condition : ((((isnotnull(d_year#84) AND isnotnull(d_qoy#85)) AND (d_year#84 = 1999)) AND (d_qoy#85 < 4)) AND isnotnull(d_date_sk#11))
 
-(54) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#72, d_qoy#73]
+(65) Project [codegen id : 1]
+Output [1]: [d_date_sk#11]
+Input [3]: [d_date_sk#11, d_year#84, d_qoy#85]
 
-(55) BroadcastExchange
-Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+(66) BroadcastExchange
+Input [1]: [d_date_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:2 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#9 IN dynamicpruning#6
+Subquery:4 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#13 IN dynamicpruning#10
 
-Subquery:3 Hosting operator id = 19 Hosting Expression = cs_sold_date_sk#13 IN dynamicpruning#6
+Subquery:5 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#17 IN dynamicpruning#10
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/simplified.txt
@@ -33,6 +33,26 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                                 Exchange [c_customer_sk] #4
                                                                   WholeStageCodegen (1)
                                                                     Filter [c_current_addr_sk,c_current_cdemo_sk]
+                                                                      Subquery #1
+                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 1000000, 8000000, 0, 0),bloomFilter,buf]
+                                                                          Exchange #5
+                                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                              Exchange [ca_address_sk] #6
+                                                                                WholeStageCodegen (1)
+                                                                                  Filter [ca_address_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                                                      Subquery #2
+                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
+                                                                          Exchange #7
+                                                                            ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                              Exchange [cd_demo_sk] #8
+                                                                                WholeStageCodegen (1)
+                                                                                  Filter [cd_demo_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
                                                                       ColumnarToRow
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
@@ -40,64 +60,57 @@ TakeOrderedAndProject [ca_state,cd_gender,cd_marital_status,cd_dep_count,cd_dep_
                                                           WholeStageCodegen (5)
                                                             Sort [ss_customer_sk]
                                                               InputAdapter
-                                                                Exchange [ss_customer_sk] #5
+                                                                Exchange [ss_customer_sk] #9
                                                                   WholeStageCodegen (4)
                                                                     Project [ss_customer_sk]
                                                                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                                BroadcastExchange #6
-                                                                                  WholeStageCodegen (1)
-                                                                                    Project [d_date_sk]
-                                                                                      Filter [d_year,d_qoy,d_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
+                                                                        Filter
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                                SubqueryBroadcast [d_date_sk] #3
+                                                                                  BroadcastExchange #10
+                                                                                    WholeStageCodegen (1)
+                                                                                      Project [d_date_sk]
+                                                                                        Filter [d_year,d_qoy,d_date_sk]
+                                                                                          ColumnarToRow
+                                                                                            InputAdapter
+                                                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
                                                                         InputAdapter
-                                                                          ReusedExchange [d_date_sk] #6
+                                                                          ReusedExchange [d_date_sk] #10
                                                   InputAdapter
                                                     WholeStageCodegen (11)
                                                       Sort [customsk]
                                                         InputAdapter
-                                                          Exchange [customsk] #7
+                                                          Exchange [customsk] #11
                                                             Union
                                                               WholeStageCodegen (8)
                                                                 Project [ws_bill_customer_sk]
                                                                   BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                          ReusedSubquery [d_date_sk] #1
+                                                                    Filter
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
+                                                                            ReusedSubquery [d_date_sk] #3
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk] #6
+                                                                      ReusedExchange [d_date_sk] #10
                                                               WholeStageCodegen (10)
                                                                 Project [cs_ship_customer_sk]
                                                                   BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                                          ReusedSubquery [d_date_sk] #1
+                                                                    Filter
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
+                                                                            ReusedSubquery [d_date_sk] #3
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk] #6
+                                                                      ReusedExchange [d_date_sk] #10
                                   InputAdapter
                                     WholeStageCodegen (15)
                                       Sort [ca_address_sk]
                                         InputAdapter
-                                          Exchange [ca_address_sk] #8
-                                            WholeStageCodegen (14)
-                                              Filter [ca_address_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                          ReusedExchange [ca_address_sk,ca_state] #6
                   InputAdapter
                     WholeStageCodegen (19)
                       Sort [cd_demo_sk]
                         InputAdapter
-                          Exchange [cd_demo_sk] #9
-                            WholeStageCodegen (18)
-                              Filter [cd_demo_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
+                          ReusedExchange [cd_demo_sk,cd_gender,cd_marital_status,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #8

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
-TakeOrderedAndProject (52)
-+- * Project (51)
-   +- * SortMergeJoin Inner (50)
-      :- * Project (43)
-      :  +- * SortMergeJoin Inner (42)
+TakeOrderedAndProject (89)
++- * Project (88)
+   +- * SortMergeJoin Inner (87)
+      :- * Project (62)
+      :  +- * SortMergeJoin Inner (61)
       :     :- * Sort (33)
       :     :  +- Exchange (32)
       :     :     +- * Project (31)
@@ -37,20 +37,57 @@ TakeOrderedAndProject (52)
       :     :                                               +- * Filter (17)
       :     :                                                  +- * ColumnarToRow (16)
       :     :                                                     +- Scan parquet spark_catalog.default.item (15)
-      :     +- * Sort (41)
-      :        +- Exchange (40)
-      :           +- * Project (39)
-      :              +- Window (38)
-      :                 +- * Sort (37)
-      :                    +- Exchange (36)
-      :                       +- * HashAggregate (35)
-      :                          +- ReusedExchange (34)
-      +- * Sort (49)
-         +- Exchange (48)
-            +- * Project (47)
-               +- Window (46)
-                  +- * Sort (45)
-                     +- ReusedExchange (44)
+      :     +- * Sort (60)
+      :        +- Exchange (59)
+      :           +- * Project (58)
+      :              +- Window (57)
+      :                 +- * Sort (56)
+      :                    +- Exchange (55)
+      :                       +- * HashAggregate (54)
+      :                          +- Exchange (53)
+      :                             +- * HashAggregate (52)
+      :                                +- * Project (51)
+      :                                   +- * SortMergeJoin Inner (50)
+      :                                      :- * Sort (47)
+      :                                      :  +- Exchange (46)
+      :                                      :     +- * Project (45)
+      :                                      :        +- * BroadcastHashJoin Inner BuildRight (44)
+      :                                      :           :- * Project (39)
+      :                                      :           :  +- * BroadcastHashJoin Inner BuildRight (38)
+      :                                      :           :     :- * Filter (36)
+      :                                      :           :     :  +- * ColumnarToRow (35)
+      :                                      :           :     :     +- Scan parquet spark_catalog.default.store_sales (34)
+      :                                      :           :     +- ReusedExchange (37)
+      :                                      :           +- BroadcastExchange (43)
+      :                                      :              +- * Filter (42)
+      :                                      :                 +- * ColumnarToRow (41)
+      :                                      :                    +- Scan parquet spark_catalog.default.store (40)
+      :                                      +- * Sort (49)
+      :                                         +- ReusedExchange (48)
+      +- * Sort (86)
+         +- Exchange (85)
+            +- * Project (84)
+               +- Window (83)
+                  +- * Sort (82)
+                     +- Exchange (81)
+                        +- * HashAggregate (80)
+                           +- Exchange (79)
+                              +- * HashAggregate (78)
+                                 +- * Project (77)
+                                    +- * SortMergeJoin Inner (76)
+                                       :- * Sort (73)
+                                       :  +- Exchange (72)
+                                       :     +- * Project (71)
+                                       :        +- * BroadcastHashJoin Inner BuildRight (70)
+                                       :           :- * Project (68)
+                                       :           :  +- * BroadcastHashJoin Inner BuildRight (67)
+                                       :           :     :- * Filter (65)
+                                       :           :     :  +- * ColumnarToRow (64)
+                                       :           :     :     +- Scan parquet spark_catalog.default.store_sales (63)
+                                       :           :     +- ReusedExchange (66)
+                                       :           +- ReusedExchange (69)
+                                       +- * Sort (75)
+                                          +- ReusedExchange (74)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -66,249 +103,521 @@ Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
 (3) Filter [codegen id : 3]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
-Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
+Condition : ((isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(ss_item_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 56]
-Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(4) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#8, d_year#9, d_moy#10]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
-Output [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8]
-Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_year#7, d_moy#8]
+Output [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#9, d_moy#10]
+Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#8, d_year#9, d_moy#10]
 
 (7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
+Output [3]: [s_store_sk#11, s_store_name#12, s_company_name#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_company_name)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
+Input [3]: [s_store_sk#11, s_store_name#12, s_company_name#13]
 
 (9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Condition : ((isnotnull(s_store_sk#9) AND isnotnull(s_store_name#10)) AND isnotnull(s_company_name#11))
+Input [3]: [s_store_sk#11, s_store_name#12, s_company_name#13]
+Condition : ((((isnotnull(s_store_sk#11) AND isnotnull(s_store_name#12)) AND isnotnull(s_company_name#13)) AND true) AND true)
 
 (10) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
+Input [3]: [s_store_sk#11, s_store_name#12, s_company_name#13]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#9]
+Right keys [1]: [s_store_sk#11]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, s_store_sk#9, s_store_name#10, s_company_name#11]
+Output [6]: [ss_item_sk#1, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
+Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#9, d_moy#10, s_store_sk#11, s_store_name#12, s_company_name#13]
 
 (13) Exchange
-Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
+Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
 Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
+Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#12, i_brand#13, i_category#14]
+Output [3]: [i_item_sk#14, i_brand#15, i_category#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
 
 (16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
 
 (17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Condition : ((isnotnull(i_item_sk#12) AND isnotnull(i_category#14)) AND isnotnull(i_brand#13))
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Condition : ((((isnotnull(i_item_sk#14) AND isnotnull(i_category#16)) AND isnotnull(i_brand#15)) AND true) AND true)
 
 (18) Exchange
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Arguments: hashpartitioning(i_item_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Arguments: [i_item_sk#14 ASC NULLS FIRST], false, 0
 
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#14]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
-Output [7]: [i_brand#13, i_category#14, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Input [9]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11, i_item_sk#12, i_brand#13, i_category#14]
+Output [7]: [i_brand#15, i_category#16, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
+Input [9]: [ss_item_sk#1, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13, i_item_sk#14, i_brand#15, i_category#16]
 
 (22) HashAggregate [codegen id : 7]
-Input [7]: [i_brand#13, i_category#14, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Keys [6]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8]
+Input [7]: [i_brand#15, i_category#16, ss_sales_price#3, d_year#9, d_moy#10, s_store_name#12, s_company_name#13]
+Keys [6]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10]
 Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
-Aggregate Attributes [1]: [sum#15]
-Results [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
+Aggregate Attributes [1]: [sum#17]
+Results [7]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum#18]
 
 (23) Exchange
-Input [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum#18]
+Arguments: hashpartitioning(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) HashAggregate [codegen id : 8]
-Input [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
-Keys [6]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8]
+Input [7]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum#18]
+Keys [6]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#17]
-Results [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#19]
+Results [8]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#19,17,2) AS sum_sales#20, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#19,17,2) AS _w0#21]
 
 (25) Exchange
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [8]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21]
+Arguments: hashpartitioning(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (26) Sort [codegen id : 9]
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#13 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST, s_company_name#11 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], false, 0
+Input [8]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21]
+Arguments: [i_category#16 ASC NULLS FIRST, i_brand#15 ASC NULLS FIRST, s_store_name#12 ASC NULLS FIRST, s_company_name#13 ASC NULLS FIRST, d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST], false, 0
 
 (27) Window
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: [rank(d_year#7, d_moy#8) windowspecdefinition(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#20], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11], [d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST]
+Input [8]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21]
+Arguments: [rank(d_year#9, d_moy#10) windowspecdefinition(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#22], [i_category#16, i_brand#15, s_store_name#12, s_company_name#13], [d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST]
 
 (28) Filter [codegen id : 10]
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
-Condition : (isnotnull(d_year#7) AND (d_year#7 = 1999))
+Input [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21, rn#22]
+Condition : (isnotnull(d_year#9) AND (d_year#9 = 1999))
 
 (29) Window
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
-Arguments: [avg(_w0#19) windowspecdefinition(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#21], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7]
+Input [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21, rn#22]
+Arguments: [avg(_w0#21) windowspecdefinition(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#23], [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9]
 
 (30) Filter [codegen id : 11]
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
-Condition : ((isnotnull(avg_monthly_sales#21) AND (avg_monthly_sales#21 > 0.000000)) AND CASE WHEN (avg_monthly_sales#21 > 0.000000) THEN ((abs((sum_sales#18 - avg_monthly_sales#21)) / avg_monthly_sales#21) > 0.1000000000000000) END)
+Input [10]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21, rn#22, avg_monthly_sales#23]
+Condition : ((isnotnull(avg_monthly_sales#23) AND (avg_monthly_sales#23 > 0.000000)) AND CASE WHEN (avg_monthly_sales#23 > 0.000000) THEN ((abs((sum_sales#20 - avg_monthly_sales#23)) / avg_monthly_sales#23) > 0.1000000000000000) END)
 
 (31) Project [codegen id : 11]
-Output [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
+Output [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22]
+Input [10]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, _w0#21, rn#22, avg_monthly_sales#23]
 
 (32) Exchange
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22]
+Arguments: hashpartitioning(i_category#16, i_brand#15, s_store_name#12, s_company_name#13, rn#22, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (33) Sort [codegen id : 12]
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#13 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST, s_company_name#11 ASC NULLS FIRST, rn#20 ASC NULLS FIRST], false, 0
+Input [9]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22]
+Arguments: [i_category#16 ASC NULLS FIRST, i_brand#15 ASC NULLS FIRST, s_store_name#12 ASC NULLS FIRST, s_company_name#13 ASC NULLS FIRST, rn#22 ASC NULLS FIRST], false, 0
 
-(34) ReusedExchange [Reuses operator id: 23]
-Output [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum#28]
+(34) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, ss_sold_date_sk#27]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#27), dynamicpruningexpression(ss_sold_date_sk#27 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(35) HashAggregate [codegen id : 20]
-Input [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum#28]
-Keys [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27]
-Functions [1]: [sum(UnscaledValue(ss_sales_price#29))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#29))#17]
-Results [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, MakeDecimal(sum(UnscaledValue(ss_sales_price#29))#17,17,2) AS sum_sales#18]
+(35) ColumnarToRow [codegen id : 15]
+Input [4]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, ss_sold_date_sk#27]
 
-(36) Exchange
-Input [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum_sales#18]
-Arguments: hashpartitioning(i_category#22, i_brand#23, s_store_name#24, s_company_name#25, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(36) Filter [codegen id : 15]
+Input [4]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, ss_sold_date_sk#27]
+Condition : ((isnotnull(ss_item_sk#24) AND isnotnull(ss_store_sk#25)) AND might_contain(Subquery scalar-subquery#28, [id=#29], xxhash64(ss_item_sk#24, 42), false))
 
-(37) Sort [codegen id : 21]
-Input [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum_sales#18]
-Arguments: [i_category#22 ASC NULLS FIRST, i_brand#23 ASC NULLS FIRST, s_store_name#24 ASC NULLS FIRST, s_company_name#25 ASC NULLS FIRST, d_year#26 ASC NULLS FIRST, d_moy#27 ASC NULLS FIRST], false, 0
+(37) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#30, d_year#31, d_moy#32]
 
-(38) Window
-Input [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum_sales#18]
-Arguments: [rank(d_year#26, d_moy#27) windowspecdefinition(i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26 ASC NULLS FIRST, d_moy#27 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#30], [i_category#22, i_brand#23, s_store_name#24, s_company_name#25], [d_year#26 ASC NULLS FIRST, d_moy#27 ASC NULLS FIRST]
-
-(39) Project [codegen id : 22]
-Output [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#18 AS sum_sales#31, rn#30]
-Input [8]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum_sales#18, rn#30]
-
-(40) Exchange
-Input [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#31, rn#30]
-Arguments: hashpartitioning(i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#30 + 1), 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(41) Sort [codegen id : 23]
-Input [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#31, rn#30]
-Arguments: [i_category#22 ASC NULLS FIRST, i_brand#23 ASC NULLS FIRST, s_store_name#24 ASC NULLS FIRST, s_company_name#25 ASC NULLS FIRST, (rn#30 + 1) ASC NULLS FIRST], false, 0
-
-(42) SortMergeJoin [codegen id : 24]
-Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
-Right keys [5]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#30 + 1)]
+(38) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ss_sold_date_sk#27]
+Right keys [1]: [d_date_sk#30]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 24]
-Output [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#31]
-Input [15]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#31, rn#30]
+(39) Project [codegen id : 15]
+Output [5]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, d_year#31, d_moy#32]
+Input [7]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, ss_sold_date_sk#27, d_date_sk#30, d_year#31, d_moy#32]
 
-(44) ReusedExchange [Reuses operator id: 36]
-Output [7]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#18]
+(40) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#33, s_store_name#34, s_company_name#35]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_company_name)]
+ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
 
-(45) Sort [codegen id : 33]
-Input [7]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#18]
-Arguments: [i_category#32 ASC NULLS FIRST, i_brand#33 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, d_year#36 ASC NULLS FIRST, d_moy#37 ASC NULLS FIRST], false, 0
+(41) ColumnarToRow [codegen id : 14]
+Input [3]: [s_store_sk#33, s_store_name#34, s_company_name#35]
 
-(46) Window
-Input [7]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#18]
-Arguments: [rank(d_year#36, d_moy#37) windowspecdefinition(i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36 ASC NULLS FIRST, d_moy#37 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#38], [i_category#32, i_brand#33, s_store_name#34, s_company_name#35], [d_year#36 ASC NULLS FIRST, d_moy#37 ASC NULLS FIRST]
+(42) Filter [codegen id : 14]
+Input [3]: [s_store_sk#33, s_store_name#34, s_company_name#35]
+Condition : ((isnotnull(s_store_sk#33) AND isnotnull(s_store_name#34)) AND isnotnull(s_company_name#35))
 
-(47) Project [codegen id : 34]
-Output [6]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#18 AS sum_sales#39, rn#38]
-Input [8]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#18, rn#38]
+(43) BroadcastExchange
+Input [3]: [s_store_sk#33, s_store_name#34, s_company_name#35]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(48) Exchange
-Input [6]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#39, rn#38]
-Arguments: hashpartitioning(i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#38 - 1), 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(49) Sort [codegen id : 35]
-Input [6]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#39, rn#38]
-Arguments: [i_category#32 ASC NULLS FIRST, i_brand#33 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, (rn#38 - 1) ASC NULLS FIRST], false, 0
-
-(50) SortMergeJoin [codegen id : 36]
-Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
-Right keys [5]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#38 - 1)]
+(44) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ss_store_sk#25]
+Right keys [1]: [s_store_sk#33]
 Join type: Inner
 Join condition: None
 
-(51) Project [codegen id : 36]
-Output [7]: [i_category#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, sum_sales#31 AS psum#40, sum_sales#39 AS nsum#41]
-Input [16]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#31, i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#39, rn#38]
+(45) Project [codegen id : 15]
+Output [6]: [ss_item_sk#24, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Input [8]: [ss_item_sk#24, ss_store_sk#25, ss_sales_price#26, d_year#31, d_moy#32, s_store_sk#33, s_store_name#34, s_company_name#35]
 
-(52) TakeOrderedAndProject
-Input [7]: [i_category#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
-Arguments: 100, [(sum_sales#18 - avg_monthly_sales#21) ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], [i_category#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
+(46) Exchange
+Input [6]: [ss_item_sk#24, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Arguments: hashpartitioning(ss_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(47) Sort [codegen id : 16]
+Input [6]: [ss_item_sk#24, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Arguments: [ss_item_sk#24 ASC NULLS FIRST], false, 0
+
+(48) ReusedExchange [Reuses operator id: 104]
+Output [3]: [i_item_sk#36, i_brand#37, i_category#38]
+
+(49) Sort [codegen id : 18]
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Arguments: [i_item_sk#36 ASC NULLS FIRST], false, 0
+
+(50) SortMergeJoin [codegen id : 19]
+Left keys [1]: [ss_item_sk#24]
+Right keys [1]: [i_item_sk#36]
+Join type: Inner
+Join condition: None
+
+(51) Project [codegen id : 19]
+Output [7]: [i_brand#37, i_category#38, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Input [9]: [ss_item_sk#24, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35, i_item_sk#36, i_brand#37, i_category#38]
+
+(52) HashAggregate [codegen id : 19]
+Input [7]: [i_brand#37, i_category#38, ss_sales_price#26, d_year#31, d_moy#32, s_store_name#34, s_company_name#35]
+Keys [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#26))]
+Aggregate Attributes [1]: [sum#39]
+Results [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum#40]
+
+(53) Exchange
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum#40]
+Arguments: hashpartitioning(i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) HashAggregate [codegen id : 20]
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum#40]
+Keys [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#26))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#26))#19]
+Results [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, MakeDecimal(sum(UnscaledValue(ss_sales_price#26))#19,17,2) AS sum_sales#20]
+
+(55) Exchange
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum_sales#20]
+Arguments: hashpartitioning(i_category#38, i_brand#37, s_store_name#34, s_company_name#35, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(56) Sort [codegen id : 21]
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum_sales#20]
+Arguments: [i_category#38 ASC NULLS FIRST, i_brand#37 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, d_year#31 ASC NULLS FIRST, d_moy#32 ASC NULLS FIRST], false, 0
+
+(57) Window
+Input [7]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum_sales#20]
+Arguments: [rank(d_year#31, d_moy#32) windowspecdefinition(i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31 ASC NULLS FIRST, d_moy#32 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#41], [i_category#38, i_brand#37, s_store_name#34, s_company_name#35], [d_year#31 ASC NULLS FIRST, d_moy#32 ASC NULLS FIRST]
+
+(58) Project [codegen id : 22]
+Output [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, sum_sales#20 AS sum_sales#42, rn#41]
+Input [8]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, d_year#31, d_moy#32, sum_sales#20, rn#41]
+
+(59) Exchange
+Input [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, sum_sales#42, rn#41]
+Arguments: hashpartitioning(i_category#38, i_brand#37, s_store_name#34, s_company_name#35, (rn#41 + 1), 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(60) Sort [codegen id : 23]
+Input [6]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, sum_sales#42, rn#41]
+Arguments: [i_category#38 ASC NULLS FIRST, i_brand#37 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, (rn#41 + 1) ASC NULLS FIRST], false, 0
+
+(61) SortMergeJoin [codegen id : 24]
+Left keys [5]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, rn#22]
+Right keys [5]: [i_category#38, i_brand#37, s_store_name#34, s_company_name#35, (rn#41 + 1)]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 24]
+Output [10]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22, sum_sales#42]
+Input [15]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22, i_category#38, i_brand#37, s_store_name#34, s_company_name#35, sum_sales#42, rn#41]
+
+(63) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, ss_sold_date_sk#46]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#46), dynamicpruningexpression(ss_sold_date_sk#46 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
+
+(64) ColumnarToRow [codegen id : 27]
+Input [4]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, ss_sold_date_sk#46]
+
+(65) Filter [codegen id : 27]
+Input [4]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, ss_sold_date_sk#46]
+Condition : ((isnotnull(ss_item_sk#43) AND isnotnull(ss_store_sk#44)) AND might_contain(ReusedSubquery Subquery scalar-subquery#6, [id=#7], xxhash64(ss_item_sk#43, 42), false))
+
+(66) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#47, d_year#48, d_moy#49]
+
+(67) BroadcastHashJoin [codegen id : 27]
+Left keys [1]: [ss_sold_date_sk#46]
+Right keys [1]: [d_date_sk#47]
+Join type: Inner
+Join condition: None
+
+(68) Project [codegen id : 27]
+Output [5]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, d_year#48, d_moy#49]
+Input [7]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, ss_sold_date_sk#46, d_date_sk#47, d_year#48, d_moy#49]
+
+(69) ReusedExchange [Reuses operator id: 43]
+Output [3]: [s_store_sk#50, s_store_name#51, s_company_name#52]
+
+(70) BroadcastHashJoin [codegen id : 27]
+Left keys [1]: [ss_store_sk#44]
+Right keys [1]: [s_store_sk#50]
+Join type: Inner
+Join condition: None
+
+(71) Project [codegen id : 27]
+Output [6]: [ss_item_sk#43, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Input [8]: [ss_item_sk#43, ss_store_sk#44, ss_sales_price#45, d_year#48, d_moy#49, s_store_sk#50, s_store_name#51, s_company_name#52]
+
+(72) Exchange
+Input [6]: [ss_item_sk#43, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Arguments: hashpartitioning(ss_item_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(73) Sort [codegen id : 28]
+Input [6]: [ss_item_sk#43, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Arguments: [ss_item_sk#43 ASC NULLS FIRST], false, 0
+
+(74) ReusedExchange [Reuses operator id: 104]
+Output [3]: [i_item_sk#53, i_brand#54, i_category#55]
+
+(75) Sort [codegen id : 30]
+Input [3]: [i_item_sk#53, i_brand#54, i_category#55]
+Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
+
+(76) SortMergeJoin [codegen id : 31]
+Left keys [1]: [ss_item_sk#43]
+Right keys [1]: [i_item_sk#53]
+Join type: Inner
+Join condition: None
+
+(77) Project [codegen id : 31]
+Output [7]: [i_brand#54, i_category#55, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Input [9]: [ss_item_sk#43, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52, i_item_sk#53, i_brand#54, i_category#55]
+
+(78) HashAggregate [codegen id : 31]
+Input [7]: [i_brand#54, i_category#55, ss_sales_price#45, d_year#48, d_moy#49, s_store_name#51, s_company_name#52]
+Keys [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#45))]
+Aggregate Attributes [1]: [sum#56]
+Results [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum#57]
+
+(79) Exchange
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum#57]
+Arguments: hashpartitioning(i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(80) HashAggregate [codegen id : 32]
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum#57]
+Keys [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#45))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#45))#19]
+Results [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, MakeDecimal(sum(UnscaledValue(ss_sales_price#45))#19,17,2) AS sum_sales#20]
+
+(81) Exchange
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum_sales#20]
+Arguments: hashpartitioning(i_category#55, i_brand#54, s_store_name#51, s_company_name#52, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(82) Sort [codegen id : 33]
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum_sales#20]
+Arguments: [i_category#55 ASC NULLS FIRST, i_brand#54 ASC NULLS FIRST, s_store_name#51 ASC NULLS FIRST, s_company_name#52 ASC NULLS FIRST, d_year#48 ASC NULLS FIRST, d_moy#49 ASC NULLS FIRST], false, 0
+
+(83) Window
+Input [7]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum_sales#20]
+Arguments: [rank(d_year#48, d_moy#49) windowspecdefinition(i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48 ASC NULLS FIRST, d_moy#49 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#58], [i_category#55, i_brand#54, s_store_name#51, s_company_name#52], [d_year#48 ASC NULLS FIRST, d_moy#49 ASC NULLS FIRST]
+
+(84) Project [codegen id : 34]
+Output [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, sum_sales#20 AS sum_sales#59, rn#58]
+Input [8]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, d_year#48, d_moy#49, sum_sales#20, rn#58]
+
+(85) Exchange
+Input [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, sum_sales#59, rn#58]
+Arguments: hashpartitioning(i_category#55, i_brand#54, s_store_name#51, s_company_name#52, (rn#58 - 1), 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(86) Sort [codegen id : 35]
+Input [6]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, sum_sales#59, rn#58]
+Arguments: [i_category#55 ASC NULLS FIRST, i_brand#54 ASC NULLS FIRST, s_store_name#51 ASC NULLS FIRST, s_company_name#52 ASC NULLS FIRST, (rn#58 - 1) ASC NULLS FIRST], false, 0
+
+(87) SortMergeJoin [codegen id : 36]
+Left keys [5]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, rn#22]
+Right keys [5]: [i_category#55, i_brand#54, s_store_name#51, s_company_name#52, (rn#58 - 1)]
+Join type: Inner
+Join condition: None
+
+(88) Project [codegen id : 36]
+Output [7]: [i_category#16, d_year#9, d_moy#10, avg_monthly_sales#23, sum_sales#20, sum_sales#42 AS psum#60, sum_sales#59 AS nsum#61]
+Input [16]: [i_category#16, i_brand#15, s_store_name#12, s_company_name#13, d_year#9, d_moy#10, sum_sales#20, avg_monthly_sales#23, rn#22, sum_sales#42, i_category#55, i_brand#54, s_store_name#51, s_company_name#52, sum_sales#59, rn#58]
+
+(89) TakeOrderedAndProject
+Input [7]: [i_category#16, d_year#9, d_moy#10, avg_monthly_sales#23, sum_sales#20, psum#60, nsum#61]
+Arguments: 100, [(sum_sales#20 - avg_monthly_sales#23) ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST], [i_category#16, d_year#9, d_moy#10, avg_monthly_sales#23, sum_sales#20, psum#60, nsum#61]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (56)
-+- * Filter (55)
-   +- * ColumnarToRow (54)
-      +- Scan parquet spark_catalog.default.date_dim (53)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (96)
++- Exchange (95)
+   +- ObjectHashAggregate (94)
+      +- Exchange (93)
+         +- * Filter (92)
+            +- * ColumnarToRow (91)
+               +- Scan parquet spark_catalog.default.item (90)
 
 
-(53) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(90) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
+
+(91) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+
+(92) Filter [codegen id : 1]
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Condition : ((isnotnull(i_item_sk#14) AND isnotnull(i_category#16)) AND isnotnull(i_brand#15))
+
+(93) Exchange
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Arguments: hashpartitioning(i_item_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(94) ObjectHashAggregate
+Input [3]: [i_item_sk#14, i_brand#15, i_category#16]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#14, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [buf#62]
+Results [1]: [buf#63]
+
+(95) Exchange
+Input [1]: [buf#63]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(96) ObjectHashAggregate
+Input [1]: [buf#63]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 203010, 1624080, 0, 0)#64]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#14, 42), 203010, 1624080, 0, 0)#64 AS bloomFilter#65]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
+BroadcastExchange (100)
++- * Filter (99)
+   +- * ColumnarToRow (98)
+      +- Scan parquet spark_catalog.default.date_dim (97)
+
+
+(97) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#8, d_year#9, d_moy#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(Or(EqualTo(d_year,1999),And(EqualTo(d_year,1998),EqualTo(d_moy,12))),And(EqualTo(d_year,2000),EqualTo(d_moy,1))), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(54) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(98) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
 
-(55) Filter [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR ((d_year#7 = 2000) AND (d_moy#8 = 1))) AND isnotnull(d_date_sk#6))
+(99) Filter [codegen id : 1]
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
+Condition : ((((d_year#9 = 1999) OR ((d_year#9 = 1998) AND (d_moy#10 = 12))) OR ((d_year#9 = 2000) AND (d_moy#10 = 1))) AND isnotnull(d_date_sk#8))
 
-(56) BroadcastExchange
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
+(100) BroadcastExchange
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
+
+Subquery:3 Hosting operator id = 36 Hosting Expression = Subquery scalar-subquery#28, [id=#29]
+ObjectHashAggregate (107)
++- Exchange (106)
+   +- ObjectHashAggregate (105)
+      +- Exchange (104)
+         +- * Filter (103)
+            +- * ColumnarToRow (102)
+               +- Scan parquet spark_catalog.default.item (101)
+
+
+(101) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
+
+(102) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+
+(103) Filter [codegen id : 1]
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Condition : ((isnotnull(i_item_sk#36) AND isnotnull(i_category#38)) AND isnotnull(i_brand#37))
+
+(104) Exchange
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Arguments: hashpartitioning(i_item_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+
+(105) ObjectHashAggregate
+Input [3]: [i_item_sk#36, i_brand#37, i_category#38]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#36, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [buf#66]
+Results [1]: [buf#67]
+
+(106) Exchange
+Input [1]: [buf#67]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+
+(107) ObjectHashAggregate
+Input [1]: [buf#67]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#36, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#36, 42), 203010, 1624080, 0, 0)#68]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#36, 42), 203010, 1624080, 0, 0)#68 AS bloomFilter#69]
+
+Subquery:4 Hosting operator id = 34 Hosting Expression = ss_sold_date_sk#27 IN dynamicpruning#5
+
+Subquery:5 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#6, [id=#7]
+
+Subquery:6 Hosting operator id = 63 Hosting Expression = ss_sold_date_sk#46 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/simplified.txt
@@ -43,6 +43,16 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,
                                                                                     Project [ss_item_sk,ss_store_sk,ss_sales_price,d_year,d_moy]
                                                                                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                                         Filter [ss_item_sk,ss_store_sk]
+                                                                                          Subquery #2
+                                                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 203010, 1624080, 0, 0),bloomFilter,buf]
+                                                                                              Exchange #6
+                                                                                                ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                                  Exchange [i_item_sk] #7
+                                                                                                    WholeStageCodegen (1)
+                                                                                                      Filter [i_item_sk,i_category,i_brand]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
                                                                                           ColumnarToRow
                                                                                             InputAdapter
                                                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
@@ -56,7 +66,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,
                                                                                         InputAdapter
                                                                                           ReusedExchange [d_date_sk,d_year,d_moy] #5
                                                                                     InputAdapter
-                                                                                      BroadcastExchange #6
+                                                                                      BroadcastExchange #8
                                                                                         WholeStageCodegen (2)
                                                                                           Filter [s_store_sk,s_store_name,s_company_name]
                                                                                             ColumnarToRow
@@ -66,7 +76,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,
                                                                       WholeStageCodegen (6)
                                                                         Sort [i_item_sk]
                                                                           InputAdapter
-                                                                            Exchange [i_item_sk] #7
+                                                                            Exchange [i_item_sk] #9
                                                                               WholeStageCodegen (5)
                                                                                 Filter [i_item_sk,i_category,i_brand]
                                                                                   ColumnarToRow
@@ -76,7 +86,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,
                   WholeStageCodegen (23)
                     Sort [i_category,i_brand,s_store_name,s_company_name,rn]
                       InputAdapter
-                        Exchange [i_category,i_brand,s_store_name,s_company_name,rn] #8
+                        Exchange [i_category,i_brand,s_store_name,s_company_name,rn] #10
                           WholeStageCodegen (22)
                             Project [i_category,i_brand,s_store_name,s_company_name,sum_sales,rn]
                               InputAdapter
@@ -84,16 +94,59 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,
                                   WholeStageCodegen (21)
                                     Sort [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy]
                                       InputAdapter
-                                        Exchange [i_category,i_brand,s_store_name,s_company_name] #9
+                                        Exchange [i_category,i_brand,s_store_name,s_company_name] #11
                                           WholeStageCodegen (20)
                                             HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,sum] [sum(UnscaledValue(ss_sales_price)),sum_sales,sum]
                                               InputAdapter
-                                                ReusedExchange [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,sum] #3
+                                                Exchange [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy] #12
+                                                  WholeStageCodegen (19)
+                                                    HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,ss_sales_price] [sum,sum]
+                                                      Project [i_brand,i_category,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
+                                                        SortMergeJoin [ss_item_sk,i_item_sk]
+                                                          InputAdapter
+                                                            WholeStageCodegen (16)
+                                                              Sort [ss_item_sk]
+                                                                InputAdapter
+                                                                  Exchange [ss_item_sk] #13
+                                                                    WholeStageCodegen (15)
+                                                                      Project [ss_item_sk,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
+                                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                          Project [ss_item_sk,ss_store_sk,ss_sales_price,d_year,d_moy]
+                                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                              Filter [ss_item_sk,ss_store_sk]
+                                                                                Subquery #3
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 203010, 1624080, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #14
+                                                                                      ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                        Exchange [i_item_sk] #15
+                                                                                          WholeStageCodegen (1)
+                                                                                            Filter [i_item_sk,i_category,i_brand]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
+                                                                                      ReusedSubquery [d_date_sk] #1
+                                                                              InputAdapter
+                                                                                ReusedExchange [d_date_sk,d_year,d_moy] #5
+                                                                          InputAdapter
+                                                                            BroadcastExchange #16
+                                                                              WholeStageCodegen (14)
+                                                                                Filter [s_store_sk,s_store_name,s_company_name]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_name]
+                                                          InputAdapter
+                                                            WholeStageCodegen (18)
+                                                              Sort [i_item_sk]
+                                                                InputAdapter
+                                                                  ReusedExchange [i_item_sk,i_brand,i_category] #15
         InputAdapter
           WholeStageCodegen (35)
             Sort [i_category,i_brand,s_store_name,s_company_name,rn]
               InputAdapter
-                Exchange [i_category,i_brand,s_store_name,s_company_name,rn] #10
+                Exchange [i_category,i_brand,s_store_name,s_company_name,rn] #17
                   WholeStageCodegen (34)
                     Project [i_category,i_brand,s_store_name,s_company_name,sum_sales,rn]
                       InputAdapter
@@ -101,4 +154,37 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,
                           WholeStageCodegen (33)
                             Sort [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy]
                               InputAdapter
-                                ReusedExchange [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,sum_sales] #9
+                                Exchange [i_category,i_brand,s_store_name,s_company_name] #18
+                                  WholeStageCodegen (32)
+                                    HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,sum] [sum(UnscaledValue(ss_sales_price)),sum_sales,sum]
+                                      InputAdapter
+                                        Exchange [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy] #19
+                                          WholeStageCodegen (31)
+                                            HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,ss_sales_price] [sum,sum]
+                                              Project [i_brand,i_category,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
+                                                SortMergeJoin [ss_item_sk,i_item_sk]
+                                                  InputAdapter
+                                                    WholeStageCodegen (28)
+                                                      Sort [ss_item_sk]
+                                                        InputAdapter
+                                                          Exchange [ss_item_sk] #20
+                                                            WholeStageCodegen (27)
+                                                              Project [ss_item_sk,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
+                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                  Project [ss_item_sk,ss_store_sk,ss_sales_price,d_year,d_moy]
+                                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                      Filter [ss_item_sk,ss_store_sk]
+                                                                        ReusedSubquery [bloomFilter] #2
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
+                                                                              ReusedSubquery [d_date_sk] #1
+                                                                      InputAdapter
+                                                                        ReusedExchange [d_date_sk,d_year,d_moy] #5
+                                                                  InputAdapter
+                                                                    ReusedExchange [s_store_sk,s_store_name,s_company_name] #16
+                                                  InputAdapter
+                                                    WholeStageCodegen (30)
+                                                      Sort [i_item_sk]
+                                                        InputAdapter
+                                                          ReusedExchange [i_item_sk,i_brand,i_category] #15

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/explain.txt
@@ -1,74 +1,68 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * Filter (69)
-   +- * HashAggregate (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin Inner (65)
-               :- Window (60)
-               :  +- * Sort (59)
-               :     +- Exchange (58)
-               :        +- * Project (57)
-               :           +- * Filter (56)
-               :              +- * SortMergeJoin FullOuter (55)
-               :                 :- * Sort (27)
-               :                 :  +- Exchange (26)
-               :                 :     +- * HashAggregate (25)
-               :                 :        +- * HashAggregate (24)
-               :                 :           +- * Project (23)
-               :                 :              +- * SortMergeJoin Inner (22)
-               :                 :                 :- * Sort (15)
-               :                 :                 :  +- Exchange (14)
-               :                 :                 :     +- * Project (13)
-               :                 :                 :        +- Window (12)
-               :                 :                 :           +- * Sort (11)
-               :                 :                 :              +- Exchange (10)
-               :                 :                 :                 +- * HashAggregate (9)
-               :                 :                 :                    +- Exchange (8)
-               :                 :                 :                       +- * HashAggregate (7)
-               :                 :                 :                          +- * Project (6)
-               :                 :                 :                             +- * BroadcastHashJoin Inner BuildRight (5)
-               :                 :                 :                                :- * Filter (3)
-               :                 :                 :                                :  +- * ColumnarToRow (2)
-               :                 :                 :                                :     +- Scan parquet spark_catalog.default.web_sales (1)
-               :                 :                 :                                +- ReusedExchange (4)
-               :                 :                 +- * Sort (21)
-               :                 :                    +- Exchange (20)
-               :                 :                       +- * Project (19)
-               :                 :                          +- Window (18)
-               :                 :                             +- * Sort (17)
-               :                 :                                +- ReusedExchange (16)
-               :                 +- * Sort (54)
-               :                    +- Exchange (53)
-               :                       +- * HashAggregate (52)
-               :                          +- * HashAggregate (51)
-               :                             +- * Project (50)
-               :                                +- * SortMergeJoin Inner (49)
-               :                                   :- * Sort (42)
-               :                                   :  +- Exchange (41)
-               :                                   :     +- * Project (40)
-               :                                   :        +- Window (39)
-               :                                   :           +- * Sort (38)
-               :                                   :              +- Exchange (37)
-               :                                   :                 +- * HashAggregate (36)
-               :                                   :                    +- Exchange (35)
-               :                                   :                       +- * HashAggregate (34)
-               :                                   :                          +- * Project (33)
-               :                                   :                             +- * BroadcastHashJoin Inner BuildRight (32)
-               :                                   :                                :- * Filter (30)
-               :                                   :                                :  +- * ColumnarToRow (29)
-               :                                   :                                :     +- Scan parquet spark_catalog.default.store_sales (28)
-               :                                   :                                +- ReusedExchange (31)
-               :                                   +- * Sort (48)
-               :                                      +- Exchange (47)
-               :                                         +- * Project (46)
-               :                                            +- Window (45)
-               :                                               +- * Sort (44)
-               :                                                  +- ReusedExchange (43)
-               +- * Project (64)
-                  +- Window (63)
-                     +- * Sort (62)
-                        +- ReusedExchange (61)
+TakeOrderedAndProject (64)
++- * Filter (63)
+   +- * HashAggregate (62)
+      +- * HashAggregate (61)
+         +- * Project (60)
+            +- * SortMergeJoin Inner (59)
+               :- Window (54)
+               :  +- * Sort (53)
+               :     +- Exchange (52)
+               :        +- * Project (51)
+               :           +- * Filter (50)
+               :              +- * SortMergeJoin FullOuter (49)
+               :                 :- * Sort (24)
+               :                 :  +- Exchange (23)
+               :                 :     +- * HashAggregate (22)
+               :                 :        +- * HashAggregate (21)
+               :                 :           +- * Project (20)
+               :                 :              +- * SortMergeJoin Inner (19)
+               :                 :                 :- * Sort (16)
+               :                 :                 :  +- Exchange (15)
+               :                 :                 :     +- * Project (14)
+               :                 :                 :        +- * Filter (13)
+               :                 :                 :           +- Window (12)
+               :                 :                 :              +- * Sort (11)
+               :                 :                 :                 +- Exchange (10)
+               :                 :                 :                    +- * HashAggregate (9)
+               :                 :                 :                       +- Exchange (8)
+               :                 :                 :                          +- * HashAggregate (7)
+               :                 :                 :                             +- * Project (6)
+               :                 :                 :                                +- * BroadcastHashJoin Inner BuildRight (5)
+               :                 :                 :                                   :- * Filter (3)
+               :                 :                 :                                   :  +- * ColumnarToRow (2)
+               :                 :                 :                                   :     +- Scan parquet spark_catalog.default.web_sales (1)
+               :                 :                 :                                   +- ReusedExchange (4)
+               :                 :                 +- * Sort (18)
+               :                 :                    +- ReusedExchange (17)
+               :                 +- * Sort (48)
+               :                    +- Exchange (47)
+               :                       +- * HashAggregate (46)
+               :                          +- * HashAggregate (45)
+               :                             +- * Project (44)
+               :                                +- * SortMergeJoin Inner (43)
+               :                                   :- * Sort (40)
+               :                                   :  +- Exchange (39)
+               :                                   :     +- * Project (38)
+               :                                   :        +- * Filter (37)
+               :                                   :           +- Window (36)
+               :                                   :              +- * Sort (35)
+               :                                   :                 +- Exchange (34)
+               :                                   :                    +- * HashAggregate (33)
+               :                                   :                       +- Exchange (32)
+               :                                   :                          +- * HashAggregate (31)
+               :                                   :                             +- * Project (30)
+               :                                   :                                +- * BroadcastHashJoin Inner BuildRight (29)
+               :                                   :                                   :- * Filter (27)
+               :                                   :                                   :  +- * ColumnarToRow (26)
+               :                                   :                                   :     +- Scan parquet spark_catalog.default.store_sales (25)
+               :                                   :                                   +- ReusedExchange (28)
+               :                                   +- * Sort (42)
+               :                                      +- ReusedExchange (41)
+               +- * Project (58)
+                  +- Window (57)
+                     +- * Sort (56)
+                        +- ReusedExchange (55)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -86,7 +80,7 @@ Input [3]: [ws_item_sk#1, ws_sales_price#2, ws_sold_date_sk#3]
 Input [3]: [ws_item_sk#1, ws_sales_price#2, ws_sold_date_sk#3]
 Condition : isnotnull(ws_item_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 75]
+(4) ReusedExchange [Reuses operator id: 77]
 Output [2]: [d_date_sk#5, d_date#6]
 
 (5) BroadcastHashJoin [codegen id : 2]
@@ -129,74 +123,62 @@ Arguments: [ws_item_sk#1 ASC NULLS FIRST, d_date#6 ASC NULLS FIRST], false, 0
 Input [4]: [item_sk#10, d_date#6, sumws#11, ws_item_sk#1]
 Arguments: [row_number() windowspecdefinition(ws_item_sk#1, d_date#6 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#12], [ws_item_sk#1], [d_date#6 ASC NULLS FIRST]
 
-(13) Project [codegen id : 5]
+(13) Filter [codegen id : 5]
+Input [5]: [item_sk#10, d_date#6, sumws#11, ws_item_sk#1, rk#12]
+Condition : might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(item_sk#10, 42), false)
+
+(14) Project [codegen id : 5]
 Output [4]: [item_sk#10, d_date#6, sumws#11, rk#12]
 Input [5]: [item_sk#10, d_date#6, sumws#11, ws_item_sk#1, rk#12]
 
-(14) Exchange
+(15) Exchange
 Input [4]: [item_sk#10, d_date#6, sumws#11, rk#12]
 Arguments: hashpartitioning(item_sk#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(15) Sort [codegen id : 6]
+(16) Sort [codegen id : 6]
 Input [4]: [item_sk#10, d_date#6, sumws#11, rk#12]
 Arguments: [item_sk#10 ASC NULLS FIRST], false, 0
 
-(16) ReusedExchange [Reuses operator id: 10]
-Output [4]: [item_sk#10, d_date#13, sumws#11, ws_item_sk#14]
+(17) ReusedExchange [Reuses operator id: 69]
+Output [3]: [item_sk#15, sumws#16, rk#17]
 
-(17) Sort [codegen id : 10]
-Input [4]: [item_sk#10, d_date#13, sumws#11, ws_item_sk#14]
-Arguments: [ws_item_sk#14 ASC NULLS FIRST, d_date#13 ASC NULLS FIRST], false, 0
+(18) Sort [codegen id : 12]
+Input [3]: [item_sk#15, sumws#16, rk#17]
+Arguments: [item_sk#15 ASC NULLS FIRST], false, 0
 
-(18) Window
-Input [4]: [item_sk#10, d_date#13, sumws#11, ws_item_sk#14]
-Arguments: [row_number() windowspecdefinition(ws_item_sk#14, d_date#13 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#15], [ws_item_sk#14], [d_date#13 ASC NULLS FIRST]
-
-(19) Project [codegen id : 11]
-Output [3]: [item_sk#10 AS item_sk#16, sumws#11 AS sumws#17, rk#15]
-Input [5]: [item_sk#10, d_date#13, sumws#11, ws_item_sk#14, rk#15]
-
-(20) Exchange
-Input [3]: [item_sk#16, sumws#17, rk#15]
-Arguments: hashpartitioning(item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(21) Sort [codegen id : 12]
-Input [3]: [item_sk#16, sumws#17, rk#15]
-Arguments: [item_sk#16 ASC NULLS FIRST], false, 0
-
-(22) SortMergeJoin [codegen id : 13]
+(19) SortMergeJoin [codegen id : 13]
 Left keys [1]: [item_sk#10]
-Right keys [1]: [item_sk#16]
+Right keys [1]: [item_sk#15]
 Join type: Inner
-Join condition: (rk#12 >= rk#15)
+Join condition: (rk#12 >= rk#17)
 
-(23) Project [codegen id : 13]
-Output [4]: [item_sk#10, d_date#6, sumws#11, sumws#17]
-Input [7]: [item_sk#10, d_date#6, sumws#11, rk#12, item_sk#16, sumws#17, rk#15]
+(20) Project [codegen id : 13]
+Output [4]: [item_sk#10, d_date#6, sumws#11, sumws#16]
+Input [7]: [item_sk#10, d_date#6, sumws#11, rk#12, item_sk#15, sumws#16, rk#17]
 
-(24) HashAggregate [codegen id : 13]
-Input [4]: [item_sk#10, d_date#6, sumws#11, sumws#17]
+(21) HashAggregate [codegen id : 13]
+Input [4]: [item_sk#10, d_date#6, sumws#11, sumws#16]
 Keys [3]: [item_sk#10, d_date#6, sumws#11]
-Functions [1]: [partial_sum(sumws#17)]
+Functions [1]: [partial_sum(sumws#16)]
 Aggregate Attributes [2]: [sum#18, isEmpty#19]
 Results [5]: [item_sk#10, d_date#6, sumws#11, sum#20, isEmpty#21]
 
-(25) HashAggregate [codegen id : 13]
+(22) HashAggregate [codegen id : 13]
 Input [5]: [item_sk#10, d_date#6, sumws#11, sum#20, isEmpty#21]
 Keys [3]: [item_sk#10, d_date#6, sumws#11]
-Functions [1]: [sum(sumws#17)]
-Aggregate Attributes [1]: [sum(sumws#17)#22]
-Results [3]: [item_sk#10, d_date#6, sum(sumws#17)#22 AS cume_sales#23]
+Functions [1]: [sum(sumws#16)]
+Aggregate Attributes [1]: [sum(sumws#16)#22]
+Results [3]: [item_sk#10, d_date#6, sum(sumws#16)#22 AS cume_sales#23]
 
-(26) Exchange
+(23) Exchange
 Input [3]: [item_sk#10, d_date#6, cume_sales#23]
-Arguments: hashpartitioning(item_sk#10, d_date#6, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Arguments: hashpartitioning(item_sk#10, d_date#6, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(27) Sort [codegen id : 14]
+(24) Sort [codegen id : 14]
 Input [3]: [item_sk#10, d_date#6, cume_sales#23]
 Arguments: [item_sk#10 ASC NULLS FIRST, d_date#6 ASC NULLS FIRST], false, 0
 
-(28) Scan parquet spark_catalog.default.store_sales
+(25) Scan parquet spark_catalog.default.store_sales
 Output [3]: [ss_item_sk#24, ss_sales_price#25, ss_sold_date_sk#26]
 Batched: true
 Location: InMemoryFileIndex []
@@ -204,228 +186,312 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#26), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_sales_price:decimal(7,2)>
 
-(29) ColumnarToRow [codegen id : 16]
+(26) ColumnarToRow [codegen id : 16]
 Input [3]: [ss_item_sk#24, ss_sales_price#25, ss_sold_date_sk#26]
 
-(30) Filter [codegen id : 16]
+(27) Filter [codegen id : 16]
 Input [3]: [ss_item_sk#24, ss_sales_price#25, ss_sold_date_sk#26]
 Condition : isnotnull(ss_item_sk#24)
 
-(31) ReusedExchange [Reuses operator id: 75]
+(28) ReusedExchange [Reuses operator id: 77]
 Output [2]: [d_date_sk#27, d_date#28]
 
-(32) BroadcastHashJoin [codegen id : 16]
+(29) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ss_sold_date_sk#26]
 Right keys [1]: [d_date_sk#27]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 16]
+(30) Project [codegen id : 16]
 Output [3]: [ss_item_sk#24, ss_sales_price#25, d_date#28]
 Input [5]: [ss_item_sk#24, ss_sales_price#25, ss_sold_date_sk#26, d_date_sk#27, d_date#28]
 
-(34) HashAggregate [codegen id : 16]
+(31) HashAggregate [codegen id : 16]
 Input [3]: [ss_item_sk#24, ss_sales_price#25, d_date#28]
 Keys [2]: [ss_item_sk#24, d_date#28]
 Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#25))]
 Aggregate Attributes [1]: [sum#29]
 Results [3]: [ss_item_sk#24, d_date#28, sum#30]
 
-(35) Exchange
+(32) Exchange
 Input [3]: [ss_item_sk#24, d_date#28, sum#30]
-Arguments: hashpartitioning(ss_item_sk#24, d_date#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(ss_item_sk#24, d_date#28, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(36) HashAggregate [codegen id : 17]
+(33) HashAggregate [codegen id : 17]
 Input [3]: [ss_item_sk#24, d_date#28, sum#30]
 Keys [2]: [ss_item_sk#24, d_date#28]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#25))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#25))#31]
 Results [4]: [ss_item_sk#24 AS item_sk#32, d_date#28, MakeDecimal(sum(UnscaledValue(ss_sales_price#25))#31,17,2) AS sumss#33, ss_item_sk#24]
 
-(37) Exchange
+(34) Exchange
 Input [4]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24]
-Arguments: hashpartitioning(ss_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: hashpartitioning(ss_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(38) Sort [codegen id : 18]
+(35) Sort [codegen id : 18]
 Input [4]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24]
 Arguments: [ss_item_sk#24 ASC NULLS FIRST, d_date#28 ASC NULLS FIRST], false, 0
 
-(39) Window
+(36) Window
 Input [4]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24]
 Arguments: [row_number() windowspecdefinition(ss_item_sk#24, d_date#28 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#34], [ss_item_sk#24], [d_date#28 ASC NULLS FIRST]
 
-(40) Project [codegen id : 19]
+(37) Filter [codegen id : 19]
+Input [5]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24, rk#34]
+Condition : might_contain(Subquery scalar-subquery#35, [id=#36], xxhash64(item_sk#32, 42), false)
+
+(38) Project [codegen id : 19]
 Output [4]: [item_sk#32, d_date#28, sumss#33, rk#34]
 Input [5]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24, rk#34]
 
-(41) Exchange
+(39) Exchange
 Input [4]: [item_sk#32, d_date#28, sumss#33, rk#34]
-Arguments: hashpartitioning(item_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: hashpartitioning(item_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(42) Sort [codegen id : 20]
+(40) Sort [codegen id : 20]
 Input [4]: [item_sk#32, d_date#28, sumss#33, rk#34]
 Arguments: [item_sk#32 ASC NULLS FIRST], false, 0
 
-(43) ReusedExchange [Reuses operator id: 37]
-Output [4]: [item_sk#32, d_date#35, sumss#33, ss_item_sk#36]
+(41) ReusedExchange [Reuses operator id: 82]
+Output [3]: [item_sk#37, sumss#38, rk#39]
 
-(44) Sort [codegen id : 24]
-Input [4]: [item_sk#32, d_date#35, sumss#33, ss_item_sk#36]
-Arguments: [ss_item_sk#36 ASC NULLS FIRST, d_date#35 ASC NULLS FIRST], false, 0
+(42) Sort [codegen id : 26]
+Input [3]: [item_sk#37, sumss#38, rk#39]
+Arguments: [item_sk#37 ASC NULLS FIRST], false, 0
 
-(45) Window
-Input [4]: [item_sk#32, d_date#35, sumss#33, ss_item_sk#36]
-Arguments: [row_number() windowspecdefinition(ss_item_sk#36, d_date#35 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#37], [ss_item_sk#36], [d_date#35 ASC NULLS FIRST]
-
-(46) Project [codegen id : 25]
-Output [3]: [item_sk#32 AS item_sk#38, sumss#33 AS sumss#39, rk#37]
-Input [5]: [item_sk#32, d_date#35, sumss#33, ss_item_sk#36, rk#37]
-
-(47) Exchange
-Input [3]: [item_sk#38, sumss#39, rk#37]
-Arguments: hashpartitioning(item_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(48) Sort [codegen id : 26]
-Input [3]: [item_sk#38, sumss#39, rk#37]
-Arguments: [item_sk#38 ASC NULLS FIRST], false, 0
-
-(49) SortMergeJoin [codegen id : 27]
+(43) SortMergeJoin [codegen id : 27]
 Left keys [1]: [item_sk#32]
-Right keys [1]: [item_sk#38]
+Right keys [1]: [item_sk#37]
 Join type: Inner
-Join condition: (rk#34 >= rk#37)
+Join condition: (rk#34 >= rk#39)
 
-(50) Project [codegen id : 27]
-Output [4]: [item_sk#32, d_date#28, sumss#33, sumss#39]
-Input [7]: [item_sk#32, d_date#28, sumss#33, rk#34, item_sk#38, sumss#39, rk#37]
+(44) Project [codegen id : 27]
+Output [4]: [item_sk#32, d_date#28, sumss#33, sumss#38]
+Input [7]: [item_sk#32, d_date#28, sumss#33, rk#34, item_sk#37, sumss#38, rk#39]
 
-(51) HashAggregate [codegen id : 27]
-Input [4]: [item_sk#32, d_date#28, sumss#33, sumss#39]
+(45) HashAggregate [codegen id : 27]
+Input [4]: [item_sk#32, d_date#28, sumss#33, sumss#38]
 Keys [3]: [item_sk#32, d_date#28, sumss#33]
-Functions [1]: [partial_sum(sumss#39)]
+Functions [1]: [partial_sum(sumss#38)]
 Aggregate Attributes [2]: [sum#40, isEmpty#41]
 Results [5]: [item_sk#32, d_date#28, sumss#33, sum#42, isEmpty#43]
 
-(52) HashAggregate [codegen id : 27]
+(46) HashAggregate [codegen id : 27]
 Input [5]: [item_sk#32, d_date#28, sumss#33, sum#42, isEmpty#43]
 Keys [3]: [item_sk#32, d_date#28, sumss#33]
-Functions [1]: [sum(sumss#39)]
-Aggregate Attributes [1]: [sum(sumss#39)#44]
-Results [3]: [item_sk#32, d_date#28, sum(sumss#39)#44 AS cume_sales#45]
+Functions [1]: [sum(sumss#38)]
+Aggregate Attributes [1]: [sum(sumss#38)#44]
+Results [3]: [item_sk#32, d_date#28, sum(sumss#38)#44 AS cume_sales#45]
 
-(53) Exchange
+(47) Exchange
 Input [3]: [item_sk#32, d_date#28, cume_sales#45]
-Arguments: hashpartitioning(item_sk#32, d_date#28, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Arguments: hashpartitioning(item_sk#32, d_date#28, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(54) Sort [codegen id : 28]
+(48) Sort [codegen id : 28]
 Input [3]: [item_sk#32, d_date#28, cume_sales#45]
 Arguments: [item_sk#32 ASC NULLS FIRST, d_date#28 ASC NULLS FIRST], false, 0
 
-(55) SortMergeJoin [codegen id : 29]
+(49) SortMergeJoin [codegen id : 29]
 Left keys [2]: [item_sk#10, d_date#6]
 Right keys [2]: [item_sk#32, d_date#28]
 Join type: FullOuter
 Join condition: None
 
-(56) Filter [codegen id : 29]
+(50) Filter [codegen id : 29]
 Input [6]: [item_sk#10, d_date#6, cume_sales#23, item_sk#32, d_date#28, cume_sales#45]
 Condition : isnotnull(CASE WHEN isnotnull(item_sk#10) THEN item_sk#10 ELSE item_sk#32 END)
 
-(57) Project [codegen id : 29]
+(51) Project [codegen id : 29]
 Output [4]: [CASE WHEN isnotnull(item_sk#10) THEN item_sk#10 ELSE item_sk#32 END AS item_sk#46, CASE WHEN isnotnull(d_date#6) THEN d_date#6 ELSE d_date#28 END AS d_date#47, cume_sales#23 AS web_sales#48, cume_sales#45 AS store_sales#49]
 Input [6]: [item_sk#10, d_date#6, cume_sales#23, item_sk#32, d_date#28, cume_sales#45]
 
-(58) Exchange
+(52) Exchange
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
-Arguments: hashpartitioning(item_sk#46, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Arguments: hashpartitioning(item_sk#46, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(59) Sort [codegen id : 30]
+(53) Sort [codegen id : 30]
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Arguments: [item_sk#46 ASC NULLS FIRST, d_date#47 ASC NULLS FIRST], false, 0
 
-(60) Window
+(54) Window
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Arguments: [row_number() windowspecdefinition(item_sk#46, d_date#47 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#50], [item_sk#46], [d_date#47 ASC NULLS FIRST]
 
-(61) ReusedExchange [Reuses operator id: 58]
+(55) ReusedExchange [Reuses operator id: 52]
 Output [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 
-(62) Sort [codegen id : 60]
+(56) Sort [codegen id : 60]
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Arguments: [item_sk#46 ASC NULLS FIRST, d_date#47 ASC NULLS FIRST], false, 0
 
-(63) Window
+(57) Window
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Arguments: [row_number() windowspecdefinition(item_sk#46, d_date#47 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#51], [item_sk#46], [d_date#47 ASC NULLS FIRST]
 
-(64) Project [codegen id : 61]
+(58) Project [codegen id : 61]
 Output [4]: [item_sk#46 AS item_sk#52, web_sales#48 AS web_sales#53, store_sales#49 AS store_sales#54, rk#51]
 Input [5]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, rk#51]
 
-(65) SortMergeJoin [codegen id : 62]
+(59) SortMergeJoin [codegen id : 62]
 Left keys [1]: [item_sk#46]
 Right keys [1]: [item_sk#52]
 Join type: Inner
 Join condition: (rk#50 >= rk#51)
 
-(66) Project [codegen id : 62]
+(60) Project [codegen id : 62]
 Output [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_sales#53, store_sales#54]
 Input [9]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, rk#50, item_sk#52, web_sales#53, store_sales#54, rk#51]
 
-(67) HashAggregate [codegen id : 62]
+(61) HashAggregate [codegen id : 62]
 Input [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_sales#53, store_sales#54]
 Keys [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Functions [2]: [partial_max(web_sales#53), partial_max(store_sales#54)]
 Aggregate Attributes [2]: [max#55, max#56]
 Results [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, max#57, max#58]
 
-(68) HashAggregate [codegen id : 62]
+(62) HashAggregate [codegen id : 62]
 Input [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, max#57, max#58]
 Keys [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Functions [2]: [max(web_sales#53), max(store_sales#54)]
 Aggregate Attributes [2]: [max(web_sales#53)#59, max(store_sales#54)#60]
 Results [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, max(web_sales#53)#59 AS web_cumulative#61, max(store_sales#54)#60 AS store_cumulative#62]
 
-(69) Filter [codegen id : 62]
+(63) Filter [codegen id : 62]
 Input [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_cumulative#61, store_cumulative#62]
 Condition : ((isnotnull(web_cumulative#61) AND isnotnull(store_cumulative#62)) AND (web_cumulative#61 > store_cumulative#62))
 
-(70) TakeOrderedAndProject
+(64) TakeOrderedAndProject
 Input [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_cumulative#61, store_cumulative#62]
 Arguments: 100, [item_sk#46 ASC NULLS FIRST, d_date#47 ASC NULLS FIRST], [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_cumulative#61, store_cumulative#62]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (75)
-+- * Project (74)
-   +- * Filter (73)
-      +- * ColumnarToRow (72)
-         +- Scan parquet spark_catalog.default.date_dim (71)
+Subquery:1 Hosting operator id = 13 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (72)
++- Exchange (71)
+   +- ObjectHashAggregate (70)
+      +- Exchange (69)
+         +- * Project (68)
+            +- Window (67)
+               +- * Sort (66)
+                  +- ReusedExchange (65)
 
 
-(71) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#5, d_date#6, d_month_seq#63]
+(65) ReusedExchange [Reuses operator id: 10]
+Output [4]: [item_sk#10, d_date#63, sumws#11, ws_item_sk#64]
+
+(66) Sort [codegen id : 4]
+Input [4]: [item_sk#10, d_date#63, sumws#11, ws_item_sk#64]
+Arguments: [ws_item_sk#64 ASC NULLS FIRST, d_date#63 ASC NULLS FIRST], false, 0
+
+(67) Window
+Input [4]: [item_sk#10, d_date#63, sumws#11, ws_item_sk#64]
+Arguments: [row_number() windowspecdefinition(ws_item_sk#64, d_date#63 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#17], [ws_item_sk#64], [d_date#63 ASC NULLS FIRST]
+
+(68) Project [codegen id : 5]
+Output [3]: [item_sk#10 AS item_sk#15, sumws#11 AS sumws#16, rk#17]
+Input [5]: [item_sk#10, d_date#63, sumws#11, ws_item_sk#64, rk#17]
+
+(69) Exchange
+Input [3]: [item_sk#15, sumws#16, rk#17]
+Arguments: hashpartitioning(item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(70) ObjectHashAggregate
+Input [3]: [item_sk#15, sumws#16, rk#17]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(item_sk#15, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#65]
+Results [1]: [buf#66]
+
+(71) Exchange
+Input [1]: [buf#66]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+
+(72) ObjectHashAggregate
+Input [1]: [buf#66]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(item_sk#15, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(item_sk#15, 42), 1000000, 8388608, 0, 0)#67]
+Results [1]: [bloom_filter_agg(xxhash64(item_sk#15, 42), 1000000, 8388608, 0, 0)#67 AS bloomFilter#68]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (77)
++- * Project (76)
+   +- * Filter (75)
+      +- * ColumnarToRow (74)
+         +- Scan parquet spark_catalog.default.date_dim (73)
+
+
+(73) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#5, d_date#6, d_month_seq#69]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_month_seq:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#5, d_date#6, d_month_seq#63]
+(74) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#5, d_date#6, d_month_seq#69]
 
-(73) Filter [codegen id : 1]
-Input [3]: [d_date_sk#5, d_date#6, d_month_seq#63]
-Condition : (((isnotnull(d_month_seq#63) AND (d_month_seq#63 >= 1212)) AND (d_month_seq#63 <= 1223)) AND isnotnull(d_date_sk#5))
+(75) Filter [codegen id : 1]
+Input [3]: [d_date_sk#5, d_date#6, d_month_seq#69]
+Condition : (((isnotnull(d_month_seq#69) AND (d_month_seq#69 >= 1212)) AND (d_month_seq#69 <= 1223)) AND isnotnull(d_date_sk#5))
 
-(74) Project [codegen id : 1]
+(76) Project [codegen id : 1]
 Output [2]: [d_date_sk#5, d_date#6]
-Input [3]: [d_date_sk#5, d_date#6, d_month_seq#63]
+Input [3]: [d_date_sk#5, d_date#6, d_month_seq#69]
 
-(75) BroadcastExchange
+(77) BroadcastExchange
 Input [2]: [d_date_sk#5, d_date#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
 
-Subquery:2 Hosting operator id = 28 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#4
+Subquery:3 Hosting operator id = 37 Hosting Expression = Subquery scalar-subquery#35, [id=#36]
+ObjectHashAggregate (85)
++- Exchange (84)
+   +- ObjectHashAggregate (83)
+      +- Exchange (82)
+         +- * Project (81)
+            +- Window (80)
+               +- * Sort (79)
+                  +- ReusedExchange (78)
+
+
+(78) ReusedExchange [Reuses operator id: 34]
+Output [4]: [item_sk#32, d_date#70, sumss#33, ss_item_sk#71]
+
+(79) Sort [codegen id : 4]
+Input [4]: [item_sk#32, d_date#70, sumss#33, ss_item_sk#71]
+Arguments: [ss_item_sk#71 ASC NULLS FIRST, d_date#70 ASC NULLS FIRST], false, 0
+
+(80) Window
+Input [4]: [item_sk#32, d_date#70, sumss#33, ss_item_sk#71]
+Arguments: [row_number() windowspecdefinition(ss_item_sk#71, d_date#70 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#39], [ss_item_sk#71], [d_date#70 ASC NULLS FIRST]
+
+(81) Project [codegen id : 5]
+Output [3]: [item_sk#32 AS item_sk#37, sumss#33 AS sumss#38, rk#39]
+Input [5]: [item_sk#32, d_date#70, sumss#33, ss_item_sk#71, rk#39]
+
+(82) Exchange
+Input [3]: [item_sk#37, sumss#38, rk#39]
+Arguments: hashpartitioning(item_sk#37, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(83) ObjectHashAggregate
+Input [3]: [item_sk#37, sumss#38, rk#39]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(item_sk#37, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#72]
+Results [1]: [buf#73]
+
+(84) Exchange
+Input [1]: [buf#73]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(85) ObjectHashAggregate
+Input [1]: [buf#73]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(item_sk#37, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(item_sk#37, 42), 1000000, 8388608, 0, 0)#74]
+Results [1]: [bloom_filter_agg(xxhash64(item_sk#37, 42), 1000000, 8388608, 0, 0)#74 AS bloomFilter#75]
+
+Subquery:4 Hosting operator id = 25 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#4
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/simplified.txt
@@ -32,52 +32,58 @@ TakeOrderedAndProject [item_sk,d_date,web_sales,store_sales,web_cumulative,store
                                                               Exchange [item_sk] #3
                                                                 WholeStageCodegen (5)
                                                                   Project [item_sk,d_date,sumws,rk]
-                                                                    InputAdapter
-                                                                      Window [ws_item_sk,d_date]
-                                                                        WholeStageCodegen (4)
-                                                                          Sort [ws_item_sk,d_date]
-                                                                            InputAdapter
-                                                                              Exchange [ws_item_sk] #4
-                                                                                WholeStageCodegen (3)
-                                                                                  HashAggregate [ws_item_sk,d_date,sum] [sum(UnscaledValue(ws_sales_price)),item_sk,sumws,sum]
+                                                                    Filter [item_sk]
+                                                                      Subquery #2
+                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(item_sk, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                          Exchange #7
+                                                                            ObjectHashAggregate [item_sk] [buf,buf]
+                                                                              Exchange [item_sk] #8
+                                                                                WholeStageCodegen (5)
+                                                                                  Project [item_sk,sumws,rk]
                                                                                     InputAdapter
-                                                                                      Exchange [ws_item_sk,d_date] #5
-                                                                                        WholeStageCodegen (2)
-                                                                                          HashAggregate [ws_item_sk,d_date,ws_sales_price] [sum,sum]
-                                                                                            Project [ws_item_sk,ws_sales_price,d_date]
-                                                                                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                Filter [ws_item_sk]
-                                                                                                  ColumnarToRow
-                                                                                                    InputAdapter
-                                                                                                      Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_sales_price,ws_sold_date_sk]
-                                                                                                        SubqueryBroadcast [d_date_sk] #1
-                                                                                                          BroadcastExchange #6
-                                                                                                            WholeStageCodegen (1)
-                                                                                                              Project [d_date_sk,d_date]
-                                                                                                                Filter [d_month_seq,d_date_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date,d_month_seq]
-                                                                                                InputAdapter
-                                                                                                  ReusedExchange [d_date_sk,d_date] #6
+                                                                                      Window [ws_item_sk,d_date]
+                                                                                        WholeStageCodegen (4)
+                                                                                          Sort [ws_item_sk,d_date]
+                                                                                            InputAdapter
+                                                                                              ReusedExchange [item_sk,d_date,sumws,ws_item_sk] #4
+                                                                      InputAdapter
+                                                                        Window [ws_item_sk,d_date]
+                                                                          WholeStageCodegen (4)
+                                                                            Sort [ws_item_sk,d_date]
+                                                                              InputAdapter
+                                                                                Exchange [ws_item_sk] #4
+                                                                                  WholeStageCodegen (3)
+                                                                                    HashAggregate [ws_item_sk,d_date,sum] [sum(UnscaledValue(ws_sales_price)),item_sk,sumws,sum]
+                                                                                      InputAdapter
+                                                                                        Exchange [ws_item_sk,d_date] #5
+                                                                                          WholeStageCodegen (2)
+                                                                                            HashAggregate [ws_item_sk,d_date,ws_sales_price] [sum,sum]
+                                                                                              Project [ws_item_sk,ws_sales_price,d_date]
+                                                                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                                  Filter [ws_item_sk]
+                                                                                                    ColumnarToRow
+                                                                                                      InputAdapter
+                                                                                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_sales_price,ws_sold_date_sk]
+                                                                                                          SubqueryBroadcast [d_date_sk] #1
+                                                                                                            BroadcastExchange #6
+                                                                                                              WholeStageCodegen (1)
+                                                                                                                Project [d_date_sk,d_date]
+                                                                                                                  Filter [d_month_seq,d_date_sk]
+                                                                                                                    ColumnarToRow
+                                                                                                                      InputAdapter
+                                                                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date,d_month_seq]
+                                                                                                  InputAdapter
+                                                                                                    ReusedExchange [d_date_sk,d_date] #6
                                                       InputAdapter
                                                         WholeStageCodegen (12)
                                                           Sort [item_sk]
                                                             InputAdapter
-                                                              Exchange [item_sk] #7
-                                                                WholeStageCodegen (11)
-                                                                  Project [item_sk,sumws,rk]
-                                                                    InputAdapter
-                                                                      Window [ws_item_sk,d_date]
-                                                                        WholeStageCodegen (10)
-                                                                          Sort [ws_item_sk,d_date]
-                                                                            InputAdapter
-                                                                              ReusedExchange [item_sk,d_date,sumws,ws_item_sk] #4
+                                                              ReusedExchange [item_sk,sumws,rk] #8
                                   InputAdapter
                                     WholeStageCodegen (28)
                                       Sort [item_sk,d_date]
                                         InputAdapter
-                                          Exchange [item_sk,d_date] #8
+                                          Exchange [item_sk,d_date] #9
                                             WholeStageCodegen (27)
                                               HashAggregate [item_sk,d_date,sumss,sum,isEmpty] [sum(sumss),cume_sales,sum,isEmpty]
                                                 HashAggregate [item_sk,d_date,sumss,sumss] [sum,isEmpty,sum,isEmpty]
@@ -87,43 +93,49 @@ TakeOrderedAndProject [item_sk,d_date,web_sales,store_sales,web_cumulative,store
                                                         WholeStageCodegen (20)
                                                           Sort [item_sk]
                                                             InputAdapter
-                                                              Exchange [item_sk] #9
+                                                              Exchange [item_sk] #10
                                                                 WholeStageCodegen (19)
                                                                   Project [item_sk,d_date,sumss,rk]
-                                                                    InputAdapter
-                                                                      Window [ss_item_sk,d_date]
-                                                                        WholeStageCodegen (18)
-                                                                          Sort [ss_item_sk,d_date]
-                                                                            InputAdapter
-                                                                              Exchange [ss_item_sk] #10
-                                                                                WholeStageCodegen (17)
-                                                                                  HashAggregate [ss_item_sk,d_date,sum] [sum(UnscaledValue(ss_sales_price)),item_sk,sumss,sum]
+                                                                    Filter [item_sk]
+                                                                      Subquery #3
+                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(item_sk, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                          Exchange #13
+                                                                            ObjectHashAggregate [item_sk] [buf,buf]
+                                                                              Exchange [item_sk] #14
+                                                                                WholeStageCodegen (5)
+                                                                                  Project [item_sk,sumss,rk]
                                                                                     InputAdapter
-                                                                                      Exchange [ss_item_sk,d_date] #11
-                                                                                        WholeStageCodegen (16)
-                                                                                          HashAggregate [ss_item_sk,d_date,ss_sales_price] [sum,sum]
-                                                                                            Project [ss_item_sk,ss_sales_price,d_date]
-                                                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                Filter [ss_item_sk]
-                                                                                                  ColumnarToRow
-                                                                                                    InputAdapter
-                                                                                                      Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sales_price,ss_sold_date_sk]
-                                                                                                        ReusedSubquery [d_date_sk] #1
-                                                                                                InputAdapter
-                                                                                                  ReusedExchange [d_date_sk,d_date] #6
+                                                                                      Window [ss_item_sk,d_date]
+                                                                                        WholeStageCodegen (4)
+                                                                                          Sort [ss_item_sk,d_date]
+                                                                                            InputAdapter
+                                                                                              ReusedExchange [item_sk,d_date,sumss,ss_item_sk] #11
+                                                                      InputAdapter
+                                                                        Window [ss_item_sk,d_date]
+                                                                          WholeStageCodegen (18)
+                                                                            Sort [ss_item_sk,d_date]
+                                                                              InputAdapter
+                                                                                Exchange [ss_item_sk] #11
+                                                                                  WholeStageCodegen (17)
+                                                                                    HashAggregate [ss_item_sk,d_date,sum] [sum(UnscaledValue(ss_sales_price)),item_sk,sumss,sum]
+                                                                                      InputAdapter
+                                                                                        Exchange [ss_item_sk,d_date] #12
+                                                                                          WholeStageCodegen (16)
+                                                                                            HashAggregate [ss_item_sk,d_date,ss_sales_price] [sum,sum]
+                                                                                              Project [ss_item_sk,ss_sales_price,d_date]
+                                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                  Filter [ss_item_sk]
+                                                                                                    ColumnarToRow
+                                                                                                      InputAdapter
+                                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sales_price,ss_sold_date_sk]
+                                                                                                          ReusedSubquery [d_date_sk] #1
+                                                                                                  InputAdapter
+                                                                                                    ReusedExchange [d_date_sk,d_date] #6
                                                       InputAdapter
                                                         WholeStageCodegen (26)
                                                           Sort [item_sk]
                                                             InputAdapter
-                                                              Exchange [item_sk] #12
-                                                                WholeStageCodegen (25)
-                                                                  Project [item_sk,sumss,rk]
-                                                                    InputAdapter
-                                                                      Window [ss_item_sk,d_date]
-                                                                        WholeStageCodegen (24)
-                                                                          Sort [ss_item_sk,d_date]
-                                                                            InputAdapter
-                                                                              ReusedExchange [item_sk,d_date,sumss,ss_item_sk] #10
+                                                              ReusedExchange [item_sk,sumss,rk] #14
               InputAdapter
                 WholeStageCodegen (61)
                   Project [item_sk,web_sales,store_sales,rk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/explain.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
-TakeOrderedAndProject (52)
-+- * Project (51)
-   +- * SortMergeJoin Inner (50)
-      :- * Project (43)
-      :  +- * SortMergeJoin Inner (42)
+TakeOrderedAndProject (89)
++- * Project (88)
+   +- * SortMergeJoin Inner (87)
+      :- * Project (62)
+      :  +- * SortMergeJoin Inner (61)
       :     :- * Sort (33)
       :     :  +- Exchange (32)
       :     :     +- * Project (31)
@@ -37,20 +37,57 @@ TakeOrderedAndProject (52)
       :     :                                               +- * Filter (17)
       :     :                                                  +- * ColumnarToRow (16)
       :     :                                                     +- Scan parquet spark_catalog.default.item (15)
-      :     +- * Sort (41)
-      :        +- Exchange (40)
-      :           +- * Project (39)
-      :              +- Window (38)
-      :                 +- * Sort (37)
-      :                    +- Exchange (36)
-      :                       +- * HashAggregate (35)
-      :                          +- ReusedExchange (34)
-      +- * Sort (49)
-         +- Exchange (48)
-            +- * Project (47)
-               +- Window (46)
-                  +- * Sort (45)
-                     +- ReusedExchange (44)
+      :     +- * Sort (60)
+      :        +- Exchange (59)
+      :           +- * Project (58)
+      :              +- Window (57)
+      :                 +- * Sort (56)
+      :                    +- Exchange (55)
+      :                       +- * HashAggregate (54)
+      :                          +- Exchange (53)
+      :                             +- * HashAggregate (52)
+      :                                +- * Project (51)
+      :                                   +- * SortMergeJoin Inner (50)
+      :                                      :- * Sort (47)
+      :                                      :  +- Exchange (46)
+      :                                      :     +- * Project (45)
+      :                                      :        +- * BroadcastHashJoin Inner BuildRight (44)
+      :                                      :           :- * Project (39)
+      :                                      :           :  +- * BroadcastHashJoin Inner BuildRight (38)
+      :                                      :           :     :- * Filter (36)
+      :                                      :           :     :  +- * ColumnarToRow (35)
+      :                                      :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (34)
+      :                                      :           :     +- ReusedExchange (37)
+      :                                      :           +- BroadcastExchange (43)
+      :                                      :              +- * Filter (42)
+      :                                      :                 +- * ColumnarToRow (41)
+      :                                      :                    +- Scan parquet spark_catalog.default.call_center (40)
+      :                                      +- * Sort (49)
+      :                                         +- ReusedExchange (48)
+      +- * Sort (86)
+         +- Exchange (85)
+            +- * Project (84)
+               +- Window (83)
+                  +- * Sort (82)
+                     +- Exchange (81)
+                        +- * HashAggregate (80)
+                           +- Exchange (79)
+                              +- * HashAggregate (78)
+                                 +- * Project (77)
+                                    +- * SortMergeJoin Inner (76)
+                                       :- * Sort (73)
+                                       :  +- Exchange (72)
+                                       :     +- * Project (71)
+                                       :        +- * BroadcastHashJoin Inner BuildRight (70)
+                                       :           :- * Project (68)
+                                       :           :  +- * BroadcastHashJoin Inner BuildRight (67)
+                                       :           :     :- * Filter (65)
+                                       :           :     :  +- * ColumnarToRow (64)
+                                       :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (63)
+                                       :           :     +- ReusedExchange (66)
+                                       :           +- ReusedExchange (69)
+                                       +- * Sort (75)
+                                          +- ReusedExchange (74)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -66,249 +103,521 @@ Input [4]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, cs_sold_date_sk
 
 (3) Filter [codegen id : 3]
 Input [4]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, cs_sold_date_sk#4]
-Condition : (isnotnull(cs_item_sk#2) AND isnotnull(cs_call_center_sk#1))
+Condition : ((isnotnull(cs_item_sk#2) AND isnotnull(cs_call_center_sk#1)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(cs_item_sk#2, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 56]
-Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(4) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#8, d_year#9, d_moy#10]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
+Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
-Output [5]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8]
-Input [7]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, cs_sold_date_sk#4, d_date_sk#6, d_year#7, d_moy#8]
+Output [5]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10]
+Input [7]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, cs_sold_date_sk#4, d_date_sk#8, d_year#9, d_moy#10]
 
 (7) Scan parquet spark_catalog.default.call_center
-Output [2]: [cc_call_center_sk#9, cc_name#10]
+Output [2]: [cc_call_center_sk#11, cc_name#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/call_center]
 PushedFilters: [IsNotNull(cc_call_center_sk), IsNotNull(cc_name)]
 ReadSchema: struct<cc_call_center_sk:int,cc_name:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [cc_call_center_sk#9, cc_name#10]
+Input [2]: [cc_call_center_sk#11, cc_name#12]
 
 (9) Filter [codegen id : 2]
-Input [2]: [cc_call_center_sk#9, cc_name#10]
-Condition : (isnotnull(cc_call_center_sk#9) AND isnotnull(cc_name#10))
+Input [2]: [cc_call_center_sk#11, cc_name#12]
+Condition : ((isnotnull(cc_call_center_sk#11) AND isnotnull(cc_name#12)) AND true)
 
 (10) BroadcastExchange
-Input [2]: [cc_call_center_sk#9, cc_name#10]
+Input [2]: [cc_call_center_sk#11, cc_name#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_call_center_sk#1]
-Right keys [1]: [cc_call_center_sk#9]
+Right keys [1]: [cc_call_center_sk#11]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [5]: [cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
-Input [7]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_call_center_sk#9, cc_name#10]
+Output [5]: [cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
+Input [7]: [cs_call_center_sk#1, cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_call_center_sk#11, cc_name#12]
 
 (13) Exchange
-Input [5]: [cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
+Input [5]: [cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
 Arguments: hashpartitioning(cs_item_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [5]: [cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
+Input [5]: [cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
 Arguments: [cs_item_sk#2 ASC NULLS FIRST], false, 0
 
 (15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#11, i_brand#12, i_category#13]
+Output [3]: [i_item_sk#13, i_brand#14, i_category#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
 
 (16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#11, i_brand#12, i_category#13]
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
 
 (17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#11, i_brand#12, i_category#13]
-Condition : ((isnotnull(i_item_sk#11) AND isnotnull(i_category#13)) AND isnotnull(i_brand#12))
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Condition : ((((isnotnull(i_item_sk#13) AND isnotnull(i_category#15)) AND isnotnull(i_brand#14)) AND true) AND true)
 
 (18) Exchange
-Input [3]: [i_item_sk#11, i_brand#12, i_category#13]
-Arguments: hashpartitioning(i_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#11, i_brand#12, i_category#13]
-Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
 
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [i_item_sk#11]
+Right keys [1]: [i_item_sk#13]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
-Output [6]: [i_brand#12, i_category#13, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
-Input [8]: [cs_item_sk#2, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10, i_item_sk#11, i_brand#12, i_category#13]
+Output [6]: [i_brand#14, i_category#15, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
+Input [8]: [cs_item_sk#2, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12, i_item_sk#13, i_brand#14, i_category#15]
 
 (22) HashAggregate [codegen id : 7]
-Input [6]: [i_brand#12, i_category#13, cs_sales_price#3, d_year#7, d_moy#8, cc_name#10]
-Keys [5]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8]
+Input [6]: [i_brand#14, i_category#15, cs_sales_price#3, d_year#9, d_moy#10, cc_name#12]
+Keys [5]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10]
 Functions [1]: [partial_sum(UnscaledValue(cs_sales_price#3))]
-Aggregate Attributes [1]: [sum#14]
-Results [6]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum#15]
+Aggregate Attributes [1]: [sum#16]
+Results [6]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum#17]
 
 (23) Exchange
-Input [6]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum#15]
-Arguments: hashpartitioning(i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [6]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum#17]
+Arguments: hashpartitioning(i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) HashAggregate [codegen id : 8]
-Input [6]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum#15]
-Keys [5]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8]
+Input [6]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum#17]
+Keys [5]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10]
 Functions [1]: [sum(UnscaledValue(cs_sales_price#3))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#3))#16]
-Results [7]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#16,17,2) AS sum_sales#17, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#16,17,2) AS _w0#18]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#3))#18]
+Results [7]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#18,17,2) AS sum_sales#19, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#18,17,2) AS _w0#20]
 
 (25) Exchange
-Input [7]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18]
-Arguments: hashpartitioning(i_category#13, i_brand#12, cc_name#10, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [7]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20]
+Arguments: hashpartitioning(i_category#15, i_brand#14, cc_name#12, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (26) Sort [codegen id : 9]
-Input [7]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18]
-Arguments: [i_category#13 ASC NULLS FIRST, i_brand#12 ASC NULLS FIRST, cc_name#10 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], false, 0
+Input [7]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20]
+Arguments: [i_category#15 ASC NULLS FIRST, i_brand#14 ASC NULLS FIRST, cc_name#12 ASC NULLS FIRST, d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST], false, 0
 
 (27) Window
-Input [7]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18]
-Arguments: [rank(d_year#7, d_moy#8) windowspecdefinition(i_category#13, i_brand#12, cc_name#10, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#19], [i_category#13, i_brand#12, cc_name#10], [d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST]
+Input [7]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20]
+Arguments: [rank(d_year#9, d_moy#10) windowspecdefinition(i_category#15, i_brand#14, cc_name#12, d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#21], [i_category#15, i_brand#14, cc_name#12], [d_year#9 ASC NULLS FIRST, d_moy#10 ASC NULLS FIRST]
 
 (28) Filter [codegen id : 10]
-Input [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18, rn#19]
-Condition : (isnotnull(d_year#7) AND (d_year#7 = 1999))
+Input [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20, rn#21]
+Condition : (isnotnull(d_year#9) AND (d_year#9 = 1999))
 
 (29) Window
-Input [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18, rn#19]
-Arguments: [avg(_w0#18) windowspecdefinition(i_category#13, i_brand#12, cc_name#10, d_year#7, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#20], [i_category#13, i_brand#12, cc_name#10, d_year#7]
+Input [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20, rn#21]
+Arguments: [avg(_w0#20) windowspecdefinition(i_category#15, i_brand#14, cc_name#12, d_year#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#22], [i_category#15, i_brand#14, cc_name#12, d_year#9]
 
 (30) Filter [codegen id : 11]
-Input [9]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18, rn#19, avg_monthly_sales#20]
-Condition : ((isnotnull(avg_monthly_sales#20) AND (avg_monthly_sales#20 > 0.000000)) AND CASE WHEN (avg_monthly_sales#20 > 0.000000) THEN ((abs((sum_sales#17 - avg_monthly_sales#20)) / avg_monthly_sales#20) > 0.1000000000000000) END)
+Input [9]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20, rn#21, avg_monthly_sales#22]
+Condition : ((isnotnull(avg_monthly_sales#22) AND (avg_monthly_sales#22 > 0.000000)) AND CASE WHEN (avg_monthly_sales#22 > 0.000000) THEN ((abs((sum_sales#19 - avg_monthly_sales#22)) / avg_monthly_sales#22) > 0.1000000000000000) END)
 
 (31) Project [codegen id : 11]
-Output [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19]
-Input [9]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, _w0#18, rn#19, avg_monthly_sales#20]
+Output [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21]
+Input [9]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, _w0#20, rn#21, avg_monthly_sales#22]
 
 (32) Exchange
-Input [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19]
-Arguments: hashpartitioning(i_category#13, i_brand#12, cc_name#10, rn#19, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21]
+Arguments: hashpartitioning(i_category#15, i_brand#14, cc_name#12, rn#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (33) Sort [codegen id : 12]
-Input [8]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19]
-Arguments: [i_category#13 ASC NULLS FIRST, i_brand#12 ASC NULLS FIRST, cc_name#10 ASC NULLS FIRST, rn#19 ASC NULLS FIRST], false, 0
+Input [8]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21]
+Arguments: [i_category#15 ASC NULLS FIRST, i_brand#14 ASC NULLS FIRST, cc_name#12 ASC NULLS FIRST, rn#21 ASC NULLS FIRST], false, 0
 
-(34) ReusedExchange [Reuses operator id: 23]
-Output [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum#26]
+(34) Scan parquet spark_catalog.default.catalog_sales
+Output [4]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, cs_sold_date_sk#26]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#26), dynamicpruningexpression(cs_sold_date_sk#26 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_call_center_sk)]
+ReadSchema: struct<cs_call_center_sk:int,cs_item_sk:int,cs_sales_price:decimal(7,2)>
 
-(35) HashAggregate [codegen id : 20]
-Input [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum#26]
-Keys [5]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25]
-Functions [1]: [sum(UnscaledValue(cs_sales_price#27))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#27))#16]
-Results [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, MakeDecimal(sum(UnscaledValue(cs_sales_price#27))#16,17,2) AS sum_sales#17]
+(35) ColumnarToRow [codegen id : 15]
+Input [4]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, cs_sold_date_sk#26]
 
-(36) Exchange
-Input [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum_sales#17]
-Arguments: hashpartitioning(i_category#21, i_brand#22, cc_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(36) Filter [codegen id : 15]
+Input [4]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, cs_sold_date_sk#26]
+Condition : ((isnotnull(cs_item_sk#24) AND isnotnull(cs_call_center_sk#23)) AND might_contain(Subquery scalar-subquery#27, [id=#28], xxhash64(cs_item_sk#24, 42), false))
 
-(37) Sort [codegen id : 21]
-Input [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum_sales#17]
-Arguments: [i_category#21 ASC NULLS FIRST, i_brand#22 ASC NULLS FIRST, cc_name#23 ASC NULLS FIRST, d_year#24 ASC NULLS FIRST, d_moy#25 ASC NULLS FIRST], false, 0
+(37) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#29, d_year#30, d_moy#31]
 
-(38) Window
-Input [6]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum_sales#17]
-Arguments: [rank(d_year#24, d_moy#25) windowspecdefinition(i_category#21, i_brand#22, cc_name#23, d_year#24 ASC NULLS FIRST, d_moy#25 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#28], [i_category#21, i_brand#22, cc_name#23], [d_year#24 ASC NULLS FIRST, d_moy#25 ASC NULLS FIRST]
-
-(39) Project [codegen id : 22]
-Output [5]: [i_category#21, i_brand#22, cc_name#23, sum_sales#17 AS sum_sales#29, rn#28]
-Input [7]: [i_category#21, i_brand#22, cc_name#23, d_year#24, d_moy#25, sum_sales#17, rn#28]
-
-(40) Exchange
-Input [5]: [i_category#21, i_brand#22, cc_name#23, sum_sales#29, rn#28]
-Arguments: hashpartitioning(i_category#21, i_brand#22, cc_name#23, (rn#28 + 1), 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(41) Sort [codegen id : 23]
-Input [5]: [i_category#21, i_brand#22, cc_name#23, sum_sales#29, rn#28]
-Arguments: [i_category#21 ASC NULLS FIRST, i_brand#22 ASC NULLS FIRST, cc_name#23 ASC NULLS FIRST, (rn#28 + 1) ASC NULLS FIRST], false, 0
-
-(42) SortMergeJoin [codegen id : 24]
-Left keys [4]: [i_category#13, i_brand#12, cc_name#10, rn#19]
-Right keys [4]: [i_category#21, i_brand#22, cc_name#23, (rn#28 + 1)]
+(38) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [cs_sold_date_sk#26]
+Right keys [1]: [d_date_sk#29]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 24]
-Output [9]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19, sum_sales#29]
-Input [13]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19, i_category#21, i_brand#22, cc_name#23, sum_sales#29, rn#28]
+(39) Project [codegen id : 15]
+Output [5]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31]
+Input [7]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, cs_sold_date_sk#26, d_date_sk#29, d_year#30, d_moy#31]
 
-(44) ReusedExchange [Reuses operator id: 36]
-Output [6]: [i_category#30, i_brand#31, cc_name#32, d_year#33, d_moy#34, sum_sales#17]
+(40) Scan parquet spark_catalog.default.call_center
+Output [2]: [cc_call_center_sk#32, cc_name#33]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/call_center]
+PushedFilters: [IsNotNull(cc_call_center_sk), IsNotNull(cc_name)]
+ReadSchema: struct<cc_call_center_sk:int,cc_name:string>
 
-(45) Sort [codegen id : 33]
-Input [6]: [i_category#30, i_brand#31, cc_name#32, d_year#33, d_moy#34, sum_sales#17]
-Arguments: [i_category#30 ASC NULLS FIRST, i_brand#31 ASC NULLS FIRST, cc_name#32 ASC NULLS FIRST, d_year#33 ASC NULLS FIRST, d_moy#34 ASC NULLS FIRST], false, 0
+(41) ColumnarToRow [codegen id : 14]
+Input [2]: [cc_call_center_sk#32, cc_name#33]
 
-(46) Window
-Input [6]: [i_category#30, i_brand#31, cc_name#32, d_year#33, d_moy#34, sum_sales#17]
-Arguments: [rank(d_year#33, d_moy#34) windowspecdefinition(i_category#30, i_brand#31, cc_name#32, d_year#33 ASC NULLS FIRST, d_moy#34 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#35], [i_category#30, i_brand#31, cc_name#32], [d_year#33 ASC NULLS FIRST, d_moy#34 ASC NULLS FIRST]
+(42) Filter [codegen id : 14]
+Input [2]: [cc_call_center_sk#32, cc_name#33]
+Condition : (isnotnull(cc_call_center_sk#32) AND isnotnull(cc_name#33))
 
-(47) Project [codegen id : 34]
-Output [5]: [i_category#30, i_brand#31, cc_name#32, sum_sales#17 AS sum_sales#36, rn#35]
-Input [7]: [i_category#30, i_brand#31, cc_name#32, d_year#33, d_moy#34, sum_sales#17, rn#35]
+(43) BroadcastExchange
+Input [2]: [cc_call_center_sk#32, cc_name#33]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(48) Exchange
-Input [5]: [i_category#30, i_brand#31, cc_name#32, sum_sales#36, rn#35]
-Arguments: hashpartitioning(i_category#30, i_brand#31, cc_name#32, (rn#35 - 1), 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(49) Sort [codegen id : 35]
-Input [5]: [i_category#30, i_brand#31, cc_name#32, sum_sales#36, rn#35]
-Arguments: [i_category#30 ASC NULLS FIRST, i_brand#31 ASC NULLS FIRST, cc_name#32 ASC NULLS FIRST, (rn#35 - 1) ASC NULLS FIRST], false, 0
-
-(50) SortMergeJoin [codegen id : 36]
-Left keys [4]: [i_category#13, i_brand#12, cc_name#10, rn#19]
-Right keys [4]: [i_category#30, i_brand#31, cc_name#32, (rn#35 - 1)]
+(44) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [cs_call_center_sk#23]
+Right keys [1]: [cc_call_center_sk#32]
 Join type: Inner
 Join condition: None
 
-(51) Project [codegen id : 36]
-Output [8]: [i_category#13, i_brand#12, d_year#7, d_moy#8, avg_monthly_sales#20, sum_sales#17, sum_sales#29 AS psum#37, sum_sales#36 AS nsum#38]
-Input [14]: [i_category#13, i_brand#12, cc_name#10, d_year#7, d_moy#8, sum_sales#17, avg_monthly_sales#20, rn#19, sum_sales#29, i_category#30, i_brand#31, cc_name#32, sum_sales#36, rn#35]
+(45) Project [codegen id : 15]
+Output [5]: [cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Input [7]: [cs_call_center_sk#23, cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_call_center_sk#32, cc_name#33]
 
-(52) TakeOrderedAndProject
-Input [8]: [i_category#13, i_brand#12, d_year#7, d_moy#8, avg_monthly_sales#20, sum_sales#17, psum#37, nsum#38]
-Arguments: 100, [(sum_sales#17 - avg_monthly_sales#20) ASC NULLS FIRST, d_year#7 ASC NULLS FIRST], [i_category#13, i_brand#12, d_year#7, d_moy#8, avg_monthly_sales#20, sum_sales#17, psum#37, nsum#38]
+(46) Exchange
+Input [5]: [cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Arguments: hashpartitioning(cs_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(47) Sort [codegen id : 16]
+Input [5]: [cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Arguments: [cs_item_sk#24 ASC NULLS FIRST], false, 0
+
+(48) ReusedExchange [Reuses operator id: 104]
+Output [3]: [i_item_sk#34, i_brand#35, i_category#36]
+
+(49) Sort [codegen id : 18]
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Arguments: [i_item_sk#34 ASC NULLS FIRST], false, 0
+
+(50) SortMergeJoin [codegen id : 19]
+Left keys [1]: [cs_item_sk#24]
+Right keys [1]: [i_item_sk#34]
+Join type: Inner
+Join condition: None
+
+(51) Project [codegen id : 19]
+Output [6]: [i_brand#35, i_category#36, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Input [8]: [cs_item_sk#24, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33, i_item_sk#34, i_brand#35, i_category#36]
+
+(52) HashAggregate [codegen id : 19]
+Input [6]: [i_brand#35, i_category#36, cs_sales_price#25, d_year#30, d_moy#31, cc_name#33]
+Keys [5]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31]
+Functions [1]: [partial_sum(UnscaledValue(cs_sales_price#25))]
+Aggregate Attributes [1]: [sum#37]
+Results [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum#38]
+
+(53) Exchange
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum#38]
+Arguments: hashpartitioning(i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) HashAggregate [codegen id : 20]
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum#38]
+Keys [5]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31]
+Functions [1]: [sum(UnscaledValue(cs_sales_price#25))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#25))#18]
+Results [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, MakeDecimal(sum(UnscaledValue(cs_sales_price#25))#18,17,2) AS sum_sales#19]
+
+(55) Exchange
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum_sales#19]
+Arguments: hashpartitioning(i_category#36, i_brand#35, cc_name#33, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(56) Sort [codegen id : 21]
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum_sales#19]
+Arguments: [i_category#36 ASC NULLS FIRST, i_brand#35 ASC NULLS FIRST, cc_name#33 ASC NULLS FIRST, d_year#30 ASC NULLS FIRST, d_moy#31 ASC NULLS FIRST], false, 0
+
+(57) Window
+Input [6]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum_sales#19]
+Arguments: [rank(d_year#30, d_moy#31) windowspecdefinition(i_category#36, i_brand#35, cc_name#33, d_year#30 ASC NULLS FIRST, d_moy#31 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#39], [i_category#36, i_brand#35, cc_name#33], [d_year#30 ASC NULLS FIRST, d_moy#31 ASC NULLS FIRST]
+
+(58) Project [codegen id : 22]
+Output [5]: [i_category#36, i_brand#35, cc_name#33, sum_sales#19 AS sum_sales#40, rn#39]
+Input [7]: [i_category#36, i_brand#35, cc_name#33, d_year#30, d_moy#31, sum_sales#19, rn#39]
+
+(59) Exchange
+Input [5]: [i_category#36, i_brand#35, cc_name#33, sum_sales#40, rn#39]
+Arguments: hashpartitioning(i_category#36, i_brand#35, cc_name#33, (rn#39 + 1), 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(60) Sort [codegen id : 23]
+Input [5]: [i_category#36, i_brand#35, cc_name#33, sum_sales#40, rn#39]
+Arguments: [i_category#36 ASC NULLS FIRST, i_brand#35 ASC NULLS FIRST, cc_name#33 ASC NULLS FIRST, (rn#39 + 1) ASC NULLS FIRST], false, 0
+
+(61) SortMergeJoin [codegen id : 24]
+Left keys [4]: [i_category#15, i_brand#14, cc_name#12, rn#21]
+Right keys [4]: [i_category#36, i_brand#35, cc_name#33, (rn#39 + 1)]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 24]
+Output [9]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21, sum_sales#40]
+Input [13]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21, i_category#36, i_brand#35, cc_name#33, sum_sales#40, rn#39]
+
+(63) Scan parquet spark_catalog.default.catalog_sales
+Output [4]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, cs_sold_date_sk#44]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#44), dynamicpruningexpression(cs_sold_date_sk#44 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_call_center_sk)]
+ReadSchema: struct<cs_call_center_sk:int,cs_item_sk:int,cs_sales_price:decimal(7,2)>
+
+(64) ColumnarToRow [codegen id : 27]
+Input [4]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, cs_sold_date_sk#44]
+
+(65) Filter [codegen id : 27]
+Input [4]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, cs_sold_date_sk#44]
+Condition : ((isnotnull(cs_item_sk#42) AND isnotnull(cs_call_center_sk#41)) AND might_contain(ReusedSubquery Subquery scalar-subquery#6, [id=#7], xxhash64(cs_item_sk#42, 42), false))
+
+(66) ReusedExchange [Reuses operator id: 100]
+Output [3]: [d_date_sk#45, d_year#46, d_moy#47]
+
+(67) BroadcastHashJoin [codegen id : 27]
+Left keys [1]: [cs_sold_date_sk#44]
+Right keys [1]: [d_date_sk#45]
+Join type: Inner
+Join condition: None
+
+(68) Project [codegen id : 27]
+Output [5]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47]
+Input [7]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, cs_sold_date_sk#44, d_date_sk#45, d_year#46, d_moy#47]
+
+(69) ReusedExchange [Reuses operator id: 43]
+Output [2]: [cc_call_center_sk#48, cc_name#49]
+
+(70) BroadcastHashJoin [codegen id : 27]
+Left keys [1]: [cs_call_center_sk#41]
+Right keys [1]: [cc_call_center_sk#48]
+Join type: Inner
+Join condition: None
+
+(71) Project [codegen id : 27]
+Output [5]: [cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Input [7]: [cs_call_center_sk#41, cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_call_center_sk#48, cc_name#49]
+
+(72) Exchange
+Input [5]: [cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Arguments: hashpartitioning(cs_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(73) Sort [codegen id : 28]
+Input [5]: [cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Arguments: [cs_item_sk#42 ASC NULLS FIRST], false, 0
+
+(74) ReusedExchange [Reuses operator id: 104]
+Output [3]: [i_item_sk#50, i_brand#51, i_category#52]
+
+(75) Sort [codegen id : 30]
+Input [3]: [i_item_sk#50, i_brand#51, i_category#52]
+Arguments: [i_item_sk#50 ASC NULLS FIRST], false, 0
+
+(76) SortMergeJoin [codegen id : 31]
+Left keys [1]: [cs_item_sk#42]
+Right keys [1]: [i_item_sk#50]
+Join type: Inner
+Join condition: None
+
+(77) Project [codegen id : 31]
+Output [6]: [i_brand#51, i_category#52, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Input [8]: [cs_item_sk#42, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49, i_item_sk#50, i_brand#51, i_category#52]
+
+(78) HashAggregate [codegen id : 31]
+Input [6]: [i_brand#51, i_category#52, cs_sales_price#43, d_year#46, d_moy#47, cc_name#49]
+Keys [5]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47]
+Functions [1]: [partial_sum(UnscaledValue(cs_sales_price#43))]
+Aggregate Attributes [1]: [sum#53]
+Results [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum#54]
+
+(79) Exchange
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum#54]
+Arguments: hashpartitioning(i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(80) HashAggregate [codegen id : 32]
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum#54]
+Keys [5]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47]
+Functions [1]: [sum(UnscaledValue(cs_sales_price#43))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#43))#18]
+Results [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, MakeDecimal(sum(UnscaledValue(cs_sales_price#43))#18,17,2) AS sum_sales#19]
+
+(81) Exchange
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum_sales#19]
+Arguments: hashpartitioning(i_category#52, i_brand#51, cc_name#49, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(82) Sort [codegen id : 33]
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum_sales#19]
+Arguments: [i_category#52 ASC NULLS FIRST, i_brand#51 ASC NULLS FIRST, cc_name#49 ASC NULLS FIRST, d_year#46 ASC NULLS FIRST, d_moy#47 ASC NULLS FIRST], false, 0
+
+(83) Window
+Input [6]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum_sales#19]
+Arguments: [rank(d_year#46, d_moy#47) windowspecdefinition(i_category#52, i_brand#51, cc_name#49, d_year#46 ASC NULLS FIRST, d_moy#47 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#55], [i_category#52, i_brand#51, cc_name#49], [d_year#46 ASC NULLS FIRST, d_moy#47 ASC NULLS FIRST]
+
+(84) Project [codegen id : 34]
+Output [5]: [i_category#52, i_brand#51, cc_name#49, sum_sales#19 AS sum_sales#56, rn#55]
+Input [7]: [i_category#52, i_brand#51, cc_name#49, d_year#46, d_moy#47, sum_sales#19, rn#55]
+
+(85) Exchange
+Input [5]: [i_category#52, i_brand#51, cc_name#49, sum_sales#56, rn#55]
+Arguments: hashpartitioning(i_category#52, i_brand#51, cc_name#49, (rn#55 - 1), 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(86) Sort [codegen id : 35]
+Input [5]: [i_category#52, i_brand#51, cc_name#49, sum_sales#56, rn#55]
+Arguments: [i_category#52 ASC NULLS FIRST, i_brand#51 ASC NULLS FIRST, cc_name#49 ASC NULLS FIRST, (rn#55 - 1) ASC NULLS FIRST], false, 0
+
+(87) SortMergeJoin [codegen id : 36]
+Left keys [4]: [i_category#15, i_brand#14, cc_name#12, rn#21]
+Right keys [4]: [i_category#52, i_brand#51, cc_name#49, (rn#55 - 1)]
+Join type: Inner
+Join condition: None
+
+(88) Project [codegen id : 36]
+Output [8]: [i_category#15, i_brand#14, d_year#9, d_moy#10, avg_monthly_sales#22, sum_sales#19, sum_sales#40 AS psum#57, sum_sales#56 AS nsum#58]
+Input [14]: [i_category#15, i_brand#14, cc_name#12, d_year#9, d_moy#10, sum_sales#19, avg_monthly_sales#22, rn#21, sum_sales#40, i_category#52, i_brand#51, cc_name#49, sum_sales#56, rn#55]
+
+(89) TakeOrderedAndProject
+Input [8]: [i_category#15, i_brand#14, d_year#9, d_moy#10, avg_monthly_sales#22, sum_sales#19, psum#57, nsum#58]
+Arguments: 100, [(sum_sales#19 - avg_monthly_sales#22) ASC NULLS FIRST, d_year#9 ASC NULLS FIRST], [i_category#15, i_brand#14, d_year#9, d_moy#10, avg_monthly_sales#22, sum_sales#19, psum#57, nsum#58]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (56)
-+- * Filter (55)
-   +- * ColumnarToRow (54)
-      +- Scan parquet spark_catalog.default.date_dim (53)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
+ObjectHashAggregate (96)
++- Exchange (95)
+   +- ObjectHashAggregate (94)
+      +- Exchange (93)
+         +- * Filter (92)
+            +- * ColumnarToRow (91)
+               +- Scan parquet spark_catalog.default.item (90)
 
 
-(53) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(90) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
+
+(91) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+
+(92) Filter [codegen id : 1]
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Condition : ((isnotnull(i_item_sk#13) AND isnotnull(i_category#15)) AND isnotnull(i_brand#14))
+
+(93) Exchange
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Arguments: hashpartitioning(i_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(94) ObjectHashAggregate
+Input [3]: [i_item_sk#13, i_brand#14, i_category#15]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#13, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [buf#59]
+Results [1]: [buf#60]
+
+(95) Exchange
+Input [1]: [buf#60]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(96) ObjectHashAggregate
+Input [1]: [buf#60]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 203010, 1624080, 0, 0)#61]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 203010, 1624080, 0, 0)#61 AS bloomFilter#62]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#4 IN dynamicpruning#5
+BroadcastExchange (100)
++- * Filter (99)
+   +- * ColumnarToRow (98)
+      +- Scan parquet spark_catalog.default.date_dim (97)
+
+
+(97) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#8, d_year#9, d_moy#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(Or(EqualTo(d_year,1999),And(EqualTo(d_year,1998),EqualTo(d_moy,12))),And(EqualTo(d_year,2000),EqualTo(d_moy,1))), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(54) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
+(98) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
 
-(55) Filter [codegen id : 1]
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Condition : ((((d_year#7 = 1999) OR ((d_year#7 = 1998) AND (d_moy#8 = 12))) OR ((d_year#7 = 2000) AND (d_moy#8 = 1))) AND isnotnull(d_date_sk#6))
+(99) Filter [codegen id : 1]
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
+Condition : ((((d_year#9 = 1999) OR ((d_year#9 = 1998) AND (d_moy#10 = 12))) OR ((d_year#9 = 2000) AND (d_moy#10 = 1))) AND isnotnull(d_date_sk#8))
 
-(56) BroadcastExchange
-Input [3]: [d_date_sk#6, d_year#7, d_moy#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
+(100) BroadcastExchange
+Input [3]: [d_date_sk#8, d_year#9, d_moy#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
+
+Subquery:3 Hosting operator id = 36 Hosting Expression = Subquery scalar-subquery#27, [id=#28]
+ObjectHashAggregate (107)
++- Exchange (106)
+   +- ObjectHashAggregate (105)
+      +- Exchange (104)
+         +- * Filter (103)
+            +- * ColumnarToRow (102)
+               +- Scan parquet spark_catalog.default.item (101)
+
+
+(101) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
+
+(102) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+
+(103) Filter [codegen id : 1]
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Condition : ((isnotnull(i_item_sk#34) AND isnotnull(i_category#36)) AND isnotnull(i_brand#35))
+
+(104) Exchange
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Arguments: hashpartitioning(i_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+
+(105) ObjectHashAggregate
+Input [3]: [i_item_sk#34, i_brand#35, i_category#36]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#34, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [buf#63]
+Results [1]: [buf#64]
+
+(106) Exchange
+Input [1]: [buf#64]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=20]
+
+(107) ObjectHashAggregate
+Input [1]: [buf#64]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#34, 42), 203010, 1624080, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#34, 42), 203010, 1624080, 0, 0)#65]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#34, 42), 203010, 1624080, 0, 0)#65 AS bloomFilter#66]
+
+Subquery:4 Hosting operator id = 34 Hosting Expression = cs_sold_date_sk#26 IN dynamicpruning#5
+
+Subquery:5 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#6, [id=#7]
+
+Subquery:6 Hosting operator id = 63 Hosting Expression = cs_sold_date_sk#44 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/simplified.txt
@@ -43,6 +43,16 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_year,i_category,i_brand,d_m
                                                                                     Project [cs_call_center_sk,cs_item_sk,cs_sales_price,d_year,d_moy]
                                                                                       BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                                         Filter [cs_item_sk,cs_call_center_sk]
+                                                                                          Subquery #2
+                                                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 203010, 1624080, 0, 0),bloomFilter,buf]
+                                                                                              Exchange #6
+                                                                                                ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                                  Exchange [i_item_sk] #7
+                                                                                                    WholeStageCodegen (1)
+                                                                                                      Filter [i_item_sk,i_category,i_brand]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
                                                                                           ColumnarToRow
                                                                                             InputAdapter
                                                                                               Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_item_sk,cs_sales_price,cs_sold_date_sk]
@@ -56,7 +66,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_year,i_category,i_brand,d_m
                                                                                         InputAdapter
                                                                                           ReusedExchange [d_date_sk,d_year,d_moy] #5
                                                                                     InputAdapter
-                                                                                      BroadcastExchange #6
+                                                                                      BroadcastExchange #8
                                                                                         WholeStageCodegen (2)
                                                                                           Filter [cc_call_center_sk,cc_name]
                                                                                             ColumnarToRow
@@ -66,7 +76,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_year,i_category,i_brand,d_m
                                                                       WholeStageCodegen (6)
                                                                         Sort [i_item_sk]
                                                                           InputAdapter
-                                                                            Exchange [i_item_sk] #7
+                                                                            Exchange [i_item_sk] #9
                                                                               WholeStageCodegen (5)
                                                                                 Filter [i_item_sk,i_category,i_brand]
                                                                                   ColumnarToRow
@@ -76,7 +86,7 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_year,i_category,i_brand,d_m
                   WholeStageCodegen (23)
                     Sort [i_category,i_brand,cc_name,rn]
                       InputAdapter
-                        Exchange [i_category,i_brand,cc_name,rn] #8
+                        Exchange [i_category,i_brand,cc_name,rn] #10
                           WholeStageCodegen (22)
                             Project [i_category,i_brand,cc_name,sum_sales,rn]
                               InputAdapter
@@ -84,16 +94,59 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_year,i_category,i_brand,d_m
                                   WholeStageCodegen (21)
                                     Sort [i_category,i_brand,cc_name,d_year,d_moy]
                                       InputAdapter
-                                        Exchange [i_category,i_brand,cc_name] #9
+                                        Exchange [i_category,i_brand,cc_name] #11
                                           WholeStageCodegen (20)
                                             HashAggregate [i_category,i_brand,cc_name,d_year,d_moy,sum] [sum(UnscaledValue(cs_sales_price)),sum_sales,sum]
                                               InputAdapter
-                                                ReusedExchange [i_category,i_brand,cc_name,d_year,d_moy,sum] #3
+                                                Exchange [i_category,i_brand,cc_name,d_year,d_moy] #12
+                                                  WholeStageCodegen (19)
+                                                    HashAggregate [i_category,i_brand,cc_name,d_year,d_moy,cs_sales_price] [sum,sum]
+                                                      Project [i_brand,i_category,cs_sales_price,d_year,d_moy,cc_name]
+                                                        SortMergeJoin [cs_item_sk,i_item_sk]
+                                                          InputAdapter
+                                                            WholeStageCodegen (16)
+                                                              Sort [cs_item_sk]
+                                                                InputAdapter
+                                                                  Exchange [cs_item_sk] #13
+                                                                    WholeStageCodegen (15)
+                                                                      Project [cs_item_sk,cs_sales_price,d_year,d_moy,cc_name]
+                                                                        BroadcastHashJoin [cs_call_center_sk,cc_call_center_sk]
+                                                                          Project [cs_call_center_sk,cs_item_sk,cs_sales_price,d_year,d_moy]
+                                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                              Filter [cs_item_sk,cs_call_center_sk]
+                                                                                Subquery #3
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 203010, 1624080, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #14
+                                                                                      ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                        Exchange [i_item_sk] #15
+                                                                                          WholeStageCodegen (1)
+                                                                                            Filter [i_item_sk,i_category,i_brand]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_item_sk,cs_sales_price,cs_sold_date_sk]
+                                                                                      ReusedSubquery [d_date_sk] #1
+                                                                              InputAdapter
+                                                                                ReusedExchange [d_date_sk,d_year,d_moy] #5
+                                                                          InputAdapter
+                                                                            BroadcastExchange #16
+                                                                              WholeStageCodegen (14)
+                                                                                Filter [cc_call_center_sk,cc_name]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.call_center [cc_call_center_sk,cc_name]
+                                                          InputAdapter
+                                                            WholeStageCodegen (18)
+                                                              Sort [i_item_sk]
+                                                                InputAdapter
+                                                                  ReusedExchange [i_item_sk,i_brand,i_category] #15
         InputAdapter
           WholeStageCodegen (35)
             Sort [i_category,i_brand,cc_name,rn]
               InputAdapter
-                Exchange [i_category,i_brand,cc_name,rn] #10
+                Exchange [i_category,i_brand,cc_name,rn] #17
                   WholeStageCodegen (34)
                     Project [i_category,i_brand,cc_name,sum_sales,rn]
                       InputAdapter
@@ -101,4 +154,37 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_year,i_category,i_brand,d_m
                           WholeStageCodegen (33)
                             Sort [i_category,i_brand,cc_name,d_year,d_moy]
                               InputAdapter
-                                ReusedExchange [i_category,i_brand,cc_name,d_year,d_moy,sum_sales] #9
+                                Exchange [i_category,i_brand,cc_name] #18
+                                  WholeStageCodegen (32)
+                                    HashAggregate [i_category,i_brand,cc_name,d_year,d_moy,sum] [sum(UnscaledValue(cs_sales_price)),sum_sales,sum]
+                                      InputAdapter
+                                        Exchange [i_category,i_brand,cc_name,d_year,d_moy] #19
+                                          WholeStageCodegen (31)
+                                            HashAggregate [i_category,i_brand,cc_name,d_year,d_moy,cs_sales_price] [sum,sum]
+                                              Project [i_brand,i_category,cs_sales_price,d_year,d_moy,cc_name]
+                                                SortMergeJoin [cs_item_sk,i_item_sk]
+                                                  InputAdapter
+                                                    WholeStageCodegen (28)
+                                                      Sort [cs_item_sk]
+                                                        InputAdapter
+                                                          Exchange [cs_item_sk] #20
+                                                            WholeStageCodegen (27)
+                                                              Project [cs_item_sk,cs_sales_price,d_year,d_moy,cc_name]
+                                                                BroadcastHashJoin [cs_call_center_sk,cc_call_center_sk]
+                                                                  Project [cs_call_center_sk,cs_item_sk,cs_sales_price,d_year,d_moy]
+                                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                      Filter [cs_item_sk,cs_call_center_sk]
+                                                                        ReusedSubquery [bloomFilter] #2
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.catalog_sales [cs_call_center_sk,cs_item_sk,cs_sales_price,cs_sold_date_sk]
+                                                                              ReusedSubquery [d_date_sk] #1
+                                                                      InputAdapter
+                                                                        ReusedExchange [d_date_sk,d_year,d_moy] #5
+                                                                  InputAdapter
+                                                                    ReusedExchange [cc_call_center_sk,cc_name] #16
+                                                  InputAdapter
+                                                    WholeStageCodegen (30)
+                                                      Sort [i_item_sk]
+                                                        InputAdapter
+                                                          ReusedExchange [i_item_sk,i_brand,i_category] #15

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
@@ -1,11 +1,11 @@
 == Physical Plan ==
-TakeOrderedAndProject (45)
-+- * Filter (44)
-   +- * HashAggregate (43)
-      +- Exchange (42)
-         +- * HashAggregate (41)
-            +- * Project (40)
-               +- * SortMergeJoin Inner (39)
+TakeOrderedAndProject (33)
++- * Filter (32)
+   +- * HashAggregate (31)
+      +- Exchange (30)
+         +- * HashAggregate (29)
+            +- * Project (28)
+               +- * SortMergeJoin Inner (27)
                   :- * Sort (24)
                   :  +- Exchange (23)
                   :     +- * Project (22)
@@ -30,20 +30,8 @@ TakeOrderedAndProject (45)
                   :           :        +- * ColumnarToRow (16)
                   :           :           +- Scan parquet spark_catalog.default.store_sales (15)
                   :           +- ReusedExchange (20)
-                  +- * Sort (38)
-                     +- Exchange (37)
-                        +- * Project (36)
-                           +- * SortMergeJoin Inner (35)
-                              :- * Sort (29)
-                              :  +- Exchange (28)
-                              :     +- * Filter (27)
-                              :        +- * ColumnarToRow (26)
-                              :           +- Scan parquet spark_catalog.default.customer_address (25)
-                              +- * Sort (34)
-                                 +- Exchange (33)
-                                    +- * Filter (32)
-                                       +- * ColumnarToRow (31)
-                                          +- Scan parquet spark_catalog.default.customer (30)
+                  +- * Sort (26)
+                     +- ReusedExchange (25)
 
 
 (1) Scan parquet spark_catalog.default.item
@@ -127,7 +115,7 @@ Input [3]: [ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 
 (17) Filter
 Input [3]: [ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
-Condition : (isnotnull(ss_customer_sk#13) AND isnotnull(ss_item_sk#12))
+Condition : ((isnotnull(ss_customer_sk#13) AND isnotnull(ss_item_sk#12)) AND might_contain(Subquery scalar-subquery#16, [id=#17], xxhash64(ss_customer_sk#13, 42), false))
 
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [i_item_sk#1]
@@ -139,18 +127,18 @@ Join condition: None
 Output [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Input [4]: [i_item_sk#1, ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 
-(20) ReusedExchange [Reuses operator id: 50]
-Output [1]: [d_date_sk#16]
+(20) ReusedExchange [Reuses operator id: 54]
+Output [1]: [d_date_sk#18]
 
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#14]
-Right keys [1]: [d_date_sk#16]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 5]
 Output [1]: [ss_customer_sk#13]
-Input [3]: [ss_customer_sk#13, ss_sold_date_sk#14, d_date_sk#16]
+Input [3]: [ss_customer_sk#13, ss_sold_date_sk#14, d_date_sk#18]
 
 (23) Exchange
 Input [1]: [ss_customer_sk#13]
@@ -160,180 +148,220 @@ Arguments: hashpartitioning(ss_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id
 Input [1]: [ss_customer_sk#13]
 Arguments: [ss_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(25) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#17, ca_state#18]
+(25) ReusedExchange [Reuses operator id: 46]
+Output [2]: [ca_state#19, c_customer_sk#20]
+
+(26) Sort [codegen id : 12]
+Input [2]: [ca_state#19, c_customer_sk#20]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
+
+(27) SortMergeJoin [codegen id : 13]
+Left keys [1]: [ss_customer_sk#13]
+Right keys [1]: [c_customer_sk#20]
+Join type: Inner
+Join condition: None
+
+(28) Project [codegen id : 13]
+Output [1]: [ca_state#19]
+Input [3]: [ss_customer_sk#13, ca_state#19, c_customer_sk#20]
+
+(29) HashAggregate [codegen id : 13]
+Input [1]: [ca_state#19]
+Keys [1]: [ca_state#19]
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#21]
+Results [2]: [ca_state#19, count#22]
+
+(30) Exchange
+Input [2]: [ca_state#19, count#22]
+Arguments: hashpartitioning(ca_state#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(31) HashAggregate [codegen id : 14]
+Input [2]: [ca_state#19, count#22]
+Keys [1]: [ca_state#19]
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#23]
+Results [3]: [ca_state#19 AS state#24, count(1)#23 AS cnt#25, ca_state#19]
+
+(32) Filter [codegen id : 14]
+Input [3]: [state#24, cnt#25, ca_state#19]
+Condition : (cnt#25 >= 10)
+
+(33) TakeOrderedAndProject
+Input [3]: [state#24, cnt#25, ca_state#19]
+Arguments: 100, [cnt#25 ASC NULLS FIRST, ca_state#19 ASC NULLS FIRST], [state#24, cnt#25]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 17 Hosting Expression = Subquery scalar-subquery#16, [id=#17]
+ObjectHashAggregate (49)
++- Exchange (48)
+   +- ObjectHashAggregate (47)
+      +- Exchange (46)
+         +- * Project (45)
+            +- * SortMergeJoin Inner (44)
+               :- * Sort (38)
+               :  +- Exchange (37)
+               :     +- * Filter (36)
+               :        +- * ColumnarToRow (35)
+               :           +- Scan parquet spark_catalog.default.customer_address (34)
+               +- * Sort (43)
+                  +- Exchange (42)
+                     +- * Filter (41)
+                        +- * ColumnarToRow (40)
+                           +- Scan parquet spark_catalog.default.customer (39)
+
+
+(34) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#26, ca_state#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(26) ColumnarToRow [codegen id : 7]
-Input [2]: [ca_address_sk#17, ca_state#18]
+(35) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#26, ca_state#19]
 
-(27) Filter [codegen id : 7]
-Input [2]: [ca_address_sk#17, ca_state#18]
-Condition : isnotnull(ca_address_sk#17)
+(36) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#26, ca_state#19]
+Condition : isnotnull(ca_address_sk#26)
 
-(28) Exchange
-Input [2]: [ca_address_sk#17, ca_state#18]
-Arguments: hashpartitioning(ca_address_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(37) Exchange
+Input [2]: [ca_address_sk#26, ca_state#19]
+Arguments: hashpartitioning(ca_address_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(29) Sort [codegen id : 8]
-Input [2]: [ca_address_sk#17, ca_state#18]
-Arguments: [ca_address_sk#17 ASC NULLS FIRST], false, 0
+(38) Sort [codegen id : 2]
+Input [2]: [ca_address_sk#26, ca_state#19]
+Arguments: [ca_address_sk#26 ASC NULLS FIRST], false, 0
 
-(30) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#19, c_current_addr_sk#20]
+(39) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#20, c_current_addr_sk#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_current_addr_sk), IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(31) ColumnarToRow [codegen id : 9]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
+(40) ColumnarToRow [codegen id : 3]
+Input [2]: [c_customer_sk#20, c_current_addr_sk#27]
 
-(32) Filter [codegen id : 9]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Condition : (isnotnull(c_current_addr_sk#20) AND isnotnull(c_customer_sk#19))
-
-(33) Exchange
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: hashpartitioning(c_current_addr_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(34) Sort [codegen id : 10]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: [c_current_addr_sk#20 ASC NULLS FIRST], false, 0
-
-(35) SortMergeJoin [codegen id : 11]
-Left keys [1]: [ca_address_sk#17]
-Right keys [1]: [c_current_addr_sk#20]
-Join type: Inner
-Join condition: None
-
-(36) Project [codegen id : 11]
-Output [2]: [ca_state#18, c_customer_sk#19]
-Input [4]: [ca_address_sk#17, ca_state#18, c_customer_sk#19, c_current_addr_sk#20]
-
-(37) Exchange
-Input [2]: [ca_state#18, c_customer_sk#19]
-Arguments: hashpartitioning(c_customer_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(38) Sort [codegen id : 12]
-Input [2]: [ca_state#18, c_customer_sk#19]
-Arguments: [c_customer_sk#19 ASC NULLS FIRST], false, 0
-
-(39) SortMergeJoin [codegen id : 13]
-Left keys [1]: [ss_customer_sk#13]
-Right keys [1]: [c_customer_sk#19]
-Join type: Inner
-Join condition: None
-
-(40) Project [codegen id : 13]
-Output [1]: [ca_state#18]
-Input [3]: [ss_customer_sk#13, ca_state#18, c_customer_sk#19]
-
-(41) HashAggregate [codegen id : 13]
-Input [1]: [ca_state#18]
-Keys [1]: [ca_state#18]
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#21]
-Results [2]: [ca_state#18, count#22]
+(41) Filter [codegen id : 3]
+Input [2]: [c_customer_sk#20, c_current_addr_sk#27]
+Condition : (isnotnull(c_current_addr_sk#27) AND isnotnull(c_customer_sk#20))
 
 (42) Exchange
-Input [2]: [ca_state#18, count#22]
-Arguments: hashpartitioning(ca_state#18, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [2]: [c_customer_sk#20, c_current_addr_sk#27]
+Arguments: hashpartitioning(c_current_addr_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(43) HashAggregate [codegen id : 14]
-Input [2]: [ca_state#18, count#22]
-Keys [1]: [ca_state#18]
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#23]
-Results [3]: [ca_state#18 AS state#24, count(1)#23 AS cnt#25, ca_state#18]
+(43) Sort [codegen id : 4]
+Input [2]: [c_customer_sk#20, c_current_addr_sk#27]
+Arguments: [c_current_addr_sk#27 ASC NULLS FIRST], false, 0
 
-(44) Filter [codegen id : 14]
-Input [3]: [state#24, cnt#25, ca_state#18]
-Condition : (cnt#25 >= 10)
+(44) SortMergeJoin [codegen id : 5]
+Left keys [1]: [ca_address_sk#26]
+Right keys [1]: [c_current_addr_sk#27]
+Join type: Inner
+Join condition: None
 
-(45) TakeOrderedAndProject
-Input [3]: [state#24, cnt#25, ca_state#18]
-Arguments: 100, [cnt#25 ASC NULLS FIRST, ca_state#18 ASC NULLS FIRST], [state#24, cnt#25]
+(45) Project [codegen id : 5]
+Output [2]: [ca_state#19, c_customer_sk#20]
+Input [4]: [ca_address_sk#26, ca_state#19, c_customer_sk#20, c_current_addr_sk#27]
 
-===== Subqueries =====
+(46) Exchange
+Input [2]: [ca_state#19, c_customer_sk#20]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-Subquery:1 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#15
-BroadcastExchange (50)
-+- * Project (49)
-   +- * Filter (48)
-      +- * ColumnarToRow (47)
-         +- Scan parquet spark_catalog.default.date_dim (46)
+(47) ObjectHashAggregate
+Input [2]: [ca_state#19, c_customer_sk#20]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2120804, 16966432, 0, 0)]
+Aggregate Attributes [1]: [buf#28]
+Results [1]: [buf#29]
+
+(48) Exchange
+Input [1]: [buf#29]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+
+(49) ObjectHashAggregate
+Input [1]: [buf#29]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2120804, 16966432, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2120804, 16966432, 0, 0)#30]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 2120804, 16966432, 0, 0)#30 AS bloomFilter#31]
+
+Subquery:2 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#15
+BroadcastExchange (54)
++- * Project (53)
+   +- * Filter (52)
+      +- * ColumnarToRow (51)
+         +- Scan parquet spark_catalog.default.date_dim (50)
 
 
-(46) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#16, d_month_seq#26]
+(50) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#18, d_month_seq#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(47) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#16, d_month_seq#26]
+(51) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#18, d_month_seq#32]
 
-(48) Filter [codegen id : 1]
-Input [2]: [d_date_sk#16, d_month_seq#26]
-Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#16))
+(52) Filter [codegen id : 1]
+Input [2]: [d_date_sk#18, d_month_seq#32]
+Condition : ((isnotnull(d_month_seq#32) AND (d_month_seq#32 = Subquery scalar-subquery#33, [id=#34])) AND isnotnull(d_date_sk#18))
 
-(49) Project [codegen id : 1]
-Output [1]: [d_date_sk#16]
-Input [2]: [d_date_sk#16, d_month_seq#26]
+(53) Project [codegen id : 1]
+Output [1]: [d_date_sk#18]
+Input [2]: [d_date_sk#18, d_month_seq#32]
 
-(50) BroadcastExchange
-Input [1]: [d_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+(54) BroadcastExchange
+Input [1]: [d_date_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:2 Hosting operator id = 48 Hosting Expression = Subquery scalar-subquery#27, [id=#28]
-* HashAggregate (57)
-+- Exchange (56)
-   +- * HashAggregate (55)
-      +- * Project (54)
-         +- * Filter (53)
-            +- * ColumnarToRow (52)
-               +- Scan parquet spark_catalog.default.date_dim (51)
+Subquery:3 Hosting operator id = 52 Hosting Expression = Subquery scalar-subquery#33, [id=#34]
+* HashAggregate (61)
++- Exchange (60)
+   +- * HashAggregate (59)
+      +- * Project (58)
+         +- * Filter (57)
+            +- * ColumnarToRow (56)
+               +- Scan parquet spark_catalog.default.date_dim (55)
 
 
-(51) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_month_seq#29, d_year#30, d_moy#31]
+(55) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_month_seq#35, d_year#36, d_moy#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,1)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(52) ColumnarToRow [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+(56) ColumnarToRow [codegen id : 1]
+Input [3]: [d_month_seq#35, d_year#36, d_moy#37]
 
-(53) Filter [codegen id : 1]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
-Condition : (((isnotnull(d_year#30) AND isnotnull(d_moy#31)) AND (d_year#30 = 2000)) AND (d_moy#31 = 1))
+(57) Filter [codegen id : 1]
+Input [3]: [d_month_seq#35, d_year#36, d_moy#37]
+Condition : (((isnotnull(d_year#36) AND isnotnull(d_moy#37)) AND (d_year#36 = 2000)) AND (d_moy#37 = 1))
 
-(54) Project [codegen id : 1]
-Output [1]: [d_month_seq#29]
-Input [3]: [d_month_seq#29, d_year#30, d_moy#31]
+(58) Project [codegen id : 1]
+Output [1]: [d_month_seq#35]
+Input [3]: [d_month_seq#35, d_year#36, d_moy#37]
 
-(55) HashAggregate [codegen id : 1]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+(59) HashAggregate [codegen id : 1]
+Input [1]: [d_month_seq#35]
+Keys [1]: [d_month_seq#35]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#35]
 
-(56) Exchange
-Input [1]: [d_month_seq#29]
-Arguments: hashpartitioning(d_month_seq#29, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(60) Exchange
+Input [1]: [d_month_seq#35]
+Arguments: hashpartitioning(d_month_seq#35, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(57) HashAggregate [codegen id : 2]
-Input [1]: [d_month_seq#29]
-Keys [1]: [d_month_seq#29]
+(61) HashAggregate [codegen id : 2]
+Input [1]: [d_month_seq#35]
+Keys [1]: [d_month_seq#35]
 Functions: []
 Aggregate Attributes: []
-Results [1]: [d_month_seq#29]
+Results [1]: [d_month_seq#35]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/simplified.txt
@@ -41,6 +41,34 @@ TakeOrderedAndProject [cnt,ca_state,state]
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.item [i_current_price,i_category]
                                         Filter [ss_customer_sk,ss_item_sk]
+                                          Subquery #3
+                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2120804, 16966432, 0, 0),bloomFilter,buf]
+                                              Exchange #8
+                                                ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                  Exchange [c_customer_sk] #9
+                                                    WholeStageCodegen (5)
+                                                      Project [ca_state,c_customer_sk]
+                                                        SortMergeJoin [ca_address_sk,c_current_addr_sk]
+                                                          InputAdapter
+                                                            WholeStageCodegen (2)
+                                                              Sort [ca_address_sk]
+                                                                InputAdapter
+                                                                  Exchange [ca_address_sk] #10
+                                                                    WholeStageCodegen (1)
+                                                                      Filter [ca_address_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                                          InputAdapter
+                                                            WholeStageCodegen (4)
+                                                              Sort [c_current_addr_sk]
+                                                                InputAdapter
+                                                                  Exchange [c_current_addr_sk] #11
+                                                                    WholeStageCodegen (3)
+                                                                      Filter [c_current_addr_sk,c_customer_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_sold_date_sk]
@@ -70,27 +98,4 @@ TakeOrderedAndProject [cnt,ca_state,state]
                       WholeStageCodegen (12)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #8
-                              WholeStageCodegen (11)
-                                Project [ca_state,c_customer_sk]
-                                  SortMergeJoin [ca_address_sk,c_current_addr_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (8)
-                                        Sort [ca_address_sk]
-                                          InputAdapter
-                                            Exchange [ca_address_sk] #9
-                                              WholeStageCodegen (7)
-                                                Filter [ca_address_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                    InputAdapter
-                                      WholeStageCodegen (10)
-                                        Sort [c_current_addr_sk]
-                                          InputAdapter
-                                            Exchange [c_current_addr_sk] #10
-                                              WholeStageCodegen (9)
-                                                Filter [c_current_addr_sk,c_customer_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                            ReusedExchange [ca_state,c_customer_sk] #9

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
@@ -1,39 +1,39 @@
 == Physical Plan ==
-* Sort (209)
-+- Exchange (208)
-   +- * Project (207)
-      +- * SortMergeJoin Inner (206)
-         :- * Sort (128)
-         :  +- Exchange (127)
-         :     +- * HashAggregate (126)
-         :        +- Exchange (125)
-         :           +- * HashAggregate (124)
-         :              +- * Project (123)
-         :                 +- * BroadcastHashJoin Inner BuildRight (122)
-         :                    :- * Project (116)
-         :                    :  +- * BroadcastHashJoin Inner BuildRight (115)
-         :                    :     :- * Project (113)
-         :                    :     :  +- * BroadcastHashJoin Inner BuildRight (112)
-         :                    :     :     :- * Project (107)
-         :                    :     :     :  +- * SortMergeJoin Inner (106)
-         :                    :     :     :     :- * Sort (103)
-         :                    :     :     :     :  +- Exchange (102)
-         :                    :     :     :     :     +- * Project (101)
-         :                    :     :     :     :        +- * SortMergeJoin Inner (100)
-         :                    :     :     :     :           :- * Sort (94)
-         :                    :     :     :     :           :  +- Exchange (93)
-         :                    :     :     :     :           :     +- * Project (92)
-         :                    :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (91)
-         :                    :     :     :     :           :           :- * Project (89)
-         :                    :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (88)
-         :                    :     :     :     :           :           :     :- * Project (83)
-         :                    :     :     :     :           :           :     :  +- * BroadcastHashJoin Inner BuildRight (82)
-         :                    :     :     :     :           :           :     :     :- * Project (77)
-         :                    :     :     :     :           :           :     :     :  +- * SortMergeJoin Inner (76)
-         :                    :     :     :     :           :           :     :     :     :- * Sort (73)
-         :                    :     :     :     :           :           :     :     :     :  +- Exchange (72)
-         :                    :     :     :     :           :           :     :     :     :     +- * Project (71)
-         :                    :     :     :     :           :           :     :     :     :        +- * SortMergeJoin Inner (70)
+* Sort (206)
++- Exchange (205)
+   +- * Project (204)
+      +- * SortMergeJoin Inner (203)
+         :- * Sort (122)
+         :  +- Exchange (121)
+         :     +- * HashAggregate (120)
+         :        +- Exchange (119)
+         :           +- * HashAggregate (118)
+         :              +- * Project (117)
+         :                 +- * BroadcastHashJoin Inner BuildRight (116)
+         :                    :- * Project (110)
+         :                    :  +- * BroadcastHashJoin Inner BuildRight (109)
+         :                    :     :- * Project (107)
+         :                    :     :  +- * BroadcastHashJoin Inner BuildRight (106)
+         :                    :     :     :- * Project (101)
+         :                    :     :     :  +- * SortMergeJoin Inner (100)
+         :                    :     :     :     :- * Sort (97)
+         :                    :     :     :     :  +- Exchange (96)
+         :                    :     :     :     :     +- * Project (95)
+         :                    :     :     :     :        +- * SortMergeJoin Inner (94)
+         :                    :     :     :     :           :- * Sort (91)
+         :                    :     :     :     :           :  +- Exchange (90)
+         :                    :     :     :     :           :     +- * Project (89)
+         :                    :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (88)
+         :                    :     :     :     :           :           :- * Project (86)
+         :                    :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (85)
+         :                    :     :     :     :           :           :     :- * Project (80)
+         :                    :     :     :     :           :           :     :  +- * BroadcastHashJoin Inner BuildRight (79)
+         :                    :     :     :     :           :           :     :     :- * Project (74)
+         :                    :     :     :     :           :           :     :     :  +- * SortMergeJoin Inner (73)
+         :                    :     :     :     :           :           :     :     :     :- * Sort (70)
+         :                    :     :     :     :           :           :     :     :     :  +- Exchange (69)
+         :                    :     :     :     :           :           :     :     :     :     +- * Project (68)
+         :                    :     :     :     :           :           :     :     :     :        +- * SortMergeJoin Inner (67)
          :                    :     :     :     :           :           :     :     :     :           :- * Sort (64)
          :                    :     :     :     :           :           :     :     :     :           :  +- Exchange (63)
          :                    :     :     :     :           :           :     :     :     :           :     +- * Project (62)
@@ -98,116 +98,113 @@
          :                    :     :     :     :           :           :     :     :     :           :           :           +- * ColumnarToRow (55)
          :                    :     :     :     :           :           :     :     :     :           :           :              +- Scan parquet spark_catalog.default.date_dim (54)
          :                    :     :     :     :           :           :     :     :     :           :           +- ReusedExchange (60)
-         :                    :     :     :     :           :           :     :     :     :           +- * Sort (69)
-         :                    :     :     :     :           :           :     :     :     :              +- Exchange (68)
-         :                    :     :     :     :           :           :     :     :     :                 +- * Filter (67)
-         :                    :     :     :     :           :           :     :     :     :                    +- * ColumnarToRow (66)
-         :                    :     :     :     :           :           :     :     :     :                       +- Scan parquet spark_catalog.default.customer_demographics (65)
-         :                    :     :     :     :           :           :     :     :     +- * Sort (75)
-         :                    :     :     :     :           :           :     :     :        +- ReusedExchange (74)
-         :                    :     :     :     :           :           :     :     +- BroadcastExchange (81)
-         :                    :     :     :     :           :           :     :        +- * Filter (80)
-         :                    :     :     :     :           :           :     :           +- * ColumnarToRow (79)
-         :                    :     :     :     :           :           :     :              +- Scan parquet spark_catalog.default.promotion (78)
-         :                    :     :     :     :           :           :     +- BroadcastExchange (87)
-         :                    :     :     :     :           :           :        +- * Filter (86)
-         :                    :     :     :     :           :           :           +- * ColumnarToRow (85)
-         :                    :     :     :     :           :           :              +- Scan parquet spark_catalog.default.household_demographics (84)
-         :                    :     :     :     :           :           +- ReusedExchange (90)
-         :                    :     :     :     :           +- * Sort (99)
-         :                    :     :     :     :              +- Exchange (98)
-         :                    :     :     :     :                 +- * Filter (97)
-         :                    :     :     :     :                    +- * ColumnarToRow (96)
-         :                    :     :     :     :                       +- Scan parquet spark_catalog.default.customer_address (95)
-         :                    :     :     :     +- * Sort (105)
-         :                    :     :     :        +- ReusedExchange (104)
-         :                    :     :     +- BroadcastExchange (111)
-         :                    :     :        +- * Filter (110)
-         :                    :     :           +- * ColumnarToRow (109)
-         :                    :     :              +- Scan parquet spark_catalog.default.income_band (108)
-         :                    :     +- ReusedExchange (114)
-         :                    +- BroadcastExchange (121)
-         :                       +- * Project (120)
-         :                          +- * Filter (119)
-         :                             +- * ColumnarToRow (118)
-         :                                +- Scan parquet spark_catalog.default.item (117)
-         +- * Sort (205)
-            +- Exchange (204)
-               +- * HashAggregate (203)
-                  +- Exchange (202)
-                     +- * HashAggregate (201)
-                        +- * Project (200)
-                           +- * BroadcastHashJoin Inner BuildRight (199)
-                              :- * Project (197)
-                              :  +- * BroadcastHashJoin Inner BuildRight (196)
-                              :     :- * Project (194)
-                              :     :  +- * BroadcastHashJoin Inner BuildRight (193)
-                              :     :     :- * Project (191)
-                              :     :     :  +- * SortMergeJoin Inner (190)
-                              :     :     :     :- * Sort (187)
-                              :     :     :     :  +- Exchange (186)
-                              :     :     :     :     +- * Project (185)
-                              :     :     :     :        +- * SortMergeJoin Inner (184)
-                              :     :     :     :           :- * Sort (181)
-                              :     :     :     :           :  +- Exchange (180)
-                              :     :     :     :           :     +- * Project (179)
-                              :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (178)
-                              :     :     :     :           :           :- * Project (176)
-                              :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (175)
-                              :     :     :     :           :           :     :- * Project (173)
-                              :     :     :     :           :           :     :  +- * BroadcastHashJoin Inner BuildRight (172)
-                              :     :     :     :           :           :     :     :- * Project (170)
-                              :     :     :     :           :           :     :     :  +- * SortMergeJoin Inner (169)
-                              :     :     :     :           :           :     :     :     :- * Sort (166)
-                              :     :     :     :           :           :     :     :     :  +- Exchange (165)
-                              :     :     :     :           :           :     :     :     :     +- * Project (164)
-                              :     :     :     :           :           :     :     :     :        +- * SortMergeJoin Inner (163)
-                              :     :     :     :           :           :     :     :     :           :- * Sort (160)
-                              :     :     :     :           :           :     :     :     :           :  +- Exchange (159)
-                              :     :     :     :           :           :     :     :     :           :     +- * Project (158)
-                              :     :     :     :           :           :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (157)
-                              :     :     :     :           :           :     :     :     :           :           :- * Project (155)
-                              :     :     :     :           :           :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (154)
-                              :     :     :     :           :           :     :     :     :           :           :     :- * Project (152)
-                              :     :     :     :           :           :     :     :     :           :           :     :  +- * SortMergeJoin Inner (151)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :- * Sort (148)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :  +- Exchange (147)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :     +- * Project (146)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :        +- * BroadcastHashJoin Inner BuildRight (145)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :- * Project (143)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :  +- * BroadcastHashJoin Inner BuildRight (142)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :- * Project (140)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (139)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :- * Project (137)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :  +- * SortMergeJoin Inner (136)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :- * Sort (133)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :  +- Exchange (132)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :     +- * Filter (131)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :        +- * ColumnarToRow (130)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :           +- Scan parquet spark_catalog.default.store_sales (129)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     +- * Sort (135)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :        +- ReusedExchange (134)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     +- ReusedExchange (138)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     +- ReusedExchange (141)
-                              :     :     :     :           :           :     :     :     :           :           :     :     :           +- ReusedExchange (144)
-                              :     :     :     :           :           :     :     :     :           :           :     :     +- * Sort (150)
-                              :     :     :     :           :           :     :     :     :           :           :     :        +- ReusedExchange (149)
-                              :     :     :     :           :           :     :     :     :           :           :     +- ReusedExchange (153)
-                              :     :     :     :           :           :     :     :     :           :           +- ReusedExchange (156)
-                              :     :     :     :           :           :     :     :     :           +- * Sort (162)
-                              :     :     :     :           :           :     :     :     :              +- ReusedExchange (161)
-                              :     :     :     :           :           :     :     :     +- * Sort (168)
-                              :     :     :     :           :           :     :     :        +- ReusedExchange (167)
-                              :     :     :     :           :           :     :     +- ReusedExchange (171)
-                              :     :     :     :           :           :     +- ReusedExchange (174)
-                              :     :     :     :           :           +- ReusedExchange (177)
-                              :     :     :     :           +- * Sort (183)
-                              :     :     :     :              +- ReusedExchange (182)
-                              :     :     :     +- * Sort (189)
-                              :     :     :        +- ReusedExchange (188)
-                              :     :     +- ReusedExchange (192)
-                              :     +- ReusedExchange (195)
-                              +- ReusedExchange (198)
+         :                    :     :     :     :           :           :     :     :     :           +- * Sort (66)
+         :                    :     :     :     :           :           :     :     :     :              +- ReusedExchange (65)
+         :                    :     :     :     :           :           :     :     :     +- * Sort (72)
+         :                    :     :     :     :           :           :     :     :        +- ReusedExchange (71)
+         :                    :     :     :     :           :           :     :     +- BroadcastExchange (78)
+         :                    :     :     :     :           :           :     :        +- * Filter (77)
+         :                    :     :     :     :           :           :     :           +- * ColumnarToRow (76)
+         :                    :     :     :     :           :           :     :              +- Scan parquet spark_catalog.default.promotion (75)
+         :                    :     :     :     :           :           :     +- BroadcastExchange (84)
+         :                    :     :     :     :           :           :        +- * Filter (83)
+         :                    :     :     :     :           :           :           +- * ColumnarToRow (82)
+         :                    :     :     :     :           :           :              +- Scan parquet spark_catalog.default.household_demographics (81)
+         :                    :     :     :     :           :           +- ReusedExchange (87)
+         :                    :     :     :     :           +- * Sort (93)
+         :                    :     :     :     :              +- ReusedExchange (92)
+         :                    :     :     :     +- * Sort (99)
+         :                    :     :     :        +- ReusedExchange (98)
+         :                    :     :     +- BroadcastExchange (105)
+         :                    :     :        +- * Filter (104)
+         :                    :     :           +- * ColumnarToRow (103)
+         :                    :     :              +- Scan parquet spark_catalog.default.income_band (102)
+         :                    :     +- ReusedExchange (108)
+         :                    +- BroadcastExchange (115)
+         :                       +- * Project (114)
+         :                          +- * Filter (113)
+         :                             +- * ColumnarToRow (112)
+         :                                +- Scan parquet spark_catalog.default.item (111)
+         +- * Sort (202)
+            +- Exchange (201)
+               +- * HashAggregate (200)
+                  +- Exchange (199)
+                     +- * HashAggregate (198)
+                        +- * Project (197)
+                           +- * BroadcastHashJoin Inner BuildRight (196)
+                              :- * Project (194)
+                              :  +- * BroadcastHashJoin Inner BuildRight (193)
+                              :     :- * Project (191)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (190)
+                              :     :     :- * Project (188)
+                              :     :     :  +- * SortMergeJoin Inner (187)
+                              :     :     :     :- * Sort (184)
+                              :     :     :     :  +- Exchange (183)
+                              :     :     :     :     +- * Project (182)
+                              :     :     :     :        +- * SortMergeJoin Inner (181)
+                              :     :     :     :           :- * Sort (178)
+                              :     :     :     :           :  +- Exchange (177)
+                              :     :     :     :           :     +- * Project (176)
+                              :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (175)
+                              :     :     :     :           :           :- * Project (173)
+                              :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (172)
+                              :     :     :     :           :           :     :- * Project (170)
+                              :     :     :     :           :           :     :  +- * BroadcastHashJoin Inner BuildRight (169)
+                              :     :     :     :           :           :     :     :- * Project (167)
+                              :     :     :     :           :           :     :     :  +- * SortMergeJoin Inner (166)
+                              :     :     :     :           :           :     :     :     :- * Sort (163)
+                              :     :     :     :           :           :     :     :     :  +- Exchange (162)
+                              :     :     :     :           :           :     :     :     :     +- * Project (161)
+                              :     :     :     :           :           :     :     :     :        +- * SortMergeJoin Inner (160)
+                              :     :     :     :           :           :     :     :     :           :- * Sort (157)
+                              :     :     :     :           :           :     :     :     :           :  +- Exchange (156)
+                              :     :     :     :           :           :     :     :     :           :     +- * Project (155)
+                              :     :     :     :           :           :     :     :     :           :        +- * BroadcastHashJoin Inner BuildRight (154)
+                              :     :     :     :           :           :     :     :     :           :           :- * Project (152)
+                              :     :     :     :           :           :     :     :     :           :           :  +- * BroadcastHashJoin Inner BuildRight (151)
+                              :     :     :     :           :           :     :     :     :           :           :     :- * Project (149)
+                              :     :     :     :           :           :     :     :     :           :           :     :  +- * SortMergeJoin Inner (148)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :- * Sort (142)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :  +- Exchange (141)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :     +- * Project (140)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :        +- * BroadcastHashJoin Inner BuildRight (139)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :- * Project (137)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :  +- * BroadcastHashJoin Inner BuildRight (136)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :- * Project (134)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (133)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :- * Project (131)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :  +- * SortMergeJoin Inner (130)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :- * Sort (127)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :  +- Exchange (126)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :     +- * Filter (125)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :        +- * ColumnarToRow (124)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     :           +- Scan parquet spark_catalog.default.store_sales (123)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :     +- * Sort (129)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     :        +- ReusedExchange (128)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     :     +- ReusedExchange (132)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           :     +- ReusedExchange (135)
+                              :     :     :     :           :           :     :     :     :           :           :     :     :           +- ReusedExchange (138)
+                              :     :     :     :           :           :     :     :     :           :           :     :     +- * Sort (147)
+                              :     :     :     :           :           :     :     :     :           :           :     :        +- Exchange (146)
+                              :     :     :     :           :           :     :     :     :           :           :     :           +- * Filter (145)
+                              :     :     :     :           :           :     :     :     :           :           :     :              +- * ColumnarToRow (144)
+                              :     :     :     :           :           :     :     :     :           :           :     :                 +- Scan parquet spark_catalog.default.customer (143)
+                              :     :     :     :           :           :     :     :     :           :           :     +- ReusedExchange (150)
+                              :     :     :     :           :           :     :     :     :           :           +- ReusedExchange (153)
+                              :     :     :     :           :           :     :     :     :           +- * Sort (159)
+                              :     :     :     :           :           :     :     :     :              +- ReusedExchange (158)
+                              :     :     :     :           :           :     :     :     +- * Sort (165)
+                              :     :     :     :           :           :     :     :        +- ReusedExchange (164)
+                              :     :     :     :           :           :     :     +- ReusedExchange (168)
+                              :     :     :     :           :           :     +- ReusedExchange (171)
+                              :     :     :     :           :           +- ReusedExchange (174)
+                              :     :     :     :           +- * Sort (180)
+                              :     :     :     :              +- ReusedExchange (179)
+                              :     :     :     +- * Sort (186)
+                              :     :     :        +- ReusedExchange (185)
+                              :     :     +- ReusedExchange (189)
+                              :     +- ReusedExchange (192)
+                              +- ReusedExchange (195)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -223,7 +220,7 @@ Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_ad
 
 (3) Filter [codegen id : 1]
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#1, 42)))
+Condition : (((((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND true) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_cdemo_sk#3, 42), false)) AND might_contain(Subquery scalar-subquery#16, [id=#17], xxhash64(ss_addr_sk#5, 42), false)) AND might_contain(Subquery scalar-subquery#18, [id=#19], xxhash64(ss_item_sk#1, 42), true))
 
 (4) Exchange
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
@@ -234,1013 +231,1186 @@ Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_ad
 Arguments: [ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#8 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Output [3]: [sr_item_sk#20, sr_ticket_number#21, sr_returned_date_sk#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Input [3]: [sr_item_sk#20, sr_ticket_number#21, sr_returned_date_sk#22]
 
 (8) Filter [codegen id : 3]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
-Condition : (isnotnull(sr_item_sk#16) AND isnotnull(sr_ticket_number#17))
+Input [3]: [sr_item_sk#20, sr_ticket_number#21, sr_returned_date_sk#22]
+Condition : (isnotnull(sr_item_sk#20) AND isnotnull(sr_ticket_number#21))
 
 (9) Project [codegen id : 3]
-Output [2]: [sr_item_sk#16, sr_ticket_number#17]
-Input [3]: [sr_item_sk#16, sr_ticket_number#17, sr_returned_date_sk#18]
+Output [2]: [sr_item_sk#20, sr_ticket_number#21]
+Input [3]: [sr_item_sk#20, sr_ticket_number#21, sr_returned_date_sk#22]
 
 (10) Exchange
-Input [2]: [sr_item_sk#16, sr_ticket_number#17]
-Arguments: hashpartitioning(sr_item_sk#16, sr_ticket_number#17, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [sr_item_sk#20, sr_ticket_number#21]
+Arguments: hashpartitioning(sr_item_sk#20, sr_ticket_number#21, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (11) Sort [codegen id : 4]
-Input [2]: [sr_item_sk#16, sr_ticket_number#17]
-Arguments: [sr_item_sk#16 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#20, sr_ticket_number#21]
+Arguments: [sr_item_sk#20 ASC NULLS FIRST, sr_ticket_number#21 ASC NULLS FIRST], false, 0
 
 (12) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#8]
-Right keys [2]: [sr_item_sk#16, sr_ticket_number#17]
+Right keys [2]: [sr_item_sk#20, sr_ticket_number#21]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 13]
 Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, sr_item_sk#16, sr_ticket_number#17]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, sr_item_sk#20, sr_ticket_number#21]
 
 (14) Scan parquet spark_catalog.default.catalog_sales
-Output [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Output [4]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cs_sold_date_sk#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_order_number)]
 ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_ext_list_price:decimal(7,2)>
 
 (15) ColumnarToRow [codegen id : 5]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Input [4]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cs_sold_date_sk#26]
 
 (16) Filter [codegen id : 5]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
-Condition : (isnotnull(cs_item_sk#19) AND isnotnull(cs_order_number#20))
+Input [4]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cs_sold_date_sk#26]
+Condition : (isnotnull(cs_item_sk#23) AND isnotnull(cs_order_number#24))
 
 (17) Project [codegen id : 5]
-Output [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Input [4]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cs_sold_date_sk#22]
+Output [3]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25]
+Input [4]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cs_sold_date_sk#26]
 
 (18) Exchange
-Input [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Arguments: hashpartitioning(cs_item_sk#19, cs_order_number#20, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25]
+Arguments: hashpartitioning(cs_item_sk#23, cs_order_number#24, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (19) Sort [codegen id : 6]
-Input [3]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21]
-Arguments: [cs_item_sk#19 ASC NULLS FIRST, cs_order_number#20 ASC NULLS FIRST], false, 0
+Input [3]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25]
+Arguments: [cs_item_sk#23 ASC NULLS FIRST, cs_order_number#24 ASC NULLS FIRST], false, 0
 
 (20) Scan parquet spark_catalog.default.catalog_returns
-Output [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Output [6]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31, cr_returned_date_sk#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_refunded_cash:decimal(7,2),cr_reversed_charge:decimal(7,2),cr_store_credit:decimal(7,2)>
 
 (21) ColumnarToRow [codegen id : 7]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Input [6]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31, cr_returned_date_sk#32]
 
 (22) Filter [codegen id : 7]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
-Condition : (isnotnull(cr_item_sk#23) AND isnotnull(cr_order_number#24))
+Input [6]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31, cr_returned_date_sk#32]
+Condition : (isnotnull(cr_item_sk#27) AND isnotnull(cr_order_number#28))
 
 (23) Project [codegen id : 7]
-Output [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Input [6]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27, cr_returned_date_sk#28]
+Output [5]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Input [6]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31, cr_returned_date_sk#32]
 
 (24) Exchange
-Input [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Arguments: hashpartitioning(cr_item_sk#23, cr_order_number#24, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [5]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Arguments: hashpartitioning(cr_item_sk#27, cr_order_number#28, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (25) Sort [codegen id : 8]
-Input [5]: [cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Arguments: [cr_item_sk#23 ASC NULLS FIRST, cr_order_number#24 ASC NULLS FIRST], false, 0
+Input [5]: [cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Arguments: [cr_item_sk#27 ASC NULLS FIRST, cr_order_number#28 ASC NULLS FIRST], false, 0
 
 (26) SortMergeJoin [codegen id : 9]
-Left keys [2]: [cs_item_sk#19, cs_order_number#20]
-Right keys [2]: [cr_item_sk#23, cr_order_number#24]
+Left keys [2]: [cs_item_sk#23, cs_order_number#24]
+Right keys [2]: [cr_item_sk#27, cr_order_number#28]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
-Output [5]: [cs_item_sk#19, cs_ext_list_price#21, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Input [8]: [cs_item_sk#19, cs_order_number#20, cs_ext_list_price#21, cr_item_sk#23, cr_order_number#24, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
+Output [5]: [cs_item_sk#23, cs_ext_list_price#25, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Input [8]: [cs_item_sk#23, cs_order_number#24, cs_ext_list_price#25, cr_item_sk#27, cr_order_number#28, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
 
 (28) HashAggregate [codegen id : 9]
-Input [5]: [cs_item_sk#19, cs_ext_list_price#21, cr_refunded_cash#25, cr_reversed_charge#26, cr_store_credit#27]
-Keys [1]: [cs_item_sk#19]
-Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#21)), partial_sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))]
-Aggregate Attributes [3]: [sum#29, sum#30, isEmpty#31]
-Results [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
+Input [5]: [cs_item_sk#23, cs_ext_list_price#25, cr_refunded_cash#29, cr_reversed_charge#30, cr_store_credit#31]
+Keys [1]: [cs_item_sk#23]
+Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#25)), partial_sum(((cr_refunded_cash#29 + cr_reversed_charge#30) + cr_store_credit#31))]
+Aggregate Attributes [3]: [sum#33, sum#34, isEmpty#35]
+Results [4]: [cs_item_sk#23, sum#36, sum#37, isEmpty#38]
 
 (29) Exchange
-Input [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(cs_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [4]: [cs_item_sk#23, sum#36, sum#37, isEmpty#38]
+Arguments: hashpartitioning(cs_item_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (30) HashAggregate [codegen id : 10]
-Input [4]: [cs_item_sk#19, sum#32, sum#33, isEmpty#34]
-Keys [1]: [cs_item_sk#19]
-Functions [2]: [sum(UnscaledValue(cs_ext_list_price#21)), sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#21))#35, sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))#36]
-Results [3]: [cs_item_sk#19, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#21))#35,17,2) AS sale#37, sum(((cr_refunded_cash#25 + cr_reversed_charge#26) + cr_store_credit#27))#36 AS refund#38]
+Input [4]: [cs_item_sk#23, sum#36, sum#37, isEmpty#38]
+Keys [1]: [cs_item_sk#23]
+Functions [2]: [sum(UnscaledValue(cs_ext_list_price#25)), sum(((cr_refunded_cash#29 + cr_reversed_charge#30) + cr_store_credit#31))]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#25))#39, sum(((cr_refunded_cash#29 + cr_reversed_charge#30) + cr_store_credit#31))#40]
+Results [3]: [cs_item_sk#23, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#25))#39,17,2) AS sale#41, sum(((cr_refunded_cash#29 + cr_reversed_charge#30) + cr_store_credit#31))#40 AS refund#42]
 
 (31) Filter [codegen id : 10]
-Input [3]: [cs_item_sk#19, sale#37, refund#38]
-Condition : ((isnotnull(sale#37) AND isnotnull(refund#38)) AND (cast(sale#37 as decimal(21,2)) > (2 * refund#38)))
+Input [3]: [cs_item_sk#23, sale#41, refund#42]
+Condition : ((isnotnull(sale#41) AND isnotnull(refund#42)) AND (cast(sale#41 as decimal(21,2)) > (2 * refund#42)))
 
 (32) Project [codegen id : 10]
-Output [1]: [cs_item_sk#19]
-Input [3]: [cs_item_sk#19, sale#37, refund#38]
+Output [1]: [cs_item_sk#23]
+Input [3]: [cs_item_sk#23, sale#41, refund#42]
 
 (33) BroadcastExchange
-Input [1]: [cs_item_sk#19]
+Input [1]: [cs_item_sk#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [cs_item_sk#19]
+Right keys [1]: [cs_item_sk#23]
 Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 13]
 Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, cs_item_sk#19]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, cs_item_sk#23]
 
-(36) ReusedExchange [Reuses operator id: 220]
-Output [2]: [d_date_sk#39, d_year#40]
+(36) ReusedExchange [Reuses operator id: 231]
+Output [2]: [d_date_sk#43, d_year#44]
 
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#39]
+Right keys [1]: [d_date_sk#43]
 Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
-Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40]
-Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, d_date_sk#39, d_year#40]
+Output [11]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44]
+Input [13]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12, d_date_sk#43, d_year#44]
 
 (39) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Output [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_zip:string>
 
 (40) ColumnarToRow [codegen id : 12]
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Input [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
 
 (41) Filter [codegen id : 12]
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
-Condition : ((isnotnull(s_store_sk#41) AND isnotnull(s_store_name#42)) AND isnotnull(s_zip#43))
+Input [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
+Condition : ((isnotnull(s_store_sk#45) AND isnotnull(s_store_name#46)) AND isnotnull(s_zip#47))
 
 (42) BroadcastExchange
-Input [3]: [s_store_sk#41, s_store_name#42, s_zip#43]
+Input [3]: [s_store_sk#45, s_store_name#46, s_zip#47]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
 (43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#6]
-Right keys [1]: [s_store_sk#41]
+Right keys [1]: [s_store_sk#45]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
-Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_sk#41, s_store_name#42, s_zip#43]
+Output [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_sk#45, s_store_name#46, s_zip#47]
 
 (45) Exchange
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (46) Sort [codegen id : 14]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (47) Scan parquet spark_catalog.default.customer
-Output [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Output [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_first_sales_date_sk), IsNotNull(c_first_shipto_date_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int,c_first_shipto_date_sk:int,c_first_sales_date_sk:int>
 
 (48) ColumnarToRow [codegen id : 15]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
 
 (49) Filter [codegen id : 15]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Condition : (((((isnotnull(c_customer_sk#44) AND isnotnull(c_first_sales_date_sk#49)) AND isnotnull(c_first_shipto_date_sk#48)) AND isnotnull(c_current_cdemo_sk#45)) AND isnotnull(c_current_hdemo_sk#46)) AND isnotnull(c_current_addr_sk#47))
+Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
+Condition : (((((((isnotnull(c_customer_sk#48) AND isnotnull(c_first_sales_date_sk#53)) AND isnotnull(c_first_shipto_date_sk#52)) AND isnotnull(c_current_cdemo_sk#49)) AND isnotnull(c_current_hdemo_sk#50)) AND isnotnull(c_current_addr_sk#51)) AND might_contain(Subquery scalar-subquery#54, [id=#55], xxhash64(c_current_cdemo_sk#49, 42), false)) AND might_contain(Subquery scalar-subquery#56, [id=#57], xxhash64(c_current_addr_sk#51, 42), false))
 
 (50) Exchange
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Arguments: hashpartitioning(c_customer_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
+Arguments: hashpartitioning(c_customer_sk#48, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (51) Sort [codegen id : 16]
-Input [6]: [c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Arguments: [c_customer_sk#44 ASC NULLS FIRST], false, 0
+Input [6]: [c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
+Arguments: [c_customer_sk#48 ASC NULLS FIRST], false, 0
 
 (52) SortMergeJoin [codegen id : 19]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#44]
+Right keys [1]: [c_customer_sk#48]
 Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
-Input [18]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_customer_sk#44, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
+Input [18]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_customer_sk#48, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53]
 
 (54) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#50, d_year#51]
+Output [2]: [d_date_sk#58, d_year#59]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (55) ColumnarToRow [codegen id : 17]
-Input [2]: [d_date_sk#50, d_year#51]
+Input [2]: [d_date_sk#58, d_year#59]
 
 (56) Filter [codegen id : 17]
-Input [2]: [d_date_sk#50, d_year#51]
-Condition : isnotnull(d_date_sk#50)
+Input [2]: [d_date_sk#58, d_year#59]
+Condition : isnotnull(d_date_sk#58)
 
 (57) BroadcastExchange
-Input [2]: [d_date_sk#50, d_year#51]
+Input [2]: [d_date_sk#58, d_year#59]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
 
 (58) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [c_first_sales_date_sk#49]
-Right keys [1]: [d_date_sk#50]
+Left keys [1]: [c_first_sales_date_sk#53]
+Right keys [1]: [d_date_sk#58]
 Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, d_year#51]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, c_first_sales_date_sk#49, d_date_sk#50, d_year#51]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, d_year#59]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, c_first_sales_date_sk#53, d_date_sk#58, d_year#59]
 
 (60) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#52, d_year#53]
+Output [2]: [d_date_sk#60, d_year#61]
 
 (61) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [c_first_shipto_date_sk#48]
-Right keys [1]: [d_date_sk#52]
+Left keys [1]: [c_first_shipto_date_sk#52]
+Right keys [1]: [d_date_sk#60]
 Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 19]
-Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, c_first_shipto_date_sk#48, d_year#51, d_date_sk#52, d_year#53]
+Output [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, c_first_shipto_date_sk#52, d_year#59, d_date_sk#60, d_year#61]
 
 (63) Exchange
-Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
+Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
 Arguments: hashpartitioning(ss_cdemo_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (64) Sort [codegen id : 20]
-Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
+Input [16]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
 Arguments: [ss_cdemo_sk#3 ASC NULLS FIRST], false, 0
 
-(65) Scan parquet spark_catalog.default.customer_demographics
-Output [2]: [cd_demo_sk#54, cd_marital_status#55]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
-ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
+(65) ReusedExchange [Reuses operator id: 235]
+Output [2]: [cd_demo_sk#62, cd_marital_status#63]
 
-(66) ColumnarToRow [codegen id : 21]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
+(66) Sort [codegen id : 22]
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+Arguments: [cd_demo_sk#62 ASC NULLS FIRST], false, 0
 
-(67) Filter [codegen id : 21]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Condition : (isnotnull(cd_demo_sk#54) AND isnotnull(cd_marital_status#55))
-
-(68) Exchange
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Arguments: hashpartitioning(cd_demo_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(69) Sort [codegen id : 22]
-Input [2]: [cd_demo_sk#54, cd_marital_status#55]
-Arguments: [cd_demo_sk#54 ASC NULLS FIRST], false, 0
-
-(70) SortMergeJoin [codegen id : 23]
+(67) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ss_cdemo_sk#3]
-Right keys [1]: [cd_demo_sk#54]
+Right keys [1]: [cd_demo_sk#62]
 Join type: Inner
 Join condition: None
 
-(71) Project [codegen id : 23]
-Output [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_demo_sk#54, cd_marital_status#55]
+(68) Project [codegen id : 23]
+Output [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_marital_status#63]
+Input [18]: [ss_item_sk#1, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_demo_sk#62, cd_marital_status#63]
 
-(72) Exchange
-Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Arguments: hashpartitioning(c_current_cdemo_sk#45, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+(69) Exchange
+Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_marital_status#63]
+Arguments: hashpartitioning(c_current_cdemo_sk#49, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(73) Sort [codegen id : 24]
-Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55]
-Arguments: [c_current_cdemo_sk#45 ASC NULLS FIRST], false, 0
+(70) Sort [codegen id : 24]
+Input [16]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_marital_status#63]
+Arguments: [c_current_cdemo_sk#49 ASC NULLS FIRST], false, 0
 
-(74) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#56, cd_marital_status#57]
+(71) ReusedExchange [Reuses operator id: 235]
+Output [2]: [cd_demo_sk#64, cd_marital_status#65]
 
-(75) Sort [codegen id : 26]
-Input [2]: [cd_demo_sk#56, cd_marital_status#57]
-Arguments: [cd_demo_sk#56 ASC NULLS FIRST], false, 0
+(72) Sort [codegen id : 26]
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+Arguments: [cd_demo_sk#64 ASC NULLS FIRST], false, 0
 
-(76) SortMergeJoin [codegen id : 30]
-Left keys [1]: [c_current_cdemo_sk#45]
-Right keys [1]: [cd_demo_sk#56]
+(73) SortMergeJoin [codegen id : 30]
+Left keys [1]: [c_current_cdemo_sk#49]
+Right keys [1]: [cd_demo_sk#64]
 Join type: Inner
-Join condition: NOT (cd_marital_status#55 = cd_marital_status#57)
+Join condition: NOT (cd_marital_status#63 = cd_marital_status#65)
 
-(77) Project [codegen id : 30]
-Output [14]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [18]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_cdemo_sk#45, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, cd_marital_status#55, cd_demo_sk#56, cd_marital_status#57]
+(74) Project [codegen id : 30]
+Output [14]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
+Input [18]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_cdemo_sk#49, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, cd_marital_status#63, cd_demo_sk#64, cd_marital_status#65]
 
-(78) Scan parquet spark_catalog.default.promotion
-Output [1]: [p_promo_sk#58]
+(75) Scan parquet spark_catalog.default.promotion
+Output [1]: [p_promo_sk#66]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(79) ColumnarToRow [codegen id : 27]
-Input [1]: [p_promo_sk#58]
+(76) ColumnarToRow [codegen id : 27]
+Input [1]: [p_promo_sk#66]
 
-(80) Filter [codegen id : 27]
-Input [1]: [p_promo_sk#58]
-Condition : isnotnull(p_promo_sk#58)
+(77) Filter [codegen id : 27]
+Input [1]: [p_promo_sk#66]
+Condition : isnotnull(p_promo_sk#66)
 
-(81) BroadcastExchange
-Input [1]: [p_promo_sk#58]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
+(78) BroadcastExchange
+Input [1]: [p_promo_sk#66]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
 
-(82) BroadcastHashJoin [codegen id : 30]
+(79) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_promo_sk#7]
-Right keys [1]: [p_promo_sk#58]
+Right keys [1]: [p_promo_sk#66]
 Join type: Inner
 Join condition: None
 
-(83) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53]
-Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, p_promo_sk#58]
+(80) Project [codegen id : 30]
+Output [13]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61]
+Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_promo_sk#7, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, p_promo_sk#66]
 
-(84) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#59, hd_income_band_sk#60]
+(81) Scan parquet spark_catalog.default.household_demographics
+Output [2]: [hd_demo_sk#67, hd_income_band_sk#68]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
-(85) ColumnarToRow [codegen id : 28]
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
+(82) ColumnarToRow [codegen id : 28]
+Input [2]: [hd_demo_sk#67, hd_income_band_sk#68]
 
-(86) Filter [codegen id : 28]
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
-Condition : (isnotnull(hd_demo_sk#59) AND isnotnull(hd_income_band_sk#60))
+(83) Filter [codegen id : 28]
+Input [2]: [hd_demo_sk#67, hd_income_band_sk#68]
+Condition : (isnotnull(hd_demo_sk#67) AND isnotnull(hd_income_band_sk#68))
 
-(87) BroadcastExchange
-Input [2]: [hd_demo_sk#59, hd_income_band_sk#60]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+(84) BroadcastExchange
+Input [2]: [hd_demo_sk#67, hd_income_band_sk#68]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
+
+(85) BroadcastHashJoin [codegen id : 30]
+Left keys [1]: [ss_hdemo_sk#4]
+Right keys [1]: [hd_demo_sk#67]
+Join type: Inner
+Join condition: None
+
+(86) Project [codegen id : 30]
+Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68]
+Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, hd_demo_sk#67, hd_income_band_sk#68]
+
+(87) ReusedExchange [Reuses operator id: 84]
+Output [2]: [hd_demo_sk#69, hd_income_band_sk#70]
 
 (88) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [ss_hdemo_sk#4]
-Right keys [1]: [hd_demo_sk#59]
+Left keys [1]: [c_current_hdemo_sk#50]
+Right keys [1]: [hd_demo_sk#69]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60]
-Input [15]: [ss_item_sk#1, ss_hdemo_sk#4, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_demo_sk#59, hd_income_band_sk#60]
+Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70]
+Input [15]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_hdemo_sk#50, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_demo_sk#69, hd_income_band_sk#70]
 
-(90) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#61, hd_income_band_sk#62]
+(90) Exchange
+Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70]
+Arguments: hashpartitioning(ss_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(91) BroadcastHashJoin [codegen id : 30]
-Left keys [1]: [c_current_hdemo_sk#46]
-Right keys [1]: [hd_demo_sk#61]
-Join type: Inner
-Join condition: None
-
-(92) Project [codegen id : 30]
-Output [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
-Input [15]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_hdemo_sk#46, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_demo_sk#61, hd_income_band_sk#62]
-
-(93) Exchange
-Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
-Arguments: hashpartitioning(ss_addr_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(94) Sort [codegen id : 31]
-Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62]
+(91) Sort [codegen id : 31]
+Input [13]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70]
 Arguments: [ss_addr_sk#5 ASC NULLS FIRST], false, 0
 
-(95) Scan parquet spark_catalog.default.customer_address
-Output [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
+(92) ReusedExchange [Reuses operator id: 242]
+Output [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
 
-(96) ColumnarToRow [codegen id : 32]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+(93) Sort [codegen id : 33]
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Arguments: [ca_address_sk#71 ASC NULLS FIRST], false, 0
 
-(97) Filter [codegen id : 32]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Condition : isnotnull(ca_address_sk#63)
-
-(98) Exchange
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: hashpartitioning(ca_address_sk#63, 5), ENSURE_REQUIREMENTS, [plan_id=17]
-
-(99) Sort [codegen id : 33]
-Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: [ca_address_sk#63 ASC NULLS FIRST], false, 0
-
-(100) SortMergeJoin [codegen id : 34]
+(94) SortMergeJoin [codegen id : 34]
 Left keys [1]: [ss_addr_sk#5]
-Right keys [1]: [ca_address_sk#63]
+Right keys [1]: [ca_address_sk#71]
 Join type: Inner
 Join condition: None
 
-(101) Project [codegen id : 34]
-Output [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Input [18]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
+(95) Project [codegen id : 34]
+Output [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Input [18]: [ss_item_sk#1, ss_addr_sk#5, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
 
-(102) Exchange
-Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: hashpartitioning(c_current_addr_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+(96) Exchange
+Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Arguments: hashpartitioning(c_current_addr_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(103) Sort [codegen id : 35]
-Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
-Arguments: [c_current_addr_sk#47 ASC NULLS FIRST], false, 0
+(97) Sort [codegen id : 35]
+Input [16]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Arguments: [c_current_addr_sk#51 ASC NULLS FIRST], false, 0
 
-(104) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
+(98) ReusedExchange [Reuses operator id: 242]
+Output [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
 
-(105) Sort [codegen id : 37]
-Input [5]: [ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Arguments: [ca_address_sk#68 ASC NULLS FIRST], false, 0
+(99) Sort [codegen id : 37]
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Arguments: [ca_address_sk#76 ASC NULLS FIRST], false, 0
 
-(106) SortMergeJoin [codegen id : 41]
-Left keys [1]: [c_current_addr_sk#47]
-Right keys [1]: [ca_address_sk#68]
+(100) SortMergeJoin [codegen id : 41]
+Left keys [1]: [c_current_addr_sk#51]
+Right keys [1]: [ca_address_sk#76]
 Join type: Inner
 Join condition: None
 
-(107) Project [codegen id : 41]
-Output [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [21]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, c_current_addr_sk#47, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_address_sk#68, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
+(101) Project [codegen id : 41]
+Output [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Input [21]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, c_current_addr_sk#51, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
 
-(108) Scan parquet spark_catalog.default.income_band
-Output [1]: [ib_income_band_sk#73]
+(102) Scan parquet spark_catalog.default.income_band
+Output [1]: [ib_income_band_sk#81]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/income_band]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
-(109) ColumnarToRow [codegen id : 38]
-Input [1]: [ib_income_band_sk#73]
+(103) ColumnarToRow [codegen id : 38]
+Input [1]: [ib_income_band_sk#81]
 
-(110) Filter [codegen id : 38]
-Input [1]: [ib_income_band_sk#73]
-Condition : isnotnull(ib_income_band_sk#73)
+(104) Filter [codegen id : 38]
+Input [1]: [ib_income_band_sk#81]
+Condition : isnotnull(ib_income_band_sk#81)
 
-(111) BroadcastExchange
-Input [1]: [ib_income_band_sk#73]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=19]
+(105) BroadcastExchange
+Input [1]: [ib_income_band_sk#81]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=17]
 
-(112) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [hd_income_band_sk#60]
-Right keys [1]: [ib_income_band_sk#73]
+(106) BroadcastHashJoin [codegen id : 41]
+Left keys [1]: [hd_income_band_sk#68]
+Right keys [1]: [ib_income_band_sk#81]
 Join type: Inner
 Join condition: None
 
-(113) Project [codegen id : 41]
-Output [18]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [20]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#60, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, ib_income_band_sk#73]
+(107) Project [codegen id : 41]
+Output [18]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Input [20]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, hd_income_band_sk#68, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, ib_income_band_sk#81]
 
-(114) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#74]
+(108) ReusedExchange [Reuses operator id: 105]
+Output [1]: [ib_income_band_sk#82]
 
-(115) BroadcastHashJoin [codegen id : 41]
-Left keys [1]: [hd_income_band_sk#62]
-Right keys [1]: [ib_income_band_sk#74]
+(109) BroadcastHashJoin [codegen id : 41]
+Left keys [1]: [hd_income_band_sk#70]
+Right keys [1]: [ib_income_band_sk#82]
 Join type: Inner
 Join condition: None
 
-(116) Project [codegen id : 41]
-Output [17]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72]
-Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, hd_income_band_sk#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, ib_income_band_sk#74]
+(110) Project [codegen id : 41]
+Output [17]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, hd_income_band_sk#70, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, ib_income_band_sk#82]
 
-(117) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+(111) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#83, i_current_price#84, i_color#85, i_product_name#86]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood           ,floral              ,indian              ,medium              ,purple              ,spring              ]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string,i_product_name:string>
 
-(118) ColumnarToRow [codegen id : 40]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+(112) ColumnarToRow [codegen id : 40]
+Input [4]: [i_item_sk#83, i_current_price#84, i_color#85, i_product_name#86]
 
-(119) Filter [codegen id : 40]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
-Condition : ((((((isnotnull(i_current_price#76) AND i_color#77 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#76 >= 64.00)) AND (i_current_price#76 <= 74.00)) AND (i_current_price#76 >= 65.00)) AND (i_current_price#76 <= 79.00)) AND isnotnull(i_item_sk#75))
+(113) Filter [codegen id : 40]
+Input [4]: [i_item_sk#83, i_current_price#84, i_color#85, i_product_name#86]
+Condition : ((((((isnotnull(i_current_price#84) AND i_color#85 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#84 >= 64.00)) AND (i_current_price#84 <= 74.00)) AND (i_current_price#84 >= 65.00)) AND (i_current_price#84 <= 79.00)) AND isnotnull(i_item_sk#83))
 
-(120) Project [codegen id : 40]
-Output [2]: [i_item_sk#75, i_product_name#78]
-Input [4]: [i_item_sk#75, i_current_price#76, i_color#77, i_product_name#78]
+(114) Project [codegen id : 40]
+Output [2]: [i_item_sk#83, i_product_name#86]
+Input [4]: [i_item_sk#83, i_current_price#84, i_color#85, i_product_name#86]
 
-(121) BroadcastExchange
-Input [2]: [i_item_sk#75, i_product_name#78]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
+(115) BroadcastExchange
+Input [2]: [i_item_sk#83, i_product_name#86]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
-(122) BroadcastHashJoin [codegen id : 41]
+(116) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#75]
+Right keys [1]: [i_item_sk#83]
 Join type: Inner
 Join condition: None
 
-(123) Project [codegen id : 41]
-Output [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, d_year#51, d_year#53, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
-Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, s_store_name#42, s_zip#43, d_year#51, d_year#53, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
+(117) Project [codegen id : 41]
+Output [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, d_year#59, d_year#61, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, i_item_sk#83, i_product_name#86]
+Input [19]: [ss_item_sk#1, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, s_store_name#46, s_zip#47, d_year#59, d_year#61, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, i_item_sk#83, i_product_name#86]
 
-(124) HashAggregate [codegen id : 41]
-Input [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#40, d_year#51, d_year#53, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, i_item_sk#75, i_product_name#78]
-Keys [15]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53]
+(118) HashAggregate [codegen id : 41]
+Input [18]: [ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, d_year#44, d_year#59, d_year#61, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, i_item_sk#83, i_product_name#86]
+Keys [15]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61]
 Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#9)), partial_sum(UnscaledValue(ss_list_price#10)), partial_sum(UnscaledValue(ss_coupon_amt#11))]
-Aggregate Attributes [4]: [count#79, sum#80, sum#81, sum#82]
-Results [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
+Aggregate Attributes [4]: [count#87, sum#88, sum#89, sum#90]
+Results [19]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61, count#91, sum#92, sum#93, sum#94]
 
-(125) Exchange
-Input [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
-Arguments: hashpartitioning(i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+(119) Exchange
+Input [19]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61, count#91, sum#92, sum#93, sum#94]
+Arguments: hashpartitioning(i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(126) HashAggregate [codegen id : 42]
-Input [19]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53, count#83, sum#84, sum#85, sum#86]
-Keys [15]: [i_product_name#78, i_item_sk#75, s_store_name#42, s_zip#43, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ca_street_number#69, ca_street_name#70, ca_city#71, ca_zip#72, d_year#40, d_year#51, d_year#53]
+(120) HashAggregate [codegen id : 42]
+Input [19]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61, count#91, sum#92, sum#93, sum#94]
+Keys [15]: [i_product_name#86, i_item_sk#83, s_store_name#46, s_zip#47, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80, d_year#44, d_year#59, d_year#61]
 Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#9)), sum(UnscaledValue(ss_list_price#10)), sum(UnscaledValue(ss_coupon_amt#11))]
-Aggregate Attributes [4]: [count(1)#87, sum(UnscaledValue(ss_wholesale_cost#9))#88, sum(UnscaledValue(ss_list_price#10))#89, sum(UnscaledValue(ss_coupon_amt#11))#90]
-Results [17]: [i_product_name#78 AS product_name#91, i_item_sk#75 AS item_sk#92, s_store_name#42 AS store_name#93, s_zip#43 AS store_zip#94, ca_street_number#64 AS b_street_number#95, ca_street_name#65 AS b_streen_name#96, ca_city#66 AS b_city#97, ca_zip#67 AS b_zip#98, ca_street_number#69 AS c_street_number#99, ca_street_name#70 AS c_street_name#100, ca_city#71 AS c_city#101, ca_zip#72 AS c_zip#102, d_year#40 AS syear#103, count(1)#87 AS cnt#104, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#9))#88,17,2) AS s1#105, MakeDecimal(sum(UnscaledValue(ss_list_price#10))#89,17,2) AS s2#106, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#11))#90,17,2) AS s3#107]
+Aggregate Attributes [4]: [count(1)#95, sum(UnscaledValue(ss_wholesale_cost#9))#96, sum(UnscaledValue(ss_list_price#10))#97, sum(UnscaledValue(ss_coupon_amt#11))#98]
+Results [17]: [i_product_name#86 AS product_name#99, i_item_sk#83 AS item_sk#100, s_store_name#46 AS store_name#101, s_zip#47 AS store_zip#102, ca_street_number#72 AS b_street_number#103, ca_street_name#73 AS b_streen_name#104, ca_city#74 AS b_city#105, ca_zip#75 AS b_zip#106, ca_street_number#77 AS c_street_number#107, ca_street_name#78 AS c_street_name#108, ca_city#79 AS c_city#109, ca_zip#80 AS c_zip#110, d_year#44 AS syear#111, count(1)#95 AS cnt#112, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#9))#96,17,2) AS s1#113, MakeDecimal(sum(UnscaledValue(ss_list_price#10))#97,17,2) AS s2#114, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#11))#98,17,2) AS s3#115]
 
-(127) Exchange
-Input [17]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107]
-Arguments: hashpartitioning(item_sk#92, store_name#93, store_zip#94, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+(121) Exchange
+Input [17]: [product_name#99, item_sk#100, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115]
+Arguments: hashpartitioning(item_sk#100, store_name#101, store_zip#102, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(128) Sort [codegen id : 43]
-Input [17]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107]
-Arguments: [item_sk#92 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, store_zip#94 ASC NULLS FIRST], false, 0
+(122) Sort [codegen id : 43]
+Input [17]: [product_name#99, item_sk#100, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115]
+Arguments: [item_sk#100 ASC NULLS FIRST, store_name#101 ASC NULLS FIRST, store_zip#102 ASC NULLS FIRST], false, 0
 
-(129) Scan parquet spark_catalog.default.store_sales
-Output [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
+(123) Scan parquet spark_catalog.default.store_sales
+Output [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#119), dynamicpruningexpression(ss_sold_date_sk#119 IN dynamicpruning#120)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#127), dynamicpruningexpression(ss_sold_date_sk#127 IN dynamicpruning#128)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_cdemo_sk), IsNotNull(ss_promo_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_cdemo_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ticket_number:int,ss_wholesale_cost:decimal(7,2),ss_list_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(130) ColumnarToRow [codegen id : 44]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
+(124) ColumnarToRow [codegen id : 44]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
 
-(131) Filter [codegen id : 44]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Condition : ((((((((isnotnull(ss_item_sk#108) AND isnotnull(ss_ticket_number#115)) AND isnotnull(ss_store_sk#113)) AND isnotnull(ss_customer_sk#109)) AND isnotnull(ss_cdemo_sk#110)) AND isnotnull(ss_promo_sk#114)) AND isnotnull(ss_hdemo_sk#111)) AND isnotnull(ss_addr_sk#112)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#108, 42)))
+(125) Filter [codegen id : 44]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Condition : ((((((((((isnotnull(ss_item_sk#116) AND isnotnull(ss_ticket_number#123)) AND isnotnull(ss_store_sk#121)) AND isnotnull(ss_customer_sk#117)) AND isnotnull(ss_cdemo_sk#118)) AND isnotnull(ss_promo_sk#122)) AND isnotnull(ss_hdemo_sk#119)) AND isnotnull(ss_addr_sk#120)) AND true) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(ss_cdemo_sk#118, 42), false)) AND might_contain(ReusedSubquery Subquery scalar-subquery#16, [id=#17], xxhash64(ss_addr_sk#120, 42), false))
 
-(132) Exchange
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Arguments: hashpartitioning(ss_item_sk#108, ss_ticket_number#115, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+(126) Exchange
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Arguments: hashpartitioning(ss_item_sk#116, ss_ticket_number#123, 5), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(133) Sort [codegen id : 45]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Arguments: [ss_item_sk#108 ASC NULLS FIRST, ss_ticket_number#115 ASC NULLS FIRST], false, 0
+(127) Sort [codegen id : 45]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Arguments: [ss_item_sk#116 ASC NULLS FIRST, ss_ticket_number#123 ASC NULLS FIRST], false, 0
 
-(134) ReusedExchange [Reuses operator id: 10]
-Output [2]: [sr_item_sk#121, sr_ticket_number#122]
+(128) ReusedExchange [Reuses operator id: 10]
+Output [2]: [sr_item_sk#129, sr_ticket_number#130]
 
-(135) Sort [codegen id : 47]
-Input [2]: [sr_item_sk#121, sr_ticket_number#122]
-Arguments: [sr_item_sk#121 ASC NULLS FIRST, sr_ticket_number#122 ASC NULLS FIRST], false, 0
+(129) Sort [codegen id : 47]
+Input [2]: [sr_item_sk#129, sr_ticket_number#130]
+Arguments: [sr_item_sk#129 ASC NULLS FIRST, sr_ticket_number#130 ASC NULLS FIRST], false, 0
 
-(136) SortMergeJoin [codegen id : 56]
-Left keys [2]: [ss_item_sk#108, ss_ticket_number#115]
-Right keys [2]: [sr_item_sk#121, sr_ticket_number#122]
+(130) SortMergeJoin [codegen id : 56]
+Left keys [2]: [ss_item_sk#116, ss_ticket_number#123]
+Right keys [2]: [sr_item_sk#129, sr_ticket_number#130]
+Join type: Inner
+Join condition: None
+
+(131) Project [codegen id : 56]
+Output [11]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Input [14]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_ticket_number#123, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127, sr_item_sk#129, sr_ticket_number#130]
+
+(132) ReusedExchange [Reuses operator id: 33]
+Output [1]: [cs_item_sk#131]
+
+(133) BroadcastHashJoin [codegen id : 56]
+Left keys [1]: [ss_item_sk#116]
+Right keys [1]: [cs_item_sk#131]
+Join type: Inner
+Join condition: None
+
+(134) Project [codegen id : 56]
+Output [11]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127, cs_item_sk#131]
+
+(135) ReusedExchange [Reuses operator id: 249]
+Output [2]: [d_date_sk#132, d_year#133]
+
+(136) BroadcastHashJoin [codegen id : 56]
+Left keys [1]: [ss_sold_date_sk#127]
+Right keys [1]: [d_date_sk#132]
 Join type: Inner
 Join condition: None
 
 (137) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Input [14]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, sr_item_sk#121, sr_ticket_number#122]
+Output [11]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133]
+Input [13]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, ss_sold_date_sk#127, d_date_sk#132, d_year#133]
 
-(138) ReusedExchange [Reuses operator id: 33]
-Output [1]: [cs_item_sk#123]
+(138) ReusedExchange [Reuses operator id: 42]
+Output [3]: [s_store_sk#134, s_store_name#135, s_zip#136]
 
 (139) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_item_sk#108]
-Right keys [1]: [cs_item_sk#123]
+Left keys [1]: [ss_store_sk#121]
+Right keys [1]: [s_store_sk#134]
 Join type: Inner
 Join condition: None
 
 (140) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, cs_item_sk#123]
+Output [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136]
+Input [14]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_store_sk#121, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_sk#134, s_store_name#135, s_zip#136]
 
-(141) ReusedExchange [Reuses operator id: 224]
-Output [2]: [d_date_sk#124, d_year#125]
+(141) Exchange
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136]
+Arguments: hashpartitioning(ss_customer_sk#117, 5), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(142) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_sold_date_sk#119]
-Right keys [1]: [d_date_sk#124]
+(142) Sort [codegen id : 57]
+Input [12]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136]
+Arguments: [ss_customer_sk#117 ASC NULLS FIRST], false, 0
+
+(143) Scan parquet spark_catalog.default.customer
+Output [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_first_sales_date_sk), IsNotNull(c_first_shipto_date_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int,c_first_shipto_date_sk:int,c_first_sales_date_sk:int>
+
+(144) ColumnarToRow [codegen id : 58]
+Input [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+
+(145) Filter [codegen id : 58]
+Input [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Condition : ((((((isnotnull(c_customer_sk#137) AND isnotnull(c_first_sales_date_sk#142)) AND isnotnull(c_first_shipto_date_sk#141)) AND isnotnull(c_current_cdemo_sk#138)) AND isnotnull(c_current_hdemo_sk#139)) AND isnotnull(c_current_addr_sk#140)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(c_current_cdemo_sk#138, 42), false))
+
+(146) Exchange
+Input [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Arguments: hashpartitioning(c_customer_sk#137, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+
+(147) Sort [codegen id : 59]
+Input [6]: [c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Arguments: [c_customer_sk#137 ASC NULLS FIRST], false, 0
+
+(148) SortMergeJoin [codegen id : 62]
+Left keys [1]: [ss_customer_sk#117]
+Right keys [1]: [c_customer_sk#137]
 Join type: Inner
 Join condition: None
 
-(143) Project [codegen id : 56]
-Output [11]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125]
-Input [13]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119, d_date_sk#124, d_year#125]
+(149) Project [codegen id : 62]
+Output [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
+Input [18]: [ss_item_sk#116, ss_customer_sk#117, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_customer_sk#137, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142]
 
-(144) ReusedExchange [Reuses operator id: 42]
-Output [3]: [s_store_sk#126, s_store_name#127, s_zip#128]
+(150) ReusedExchange [Reuses operator id: 57]
+Output [2]: [d_date_sk#143, d_year#144]
 
-(145) BroadcastHashJoin [codegen id : 56]
-Left keys [1]: [ss_store_sk#113]
-Right keys [1]: [s_store_sk#126]
-Join type: Inner
-Join condition: None
-
-(146) Project [codegen id : 56]
-Output [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Input [14]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_sk#126, s_store_name#127, s_zip#128]
-
-(147) Exchange
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Arguments: hashpartitioning(ss_customer_sk#109, 5), ENSURE_REQUIREMENTS, [plan_id=24]
-
-(148) Sort [codegen id : 57]
-Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128]
-Arguments: [ss_customer_sk#109 ASC NULLS FIRST], false, 0
-
-(149) ReusedExchange [Reuses operator id: 50]
-Output [6]: [c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-
-(150) Sort [codegen id : 59]
-Input [6]: [c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-Arguments: [c_customer_sk#129 ASC NULLS FIRST], false, 0
-
-(151) SortMergeJoin [codegen id : 62]
-Left keys [1]: [ss_customer_sk#109]
-Right keys [1]: [c_customer_sk#129]
+(151) BroadcastHashJoin [codegen id : 62]
+Left keys [1]: [c_first_sales_date_sk#142]
+Right keys [1]: [d_date_sk#143]
 Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
-Input [18]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_customer_sk#129, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134]
+Output [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, d_year#144]
+Input [18]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, c_first_sales_date_sk#142, d_date_sk#143, d_year#144]
 
 (153) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#135, d_year#136]
+Output [2]: [d_date_sk#145, d_year#146]
 
 (154) BroadcastHashJoin [codegen id : 62]
-Left keys [1]: [c_first_sales_date_sk#134]
-Right keys [1]: [d_date_sk#135]
+Left keys [1]: [c_first_shipto_date_sk#141]
+Right keys [1]: [d_date_sk#145]
 Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, d_year#136]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, c_first_sales_date_sk#134, d_date_sk#135, d_year#136]
+Output [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Input [18]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, c_first_shipto_date_sk#141, d_year#144, d_date_sk#145, d_year#146]
 
-(156) ReusedExchange [Reuses operator id: 57]
-Output [2]: [d_date_sk#137, d_year#138]
+(156) Exchange
+Input [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Arguments: hashpartitioning(ss_cdemo_sk#118, 5), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(157) BroadcastHashJoin [codegen id : 62]
-Left keys [1]: [c_first_shipto_date_sk#133]
-Right keys [1]: [d_date_sk#137]
+(157) Sort [codegen id : 63]
+Input [16]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Arguments: [ss_cdemo_sk#118 ASC NULLS FIRST], false, 0
+
+(158) ReusedExchange [Reuses operator id: 235]
+Output [2]: [cd_demo_sk#147, cd_marital_status#148]
+
+(159) Sort [codegen id : 65]
+Input [2]: [cd_demo_sk#147, cd_marital_status#148]
+Arguments: [cd_demo_sk#147 ASC NULLS FIRST], false, 0
+
+(160) SortMergeJoin [codegen id : 66]
+Left keys [1]: [ss_cdemo_sk#118]
+Right keys [1]: [cd_demo_sk#147]
 Join type: Inner
 Join condition: None
 
-(158) Project [codegen id : 62]
-Output [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, c_first_shipto_date_sk#133, d_year#136, d_date_sk#137, d_year#138]
+(161) Project [codegen id : 66]
+Output [16]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_marital_status#148]
+Input [18]: [ss_item_sk#116, ss_cdemo_sk#118, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_demo_sk#147, cd_marital_status#148]
 
-(159) Exchange
-Input [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Arguments: hashpartitioning(ss_cdemo_sk#110, 5), ENSURE_REQUIREMENTS, [plan_id=25]
+(162) Exchange
+Input [16]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_marital_status#148]
+Arguments: hashpartitioning(c_current_cdemo_sk#138, 5), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(160) Sort [codegen id : 63]
-Input [16]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Arguments: [ss_cdemo_sk#110 ASC NULLS FIRST], false, 0
+(163) Sort [codegen id : 67]
+Input [16]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_marital_status#148]
+Arguments: [c_current_cdemo_sk#138 ASC NULLS FIRST], false, 0
 
-(161) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#139, cd_marital_status#140]
+(164) ReusedExchange [Reuses operator id: 235]
+Output [2]: [cd_demo_sk#149, cd_marital_status#150]
 
-(162) Sort [codegen id : 65]
-Input [2]: [cd_demo_sk#139, cd_marital_status#140]
-Arguments: [cd_demo_sk#139 ASC NULLS FIRST], false, 0
+(165) Sort [codegen id : 69]
+Input [2]: [cd_demo_sk#149, cd_marital_status#150]
+Arguments: [cd_demo_sk#149 ASC NULLS FIRST], false, 0
 
-(163) SortMergeJoin [codegen id : 66]
-Left keys [1]: [ss_cdemo_sk#110]
-Right keys [1]: [cd_demo_sk#139]
+(166) SortMergeJoin [codegen id : 73]
+Left keys [1]: [c_current_cdemo_sk#138]
+Right keys [1]: [cd_demo_sk#149]
+Join type: Inner
+Join condition: NOT (cd_marital_status#148 = cd_marital_status#150)
+
+(167) Project [codegen id : 73]
+Output [14]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Input [18]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_cdemo_sk#138, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, cd_marital_status#148, cd_demo_sk#149, cd_marital_status#150]
+
+(168) ReusedExchange [Reuses operator id: 78]
+Output [1]: [p_promo_sk#151]
+
+(169) BroadcastHashJoin [codegen id : 73]
+Left keys [1]: [ss_promo_sk#122]
+Right keys [1]: [p_promo_sk#151]
 Join type: Inner
 Join condition: None
-
-(164) Project [codegen id : 66]
-Output [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Input [18]: [ss_item_sk#108, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_demo_sk#139, cd_marital_status#140]
-
-(165) Exchange
-Input [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Arguments: hashpartitioning(c_current_cdemo_sk#130, 5), ENSURE_REQUIREMENTS, [plan_id=26]
-
-(166) Sort [codegen id : 67]
-Input [16]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140]
-Arguments: [c_current_cdemo_sk#130 ASC NULLS FIRST], false, 0
-
-(167) ReusedExchange [Reuses operator id: 68]
-Output [2]: [cd_demo_sk#141, cd_marital_status#142]
-
-(168) Sort [codegen id : 69]
-Input [2]: [cd_demo_sk#141, cd_marital_status#142]
-Arguments: [cd_demo_sk#141 ASC NULLS FIRST], false, 0
-
-(169) SortMergeJoin [codegen id : 73]
-Left keys [1]: [c_current_cdemo_sk#130]
-Right keys [1]: [cd_demo_sk#141]
-Join type: Inner
-Join condition: NOT (cd_marital_status#140 = cd_marital_status#142)
 
 (170) Project [codegen id : 73]
-Output [14]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [18]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_cdemo_sk#130, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, cd_marital_status#140, cd_demo_sk#141, cd_marital_status#142]
+Output [13]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146]
+Input [15]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_promo_sk#122, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, p_promo_sk#151]
 
-(171) ReusedExchange [Reuses operator id: 81]
-Output [1]: [p_promo_sk#143]
+(171) ReusedExchange [Reuses operator id: 84]
+Output [2]: [hd_demo_sk#152, hd_income_band_sk#153]
 
 (172) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [ss_promo_sk#114]
-Right keys [1]: [p_promo_sk#143]
+Left keys [1]: [ss_hdemo_sk#119]
+Right keys [1]: [hd_demo_sk#152]
 Join type: Inner
 Join condition: None
 
 (173) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138]
-Input [15]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_promo_sk#114, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, p_promo_sk#143]
+Output [13]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153]
+Input [15]: [ss_item_sk#116, ss_hdemo_sk#119, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, hd_demo_sk#152, hd_income_band_sk#153]
 
-(174) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#144, hd_income_band_sk#145]
+(174) ReusedExchange [Reuses operator id: 84]
+Output [2]: [hd_demo_sk#154, hd_income_band_sk#155]
 
 (175) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [ss_hdemo_sk#111]
-Right keys [1]: [hd_demo_sk#144]
+Left keys [1]: [c_current_hdemo_sk#139]
+Right keys [1]: [hd_demo_sk#154]
 Join type: Inner
 Join condition: None
 
 (176) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145]
-Input [15]: [ss_item_sk#108, ss_hdemo_sk#111, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_demo_sk#144, hd_income_band_sk#145]
+Output [13]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155]
+Input [15]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_hdemo_sk#139, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_demo_sk#154, hd_income_band_sk#155]
 
-(177) ReusedExchange [Reuses operator id: 87]
-Output [2]: [hd_demo_sk#146, hd_income_band_sk#147]
+(177) Exchange
+Input [13]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155]
+Arguments: hashpartitioning(ss_addr_sk#120, 5), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(178) BroadcastHashJoin [codegen id : 73]
-Left keys [1]: [c_current_hdemo_sk#131]
-Right keys [1]: [hd_demo_sk#146]
+(178) Sort [codegen id : 74]
+Input [13]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155]
+Arguments: [ss_addr_sk#120 ASC NULLS FIRST], false, 0
+
+(179) ReusedExchange [Reuses operator id: 242]
+Output [5]: [ca_address_sk#156, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+
+(180) Sort [codegen id : 76]
+Input [5]: [ca_address_sk#156, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+Arguments: [ca_address_sk#156 ASC NULLS FIRST], false, 0
+
+(181) SortMergeJoin [codegen id : 77]
+Left keys [1]: [ss_addr_sk#120]
+Right keys [1]: [ca_address_sk#156]
 Join type: Inner
 Join condition: None
 
-(179) Project [codegen id : 73]
-Output [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Input [15]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_hdemo_sk#131, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_demo_sk#146, hd_income_band_sk#147]
+(182) Project [codegen id : 77]
+Output [16]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+Input [18]: [ss_item_sk#116, ss_addr_sk#120, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_address_sk#156, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
 
-(180) Exchange
-Input [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Arguments: hashpartitioning(ss_addr_sk#112, 5), ENSURE_REQUIREMENTS, [plan_id=27]
+(183) Exchange
+Input [16]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+Arguments: hashpartitioning(c_current_addr_sk#140, 5), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(181) Sort [codegen id : 74]
-Input [13]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147]
-Arguments: [ss_addr_sk#112 ASC NULLS FIRST], false, 0
+(184) Sort [codegen id : 78]
+Input [16]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160]
+Arguments: [c_current_addr_sk#140 ASC NULLS FIRST], false, 0
 
-(182) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
+(185) ReusedExchange [Reuses operator id: 242]
+Output [5]: [ca_address_sk#161, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
 
-(183) Sort [codegen id : 76]
-Input [5]: [ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: [ca_address_sk#148 ASC NULLS FIRST], false, 0
+(186) Sort [codegen id : 80]
+Input [5]: [ca_address_sk#161, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
+Arguments: [ca_address_sk#161 ASC NULLS FIRST], false, 0
 
-(184) SortMergeJoin [codegen id : 77]
-Left keys [1]: [ss_addr_sk#112]
-Right keys [1]: [ca_address_sk#148]
+(187) SortMergeJoin [codegen id : 84]
+Left keys [1]: [c_current_addr_sk#140]
+Right keys [1]: [ca_address_sk#161]
 Join type: Inner
 Join condition: None
 
-(185) Project [codegen id : 77]
-Output [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Input [18]: [ss_item_sk#108, ss_addr_sk#112, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_address_sk#148, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
+(188) Project [codegen id : 84]
+Output [19]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
+Input [21]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, c_current_addr_sk#140, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_address_sk#161, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
 
-(186) Exchange
-Input [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: hashpartitioning(c_current_addr_sk#132, 5), ENSURE_REQUIREMENTS, [plan_id=28]
+(189) ReusedExchange [Reuses operator id: 105]
+Output [1]: [ib_income_band_sk#166]
 
-(187) Sort [codegen id : 78]
-Input [16]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152]
-Arguments: [c_current_addr_sk#132 ASC NULLS FIRST], false, 0
-
-(188) ReusedExchange [Reuses operator id: 98]
-Output [5]: [ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-
-(189) Sort [codegen id : 80]
-Input [5]: [ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Arguments: [ca_address_sk#153 ASC NULLS FIRST], false, 0
-
-(190) SortMergeJoin [codegen id : 84]
-Left keys [1]: [c_current_addr_sk#132]
-Right keys [1]: [ca_address_sk#153]
+(190) BroadcastHashJoin [codegen id : 84]
+Left keys [1]: [hd_income_band_sk#153]
+Right keys [1]: [ib_income_band_sk#166]
 Join type: Inner
 Join condition: None
 
 (191) Project [codegen id : 84]
-Output [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [21]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, c_current_addr_sk#132, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_address_sk#153, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
+Output [18]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
+Input [20]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, hd_income_band_sk#153, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, ib_income_band_sk#166]
 
-(192) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#158]
+(192) ReusedExchange [Reuses operator id: 105]
+Output [1]: [ib_income_band_sk#167]
 
 (193) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [hd_income_band_sk#145]
-Right keys [1]: [ib_income_band_sk#158]
+Left keys [1]: [hd_income_band_sk#155]
+Right keys [1]: [ib_income_band_sk#167]
 Join type: Inner
 Join condition: None
 
 (194) Project [codegen id : 84]
-Output [18]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [20]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#145, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, ib_income_band_sk#158]
+Output [17]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165]
+Input [19]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, hd_income_band_sk#155, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, ib_income_band_sk#167]
 
-(195) ReusedExchange [Reuses operator id: 111]
-Output [1]: [ib_income_band_sk#159]
+(195) ReusedExchange [Reuses operator id: 115]
+Output [2]: [i_item_sk#168, i_product_name#169]
 
 (196) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [hd_income_band_sk#147]
-Right keys [1]: [ib_income_band_sk#159]
+Left keys [1]: [ss_item_sk#116]
+Right keys [1]: [i_item_sk#168]
 Join type: Inner
 Join condition: None
 
 (197) Project [codegen id : 84]
-Output [17]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157]
-Input [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, hd_income_band_sk#147, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, ib_income_band_sk#159]
+Output [18]: [ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, d_year#144, d_year#146, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, i_item_sk#168, i_product_name#169]
+Input [19]: [ss_item_sk#116, ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, s_store_name#135, s_zip#136, d_year#144, d_year#146, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, i_item_sk#168, i_product_name#169]
 
-(198) ReusedExchange [Reuses operator id: 121]
-Output [2]: [i_item_sk#160, i_product_name#161]
+(198) HashAggregate [codegen id : 84]
+Input [18]: [ss_wholesale_cost#124, ss_list_price#125, ss_coupon_amt#126, d_year#133, d_year#144, d_year#146, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, i_item_sk#168, i_product_name#169]
+Keys [15]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146]
+Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#124)), partial_sum(UnscaledValue(ss_list_price#125)), partial_sum(UnscaledValue(ss_coupon_amt#126))]
+Aggregate Attributes [4]: [count#87, sum#170, sum#171, sum#172]
+Results [19]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146, count#91, sum#173, sum#174, sum#175]
 
-(199) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [ss_item_sk#108]
-Right keys [1]: [i_item_sk#160]
+(199) Exchange
+Input [19]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146, count#91, sum#173, sum#174, sum#175]
+Arguments: hashpartitioning(i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146, 5), ENSURE_REQUIREMENTS, [plan_id=28]
+
+(200) HashAggregate [codegen id : 85]
+Input [19]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146, count#91, sum#173, sum#174, sum#175]
+Keys [15]: [i_product_name#169, i_item_sk#168, s_store_name#135, s_zip#136, ca_street_number#157, ca_street_name#158, ca_city#159, ca_zip#160, ca_street_number#162, ca_street_name#163, ca_city#164, ca_zip#165, d_year#133, d_year#144, d_year#146]
+Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#124)), sum(UnscaledValue(ss_list_price#125)), sum(UnscaledValue(ss_coupon_amt#126))]
+Aggregate Attributes [4]: [count(1)#95, sum(UnscaledValue(ss_wholesale_cost#124))#96, sum(UnscaledValue(ss_list_price#125))#97, sum(UnscaledValue(ss_coupon_amt#126))#98]
+Results [8]: [i_item_sk#168 AS item_sk#176, s_store_name#135 AS store_name#177, s_zip#136 AS store_zip#178, d_year#133 AS syear#179, count(1)#95 AS cnt#180, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#124))#96,17,2) AS s1#181, MakeDecimal(sum(UnscaledValue(ss_list_price#125))#97,17,2) AS s2#182, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#126))#98,17,2) AS s3#183]
+
+(201) Exchange
+Input [8]: [item_sk#176, store_name#177, store_zip#178, syear#179, cnt#180, s1#181, s2#182, s3#183]
+Arguments: hashpartitioning(item_sk#176, store_name#177, store_zip#178, 5), ENSURE_REQUIREMENTS, [plan_id=29]
+
+(202) Sort [codegen id : 86]
+Input [8]: [item_sk#176, store_name#177, store_zip#178, syear#179, cnt#180, s1#181, s2#182, s3#183]
+Arguments: [item_sk#176 ASC NULLS FIRST, store_name#177 ASC NULLS FIRST, store_zip#178 ASC NULLS FIRST], false, 0
+
+(203) SortMergeJoin [codegen id : 87]
+Left keys [3]: [item_sk#100, store_name#101, store_zip#102]
+Right keys [3]: [item_sk#176, store_name#177, store_zip#178]
 Join type: Inner
-Join condition: None
+Join condition: (cnt#180 <= cnt#112)
 
-(200) Project [codegen id : 84]
-Output [18]: [ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, d_year#136, d_year#138, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
-Input [19]: [ss_item_sk#108, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, s_store_name#127, s_zip#128, d_year#136, d_year#138, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
+(204) Project [codegen id : 87]
+Output [21]: [product_name#99, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115, s1#181, s2#182, s3#183, syear#179, cnt#180]
+Input [25]: [product_name#99, item_sk#100, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115, item_sk#176, store_name#177, store_zip#178, syear#179, cnt#180, s1#181, s2#182, s3#183]
 
-(201) HashAggregate [codegen id : 84]
-Input [18]: [ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, d_year#125, d_year#136, d_year#138, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, i_item_sk#160, i_product_name#161]
-Keys [15]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138]
-Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#116)), partial_sum(UnscaledValue(ss_list_price#117)), partial_sum(UnscaledValue(ss_coupon_amt#118))]
-Aggregate Attributes [4]: [count#79, sum#162, sum#163, sum#164]
-Results [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
+(205) Exchange
+Input [21]: [product_name#99, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115, s1#181, s2#182, s3#183, syear#179, cnt#180]
+Arguments: rangepartitioning(product_name#99 ASC NULLS FIRST, store_name#101 ASC NULLS FIRST, cnt#180 ASC NULLS FIRST, s1#113 ASC NULLS FIRST, s1#181 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(202) Exchange
-Input [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
-Arguments: hashpartitioning(i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, 5), ENSURE_REQUIREMENTS, [plan_id=29]
-
-(203) HashAggregate [codegen id : 85]
-Input [19]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138, count#83, sum#165, sum#166, sum#167]
-Keys [15]: [i_product_name#161, i_item_sk#160, s_store_name#127, s_zip#128, ca_street_number#149, ca_street_name#150, ca_city#151, ca_zip#152, ca_street_number#154, ca_street_name#155, ca_city#156, ca_zip#157, d_year#125, d_year#136, d_year#138]
-Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#116)), sum(UnscaledValue(ss_list_price#117)), sum(UnscaledValue(ss_coupon_amt#118))]
-Aggregate Attributes [4]: [count(1)#87, sum(UnscaledValue(ss_wholesale_cost#116))#88, sum(UnscaledValue(ss_list_price#117))#89, sum(UnscaledValue(ss_coupon_amt#118))#90]
-Results [8]: [i_item_sk#160 AS item_sk#168, s_store_name#127 AS store_name#169, s_zip#128 AS store_zip#170, d_year#125 AS syear#171, count(1)#87 AS cnt#172, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#116))#88,17,2) AS s1#173, MakeDecimal(sum(UnscaledValue(ss_list_price#117))#89,17,2) AS s2#174, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#118))#90,17,2) AS s3#175]
-
-(204) Exchange
-Input [8]: [item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-Arguments: hashpartitioning(item_sk#168, store_name#169, store_zip#170, 5), ENSURE_REQUIREMENTS, [plan_id=30]
-
-(205) Sort [codegen id : 86]
-Input [8]: [item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-Arguments: [item_sk#168 ASC NULLS FIRST, store_name#169 ASC NULLS FIRST, store_zip#170 ASC NULLS FIRST], false, 0
-
-(206) SortMergeJoin [codegen id : 87]
-Left keys [3]: [item_sk#92, store_name#93, store_zip#94]
-Right keys [3]: [item_sk#168, store_name#169, store_zip#170]
-Join type: Inner
-Join condition: (cnt#172 <= cnt#104)
-
-(207) Project [codegen id : 87]
-Output [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Input [25]: [product_name#91, item_sk#92, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, item_sk#168, store_name#169, store_zip#170, syear#171, cnt#172, s1#173, s2#174, s3#175]
-
-(208) Exchange
-Input [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Arguments: rangepartitioning(product_name#91 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, cnt#172 ASC NULLS FIRST, s1#105 ASC NULLS FIRST, s1#173 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=31]
-
-(209) Sort [codegen id : 88]
-Input [21]: [product_name#91, store_name#93, store_zip#94, b_street_number#95, b_streen_name#96, b_city#97, b_zip#98, c_street_number#99, c_street_name#100, c_city#101, c_zip#102, syear#103, cnt#104, s1#105, s2#106, s3#107, s1#173, s2#174, s3#175, syear#171, cnt#172]
-Arguments: [product_name#91 ASC NULLS FIRST, store_name#93 ASC NULLS FIRST, cnt#172 ASC NULLS FIRST, s1#105 ASC NULLS FIRST, s1#173 ASC NULLS FIRST], true, 0
+(206) Sort [codegen id : 88]
+Input [21]: [product_name#99, store_name#101, store_zip#102, b_street_number#103, b_streen_name#104, b_city#105, b_zip#106, c_street_number#107, c_street_name#108, c_city#109, c_zip#110, syear#111, cnt#112, s1#113, s2#114, s3#115, s1#181, s2#182, s3#183, syear#179, cnt#180]
+Arguments: [product_name#99 ASC NULLS FIRST, store_name#101 ASC NULLS FIRST, cnt#180 ASC NULLS FIRST, s1#113 ASC NULLS FIRST, s1#181 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#14, [id=#15]
-ObjectHashAggregate (216)
-+- Exchange (215)
-   +- ObjectHashAggregate (214)
-      +- * Project (213)
-         +- * Filter (212)
-            +- * ColumnarToRow (211)
-               +- Scan parquet spark_catalog.default.item (210)
+ObjectHashAggregate (213)
++- Exchange (212)
+   +- ObjectHashAggregate (211)
+      +- Exchange (210)
+         +- * Filter (209)
+            +- * ColumnarToRow (208)
+               +- Scan parquet spark_catalog.default.customer_demographics (207)
 
 
-(210) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+(207) Scan parquet spark_catalog.default.customer_demographics
+Output [2]: [cd_demo_sk#62, cd_marital_status#63]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
+
+(208) ColumnarToRow [codegen id : 1]
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+
+(209) Filter [codegen id : 1]
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+Condition : (isnotnull(cd_demo_sk#62) AND isnotnull(cd_marital_status#63))
+
+(210) Exchange
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+Arguments: hashpartitioning(cd_demo_sk#64, 5), ENSURE_REQUIREMENTS, [plan_id=31]
+
+(211) ObjectHashAggregate
+Input [2]: [cd_demo_sk#62, cd_marital_status#63]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#62, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#184]
+Results [1]: [buf#185]
+
+(212) Exchange
+Input [1]: [buf#185]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=32]
+
+(213) ObjectHashAggregate
+Input [1]: [buf#185]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#62, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#62, 42), 1920800, 15366400, 0, 0)#186]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#62, 42), 1920800, 15366400, 0, 0)#186 AS bloomFilter#187]
+
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#16, [id=#17]
+ObjectHashAggregate (220)
++- Exchange (219)
+   +- ObjectHashAggregate (218)
+      +- Exchange (217)
+         +- * Filter (216)
+            +- * ColumnarToRow (215)
+               +- Scan parquet spark_catalog.default.customer_address (214)
+
+
+(214) Scan parquet spark_catalog.default.customer_address
+Output [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
+
+(215) ColumnarToRow [codegen id : 1]
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+
+(216) Filter [codegen id : 1]
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Condition : isnotnull(ca_address_sk#71)
+
+(217) Exchange
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Arguments: hashpartitioning(ca_address_sk#76, 5), ENSURE_REQUIREMENTS, [plan_id=33]
+
+(218) ObjectHashAggregate
+Input [5]: [ca_address_sk#71, ca_street_number#72, ca_street_name#73, ca_city#74, ca_zip#75]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#71, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [buf#188]
+Results [1]: [buf#189]
+
+(219) Exchange
+Input [1]: [buf#189]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=34]
+
+(220) ObjectHashAggregate
+Input [1]: [buf#189]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#71, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#71, 42), 1000000, 8000000, 0, 0)#190]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#71, 42), 1000000, 8000000, 0, 0)#190 AS bloomFilter#191]
+
+Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#18, [id=#19]
+ObjectHashAggregate (227)
++- Exchange (226)
+   +- ObjectHashAggregate (225)
+      +- * Project (224)
+         +- * Filter (223)
+            +- * ColumnarToRow (222)
+               +- Scan parquet spark_catalog.default.item (221)
+
+
+(221) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#83, i_current_price#84, i_color#85]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood           ,floral              ,indian              ,medium              ,purple              ,spring              ]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string>
 
-(211) ColumnarToRow [codegen id : 1]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+(222) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#83, i_current_price#84, i_color#85]
 
-(212) Filter [codegen id : 1]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
-Condition : ((((((isnotnull(i_current_price#76) AND i_color#77 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#76 >= 64.00)) AND (i_current_price#76 <= 74.00)) AND (i_current_price#76 >= 65.00)) AND (i_current_price#76 <= 79.00)) AND isnotnull(i_item_sk#75))
+(223) Filter [codegen id : 1]
+Input [3]: [i_item_sk#83, i_current_price#84, i_color#85]
+Condition : ((((((isnotnull(i_current_price#84) AND i_color#85 IN (purple              ,burlywood           ,indian              ,spring              ,floral              ,medium              )) AND (i_current_price#84 >= 64.00)) AND (i_current_price#84 <= 74.00)) AND (i_current_price#84 >= 65.00)) AND (i_current_price#84 <= 79.00)) AND isnotnull(i_item_sk#83))
 
-(213) Project [codegen id : 1]
-Output [1]: [i_item_sk#75]
-Input [3]: [i_item_sk#75, i_current_price#76, i_color#77]
+(224) Project [codegen id : 1]
+Output [1]: [i_item_sk#83]
+Input [3]: [i_item_sk#83, i_current_price#84, i_color#85]
 
-(214) ObjectHashAggregate
-Input [1]: [i_item_sk#75]
+(225) ObjectHashAggregate
+Input [1]: [i_item_sk#83]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 10000, 0, 0)]
-Aggregate Attributes [1]: [buf#176]
-Results [1]: [buf#177]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#83, 42), 1250, 10000, 0, 0)]
+Aggregate Attributes [1]: [buf#192]
+Results [1]: [buf#193]
 
-(215) Exchange
-Input [1]: [buf#177]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=32]
+(226) Exchange
+Input [1]: [buf#193]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=35]
 
-(216) ObjectHashAggregate
-Input [1]: [buf#177]
+(227) ObjectHashAggregate
+Input [1]: [buf#193]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 10000, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 10000, 0, 0)#178]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#75, 42), 1250, 10000, 0, 0)#178 AS bloomFilter#179]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#83, 42), 1250, 10000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#83, 42), 1250, 10000, 0, 0)#194]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#83, 42), 1250, 10000, 0, 0)#194 AS bloomFilter#195]
 
-Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
-BroadcastExchange (220)
-+- * Filter (219)
-   +- * ColumnarToRow (218)
-      +- Scan parquet spark_catalog.default.date_dim (217)
+Subquery:4 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
+BroadcastExchange (231)
++- * Filter (230)
+   +- * ColumnarToRow (229)
+      +- Scan parquet spark_catalog.default.date_dim (228)
 
 
-(217) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#39, d_year#40]
+(228) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#43, d_year#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(218) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#39, d_year#40]
+(229) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#43, d_year#44]
 
-(219) Filter [codegen id : 1]
-Input [2]: [d_date_sk#39, d_year#40]
-Condition : ((isnotnull(d_year#40) AND (d_year#40 = 1999)) AND isnotnull(d_date_sk#39))
+(230) Filter [codegen id : 1]
+Input [2]: [d_date_sk#43, d_year#44]
+Condition : ((isnotnull(d_year#44) AND (d_year#44 = 1999)) AND isnotnull(d_date_sk#43))
 
-(220) BroadcastExchange
-Input [2]: [d_date_sk#39, d_year#40]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=33]
+(231) BroadcastExchange
+Input [2]: [d_date_sk#43, d_year#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=36]
 
-Subquery:3 Hosting operator id = 131 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+Subquery:5 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#54, [id=#55]
+ObjectHashAggregate (238)
++- Exchange (237)
+   +- ObjectHashAggregate (236)
+      +- Exchange (235)
+         +- * Filter (234)
+            +- * ColumnarToRow (233)
+               +- Scan parquet spark_catalog.default.customer_demographics (232)
 
-Subquery:4 Hosting operator id = 129 Hosting Expression = ss_sold_date_sk#119 IN dynamicpruning#120
-BroadcastExchange (224)
-+- * Filter (223)
-   +- * ColumnarToRow (222)
-      +- Scan parquet spark_catalog.default.date_dim (221)
+
+(232) Scan parquet spark_catalog.default.customer_demographics
+Output [2]: [cd_demo_sk#64, cd_marital_status#65]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
+
+(233) ColumnarToRow [codegen id : 1]
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+
+(234) Filter [codegen id : 1]
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+Condition : (isnotnull(cd_demo_sk#64) AND isnotnull(cd_marital_status#65))
+
+(235) Exchange
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+Arguments: hashpartitioning(cd_demo_sk#64, 5), ENSURE_REQUIREMENTS, [plan_id=37]
+
+(236) ObjectHashAggregate
+Input [2]: [cd_demo_sk#64, cd_marital_status#65]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#64, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [buf#196]
+Results [1]: [buf#197]
+
+(237) Exchange
+Input [1]: [buf#197]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=38]
+
+(238) ObjectHashAggregate
+Input [1]: [buf#197]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#64, 42), 1920800, 15366400, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#64, 42), 1920800, 15366400, 0, 0)#198]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#64, 42), 1920800, 15366400, 0, 0)#198 AS bloomFilter#199]
+
+Subquery:6 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#56, [id=#57]
+ObjectHashAggregate (245)
++- Exchange (244)
+   +- ObjectHashAggregate (243)
+      +- Exchange (242)
+         +- * Filter (241)
+            +- * ColumnarToRow (240)
+               +- Scan parquet spark_catalog.default.customer_address (239)
 
 
-(221) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#124, d_year#125]
+(239) Scan parquet spark_catalog.default.customer_address
+Output [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
+
+(240) ColumnarToRow [codegen id : 1]
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+
+(241) Filter [codegen id : 1]
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Condition : isnotnull(ca_address_sk#76)
+
+(242) Exchange
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Arguments: hashpartitioning(ca_address_sk#76, 5), ENSURE_REQUIREMENTS, [plan_id=39]
+
+(243) ObjectHashAggregate
+Input [5]: [ca_address_sk#76, ca_street_number#77, ca_street_name#78, ca_city#79, ca_zip#80]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#76, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [buf#200]
+Results [1]: [buf#201]
+
+(244) Exchange
+Input [1]: [buf#201]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=40]
+
+(245) ObjectHashAggregate
+Input [1]: [buf#201]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#76, 42), 1000000, 8000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#76, 42), 1000000, 8000000, 0, 0)#202]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#76, 42), 1000000, 8000000, 0, 0)#202 AS bloomFilter#203]
+
+Subquery:7 Hosting operator id = 125 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
+
+Subquery:8 Hosting operator id = 125 Hosting Expression = ReusedSubquery Subquery scalar-subquery#16, [id=#17]
+
+Subquery:9 Hosting operator id = 123 Hosting Expression = ss_sold_date_sk#127 IN dynamicpruning#128
+BroadcastExchange (249)
++- * Filter (248)
+   +- * ColumnarToRow (247)
+      +- Scan parquet spark_catalog.default.date_dim (246)
+
+
+(246) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#132, d_year#133]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(222) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#124, d_year#125]
+(247) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#132, d_year#133]
 
-(223) Filter [codegen id : 1]
-Input [2]: [d_date_sk#124, d_year#125]
-Condition : ((isnotnull(d_year#125) AND (d_year#125 = 2000)) AND isnotnull(d_date_sk#124))
+(248) Filter [codegen id : 1]
+Input [2]: [d_date_sk#132, d_year#133]
+Condition : ((isnotnull(d_year#133) AND (d_year#133 = 2000)) AND isnotnull(d_date_sk#132))
 
-(224) BroadcastExchange
-Input [2]: [d_date_sk#124, d_year#125]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=34]
+(249) BroadcastExchange
+Input [2]: [d_date_sk#132, d_year#133]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=41]
+
+Subquery:10 Hosting operator id = 145 Hosting Expression = ReusedSubquery Subquery scalar-subquery#14, [id=#15]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/simplified.txt
@@ -88,8 +88,28 @@ WholeStageCodegen (88)
                                                                                                                                                                               WholeStageCodegen (1)
                                                                                                                                                                                 Filter [ss_item_sk,ss_ticket_number,ss_store_sk,ss_customer_sk,ss_cdemo_sk,ss_promo_sk,ss_hdemo_sk,ss_addr_sk]
                                                                                                                                                                                   Subquery #2
-                                                                                                                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 1250, 10000, 0, 0),bloomFilter,buf]
+                                                                                                                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
                                                                                                                                                                                       Exchange #11
+                                                                                                                                                                                        ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                                                                                                                                          Exchange [cd_demo_sk] #12
+                                                                                                                                                                                            WholeStageCodegen (1)
+                                                                                                                                                                                              Filter [cd_demo_sk,cd_marital_status]
+                                                                                                                                                                                                ColumnarToRow
+                                                                                                                                                                                                  InputAdapter
+                                                                                                                                                                                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
+                                                                                                                                                                                  Subquery #3
+                                                                                                                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 1000000, 8000000, 0, 0),bloomFilter,buf]
+                                                                                                                                                                                      Exchange #13
+                                                                                                                                                                                        ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                                                                                                                                          Exchange [ca_address_sk] #14
+                                                                                                                                                                                            WholeStageCodegen (1)
+                                                                                                                                                                                              Filter [ca_address_sk]
+                                                                                                                                                                                                ColumnarToRow
+                                                                                                                                                                                                  InputAdapter
+                                                                                                                                                                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip]
+                                                                                                                                                                                  Subquery #4
+                                                                                                                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 1250, 10000, 0, 0),bloomFilter,buf]
+                                                                                                                                                                                      Exchange #15
                                                                                                                                                                                         ObjectHashAggregate [i_item_sk] [buf,buf]
                                                                                                                                                                                           WholeStageCodegen (1)
                                                                                                                                                                                             Project [i_item_sk]
@@ -111,7 +131,7 @@ WholeStageCodegen (88)
                                                                                                                                                                       WholeStageCodegen (4)
                                                                                                                                                                         Sort [sr_item_sk,sr_ticket_number]
                                                                                                                                                                           InputAdapter
-                                                                                                                                                                            Exchange [sr_item_sk,sr_ticket_number] #12
+                                                                                                                                                                            Exchange [sr_item_sk,sr_ticket_number] #16
                                                                                                                                                                               WholeStageCodegen (3)
                                                                                                                                                                                 Project [sr_item_sk,sr_ticket_number]
                                                                                                                                                                                   Filter [sr_item_sk,sr_ticket_number]
@@ -119,13 +139,13 @@ WholeStageCodegen (88)
                                                                                                                                                                                       InputAdapter
                                                                                                                                                                                         Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                                                                                                                                                                 InputAdapter
-                                                                                                                                                                  BroadcastExchange #13
+                                                                                                                                                                  BroadcastExchange #17
                                                                                                                                                                     WholeStageCodegen (10)
                                                                                                                                                                       Project [cs_item_sk]
                                                                                                                                                                         Filter [sale,refund]
                                                                                                                                                                           HashAggregate [cs_item_sk,sum,sum,isEmpty] [sum(UnscaledValue(cs_ext_list_price)),sum(((cr_refunded_cash + cr_reversed_charge) + cr_store_credit)),sale,refund,sum,sum,isEmpty]
                                                                                                                                                                             InputAdapter
-                                                                                                                                                                              Exchange [cs_item_sk] #14
+                                                                                                                                                                              Exchange [cs_item_sk] #18
                                                                                                                                                                                 WholeStageCodegen (9)
                                                                                                                                                                                   HashAggregate [cs_item_sk,cs_ext_list_price,cr_refunded_cash,cr_reversed_charge,cr_store_credit] [sum,sum,isEmpty,sum,sum,isEmpty]
                                                                                                                                                                                     Project [cs_item_sk,cs_ext_list_price,cr_refunded_cash,cr_reversed_charge,cr_store_credit]
@@ -134,7 +154,7 @@ WholeStageCodegen (88)
                                                                                                                                                                                           WholeStageCodegen (6)
                                                                                                                                                                                             Sort [cs_item_sk,cs_order_number]
                                                                                                                                                                                               InputAdapter
-                                                                                                                                                                                                Exchange [cs_item_sk,cs_order_number] #15
+                                                                                                                                                                                                Exchange [cs_item_sk,cs_order_number] #19
                                                                                                                                                                                                   WholeStageCodegen (5)
                                                                                                                                                                                                     Project [cs_item_sk,cs_order_number,cs_ext_list_price]
                                                                                                                                                                                                       Filter [cs_item_sk,cs_order_number]
@@ -145,7 +165,7 @@ WholeStageCodegen (88)
                                                                                                                                                                                           WholeStageCodegen (8)
                                                                                                                                                                                             Sort [cr_item_sk,cr_order_number]
                                                                                                                                                                                               InputAdapter
-                                                                                                                                                                                                Exchange [cr_item_sk,cr_order_number] #16
+                                                                                                                                                                                                Exchange [cr_item_sk,cr_order_number] #20
                                                                                                                                                                                                   WholeStageCodegen (7)
                                                                                                                                                                                                     Project [cr_item_sk,cr_order_number,cr_refunded_cash,cr_reversed_charge,cr_store_credit]
                                                                                                                                                                                                       Filter [cr_item_sk,cr_order_number]
@@ -155,7 +175,7 @@ WholeStageCodegen (88)
                                                                                                                                                             InputAdapter
                                                                                                                                                               ReusedExchange [d_date_sk,d_year] #10
                                                                                                                                                         InputAdapter
-                                                                                                                                                          BroadcastExchange #17
+                                                                                                                                                          BroadcastExchange #21
                                                                                                                                                             WholeStageCodegen (12)
                                                                                                                                                               Filter [s_store_sk,s_store_name,s_zip]
                                                                                                                                                                 ColumnarToRow
@@ -165,78 +185,88 @@ WholeStageCodegen (88)
                                                                                                                                           WholeStageCodegen (16)
                                                                                                                                             Sort [c_customer_sk]
                                                                                                                                               InputAdapter
-                                                                                                                                                Exchange [c_customer_sk] #18
+                                                                                                                                                Exchange [c_customer_sk] #22
                                                                                                                                                   WholeStageCodegen (15)
                                                                                                                                                     Filter [c_customer_sk,c_first_sales_date_sk,c_first_shipto_date_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk]
+                                                                                                                                                      Subquery #5
+                                                                                                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 1920800, 15366400, 0, 0),bloomFilter,buf]
+                                                                                                                                                          Exchange #23
+                                                                                                                                                            ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                                                                                                              Exchange [cd_demo_sk] #24
+                                                                                                                                                                WholeStageCodegen (1)
+                                                                                                                                                                  Filter [cd_demo_sk,cd_marital_status]
+                                                                                                                                                                    ColumnarToRow
+                                                                                                                                                                      InputAdapter
+                                                                                                                                                                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
+                                                                                                                                                      Subquery #6
+                                                                                                                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 1000000, 8000000, 0, 0),bloomFilter,buf]
+                                                                                                                                                          Exchange #25
+                                                                                                                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                                                                                                              Exchange [ca_address_sk] #26
+                                                                                                                                                                WholeStageCodegen (1)
+                                                                                                                                                                  Filter [ca_address_sk]
+                                                                                                                                                                    ColumnarToRow
+                                                                                                                                                                      InputAdapter
+                                                                                                                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip]
                                                                                                                                                       ColumnarToRow
                                                                                                                                                         InputAdapter
                                                                                                                                                           Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,c_first_shipto_date_sk,c_first_sales_date_sk]
                                                                                                                                     InputAdapter
-                                                                                                                                      BroadcastExchange #19
+                                                                                                                                      BroadcastExchange #27
                                                                                                                                         WholeStageCodegen (17)
                                                                                                                                           Filter [d_date_sk]
                                                                                                                                             ColumnarToRow
                                                                                                                                               InputAdapter
                                                                                                                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                                                                                 InputAdapter
-                                                                                                                                  ReusedExchange [d_date_sk,d_year] #19
+                                                                                                                                  ReusedExchange [d_date_sk,d_year] #27
                                                                                                                 InputAdapter
                                                                                                                   WholeStageCodegen (22)
                                                                                                                     Sort [cd_demo_sk]
                                                                                                                       InputAdapter
-                                                                                                                        Exchange [cd_demo_sk] #20
-                                                                                                                          WholeStageCodegen (21)
-                                                                                                                            Filter [cd_demo_sk,cd_marital_status]
-                                                                                                                              ColumnarToRow
-                                                                                                                                InputAdapter
-                                                                                                                                  Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
+                                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #24
                                                                                                 InputAdapter
                                                                                                   WholeStageCodegen (26)
                                                                                                     Sort [cd_demo_sk]
                                                                                                       InputAdapter
-                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #20
+                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #24
                                                                                             InputAdapter
-                                                                                              BroadcastExchange #21
+                                                                                              BroadcastExchange #28
                                                                                                 WholeStageCodegen (27)
                                                                                                   Filter [p_promo_sk]
                                                                                                     ColumnarToRow
                                                                                                       InputAdapter
                                                                                                         Scan parquet spark_catalog.default.promotion [p_promo_sk]
                                                                                         InputAdapter
-                                                                                          BroadcastExchange #22
+                                                                                          BroadcastExchange #29
                                                                                             WholeStageCodegen (28)
                                                                                               Filter [hd_demo_sk,hd_income_band_sk]
                                                                                                 ColumnarToRow
                                                                                                   InputAdapter
                                                                                                     Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_income_band_sk]
                                                                                     InputAdapter
-                                                                                      ReusedExchange [hd_demo_sk,hd_income_band_sk] #22
+                                                                                      ReusedExchange [hd_demo_sk,hd_income_band_sk] #29
                                                                     InputAdapter
                                                                       WholeStageCodegen (33)
                                                                         Sort [ca_address_sk]
                                                                           InputAdapter
-                                                                            Exchange [ca_address_sk] #23
-                                                                              WholeStageCodegen (32)
-                                                                                Filter [ca_address_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip]
+                                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #26
                                                     InputAdapter
                                                       WholeStageCodegen (37)
                                                         Sort [ca_address_sk]
                                                           InputAdapter
-                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #23
+                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #26
                                                 InputAdapter
-                                                  BroadcastExchange #24
+                                                  BroadcastExchange #30
                                                     WholeStageCodegen (38)
                                                       Filter [ib_income_band_sk]
                                                         ColumnarToRow
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.income_band [ib_income_band_sk]
                                             InputAdapter
-                                              ReusedExchange [ib_income_band_sk] #24
+                                              ReusedExchange [ib_income_band_sk] #30
                                         InputAdapter
-                                          BroadcastExchange #25
+                                          BroadcastExchange #31
                                             WholeStageCodegen (40)
                                               Project [i_item_sk,i_product_name]
                                                 Filter [i_current_price,i_color,i_item_sk]
@@ -247,11 +277,11 @@ WholeStageCodegen (88)
                 WholeStageCodegen (86)
                   Sort [item_sk,store_name,store_zip]
                     InputAdapter
-                      Exchange [item_sk,store_name,store_zip] #26
+                      Exchange [item_sk,store_name,store_zip] #32
                         WholeStageCodegen (85)
                           HashAggregate [i_product_name,i_item_sk,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,d_year,d_year,d_year,count,sum,sum,sum] [count(1),sum(UnscaledValue(ss_wholesale_cost)),sum(UnscaledValue(ss_list_price)),sum(UnscaledValue(ss_coupon_amt)),item_sk,store_name,store_zip,syear,cnt,s1,s2,s3,count,sum,sum,sum]
                             InputAdapter
-                              Exchange [i_product_name,i_item_sk,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,d_year,d_year,d_year] #27
+                              Exchange [i_product_name,i_item_sk,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,d_year,d_year,d_year] #33
                                 WholeStageCodegen (84)
                                   HashAggregate [i_product_name,i_item_sk,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,d_year,d_year,d_year,ss_wholesale_cost,ss_list_price,ss_coupon_amt] [count,sum,sum,sum,count,sum,sum,sum]
                                     Project [ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,d_year,d_year,s_store_name,s_zip,ca_street_number,ca_street_name,ca_city,ca_zip,ca_street_number,ca_street_name,ca_city,ca_zip,i_item_sk,i_product_name]
@@ -266,7 +296,7 @@ WholeStageCodegen (88)
                                                       WholeStageCodegen (78)
                                                         Sort [c_current_addr_sk]
                                                           InputAdapter
-                                                            Exchange [c_current_addr_sk] #28
+                                                            Exchange [c_current_addr_sk] #34
                                                               WholeStageCodegen (77)
                                                                 Project [ss_item_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip,c_current_addr_sk,d_year,d_year,hd_income_band_sk,hd_income_band_sk,ca_street_number,ca_street_name,ca_city,ca_zip]
                                                                   SortMergeJoin [ss_addr_sk,ca_address_sk]
@@ -274,7 +304,7 @@ WholeStageCodegen (88)
                                                                       WholeStageCodegen (74)
                                                                         Sort [ss_addr_sk]
                                                                           InputAdapter
-                                                                            Exchange [ss_addr_sk] #29
+                                                                            Exchange [ss_addr_sk] #35
                                                                               WholeStageCodegen (73)
                                                                                 Project [ss_item_sk,ss_addr_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip,c_current_addr_sk,d_year,d_year,hd_income_band_sk,hd_income_band_sk]
                                                                                   BroadcastHashJoin [c_current_hdemo_sk,hd_demo_sk]
@@ -288,7 +318,7 @@ WholeStageCodegen (88)
                                                                                                   WholeStageCodegen (67)
                                                                                                     Sort [c_current_cdemo_sk]
                                                                                                       InputAdapter
-                                                                                                        Exchange [c_current_cdemo_sk] #30
+                                                                                                        Exchange [c_current_cdemo_sk] #36
                                                                                                           WholeStageCodegen (66)
                                                                                                             Project [ss_item_sk,ss_hdemo_sk,ss_addr_sk,ss_promo_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,d_year,d_year,cd_marital_status]
                                                                                                               SortMergeJoin [ss_cdemo_sk,cd_demo_sk]
@@ -296,7 +326,7 @@ WholeStageCodegen (88)
                                                                                                                   WholeStageCodegen (63)
                                                                                                                     Sort [ss_cdemo_sk]
                                                                                                                       InputAdapter
-                                                                                                                        Exchange [ss_cdemo_sk] #31
+                                                                                                                        Exchange [ss_cdemo_sk] #37
                                                                                                                           WholeStageCodegen (62)
                                                                                                                             Project [ss_item_sk,ss_cdemo_sk,ss_hdemo_sk,ss_addr_sk,ss_promo_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,d_year,d_year]
                                                                                                                               BroadcastHashJoin [c_first_shipto_date_sk,d_date_sk]
@@ -308,7 +338,7 @@ WholeStageCodegen (88)
                                                                                                                                           WholeStageCodegen (57)
                                                                                                                                             Sort [ss_customer_sk]
                                                                                                                                               InputAdapter
-                                                                                                                                                Exchange [ss_customer_sk] #32
+                                                                                                                                                Exchange [ss_customer_sk] #38
                                                                                                                                                   WholeStageCodegen (56)
                                                                                                                                                     Project [ss_item_sk,ss_customer_sk,ss_cdemo_sk,ss_hdemo_sk,ss_addr_sk,ss_promo_sk,ss_wholesale_cost,ss_list_price,ss_coupon_amt,d_year,s_store_name,s_zip]
                                                                                                                                                       BroadcastHashJoin [ss_store_sk,s_store_sk]
@@ -322,15 +352,16 @@ WholeStageCodegen (88)
                                                                                                                                                                       WholeStageCodegen (45)
                                                                                                                                                                         Sort [ss_item_sk,ss_ticket_number]
                                                                                                                                                                           InputAdapter
-                                                                                                                                                                            Exchange [ss_item_sk,ss_ticket_number] #33
+                                                                                                                                                                            Exchange [ss_item_sk,ss_ticket_number] #39
                                                                                                                                                                               WholeStageCodegen (44)
                                                                                                                                                                                 Filter [ss_item_sk,ss_ticket_number,ss_store_sk,ss_customer_sk,ss_cdemo_sk,ss_promo_sk,ss_hdemo_sk,ss_addr_sk]
                                                                                                                                                                                   ReusedSubquery [bloomFilter] #2
+                                                                                                                                                                                  ReusedSubquery [bloomFilter] #3
                                                                                                                                                                                   ColumnarToRow
                                                                                                                                                                                     InputAdapter
                                                                                                                                                                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_cdemo_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_promo_sk,ss_ticket_number,ss_wholesale_cost,ss_list_price,ss_coupon_amt,ss_sold_date_sk]
-                                                                                                                                                                                        SubqueryBroadcast [d_date_sk] #3
-                                                                                                                                                                                          BroadcastExchange #34
+                                                                                                                                                                                        SubqueryBroadcast [d_date_sk] #7
+                                                                                                                                                                                          BroadcastExchange #40
                                                                                                                                                                                             WholeStageCodegen (1)
                                                                                                                                                                                               Filter [d_year,d_date_sk]
                                                                                                                                                                                                 ColumnarToRow
@@ -340,51 +371,57 @@ WholeStageCodegen (88)
                                                                                                                                                                       WholeStageCodegen (47)
                                                                                                                                                                         Sort [sr_item_sk,sr_ticket_number]
                                                                                                                                                                           InputAdapter
-                                                                                                                                                                            ReusedExchange [sr_item_sk,sr_ticket_number] #12
+                                                                                                                                                                            ReusedExchange [sr_item_sk,sr_ticket_number] #16
                                                                                                                                                                 InputAdapter
-                                                                                                                                                                  ReusedExchange [cs_item_sk] #13
+                                                                                                                                                                  ReusedExchange [cs_item_sk] #17
                                                                                                                                                             InputAdapter
-                                                                                                                                                              ReusedExchange [d_date_sk,d_year] #34
+                                                                                                                                                              ReusedExchange [d_date_sk,d_year] #40
                                                                                                                                                         InputAdapter
-                                                                                                                                                          ReusedExchange [s_store_sk,s_store_name,s_zip] #17
+                                                                                                                                                          ReusedExchange [s_store_sk,s_store_name,s_zip] #21
                                                                                                                                         InputAdapter
                                                                                                                                           WholeStageCodegen (59)
                                                                                                                                             Sort [c_customer_sk]
                                                                                                                                               InputAdapter
-                                                                                                                                                ReusedExchange [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,c_first_shipto_date_sk,c_first_sales_date_sk] #18
+                                                                                                                                                Exchange [c_customer_sk] #41
+                                                                                                                                                  WholeStageCodegen (58)
+                                                                                                                                                    Filter [c_customer_sk,c_first_sales_date_sk,c_first_shipto_date_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk]
+                                                                                                                                                      ReusedSubquery [bloomFilter] #2
+                                                                                                                                                      ColumnarToRow
+                                                                                                                                                        InputAdapter
+                                                                                                                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,c_first_shipto_date_sk,c_first_sales_date_sk]
                                                                                                                                     InputAdapter
-                                                                                                                                      ReusedExchange [d_date_sk,d_year] #19
+                                                                                                                                      ReusedExchange [d_date_sk,d_year] #27
                                                                                                                                 InputAdapter
-                                                                                                                                  ReusedExchange [d_date_sk,d_year] #19
+                                                                                                                                  ReusedExchange [d_date_sk,d_year] #27
                                                                                                                 InputAdapter
                                                                                                                   WholeStageCodegen (65)
                                                                                                                     Sort [cd_demo_sk]
                                                                                                                       InputAdapter
-                                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #20
+                                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #24
                                                                                                 InputAdapter
                                                                                                   WholeStageCodegen (69)
                                                                                                     Sort [cd_demo_sk]
                                                                                                       InputAdapter
-                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #20
+                                                                                                        ReusedExchange [cd_demo_sk,cd_marital_status] #24
                                                                                             InputAdapter
-                                                                                              ReusedExchange [p_promo_sk] #21
+                                                                                              ReusedExchange [p_promo_sk] #28
                                                                                         InputAdapter
-                                                                                          ReusedExchange [hd_demo_sk,hd_income_band_sk] #22
+                                                                                          ReusedExchange [hd_demo_sk,hd_income_band_sk] #29
                                                                                     InputAdapter
-                                                                                      ReusedExchange [hd_demo_sk,hd_income_band_sk] #22
+                                                                                      ReusedExchange [hd_demo_sk,hd_income_band_sk] #29
                                                                     InputAdapter
                                                                       WholeStageCodegen (76)
                                                                         Sort [ca_address_sk]
                                                                           InputAdapter
-                                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #23
+                                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #26
                                                     InputAdapter
                                                       WholeStageCodegen (80)
                                                         Sort [ca_address_sk]
                                                           InputAdapter
-                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #23
+                                                            ReusedExchange [ca_address_sk,ca_street_number,ca_street_name,ca_city,ca_zip] #26
                                                 InputAdapter
-                                                  ReusedExchange [ib_income_band_sk] #24
+                                                  ReusedExchange [ib_income_band_sk] #30
                                             InputAdapter
-                                              ReusedExchange [ib_income_band_sk] #24
+                                              ReusedExchange [ib_income_band_sk] #30
                                         InputAdapter
-                                          ReusedExchange [i_item_sk,i_product_name] #25
+                                          ReusedExchange [i_item_sk,i_product_name] #31

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/explain.txt
@@ -1,15 +1,15 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * Filter (69)
-   +- Window (68)
-      +- * Sort (67)
-         +- Exchange (66)
-            +- Union (65)
-               :- * HashAggregate (24)
-               :  +- Exchange (23)
-               :     +- * HashAggregate (22)
-               :        +- * Project (21)
-               :           +- * SortMergeJoin Inner (20)
+TakeOrderedAndProject (67)
++- * Filter (66)
+   +- Window (65)
+      +- * Sort (64)
+         +- Exchange (63)
+            +- Union (62)
+               :- * HashAggregate (21)
+               :  +- Exchange (20)
+               :     +- * HashAggregate (19)
+               :        +- * Project (18)
+               :           +- * SortMergeJoin Inner (17)
                :              :- * Sort (14)
                :              :  +- Exchange (13)
                :              :     +- * Project (12)
@@ -24,51 +24,48 @@ TakeOrderedAndProject (70)
                :              :              +- * Filter (9)
                :              :                 +- * ColumnarToRow (8)
                :              :                    +- Scan parquet spark_catalog.default.store (7)
-               :              +- * Sort (19)
-               :                 +- Exchange (18)
-               :                    +- * Filter (17)
-               :                       +- * ColumnarToRow (16)
-               :                          +- Scan parquet spark_catalog.default.item (15)
-               :- * HashAggregate (29)
-               :  +- Exchange (28)
-               :     +- * HashAggregate (27)
-               :        +- * HashAggregate (26)
-               :           +- ReusedExchange (25)
-               :- * HashAggregate (34)
-               :  +- Exchange (33)
-               :     +- * HashAggregate (32)
-               :        +- * HashAggregate (31)
-               :           +- ReusedExchange (30)
-               :- * HashAggregate (39)
-               :  +- Exchange (38)
-               :     +- * HashAggregate (37)
-               :        +- * HashAggregate (36)
-               :           +- ReusedExchange (35)
-               :- * HashAggregate (44)
-               :  +- Exchange (43)
-               :     +- * HashAggregate (42)
-               :        +- * HashAggregate (41)
-               :           +- ReusedExchange (40)
-               :- * HashAggregate (49)
-               :  +- Exchange (48)
-               :     +- * HashAggregate (47)
-               :        +- * HashAggregate (46)
-               :           +- ReusedExchange (45)
-               :- * HashAggregate (54)
-               :  +- Exchange (53)
-               :     +- * HashAggregate (52)
-               :        +- * HashAggregate (51)
-               :           +- ReusedExchange (50)
-               :- * HashAggregate (59)
-               :  +- Exchange (58)
-               :     +- * HashAggregate (57)
-               :        +- * HashAggregate (56)
-               :           +- ReusedExchange (55)
-               +- * HashAggregate (64)
-                  +- Exchange (63)
-                     +- * HashAggregate (62)
-                        +- * HashAggregate (61)
-                           +- ReusedExchange (60)
+               :              +- * Sort (16)
+               :                 +- ReusedExchange (15)
+               :- * HashAggregate (26)
+               :  +- Exchange (25)
+               :     +- * HashAggregate (24)
+               :        +- * HashAggregate (23)
+               :           +- ReusedExchange (22)
+               :- * HashAggregate (31)
+               :  +- Exchange (30)
+               :     +- * HashAggregate (29)
+               :        +- * HashAggregate (28)
+               :           +- ReusedExchange (27)
+               :- * HashAggregate (36)
+               :  +- Exchange (35)
+               :     +- * HashAggregate (34)
+               :        +- * HashAggregate (33)
+               :           +- ReusedExchange (32)
+               :- * HashAggregate (41)
+               :  +- Exchange (40)
+               :     +- * HashAggregate (39)
+               :        +- * HashAggregate (38)
+               :           +- ReusedExchange (37)
+               :- * HashAggregate (46)
+               :  +- Exchange (45)
+               :     +- * HashAggregate (44)
+               :        +- * HashAggregate (43)
+               :           +- ReusedExchange (42)
+               :- * HashAggregate (51)
+               :  +- Exchange (50)
+               :     +- * HashAggregate (49)
+               :        +- * HashAggregate (48)
+               :           +- ReusedExchange (47)
+               :- * HashAggregate (56)
+               :  +- Exchange (55)
+               :     +- * HashAggregate (54)
+               :        +- * HashAggregate (53)
+               :           +- ReusedExchange (52)
+               +- * HashAggregate (61)
+                  +- Exchange (60)
+                     +- * HashAggregate (59)
+                        +- * HashAggregate (58)
+                           +- ReusedExchange (57)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -84,383 +81,414 @@ Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sol
 
 (3) Filter [codegen id : 3]
 Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5]
-Condition : (isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
+Condition : ((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_item_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 75]
-Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
+(4) ReusedExchange [Reuses operator id: 79]
+Output [4]: [d_date_sk#9, d_year#10, d_moy#11, d_qoy#12]
 
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
-Output [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10]
-Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5, d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
+Output [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12]
+Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5, d_date_sk#9, d_year#10, d_moy#11, d_qoy#12]
 
 (7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#11, s_store_id#12]
+Output [2]: [s_store_sk#13, s_store_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
 (8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#11, s_store_id#12]
+Input [2]: [s_store_sk#13, s_store_id#14]
 
 (9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#11, s_store_id#12]
-Condition : isnotnull(s_store_sk#11)
+Input [2]: [s_store_sk#13, s_store_id#14]
+Condition : isnotnull(s_store_sk#13)
 
 (10) BroadcastExchange
-Input [2]: [s_store_sk#11, s_store_id#12]
+Input [2]: [s_store_sk#13, s_store_id#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#11]
+Right keys [1]: [s_store_sk#13]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
-Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_sk#11, s_store_id#12]
+Output [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14]
+Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_sk#13, s_store_id#14]
 
 (13) Exchange
-Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
+Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14]
 Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (14) Sort [codegen id : 4]
-Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
+Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(15) ReusedExchange [Reuses operator id: 71]
+Output [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+
+(16) Sort [codegen id : 6]
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Arguments: [i_item_sk#15 ASC NULLS FIRST], false, 0
+
+(17) SortMergeJoin [codegen id : 7]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#15]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 7]
+Output [10]: [ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Input [12]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14, i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+
+(19) HashAggregate [codegen id : 7]
+Input [10]: [ss_quantity#3, ss_sales_price#4, d_year#10, d_moy#11, d_qoy#12, s_store_id#14, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [partial_sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [2]: [sum#20, isEmpty#21]
+Results [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#22, isEmpty#23]
+
+(20) Exchange
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#22, isEmpty#23]
+Arguments: hashpartitioning(i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(21) HashAggregate [codegen id : 8]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#22, isEmpty#23]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, cast(sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 as decimal(38,2)) AS sumsales#25]
+
+(22) ReusedExchange [Reuses operator id: 20]
+Output [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#26, isEmpty#27]
+
+(23) HashAggregate [codegen id : 16]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#26, isEmpty#27]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 AS sumsales#28]
+
+(24) HashAggregate [codegen id : 16]
+Input [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, sumsales#28]
+Keys [7]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11]
+Functions [1]: [partial_sum(sumsales#28)]
+Aggregate Attributes [2]: [sum#29, isEmpty#30]
+Results [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, sum#31, isEmpty#32]
+
+(25) Exchange
+Input [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, sum#31, isEmpty#32]
+Arguments: hashpartitioning(i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) HashAggregate [codegen id : 17]
+Input [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, sum#31, isEmpty#32]
+Keys [7]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11]
+Functions [1]: [sum(sumsales#28)]
+Aggregate Attributes [1]: [sum(sumsales#28)#33]
+Results [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, null AS s_store_id#34, sum(sumsales#28)#33 AS sumsales#35]
+
+(27) ReusedExchange [Reuses operator id: 20]
+Output [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#36, isEmpty#37]
+
+(28) HashAggregate [codegen id : 25]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#36, isEmpty#37]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [7]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 AS sumsales#28]
+
+(29) HashAggregate [codegen id : 25]
+Input [7]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, sumsales#28]
+Keys [6]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12]
+Functions [1]: [partial_sum(sumsales#28)]
+Aggregate Attributes [2]: [sum#38, isEmpty#39]
+Results [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, sum#40, isEmpty#41]
+
+(30) Exchange
+Input [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, sum#40, isEmpty#41]
+Arguments: hashpartitioning(i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(31) HashAggregate [codegen id : 26]
+Input [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, sum#40, isEmpty#41]
+Keys [6]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12]
+Functions [1]: [sum(sumsales#28)]
+Aggregate Attributes [1]: [sum(sumsales#28)#42]
+Results [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, null AS d_moy#43, null AS s_store_id#44, sum(sumsales#28)#42 AS sumsales#45]
+
+(32) ReusedExchange [Reuses operator id: 20]
+Output [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#46, isEmpty#47]
+
+(33) HashAggregate [codegen id : 34]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#46, isEmpty#47]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [6]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 AS sumsales#28]
+
+(34) HashAggregate [codegen id : 34]
+Input [6]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, sumsales#28]
+Keys [5]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10]
+Functions [1]: [partial_sum(sumsales#28)]
+Aggregate Attributes [2]: [sum#48, isEmpty#49]
+Results [7]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, sum#50, isEmpty#51]
+
+(35) Exchange
+Input [7]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, sum#50, isEmpty#51]
+Arguments: hashpartitioning(i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(36) HashAggregate [codegen id : 35]
+Input [7]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, sum#50, isEmpty#51]
+Keys [5]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10]
+Functions [1]: [sum(sumsales#28)]
+Aggregate Attributes [1]: [sum(sumsales#28)#52]
+Results [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, null AS d_qoy#53, null AS d_moy#54, null AS s_store_id#55, sum(sumsales#28)#52 AS sumsales#56]
+
+(37) ReusedExchange [Reuses operator id: 20]
+Output [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#57, isEmpty#58]
+
+(38) HashAggregate [codegen id : 43]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#57, isEmpty#58]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [5]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 AS sumsales#28]
+
+(39) HashAggregate [codegen id : 43]
+Input [5]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, sumsales#28]
+Keys [4]: [i_category#18, i_class#17, i_brand#16, i_product_name#19]
+Functions [1]: [partial_sum(sumsales#28)]
+Aggregate Attributes [2]: [sum#59, isEmpty#60]
+Results [6]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, sum#61, isEmpty#62]
+
+(40) Exchange
+Input [6]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, sum#61, isEmpty#62]
+Arguments: hashpartitioning(i_category#18, i_class#17, i_brand#16, i_product_name#19, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(41) HashAggregate [codegen id : 44]
+Input [6]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, sum#61, isEmpty#62]
+Keys [4]: [i_category#18, i_class#17, i_brand#16, i_product_name#19]
+Functions [1]: [sum(sumsales#28)]
+Aggregate Attributes [1]: [sum(sumsales#28)#63]
+Results [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, null AS d_year#64, null AS d_qoy#65, null AS d_moy#66, null AS s_store_id#67, sum(sumsales#28)#63 AS sumsales#68]
+
+(42) ReusedExchange [Reuses operator id: 20]
+Output [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#69, isEmpty#70]
+
+(43) HashAggregate [codegen id : 52]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#69, isEmpty#70]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [4]: [i_category#18, i_class#17, i_brand#16, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 AS sumsales#28]
+
+(44) HashAggregate [codegen id : 52]
+Input [4]: [i_category#18, i_class#17, i_brand#16, sumsales#28]
+Keys [3]: [i_category#18, i_class#17, i_brand#16]
+Functions [1]: [partial_sum(sumsales#28)]
+Aggregate Attributes [2]: [sum#71, isEmpty#72]
+Results [5]: [i_category#18, i_class#17, i_brand#16, sum#73, isEmpty#74]
+
+(45) Exchange
+Input [5]: [i_category#18, i_class#17, i_brand#16, sum#73, isEmpty#74]
+Arguments: hashpartitioning(i_category#18, i_class#17, i_brand#16, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(46) HashAggregate [codegen id : 53]
+Input [5]: [i_category#18, i_class#17, i_brand#16, sum#73, isEmpty#74]
+Keys [3]: [i_category#18, i_class#17, i_brand#16]
+Functions [1]: [sum(sumsales#28)]
+Aggregate Attributes [1]: [sum(sumsales#28)#75]
+Results [9]: [i_category#18, i_class#17, i_brand#16, null AS i_product_name#76, null AS d_year#77, null AS d_qoy#78, null AS d_moy#79, null AS s_store_id#80, sum(sumsales#28)#75 AS sumsales#81]
+
+(47) ReusedExchange [Reuses operator id: 20]
+Output [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#82, isEmpty#83]
+
+(48) HashAggregate [codegen id : 61]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#82, isEmpty#83]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [3]: [i_category#18, i_class#17, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 AS sumsales#28]
+
+(49) HashAggregate [codegen id : 61]
+Input [3]: [i_category#18, i_class#17, sumsales#28]
+Keys [2]: [i_category#18, i_class#17]
+Functions [1]: [partial_sum(sumsales#28)]
+Aggregate Attributes [2]: [sum#84, isEmpty#85]
+Results [4]: [i_category#18, i_class#17, sum#86, isEmpty#87]
+
+(50) Exchange
+Input [4]: [i_category#18, i_class#17, sum#86, isEmpty#87]
+Arguments: hashpartitioning(i_category#18, i_class#17, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(51) HashAggregate [codegen id : 62]
+Input [4]: [i_category#18, i_class#17, sum#86, isEmpty#87]
+Keys [2]: [i_category#18, i_class#17]
+Functions [1]: [sum(sumsales#28)]
+Aggregate Attributes [1]: [sum(sumsales#28)#88]
+Results [9]: [i_category#18, i_class#17, null AS i_brand#89, null AS i_product_name#90, null AS d_year#91, null AS d_qoy#92, null AS d_moy#93, null AS s_store_id#94, sum(sumsales#28)#88 AS sumsales#95]
+
+(52) ReusedExchange [Reuses operator id: 20]
+Output [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#96, isEmpty#97]
+
+(53) HashAggregate [codegen id : 70]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#96, isEmpty#97]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [2]: [i_category#18, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 AS sumsales#28]
+
+(54) HashAggregate [codegen id : 70]
+Input [2]: [i_category#18, sumsales#28]
+Keys [1]: [i_category#18]
+Functions [1]: [partial_sum(sumsales#28)]
+Aggregate Attributes [2]: [sum#98, isEmpty#99]
+Results [3]: [i_category#18, sum#100, isEmpty#101]
+
+(55) Exchange
+Input [3]: [i_category#18, sum#100, isEmpty#101]
+Arguments: hashpartitioning(i_category#18, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(56) HashAggregate [codegen id : 71]
+Input [3]: [i_category#18, sum#100, isEmpty#101]
+Keys [1]: [i_category#18]
+Functions [1]: [sum(sumsales#28)]
+Aggregate Attributes [1]: [sum(sumsales#28)#102]
+Results [9]: [i_category#18, null AS i_class#103, null AS i_brand#104, null AS i_product_name#105, null AS d_year#106, null AS d_qoy#107, null AS d_moy#108, null AS s_store_id#109, sum(sumsales#28)#102 AS sumsales#110]
+
+(57) ReusedExchange [Reuses operator id: 20]
+Output [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#111, isEmpty#112]
+
+(58) HashAggregate [codegen id : 79]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sum#111, isEmpty#112]
+Keys [8]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14]
+Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
+Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24]
+Results [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#24 AS sumsales#28]
+
+(59) HashAggregate [codegen id : 79]
+Input [1]: [sumsales#28]
+Keys: []
+Functions [1]: [partial_sum(sumsales#28)]
+Aggregate Attributes [2]: [sum#113, isEmpty#114]
+Results [2]: [sum#115, isEmpty#116]
+
+(60) Exchange
+Input [2]: [sum#115, isEmpty#116]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+
+(61) HashAggregate [codegen id : 80]
+Input [2]: [sum#115, isEmpty#116]
+Keys: []
+Functions [1]: [sum(sumsales#28)]
+Aggregate Attributes [1]: [sum(sumsales#28)#117]
+Results [9]: [null AS i_category#118, null AS i_class#119, null AS i_brand#120, null AS i_product_name#121, null AS d_year#122, null AS d_qoy#123, null AS d_moy#124, null AS s_store_id#125, sum(sumsales#28)#117 AS sumsales#126]
+
+(62) Union
+
+(63) Exchange
+Input [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sumsales#25]
+Arguments: hashpartitioning(i_category#18, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(64) Sort [codegen id : 81]
+Input [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sumsales#25]
+Arguments: [i_category#18 ASC NULLS FIRST, sumsales#25 DESC NULLS LAST], false, 0
+
+(65) Window
+Input [9]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sumsales#25]
+Arguments: [rank(sumsales#25) windowspecdefinition(i_category#18, sumsales#25 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#127], [i_category#18], [sumsales#25 DESC NULLS LAST]
+
+(66) Filter [codegen id : 82]
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sumsales#25, rk#127]
+Condition : (rk#127 <= 100)
+
+(67) TakeOrderedAndProject
+Input [10]: [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sumsales#25, rk#127]
+Arguments: 100, [i_category#18 ASC NULLS FIRST, i_class#17 ASC NULLS FIRST, i_brand#16 ASC NULLS FIRST, i_product_name#19 ASC NULLS FIRST, d_year#10 ASC NULLS FIRST, d_qoy#12 ASC NULLS FIRST, d_moy#11 ASC NULLS FIRST, s_store_id#14 ASC NULLS FIRST, sumsales#25 ASC NULLS FIRST, rk#127 ASC NULLS FIRST], [i_category#18, i_class#17, i_brand#16, i_product_name#19, d_year#10, d_qoy#12, d_moy#11, s_store_id#14, sumsales#25, rk#127]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (74)
++- Exchange (73)
+   +- ObjectHashAggregate (72)
+      +- Exchange (71)
+         +- * Filter (70)
+            +- * ColumnarToRow (69)
+               +- Scan parquet spark_catalog.default.item (68)
+
+
+(68) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_product_name:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(69) ColumnarToRow [codegen id : 1]
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
 
-(17) Filter [codegen id : 5]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Condition : isnotnull(i_item_sk#13)
+(70) Filter [codegen id : 1]
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Condition : isnotnull(i_item_sk#15)
 
-(18) Exchange
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(71) Exchange
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
+Arguments: hashpartitioning(i_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(19) Sort [codegen id : 6]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
-
-(20) SortMergeJoin [codegen id : 7]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#13]
-Join type: Inner
-Join condition: None
-
-(21) Project [codegen id : 7]
-Output [10]: [ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Input [12]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12, i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-
-(22) HashAggregate [codegen id : 7]
-Input [10]: [ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [partial_sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [2]: [sum#18, isEmpty#19]
-Results [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#20, isEmpty#21]
-
-(23) Exchange
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#20, isEmpty#21]
-Arguments: hashpartitioning(i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(24) HashAggregate [codegen id : 8]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#20, isEmpty#21]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, cast(sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 as decimal(38,2)) AS sumsales#23]
-
-(25) ReusedExchange [Reuses operator id: 23]
-Output [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#24, isEmpty#25]
-
-(26) HashAggregate [codegen id : 16]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#24, isEmpty#25]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 AS sumsales#26]
-
-(27) HashAggregate [codegen id : 16]
-Input [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, sumsales#26]
-Keys [7]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9]
-Functions [1]: [partial_sum(sumsales#26)]
-Aggregate Attributes [2]: [sum#27, isEmpty#28]
-Results [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, sum#29, isEmpty#30]
-
-(28) Exchange
-Input [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, sum#29, isEmpty#30]
-Arguments: hashpartitioning(i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(29) HashAggregate [codegen id : 17]
-Input [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, sum#29, isEmpty#30]
-Keys [7]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9]
-Functions [1]: [sum(sumsales#26)]
-Aggregate Attributes [1]: [sum(sumsales#26)#31]
-Results [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, null AS s_store_id#32, sum(sumsales#26)#31 AS sumsales#33]
-
-(30) ReusedExchange [Reuses operator id: 23]
-Output [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#34, isEmpty#35]
-
-(31) HashAggregate [codegen id : 25]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#34, isEmpty#35]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [7]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 AS sumsales#26]
-
-(32) HashAggregate [codegen id : 25]
-Input [7]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, sumsales#26]
-Keys [6]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10]
-Functions [1]: [partial_sum(sumsales#26)]
-Aggregate Attributes [2]: [sum#36, isEmpty#37]
-Results [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, sum#38, isEmpty#39]
-
-(33) Exchange
-Input [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, sum#38, isEmpty#39]
-Arguments: hashpartitioning(i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(34) HashAggregate [codegen id : 26]
-Input [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, sum#38, isEmpty#39]
-Keys [6]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10]
-Functions [1]: [sum(sumsales#26)]
-Aggregate Attributes [1]: [sum(sumsales#26)#40]
-Results [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, null AS d_moy#41, null AS s_store_id#42, sum(sumsales#26)#40 AS sumsales#43]
-
-(35) ReusedExchange [Reuses operator id: 23]
-Output [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#44, isEmpty#45]
-
-(36) HashAggregate [codegen id : 34]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#44, isEmpty#45]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [6]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 AS sumsales#26]
-
-(37) HashAggregate [codegen id : 34]
-Input [6]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, sumsales#26]
-Keys [5]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8]
-Functions [1]: [partial_sum(sumsales#26)]
-Aggregate Attributes [2]: [sum#46, isEmpty#47]
-Results [7]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, sum#48, isEmpty#49]
-
-(38) Exchange
-Input [7]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, sum#48, isEmpty#49]
-Arguments: hashpartitioning(i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(39) HashAggregate [codegen id : 35]
-Input [7]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, sum#48, isEmpty#49]
-Keys [5]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8]
-Functions [1]: [sum(sumsales#26)]
-Aggregate Attributes [1]: [sum(sumsales#26)#50]
-Results [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, null AS d_qoy#51, null AS d_moy#52, null AS s_store_id#53, sum(sumsales#26)#50 AS sumsales#54]
-
-(40) ReusedExchange [Reuses operator id: 23]
-Output [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#55, isEmpty#56]
-
-(41) HashAggregate [codegen id : 43]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#55, isEmpty#56]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [5]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 AS sumsales#26]
-
-(42) HashAggregate [codegen id : 43]
-Input [5]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, sumsales#26]
-Keys [4]: [i_category#16, i_class#15, i_brand#14, i_product_name#17]
-Functions [1]: [partial_sum(sumsales#26)]
-Aggregate Attributes [2]: [sum#57, isEmpty#58]
-Results [6]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, sum#59, isEmpty#60]
-
-(43) Exchange
-Input [6]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, sum#59, isEmpty#60]
-Arguments: hashpartitioning(i_category#16, i_class#15, i_brand#14, i_product_name#17, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(44) HashAggregate [codegen id : 44]
-Input [6]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, sum#59, isEmpty#60]
-Keys [4]: [i_category#16, i_class#15, i_brand#14, i_product_name#17]
-Functions [1]: [sum(sumsales#26)]
-Aggregate Attributes [1]: [sum(sumsales#26)#61]
-Results [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, null AS d_year#62, null AS d_qoy#63, null AS d_moy#64, null AS s_store_id#65, sum(sumsales#26)#61 AS sumsales#66]
-
-(45) ReusedExchange [Reuses operator id: 23]
-Output [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#67, isEmpty#68]
-
-(46) HashAggregate [codegen id : 52]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#67, isEmpty#68]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [4]: [i_category#16, i_class#15, i_brand#14, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 AS sumsales#26]
-
-(47) HashAggregate [codegen id : 52]
-Input [4]: [i_category#16, i_class#15, i_brand#14, sumsales#26]
-Keys [3]: [i_category#16, i_class#15, i_brand#14]
-Functions [1]: [partial_sum(sumsales#26)]
-Aggregate Attributes [2]: [sum#69, isEmpty#70]
-Results [5]: [i_category#16, i_class#15, i_brand#14, sum#71, isEmpty#72]
-
-(48) Exchange
-Input [5]: [i_category#16, i_class#15, i_brand#14, sum#71, isEmpty#72]
-Arguments: hashpartitioning(i_category#16, i_class#15, i_brand#14, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(49) HashAggregate [codegen id : 53]
-Input [5]: [i_category#16, i_class#15, i_brand#14, sum#71, isEmpty#72]
-Keys [3]: [i_category#16, i_class#15, i_brand#14]
-Functions [1]: [sum(sumsales#26)]
-Aggregate Attributes [1]: [sum(sumsales#26)#73]
-Results [9]: [i_category#16, i_class#15, i_brand#14, null AS i_product_name#74, null AS d_year#75, null AS d_qoy#76, null AS d_moy#77, null AS s_store_id#78, sum(sumsales#26)#73 AS sumsales#79]
-
-(50) ReusedExchange [Reuses operator id: 23]
-Output [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#80, isEmpty#81]
-
-(51) HashAggregate [codegen id : 61]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#80, isEmpty#81]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [3]: [i_category#16, i_class#15, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 AS sumsales#26]
-
-(52) HashAggregate [codegen id : 61]
-Input [3]: [i_category#16, i_class#15, sumsales#26]
-Keys [2]: [i_category#16, i_class#15]
-Functions [1]: [partial_sum(sumsales#26)]
-Aggregate Attributes [2]: [sum#82, isEmpty#83]
-Results [4]: [i_category#16, i_class#15, sum#84, isEmpty#85]
-
-(53) Exchange
-Input [4]: [i_category#16, i_class#15, sum#84, isEmpty#85]
-Arguments: hashpartitioning(i_category#16, i_class#15, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(54) HashAggregate [codegen id : 62]
-Input [4]: [i_category#16, i_class#15, sum#84, isEmpty#85]
-Keys [2]: [i_category#16, i_class#15]
-Functions [1]: [sum(sumsales#26)]
-Aggregate Attributes [1]: [sum(sumsales#26)#86]
-Results [9]: [i_category#16, i_class#15, null AS i_brand#87, null AS i_product_name#88, null AS d_year#89, null AS d_qoy#90, null AS d_moy#91, null AS s_store_id#92, sum(sumsales#26)#86 AS sumsales#93]
-
-(55) ReusedExchange [Reuses operator id: 23]
-Output [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#94, isEmpty#95]
-
-(56) HashAggregate [codegen id : 70]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#94, isEmpty#95]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [2]: [i_category#16, sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 AS sumsales#26]
-
-(57) HashAggregate [codegen id : 70]
-Input [2]: [i_category#16, sumsales#26]
-Keys [1]: [i_category#16]
-Functions [1]: [partial_sum(sumsales#26)]
-Aggregate Attributes [2]: [sum#96, isEmpty#97]
-Results [3]: [i_category#16, sum#98, isEmpty#99]
-
-(58) Exchange
-Input [3]: [i_category#16, sum#98, isEmpty#99]
-Arguments: hashpartitioning(i_category#16, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(59) HashAggregate [codegen id : 71]
-Input [3]: [i_category#16, sum#98, isEmpty#99]
-Keys [1]: [i_category#16]
-Functions [1]: [sum(sumsales#26)]
-Aggregate Attributes [1]: [sum(sumsales#26)#100]
-Results [9]: [i_category#16, null AS i_class#101, null AS i_brand#102, null AS i_product_name#103, null AS d_year#104, null AS d_qoy#105, null AS d_moy#106, null AS s_store_id#107, sum(sumsales#26)#100 AS sumsales#108]
-
-(60) ReusedExchange [Reuses operator id: 23]
-Output [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#109, isEmpty#110]
-
-(61) HashAggregate [codegen id : 79]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#109, isEmpty#110]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
-Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 AS sumsales#26]
-
-(62) HashAggregate [codegen id : 79]
-Input [1]: [sumsales#26]
+(72) ObjectHashAggregate
+Input [5]: [i_item_sk#15, i_brand#16, i_class#17, i_category#18, i_product_name#19]
 Keys: []
-Functions [1]: [partial_sum(sumsales#26)]
-Aggregate Attributes [2]: [sum#111, isEmpty#112]
-Results [2]: [sum#113, isEmpty#114]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#15, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#128]
+Results [1]: [buf#129]
 
-(63) Exchange
-Input [2]: [sum#113, isEmpty#114]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
+(73) Exchange
+Input [1]: [buf#129]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
 
-(64) HashAggregate [codegen id : 80]
-Input [2]: [sum#113, isEmpty#114]
+(74) ObjectHashAggregate
+Input [1]: [buf#129]
 Keys: []
-Functions [1]: [sum(sumsales#26)]
-Aggregate Attributes [1]: [sum(sumsales#26)#115]
-Results [9]: [null AS i_category#116, null AS i_class#117, null AS i_brand#118, null AS i_product_name#119, null AS d_year#120, null AS d_qoy#121, null AS d_moy#122, null AS s_store_id#123, sum(sumsales#26)#115 AS sumsales#124]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 204000, 1632000, 0, 0)#130]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 204000, 1632000, 0, 0)#130 AS bloomFilter#131]
 
-(65) Union
-
-(66) Exchange
-Input [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sumsales#23]
-Arguments: hashpartitioning(i_category#16, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(67) Sort [codegen id : 81]
-Input [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sumsales#23]
-Arguments: [i_category#16 ASC NULLS FIRST, sumsales#23 DESC NULLS LAST], false, 0
-
-(68) Window
-Input [9]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sumsales#23]
-Arguments: [rank(sumsales#23) windowspecdefinition(i_category#16, sumsales#23 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#125], [i_category#16], [sumsales#23 DESC NULLS LAST]
-
-(69) Filter [codegen id : 82]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sumsales#23, rk#125]
-Condition : (rk#125 <= 100)
-
-(70) TakeOrderedAndProject
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sumsales#23, rk#125]
-Arguments: 100, [i_category#16 ASC NULLS FIRST, i_class#15 ASC NULLS FIRST, i_brand#14 ASC NULLS FIRST, i_product_name#17 ASC NULLS FIRST, d_year#8 ASC NULLS FIRST, d_qoy#10 ASC NULLS FIRST, d_moy#9 ASC NULLS FIRST, s_store_id#12 ASC NULLS FIRST, sumsales#23 ASC NULLS FIRST, rk#125 ASC NULLS FIRST], [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sumsales#23, rk#125]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (75)
-+- * Project (74)
-   +- * Filter (73)
-      +- * ColumnarToRow (72)
-         +- Scan parquet spark_catalog.default.date_dim (71)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
+BroadcastExchange (79)
++- * Project (78)
+   +- * Filter (77)
+      +- * ColumnarToRow (76)
+         +- Scan parquet spark_catalog.default.date_dim (75)
 
 
-(71) Scan parquet spark_catalog.default.date_dim
-Output [5]: [d_date_sk#7, d_month_seq#126, d_year#8, d_moy#9, d_qoy#10]
+(75) Scan parquet spark_catalog.default.date_dim
+Output [5]: [d_date_sk#9, d_month_seq#132, d_year#10, d_moy#11, d_qoy#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int,d_year:int,d_moy:int,d_qoy:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [5]: [d_date_sk#7, d_month_seq#126, d_year#8, d_moy#9, d_qoy#10]
+(76) ColumnarToRow [codegen id : 1]
+Input [5]: [d_date_sk#9, d_month_seq#132, d_year#10, d_moy#11, d_qoy#12]
 
-(73) Filter [codegen id : 1]
-Input [5]: [d_date_sk#7, d_month_seq#126, d_year#8, d_moy#9, d_qoy#10]
-Condition : (((isnotnull(d_month_seq#126) AND (d_month_seq#126 >= 1212)) AND (d_month_seq#126 <= 1223)) AND isnotnull(d_date_sk#7))
+(77) Filter [codegen id : 1]
+Input [5]: [d_date_sk#9, d_month_seq#132, d_year#10, d_moy#11, d_qoy#12]
+Condition : (((isnotnull(d_month_seq#132) AND (d_month_seq#132 >= 1212)) AND (d_month_seq#132 <= 1223)) AND isnotnull(d_date_sk#9))
 
-(74) Project [codegen id : 1]
-Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
-Input [5]: [d_date_sk#7, d_month_seq#126, d_year#8, d_moy#9, d_qoy#10]
+(78) Project [codegen id : 1]
+Output [4]: [d_date_sk#9, d_year#10, d_moy#11, d_qoy#12]
+Input [5]: [d_date_sk#9, d_month_seq#132, d_year#10, d_moy#11, d_qoy#12]
 
-(75) BroadcastExchange
-Input [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+(79) BroadcastExchange
+Input [4]: [d_date_sk#9, d_year#10, d_moy#11, d_qoy#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/simplified.txt
@@ -27,6 +27,16 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                                     Project [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy]
                                                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                         Filter [ss_store_sk,ss_item_sk]
+                                                          Subquery #2
+                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                              Exchange #5
+                                                                ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                  Exchange [i_item_sk] #6
+                                                                    WholeStageCodegen (1)
+                                                                      Filter [i_item_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,ss_sold_date_sk]
@@ -41,7 +51,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                                         InputAdapter
                                                           ReusedExchange [d_date_sk,d_year,d_moy,d_qoy] #4
                                                     InputAdapter
-                                                      BroadcastExchange #5
+                                                      BroadcastExchange #7
                                                         WholeStageCodegen (2)
                                                           Filter [s_store_sk]
                                                             ColumnarToRow
@@ -51,16 +61,11 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                       WholeStageCodegen (6)
                                         Sort [i_item_sk]
                                           InputAdapter
-                                            Exchange [i_item_sk] #6
-                                              WholeStageCodegen (5)
-                                                Filter [i_item_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
+                                            ReusedExchange [i_item_sk,i_brand,i_class,i_category,i_product_name] #6
                     WholeStageCodegen (17)
                       HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,sum,isEmpty] [sum(sumsales),s_store_id,sumsales,sum,isEmpty]
                         InputAdapter
-                          Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy] #7
+                          Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy] #8
                             WholeStageCodegen (16)
                               HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,sumsales] [sum,isEmpty,sum,isEmpty]
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
@@ -69,7 +74,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                     WholeStageCodegen (26)
                       HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,sum,isEmpty] [sum(sumsales),d_moy,s_store_id,sumsales,sum,isEmpty]
                         InputAdapter
-                          Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy] #8
+                          Exchange [i_category,i_class,i_brand,i_product_name,d_year,d_qoy] #9
                             WholeStageCodegen (25)
                               HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,sumsales] [sum,isEmpty,sum,isEmpty]
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
@@ -78,7 +83,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                     WholeStageCodegen (35)
                       HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,sum,isEmpty] [sum(sumsales),d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
                         InputAdapter
-                          Exchange [i_category,i_class,i_brand,i_product_name,d_year] #9
+                          Exchange [i_category,i_class,i_brand,i_product_name,d_year] #10
                             WholeStageCodegen (34)
                               HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,sumsales] [sum,isEmpty,sum,isEmpty]
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
@@ -87,7 +92,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                     WholeStageCodegen (44)
                       HashAggregate [i_category,i_class,i_brand,i_product_name,sum,isEmpty] [sum(sumsales),d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
                         InputAdapter
-                          Exchange [i_category,i_class,i_brand,i_product_name] #10
+                          Exchange [i_category,i_class,i_brand,i_product_name] #11
                             WholeStageCodegen (43)
                               HashAggregate [i_category,i_class,i_brand,i_product_name,sumsales] [sum,isEmpty,sum,isEmpty]
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
@@ -96,7 +101,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                     WholeStageCodegen (53)
                       HashAggregate [i_category,i_class,i_brand,sum,isEmpty] [sum(sumsales),i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
                         InputAdapter
-                          Exchange [i_category,i_class,i_brand] #11
+                          Exchange [i_category,i_class,i_brand] #12
                             WholeStageCodegen (52)
                               HashAggregate [i_category,i_class,i_brand,sumsales] [sum,isEmpty,sum,isEmpty]
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
@@ -105,7 +110,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                     WholeStageCodegen (62)
                       HashAggregate [i_category,i_class,sum,isEmpty] [sum(sumsales),i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
                         InputAdapter
-                          Exchange [i_category,i_class] #12
+                          Exchange [i_category,i_class] #13
                             WholeStageCodegen (61)
                               HashAggregate [i_category,i_class,sumsales] [sum,isEmpty,sum,isEmpty]
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
@@ -114,7 +119,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                     WholeStageCodegen (71)
                       HashAggregate [i_category,sum,isEmpty] [sum(sumsales),i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
                         InputAdapter
-                          Exchange [i_category] #13
+                          Exchange [i_category] #14
                             WholeStageCodegen (70)
                               HashAggregate [i_category,sumsales] [sum,isEmpty,sum,isEmpty]
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]
@@ -123,7 +128,7 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                     WholeStageCodegen (80)
                       HashAggregate [sum,isEmpty] [sum(sumsales),i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sumsales,sum,isEmpty]
                         InputAdapter
-                          Exchange #14
+                          Exchange #15
                             WholeStageCodegen (79)
                               HashAggregate [sumsales] [sum,isEmpty,sum,isEmpty]
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,sum,isEmpty] [sum(coalesce((ss_sales_price * cast(ss_quantity as decimal(10,0))), 0.00)),sumsales,sum,isEmpty]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
@@ -1,22 +1,22 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * HashAggregate (69)
-   +- Exchange (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin LeftOuter (65)
-               :- * Sort (58)
-               :  +- Exchange (57)
-               :     +- * Project (56)
-               :        +- * BroadcastHashJoin LeftOuter BuildRight (55)
-               :           :- * Project (50)
-               :           :  +- * SortMergeJoin Inner (49)
-               :           :     :- * Sort (37)
-               :           :     :  +- Exchange (36)
-               :           :     :     +- * Project (35)
-               :           :     :        +- * BroadcastHashJoin Inner BuildRight (34)
-               :           :     :           :- * Project (32)
-               :           :     :           :  +- * SortMergeJoin Inner (31)
+TakeOrderedAndProject (67)
++- * HashAggregate (66)
+   +- Exchange (65)
+      +- * HashAggregate (64)
+         +- * Project (63)
+            +- * SortMergeJoin LeftOuter (62)
+               :- * Sort (55)
+               :  +- Exchange (54)
+               :     +- * Project (53)
+               :        +- * BroadcastHashJoin LeftOuter BuildRight (52)
+               :           :- * Project (47)
+               :           :  +- * SortMergeJoin Inner (46)
+               :           :     :- * Sort (34)
+               :           :     :  +- Exchange (33)
+               :           :     :     +- * Project (32)
+               :           :     :        +- * BroadcastHashJoin Inner BuildRight (31)
+               :           :     :           :- * Project (29)
+               :           :     :           :  +- * SortMergeJoin Inner (28)
                :           :     :           :     :- * Sort (25)
                :           :     :           :     :  +- Exchange (24)
                :           :     :           :     :     +- * Project (23)
@@ -42,33 +42,30 @@ TakeOrderedAndProject (70)
                :           :     :           :     :              +- * Filter (20)
                :           :     :           :     :                 +- * ColumnarToRow (19)
                :           :     :           :     :                    +- Scan parquet spark_catalog.default.date_dim (18)
-               :           :     :           :     +- * Sort (30)
-               :           :     :           :        +- Exchange (29)
-               :           :     :           :           +- * Filter (28)
-               :           :     :           :              +- * ColumnarToRow (27)
-               :           :     :           :                 +- Scan parquet spark_catalog.default.item (26)
-               :           :     :           +- ReusedExchange (33)
-               :           :     +- * Sort (48)
-               :           :        +- Exchange (47)
-               :           :           +- * Project (46)
-               :           :              +- * BroadcastHashJoin Inner BuildRight (45)
-               :           :                 :- * Filter (40)
-               :           :                 :  +- * ColumnarToRow (39)
-               :           :                 :     +- Scan parquet spark_catalog.default.inventory (38)
-               :           :                 +- BroadcastExchange (44)
-               :           :                    +- * Filter (43)
-               :           :                       +- * ColumnarToRow (42)
-               :           :                          +- Scan parquet spark_catalog.default.warehouse (41)
-               :           +- BroadcastExchange (54)
-               :              +- * Filter (53)
-               :                 +- * ColumnarToRow (52)
-               :                    +- Scan parquet spark_catalog.default.promotion (51)
-               +- * Sort (64)
-                  +- Exchange (63)
-                     +- * Project (62)
-                        +- * Filter (61)
-                           +- * ColumnarToRow (60)
-                              +- Scan parquet spark_catalog.default.catalog_returns (59)
+               :           :     :           :     +- * Sort (27)
+               :           :     :           :        +- ReusedExchange (26)
+               :           :     :           +- ReusedExchange (30)
+               :           :     +- * Sort (45)
+               :           :        +- Exchange (44)
+               :           :           +- * Project (43)
+               :           :              +- * BroadcastHashJoin Inner BuildRight (42)
+               :           :                 :- * Filter (37)
+               :           :                 :  +- * ColumnarToRow (36)
+               :           :                 :     +- Scan parquet spark_catalog.default.inventory (35)
+               :           :                 +- BroadcastExchange (41)
+               :           :                    +- * Filter (40)
+               :           :                       +- * ColumnarToRow (39)
+               :           :                          +- Scan parquet spark_catalog.default.warehouse (38)
+               :           +- BroadcastExchange (51)
+               :              +- * Filter (50)
+               :                 +- * ColumnarToRow (49)
+               :                    +- Scan parquet spark_catalog.default.promotion (48)
+               +- * Sort (61)
+                  +- Exchange (60)
+                     +- * Project (59)
+                        +- * Filter (58)
+                           +- * ColumnarToRow (57)
+                              +- Scan parquet spark_catalog.default.catalog_returns (56)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -84,380 +81,411 @@ Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_s
 
 (3) Filter [codegen id : 4]
 Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Condition : ((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
+Condition : (((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1)) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(cs_item_sk#4, 42), false))
 
 (4) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [2]: [hd_demo_sk#12, hd_buy_potential#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,1001-5000      ), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Input [2]: [hd_demo_sk#12, hd_buy_potential#13]
 
 (6) Filter [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
-Condition : ((isnotnull(hd_buy_potential#11) AND (hd_buy_potential#11 = 1001-5000      )) AND isnotnull(hd_demo_sk#10))
+Input [2]: [hd_demo_sk#12, hd_buy_potential#13]
+Condition : ((isnotnull(hd_buy_potential#13) AND (hd_buy_potential#13 = 1001-5000      )) AND isnotnull(hd_demo_sk#12))
 
 (7) Project [codegen id : 1]
-Output [1]: [hd_demo_sk#10]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [1]: [hd_demo_sk#12]
+Input [2]: [hd_demo_sk#12, hd_buy_potential#13]
 
 (8) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [hd_demo_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#12]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
 Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#10]
+Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#12]
 
 (11) Scan parquet spark_catalog.default.customer_demographics
-Output [2]: [cd_demo_sk#12, cd_marital_status#13]
+Output [2]: [cd_demo_sk#14, cd_marital_status#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,M), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (12) ColumnarToRow [codegen id : 2]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
+Input [2]: [cd_demo_sk#14, cd_marital_status#15]
 
 (13) Filter [codegen id : 2]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
-Condition : ((isnotnull(cd_marital_status#13) AND (cd_marital_status#13 = M)) AND isnotnull(cd_demo_sk#12))
+Input [2]: [cd_demo_sk#14, cd_marital_status#15]
+Condition : ((isnotnull(cd_marital_status#15) AND (cd_marital_status#15 = M)) AND isnotnull(cd_demo_sk#14))
 
 (14) Project [codegen id : 2]
-Output [1]: [cd_demo_sk#12]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
+Output [1]: [cd_demo_sk#14]
+Input [2]: [cd_demo_sk#14, cd_marital_status#15]
 
 (15) BroadcastExchange
-Input [1]: [cd_demo_sk#12]
+Input [1]: [cd_demo_sk#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#12]
+Right keys [1]: [cd_demo_sk#14]
 Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
 Output [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#12]
+Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#14]
 
 (18) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#14, d_date#15]
+Output [2]: [d_date_sk#16, d_date#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (19) ColumnarToRow [codegen id : 3]
-Input [2]: [d_date_sk#14, d_date#15]
+Input [2]: [d_date_sk#16, d_date#17]
 
 (20) Filter [codegen id : 3]
-Input [2]: [d_date_sk#14, d_date#15]
-Condition : (isnotnull(d_date#15) AND isnotnull(d_date_sk#14))
+Input [2]: [d_date_sk#16, d_date#17]
+Condition : (isnotnull(d_date#17) AND isnotnull(d_date_sk#16))
 
 (21) BroadcastExchange
-Input [2]: [d_date_sk#14, d_date#15]
+Input [2]: [d_date_sk#16, d_date#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#14]
+Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 4]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
-Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date_sk#14, d_date#15]
+Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
+Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date_sk#16, d_date#17]
 
 (24) Exchange
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
+Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
 Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (25) Sort [codegen id : 5]
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
+Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17]
 Arguments: [cs_item_sk#4 ASC NULLS FIRST], false, 0
 
-(26) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#16, i_item_desc#17]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_item_desc:string>
+(26) ReusedExchange [Reuses operator id: 71]
+Output [2]: [i_item_sk#18, i_item_desc#19]
 
-(27) ColumnarToRow [codegen id : 6]
-Input [2]: [i_item_sk#16, i_item_desc#17]
+(27) Sort [codegen id : 7]
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Arguments: [i_item_sk#18 ASC NULLS FIRST], false, 0
 
-(28) Filter [codegen id : 6]
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Condition : isnotnull(i_item_sk#16)
-
-(29) Exchange
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Arguments: hashpartitioning(i_item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(30) Sort [codegen id : 7]
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
-
-(31) SortMergeJoin [codegen id : 10]
+(28) SortMergeJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
-(32) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_desc#17]
-Input [8]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_sk#16, i_item_desc#17]
+(29) Project [codegen id : 10]
+Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_desc#19]
+Input [8]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_sk#18, i_item_desc#19]
 
-(33) ReusedExchange [Reuses operator id: 81]
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
+(30) ReusedExchange [Reuses operator id: 85]
+Output [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23]
 
-(34) BroadcastHashJoin [codegen id : 10]
+(31) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#18]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
-Join condition: (d_date#15 > date_add(d_date#19, 5))
+Join condition: (d_date#17 > date_add(d_date#21, 5))
 
-(35) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_desc#17, d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
+(32) Project [codegen id : 10]
+Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#19, d_week_seq#22, d_date_sk#23]
+Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#17, i_item_desc#19, d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23]
 
-(36) Exchange
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(33) Exchange
+Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#19, d_week_seq#22, d_date_sk#23]
+Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(37) Sort [codegen id : 11]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#21 ASC NULLS FIRST], false, 0
+(34) Sort [codegen id : 11]
+Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#19, d_week_seq#22, d_date_sk#23]
+Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#23 ASC NULLS FIRST], false, 0
 
-(38) Scan parquet spark_catalog.default.inventory
-Output [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
+(35) Scan parquet spark_catalog.default.inventory
+Output [4]: [inv_item_sk#24, inv_warehouse_sk#25, inv_quantity_on_hand#26, inv_date_sk#27]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#25), dynamicpruningexpression(true)]
+PartitionFilters: [isnotnull(inv_date_sk#27), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
-(39) ColumnarToRow [codegen id : 13]
-Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
+(36) ColumnarToRow [codegen id : 13]
+Input [4]: [inv_item_sk#24, inv_warehouse_sk#25, inv_quantity_on_hand#26, inv_date_sk#27]
 
-(40) Filter [codegen id : 13]
-Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
-Condition : ((isnotnull(inv_quantity_on_hand#24) AND isnotnull(inv_item_sk#22)) AND isnotnull(inv_warehouse_sk#23))
+(37) Filter [codegen id : 13]
+Input [4]: [inv_item_sk#24, inv_warehouse_sk#25, inv_quantity_on_hand#26, inv_date_sk#27]
+Condition : ((isnotnull(inv_quantity_on_hand#26) AND isnotnull(inv_item_sk#24)) AND isnotnull(inv_warehouse_sk#25))
 
-(41) Scan parquet spark_catalog.default.warehouse
-Output [2]: [w_warehouse_sk#26, w_warehouse_name#27]
+(38) Scan parquet spark_catalog.default.warehouse
+Output [2]: [w_warehouse_sk#28, w_warehouse_name#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
-(42) ColumnarToRow [codegen id : 12]
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
+(39) ColumnarToRow [codegen id : 12]
+Input [2]: [w_warehouse_sk#28, w_warehouse_name#29]
 
-(43) Filter [codegen id : 12]
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
-Condition : isnotnull(w_warehouse_sk#26)
+(40) Filter [codegen id : 12]
+Input [2]: [w_warehouse_sk#28, w_warehouse_name#29]
+Condition : isnotnull(w_warehouse_sk#28)
 
-(44) BroadcastExchange
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+(41) BroadcastExchange
+Input [2]: [w_warehouse_sk#28, w_warehouse_name#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(45) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [inv_warehouse_sk#23]
-Right keys [1]: [w_warehouse_sk#26]
+(42) BroadcastHashJoin [codegen id : 13]
+Left keys [1]: [inv_warehouse_sk#25]
+Right keys [1]: [w_warehouse_sk#28]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 13]
-Output [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Input [6]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_sk#26, w_warehouse_name#27]
+(43) Project [codegen id : 13]
+Output [4]: [inv_item_sk#24, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_name#29]
+Input [6]: [inv_item_sk#24, inv_warehouse_sk#25, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_sk#28, w_warehouse_name#29]
 
-(47) Exchange
-Input [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Arguments: hashpartitioning(inv_item_sk#22, inv_date_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(44) Exchange
+Input [4]: [inv_item_sk#24, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_name#29]
+Arguments: hashpartitioning(inv_item_sk#24, inv_date_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(48) Sort [codegen id : 14]
-Input [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Arguments: [inv_item_sk#22 ASC NULLS FIRST, inv_date_sk#25 ASC NULLS FIRST], false, 0
+(45) Sort [codegen id : 14]
+Input [4]: [inv_item_sk#24, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_name#29]
+Arguments: [inv_item_sk#24 ASC NULLS FIRST, inv_date_sk#27 ASC NULLS FIRST], false, 0
 
-(49) SortMergeJoin [codegen id : 16]
-Left keys [2]: [cs_item_sk#4, d_date_sk#21]
-Right keys [2]: [inv_item_sk#22, inv_date_sk#25]
+(46) SortMergeJoin [codegen id : 16]
+Left keys [2]: [cs_item_sk#4, d_date_sk#23]
+Right keys [2]: [inv_item_sk#24, inv_date_sk#27]
 Join type: Inner
-Join condition: (inv_quantity_on_hand#24 < cs_quantity#7)
+Join condition: (inv_quantity_on_hand#26 < cs_quantity#7)
 
-(50) Project [codegen id : 16]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21, inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
+(47) Project [codegen id : 16]
+Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#19, d_week_seq#22, d_date_sk#23, inv_item_sk#24, inv_quantity_on_hand#26, inv_date_sk#27, w_warehouse_name#29]
 
-(51) Scan parquet spark_catalog.default.promotion
-Output [1]: [p_promo_sk#28]
+(48) Scan parquet spark_catalog.default.promotion
+Output [1]: [p_promo_sk#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(52) ColumnarToRow [codegen id : 15]
-Input [1]: [p_promo_sk#28]
+(49) ColumnarToRow [codegen id : 15]
+Input [1]: [p_promo_sk#30]
 
-(53) Filter [codegen id : 15]
-Input [1]: [p_promo_sk#28]
-Condition : isnotnull(p_promo_sk#28)
+(50) Filter [codegen id : 15]
+Input [1]: [p_promo_sk#30]
+Condition : isnotnull(p_promo_sk#30)
 
-(54) BroadcastExchange
-Input [1]: [p_promo_sk#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+(51) BroadcastExchange
+Input [1]: [p_promo_sk#30]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(55) BroadcastHashJoin [codegen id : 16]
+(52) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [cs_promo_sk#5]
-Right keys [1]: [p_promo_sk#28]
+Right keys [1]: [p_promo_sk#30]
 Join type: LeftOuter
 Join condition: None
 
-(56) Project [codegen id : 16]
-Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20, p_promo_sk#28]
+(53) Project [codegen id : 16]
+Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22, p_promo_sk#30]
 
-(57) Exchange
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(54) Exchange
+Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(58) Sort [codegen id : 17]
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
+(55) Sort [codegen id : 17]
+Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
 Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
 
-(59) Scan parquet spark_catalog.default.catalog_returns
-Output [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
+(56) Scan parquet spark_catalog.default.catalog_returns
+Output [3]: [cr_item_sk#31, cr_order_number#32, cr_returned_date_sk#33]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
 
-(60) ColumnarToRow [codegen id : 18]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
+(57) ColumnarToRow [codegen id : 18]
+Input [3]: [cr_item_sk#31, cr_order_number#32, cr_returned_date_sk#33]
 
-(61) Filter [codegen id : 18]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-Condition : (isnotnull(cr_item_sk#29) AND isnotnull(cr_order_number#30))
+(58) Filter [codegen id : 18]
+Input [3]: [cr_item_sk#31, cr_order_number#32, cr_returned_date_sk#33]
+Condition : (isnotnull(cr_item_sk#31) AND isnotnull(cr_order_number#32))
 
-(62) Project [codegen id : 18]
-Output [2]: [cr_item_sk#29, cr_order_number#30]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
+(59) Project [codegen id : 18]
+Output [2]: [cr_item_sk#31, cr_order_number#32]
+Input [3]: [cr_item_sk#31, cr_order_number#32, cr_returned_date_sk#33]
 
-(63) Exchange
-Input [2]: [cr_item_sk#29, cr_order_number#30]
-Arguments: hashpartitioning(cr_item_sk#29, cr_order_number#30, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(60) Exchange
+Input [2]: [cr_item_sk#31, cr_order_number#32]
+Arguments: hashpartitioning(cr_item_sk#31, cr_order_number#32, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(64) Sort [codegen id : 19]
-Input [2]: [cr_item_sk#29, cr_order_number#30]
-Arguments: [cr_item_sk#29 ASC NULLS FIRST, cr_order_number#30 ASC NULLS FIRST], false, 0
+(61) Sort [codegen id : 19]
+Input [2]: [cr_item_sk#31, cr_order_number#32]
+Arguments: [cr_item_sk#31 ASC NULLS FIRST, cr_order_number#32 ASC NULLS FIRST], false, 0
 
-(65) SortMergeJoin [codegen id : 20]
+(62) SortMergeJoin [codegen id : 20]
 Left keys [2]: [cs_item_sk#4, cs_order_number#6]
-Right keys [2]: [cr_item_sk#29, cr_order_number#30]
+Right keys [2]: [cr_item_sk#31, cr_order_number#32]
 Join type: LeftOuter
 Join condition: None
 
-(66) Project [codegen id : 20]
-Output [3]: [w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20, cr_item_sk#29, cr_order_number#30]
+(63) Project [codegen id : 20]
+Output [3]: [w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#29, i_item_desc#19, d_week_seq#22, cr_item_sk#31, cr_order_number#32]
 
-(67) HashAggregate [codegen id : 20]
-Input [3]: [w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Keys [3]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20]
+(64) HashAggregate [codegen id : 20]
+Input [3]: [w_warehouse_name#29, i_item_desc#19, d_week_seq#22]
+Keys [3]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#32]
-Results [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
+Aggregate Attributes [1]: [count#34]
+Results [4]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, count#35]
 
-(68) Exchange
-Input [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-Arguments: hashpartitioning(i_item_desc#17, w_warehouse_name#27, d_week_seq#20, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(65) Exchange
+Input [4]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, count#35]
+Arguments: hashpartitioning(i_item_desc#19, w_warehouse_name#29, d_week_seq#22, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(69) HashAggregate [codegen id : 21]
-Input [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-Keys [3]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20]
+(66) HashAggregate [codegen id : 21]
+Input [4]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, count#35]
+Keys [3]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#34]
-Results [6]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count(1)#34 AS no_promo#35, count(1)#34 AS promo#36, count(1)#34 AS total_cnt#37]
+Aggregate Attributes [1]: [count(1)#36]
+Results [6]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, count(1)#36 AS no_promo#37, count(1)#36 AS promo#38, count(1)#36 AS total_cnt#39]
 
-(70) TakeOrderedAndProject
-Input [6]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, no_promo#35, promo#36, total_cnt#37]
-Arguments: 100, [total_cnt#37 DESC NULLS LAST, i_item_desc#17 ASC NULLS FIRST, w_warehouse_name#27 ASC NULLS FIRST, d_week_seq#20 ASC NULLS FIRST], [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, no_promo#35, promo#36, total_cnt#37]
+(67) TakeOrderedAndProject
+Input [6]: [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, no_promo#37, promo#38, total_cnt#39]
+Arguments: 100, [total_cnt#39 DESC NULLS LAST, i_item_desc#19 ASC NULLS FIRST, w_warehouse_name#29 ASC NULLS FIRST, d_week_seq#22 ASC NULLS FIRST], [i_item_desc#19, w_warehouse_name#29, d_week_seq#22, no_promo#37, promo#38, total_cnt#39]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (81)
-+- * Project (80)
-   +- * BroadcastHashJoin Inner BuildLeft (79)
-      :- BroadcastExchange (75)
-      :  +- * Project (74)
-      :     +- * Filter (73)
-      :        +- * ColumnarToRow (72)
-      :           +- Scan parquet spark_catalog.default.date_dim (71)
-      +- * Filter (78)
-         +- * ColumnarToRow (77)
-            +- Scan parquet spark_catalog.default.date_dim (76)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
+ObjectHashAggregate (74)
++- Exchange (73)
+   +- ObjectHashAggregate (72)
+      +- Exchange (71)
+         +- * Filter (70)
+            +- * ColumnarToRow (69)
+               +- Scan parquet spark_catalog.default.item (68)
 
 
-(71) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(68) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#18, i_item_desc#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_item_desc:string>
+
+(69) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#18, i_item_desc#19]
+
+(70) Filter [codegen id : 1]
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Condition : isnotnull(i_item_sk#18)
+
+(71) Exchange
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Arguments: hashpartitioning(i_item_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(72) ObjectHashAggregate
+Input [2]: [i_item_sk#18, i_item_desc#19]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [buf#40]
+Results [1]: [buf#41]
+
+(73) Exchange
+Input [1]: [buf#41]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
+
+(74) ObjectHashAggregate
+Input [1]: [buf#41]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)#42]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 204000, 1632000, 0, 0)#42 AS bloomFilter#43]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
+BroadcastExchange (85)
++- * Project (84)
+   +- * BroadcastHashJoin Inner BuildLeft (83)
+      :- BroadcastExchange (79)
+      :  +- * Project (78)
+      :     +- * Filter (77)
+      :        +- * ColumnarToRow (76)
+      :           +- Scan parquet spark_catalog.default.date_dim (75)
+      +- * Filter (82)
+         +- * ColumnarToRow (81)
+            +- Scan parquet spark_catalog.default.date_dim (80)
+
+
+(75) Scan parquet spark_catalog.default.date_dim
+Output [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_year#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(76) ColumnarToRow [codegen id : 1]
+Input [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_year#44]
 
-(73) Filter [codegen id : 1]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
-Condition : ((((isnotnull(d_year#38) AND (d_year#38 = 2001)) AND isnotnull(d_date_sk#18)) AND isnotnull(d_week_seq#20)) AND isnotnull(d_date#19))
+(77) Filter [codegen id : 1]
+Input [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_year#44]
+Condition : ((((isnotnull(d_year#44) AND (d_year#44 = 2001)) AND isnotnull(d_date_sk#20)) AND isnotnull(d_week_seq#22)) AND isnotnull(d_date#21))
 
-(74) Project [codegen id : 1]
-Output [3]: [d_date_sk#18, d_date#19, d_week_seq#20]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(78) Project [codegen id : 1]
+Output [3]: [d_date_sk#20, d_date#21, d_week_seq#22]
+Input [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_year#44]
 
-(75) BroadcastExchange
-Input [3]: [d_date_sk#18, d_date#19, d_week_seq#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=13]
+(79) BroadcastExchange
+Input [3]: [d_date_sk#20, d_date#21, d_week_seq#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=14]
 
-(76) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#21, d_week_seq#39]
+(80) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#23, d_week_seq#45]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(77) ColumnarToRow
-Input [2]: [d_date_sk#21, d_week_seq#39]
+(81) ColumnarToRow
+Input [2]: [d_date_sk#23, d_week_seq#45]
 
-(78) Filter
-Input [2]: [d_date_sk#21, d_week_seq#39]
-Condition : (isnotnull(d_week_seq#39) AND isnotnull(d_date_sk#21))
+(82) Filter
+Input [2]: [d_date_sk#23, d_week_seq#45]
+Condition : (isnotnull(d_week_seq#45) AND isnotnull(d_date_sk#23))
 
-(79) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [d_week_seq#20]
-Right keys [1]: [d_week_seq#39]
+(83) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [d_week_seq#22]
+Right keys [1]: [d_week_seq#45]
 Join type: Inner
 Join condition: None
 
-(80) Project [codegen id : 2]
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-Input [5]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21, d_week_seq#39]
+(84) Project [codegen id : 2]
+Output [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23]
+Input [5]: [d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23, d_week_seq#45]
 
-(81) BroadcastExchange
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+(85) BroadcastExchange
+Input [4]: [d_date_sk#20, d_date#21, d_week_seq#22, d_date_sk#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/simplified.txt
@@ -40,6 +40,16 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                               Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
                                                                                 BroadcastHashJoin [cs_bill_hdemo_sk,hd_demo_sk]
                                                                                   Filter [cs_quantity,cs_item_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_ship_date_sk]
+                                                                                    Subquery #2
+                                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 204000, 1632000, 0, 0),bloomFilter,buf]
+                                                                                        Exchange #7
+                                                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                                            Exchange [i_item_sk] #8
+                                                                                              WholeStageCodegen (1)
+                                                                                                Filter [i_item_sk]
+                                                                                                  ColumnarToRow
+                                                                                                    InputAdapter
+                                                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
                                                                                     ColumnarToRow
                                                                                       InputAdapter
                                                                                         Scan parquet spark_catalog.default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
@@ -61,7 +71,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                                         InputAdapter
                                                                                                           Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq]
                                                                                   InputAdapter
-                                                                                    BroadcastExchange #7
+                                                                                    BroadcastExchange #9
                                                                                       WholeStageCodegen (1)
                                                                                         Project [hd_demo_sk]
                                                                                           Filter [hd_buy_potential,hd_demo_sk]
@@ -69,7 +79,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                               InputAdapter
                                                                                                 Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential]
                                                                               InputAdapter
-                                                                                BroadcastExchange #8
+                                                                                BroadcastExchange #10
                                                                                   WholeStageCodegen (2)
                                                                                     Project [cd_demo_sk]
                                                                                       Filter [cd_marital_status,cd_demo_sk]
@@ -77,7 +87,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                           InputAdapter
                                                                                             Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
                                                                           InputAdapter
-                                                                            BroadcastExchange #9
+                                                                            BroadcastExchange #11
                                                                               WholeStageCodegen (3)
                                                                                 Filter [d_date,d_date_sk]
                                                                                   ColumnarToRow
@@ -87,19 +97,14 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                             WholeStageCodegen (7)
                                                               Sort [i_item_sk]
                                                                 InputAdapter
-                                                                  Exchange [i_item_sk] #10
-                                                                    WholeStageCodegen (6)
-                                                                      Filter [i_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
+                                                                  ReusedExchange [i_item_sk,i_item_desc] #8
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk,d_date,d_week_seq,d_date_sk] #5
                                       InputAdapter
                                         WholeStageCodegen (14)
                                           Sort [inv_item_sk,inv_date_sk]
                                             InputAdapter
-                                              Exchange [inv_item_sk,inv_date_sk] #11
+                                              Exchange [inv_item_sk,inv_date_sk] #12
                                                 WholeStageCodegen (13)
                                                   Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
                                                     BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
@@ -108,14 +113,14 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
                                                       InputAdapter
-                                                        BroadcastExchange #12
+                                                        BroadcastExchange #13
                                                           WholeStageCodegen (12)
                                                             Filter [w_warehouse_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_warehouse_name]
                                   InputAdapter
-                                    BroadcastExchange #13
+                                    BroadcastExchange #14
                                       WholeStageCodegen (15)
                                         Filter [p_promo_sk]
                                           ColumnarToRow
@@ -125,7 +130,7 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                     WholeStageCodegen (19)
                       Sort [cr_item_sk,cr_order_number]
                         InputAdapter
-                          Exchange [cr_item_sk,cr_order_number] #14
+                          Exchange [cr_item_sk,cr_order_number] #15
                             WholeStageCodegen (18)
                               Project [cr_item_sk,cr_order_number]
                                 Filter [cr_item_sk,cr_order_number]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74.sf100/explain.txt
@@ -1,18 +1,18 @@
 == Physical Plan ==
-TakeOrderedAndProject (79)
-+- * Project (78)
-   +- * SortMergeJoin Inner (77)
-      :- * Project (59)
-      :  +- * SortMergeJoin Inner (58)
-      :     :- * SortMergeJoin Inner (39)
-      :     :  :- * Sort (21)
-      :     :  :  +- Exchange (20)
-      :     :  :     +- * Filter (19)
-      :     :  :        +- * HashAggregate (18)
-      :     :  :           +- Exchange (17)
-      :     :  :              +- * HashAggregate (16)
-      :     :  :                 +- * Project (15)
-      :     :  :                    +- * SortMergeJoin Inner (14)
+TakeOrderedAndProject (76)
++- * Project (75)
+   +- * SortMergeJoin Inner (74)
+      :- * Project (56)
+      :  +- * SortMergeJoin Inner (55)
+      :     :- * SortMergeJoin Inner (36)
+      :     :  :- * Sort (18)
+      :     :  :  +- Exchange (17)
+      :     :  :     +- * Filter (16)
+      :     :  :        +- * HashAggregate (15)
+      :     :  :           +- Exchange (14)
+      :     :  :              +- * HashAggregate (13)
+      :     :  :                 +- * Project (12)
+      :     :  :                    +- * SortMergeJoin Inner (11)
       :     :  :                       :- * Sort (8)
       :     :  :                       :  +- Exchange (7)
       :     :  :                       :     +- * Project (6)
@@ -21,63 +21,60 @@ TakeOrderedAndProject (79)
       :     :  :                       :           :  +- * ColumnarToRow (2)
       :     :  :                       :           :     +- Scan parquet spark_catalog.default.store_sales (1)
       :     :  :                       :           +- ReusedExchange (4)
-      :     :  :                       +- * Sort (13)
-      :     :  :                          +- Exchange (12)
-      :     :  :                             +- * Filter (11)
-      :     :  :                                +- * ColumnarToRow (10)
-      :     :  :                                   +- Scan parquet spark_catalog.default.customer (9)
-      :     :  +- * Sort (38)
-      :     :     +- Exchange (37)
-      :     :        +- * HashAggregate (36)
-      :     :           +- Exchange (35)
-      :     :              +- * HashAggregate (34)
-      :     :                 +- * Project (33)
-      :     :                    +- * SortMergeJoin Inner (32)
-      :     :                       :- * Sort (29)
-      :     :                       :  +- Exchange (28)
-      :     :                       :     +- * Project (27)
-      :     :                       :        +- * BroadcastHashJoin Inner BuildRight (26)
-      :     :                       :           :- * Filter (24)
-      :     :                       :           :  +- * ColumnarToRow (23)
-      :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (22)
-      :     :                       :           +- ReusedExchange (25)
-      :     :                       +- * Sort (31)
-      :     :                          +- ReusedExchange (30)
-      :     +- * Sort (57)
-      :        +- Exchange (56)
-      :           +- * Filter (55)
-      :              +- * HashAggregate (54)
-      :                 +- Exchange (53)
-      :                    +- * HashAggregate (52)
-      :                       +- * Project (51)
-      :                          +- * SortMergeJoin Inner (50)
-      :                             :- * Sort (47)
-      :                             :  +- Exchange (46)
-      :                             :     +- * Project (45)
-      :                             :        +- * BroadcastHashJoin Inner BuildRight (44)
-      :                             :           :- * Filter (42)
-      :                             :           :  +- * ColumnarToRow (41)
-      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (40)
-      :                             :           +- ReusedExchange (43)
-      :                             +- * Sort (49)
-      :                                +- ReusedExchange (48)
-      +- * Sort (76)
-         +- Exchange (75)
-            +- * HashAggregate (74)
-               +- Exchange (73)
-                  +- * HashAggregate (72)
-                     +- * Project (71)
-                        +- * SortMergeJoin Inner (70)
-                           :- * Sort (67)
-                           :  +- Exchange (66)
-                           :     +- * Project (65)
-                           :        +- * BroadcastHashJoin Inner BuildRight (64)
-                           :           :- * Filter (62)
-                           :           :  +- * ColumnarToRow (61)
-                           :           :     +- Scan parquet spark_catalog.default.web_sales (60)
-                           :           +- ReusedExchange (63)
-                           +- * Sort (69)
-                              +- ReusedExchange (68)
+      :     :  :                       +- * Sort (10)
+      :     :  :                          +- ReusedExchange (9)
+      :     :  +- * Sort (35)
+      :     :     +- Exchange (34)
+      :     :        +- * HashAggregate (33)
+      :     :           +- Exchange (32)
+      :     :              +- * HashAggregate (31)
+      :     :                 +- * Project (30)
+      :     :                    +- * SortMergeJoin Inner (29)
+      :     :                       :- * Sort (26)
+      :     :                       :  +- Exchange (25)
+      :     :                       :     +- * Project (24)
+      :     :                       :        +- * BroadcastHashJoin Inner BuildRight (23)
+      :     :                       :           :- * Filter (21)
+      :     :                       :           :  +- * ColumnarToRow (20)
+      :     :                       :           :     +- Scan parquet spark_catalog.default.store_sales (19)
+      :     :                       :           +- ReusedExchange (22)
+      :     :                       +- * Sort (28)
+      :     :                          +- ReusedExchange (27)
+      :     +- * Sort (54)
+      :        +- Exchange (53)
+      :           +- * Filter (52)
+      :              +- * HashAggregate (51)
+      :                 +- Exchange (50)
+      :                    +- * HashAggregate (49)
+      :                       +- * Project (48)
+      :                          +- * SortMergeJoin Inner (47)
+      :                             :- * Sort (44)
+      :                             :  +- Exchange (43)
+      :                             :     +- * Project (42)
+      :                             :        +- * BroadcastHashJoin Inner BuildRight (41)
+      :                             :           :- * Filter (39)
+      :                             :           :  +- * ColumnarToRow (38)
+      :                             :           :     +- Scan parquet spark_catalog.default.web_sales (37)
+      :                             :           +- ReusedExchange (40)
+      :                             +- * Sort (46)
+      :                                +- ReusedExchange (45)
+      +- * Sort (73)
+         +- Exchange (72)
+            +- * HashAggregate (71)
+               +- Exchange (70)
+                  +- * HashAggregate (69)
+                     +- * Project (68)
+                        +- * SortMergeJoin Inner (67)
+                           :- * Sort (64)
+                           :  +- Exchange (63)
+                           :     +- * Project (62)
+                           :        +- * BroadcastHashJoin Inner BuildRight (61)
+                           :           :- * Filter (59)
+                           :           :  +- * ColumnarToRow (58)
+                           :           :     +- Scan parquet spark_catalog.default.web_sales (57)
+                           :           +- ReusedExchange (60)
+                           +- * Sort (66)
+                              +- ReusedExchange (65)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -93,390 +90,396 @@ Input [3]: [ss_customer_sk#1, ss_net_paid#2, ss_sold_date_sk#3]
 
 (3) Filter [codegen id : 2]
 Input [3]: [ss_customer_sk#1, ss_net_paid#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_customer_sk#1)
+Condition : (isnotnull(ss_customer_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ss_customer_sk#1, 42), false))
 
-(4) ReusedExchange [Reuses operator id: 83]
-Output [2]: [d_date_sk#5, d_year#6]
+(4) ReusedExchange [Reuses operator id: 87]
+Output [2]: [d_date_sk#7, d_year#8]
 
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#5]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
-Output [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#6]
-Input [5]: [ss_customer_sk#1, ss_net_paid#2, ss_sold_date_sk#3, d_date_sk#5, d_year#6]
+Output [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#8]
+Input [5]: [ss_customer_sk#1, ss_net_paid#2, ss_sold_date_sk#3, d_date_sk#7, d_year#8]
 
 (7) Exchange
-Input [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#6]
+Input [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#8]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
 (8) Sort [codegen id : 3]
-Input [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#6]
+Input [3]: [ss_customer_sk#1, ss_net_paid#2, d_year#8]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
+(9) ReusedExchange [Reuses operator id: 80]
+Output [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+
+(10) Sort [codegen id : 5]
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+Arguments: [c_customer_sk#9 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_customer_sk#1]
+Right keys [1]: [c_customer_sk#9]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, ss_net_paid#2, d_year#8]
+Input [7]: [ss_customer_sk#1, ss_net_paid#2, d_year#8, c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+
+(13) HashAggregate [codegen id : 6]
+Input [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, ss_net_paid#2, d_year#8]
+Keys [4]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#2))]
+Aggregate Attributes [1]: [sum#13]
+Results [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8, sum#14]
+
+(14) Exchange
+Input [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8, sum#14]
+Arguments: hashpartitioning(c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [5]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8, sum#14]
+Keys [4]: [c_customer_id#10, c_first_name#11, c_last_name#12, d_year#8]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#2))#15]
+Results [2]: [c_customer_id#10 AS customer_id#16, MakeDecimal(sum(UnscaledValue(ss_net_paid#2))#15,17,2) AS year_total#17]
+
+(16) Filter [codegen id : 7]
+Input [2]: [customer_id#16, year_total#17]
+Condition : (isnotnull(year_total#17) AND (year_total#17 > 0.00))
+
+(17) Exchange
+Input [2]: [customer_id#16, year_total#17]
+Arguments: hashpartitioning(customer_id#16, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(18) Sort [codegen id : 8]
+Input [2]: [customer_id#16, year_total#17]
+Arguments: [customer_id#16 ASC NULLS FIRST], false, 0
+
+(19) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_customer_sk#18, ss_net_paid#19, ss_sold_date_sk#20]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#20), dynamicpruningexpression(ss_sold_date_sk#20 IN dynamicpruning#21)]
+PushedFilters: [IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_customer_sk:int,ss_net_paid:decimal(7,2)>
+
+(20) ColumnarToRow [codegen id : 10]
+Input [3]: [ss_customer_sk#18, ss_net_paid#19, ss_sold_date_sk#20]
+
+(21) Filter [codegen id : 10]
+Input [3]: [ss_customer_sk#18, ss_net_paid#19, ss_sold_date_sk#20]
+Condition : (isnotnull(ss_customer_sk#18) AND might_contain(Subquery scalar-subquery#22, [id=#23], xxhash64(ss_customer_sk#18, 42), false))
+
+(22) ReusedExchange [Reuses operator id: 98]
+Output [2]: [d_date_sk#24, d_year#25]
+
+(23) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#20]
+Right keys [1]: [d_date_sk#24]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 10]
+Output [3]: [ss_customer_sk#18, ss_net_paid#19, d_year#25]
+Input [5]: [ss_customer_sk#18, ss_net_paid#19, ss_sold_date_sk#20, d_date_sk#24, d_year#25]
+
+(25) Exchange
+Input [3]: [ss_customer_sk#18, ss_net_paid#19, d_year#25]
+Arguments: hashpartitioning(ss_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(26) Sort [codegen id : 11]
+Input [3]: [ss_customer_sk#18, ss_net_paid#19, d_year#25]
+Arguments: [ss_customer_sk#18 ASC NULLS FIRST], false, 0
+
+(27) ReusedExchange [Reuses operator id: 80]
+Output [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+
+(28) Sort [codegen id : 13]
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Arguments: [c_customer_sk#26 ASC NULLS FIRST], false, 0
+
+(29) SortMergeJoin [codegen id : 14]
+Left keys [1]: [ss_customer_sk#18]
+Right keys [1]: [c_customer_sk#26]
+Join type: Inner
+Join condition: None
+
+(30) Project [codegen id : 14]
+Output [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, ss_net_paid#19, d_year#25]
+Input [7]: [ss_customer_sk#18, ss_net_paid#19, d_year#25, c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+
+(31) HashAggregate [codegen id : 14]
+Input [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, ss_net_paid#19, d_year#25]
+Keys [4]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#19))]
+Aggregate Attributes [1]: [sum#30]
+Results [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25, sum#31]
+
+(32) Exchange
+Input [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25, sum#31]
+Arguments: hashpartitioning(c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(33) HashAggregate [codegen id : 15]
+Input [5]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25, sum#31]
+Keys [4]: [c_customer_id#27, c_first_name#28, c_last_name#29, d_year#25]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#19))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#19))#15]
+Results [4]: [c_customer_id#27 AS customer_id#32, c_first_name#28 AS customer_first_name#33, c_last_name#29 AS customer_last_name#34, MakeDecimal(sum(UnscaledValue(ss_net_paid#19))#15,17,2) AS year_total#35]
+
+(34) Exchange
+Input [4]: [customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35]
+Arguments: hashpartitioning(customer_id#32, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(35) Sort [codegen id : 16]
+Input [4]: [customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35]
+Arguments: [customer_id#32 ASC NULLS FIRST], false, 0
+
+(36) SortMergeJoin [codegen id : 17]
+Left keys [1]: [customer_id#16]
+Right keys [1]: [customer_id#32]
+Join type: Inner
+Join condition: None
+
+(37) Scan parquet spark_catalog.default.web_sales
+Output [3]: [ws_bill_customer_sk#36, ws_net_paid#37, ws_sold_date_sk#38]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#38), dynamicpruningexpression(ws_sold_date_sk#38 IN dynamicpruning#4)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_net_paid:decimal(7,2)>
+
+(38) ColumnarToRow [codegen id : 19]
+Input [3]: [ws_bill_customer_sk#36, ws_net_paid#37, ws_sold_date_sk#38]
+
+(39) Filter [codegen id : 19]
+Input [3]: [ws_bill_customer_sk#36, ws_net_paid#37, ws_sold_date_sk#38]
+Condition : (isnotnull(ws_bill_customer_sk#36) AND might_contain(ReusedSubquery Subquery scalar-subquery#22, [id=#23], xxhash64(ws_bill_customer_sk#36, 42), false))
+
+(40) ReusedExchange [Reuses operator id: 87]
+Output [2]: [d_date_sk#39, d_year#40]
+
+(41) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [ws_sold_date_sk#38]
+Right keys [1]: [d_date_sk#39]
+Join type: Inner
+Join condition: None
+
+(42) Project [codegen id : 19]
+Output [3]: [ws_bill_customer_sk#36, ws_net_paid#37, d_year#40]
+Input [5]: [ws_bill_customer_sk#36, ws_net_paid#37, ws_sold_date_sk#38, d_date_sk#39, d_year#40]
+
+(43) Exchange
+Input [3]: [ws_bill_customer_sk#36, ws_net_paid#37, d_year#40]
+Arguments: hashpartitioning(ws_bill_customer_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(44) Sort [codegen id : 20]
+Input [3]: [ws_bill_customer_sk#36, ws_net_paid#37, d_year#40]
+Arguments: [ws_bill_customer_sk#36 ASC NULLS FIRST], false, 0
+
+(45) ReusedExchange [Reuses operator id: 80]
+Output [4]: [c_customer_sk#41, c_customer_id#42, c_first_name#43, c_last_name#44]
+
+(46) Sort [codegen id : 22]
+Input [4]: [c_customer_sk#41, c_customer_id#42, c_first_name#43, c_last_name#44]
+Arguments: [c_customer_sk#41 ASC NULLS FIRST], false, 0
+
+(47) SortMergeJoin [codegen id : 23]
+Left keys [1]: [ws_bill_customer_sk#36]
+Right keys [1]: [c_customer_sk#41]
+Join type: Inner
+Join condition: None
+
+(48) Project [codegen id : 23]
+Output [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, ws_net_paid#37, d_year#40]
+Input [7]: [ws_bill_customer_sk#36, ws_net_paid#37, d_year#40, c_customer_sk#41, c_customer_id#42, c_first_name#43, c_last_name#44]
+
+(49) HashAggregate [codegen id : 23]
+Input [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, ws_net_paid#37, d_year#40]
+Keys [4]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40]
+Functions [1]: [partial_sum(UnscaledValue(ws_net_paid#37))]
+Aggregate Attributes [1]: [sum#45]
+Results [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40, sum#46]
+
+(50) Exchange
+Input [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40, sum#46]
+Arguments: hashpartitioning(c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(51) HashAggregate [codegen id : 24]
+Input [5]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40, sum#46]
+Keys [4]: [c_customer_id#42, c_first_name#43, c_last_name#44, d_year#40]
+Functions [1]: [sum(UnscaledValue(ws_net_paid#37))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#37))#47]
+Results [2]: [c_customer_id#42 AS customer_id#48, MakeDecimal(sum(UnscaledValue(ws_net_paid#37))#47,17,2) AS year_total#49]
+
+(52) Filter [codegen id : 24]
+Input [2]: [customer_id#48, year_total#49]
+Condition : (isnotnull(year_total#49) AND (year_total#49 > 0.00))
+
+(53) Exchange
+Input [2]: [customer_id#48, year_total#49]
+Arguments: hashpartitioning(customer_id#48, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+
+(54) Sort [codegen id : 25]
+Input [2]: [customer_id#48, year_total#49]
+Arguments: [customer_id#48 ASC NULLS FIRST], false, 0
+
+(55) SortMergeJoin [codegen id : 26]
+Left keys [1]: [customer_id#16]
+Right keys [1]: [customer_id#48]
+Join type: Inner
+Join condition: None
+
+(56) Project [codegen id : 26]
+Output [7]: [customer_id#16, year_total#17, customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35, year_total#49]
+Input [8]: [customer_id#16, year_total#17, customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35, customer_id#48, year_total#49]
+
+(57) Scan parquet spark_catalog.default.web_sales
+Output [3]: [ws_bill_customer_sk#50, ws_net_paid#51, ws_sold_date_sk#52]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#52), dynamicpruningexpression(ws_sold_date_sk#52 IN dynamicpruning#21)]
+PushedFilters: [IsNotNull(ws_bill_customer_sk)]
+ReadSchema: struct<ws_bill_customer_sk:int,ws_net_paid:decimal(7,2)>
+
+(58) ColumnarToRow [codegen id : 28]
+Input [3]: [ws_bill_customer_sk#50, ws_net_paid#51, ws_sold_date_sk#52]
+
+(59) Filter [codegen id : 28]
+Input [3]: [ws_bill_customer_sk#50, ws_net_paid#51, ws_sold_date_sk#52]
+Condition : (isnotnull(ws_bill_customer_sk#50) AND might_contain(ReusedSubquery Subquery scalar-subquery#22, [id=#23], xxhash64(ws_bill_customer_sk#50, 42), false))
+
+(60) ReusedExchange [Reuses operator id: 98]
+Output [2]: [d_date_sk#53, d_year#54]
+
+(61) BroadcastHashJoin [codegen id : 28]
+Left keys [1]: [ws_sold_date_sk#52]
+Right keys [1]: [d_date_sk#53]
+Join type: Inner
+Join condition: None
+
+(62) Project [codegen id : 28]
+Output [3]: [ws_bill_customer_sk#50, ws_net_paid#51, d_year#54]
+Input [5]: [ws_bill_customer_sk#50, ws_net_paid#51, ws_sold_date_sk#52, d_date_sk#53, d_year#54]
+
+(63) Exchange
+Input [3]: [ws_bill_customer_sk#50, ws_net_paid#51, d_year#54]
+Arguments: hashpartitioning(ws_bill_customer_sk#50, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(64) Sort [codegen id : 29]
+Input [3]: [ws_bill_customer_sk#50, ws_net_paid#51, d_year#54]
+Arguments: [ws_bill_customer_sk#50 ASC NULLS FIRST], false, 0
+
+(65) ReusedExchange [Reuses operator id: 80]
+Output [4]: [c_customer_sk#55, c_customer_id#56, c_first_name#57, c_last_name#58]
+
+(66) Sort [codegen id : 31]
+Input [4]: [c_customer_sk#55, c_customer_id#56, c_first_name#57, c_last_name#58]
+Arguments: [c_customer_sk#55 ASC NULLS FIRST], false, 0
+
+(67) SortMergeJoin [codegen id : 32]
+Left keys [1]: [ws_bill_customer_sk#50]
+Right keys [1]: [c_customer_sk#55]
+Join type: Inner
+Join condition: None
+
+(68) Project [codegen id : 32]
+Output [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, ws_net_paid#51, d_year#54]
+Input [7]: [ws_bill_customer_sk#50, ws_net_paid#51, d_year#54, c_customer_sk#55, c_customer_id#56, c_first_name#57, c_last_name#58]
+
+(69) HashAggregate [codegen id : 32]
+Input [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, ws_net_paid#51, d_year#54]
+Keys [4]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54]
+Functions [1]: [partial_sum(UnscaledValue(ws_net_paid#51))]
+Aggregate Attributes [1]: [sum#59]
+Results [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54, sum#60]
+
+(70) Exchange
+Input [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54, sum#60]
+Arguments: hashpartitioning(c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(71) HashAggregate [codegen id : 33]
+Input [5]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54, sum#60]
+Keys [4]: [c_customer_id#56, c_first_name#57, c_last_name#58, d_year#54]
+Functions [1]: [sum(UnscaledValue(ws_net_paid#51))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#51))#47]
+Results [2]: [c_customer_id#56 AS customer_id#61, MakeDecimal(sum(UnscaledValue(ws_net_paid#51))#47,17,2) AS year_total#62]
+
+(72) Exchange
+Input [2]: [customer_id#61, year_total#62]
+Arguments: hashpartitioning(customer_id#61, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(73) Sort [codegen id : 34]
+Input [2]: [customer_id#61, year_total#62]
+Arguments: [customer_id#61 ASC NULLS FIRST], false, 0
+
+(74) SortMergeJoin [codegen id : 35]
+Left keys [1]: [customer_id#16]
+Right keys [1]: [customer_id#61]
+Join type: Inner
+Join condition: (CASE WHEN (year_total#49 > 0.00) THEN (year_total#62 / year_total#49) END > CASE WHEN (year_total#17 > 0.00) THEN (year_total#35 / year_total#17) END)
+
+(75) Project [codegen id : 35]
+Output [3]: [customer_id#32, customer_first_name#33, customer_last_name#34]
+Input [9]: [customer_id#16, year_total#17, customer_id#32, customer_first_name#33, customer_last_name#34, year_total#35, year_total#49, customer_id#61, year_total#62]
+
+(76) TakeOrderedAndProject
+Input [3]: [customer_id#32, customer_first_name#33, customer_last_name#34]
+Arguments: 100, [customer_first_name#33 ASC NULLS FIRST, customer_id#32 ASC NULLS FIRST, customer_last_name#34 ASC NULLS FIRST], [customer_id#32, customer_first_name#33, customer_last_name#34]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (83)
++- Exchange (82)
+   +- ObjectHashAggregate (81)
+      +- Exchange (80)
+         +- * Filter (79)
+            +- * ColumnarToRow (78)
+               +- Scan parquet spark_catalog.default.customer (77)
+
+
+(77) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string>
 
-(10) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-
-(11) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-Condition : (isnotnull(c_customer_sk#7) AND isnotnull(c_customer_id#8))
-
-(12) Exchange
-Input [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-Arguments: hashpartitioning(c_customer_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(13) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-Arguments: [c_customer_sk#7 ASC NULLS FIRST], false, 0
-
-(14) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#7]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, ss_net_paid#2, d_year#6]
-Input [7]: [ss_customer_sk#1, ss_net_paid#2, d_year#6, c_customer_sk#7, c_customer_id#8, c_first_name#9, c_last_name#10]
-
-(16) HashAggregate [codegen id : 6]
-Input [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, ss_net_paid#2, d_year#6]
-Keys [4]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#2))]
-Aggregate Attributes [1]: [sum#11]
-Results [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6, sum#12]
-
-(17) Exchange
-Input [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6, sum#12]
-Arguments: hashpartitioning(c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [5]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6, sum#12]
-Keys [4]: [c_customer_id#8, c_first_name#9, c_last_name#10, d_year#6]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#2))#13]
-Results [2]: [c_customer_id#8 AS customer_id#14, MakeDecimal(sum(UnscaledValue(ss_net_paid#2))#13,17,2) AS year_total#15]
-
-(19) Filter [codegen id : 7]
-Input [2]: [customer_id#14, year_total#15]
-Condition : (isnotnull(year_total#15) AND (year_total#15 > 0.00))
-
-(20) Exchange
-Input [2]: [customer_id#14, year_total#15]
-Arguments: hashpartitioning(customer_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(21) Sort [codegen id : 8]
-Input [2]: [customer_id#14, year_total#15]
-Arguments: [customer_id#14 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_customer_sk#16, ss_net_paid#17, ss_sold_date_sk#18]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#18), dynamicpruningexpression(ss_sold_date_sk#18 IN dynamicpruning#19)]
-PushedFilters: [IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_customer_sk:int,ss_net_paid:decimal(7,2)>
-
-(23) ColumnarToRow [codegen id : 10]
-Input [3]: [ss_customer_sk#16, ss_net_paid#17, ss_sold_date_sk#18]
-
-(24) Filter [codegen id : 10]
-Input [3]: [ss_customer_sk#16, ss_net_paid#17, ss_sold_date_sk#18]
-Condition : isnotnull(ss_customer_sk#16)
-
-(25) ReusedExchange [Reuses operator id: 87]
-Output [2]: [d_date_sk#20, d_year#21]
-
-(26) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#18]
-Right keys [1]: [d_date_sk#20]
-Join type: Inner
-Join condition: None
-
-(27) Project [codegen id : 10]
-Output [3]: [ss_customer_sk#16, ss_net_paid#17, d_year#21]
-Input [5]: [ss_customer_sk#16, ss_net_paid#17, ss_sold_date_sk#18, d_date_sk#20, d_year#21]
-
-(28) Exchange
-Input [3]: [ss_customer_sk#16, ss_net_paid#17, d_year#21]
-Arguments: hashpartitioning(ss_customer_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(29) Sort [codegen id : 11]
-Input [3]: [ss_customer_sk#16, ss_net_paid#17, d_year#21]
-Arguments: [ss_customer_sk#16 ASC NULLS FIRST], false, 0
-
-(30) ReusedExchange [Reuses operator id: 12]
-Output [4]: [c_customer_sk#22, c_customer_id#23, c_first_name#24, c_last_name#25]
-
-(31) Sort [codegen id : 13]
-Input [4]: [c_customer_sk#22, c_customer_id#23, c_first_name#24, c_last_name#25]
-Arguments: [c_customer_sk#22 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 14]
-Left keys [1]: [ss_customer_sk#16]
-Right keys [1]: [c_customer_sk#22]
-Join type: Inner
-Join condition: None
-
-(33) Project [codegen id : 14]
-Output [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, ss_net_paid#17, d_year#21]
-Input [7]: [ss_customer_sk#16, ss_net_paid#17, d_year#21, c_customer_sk#22, c_customer_id#23, c_first_name#24, c_last_name#25]
-
-(34) HashAggregate [codegen id : 14]
-Input [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, ss_net_paid#17, d_year#21]
-Keys [4]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#17))]
-Aggregate Attributes [1]: [sum#26]
-Results [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21, sum#27]
-
-(35) Exchange
-Input [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21, sum#27]
-Arguments: hashpartitioning(c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(36) HashAggregate [codegen id : 15]
-Input [5]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21, sum#27]
-Keys [4]: [c_customer_id#23, c_first_name#24, c_last_name#25, d_year#21]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#17))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#17))#13]
-Results [4]: [c_customer_id#23 AS customer_id#28, c_first_name#24 AS customer_first_name#29, c_last_name#25 AS customer_last_name#30, MakeDecimal(sum(UnscaledValue(ss_net_paid#17))#13,17,2) AS year_total#31]
-
-(37) Exchange
-Input [4]: [customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31]
-Arguments: hashpartitioning(customer_id#28, 5), ENSURE_REQUIREMENTS, [plan_id=7]
-
-(38) Sort [codegen id : 16]
-Input [4]: [customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31]
-Arguments: [customer_id#28 ASC NULLS FIRST], false, 0
-
-(39) SortMergeJoin [codegen id : 17]
-Left keys [1]: [customer_id#14]
-Right keys [1]: [customer_id#28]
-Join type: Inner
-Join condition: None
-
-(40) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_bill_customer_sk#32, ws_net_paid#33, ws_sold_date_sk#34]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#34), dynamicpruningexpression(ws_sold_date_sk#34 IN dynamicpruning#4)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_net_paid:decimal(7,2)>
-
-(41) ColumnarToRow [codegen id : 19]
-Input [3]: [ws_bill_customer_sk#32, ws_net_paid#33, ws_sold_date_sk#34]
-
-(42) Filter [codegen id : 19]
-Input [3]: [ws_bill_customer_sk#32, ws_net_paid#33, ws_sold_date_sk#34]
-Condition : isnotnull(ws_bill_customer_sk#32)
-
-(43) ReusedExchange [Reuses operator id: 83]
-Output [2]: [d_date_sk#35, d_year#36]
-
-(44) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [ws_sold_date_sk#34]
-Right keys [1]: [d_date_sk#35]
-Join type: Inner
-Join condition: None
-
-(45) Project [codegen id : 19]
-Output [3]: [ws_bill_customer_sk#32, ws_net_paid#33, d_year#36]
-Input [5]: [ws_bill_customer_sk#32, ws_net_paid#33, ws_sold_date_sk#34, d_date_sk#35, d_year#36]
-
-(46) Exchange
-Input [3]: [ws_bill_customer_sk#32, ws_net_paid#33, d_year#36]
-Arguments: hashpartitioning(ws_bill_customer_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(47) Sort [codegen id : 20]
-Input [3]: [ws_bill_customer_sk#32, ws_net_paid#33, d_year#36]
-Arguments: [ws_bill_customer_sk#32 ASC NULLS FIRST], false, 0
-
-(48) ReusedExchange [Reuses operator id: 12]
-Output [4]: [c_customer_sk#37, c_customer_id#38, c_first_name#39, c_last_name#40]
-
-(49) Sort [codegen id : 22]
-Input [4]: [c_customer_sk#37, c_customer_id#38, c_first_name#39, c_last_name#40]
-Arguments: [c_customer_sk#37 ASC NULLS FIRST], false, 0
-
-(50) SortMergeJoin [codegen id : 23]
-Left keys [1]: [ws_bill_customer_sk#32]
-Right keys [1]: [c_customer_sk#37]
-Join type: Inner
-Join condition: None
-
-(51) Project [codegen id : 23]
-Output [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, ws_net_paid#33, d_year#36]
-Input [7]: [ws_bill_customer_sk#32, ws_net_paid#33, d_year#36, c_customer_sk#37, c_customer_id#38, c_first_name#39, c_last_name#40]
-
-(52) HashAggregate [codegen id : 23]
-Input [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, ws_net_paid#33, d_year#36]
-Keys [4]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36]
-Functions [1]: [partial_sum(UnscaledValue(ws_net_paid#33))]
-Aggregate Attributes [1]: [sum#41]
-Results [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36, sum#42]
-
-(53) Exchange
-Input [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36, sum#42]
-Arguments: hashpartitioning(c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(54) HashAggregate [codegen id : 24]
-Input [5]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36, sum#42]
-Keys [4]: [c_customer_id#38, c_first_name#39, c_last_name#40, d_year#36]
-Functions [1]: [sum(UnscaledValue(ws_net_paid#33))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#33))#43]
-Results [2]: [c_customer_id#38 AS customer_id#44, MakeDecimal(sum(UnscaledValue(ws_net_paid#33))#43,17,2) AS year_total#45]
-
-(55) Filter [codegen id : 24]
-Input [2]: [customer_id#44, year_total#45]
-Condition : (isnotnull(year_total#45) AND (year_total#45 > 0.00))
-
-(56) Exchange
-Input [2]: [customer_id#44, year_total#45]
-Arguments: hashpartitioning(customer_id#44, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(57) Sort [codegen id : 25]
-Input [2]: [customer_id#44, year_total#45]
-Arguments: [customer_id#44 ASC NULLS FIRST], false, 0
-
-(58) SortMergeJoin [codegen id : 26]
-Left keys [1]: [customer_id#14]
-Right keys [1]: [customer_id#44]
-Join type: Inner
-Join condition: None
-
-(59) Project [codegen id : 26]
-Output [7]: [customer_id#14, year_total#15, customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31, year_total#45]
-Input [8]: [customer_id#14, year_total#15, customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31, customer_id#44, year_total#45]
-
-(60) Scan parquet spark_catalog.default.web_sales
-Output [3]: [ws_bill_customer_sk#46, ws_net_paid#47, ws_sold_date_sk#48]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#48), dynamicpruningexpression(ws_sold_date_sk#48 IN dynamicpruning#19)]
-PushedFilters: [IsNotNull(ws_bill_customer_sk)]
-ReadSchema: struct<ws_bill_customer_sk:int,ws_net_paid:decimal(7,2)>
-
-(61) ColumnarToRow [codegen id : 28]
-Input [3]: [ws_bill_customer_sk#46, ws_net_paid#47, ws_sold_date_sk#48]
-
-(62) Filter [codegen id : 28]
-Input [3]: [ws_bill_customer_sk#46, ws_net_paid#47, ws_sold_date_sk#48]
-Condition : isnotnull(ws_bill_customer_sk#46)
-
-(63) ReusedExchange [Reuses operator id: 87]
-Output [2]: [d_date_sk#49, d_year#50]
-
-(64) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [ws_sold_date_sk#48]
-Right keys [1]: [d_date_sk#49]
-Join type: Inner
-Join condition: None
-
-(65) Project [codegen id : 28]
-Output [3]: [ws_bill_customer_sk#46, ws_net_paid#47, d_year#50]
-Input [5]: [ws_bill_customer_sk#46, ws_net_paid#47, ws_sold_date_sk#48, d_date_sk#49, d_year#50]
-
-(66) Exchange
-Input [3]: [ws_bill_customer_sk#46, ws_net_paid#47, d_year#50]
-Arguments: hashpartitioning(ws_bill_customer_sk#46, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(67) Sort [codegen id : 29]
-Input [3]: [ws_bill_customer_sk#46, ws_net_paid#47, d_year#50]
-Arguments: [ws_bill_customer_sk#46 ASC NULLS FIRST], false, 0
-
-(68) ReusedExchange [Reuses operator id: 12]
-Output [4]: [c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54]
-
-(69) Sort [codegen id : 31]
-Input [4]: [c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54]
-Arguments: [c_customer_sk#51 ASC NULLS FIRST], false, 0
-
-(70) SortMergeJoin [codegen id : 32]
-Left keys [1]: [ws_bill_customer_sk#46]
-Right keys [1]: [c_customer_sk#51]
-Join type: Inner
-Join condition: None
-
-(71) Project [codegen id : 32]
-Output [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, ws_net_paid#47, d_year#50]
-Input [7]: [ws_bill_customer_sk#46, ws_net_paid#47, d_year#50, c_customer_sk#51, c_customer_id#52, c_first_name#53, c_last_name#54]
-
-(72) HashAggregate [codegen id : 32]
-Input [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, ws_net_paid#47, d_year#50]
-Keys [4]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50]
-Functions [1]: [partial_sum(UnscaledValue(ws_net_paid#47))]
-Aggregate Attributes [1]: [sum#55]
-Results [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50, sum#56]
-
-(73) Exchange
-Input [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50, sum#56]
-Arguments: hashpartitioning(c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(74) HashAggregate [codegen id : 33]
-Input [5]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50, sum#56]
-Keys [4]: [c_customer_id#52, c_first_name#53, c_last_name#54, d_year#50]
-Functions [1]: [sum(UnscaledValue(ws_net_paid#47))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_net_paid#47))#43]
-Results [2]: [c_customer_id#52 AS customer_id#57, MakeDecimal(sum(UnscaledValue(ws_net_paid#47))#43,17,2) AS year_total#58]
-
-(75) Exchange
-Input [2]: [customer_id#57, year_total#58]
-Arguments: hashpartitioning(customer_id#57, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(76) Sort [codegen id : 34]
-Input [2]: [customer_id#57, year_total#58]
-Arguments: [customer_id#57 ASC NULLS FIRST], false, 0
-
-(77) SortMergeJoin [codegen id : 35]
-Left keys [1]: [customer_id#14]
-Right keys [1]: [customer_id#57]
-Join type: Inner
-Join condition: (CASE WHEN (year_total#45 > 0.00) THEN (year_total#58 / year_total#45) END > CASE WHEN (year_total#15 > 0.00) THEN (year_total#31 / year_total#15) END)
-
-(78) Project [codegen id : 35]
-Output [3]: [customer_id#28, customer_first_name#29, customer_last_name#30]
-Input [9]: [customer_id#14, year_total#15, customer_id#28, customer_first_name#29, customer_last_name#30, year_total#31, year_total#45, customer_id#57, year_total#58]
-
-(79) TakeOrderedAndProject
-Input [3]: [customer_id#28, customer_first_name#29, customer_last_name#30]
-Arguments: 100, [customer_first_name#29 ASC NULLS FIRST, customer_id#28 ASC NULLS FIRST, customer_last_name#30 ASC NULLS FIRST], [customer_id#28, customer_first_name#29, customer_last_name#30]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (83)
-+- * Filter (82)
-   +- * ColumnarToRow (81)
-      +- Scan parquet spark_catalog.default.date_dim (80)
-
-
-(80) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#5, d_year#6]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), In(d_year, [2001,2002]), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int>
-
-(81) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#5, d_year#6]
-
-(82) Filter [codegen id : 1]
-Input [2]: [d_date_sk#5, d_year#6]
-Condition : (((isnotnull(d_year#6) AND (d_year#6 = 2001)) AND d_year#6 IN (2001,2002)) AND isnotnull(d_date_sk#5))
-
-(83) BroadcastExchange
-Input [2]: [d_date_sk#5, d_year#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=14]
-
-Subquery:2 Hosting operator id = 22 Hosting Expression = ss_sold_date_sk#18 IN dynamicpruning#19
+(78) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+
+(79) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+Condition : (isnotnull(c_customer_sk#9) AND isnotnull(c_customer_id#10))
+
+(80) Exchange
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+Arguments: hashpartitioning(c_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(81) ObjectHashAggregate
+Input [4]: [c_customer_sk#9, c_customer_id#10, c_first_name#11, c_last_name#12]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#9, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#63]
+Results [1]: [buf#64]
+
+(82) Exchange
+Input [1]: [buf#64]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(83) ObjectHashAggregate
+Input [1]: [buf#64]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#9, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#9, 42), 2000000, 16000000, 0, 0)#65]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#9, 42), 2000000, 16000000, 0, 0)#65 AS bloomFilter#66]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
 BroadcastExchange (87)
 +- * Filter (86)
    +- * ColumnarToRow (85)
@@ -484,25 +487,100 @@ BroadcastExchange (87)
 
 
 (84) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#20, d_year#21]
+Output [2]: [d_date_sk#7, d_year#8]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), In(d_year, [2001,2002]), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int>
+
+(85) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#7, d_year#8]
+
+(86) Filter [codegen id : 1]
+Input [2]: [d_date_sk#7, d_year#8]
+Condition : (((isnotnull(d_year#8) AND (d_year#8 = 2001)) AND d_year#8 IN (2001,2002)) AND isnotnull(d_date_sk#7))
+
+(87) BroadcastExchange
+Input [2]: [d_date_sk#7, d_year#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+
+Subquery:3 Hosting operator id = 21 Hosting Expression = Subquery scalar-subquery#22, [id=#23]
+ObjectHashAggregate (94)
++- Exchange (93)
+   +- ObjectHashAggregate (92)
+      +- Exchange (91)
+         +- * Filter (90)
+            +- * ColumnarToRow (89)
+               +- Scan parquet spark_catalog.default.customer (88)
+
+
+(88) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
+ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string>
+
+(89) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+
+(90) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Condition : (isnotnull(c_customer_sk#26) AND isnotnull(c_customer_id#27))
+
+(91) Exchange
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Arguments: hashpartitioning(c_customer_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(92) ObjectHashAggregate
+Input [4]: [c_customer_sk#26, c_customer_id#27, c_first_name#28, c_last_name#29]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#26, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [buf#67]
+Results [1]: [buf#68]
+
+(93) Exchange
+Input [1]: [buf#68]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(94) ObjectHashAggregate
+Input [1]: [buf#68]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#26, 42), 2000000, 16000000, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#26, 42), 2000000, 16000000, 0, 0)#69]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#26, 42), 2000000, 16000000, 0, 0)#69 AS bloomFilter#70]
+
+Subquery:4 Hosting operator id = 19 Hosting Expression = ss_sold_date_sk#20 IN dynamicpruning#21
+BroadcastExchange (98)
++- * Filter (97)
+   +- * ColumnarToRow (96)
+      +- Scan parquet spark_catalog.default.date_dim (95)
+
+
+(95) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#24, d_year#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), In(d_year, [2001,2002]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(85) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#20, d_year#21]
+(96) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#24, d_year#25]
 
-(86) Filter [codegen id : 1]
-Input [2]: [d_date_sk#20, d_year#21]
-Condition : (((isnotnull(d_year#21) AND (d_year#21 = 2002)) AND d_year#21 IN (2001,2002)) AND isnotnull(d_date_sk#20))
+(97) Filter [codegen id : 1]
+Input [2]: [d_date_sk#24, d_year#25]
+Condition : (((isnotnull(d_year#25) AND (d_year#25 = 2002)) AND d_year#25 IN (2001,2002)) AND isnotnull(d_date_sk#24))
 
-(87) BroadcastExchange
-Input [2]: [d_date_sk#20, d_year#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=15]
+(98) BroadcastExchange
+Input [2]: [d_date_sk#24, d_year#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
 
-Subquery:3 Hosting operator id = 40 Hosting Expression = ws_sold_date_sk#34 IN dynamicpruning#4
+Subquery:5 Hosting operator id = 39 Hosting Expression = ReusedSubquery Subquery scalar-subquery#22, [id=#23]
 
-Subquery:4 Hosting operator id = 60 Hosting Expression = ws_sold_date_sk#48 IN dynamicpruning#19
+Subquery:6 Hosting operator id = 37 Hosting Expression = ws_sold_date_sk#38 IN dynamicpruning#4
+
+Subquery:7 Hosting operator id = 59 Hosting Expression = ReusedSubquery Subquery scalar-subquery#22, [id=#23]
+
+Subquery:8 Hosting operator id = 57 Hosting Expression = ws_sold_date_sk#52 IN dynamicpruning#21
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74.sf100/simplified.txt
@@ -32,6 +32,16 @@ TakeOrderedAndProject [customer_first_name,customer_id,customer_last_name]
                                                               Project [ss_customer_sk,ss_net_paid,d_year]
                                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                   Filter [ss_customer_sk]
+                                                                    Subquery #2
+                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                        Exchange #5
+                                                                          ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                            Exchange [c_customer_sk] #6
+                                                                              WholeStageCodegen (1)
+                                                                                Filter [c_customer_sk,c_customer_id]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_net_paid,ss_sold_date_sk]
@@ -48,21 +58,16 @@ TakeOrderedAndProject [customer_first_name,customer_id,customer_last_name]
                                                     WholeStageCodegen (5)
                                                       Sort [c_customer_sk]
                                                         InputAdapter
-                                                          Exchange [c_customer_sk] #5
-                                                            WholeStageCodegen (4)
-                                                              Filter [c_customer_sk,c_customer_id]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name]
+                                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #6
                       InputAdapter
                         WholeStageCodegen (16)
                           Sort [customer_id]
                             InputAdapter
-                              Exchange [customer_id] #6
+                              Exchange [customer_id] #7
                                 WholeStageCodegen (15)
                                   HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,sum] [sum(UnscaledValue(ss_net_paid)),customer_id,customer_first_name,customer_last_name,year_total,sum]
                                     InputAdapter
-                                      Exchange [c_customer_id,c_first_name,c_last_name,d_year] #7
+                                      Exchange [c_customer_id,c_first_name,c_last_name,d_year] #8
                                         WholeStageCodegen (14)
                                           HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,ss_net_paid] [sum,sum]
                                             Project [c_customer_id,c_first_name,c_last_name,ss_net_paid,d_year]
@@ -71,38 +76,48 @@ TakeOrderedAndProject [customer_first_name,customer_id,customer_last_name]
                                                   WholeStageCodegen (11)
                                                     Sort [ss_customer_sk]
                                                       InputAdapter
-                                                        Exchange [ss_customer_sk] #8
+                                                        Exchange [ss_customer_sk] #9
                                                           WholeStageCodegen (10)
                                                             Project [ss_customer_sk,ss_net_paid,d_year]
                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                 Filter [ss_customer_sk]
+                                                                  Subquery #4
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 2000000, 16000000, 0, 0),bloomFilter,buf]
+                                                                      Exchange #11
+                                                                        ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                                          Exchange [c_customer_sk] #12
+                                                                            WholeStageCodegen (1)
+                                                                              Filter [c_customer_sk,c_customer_id]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_first_name,c_last_name]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_net_paid,ss_sold_date_sk]
-                                                                        SubqueryBroadcast [d_date_sk] #2
-                                                                          BroadcastExchange #9
+                                                                        SubqueryBroadcast [d_date_sk] #3
+                                                                          BroadcastExchange #10
                                                                             WholeStageCodegen (1)
                                                                               Filter [d_year,d_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                 InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_year] #9
+                                                                  ReusedExchange [d_date_sk,d_year] #10
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #5
+                                                        ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #6
                 InputAdapter
                   WholeStageCodegen (25)
                     Sort [customer_id]
                       InputAdapter
-                        Exchange [customer_id] #10
+                        Exchange [customer_id] #13
                           WholeStageCodegen (24)
                             Filter [year_total]
                               HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,sum] [sum(UnscaledValue(ws_net_paid)),customer_id,year_total,sum]
                                 InputAdapter
-                                  Exchange [c_customer_id,c_first_name,c_last_name,d_year] #11
+                                  Exchange [c_customer_id,c_first_name,c_last_name,d_year] #14
                                     WholeStageCodegen (23)
                                       HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,ws_net_paid] [sum,sum]
                                         Project [c_customer_id,c_first_name,c_last_name,ws_net_paid,d_year]
@@ -111,11 +126,12 @@ TakeOrderedAndProject [customer_first_name,customer_id,customer_last_name]
                                               WholeStageCodegen (20)
                                                 Sort [ws_bill_customer_sk]
                                                   InputAdapter
-                                                    Exchange [ws_bill_customer_sk] #12
+                                                    Exchange [ws_bill_customer_sk] #15
                                                       WholeStageCodegen (19)
                                                         Project [ws_bill_customer_sk,ws_net_paid,d_year]
                                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                             Filter [ws_bill_customer_sk]
+                                                              ReusedSubquery [bloomFilter] #4
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_net_paid,ws_sold_date_sk]
@@ -126,16 +142,16 @@ TakeOrderedAndProject [customer_first_name,customer_id,customer_last_name]
                                               WholeStageCodegen (22)
                                                 Sort [c_customer_sk]
                                                   InputAdapter
-                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #5
+                                                    ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #6
         InputAdapter
           WholeStageCodegen (34)
             Sort [customer_id]
               InputAdapter
-                Exchange [customer_id] #13
+                Exchange [customer_id] #16
                   WholeStageCodegen (33)
                     HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,sum] [sum(UnscaledValue(ws_net_paid)),customer_id,year_total,sum]
                       InputAdapter
-                        Exchange [c_customer_id,c_first_name,c_last_name,d_year] #14
+                        Exchange [c_customer_id,c_first_name,c_last_name,d_year] #17
                           WholeStageCodegen (32)
                             HashAggregate [c_customer_id,c_first_name,c_last_name,d_year,ws_net_paid] [sum,sum]
                               Project [c_customer_id,c_first_name,c_last_name,ws_net_paid,d_year]
@@ -144,19 +160,20 @@ TakeOrderedAndProject [customer_first_name,customer_id,customer_last_name]
                                     WholeStageCodegen (29)
                                       Sort [ws_bill_customer_sk]
                                         InputAdapter
-                                          Exchange [ws_bill_customer_sk] #15
+                                          Exchange [ws_bill_customer_sk] #18
                                             WholeStageCodegen (28)
                                               Project [ws_bill_customer_sk,ws_net_paid,d_year]
                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                   Filter [ws_bill_customer_sk]
+                                                    ReusedSubquery [bloomFilter] #4
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_net_paid,ws_sold_date_sk]
-                                                          ReusedSubquery [d_date_sk] #2
+                                                          ReusedSubquery [d_date_sk] #3
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk,d_year] #9
+                                                    ReusedExchange [d_date_sk,d_year] #10
                                   InputAdapter
                                     WholeStageCodegen (31)
                                       Sort [c_customer_sk]
                                         InputAdapter
-                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #5
+                                          ReusedExchange [c_customer_sk,c_customer_id,c_first_name,c_last_name] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
@@ -1,19 +1,19 @@
 == Physical Plan ==
-TakeOrderedAndProject (129)
-+- * Project (128)
-   +- * SortMergeJoin Inner (127)
-      :- * Sort (71)
-      :  +- Exchange (70)
-      :     +- * Filter (69)
-      :        +- * HashAggregate (68)
-      :           +- Exchange (67)
-      :              +- * HashAggregate (66)
-      :                 +- * HashAggregate (65)
-      :                    +- Exchange (64)
-      :                       +- * HashAggregate (63)
-      :                          +- Union (62)
-      :                             :- * Project (23)
-      :                             :  +- * SortMergeJoin LeftOuter (22)
+TakeOrderedAndProject (64)
++- * Project (63)
+   +- * SortMergeJoin Inner (62)
+      :- * Sort (59)
+      :  +- Exchange (58)
+      :     +- * Filter (57)
+      :        +- * HashAggregate (56)
+      :           +- Exchange (55)
+      :              +- * HashAggregate (54)
+      :                 +- * HashAggregate (53)
+      :                    +- Exchange (52)
+      :                       +- * HashAggregate (51)
+      :                          +- Union (50)
+      :                             :- * Project (19)
+      :                             :  +- * SortMergeJoin LeftOuter (18)
       :                             :     :- * Sort (15)
       :                             :     :  +- Exchange (14)
       :                             :     :     +- * Project (13)
@@ -29,105 +29,40 @@ TakeOrderedAndProject (129)
       :                             :     :           :              +- * ColumnarToRow (5)
       :                             :     :           :                 +- Scan parquet spark_catalog.default.item (4)
       :                             :     :           +- ReusedExchange (11)
-      :                             :     +- * Sort (21)
-      :                             :        +- Exchange (20)
-      :                             :           +- * Project (19)
-      :                             :              +- * Filter (18)
-      :                             :                 +- * ColumnarToRow (17)
-      :                             :                    +- Scan parquet spark_catalog.default.catalog_returns (16)
-      :                             :- * Project (42)
-      :                             :  +- * SortMergeJoin LeftOuter (41)
-      :                             :     :- * Sort (34)
-      :                             :     :  +- Exchange (33)
-      :                             :     :     +- * Project (32)
-      :                             :     :        +- * BroadcastHashJoin Inner BuildRight (31)
-      :                             :     :           :- * Project (29)
-      :                             :     :           :  +- * BroadcastHashJoin Inner BuildRight (28)
-      :                             :     :           :     :- * Filter (26)
-      :                             :     :           :     :  +- * ColumnarToRow (25)
-      :                             :     :           :     :     +- Scan parquet spark_catalog.default.store_sales (24)
-      :                             :     :           :     +- ReusedExchange (27)
-      :                             :     :           +- ReusedExchange (30)
-      :                             :     +- * Sort (40)
-      :                             :        +- Exchange (39)
-      :                             :           +- * Project (38)
-      :                             :              +- * Filter (37)
-      :                             :                 +- * ColumnarToRow (36)
-      :                             :                    +- Scan parquet spark_catalog.default.store_returns (35)
-      :                             +- * Project (61)
-      :                                +- * SortMergeJoin LeftOuter (60)
-      :                                   :- * Sort (53)
-      :                                   :  +- Exchange (52)
-      :                                   :     +- * Project (51)
-      :                                   :        +- * BroadcastHashJoin Inner BuildRight (50)
-      :                                   :           :- * Project (48)
-      :                                   :           :  +- * BroadcastHashJoin Inner BuildRight (47)
-      :                                   :           :     :- * Filter (45)
-      :                                   :           :     :  +- * ColumnarToRow (44)
-      :                                   :           :     :     +- Scan parquet spark_catalog.default.web_sales (43)
-      :                                   :           :     +- ReusedExchange (46)
-      :                                   :           +- ReusedExchange (49)
-      :                                   +- * Sort (59)
-      :                                      +- Exchange (58)
-      :                                         +- * Project (57)
-      :                                            +- * Filter (56)
-      :                                               +- * ColumnarToRow (55)
-      :                                                  +- Scan parquet spark_catalog.default.web_returns (54)
-      +- * Sort (126)
-         +- Exchange (125)
-            +- * Filter (124)
-               +- * HashAggregate (123)
-                  +- Exchange (122)
-                     +- * HashAggregate (121)
-                        +- * HashAggregate (120)
-                           +- Exchange (119)
-                              +- * HashAggregate (118)
-                                 +- Union (117)
-                                    :- * Project (86)
-                                    :  +- * SortMergeJoin LeftOuter (85)
-                                    :     :- * Sort (82)
-                                    :     :  +- Exchange (81)
-                                    :     :     +- * Project (80)
-                                    :     :        +- * BroadcastHashJoin Inner BuildRight (79)
-                                    :     :           :- * Project (77)
-                                    :     :           :  +- * BroadcastHashJoin Inner BuildRight (76)
-                                    :     :           :     :- * Filter (74)
-                                    :     :           :     :  +- * ColumnarToRow (73)
-                                    :     :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (72)
-                                    :     :           :     +- ReusedExchange (75)
-                                    :     :           +- ReusedExchange (78)
-                                    :     +- * Sort (84)
-                                    :        +- ReusedExchange (83)
-                                    :- * Project (101)
-                                    :  +- * SortMergeJoin LeftOuter (100)
-                                    :     :- * Sort (97)
-                                    :     :  +- Exchange (96)
-                                    :     :     +- * Project (95)
-                                    :     :        +- * BroadcastHashJoin Inner BuildRight (94)
-                                    :     :           :- * Project (92)
-                                    :     :           :  +- * BroadcastHashJoin Inner BuildRight (91)
-                                    :     :           :     :- * Filter (89)
-                                    :     :           :     :  +- * ColumnarToRow (88)
-                                    :     :           :     :     +- Scan parquet spark_catalog.default.store_sales (87)
-                                    :     :           :     +- ReusedExchange (90)
-                                    :     :           +- ReusedExchange (93)
-                                    :     +- * Sort (99)
-                                    :        +- ReusedExchange (98)
-                                    +- * Project (116)
-                                       +- * SortMergeJoin LeftOuter (115)
-                                          :- * Sort (112)
-                                          :  +- Exchange (111)
-                                          :     +- * Project (110)
-                                          :        +- * BroadcastHashJoin Inner BuildRight (109)
-                                          :           :- * Project (107)
-                                          :           :  +- * BroadcastHashJoin Inner BuildRight (106)
-                                          :           :     :- * Filter (104)
-                                          :           :     :  +- * ColumnarToRow (103)
-                                          :           :     :     +- Scan parquet spark_catalog.default.web_sales (102)
-                                          :           :     +- ReusedExchange (105)
-                                          :           +- ReusedExchange (108)
-                                          +- * Sort (114)
-                                             +- ReusedExchange (113)
+      :                             :     +- * Sort (17)
+      :                             :        +- ReusedExchange (16)
+      :                             :- * Project (34)
+      :                             :  +- * SortMergeJoin LeftOuter (33)
+      :                             :     :- * Sort (30)
+      :                             :     :  +- Exchange (29)
+      :                             :     :     +- * Project (28)
+      :                             :     :        +- * BroadcastHashJoin Inner BuildRight (27)
+      :                             :     :           :- * Project (25)
+      :                             :     :           :  +- * BroadcastHashJoin Inner BuildRight (24)
+      :                             :     :           :     :- * Filter (22)
+      :                             :     :           :     :  +- * ColumnarToRow (21)
+      :                             :     :           :     :     +- Scan parquet spark_catalog.default.store_sales (20)
+      :                             :     :           :     +- ReusedExchange (23)
+      :                             :     :           +- ReusedExchange (26)
+      :                             :     +- * Sort (32)
+      :                             :        +- ReusedExchange (31)
+      :                             +- * Project (49)
+      :                                +- * SortMergeJoin LeftOuter (48)
+      :                                   :- * Sort (45)
+      :                                   :  +- Exchange (44)
+      :                                   :     +- * Project (43)
+      :                                   :        +- * BroadcastHashJoin Inner BuildRight (42)
+      :                                   :           :- * Project (40)
+      :                                   :           :  +- * BroadcastHashJoin Inner BuildRight (39)
+      :                                   :           :     :- * Filter (37)
+      :                                   :           :     :  +- * ColumnarToRow (36)
+      :                                   :           :     :     +- Scan parquet spark_catalog.default.web_sales (35)
+      :                                   :           :     +- ReusedExchange (38)
+      :                                   :           +- ReusedExchange (41)
+      :                                   +- * Sort (47)
+      :                                      +- ReusedExchange (46)
+      +- * Sort (61)
+         +- ReusedExchange (60)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -157,7 +92,7 @@ Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_categor
 
 (6) Filter [codegen id : 1]
 Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
-Condition : ((((((isnotnull(i_category#11) AND (i_category#11 = Books                                             )) AND isnotnull(i_item_sk#7)) AND isnotnull(i_brand_id#8)) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10)) AND isnotnull(i_manufact_id#12))
+Condition : ((((((((((isnotnull(i_category#11) AND (i_category#11 = Books                                             )) AND isnotnull(i_item_sk#7)) AND isnotnull(i_brand_id#8)) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10)) AND isnotnull(i_manufact_id#12)) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(i_brand_id#8, 42), false)) AND might_contain(Subquery scalar-subquery#15, [id=#16], xxhash64(i_class_id#9, 42), false)) AND might_contain(Subquery scalar-subquery#17, [id=#18], xxhash64(i_category_id#10, 42), false)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(i_manufact_id#12, 42), false))
 
 (7) Project [codegen id : 1]
 Output [5]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
@@ -177,603 +112,803 @@ Join condition: None
 Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
 Input [10]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
 
-(11) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#13, d_year#14]
+(11) ReusedExchange [Reuses operator id: 68]
+Output [2]: [d_date_sk#21, d_year#22]
 
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#13]
+Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]
-Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
-Input [11]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_date_sk#13, d_year#14]
+Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#22]
+Input [11]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_date_sk#21, d_year#22]
 
 (14) Exchange
-Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
+Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#22]
 Arguments: hashpartitioning(cs_order_number#2, cs_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) Sort [codegen id : 4]
-Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
+Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#22]
 Arguments: [cs_order_number#2 ASC NULLS FIRST, cs_item_sk#1 ASC NULLS FIRST], false, 0
 
-(16) Scan parquet spark_catalog.default.catalog_returns
-Output [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
-ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_quantity:int,cr_return_amount:decimal(7,2)>
+(16) ReusedExchange [Reuses operator id: 88]
+Output [4]: [cr_item_sk#23, cr_order_number#24, cr_return_quantity#25, cr_return_amount#26]
 
-(17) ColumnarToRow [codegen id : 5]
-Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
+(17) Sort [codegen id : 6]
+Input [4]: [cr_item_sk#23, cr_order_number#24, cr_return_quantity#25, cr_return_amount#26]
+Arguments: [cr_order_number#24 ASC NULLS FIRST, cr_item_sk#23 ASC NULLS FIRST], false, 0
 
-(18) Filter [codegen id : 5]
-Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
-Condition : (isnotnull(cr_order_number#16) AND isnotnull(cr_item_sk#15))
-
-(19) Project [codegen id : 5]
-Output [4]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
-Input [5]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18, cr_returned_date_sk#19]
-
-(20) Exchange
-Input [4]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
-Arguments: hashpartitioning(cr_order_number#16, cr_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(21) Sort [codegen id : 6]
-Input [4]: [cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
-Arguments: [cr_order_number#16 ASC NULLS FIRST, cr_item_sk#15 ASC NULLS FIRST], false, 0
-
-(22) SortMergeJoin [codegen id : 7]
+(18) SortMergeJoin [codegen id : 7]
 Left keys [2]: [cs_order_number#2, cs_item_sk#1]
-Right keys [2]: [cr_order_number#16, cr_item_sk#15]
+Right keys [2]: [cr_order_number#24, cr_item_sk#23]
 Join type: LeftOuter
 Join condition: None
 
-(23) Project [codegen id : 7]
-Output [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, (cs_quantity#3 - coalesce(cr_return_quantity#17, 0)) AS sales_cnt#20, (cs_ext_sales_price#4 - coalesce(cr_return_amount#18, 0.00)) AS sales_amt#21]
-Input [13]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14, cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
+(19) Project [codegen id : 7]
+Output [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, (cs_quantity#3 - coalesce(cr_return_quantity#25, 0)) AS sales_cnt#27, (cs_ext_sales_price#4 - coalesce(cr_return_amount#26, 0.00)) AS sales_amt#28]
+Input [13]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#22, cr_item_sk#23, cr_order_number#24, cr_return_quantity#25, cr_return_amount#26]
 
-(24) Scan parquet spark_catalog.default.store_sales
-Output [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
+(20) Scan parquet spark_catalog.default.store_sales
+Output [5]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#26), dynamicpruningexpression(ss_sold_date_sk#26 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#33), dynamicpruningexpression(ss_sold_date_sk#33 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
 
-(25) ColumnarToRow [codegen id : 10]
-Input [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
+(21) ColumnarToRow [codegen id : 10]
+Input [5]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33]
 
-(26) Filter [codegen id : 10]
-Input [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
-Condition : isnotnull(ss_item_sk#22)
+(22) Filter [codegen id : 10]
+Input [5]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33]
+Condition : isnotnull(ss_item_sk#29)
 
-(27) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
+(23) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#34, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38]
 
-(28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_item_sk#22]
-Right keys [1]: [i_item_sk#27]
+(24) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_item_sk#29]
+Right keys [1]: [i_item_sk#34]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 10]
-Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
-Input [10]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
+(25) Project [codegen id : 10]
+Output [9]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38]
+Input [10]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33, i_item_sk#34, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38]
 
-(30) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#32, d_year#33]
+(26) ReusedExchange [Reuses operator id: 68]
+Output [2]: [d_date_sk#39, d_year#40]
 
-(31) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#26]
-Right keys [1]: [d_date_sk#32]
+(27) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#33]
+Right keys [1]: [d_date_sk#39]
 Join type: Inner
 Join condition: None
 
-(32) Project [codegen id : 10]
-Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
-Input [11]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_date_sk#32, d_year#33]
+(28) Project [codegen id : 10]
+Output [9]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_year#40]
+Input [11]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, ss_sold_date_sk#33, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_date_sk#39, d_year#40]
 
-(33) Exchange
-Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
-Arguments: hashpartitioning(ss_ticket_number#23, ss_item_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(29) Exchange
+Input [9]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_year#40]
+Arguments: hashpartitioning(ss_ticket_number#30, ss_item_sk#29, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(34) Sort [codegen id : 11]
-Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
-Arguments: [ss_ticket_number#23 ASC NULLS FIRST, ss_item_sk#22 ASC NULLS FIRST], false, 0
+(30) Sort [codegen id : 11]
+Input [9]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_year#40]
+Arguments: [ss_ticket_number#30 ASC NULLS FIRST, ss_item_sk#29 ASC NULLS FIRST], false, 0
 
-(35) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store_returns]
-PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
-ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_quantity:int,sr_return_amt:decimal(7,2)>
+(31) ReusedExchange [Reuses operator id: 107]
+Output [4]: [sr_item_sk#41, sr_ticket_number#42, sr_return_quantity#43, sr_return_amt#44]
 
-(36) ColumnarToRow [codegen id : 12]
-Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
+(32) Sort [codegen id : 13]
+Input [4]: [sr_item_sk#41, sr_ticket_number#42, sr_return_quantity#43, sr_return_amt#44]
+Arguments: [sr_ticket_number#42 ASC NULLS FIRST, sr_item_sk#41 ASC NULLS FIRST], false, 0
 
-(37) Filter [codegen id : 12]
-Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
-Condition : (isnotnull(sr_ticket_number#35) AND isnotnull(sr_item_sk#34))
-
-(38) Project [codegen id : 12]
-Output [4]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
-Input [5]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37, sr_returned_date_sk#38]
-
-(39) Exchange
-Input [4]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
-Arguments: hashpartitioning(sr_ticket_number#35, sr_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(40) Sort [codegen id : 13]
-Input [4]: [sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
-Arguments: [sr_ticket_number#35 ASC NULLS FIRST, sr_item_sk#34 ASC NULLS FIRST], false, 0
-
-(41) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#23, ss_item_sk#22]
-Right keys [2]: [sr_ticket_number#35, sr_item_sk#34]
+(33) SortMergeJoin [codegen id : 14]
+Left keys [2]: [ss_ticket_number#30, ss_item_sk#29]
+Right keys [2]: [sr_ticket_number#42, sr_item_sk#41]
 Join type: LeftOuter
 Join condition: None
 
-(42) Project [codegen id : 14]
-Output [7]: [d_year#33, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, (ss_quantity#24 - coalesce(sr_return_quantity#36, 0)) AS sales_cnt#39, (ss_ext_sales_price#25 - coalesce(sr_return_amt#37, 0.00)) AS sales_amt#40]
-Input [13]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33, sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
+(34) Project [codegen id : 14]
+Output [7]: [d_year#40, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, (ss_quantity#31 - coalesce(sr_return_quantity#43, 0)) AS sales_cnt#45, (ss_ext_sales_price#32 - coalesce(sr_return_amt#44, 0.00)) AS sales_amt#46]
+Input [13]: [ss_item_sk#29, ss_ticket_number#30, ss_quantity#31, ss_ext_sales_price#32, i_brand_id#35, i_class_id#36, i_category_id#37, i_manufact_id#38, d_year#40, sr_item_sk#41, sr_ticket_number#42, sr_return_quantity#43, sr_return_amt#44]
 
-(43) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
+(35) Scan parquet spark_catalog.default.web_sales
+Output [5]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#45), dynamicpruningexpression(ws_sold_date_sk#45 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#51), dynamicpruningexpression(ws_sold_date_sk#51 IN dynamicpruning#6)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
 
-(44) ColumnarToRow [codegen id : 17]
-Input [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
+(36) ColumnarToRow [codegen id : 17]
+Input [5]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51]
 
-(45) Filter [codegen id : 17]
-Input [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
-Condition : isnotnull(ws_item_sk#41)
+(37) Filter [codegen id : 17]
+Input [5]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51]
+Condition : isnotnull(ws_item_sk#47)
 
-(46) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
+(38) ReusedExchange [Reuses operator id: 8]
+Output [5]: [i_item_sk#52, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56]
 
-(47) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_item_sk#41]
-Right keys [1]: [i_item_sk#46]
+(39) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#47]
+Right keys [1]: [i_item_sk#52]
 Join type: Inner
 Join condition: None
 
-(48) Project [codegen id : 17]
-Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
-Input [10]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
+(40) Project [codegen id : 17]
+Output [9]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56]
+Input [10]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51, i_item_sk#52, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56]
 
-(49) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#51, d_year#52]
+(41) ReusedExchange [Reuses operator id: 68]
+Output [2]: [d_date_sk#57, d_year#58]
 
-(50) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_sold_date_sk#45]
-Right keys [1]: [d_date_sk#51]
+(42) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#51]
+Right keys [1]: [d_date_sk#57]
 Join type: Inner
 Join condition: None
 
-(51) Project [codegen id : 17]
-Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
-Input [11]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_date_sk#51, d_year#52]
+(43) Project [codegen id : 17]
+Output [9]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_year#58]
+Input [11]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, ws_sold_date_sk#51, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_date_sk#57, d_year#58]
+
+(44) Exchange
+Input [9]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_year#58]
+Arguments: hashpartitioning(ws_order_number#48, ws_item_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(45) Sort [codegen id : 18]
+Input [9]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_year#58]
+Arguments: [ws_order_number#48 ASC NULLS FIRST, ws_item_sk#47 ASC NULLS FIRST], false, 0
+
+(46) ReusedExchange [Reuses operator id: 126]
+Output [4]: [wr_item_sk#59, wr_order_number#60, wr_return_quantity#61, wr_return_amt#62]
+
+(47) Sort [codegen id : 20]
+Input [4]: [wr_item_sk#59, wr_order_number#60, wr_return_quantity#61, wr_return_amt#62]
+Arguments: [wr_order_number#60 ASC NULLS FIRST, wr_item_sk#59 ASC NULLS FIRST], false, 0
+
+(48) SortMergeJoin [codegen id : 21]
+Left keys [2]: [ws_order_number#48, ws_item_sk#47]
+Right keys [2]: [wr_order_number#60, wr_item_sk#59]
+Join type: LeftOuter
+Join condition: None
+
+(49) Project [codegen id : 21]
+Output [7]: [d_year#58, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, (ws_quantity#49 - coalesce(wr_return_quantity#61, 0)) AS sales_cnt#63, (ws_ext_sales_price#50 - coalesce(wr_return_amt#62, 0.00)) AS sales_amt#64]
+Input [13]: [ws_item_sk#47, ws_order_number#48, ws_quantity#49, ws_ext_sales_price#50, i_brand_id#53, i_class_id#54, i_category_id#55, i_manufact_id#56, d_year#58, wr_item_sk#59, wr_order_number#60, wr_return_quantity#61, wr_return_amt#62]
+
+(50) Union
+
+(51) HashAggregate [codegen id : 22]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Keys [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
 
 (52) Exchange
-Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
-Arguments: hashpartitioning(ws_order_number#42, ws_item_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Arguments: hashpartitioning(d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(53) Sort [codegen id : 18]
-Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
-Arguments: [ws_order_number#42 ASC NULLS FIRST, ws_item_sk#41 ASC NULLS FIRST], false, 0
+(53) HashAggregate [codegen id : 23]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Keys [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
 
-(54) Scan parquet spark_catalog.default.web_returns
-Output [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/web_returns]
-PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
-ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
+(54) HashAggregate [codegen id : 23]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#27, sales_amt#28]
+Keys [5]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+Functions [2]: [partial_sum(sales_cnt#27), partial_sum(UnscaledValue(sales_amt#28))]
+Aggregate Attributes [2]: [sum#65, sum#66]
+Results [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#67, sum#68]
 
-(55) ColumnarToRow [codegen id : 19]
-Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
+(55) Exchange
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#67, sum#68]
+Arguments: hashpartitioning(d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(56) Filter [codegen id : 19]
-Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
-Condition : (isnotnull(wr_order_number#54) AND isnotnull(wr_item_sk#53))
+(56) HashAggregate [codegen id : 24]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#67, sum#68]
+Keys [5]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+Functions [2]: [sum(sales_cnt#27), sum(UnscaledValue(sales_amt#28))]
+Aggregate Attributes [2]: [sum(sales_cnt#27)#69, sum(UnscaledValue(sales_amt#28))#70]
+Results [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum(sales_cnt#27)#69 AS sales_cnt#71, MakeDecimal(sum(UnscaledValue(sales_amt#28))#70,18,2) AS sales_amt#72]
 
-(57) Project [codegen id : 19]
-Output [4]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
-Input [5]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56, wr_returned_date_sk#57]
+(57) Filter [codegen id : 24]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#71, sales_amt#72]
+Condition : isnotnull(sales_cnt#71)
 
 (58) Exchange
-Input [4]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
-Arguments: hashpartitioning(wr_order_number#54, wr_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#71, sales_amt#72]
+Arguments: hashpartitioning(i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(59) Sort [codegen id : 20]
-Input [4]: [wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
-Arguments: [wr_order_number#54 ASC NULLS FIRST, wr_item_sk#53 ASC NULLS FIRST], false, 0
-
-(60) SortMergeJoin [codegen id : 21]
-Left keys [2]: [ws_order_number#42, ws_item_sk#41]
-Right keys [2]: [wr_order_number#54, wr_item_sk#53]
-Join type: LeftOuter
-Join condition: None
-
-(61) Project [codegen id : 21]
-Output [7]: [d_year#52, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, (ws_quantity#43 - coalesce(wr_return_quantity#55, 0)) AS sales_cnt#58, (ws_ext_sales_price#44 - coalesce(wr_return_amt#56, 0.00)) AS sales_amt#59]
-Input [13]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52, wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
-
-(62) Union
-
-(63) HashAggregate [codegen id : 22]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-
-(64) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Arguments: hashpartitioning(d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21, 5), ENSURE_REQUIREMENTS, [plan_id=8]
-
-(65) HashAggregate [codegen id : 23]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-
-(66) HashAggregate [codegen id : 23]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [5]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Functions [2]: [partial_sum(sales_cnt#20), partial_sum(UnscaledValue(sales_amt#21))]
-Aggregate Attributes [2]: [sum#60, sum#61]
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-
-(67) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-Arguments: hashpartitioning(d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(68) HashAggregate [codegen id : 24]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-Keys [5]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Functions [2]: [sum(sales_cnt#20), sum(UnscaledValue(sales_amt#21))]
-Aggregate Attributes [2]: [sum(sales_cnt#20)#64, sum(UnscaledValue(sales_amt#21))#65]
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum(sales_cnt#20)#64 AS sales_cnt#66, MakeDecimal(sum(UnscaledValue(sales_amt#21))#65,18,2) AS sales_amt#67]
-
-(69) Filter [codegen id : 24]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
-Condition : isnotnull(sales_cnt#66)
-
-(70) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
-Arguments: hashpartitioning(i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(71) Sort [codegen id : 25]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
+(59) Sort [codegen id : 25]
+Input [7]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#71, sales_amt#72]
 Arguments: [i_brand_id#8 ASC NULLS FIRST, i_class_id#9 ASC NULLS FIRST, i_category_id#10 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST], false, 0
 
-(72) Scan parquet spark_catalog.default.catalog_sales
-Output [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#72), dynamicpruningexpression(cs_sold_date_sk#72 IN dynamicpruning#73)]
-PushedFilters: [IsNotNull(cs_item_sk)]
-ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_ext_sales_price:decimal(7,2)>
+(60) ReusedExchange [Reuses operator id: 138]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
 
-(73) ColumnarToRow [codegen id : 28]
-Input [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
+(61) Sort [codegen id : 50]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Arguments: [i_brand_id#74 ASC NULLS FIRST, i_class_id#75 ASC NULLS FIRST, i_category_id#76 ASC NULLS FIRST, i_manufact_id#77 ASC NULLS FIRST], false, 0
 
-(74) Filter [codegen id : 28]
-Input [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
-Condition : isnotnull(cs_item_sk#68)
-
-(75) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-
-(76) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_item_sk#68]
-Right keys [1]: [i_item_sk#74]
-Join type: Inner
-Join condition: None
-
-(77) Project [codegen id : 28]
-Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-Input [10]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-
-(78) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#79, d_year#80]
-
-(79) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_sold_date_sk#72]
-Right keys [1]: [d_date_sk#79]
-Join type: Inner
-Join condition: None
-
-(80) Project [codegen id : 28]
-Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
-Input [11]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_date_sk#79, d_year#80]
-
-(81) Exchange
-Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
-Arguments: hashpartitioning(cs_order_number#69, cs_item_sk#68, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(82) Sort [codegen id : 29]
-Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
-Arguments: [cs_order_number#69 ASC NULLS FIRST, cs_item_sk#68 ASC NULLS FIRST], false, 0
-
-(83) ReusedExchange [Reuses operator id: 20]
-Output [4]: [cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
-
-(84) Sort [codegen id : 31]
-Input [4]: [cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
-Arguments: [cr_order_number#82 ASC NULLS FIRST, cr_item_sk#81 ASC NULLS FIRST], false, 0
-
-(85) SortMergeJoin [codegen id : 32]
-Left keys [2]: [cs_order_number#69, cs_item_sk#68]
-Right keys [2]: [cr_order_number#82, cr_item_sk#81]
-Join type: LeftOuter
-Join condition: None
-
-(86) Project [codegen id : 32]
-Output [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, (cs_quantity#70 - coalesce(cr_return_quantity#83, 0)) AS sales_cnt#20, (cs_ext_sales_price#71 - coalesce(cr_return_amount#84, 0.00)) AS sales_amt#21]
-Input [13]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80, cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
-
-(87) Scan parquet spark_catalog.default.store_sales
-Output [5]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#89), dynamicpruningexpression(ss_sold_date_sk#89 IN dynamicpruning#73)]
-PushedFilters: [IsNotNull(ss_item_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
-
-(88) ColumnarToRow [codegen id : 35]
-Input [5]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89]
-
-(89) Filter [codegen id : 35]
-Input [5]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89]
-Condition : isnotnull(ss_item_sk#85)
-
-(90) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#90, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94]
-
-(91) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ss_item_sk#85]
-Right keys [1]: [i_item_sk#90]
-Join type: Inner
-Join condition: None
-
-(92) Project [codegen id : 35]
-Output [9]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94]
-Input [10]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89, i_item_sk#90, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94]
-
-(93) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#95, d_year#96]
-
-(94) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ss_sold_date_sk#89]
-Right keys [1]: [d_date_sk#95]
-Join type: Inner
-Join condition: None
-
-(95) Project [codegen id : 35]
-Output [9]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_year#96]
-Input [11]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, ss_sold_date_sk#89, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_date_sk#95, d_year#96]
-
-(96) Exchange
-Input [9]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_year#96]
-Arguments: hashpartitioning(ss_ticket_number#86, ss_item_sk#85, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(97) Sort [codegen id : 36]
-Input [9]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_year#96]
-Arguments: [ss_ticket_number#86 ASC NULLS FIRST, ss_item_sk#85 ASC NULLS FIRST], false, 0
-
-(98) ReusedExchange [Reuses operator id: 39]
-Output [4]: [sr_item_sk#97, sr_ticket_number#98, sr_return_quantity#99, sr_return_amt#100]
-
-(99) Sort [codegen id : 38]
-Input [4]: [sr_item_sk#97, sr_ticket_number#98, sr_return_quantity#99, sr_return_amt#100]
-Arguments: [sr_ticket_number#98 ASC NULLS FIRST, sr_item_sk#97 ASC NULLS FIRST], false, 0
-
-(100) SortMergeJoin [codegen id : 39]
-Left keys [2]: [ss_ticket_number#86, ss_item_sk#85]
-Right keys [2]: [sr_ticket_number#98, sr_item_sk#97]
-Join type: LeftOuter
-Join condition: None
-
-(101) Project [codegen id : 39]
-Output [7]: [d_year#96, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, (ss_quantity#87 - coalesce(sr_return_quantity#99, 0)) AS sales_cnt#39, (ss_ext_sales_price#88 - coalesce(sr_return_amt#100, 0.00)) AS sales_amt#40]
-Input [13]: [ss_item_sk#85, ss_ticket_number#86, ss_quantity#87, ss_ext_sales_price#88, i_brand_id#91, i_class_id#92, i_category_id#93, i_manufact_id#94, d_year#96, sr_item_sk#97, sr_ticket_number#98, sr_return_quantity#99, sr_return_amt#100]
-
-(102) Scan parquet spark_catalog.default.web_sales
-Output [5]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#105), dynamicpruningexpression(ws_sold_date_sk#105 IN dynamicpruning#73)]
-PushedFilters: [IsNotNull(ws_item_sk)]
-ReadSchema: struct<ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
-
-(103) ColumnarToRow [codegen id : 42]
-Input [5]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105]
-
-(104) Filter [codegen id : 42]
-Input [5]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105]
-Condition : isnotnull(ws_item_sk#101)
-
-(105) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#106, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110]
-
-(106) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ws_item_sk#101]
-Right keys [1]: [i_item_sk#106]
-Join type: Inner
-Join condition: None
-
-(107) Project [codegen id : 42]
-Output [9]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110]
-Input [10]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105, i_item_sk#106, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110]
-
-(108) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#111, d_year#112]
-
-(109) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ws_sold_date_sk#105]
-Right keys [1]: [d_date_sk#111]
-Join type: Inner
-Join condition: None
-
-(110) Project [codegen id : 42]
-Output [9]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_year#112]
-Input [11]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, ws_sold_date_sk#105, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_date_sk#111, d_year#112]
-
-(111) Exchange
-Input [9]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_year#112]
-Arguments: hashpartitioning(ws_order_number#102, ws_item_sk#101, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(112) Sort [codegen id : 43]
-Input [9]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_year#112]
-Arguments: [ws_order_number#102 ASC NULLS FIRST, ws_item_sk#101 ASC NULLS FIRST], false, 0
-
-(113) ReusedExchange [Reuses operator id: 58]
-Output [4]: [wr_item_sk#113, wr_order_number#114, wr_return_quantity#115, wr_return_amt#116]
-
-(114) Sort [codegen id : 45]
-Input [4]: [wr_item_sk#113, wr_order_number#114, wr_return_quantity#115, wr_return_amt#116]
-Arguments: [wr_order_number#114 ASC NULLS FIRST, wr_item_sk#113 ASC NULLS FIRST], false, 0
-
-(115) SortMergeJoin [codegen id : 46]
-Left keys [2]: [ws_order_number#102, ws_item_sk#101]
-Right keys [2]: [wr_order_number#114, wr_item_sk#113]
-Join type: LeftOuter
-Join condition: None
-
-(116) Project [codegen id : 46]
-Output [7]: [d_year#112, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, (ws_quantity#103 - coalesce(wr_return_quantity#115, 0)) AS sales_cnt#58, (ws_ext_sales_price#104 - coalesce(wr_return_amt#116, 0.00)) AS sales_amt#59]
-Input [13]: [ws_item_sk#101, ws_order_number#102, ws_quantity#103, ws_ext_sales_price#104, i_brand_id#107, i_class_id#108, i_category_id#109, i_manufact_id#110, d_year#112, wr_item_sk#113, wr_order_number#114, wr_return_quantity#115, wr_return_amt#116]
-
-(117) Union
-
-(118) HashAggregate [codegen id : 47]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-
-(119) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Arguments: hashpartitioning(d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21, 5), ENSURE_REQUIREMENTS, [plan_id=14]
-
-(120) HashAggregate [codegen id : 48]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Functions: []
-Aggregate Attributes: []
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-
-(121) HashAggregate [codegen id : 48]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#20, sales_amt#21]
-Keys [5]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-Functions [2]: [partial_sum(sales_cnt#20), partial_sum(UnscaledValue(sales_amt#21))]
-Aggregate Attributes [2]: [sum#60, sum#117]
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#62, sum#118]
-
-(122) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#62, sum#118]
-Arguments: hashpartitioning(d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=15]
-
-(123) HashAggregate [codegen id : 49]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#62, sum#118]
-Keys [5]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-Functions [2]: [sum(sales_cnt#20), sum(UnscaledValue(sales_amt#21))]
-Aggregate Attributes [2]: [sum(sales_cnt#20)#64, sum(UnscaledValue(sales_amt#21))#65]
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum(sales_cnt#20)#64 AS sales_cnt#119, MakeDecimal(sum(UnscaledValue(sales_amt#21))#65,18,2) AS sales_amt#120]
-
-(124) Filter [codegen id : 49]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#119, sales_amt#120]
-Condition : isnotnull(sales_cnt#119)
-
-(125) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#119, sales_amt#120]
-Arguments: hashpartitioning(i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(126) Sort [codegen id : 50]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#119, sales_amt#120]
-Arguments: [i_brand_id#75 ASC NULLS FIRST, i_class_id#76 ASC NULLS FIRST, i_category_id#77 ASC NULLS FIRST, i_manufact_id#78 ASC NULLS FIRST], false, 0
-
-(127) SortMergeJoin [codegen id : 51]
+(62) SortMergeJoin [codegen id : 51]
 Left keys [4]: [i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Right keys [4]: [i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Right keys [4]: [i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
 Join type: Inner
-Join condition: ((cast(sales_cnt#66 as decimal(17,2)) / cast(sales_cnt#119 as decimal(17,2))) < 0.90000000000000000000)
+Join condition: ((cast(sales_cnt#71 as decimal(17,2)) / cast(sales_cnt#78 as decimal(17,2))) < 0.90000000000000000000)
 
-(128) Project [codegen id : 51]
-Output [10]: [d_year#80 AS prev_year#121, d_year#14 AS year#122, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#119 AS prev_yr_cnt#123, sales_cnt#66 AS curr_yr_cnt#124, (sales_cnt#66 - sales_cnt#119) AS sales_cnt_diff#125, (sales_amt#67 - sales_amt#120) AS sales_amt_diff#126]
-Input [14]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67, d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#119, sales_amt#120]
+(63) Project [codegen id : 51]
+Output [10]: [d_year#73 AS prev_year#80, d_year#22 AS year#81, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#78 AS prev_yr_cnt#82, sales_cnt#71 AS curr_yr_cnt#83, (sales_cnt#71 - sales_cnt#78) AS sales_cnt_diff#84, (sales_amt#72 - sales_amt#79) AS sales_amt_diff#85]
+Input [14]: [d_year#22, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#71, sales_amt#72, d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
 
-(129) TakeOrderedAndProject
-Input [10]: [prev_year#121, year#122, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#123, curr_yr_cnt#124, sales_cnt_diff#125, sales_amt_diff#126]
-Arguments: 100, [sales_cnt_diff#125 ASC NULLS FIRST, sales_amt_diff#126 ASC NULLS FIRST], [prev_year#121, year#122, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#123, curr_yr_cnt#124, sales_cnt_diff#125, sales_amt_diff#126]
+(64) TakeOrderedAndProject
+Input [10]: [prev_year#80, year#81, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#82, curr_yr_cnt#83, sales_cnt_diff#84, sales_amt_diff#85]
+Arguments: 100, [sales_cnt_diff#84 ASC NULLS FIRST, sales_amt_diff#85 ASC NULLS FIRST], [prev_year#80, year#81, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#82, curr_yr_cnt#83, sales_cnt_diff#84, sales_amt_diff#85]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (133)
-+- * Filter (132)
-   +- * ColumnarToRow (131)
-      +- Scan parquet spark_catalog.default.date_dim (130)
+BroadcastExchange (68)
++- * Filter (67)
+   +- * ColumnarToRow (66)
+      +- Scan parquet spark_catalog.default.date_dim (65)
 
 
-(130) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#13, d_year#14]
+(65) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#21, d_year#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(131) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#14]
+(66) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#21, d_year#22]
 
-(132) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#14]
-Condition : ((isnotnull(d_year#14) AND (d_year#14 = 2002)) AND isnotnull(d_date_sk#13))
+(67) Filter [codegen id : 1]
+Input [2]: [d_date_sk#21, d_year#22]
+Condition : ((isnotnull(d_year#22) AND (d_year#22 = 2002)) AND isnotnull(d_date_sk#21))
 
-(133) BroadcastExchange
-Input [2]: [d_date_sk#13, d_year#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=17]
+(68) BroadcastExchange
+Input [2]: [d_date_sk#21, d_year#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-Subquery:2 Hosting operator id = 24 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#6
+Subquery:2 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (141)
++- Exchange (140)
+   +- ObjectHashAggregate (139)
+      +- Exchange (138)
+         +- * Filter (137)
+            +- * HashAggregate (136)
+               +- Exchange (135)
+                  +- * HashAggregate (134)
+                     +- * HashAggregate (133)
+                        +- Exchange (132)
+                           +- * HashAggregate (131)
+                              +- Union (130)
+                                 :- * Project (91)
+                                 :  +- * SortMergeJoin LeftOuter (90)
+                                 :     :- * Sort (83)
+                                 :     :  +- Exchange (82)
+                                 :     :     +- * Project (81)
+                                 :     :        +- * BroadcastHashJoin Inner BuildRight (80)
+                                 :     :           :- * Project (78)
+                                 :     :           :  +- * BroadcastHashJoin Inner BuildRight (77)
+                                 :     :           :     :- * Filter (71)
+                                 :     :           :     :  +- * ColumnarToRow (70)
+                                 :     :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (69)
+                                 :     :           :     +- BroadcastExchange (76)
+                                 :     :           :        +- * Project (75)
+                                 :     :           :           +- * Filter (74)
+                                 :     :           :              +- * ColumnarToRow (73)
+                                 :     :           :                 +- Scan parquet spark_catalog.default.item (72)
+                                 :     :           +- ReusedExchange (79)
+                                 :     +- * Sort (89)
+                                 :        +- Exchange (88)
+                                 :           +- * Project (87)
+                                 :              +- * Filter (86)
+                                 :                 +- * ColumnarToRow (85)
+                                 :                    +- Scan parquet spark_catalog.default.catalog_returns (84)
+                                 :- * Project (110)
+                                 :  +- * SortMergeJoin LeftOuter (109)
+                                 :     :- * Sort (102)
+                                 :     :  +- Exchange (101)
+                                 :     :     +- * Project (100)
+                                 :     :        +- * BroadcastHashJoin Inner BuildRight (99)
+                                 :     :           :- * Project (97)
+                                 :     :           :  +- * BroadcastHashJoin Inner BuildRight (96)
+                                 :     :           :     :- * Filter (94)
+                                 :     :           :     :  +- * ColumnarToRow (93)
+                                 :     :           :     :     +- Scan parquet spark_catalog.default.store_sales (92)
+                                 :     :           :     +- ReusedExchange (95)
+                                 :     :           +- ReusedExchange (98)
+                                 :     +- * Sort (108)
+                                 :        +- Exchange (107)
+                                 :           +- * Project (106)
+                                 :              +- * Filter (105)
+                                 :                 +- * ColumnarToRow (104)
+                                 :                    +- Scan parquet spark_catalog.default.store_returns (103)
+                                 +- * Project (129)
+                                    +- * SortMergeJoin LeftOuter (128)
+                                       :- * Sort (121)
+                                       :  +- Exchange (120)
+                                       :     +- * Project (119)
+                                       :        +- * BroadcastHashJoin Inner BuildRight (118)
+                                       :           :- * Project (116)
+                                       :           :  +- * BroadcastHashJoin Inner BuildRight (115)
+                                       :           :     :- * Filter (113)
+                                       :           :     :  +- * ColumnarToRow (112)
+                                       :           :     :     +- Scan parquet spark_catalog.default.web_sales (111)
+                                       :           :     +- ReusedExchange (114)
+                                       :           +- ReusedExchange (117)
+                                       +- * Sort (127)
+                                          +- Exchange (126)
+                                             +- * Project (125)
+                                                +- * Filter (124)
+                                                   +- * ColumnarToRow (123)
+                                                      +- Scan parquet spark_catalog.default.web_returns (122)
 
-Subquery:3 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#45 IN dynamicpruning#6
 
-Subquery:4 Hosting operator id = 72 Hosting Expression = cs_sold_date_sk#72 IN dynamicpruning#73
-BroadcastExchange (137)
-+- * Filter (136)
-   +- * ColumnarToRow (135)
-      +- Scan parquet spark_catalog.default.date_dim (134)
+(69) Scan parquet spark_catalog.default.catalog_sales
+Output [5]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(cs_sold_date_sk#90), dynamicpruningexpression(cs_sold_date_sk#90 IN dynamicpruning#91)]
+PushedFilters: [IsNotNull(cs_item_sk)]
+ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_ext_sales_price:decimal(7,2)>
+
+(70) ColumnarToRow [codegen id : 3]
+Input [5]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90]
+
+(71) Filter [codegen id : 3]
+Input [5]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90]
+Condition : isnotnull(cs_item_sk#86)
+
+(72) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_category#93, i_manufact_id#77]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_category), EqualTo(i_category,Books                                             ), IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id), IsNotNull(i_manufact_id)]
+ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int,i_category:string,i_manufact_id:int>
+
+(73) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_category#93, i_manufact_id#77]
+
+(74) Filter [codegen id : 1]
+Input [6]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_category#93, i_manufact_id#77]
+Condition : ((((((isnotnull(i_category#93) AND (i_category#93 = Books                                             )) AND isnotnull(i_item_sk#92)) AND isnotnull(i_brand_id#74)) AND isnotnull(i_class_id#75)) AND isnotnull(i_category_id#76)) AND isnotnull(i_manufact_id#77))
+
+(75) Project [codegen id : 1]
+Output [5]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Input [6]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_category#93, i_manufact_id#77]
+
+(76) BroadcastExchange
+Input [5]: [i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+
+(77) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [cs_item_sk#86]
+Right keys [1]: [i_item_sk#92]
+Join type: Inner
+Join condition: None
+
+(78) Project [codegen id : 3]
+Output [9]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Input [10]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90, i_item_sk#92, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+
+(79) ReusedExchange [Reuses operator id: 145]
+Output [2]: [d_date_sk#94, d_year#73]
+
+(80) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [cs_sold_date_sk#90]
+Right keys [1]: [d_date_sk#94]
+Join type: Inner
+Join condition: None
+
+(81) Project [codegen id : 3]
+Output [9]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_year#73]
+Input [11]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, cs_sold_date_sk#90, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_date_sk#94, d_year#73]
+
+(82) Exchange
+Input [9]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_year#73]
+Arguments: hashpartitioning(cs_order_number#87, cs_item_sk#86, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(83) Sort [codegen id : 4]
+Input [9]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_year#73]
+Arguments: [cs_order_number#87 ASC NULLS FIRST, cs_item_sk#86 ASC NULLS FIRST], false, 0
+
+(84) Scan parquet spark_catalog.default.catalog_returns
+Output [5]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98, cr_returned_date_sk#99]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/catalog_returns]
+PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
+ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_quantity:int,cr_return_amount:decimal(7,2)>
+
+(85) ColumnarToRow [codegen id : 5]
+Input [5]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98, cr_returned_date_sk#99]
+
+(86) Filter [codegen id : 5]
+Input [5]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98, cr_returned_date_sk#99]
+Condition : (isnotnull(cr_order_number#96) AND isnotnull(cr_item_sk#95))
+
+(87) Project [codegen id : 5]
+Output [4]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98]
+Input [5]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98, cr_returned_date_sk#99]
+
+(88) Exchange
+Input [4]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98]
+Arguments: hashpartitioning(cr_order_number#96, cr_item_sk#95, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(89) Sort [codegen id : 6]
+Input [4]: [cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98]
+Arguments: [cr_order_number#96 ASC NULLS FIRST, cr_item_sk#95 ASC NULLS FIRST], false, 0
+
+(90) SortMergeJoin [codegen id : 7]
+Left keys [2]: [cs_order_number#87, cs_item_sk#86]
+Right keys [2]: [cr_order_number#96, cr_item_sk#95]
+Join type: LeftOuter
+Join condition: None
+
+(91) Project [codegen id : 7]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, (cs_quantity#88 - coalesce(cr_return_quantity#97, 0)) AS sales_cnt#27, (cs_ext_sales_price#89 - coalesce(cr_return_amount#98, 0.00)) AS sales_amt#28]
+Input [13]: [cs_item_sk#86, cs_order_number#87, cs_quantity#88, cs_ext_sales_price#89, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, d_year#73, cr_item_sk#95, cr_order_number#96, cr_return_quantity#97, cr_return_amount#98]
+
+(92) Scan parquet spark_catalog.default.store_sales
+Output [5]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#104), dynamicpruningexpression(ss_sold_date_sk#104 IN dynamicpruning#91)]
+PushedFilters: [IsNotNull(ss_item_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_ext_sales_price:decimal(7,2)>
+
+(93) ColumnarToRow [codegen id : 10]
+Input [5]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104]
+
+(94) Filter [codegen id : 10]
+Input [5]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104]
+Condition : isnotnull(ss_item_sk#100)
+
+(95) ReusedExchange [Reuses operator id: 76]
+Output [5]: [i_item_sk#105, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109]
+
+(96) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_item_sk#100]
+Right keys [1]: [i_item_sk#105]
+Join type: Inner
+Join condition: None
+
+(97) Project [codegen id : 10]
+Output [9]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109]
+Input [10]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104, i_item_sk#105, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109]
+
+(98) ReusedExchange [Reuses operator id: 145]
+Output [2]: [d_date_sk#110, d_year#111]
+
+(99) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#104]
+Right keys [1]: [d_date_sk#110]
+Join type: Inner
+Join condition: None
+
+(100) Project [codegen id : 10]
+Output [9]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_year#111]
+Input [11]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, ss_sold_date_sk#104, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_date_sk#110, d_year#111]
+
+(101) Exchange
+Input [9]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_year#111]
+Arguments: hashpartitioning(ss_ticket_number#101, ss_item_sk#100, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(102) Sort [codegen id : 11]
+Input [9]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_year#111]
+Arguments: [ss_ticket_number#101 ASC NULLS FIRST, ss_item_sk#100 ASC NULLS FIRST], false, 0
+
+(103) Scan parquet spark_catalog.default.store_returns
+Output [5]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115, sr_returned_date_sk#116]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store_returns]
+PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
+ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_quantity:int,sr_return_amt:decimal(7,2)>
+
+(104) ColumnarToRow [codegen id : 12]
+Input [5]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115, sr_returned_date_sk#116]
+
+(105) Filter [codegen id : 12]
+Input [5]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115, sr_returned_date_sk#116]
+Condition : (isnotnull(sr_ticket_number#113) AND isnotnull(sr_item_sk#112))
+
+(106) Project [codegen id : 12]
+Output [4]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115]
+Input [5]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115, sr_returned_date_sk#116]
+
+(107) Exchange
+Input [4]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115]
+Arguments: hashpartitioning(sr_ticket_number#113, sr_item_sk#112, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(108) Sort [codegen id : 13]
+Input [4]: [sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115]
+Arguments: [sr_ticket_number#113 ASC NULLS FIRST, sr_item_sk#112 ASC NULLS FIRST], false, 0
+
+(109) SortMergeJoin [codegen id : 14]
+Left keys [2]: [ss_ticket_number#101, ss_item_sk#100]
+Right keys [2]: [sr_ticket_number#113, sr_item_sk#112]
+Join type: LeftOuter
+Join condition: None
+
+(110) Project [codegen id : 14]
+Output [7]: [d_year#111, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, (ss_quantity#102 - coalesce(sr_return_quantity#114, 0)) AS sales_cnt#45, (ss_ext_sales_price#103 - coalesce(sr_return_amt#115, 0.00)) AS sales_amt#46]
+Input [13]: [ss_item_sk#100, ss_ticket_number#101, ss_quantity#102, ss_ext_sales_price#103, i_brand_id#106, i_class_id#107, i_category_id#108, i_manufact_id#109, d_year#111, sr_item_sk#112, sr_ticket_number#113, sr_return_quantity#114, sr_return_amt#115]
+
+(111) Scan parquet spark_catalog.default.web_sales
+Output [5]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ws_sold_date_sk#121), dynamicpruningexpression(ws_sold_date_sk#121 IN dynamicpruning#91)]
+PushedFilters: [IsNotNull(ws_item_sk)]
+ReadSchema: struct<ws_item_sk:int,ws_order_number:int,ws_quantity:int,ws_ext_sales_price:decimal(7,2)>
+
+(112) ColumnarToRow [codegen id : 17]
+Input [5]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121]
+
+(113) Filter [codegen id : 17]
+Input [5]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121]
+Condition : isnotnull(ws_item_sk#117)
+
+(114) ReusedExchange [Reuses operator id: 76]
+Output [5]: [i_item_sk#122, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126]
+
+(115) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#117]
+Right keys [1]: [i_item_sk#122]
+Join type: Inner
+Join condition: None
+
+(116) Project [codegen id : 17]
+Output [9]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126]
+Input [10]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121, i_item_sk#122, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126]
+
+(117) ReusedExchange [Reuses operator id: 145]
+Output [2]: [d_date_sk#127, d_year#128]
+
+(118) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#121]
+Right keys [1]: [d_date_sk#127]
+Join type: Inner
+Join condition: None
+
+(119) Project [codegen id : 17]
+Output [9]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_year#128]
+Input [11]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, ws_sold_date_sk#121, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_date_sk#127, d_year#128]
+
+(120) Exchange
+Input [9]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_year#128]
+Arguments: hashpartitioning(ws_order_number#118, ws_item_sk#117, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(121) Sort [codegen id : 18]
+Input [9]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_year#128]
+Arguments: [ws_order_number#118 ASC NULLS FIRST, ws_item_sk#117 ASC NULLS FIRST], false, 0
+
+(122) Scan parquet spark_catalog.default.web_returns
+Output [5]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132, wr_returned_date_sk#133]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/web_returns]
+PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
+ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
+
+(123) ColumnarToRow [codegen id : 19]
+Input [5]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132, wr_returned_date_sk#133]
+
+(124) Filter [codegen id : 19]
+Input [5]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132, wr_returned_date_sk#133]
+Condition : (isnotnull(wr_order_number#130) AND isnotnull(wr_item_sk#129))
+
+(125) Project [codegen id : 19]
+Output [4]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132]
+Input [5]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132, wr_returned_date_sk#133]
+
+(126) Exchange
+Input [4]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132]
+Arguments: hashpartitioning(wr_order_number#130, wr_item_sk#129, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+
+(127) Sort [codegen id : 20]
+Input [4]: [wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132]
+Arguments: [wr_order_number#130 ASC NULLS FIRST, wr_item_sk#129 ASC NULLS FIRST], false, 0
+
+(128) SortMergeJoin [codegen id : 21]
+Left keys [2]: [ws_order_number#118, ws_item_sk#117]
+Right keys [2]: [wr_order_number#130, wr_item_sk#129]
+Join type: LeftOuter
+Join condition: None
+
+(129) Project [codegen id : 21]
+Output [7]: [d_year#128, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, (ws_quantity#119 - coalesce(wr_return_quantity#131, 0)) AS sales_cnt#63, (ws_ext_sales_price#120 - coalesce(wr_return_amt#132, 0.00)) AS sales_amt#64]
+Input [13]: [ws_item_sk#117, ws_order_number#118, ws_quantity#119, ws_ext_sales_price#120, i_brand_id#123, i_class_id#124, i_category_id#125, i_manufact_id#126, d_year#128, wr_item_sk#129, wr_order_number#130, wr_return_quantity#131, wr_return_amt#132]
+
+(130) Union
+
+(131) HashAggregate [codegen id : 22]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Keys [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+
+(132) Exchange
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Arguments: hashpartitioning(d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(133) HashAggregate [codegen id : 23]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Keys [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Functions: []
+Aggregate Attributes: []
+Results [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+
+(134) HashAggregate [codegen id : 23]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#27, sales_amt#28]
+Keys [5]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Functions [2]: [partial_sum(sales_cnt#27), partial_sum(UnscaledValue(sales_amt#28))]
+Aggregate Attributes [2]: [sum#65, sum#134]
+Results [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sum#67, sum#135]
+
+(135) Exchange
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sum#67, sum#135]
+Arguments: hashpartitioning(d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+
+(136) HashAggregate [codegen id : 24]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sum#67, sum#135]
+Keys [5]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77]
+Functions [2]: [sum(sales_cnt#27), sum(UnscaledValue(sales_amt#28))]
+Aggregate Attributes [2]: [sum(sales_cnt#27)#69, sum(UnscaledValue(sales_amt#28))#70]
+Results [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sum(sales_cnt#27)#69 AS sales_cnt#78, MakeDecimal(sum(UnscaledValue(sales_amt#28))#70,18,2) AS sales_amt#79]
+
+(137) Filter [codegen id : 24]
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Condition : isnotnull(sales_cnt#78)
+
+(138) Exchange
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Arguments: hashpartitioning(i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+
+(139) ObjectHashAggregate
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_brand_id#74, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#136]
+Results [1]: [buf#137]
+
+(140) Exchange
+Input [1]: [buf#137]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+
+(141) ObjectHashAggregate
+Input [1]: [buf#137]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_brand_id#74, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_brand_id#74, 42), 1000000, 8388608, 0, 0)#138]
+Results [1]: [bloom_filter_agg(xxhash64(i_brand_id#74, 42), 1000000, 8388608, 0, 0)#138 AS bloomFilter#139]
+
+Subquery:3 Hosting operator id = 69 Hosting Expression = cs_sold_date_sk#90 IN dynamicpruning#91
+BroadcastExchange (145)
++- * Filter (144)
+   +- * ColumnarToRow (143)
+      +- Scan parquet spark_catalog.default.date_dim (142)
 
 
-(134) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#79, d_year#80]
+(142) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#94, d_year#73]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(135) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#79, d_year#80]
+(143) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#94, d_year#73]
 
-(136) Filter [codegen id : 1]
-Input [2]: [d_date_sk#79, d_year#80]
-Condition : ((isnotnull(d_year#80) AND (d_year#80 = 2001)) AND isnotnull(d_date_sk#79))
+(144) Filter [codegen id : 1]
+Input [2]: [d_date_sk#94, d_year#73]
+Condition : ((isnotnull(d_year#73) AND (d_year#73 = 2001)) AND isnotnull(d_date_sk#94))
 
-(137) BroadcastExchange
-Input [2]: [d_date_sk#79, d_year#80]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
+(145) BroadcastExchange
+Input [2]: [d_date_sk#94, d_year#73]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=20]
 
-Subquery:5 Hosting operator id = 87 Hosting Expression = ss_sold_date_sk#89 IN dynamicpruning#73
+Subquery:4 Hosting operator id = 92 Hosting Expression = ss_sold_date_sk#104 IN dynamicpruning#91
 
-Subquery:6 Hosting operator id = 102 Hosting Expression = ws_sold_date_sk#105 IN dynamicpruning#73
+Subquery:5 Hosting operator id = 111 Hosting Expression = ws_sold_date_sk#121 IN dynamicpruning#91
+
+Subquery:6 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#15, [id=#16]
+ObjectHashAggregate (149)
++- Exchange (148)
+   +- ObjectHashAggregate (147)
+      +- ReusedExchange (146)
+
+
+(146) ReusedExchange [Reuses operator id: 138]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+
+(147) ObjectHashAggregate
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_class_id#75, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#140]
+Results [1]: [buf#141]
+
+(148) Exchange
+Input [1]: [buf#141]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=21]
+
+(149) ObjectHashAggregate
+Input [1]: [buf#141]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_class_id#75, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_class_id#75, 42), 1000000, 8388608, 0, 0)#142]
+Results [1]: [bloom_filter_agg(xxhash64(i_class_id#75, 42), 1000000, 8388608, 0, 0)#142 AS bloomFilter#143]
+
+Subquery:7 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#17, [id=#18]
+ObjectHashAggregate (153)
++- Exchange (152)
+   +- ObjectHashAggregate (151)
+      +- ReusedExchange (150)
+
+
+(150) ReusedExchange [Reuses operator id: 138]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+
+(151) ObjectHashAggregate
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_category_id#76, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#144]
+Results [1]: [buf#145]
+
+(152) Exchange
+Input [1]: [buf#145]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
+
+(153) ObjectHashAggregate
+Input [1]: [buf#145]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_category_id#76, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_category_id#76, 42), 1000000, 8388608, 0, 0)#146]
+Results [1]: [bloom_filter_agg(xxhash64(i_category_id#76, 42), 1000000, 8388608, 0, 0)#146 AS bloomFilter#147]
+
+Subquery:8 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#19, [id=#20]
+ObjectHashAggregate (157)
++- Exchange (156)
+   +- ObjectHashAggregate (155)
+      +- ReusedExchange (154)
+
+
+(154) ReusedExchange [Reuses operator id: 138]
+Output [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+
+(155) ObjectHashAggregate
+Input [7]: [d_year#73, i_brand_id#74, i_class_id#75, i_category_id#76, i_manufact_id#77, sales_cnt#78, sales_amt#79]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_manufact_id#77, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [buf#148]
+Results [1]: [buf#149]
+
+(156) Exchange
+Input [1]: [buf#149]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=23]
+
+(157) ObjectHashAggregate
+Input [1]: [buf#149]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_manufact_id#77, 42), 1000000, 8388608, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_manufact_id#77, 42), 1000000, 8388608, 0, 0)#150]
+Results [1]: [bloom_filter_agg(xxhash64(i_manufact_id#77, 42), 1000000, 8388608, 0, 0)#150 AS bloomFilter#151]
+
+Subquery:9 Hosting operator id = 20 Hosting Expression = ss_sold_date_sk#33 IN dynamicpruning#6
+
+Subquery:10 Hosting operator id = 35 Hosting Expression = ws_sold_date_sk#51 IN dynamicpruning#6
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/simplified.txt
@@ -50,6 +50,151 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                                             WholeStageCodegen (1)
                                                                               Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
                                                                                 Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                  Subquery #2
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_brand_id, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #7
+                                                                                        ObjectHashAggregate [i_brand_id] [buf,buf]
+                                                                                          Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #8
+                                                                                            WholeStageCodegen (24)
+                                                                                              Filter [sales_cnt]
+                                                                                                HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(sales_cnt),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
+                                                                                                  InputAdapter
+                                                                                                    Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #9
+                                                                                                      WholeStageCodegen (23)
+                                                                                                        HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
+                                                                                                          HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                                                                                            InputAdapter
+                                                                                                              Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #10
+                                                                                                                WholeStageCodegen (22)
+                                                                                                                  HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
+                                                                                                                    InputAdapter
+                                                                                                                      Union
+                                                                                                                        WholeStageCodegen (7)
+                                                                                                                          Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
+                                                                                                                            SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (4)
+                                                                                                                                  Sort [cs_order_number,cs_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [cs_order_number,cs_item_sk] #11
+                                                                                                                                        WholeStageCodegen (3)
+                                                                                                                                          Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                                                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                                                              Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                                                                  Filter [cs_item_sk]
+                                                                                                                                                    ColumnarToRow
+                                                                                                                                                      InputAdapter
+                                                                                                                                                        Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk]
+                                                                                                                                                          SubqueryBroadcast [d_date_sk] #3
+                                                                                                                                                            BroadcastExchange #12
+                                                                                                                                                              WholeStageCodegen (1)
+                                                                                                                                                                Filter [d_year,d_date_sk]
+                                                                                                                                                                  ColumnarToRow
+                                                                                                                                                                    InputAdapter
+                                                                                                                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
+                                                                                                                                                  InputAdapter
+                                                                                                                                                    BroadcastExchange #13
+                                                                                                                                                      WholeStageCodegen (1)
+                                                                                                                                                        Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                          Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                            ColumnarToRow
+                                                                                                                                                              InputAdapter
+                                                                                                                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                                                                                                                              InputAdapter
+                                                                                                                                                ReusedExchange [d_date_sk,d_year] #12
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (6)
+                                                                                                                                  Sort [cr_order_number,cr_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [cr_order_number,cr_item_sk] #14
+                                                                                                                                        WholeStageCodegen (5)
+                                                                                                                                          Project [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
+                                                                                                                                            Filter [cr_order_number,cr_item_sk]
+                                                                                                                                              ColumnarToRow
+                                                                                                                                                InputAdapter
+                                                                                                                                                  Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount,cr_returned_date_sk]
+                                                                                                                        WholeStageCodegen (14)
+                                                                                                                          Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
+                                                                                                                            SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (11)
+                                                                                                                                  Sort [ss_ticket_number,ss_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [ss_ticket_number,ss_item_sk] #15
+                                                                                                                                        WholeStageCodegen (10)
+                                                                                                                                          Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                                                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                                                              Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                                                                                  Filter [ss_item_sk]
+                                                                                                                                                    ColumnarToRow
+                                                                                                                                                      InputAdapter
+                                                                                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk]
+                                                                                                                                                          ReusedSubquery [d_date_sk] #3
+                                                                                                                                                  InputAdapter
+                                                                                                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
+                                                                                                                                              InputAdapter
+                                                                                                                                                ReusedExchange [d_date_sk,d_year] #12
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (13)
+                                                                                                                                  Sort [sr_ticket_number,sr_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [sr_ticket_number,sr_item_sk] #16
+                                                                                                                                        WholeStageCodegen (12)
+                                                                                                                                          Project [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
+                                                                                                                                            Filter [sr_ticket_number,sr_item_sk]
+                                                                                                                                              ColumnarToRow
+                                                                                                                                                InputAdapter
+                                                                                                                                                  Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt,sr_returned_date_sk]
+                                                                                                                        WholeStageCodegen (21)
+                                                                                                                          Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
+                                                                                                                            SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (18)
+                                                                                                                                  Sort [ws_order_number,ws_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [ws_order_number,ws_item_sk] #17
+                                                                                                                                        WholeStageCodegen (17)
+                                                                                                                                          Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
+                                                                                                                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                                                                              Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                                                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                                                                                  Filter [ws_item_sk]
+                                                                                                                                                    ColumnarToRow
+                                                                                                                                                      InputAdapter
+                                                                                                                                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk]
+                                                                                                                                                          ReusedSubquery [d_date_sk] #3
+                                                                                                                                                  InputAdapter
+                                                                                                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
+                                                                                                                                              InputAdapter
+                                                                                                                                                ReusedExchange [d_date_sk,d_year] #12
+                                                                                                                              InputAdapter
+                                                                                                                                WholeStageCodegen (20)
+                                                                                                                                  Sort [wr_order_number,wr_item_sk]
+                                                                                                                                    InputAdapter
+                                                                                                                                      Exchange [wr_order_number,wr_item_sk] #18
+                                                                                                                                        WholeStageCodegen (19)
+                                                                                                                                          Project [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
+                                                                                                                                            Filter [wr_order_number,wr_item_sk]
+                                                                                                                                              ColumnarToRow
+                                                                                                                                                InputAdapter
+                                                                                                                                                  Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt,wr_returned_date_sk]
+                                                                                  Subquery #4
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_class_id, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #19
+                                                                                        ObjectHashAggregate [i_class_id] [buf,buf]
+                                                                                          ReusedExchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #8
+                                                                                  Subquery #5
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_category_id, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #20
+                                                                                        ObjectHashAggregate [i_category_id] [buf,buf]
+                                                                                          ReusedExchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #8
+                                                                                  Subquery #6
+                                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_manufact_id, 42), 1000000, 8388608, 0, 0),bloomFilter,buf]
+                                                                                      Exchange #21
+                                                                                        ObjectHashAggregate [i_manufact_id] [buf,buf]
+                                                                                          ReusedExchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #8
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
@@ -59,13 +204,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                       WholeStageCodegen (6)
                                                         Sort [cr_order_number,cr_item_sk]
                                                           InputAdapter
-                                                            Exchange [cr_order_number,cr_item_sk] #7
-                                                              WholeStageCodegen (5)
-                                                                Project [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
-                                                                  Filter [cr_order_number,cr_item_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount,cr_returned_date_sk]
+                                                            ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #14
                                               WholeStageCodegen (14)
                                                 Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
                                                   SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
@@ -73,7 +212,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                       WholeStageCodegen (11)
                                                         Sort [ss_ticket_number,ss_item_sk]
                                                           InputAdapter
-                                                            Exchange [ss_ticket_number,ss_item_sk] #8
+                                                            Exchange [ss_ticket_number,ss_item_sk] #22
                                                               WholeStageCodegen (10)
                                                                 Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
                                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -92,13 +231,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                       WholeStageCodegen (13)
                                                         Sort [sr_ticket_number,sr_item_sk]
                                                           InputAdapter
-                                                            Exchange [sr_ticket_number,sr_item_sk] #9
-                                                              WholeStageCodegen (12)
-                                                                Project [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
-                                                                  Filter [sr_ticket_number,sr_item_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt,sr_returned_date_sk]
+                                                            ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #16
                                               WholeStageCodegen (21)
                                                 Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
                                                   SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
@@ -106,7 +239,7 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                       WholeStageCodegen (18)
                                                         Sort [ws_order_number,ws_item_sk]
                                                           InputAdapter
-                                                            Exchange [ws_order_number,ws_item_sk] #10
+                                                            Exchange [ws_order_number,ws_item_sk] #23
                                                               WholeStageCodegen (17)
                                                                 Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
                                                                   BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
@@ -125,116 +258,9 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                       WholeStageCodegen (20)
                                                         Sort [wr_order_number,wr_item_sk]
                                                           InputAdapter
-                                                            Exchange [wr_order_number,wr_item_sk] #11
-                                                              WholeStageCodegen (19)
-                                                                Project [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
-                                                                  Filter [wr_order_number,wr_item_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt,wr_returned_date_sk]
+                                                            ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #18
         InputAdapter
           WholeStageCodegen (50)
             Sort [i_brand_id,i_class_id,i_category_id,i_manufact_id]
               InputAdapter
-                Exchange [i_brand_id,i_class_id,i_category_id,i_manufact_id] #12
-                  WholeStageCodegen (49)
-                    Filter [sales_cnt]
-                      HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sum,sum] [sum(sales_cnt),sum(UnscaledValue(sales_amt)),sales_cnt,sales_amt,sum,sum]
-                        InputAdapter
-                          Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id] #13
-                            WholeStageCodegen (48)
-                              HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] [sum,sum,sum,sum]
-                                HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                  InputAdapter
-                                    Exchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #14
-                                      WholeStageCodegen (47)
-                                        HashAggregate [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt]
-                                          InputAdapter
-                                            Union
-                                              WholeStageCodegen (32)
-                                                Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,cs_quantity,cr_return_quantity,cs_ext_sales_price,cr_return_amount]
-                                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                                    InputAdapter
-                                                      WholeStageCodegen (29)
-                                                        Sort [cs_order_number,cs_item_sk]
-                                                          InputAdapter
-                                                            Exchange [cs_order_number,cs_item_sk] #15
-                                                              WholeStageCodegen (28)
-                                                                Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                        Filter [cs_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk]
-                                                                                SubqueryBroadcast [d_date_sk] #2
-                                                                                  BroadcastExchange #16
-                                                                                    WholeStageCodegen (1)
-                                                                                      Filter [d_year,d_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
-                                                                        InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                    InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
-                                                    InputAdapter
-                                                      WholeStageCodegen (31)
-                                                        Sort [cr_order_number,cr_item_sk]
-                                                          InputAdapter
-                                                            ReusedExchange [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount] #7
-                                              WholeStageCodegen (39)
-                                                Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ss_quantity,sr_return_quantity,ss_ext_sales_price,sr_return_amt]
-                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                                    InputAdapter
-                                                      WholeStageCodegen (36)
-                                                        Sort [ss_ticket_number,ss_item_sk]
-                                                          InputAdapter
-                                                            Exchange [ss_ticket_number,ss_item_sk] #17
-                                                              WholeStageCodegen (35)
-                                                                Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                        Filter [ss_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk]
-                                                                                ReusedSubquery [d_date_sk] #2
-                                                                        InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                    InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
-                                                    InputAdapter
-                                                      WholeStageCodegen (38)
-                                                        Sort [sr_ticket_number,sr_item_sk]
-                                                          InputAdapter
-                                                            ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt] #9
-                                              WholeStageCodegen (46)
-                                                Project [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,ws_quantity,wr_return_quantity,ws_ext_sales_price,wr_return_amt]
-                                                  SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
-                                                    InputAdapter
-                                                      WholeStageCodegen (43)
-                                                        Sort [ws_order_number,ws_item_sk]
-                                                          InputAdapter
-                                                            Exchange [ws_order_number,ws_item_sk] #18
-                                                              WholeStageCodegen (42)
-                                                                Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                        Filter [ws_item_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk]
-                                                                                ReusedSubquery [d_date_sk] #2
-                                                                        InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
-                                                                    InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
-                                                    InputAdapter
-                                                      WholeStageCodegen (45)
-                                                        Sort [wr_order_number,wr_item_sk]
-                                                          InputAdapter
-                                                            ReusedExchange [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt] #11
+                ReusedExchange [d_year,i_brand_id,i_class_id,i_category_id,i_manufact_id,sales_cnt,sales_amt] #8

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
@@ -216,7 +216,7 @@ Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_e
 
 (3) Filter [codegen id : 1]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
-Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ss_item_sk#1, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ss_promo_sk#3, 42)))
+Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ss_item_sk#1, 42), true)) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ss_promo_sk#3, 42), true))
 
 (4) Exchange
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
@@ -398,7 +398,7 @@ Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_numbe
 
 (42) Filter [codegen id : 11]
 Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42)))
+Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42), true)) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42), true))
 
 (43) Exchange
 Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
@@ -542,7 +542,7 @@ Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81
 
 (73) Filter [codegen id : 21]
 Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42)))
+Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42), true)) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42), true))
 
 (74) Exchange
 Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/explain.txt
@@ -1,28 +1,25 @@
 == Physical Plan ==
-* Sort (24)
-+- Exchange (23)
-   +- * Project (22)
-      +- Window (21)
-         +- * Sort (20)
-            +- Exchange (19)
-               +- * HashAggregate (18)
-                  +- Exchange (17)
-                     +- * HashAggregate (16)
-                        +- * Project (15)
-                           +- * BroadcastHashJoin Inner BuildRight (14)
-                              :- * Project (12)
-                              :  +- * SortMergeJoin Inner (11)
+* Sort (21)
++- Exchange (20)
+   +- * Project (19)
+      +- Window (18)
+         +- * Sort (17)
+            +- Exchange (16)
+               +- * HashAggregate (15)
+                  +- Exchange (14)
+                     +- * HashAggregate (13)
+                        +- * Project (12)
+                           +- * BroadcastHashJoin Inner BuildRight (11)
+                              :- * Project (9)
+                              :  +- * SortMergeJoin Inner (8)
                               :     :- * Sort (5)
                               :     :  +- Exchange (4)
                               :     :     +- * Filter (3)
                               :     :        +- * ColumnarToRow (2)
                               :     :           +- Scan parquet spark_catalog.default.store_sales (1)
-                              :     +- * Sort (10)
-                              :        +- Exchange (9)
-                              :           +- * Filter (8)
-                              :              +- * ColumnarToRow (7)
-                              :                 +- Scan parquet spark_catalog.default.item (6)
-                              +- ReusedExchange (13)
+                              :     +- * Sort (7)
+                              :        +- ReusedExchange (6)
+                              +- ReusedExchange (10)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -38,7 +35,7 @@ Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_item_sk#1)
+Condition : (isnotnull(ss_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ss_item_sk#1, 42), false))
 
 (4) Exchange
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
@@ -48,123 +45,154 @@ Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(6) ReusedExchange [Reuses operator id: 25]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(7) Sort [codegen id : 4]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
+
+(8) SortMergeJoin [codegen id : 6]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#7]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 6]
+Output [7]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+
+(10) ReusedExchange [Reuses operator id: 33]
+Output [1]: [d_date_sk#13]
+
+(11) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_sold_date_sk#3]
+Right keys [1]: [d_date_sk#13]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 6]
+Output [6]: [ss_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
+
+(13) HashAggregate [codegen id : 6]
+Input [6]: [ss_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+
+(14) Exchange
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(15) HashAggregate [codegen id : 7]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#16]
+Results [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS _w0#18, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS _w1#19]
+
+(16) Exchange
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(17) Sort [codegen id : 8]
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
+
+(18) Window
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19]
+Arguments: [sum(_w1#19) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#20], [i_class#11]
+
+(19) Project [codegen id : 9]
+Output [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#20) AS revenueratio#21]
+Input [9]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _w1#19, _we0#20]
+
+(20) Exchange
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+Arguments: rangepartitioning(i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#21 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(21) Sort [codegen id : 10]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#21]
+Arguments: [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#21 ASC NULLS FIRST], true, 0
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (28)
++- Exchange (27)
+   +- ObjectHashAggregate (26)
+      +- Exchange (25)
+         +- * Filter (24)
+            +- * ColumnarToRow (23)
+               +- Scan parquet spark_catalog.default.item (22)
+
+
+(22) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
-(7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(23) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+(24) Filter [codegen id : 1]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
-(9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(25) Exchange
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+(26) ObjectHashAggregate
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [buf#22]
+Results [1]: [buf#23]
 
-(11) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
+(27) Exchange
+Input [1]: [buf#23]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
-(12) Project [codegen id : 6]
-Output [7]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+(28) ObjectHashAggregate
+Input [1]: [buf#23]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 489600, 0, 0)#24 AS bloomFilter#25]
 
-(13) ReusedExchange [Reuses operator id: 29]
-Output [1]: [d_date_sk#11]
-
-(14) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(15) Project [codegen id : 6]
-Output [6]: [ss_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
-
-(16) HashAggregate [codegen id : 6]
-Input [6]: [ss_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-
-(17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#14]
-Results [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS _w0#16, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS _w1#17]
-
-(19) Exchange
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(20) Sort [codegen id : 8]
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
-
-(21) Window
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17]
-Arguments: [sum(_w1#17) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#18], [i_class#9]
-
-(22) Project [codegen id : 9]
-Output [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#18) AS revenueratio#19]
-Input [9]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _w1#17, _we0#18]
-
-(23) Exchange
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-Arguments: rangepartitioning(i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#19 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(24) Sort [codegen id : 10]
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#19]
-Arguments: [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#19 ASC NULLS FIRST], true, 0
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (29)
-+- * Project (28)
-   +- * Filter (27)
-      +- * ColumnarToRow (26)
-         +- Scan parquet spark_catalog.default.date_dim (25)
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (33)
++- * Project (32)
+   +- * Filter (31)
+      +- * ColumnarToRow (30)
+         +- Scan parquet spark_catalog.default.date_dim (29)
 
 
-(25) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#20]
+(29) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(26) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
+(30) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(27) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#20]
-Condition : (((isnotnull(d_date#20) AND (d_date#20 >= 1999-02-22)) AND (d_date#20 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(31) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#26]
+Condition : (((isnotnull(d_date#26) AND (d_date#26 >= 1999-02-22)) AND (d_date#26 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(28) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#20]
+(32) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#26]
 
-(29) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+(33) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/simplified.txt
@@ -27,6 +27,16 @@ WholeStageCodegen (10)
                                                     Exchange [ss_item_sk] #4
                                                       WholeStageCodegen (1)
                                                         Filter [ss_item_sk]
+                                                          Subquery #2
+                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 489600, 0, 0),bloomFilter,buf]
+                                                              Exchange #6
+                                                                ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                  Exchange [i_item_sk] #7
+                                                                    WholeStageCodegen (1)
+                                                                      Filter [i_category,i_item_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
@@ -42,11 +52,6 @@ WholeStageCodegen (10)
                                               WholeStageCodegen (4)
                                                 Sort [i_item_sk]
                                                   InputAdapter
-                                                    Exchange [i_item_sk] #6
-                                                      WholeStageCodegen (3)
-                                                        Filter [i_category,i_item_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category]
+                                                    ReusedExchange [i_item_sk,i_item_id,i_item_desc,i_current_price,i_class,i_category] #7
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #5

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterReuseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterReuseSuite.scala
@@ -159,7 +159,7 @@ abstract class InjectRuntimeFilterReuseSuite
       case _ => fail(s"Invalid child node found in\n$plan")
     }
   }
-  
+
   def checkSubqueryForReuseExchange(reuseExpected: Boolean,
                                     plan: SparkPlan, rootPlan: SparkPlan): Unit = {
     plan match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterReuseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterReuseSuite.scala
@@ -1,0 +1,412 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{BloomFilterMightContain, Expression, Literal}
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
+import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
+import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+abstract class InjectRuntimeFilterReuseSuite
+    extends QueryTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
+
+  val tableFormat: String = "parquet"
+
+  val adaptiveExecutionOn: Boolean
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    spark.sessionState.conf.setConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED, adaptiveExecutionOn)
+    spark.sessionState.conf.setConf(SQLConf.AUTO_SIZE_UPDATE_ENABLED, true)
+    spark.sessionState.conf.setConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, 5000L)
+    spark.sessionState.conf.setConf(SQLConf.PARQUET_COMPRESSION, "uncompressed")
+    spark.sessionState.conf.setConf(SQLConf.CBO_ENABLED, true)
+
+    spark
+      .range(2000)
+      .select(col("id").as("a"), col("id").as("b"))
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t1")
+
+    spark
+      .range(2000)
+      .select(col("id").as("a"), col("id").as("b"), col("id").as("c"))
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t2")
+
+    spark
+      .range(100)
+      .select(col("id").as("a"), col("id").as("b"), col("id").as("c"))
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t3")
+
+    import testImplicits._
+    val expr5 = when($"id" % 4 === lit(0), col("id").cast("string"))
+      .otherwise(col("id").*(2).cast("string"))
+      .as("c")
+
+    val expr6 = when($"id" % 4 === lit(0), col("id").cast("string"))
+      .otherwise(col("id").*(3).cast("string"))
+      .as("c")
+
+    spark
+      .range(2000)
+      .select(col("id").as("a"), col("id").as("b"), expr5)
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t5")
+
+    spark
+      .range(100)
+      .select(col("id").as("a"), col("id").as("b"), expr6)
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("t6")
+
+    Seq(13, 27, 8, 26, 15, 27, 14, 17, 24, 26, 17, 18, 4, 28, 16, 11, 17, 8, 19, 28, 4, 8, 2, 19,
+      26, 30, 7, 14, 7, 17, 1, 5, 19, 21, 15, 20, 3, 19, 3, 4, 26, 25, 18, 30, 12, 22, 11, 24, 3,
+      17, 16, 22, 26, 9, 28, 8, 18, 22, 11, 21, 5, 25, 1, 4, 28, 15, 28, 24, 18, 16, 24, 16, 27,
+      27, 1, 23, 19, 9, 18, 21, 2, 8, 24, 5, 8, 23, 8, 19, 28, 20, 5, 4, 30, 23, 30, 12, 9, 10,
+      23, 7).zipWithIndex
+      .toDF("a", "b")
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("ct4")
+
+    Seq(10, 7, 21, 13, 28, 11, 1, 2, 20, 24, 9, 18, 19, 17, 8, 6, 5, 30, 12, 23, 5, 21, 19, 18,
+      21, 30, 8, 26, 24, 30, 5, 27, 13, 10, 14, 24, 5, 7, 1, 5, 16, 12, 5, 4, 1, 29, 9, 1, 6, 5,
+      5, 14, 9, 29, 13, 8, 21, 2, 11, 5, 1, 7, 11, 30, 23, 2, 30, 10, 4, 22, 25, 21, 9, 6, 23, 6,
+      19, 14, 1, 17, 8, 24, 30, 25, 20, 27, 11, 21, 4, 5, 3, 4, 4, 21, 28, 10, 28, 5, 11,
+      25).zipWithIndex
+      .toDF("a", "b")
+      .write
+      .format(tableFormat)
+      .mode(SaveMode.Overwrite)
+      .saveAsTable("ct3")
+
+    spark.sql("analyze table t1 compute statistics for columns a, b").collect()
+    spark.sql("analyze table t2 compute statistics for columns a, b").collect()
+    spark.sql("analyze table t3 compute statistics for columns a, b").collect()
+    spark.sql("analyze table ct3 compute statistics for columns a, b").collect()
+    spark.sql("analyze table ct4 compute statistics for columns a, b").collect()
+    spark.sql("analyze table t5 compute statistics for columns a, b, c").collect()
+    spark.sql("analyze table t6 compute statistics for columns a, b, c").collect()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      sql("DROP TABLE IF EXISTS t1")
+      sql("DROP TABLE IF EXISTS t2")
+      sql("DROP TABLE IF EXISTS t3")
+      sql("DROP TABLE IF EXISTS ct3")
+      sql("DROP TABLE IF EXISTS ct4")
+      sql("DROP TABLE IF EXISTS t5")
+      sql("DROP TABLE IF EXISTS t6")
+    } finally {
+      spark.sessionState.conf.unsetConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED)
+      spark.sessionState.conf.unsetConf(SQLConf.AUTO_SIZE_UPDATE_ENABLED)
+      spark.sessionState.conf.unsetConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD)
+      spark.sessionState.conf.unsetConf(SQLConf.PARQUET_COMPRESSION)
+      super.afterAll()
+    }
+  }
+
+  def checkForReuseExchange(
+      reuseExpected: Boolean,
+      plan: SparkPlan,
+      rootPlan: SparkPlan): Unit = {
+    val reuseStr = if (reuseExpected) "Should" else "Shoudn't"
+    plan match {
+      case _: ReusedExchangeExec =>
+      case ex: ShuffleExchangeExec =>
+        val hasReuse = find(rootPlan) {
+          case ReusedExchangeExec(_, e) => e eq ex
+          case _ => false
+        }.isDefined
+        assert(hasReuse == reuseExpected, s"$plan\n${reuseStr} have been reused in\n$rootPlan")
+      case _ => fail(s"Invalid child node found in\n$plan")
+    }
+  }
+  
+  def checkSubqueryForReuseExchange(reuseExpected: Boolean,
+                                    plan: SparkPlan, rootPlan: SparkPlan): Unit = {
+    plan match {
+      case ObjectHashAggregateExec(_, _, _, _, _, _, _, _,
+      ShuffleExchangeExec(_,
+      ObjectHashAggregateExec(_, _, _, _, _, _, _, _, child), _)) =>
+        checkForReuseExchange(reuseExpected, child, rootPlan)
+      case a: AdaptiveSparkPlanExec =>
+        checkSubqueryForReuseExchange(reuseExpected, a.executedPlan, rootPlan)
+      case _ =>
+    }
+  }
+
+  /**
+   * Check if the query plan has a bloom filter inserted either
+   * with Reusable Exchange or not
+   */
+  def checkBloomFilterPredicate(
+                                 df: DataFrame,
+                                 hasBloomFilter: Boolean,
+                                 hadBroadcastBloom: Boolean,
+                                 reuseExpected: Boolean = true): Unit = {
+    df.collect()
+
+    val plan = df.queryExecution.executedPlan
+    val bloomExprs = collectBloomFilterExpressions(plan)
+    val hasSubquery = bloomExprs.exists {
+      case BloomFilterMightContain(_, _, false) => true
+      case _ => false
+    }
+
+    val subqueryExecs = bloomExprs.collect {
+      case BloomFilterMightContain(s, _, false) => s.asInstanceOf[ScalarSubquery].plan
+    }
+
+    val name = "trigger bloom filter"
+    val hasFilter = if (hasBloomFilter) "Should" else "Shouldn't"
+    assert(
+      hasSubquery == hasBloomFilter,
+      s"$hasFilter $name with a subquery duplicate:\n${df.queryExecution}")
+
+    val reuseStr = if (reuseExpected) "Should" else "Shoudn't"
+    subqueryExecs.foreach { s =>
+      checkSubqueryForReuseExchange(reuseExpected, s.child, plan)
+    }
+  }
+
+  private def collectBloomFilterExpressions(plan: SparkPlan): Seq[Expression] = {
+    flatMap(plan) {
+      case s: FilterExec =>
+        s.condition.collect {
+          case d: BloomFilterMightContain => d
+        }
+      case _ => Nil
+    }
+  }
+
+  test("Bloom Filter: check table stats") {
+    val catalog = spark.sessionState.catalog
+    assert(catalog.getTableMetadata(TableIdentifier("t1")).stats.get.rowCount.get == 2000)
+    assert(catalog.getTableMetadata(TableIdentifier("t2")).stats.get.rowCount.get == 2000)
+    assert(catalog.getTableMetadata(TableIdentifier("t3")).stats.get.rowCount.get == 100)
+    assert(catalog.getTableMetadata(TableIdentifier("t1")).stats.get.sizeInBytes > 10000L)
+    assert(catalog.getTableMetadata(TableIdentifier("t2")).stats.get.sizeInBytes > 10000L)
+    assert(catalog.getTableMetadata(TableIdentifier("t3")).stats.get.sizeInBytes < 5000L)
+  }
+
+  test("Bloom Filter with reuse exchange") {
+    withSQLConf(
+      SQLConf.RUNTIME_FILTER_SEMI_JOIN_REDUCTION_ENABLED.key -> "false",
+      SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "10000") {
+      val df = sql("""
+          |SELECT t11.a,
+          |       t11.b
+          |FROM   (SELECT t1.a,
+          |               t2.b
+          |        FROM t1
+          |        JOIN t2
+          |            ON t1.a = t2.a AND t2.b < 10) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a AND t3.b < 6
+          |""".stripMargin)
+      checkBloomFilterPredicate(df, true, false)
+    }
+  }
+
+  test("Bloom Filter is not triggered if SMJ doesn't introduce Exchange") {
+    withSQLConf(
+      SQLConf.RUNTIME_FILTER_SEMI_JOIN_REDUCTION_ENABLED.key -> "false",
+      SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "10000") {
+      val df = sql("""
+          |SELECT t5.a,
+          |       t5.b
+          |FROM   t5
+          |JOIN (SELECT t3.a, sum(t3.b) sumb
+          |       FROM t3
+          |       GROUP BY t3.a) t3new
+          |ON t5.a = t3new.a
+          |WHERE coalesce(t3new.sumb, 0) > 0
+          |""".stripMargin)
+
+      checkBloomFilterPredicate(df, false, false)
+      val trueNode = find(df.queryExecution.executedPlan) {
+        case fe: FilterExec => fe.condition.containsChild.contains(Literal.TrueLiteral)
+        case _ => false
+      }
+      assert(trueNode.isDefined)
+    }
+  }
+
+  test("Bloom Filter is not triggered with SMJ if Exchange reuse is disabled") {
+    withSQLConf(
+      SQLConf.RUNTIME_FILTER_SEMI_JOIN_REDUCTION_ENABLED.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false",
+      SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "10000") {
+      val df = sql("""
+          |SELECT t11.a,
+          |       t11.b
+          |FROM   (SELECT t5.a,
+          |               t6.b
+          |        FROM t5
+          |        JOIN t6
+          |            ON t5.a = t6.a AND t5.c = t6.c AND t6.b < 10) t11
+          |       JOIN t3
+          |         ON t11.a = t3.a
+          |""".stripMargin)
+
+      checkBloomFilterPredicate(df, false, false)
+    }
+  }
+
+  test("Bloom Filter reuses as much plan possible when AQE removes the" +
+    "top Exchange use by Bloom filter") {
+    withSQLConf(
+      SQLConf.RUNTIME_FILTER_SEMI_JOIN_REDUCTION_ENABLED.key -> "false",
+      SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "400",
+      SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "20000",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "10000") {
+      val df = sql(
+        """
+          |SELECT t1.a, t1.b
+          |FROM t1
+          |JOIN (
+          | SELECT ct4.a ct4a, ct4.b ct4b
+          | FROM ct4
+          | JOIN ct3
+          | ON ct4.a = ct3.a
+          | AND ct4.a > ct4.b + 20) newt
+          |ON t1.b = newt.ct4b
+          |""".stripMargin)
+      // With AQE
+      // The initial plan will have SMJ whose right side is used as build plan for Bloom
+      // But AQE will convert that SMJ to BHJ replacing ShuffleExchange with BroadcastExchange
+      // Bloom build plan will try to reuse the plan till last exchanges
+
+      // Initial Plan
+      //   Project
+      //   +- SortMergeJoin
+      //      :- Sort
+      //      :  +- Exchange
+      //      :     +- Filter -> contains bloom filter
+      //      :        :  +- Subquery
+      //      :        :     +- AdaptiveSparkPlan
+      //                        +- ObjectHashAggregate
+      //                           +- Exchange
+      //                              +- ObjectHashAggregate
+      //                                 +- Exchange
+      //                                    +- Project
+      //                                       +- SortMergeJoin
+      //                                          :- Sort
+      //                                          :  +- Exchange
+      //                                          :     +- Filter
+      //                                          :        +- FileScan
+      //                                          +- Sort
+      //                                             +- Exchange
+      //                                                +- Filter
+      //                                                   +- FileScan
+      //      :        +- FileScan
+      //      +- Sort
+      //         +- Exchange -> this exchanges is used by bloom initially and will be removed by AQE
+      //            +- Project
+      //               +- SortMergeJoin
+      //                  :- Sort
+      //                  :  +- Exchange
+      //                  :     +- Filter
+      //                  :        +- FileScan
+      //                  +- Sort
+      //                     +- Exchange
+      //                        +- Filter
+      //                           +- FileScan
+
+      // Final Plan
+      // Project
+      // +- BroadcastHashJoin
+      //   :- AQEShuffleRead
+      //   :  +- ShuffleQueryStage
+      //   :     +- Exchange
+      //   :        +- Filter -> contains bloom filter
+      //   :           :  +- Subquery
+      //   :           :     +- AdaptiveSparkPlan
+      //                        +- ObjectHashAggregate
+      //                           +- ShuffleQueryStage
+      //                              +- Exchange
+      //                                  +- ObjectHashAggregate
+      //                                     +- AQEShuffleRead coalesced
+      //                                        +- ShuffleQueryStage
+      //                                           +- Exchange
+      //                                              +- Project
+      //                                                 +- BroadcastHashJoin
+      //                                                 :- BroadcastQueryStage
+      //                                                 :  +- BroadcastExchange
+      //                                                 :     +- AQEShuffleRead
+      //                                                 :        +- ShuffleQueryStage
+      //                                                 :           +- ReusedExchange
+      //                                                 +- AQEShuffleRead
+      //                                                    +- ShuffleQueryStage
+      //                                                        +- ReusedExchange
+      //   :           +- ColumnarToRow
+      //   :              +- FileScan
+      //   +- BroadcastQueryStage
+      //      +- BroadcastExchange
+      //         +- Project
+      //            +- BroadcastHashJoin
+      //               :- BroadcastQueryStage
+      //               :  +- ReusedExchange
+      //               +- AQEShuffleRead
+      //                  +- ShuffleQueryStage
+      //                     +- Exchange
+      //                        +- Filter
+      //                           +- ColumnarToRow
+      //                              +- FileScan
+      checkBloomFilterPredicate(df, true, false, !adaptiveExecutionOn)
+    }
+  }
+}
+
+class InjectRuntimeFilterReuseSuiteAEOff extends InjectRuntimeFilterReuseSuite {
+  override val adaptiveExecutionOn: Boolean = false
+}
+
+class InjectRuntimeFilterReuseSuiteAEOn extends InjectRuntimeFilterReuseSuite {
+  override val adaptiveExecutionOn: Boolean = true
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterReuseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterReuseSuite.scala
@@ -233,15 +233,10 @@ abstract class InjectRuntimeFilterReuseSuite
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1",
       SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "10000") {
       val df = sql("""
-          |SELECT t11.a,
-          |       t11.b
-          |FROM   (SELECT t1.a,
-          |               t2.b
-          |        FROM t1
-          |        JOIN t2
-          |            ON t1.a = t2.a AND t2.b < 10) t11
-          |       JOIN t3
-          |         ON t11.a = t3.a AND t3.b < 6
+          |SELECT t1.a, t2.b
+          |FROM t1
+          |JOIN t2
+          |ON t1.a = t2.a AND t2.b < 10
           |""".stripMargin)
       checkBloomFilterPredicate(df, true)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterReuseSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterReuseSuite.scala
@@ -180,7 +180,6 @@ abstract class InjectRuntimeFilterReuseSuite
   def checkBloomFilterPredicate(
                                  df: DataFrame,
                                  hasBloomFilter: Boolean,
-                                 hadBroadcastBloom: Boolean,
                                  reuseExpected: Boolean = true): Unit = {
     df.collect()
 
@@ -244,7 +243,7 @@ abstract class InjectRuntimeFilterReuseSuite
           |       JOIN t3
           |         ON t11.a = t3.a AND t3.b < 6
           |""".stripMargin)
-      checkBloomFilterPredicate(df, true, false)
+      checkBloomFilterPredicate(df, true)
     }
   }
 
@@ -265,7 +264,7 @@ abstract class InjectRuntimeFilterReuseSuite
           |WHERE coalesce(t3new.sumb, 0) > 0
           |""".stripMargin)
 
-      checkBloomFilterPredicate(df, false, false)
+      checkBloomFilterPredicate(df, false)
       val trueNode = find(df.queryExecution.executedPlan) {
         case fe: FilterExec => fe.condition.containsChild.contains(Literal.TrueLiteral)
         case _ => false
@@ -293,7 +292,7 @@ abstract class InjectRuntimeFilterReuseSuite
           |         ON t11.a = t3.a
           |""".stripMargin)
 
-      checkBloomFilterPredicate(df, false, false)
+      checkBloomFilterPredicate(df, false)
     }
   }
 
@@ -398,7 +397,7 @@ abstract class InjectRuntimeFilterReuseSuite
       //                        +- Filter
       //                           +- ColumnarToRow
       //                              +- FileScan
-      checkBloomFilterPredicate(df, true, false, !adaptiveExecutionOn)
+      checkBloomFilterPredicate(df, true, !adaptiveExecutionOn)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently we allow only a specific pattern in bloom creation side plan (consecutive Filter/Project/Scan nodes) with added column pruning. This is fine when bloom was added due to a BroadcastHashJoin as exchange side would be small and we can do extra scan while creating bloom. 
But when Bloom is introduced through SortMergeJoin (Shuffle Join) the exchange can be bigger, and extra scan and other operators can incur cost. In this case we can take advantage of reusing the whole Exchange while creating bloom. 
This can further allow complex plans in bloom creation plan as there won't be extra cost of running them twice.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Add Reusable exchange on Bloom creation side plan to improve query performance.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests
