### PR TITLE
[SPARK-40536][CONNECT] Make Spark Connect port configurable

### DIFF
--- a/connect/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connect/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -14,20 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.spark.sql.connect.config
 
-package org.apache.spark.internal.config
+import org.apache.spark.internal.config.ConfigBuilder
 
-private[spark] object Connect {
-
-  private[spark] val CONNECT_GRPC_DEBUG_MODE =
-    ConfigBuilder("spark.connect.grpc.debug.enabled")
-      .version("3.4.0")
-      .booleanConf
-      .createOptional
+object Connect {
 
   private[spark] val CONNECT_GRPC_BINDING_PORT =
     ConfigBuilder("spark.connect.grpc.binding.port")
       .version("3.4.0")
       .intConf
       .createWithDefault(15002)
+
 }

--- a/connect/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connect/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -18,9 +18,9 @@ package org.apache.spark.sql.connect.config
 
 import org.apache.spark.internal.config.ConfigBuilder
 
-object Connect {
+private[spark] object Connect {
 
-  private[spark] val CONNECT_GRPC_BINDING_PORT =
+  val CONNECT_GRPC_BINDING_PORT =
     ConfigBuilder("spark.connect.grpc.binding.port")
       .version("3.4.0")
       .intConf

--- a/connect/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connect/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -34,6 +34,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AnalyzeResponse, Request, Response, SparkConnectServiceGrpc}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.connect.config.Connect.CONNECT_GRPC_BINDING_PORT
 import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 import org.apache.spark.sql.execution.ExtendedMode
 
@@ -185,11 +186,10 @@ object SparkConnectService {
   /**
    * Starts the GRPC Serivce.
    *
-   * TODO(SPARK-40536) Make port number configurable.
    */
   def startGRPCService(): Unit = {
     val debugMode = SparkEnv.get.conf.getBoolean("spark.connect.grpc.debug.enabled", true)
-    val port = SparkEnv.get.conf.getInt("spark.connect.grpc.binding.port", 15002)
+    val port = SparkEnv.get.conf.getInt(CONNECT_GRPC_BINDING_PORT.key, 15002)
     val sb = NettyServerBuilder
       .forPort(port)
       .addService(new SparkConnectService(debugMode))

--- a/connect/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connect/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -189,7 +189,7 @@ object SparkConnectService {
    */
   def startGRPCService(): Unit = {
     val debugMode = SparkEnv.get.conf.getBoolean("spark.connect.grpc.debug.enabled", true)
-    val port = 15002
+    val port = SparkEnv.get.conf.getInt("spark.connect.grpc.binding.port", 15002)
     val sb = NettyServerBuilder
       .forPort(port)
       .addService(new SparkConnectService(debugMode))

--- a/connect/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connect/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -189,7 +189,7 @@ object SparkConnectService {
    */
   def startGRPCService(): Unit = {
     val debugMode = SparkEnv.get.conf.getBoolean("spark.connect.grpc.debug.enabled", true)
-    val port = SparkEnv.get.conf.getInt(CONNECT_GRPC_BINDING_PORT.key, 15002)
+    val port = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_PORT)
     val sb = NettyServerBuilder
       .forPort(port)
       .addService(new SparkConnectService(debugMode))

--- a/core/src/main/scala/org/apache/spark/internal/config/Connect.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Connect.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.config
+
+private[spark] object Connect {
+
+  private[spark] val CONNECT_GRPC_DEBUG_MODE =
+    ConfigBuilder("spark.connect.grpc.debug.enabled")
+      .version("3.4.0")
+      .booleanConf
+      .createOptional
+
+  private[spark] val CONNECT_GRPC_BINDING_PORT =
+    ConfigBuilder("spark.connect.grpc.binding.port")
+      .version("3.4.0")
+      .intConf
+      .createWithDefault(15002)
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add `Connect` config and one connect gRPC config keys: `spark.connect.grpc.binding.port` as Int type.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->

Currently Spark Connect gRPC port is hardcoded and we can make it configurable. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT
