### PR TITLE
[SPARK-40566][SQL] Add showIndex function

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -216,6 +216,7 @@ statement
         LEFT_PAREN columns=multipartIdentifierPropertyList RIGHT_PAREN
         (OPTIONS options=propertyList)?                                #createIndex
     | DROP INDEX (IF EXISTS)? identifier ON TABLE? multipartIdentifier #dropIndex
+    | SHOW (INDEX|INDEXES) (FROM|ON|IN) TABLE? multipartIdentifier     #showIndex
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
     ;
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4617,6 +4617,18 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
       ctx.EXISTS != null)
   }
 
+  /**
+   * Show indexes, returning a [[ShowIndex]] logical plan.
+   * For example:
+   * {{{
+   *   SHOW INDEX ON [TABLE] table_name
+   * }}}
+   */
+  override def visitShowIndex(ctx: ShowIndexContext): LogicalPlan = withOrigin(ctx) {
+    ShowIndex(
+      createUnresolvedTable(ctx.multipartIdentifier(), "SHOW INDEX"))
+  }
+
   private def alterViewTypeMismatchHint: Option[String] = Some("Please use ALTER TABLE instead.")
 
   private def alterTableTypeMismatchHint: Option[String] = Some("Please use ALTER VIEW instead.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.write.{RowLevelOperation, RowLevelOperationTable, Write}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.types.{BooleanType, DataType, MetadataBuilder, StringType, StructType}
+import org.apache.spark.sql.types.{ArrayType, BooleanType, DataType, MapType, MetadataBuilder, StringType, StructType}
 
 /**
  * Base trait for DataSourceV2 write commands
@@ -1208,6 +1208,27 @@ case class DropIndex(
     ignoreIfNotExists: Boolean) extends UnaryCommand {
   override def child: LogicalPlan = table
   override protected def withNewChildInternal(newChild: LogicalPlan): DropIndex =
+    copy(table = newChild)
+}
+
+object ShowIndex {
+  def getOutputAttrs: Seq[Attribute] = Seq(
+    AttributeReference("Index Name", StringType, nullable = false)(),
+    AttributeReference("Index Type", StringType, nullable = false)(),
+    AttributeReference("Columns", ArrayType.apply(StringType), nullable = false)(),
+    AttributeReference("Column Properties", MapType.apply(StringType, StringType),
+      nullable = false)(),
+    AttributeReference("Properties", MapType.apply(StringType, StringType), nullable = false)())
+}
+
+/**
+ * The logical plan of the SHOW INDEX command.
+ */
+case class ShowIndex(
+    table: LogicalPlan,
+    override val output: Seq[Attribute] = ShowIndex.getOutputAttrs) extends UnaryCommand {
+  override def child: LogicalPlan = table
+  override protected def withNewChildInternal(newChild: LogicalPlan): ShowIndex =
     copy(table = newChild)
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1928,6 +1928,14 @@ class DDLParserSuite extends AnalysisTest {
       DropIndex(UnresolvedTable(Seq("a", "b", "c"), "DROP INDEX", None), "i1", true))
   }
 
+  test("SHOW INDEX") {
+    parseCompare("SHOW INDEX ON a.b.c",
+      ShowIndex(UnresolvedTable(Seq("a", "b", "c"), "SHOW INDEX", None), ShowIndex.getOutputAttrs))
+
+    parseCompare("SHOW INDEXES FROM TABLE a.b.c",
+      ShowIndex(UnresolvedTable(Seq("a", "b", "c"), "SHOW INDEX", None), ShowIndex.getOutputAttrs))
+  }
+
   private case class TableSpec(
       name: Seq[String],
       schema: Option[StructType],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -494,6 +494,14 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
           s"DropIndex is not supported in this table ${table.name}.")
       }
 
+    case ShowIndex(ResolvedTable(_, _, table, _), output) =>
+      table match {
+        case s: SupportsIndex =>
+          ShowIndexExec(output, s) :: Nil
+        case _ => throw QueryCompilationErrors.tableIndexNotSupportedError(
+          s"ShowIndex is not supported in this table ${table.name}.")
+      }
+
     case ShowFunctions(ResolvedNamespace(catalog, ns), userScope, systemScope, pattern, output) =>
       ShowFunctionsExec(
         output,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexExec.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.index.SupportsIndex
+import org.apache.spark.sql.execution.LeafExecNode
+
+/**
+ * Physical plan node for show indexes.
+ */
+case class ShowIndexExec(output: Seq[Attribute],
+    table: SupportsIndex) extends V2CommandExec with LeafExecNode {
+
+  override protected def run(): Seq[InternalRow] = {
+    val rows = new ArrayBuffer[InternalRow]()
+    table.listIndexes().foreach(tableIndex =>
+      rows += toCatalystRow(tableIndex.indexName(),
+        tableIndex.indexType(),
+        tableIndex.columns().map(x => x.fieldNames().mkString(",")),
+        tableIndex.columnProperties().asScala.toMap,
+        tableIndex.properties().asScala.toMap))
+
+    rows.toSeq
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -2635,6 +2635,10 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     val tableIndex = indexes2.head
     assert(tableIndex.indexName() == "people_index")
 
+
+    val df = sql(s"SHOW INDEX ON TABLE h2.test.people")
+    checkAnswer(df, Seq(Row("people_index", "INDEX", Array("ID"), Map(), Map())))
+
     sql(s"DROP INDEX people_index ON TABLE h2.test.people")
     assert(jdbcTable.indexExists("people_index") == false)
     val indexes3 = jdbcTable.listIndexes()

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -1421,7 +1421,6 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
   test("some show commands are not supported") {
     assertUnsupportedFeature { sql("SHOW COMPACTIONS") }
     assertUnsupportedFeature { sql("SHOW TRANSACTIONS") }
-    assertUnsupportedFeature { sql("SHOW INDEXES ON my_table") }
     assertUnsupportedFeature { sql("SHOW LOCKS my_table") }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
I create an index  for a table.I want to know what indexes are in the table. But SHOW INDEX syntax is not supported. So I think the SHOW INDEX syntax should be added in the Spark code. Please let me know if you have any thoughts.

This PR adds `SHOW INDEX` syntax, and realize its function.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The `CREATE INDEX` syntax has been supported. Now I think we should provide the API to check what indexes  in the table.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes,  add new SQL syntax
```
SHOW [INDEX | INDEXES] [FROM | ON | IN] tbl_name
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tests will be added.