### PR TITLE
[SPARK-40574][DOCS] Enhance DROP TABLE documentation

### DIFF
--- a/docs/sql-ref-syntax-ddl-drop-table.md
+++ b/docs/sql-ref-syntax-ddl-drop-table.md
@@ -31,7 +31,7 @@ If the table is cached, the command uncaches the table and all its dependents.
 ### Syntax
 
 ```sql
-DROP TABLE [ IF EXISTS ] table_identifier
+DROP TABLE [ IF EXISTS ] table_identifier [ PURGE ]
 ```
 
 ### Parameter
@@ -45,6 +45,10 @@ DROP TABLE [ IF EXISTS ] table_identifier
     Specifies the table name to be dropped. The table name may be optionally qualified with a database name.
 
     **Syntax:** `[ database_name. ] table_name`
+
+* **PURGE**
+
+    If specified, completely purge the table skipping trash while dropping table(Note: PURGE available in Hive Metastore 0.14.0 and later).
 
 ### Examples
 
@@ -64,6 +68,9 @@ Error: org.apache.spark.sql.AnalysisException: Table or view not found: employee
 -- Assumes a table named `employeetable` does not exist,Try with IF EXISTS
 -- this time it will not throw exception
 DROP TABLE IF EXISTS employeetable;
+
+-- Completely purge the table skipping trash.
+DROP TABLE employeetable PURGE;
 ```
 
 ### Related Statements


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `PURGE` in `DROP TABLE` documentation.

Related documentation and code:
1. Hive `DROP TABLE` documentation:
    https://cwiki.apache.org/confluence/display/hive/languagemanual+ddl
    <img width="877" alt="image" src="https://user-images.githubusercontent.com/5399861/192425153-63ac5373-dd34-48b3-864c-324cf5ba5db9.png">
2. Hive code:
    https://github.com/apache/hive/blob/rel/release-2.3.9/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L1185-L1209
3. Spark code:
    https://github.com/apache/spark/blob/v3.3.0/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala#L1317-L1327

### Why are the changes needed?

Enhance documentation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

manual test.
