### PR TITLE
[SPARK-40560][SQL] Rename `message` to `messageTemplate` in the `STANDARD` format of errors

### DIFF
--- a/core/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
+++ b/core/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala
@@ -74,12 +74,12 @@ class ErrorClassesJsonReader(jsonFileURLs: Seq[URL]) {
     assert(errorInfo.subClass.isDefined == subErrorClass.isDefined)
 
     if (subErrorClass.isEmpty) {
-      errorInfo.messageFormat
+      errorInfo.messageTemplate
     } else {
       val errorSubInfo = errorInfo.subClass.get.getOrElse(
         subErrorClass.get,
         throw SparkException.internalError(s"Cannot find sub error class '$errorClass'"))
-      errorInfo.messageFormat + " " + errorSubInfo.messageFormat
+      errorInfo.messageTemplate + " " + errorSubInfo.messageTemplate
     }
   }
 
@@ -102,7 +102,7 @@ private case class ErrorInfo(
     sqlState: Option[String]) {
   // For compatibility with multi-line error messages
   @JsonIgnore
-  val messageFormat: String = message.mkString("\n")
+  val messageTemplate: String = message.mkString("\n")
 }
 
 /**
@@ -114,5 +114,5 @@ private case class ErrorInfo(
 private case class ErrorSubInfo(message: Seq[String]) {
   // For compatibility with multi-line error messages
   @JsonIgnore
-  val messageFormat: String = message.mkString("\n")
+  val messageTemplate: String = message.mkString("\n")
 }

--- a/core/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/core/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -181,7 +181,7 @@ private[spark] object SparkThrowableHelper {
           if (format == STANDARD) {
             val errorInfo = errorClassToInfoMap.getOrElse(errorClass,
               throw SparkException.internalError(s"Cannot find the error class '$errorClass'"))
-            g.writeStringField("message", errorInfo.messageFormat)
+            g.writeStringField("messageFormat", errorInfo.messageFormat)
           }
           val sqlState = e.getSqlState
           if (sqlState != null) g.writeStringField("sqlState", sqlState)

--- a/core/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/core/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -92,7 +92,7 @@ private[spark] object SparkThrowableHelper {
           if (errorSubClass != null) g.writeStringField("errorSubClass", errorSubClass)
           if (format == STANDARD) {
             val finalClass = errorClass + Option(errorSubClass).map("." + _).getOrElse("")
-            g.writeStringField("messageFormat", errorReader.getMessageTemplate(finalClass))
+            g.writeStringField("messageTemplate", errorReader.getMessageTemplate(finalClass))
           }
           val sqlState = e.getSqlState
           if (sqlState != null) g.writeStringField("sqlState", sqlState)

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -280,7 +280,7 @@ class SparkThrowableSuite extends SparkFunSuite {
     assert(SparkThrowableHelper.getMessage(e, STANDARD) ===
       """{
         |  "errorClass" : "DIVIDE_BY_ZERO",
-        |  "message" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
+        |  "messageFormat" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
         |  "sqlState" : "22012",
         |  "messageParameters" : {
         |    "config" : "CONFIG"
@@ -302,7 +302,7 @@ class SparkThrowableSuite extends SparkFunSuite {
       """{
         |  "errorClass" : "UNSUPPORTED_SAVE_MODE",
         |  "errorSubClass" : "EXISTENT_PATH",
-        |  "message" : "The save mode <saveMode> is not supported for:",
+        |  "messageFormat" : "The save mode <saveMode> is not supported for:",
         |  "messageParameters" : {
         |    "saveMode" : "UNSUPPORTED_MODE"
         |  }

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -128,7 +128,7 @@ class SparkThrowableSuite extends SparkFunSuite {
   test("Message format invariants") {
     val messageFormats = errorReader.errorInfoMap
       .filterKeys(!_.startsWith("_LEGACY_ERROR_TEMP_"))
-      .values.toSeq.flatMap { i => Seq(i.messageFormat) }
+      .values.toSeq.flatMap { i => Seq(i.messageTemplate) }
     checkCondition(messageFormats, s => s != null)
     checkIfUnique(messageFormats)
   }
@@ -282,7 +282,7 @@ class SparkThrowableSuite extends SparkFunSuite {
     assert(SparkThrowableHelper.getMessage(e, STANDARD) ===
       """{
         |  "errorClass" : "DIVIDE_BY_ZERO",
-        |  "messageFormat" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
+        |  "messageTemplate" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
         |  "sqlState" : "22012",
         |  "messageParameters" : {
         |    "config" : "CONFIG"
@@ -304,7 +304,7 @@ class SparkThrowableSuite extends SparkFunSuite {
       """{
         |  "errorClass" : "UNSUPPORTED_SAVE_MODE",
         |  "errorSubClass" : "EXISTENT_PATH",
-        |  "messageFormat" : "The save mode <saveMode> is not supported for: an existent path.",
+        |  "messageTemplate" : "The save mode <saveMode> is not supported for: an existent path.",
         |  "messageParameters" : {
         |    "saveMode" : "UNSUPPORTED_MODE"
         |  }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -755,7 +755,7 @@ class CliSuite extends SparkFunSuite {
         errorMessage =
           """{
             |  "errorClass" : "DIVIDE_BY_ZERO",
-            |  "messageFormat" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
+            |  "messageTemplate" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
             |  "sqlState" : "22012",
             |  "messageParameters" : {
             |    "config" : "\"spark.sql.ansi.enabled\""

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -755,7 +755,7 @@ class CliSuite extends SparkFunSuite {
         errorMessage =
           """{
             |  "errorClass" : "DIVIDE_BY_ZERO",
-            |  "message" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
+            |  "messageFormat" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
             |  "sqlState" : "22012",
             |  "messageParameters" : {
             |    "config" : "\"spark.sql.ansi.enabled\""

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -191,7 +191,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
       assert(e3.getMessage ===
         """{
           |  "errorClass" : "DIVIDE_BY_ZERO",
-          |  "messageFormat" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
+          |  "messageTemplate" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
           |  "sqlState" : "22012",
           |  "messageParameters" : {
           |    "config" : "\"spark.sql.ansi.enabled\""

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -191,7 +191,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
       assert(e3.getMessage ===
         """{
           |  "errorClass" : "DIVIDE_BY_ZERO",
-          |  "message" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
+          |  "messageFormat" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
           |  "sqlState" : "22012",
           |  "messageParameters" : {
           |    "config" : "\"spark.sql.ansi.enabled\""


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the `STANDARD` format of error messages, rename the `message` field to `messageTemplate`.

### Why are the changes needed?
Because the field contains a template of an error message, actually.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "core/testOnly *SparkThrowableSuite"
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly org.apache.spark.sql.hive.thriftserver.CliSuite"
$ build/sbt -Phive -Phive-thriftserver "test:testOnly *ThriftServerWithSparkContextInBinarySuite"
```