### PR TITLE
[SPARK-40509][SS][PYTHON] Add example for applyInPandasWithState

### DIFF
--- a/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
+++ b/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
@@ -59,8 +59,6 @@ if __name__ == "__main__":
         "StructuredNetworkWordCountSessionWindow"
     ).getOrCreate()
 
-    spark.sparkContext.setLogLevel("WARN")
-
     # Create DataFrame representing the stream of input lines from connection to host:port
     lines = (
         spark.readStream.format("socket")

--- a/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
+++ b/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
@@ -16,7 +16,7 @@
 #
 
 r"""
- split lines into words, group by words and use the state per key to track session of each key.
+ Split lines into words, group by words and use the state per key to track session of each key.
 
  Usage: structured_network_wordcount_windowed.py <hostname> <port>
  <hostname> and <port> describe the TCP server that Structured Streaming
@@ -31,6 +31,9 @@ r"""
 """
 import sys
 import math
+from typing import Iterable, Any
+
+import pandas as pd
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import explode
@@ -42,8 +45,6 @@ from pyspark.sql.types import (
     StructField,
 )
 from pyspark.sql.streaming.state import GroupStateTimeout, GroupState
-import pandas as pd
-from typing import Iterable, Any
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
@@ -69,8 +70,7 @@ if __name__ == "__main__":
         .load()
     )
 
-    # Split the lines into words, retaining timestamps
-    # split() splits each line into an array, and explode() turns the array into multiple rows
+    # Split the lines into words, retaining timestamps, each word become a sessionId
     events = lines.select(
         explode(split(lines.value, " ")).alias("sessionId"),
         lines.timestamp.cast("long"),

--- a/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
+++ b/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
@@ -1,0 +1,116 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+r"""
+ Counts words in UTF8 encoded, '\n' delimited text received from the network over a
+ sliding window of configurable duration. Each line from the network is tagged
+ with a timestamp that is used to determine the windows into which it falls.
+
+ Usage: structured_network_wordcount_windowed.py <hostname> <port>
+ <hostname> and <port> describe the TCP server that Structured Streaming
+ would connect to receive data.
+
+ To run this on your local machine, you need to first run a Netcat server
+    `$ nc -lk 9999`
+ and then run the example
+    `$ bin/spark-submit
+    examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
+    localhost 9999`
+"""
+import sys
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import explode
+from pyspark.sql.functions import split
+from pyspark.sql.functions import window
+from pyspark.sql.types import (
+    LongType,
+    StringType,
+    StructType,
+    StructField,
+    Row,
+)
+from pyspark.sql.streaming.state import GroupStateTimeout, GroupState
+import pandas as pd
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        msg = ("Usage: structured_network_wordcount_session_window.py <hostname> <port>")
+        print(msg, file=sys.stderr)
+        sys.exit(-1)
+
+    host = sys.argv[1]
+    port = int(sys.argv[2])
+
+    spark = SparkSession\
+        .builder\
+        .appName("StructuredNetworkWordCountSessionWindow")\
+        .getOrCreate()
+
+    spark.sparkContext.setLogLevel("WARN")
+
+    # Create DataFrame representing the stream of input lines from connection to host:port
+    lines = spark\
+        .readStream\
+        .format('socket')\
+        .option('host', host)\
+        .option('port', port)\
+        .option('includeTimestamp', 'true')\
+        .load()
+
+    # Split the lines into words, retaining timestamps
+    # split() splits each line into an array, and explode() turns the array into multiple rows
+    events = lines.select(
+        explode(split(lines.value, ' ')).alias('sessionId'),
+        lines.timestamp.cast("long")
+    )
+
+    session_type = StructType(
+    [StructField("sessionId", StringType()), StructField("count", LongType()),
+    StructField("start", LongType()), StructField("end", LongType())]
+    )
+
+    def func(key, pdf_iter, state):
+        if state.hasTimedOut:
+            finished_session = state.get
+            state.remove()
+            yield pd.DataFrame({"sessionId": [finished_session[0]], "count": [finished_session[1]], "start": [finished_session[2]], "end": [finished_session[3]]})
+        else:
+            pdfs = list(pdf_iter)
+            count = sum(len(pdf) for pdf in pdfs)
+            start = min(min(pdf['timestamp']) for pdf in pdfs)
+            end = max(max(pdf['timestamp']) for pdf in pdfs)
+            if state.exists:
+                old_session = state.get
+                count = count + old_session[1]
+                start = old_session[2]
+                end = max(end, old_session[3])
+            state.update((key[0], count, start, end))
+            state.setTimeoutDuration(30000)
+            yield pd.DataFrame({"sessionId": [], "count": [], "start": [], "end": []})
+
+    # Group the data by window and word and compute the count of each group
+    sessions = events.groupBy(events["sessionId"]).applyInPandasWithState(func, session_type, session_type, "Update", GroupStateTimeout.ProcessingTimeTimeout)
+
+    # Start running the query that prints the windowed word counts to the console
+    query = sessions\
+        .writeStream\
+        .outputMode('update')\
+        .format('console')\
+        .start()
+
+    query.awaitTermination()

--- a/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
+++ b/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
@@ -16,9 +16,7 @@
 #
 
 r"""
- Counts words in UTF8 encoded, '\n' delimited text received from the network over a
- sliding window of configurable duration. Each line from the network is tagged
- with a timestamp that is used to determine the windows into which it falls.
+ split lines into words, group by words as key and use the state per key to track session of each key.
 
  Usage: structured_network_wordcount_windowed.py <hostname> <port>
  <hostname> and <port> describe the TCP server that Structured Streaming

--- a/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
+++ b/examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
@@ -43,7 +43,7 @@ from pyspark.sql.types import (
 )
 from pyspark.sql.streaming.state import GroupStateTimeout, GroupState
 import pandas as pd
-from typing import Iterator
+from typing import Iterable, Any
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
@@ -83,8 +83,8 @@ if __name__ == "__main__":
     ]
 
     def func(
-        key: tuple, pdf_iter: Iterator[pd.DataFrame], state: GroupState
-    ) -> Iterator[pd.DataFrame]:
+        key: Any, pdf_iter: Iterable[pd.DataFrame], state: GroupState
+    ) -> Iterable[pd.DataFrame]:
         if state.hasTimedOut:
             count, start, end = state.get
             state.remove()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
An example for applyInPandasWithState usage. This example split lines into words, group by words as key and use the state per key to track session of each key.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
To demonstrate the usage of applyInPandasWithState
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
This is an example that can be run manually.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
 To run this on your local machine, you need to first run a Netcat server
    `$ nc -lk 9999`
 and then run the example
    `$ bin/spark-submit
    examples/src/main/python/sql/streaming/structured_network_wordcount_session_window.py
    localhost 9999`