### PR TITLE
[SPARK-39877][FOLLOW-UP] PySpark DataFrame.unpivot allows for column names only

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3064,8 +3064,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
     def unpivot(
         self,
-        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
-        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
+        ids: Optional[Union[str, List[str], Tuple[str, ...]]],
+        values: Optional[Union[str, List[str], Tuple[str, ...]]],
         variableColumnName: str,
         valueColumnName: str,
     ) -> "DataFrame":
@@ -3091,12 +3091,12 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Parameters
         ----------
-        ids : str, Column, tuple, list, optional
-            Column(s) to use as identifiers. Can be a single column or column name,
-            or a list or tuple for multiple columns.
-        values : str, Column, tuple, list, optional
-            Column(s) to unpivot. Can be a single column or column name, or a list or tuple
-            for multiple columns. If not specified or empty, uses all columns that
+        ids : str, list, tuple, optional
+            Column name(s) to use as identifiers. Can be a single column name,
+            or a list or tuple for multiple column names.
+        values : str, list, tuple, optional
+            Column name(s) to unpivot. Can be a single column name, or a list or tuple
+            for multiple column names. If not specified or empty, uses all columns that
             are not set as `ids`.
         variableColumnName : str
             Name of the variable column.
@@ -3138,7 +3138,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
 
         def to_jcols(
-            cols: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]]
+            cols: Optional[Union[str, List[str], Tuple[str, ...]]]
         ) -> JavaObject:
             if cols is None:
                 lst = []
@@ -3148,6 +3148,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                 lst = cols
             else:
                 lst = [cols]
+
+            assert all([isinstance(col, str) for col in lst]), "columns names must be strings"
             return self._jcols(*lst)
 
         return DataFrame(
@@ -3159,8 +3161,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
     def melt(
         self,
-        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
-        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
+        ids: Optional[Union[str, List[str], Tuple[str, ...]]],
+        values: Optional[Union[str, List[str], Tuple[str, ...]]],
         variableColumnName: str,
         valueColumnName: str,
     ) -> "DataFrame":
@@ -3175,12 +3177,12 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Parameters
         ----------
-        ids : str, Column, tuple, list, optional
-            Column(s) to use as identifiers. Can be a single column or column name,
-            or a list or tuple for multiple columns.
-        values : str, Column, tuple, list, optional
-            Column(s) to unpivot. Can be a single column or column name, or a list or tuple
-            for multiple columns. If not specified or empty, uses all columns that
+        ids : str, list, tuple, optional
+            Column name(s) to use as identifiers. Can be a single column name,
+            or a list or tuple for multiple column names.
+        values : str, list, tuple, optional
+            Column name(s) to unpivot. Can be a single column name, or a list or tuple
+            for multiple column names. If not specified or empty, uses all columns that
             are not set as `ids`.
         variableColumnName : str
             Name of the variable column.

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -664,23 +664,12 @@ class DataFrameTests(ReusedSQLTestCase):
             ):
                 df.unpivot("id", ["int", "str"], "var", "val")
 
-        with self.subTest(desc="with columns"):
-            for id in [df.id, [df.id], (df.id,)]:
-                for values in [[df.int, df.double], (df.int, df.double)]:
-                    with self.subTest(ids=id, values=values):
-                        self.assertEqual(
-                            df.unpivot(id, values, "var", "val").collect(),
-                            df.unpivot("id", ["int", "double"], "var", "val").collect(),
-                        )
-
         with self.subTest(desc="with column names and columns"):
             for ids in [[df.id, "str"], (df.id, "str")]:
                 for values in [[df.int, "double"], (df.int, "double")]:
                     with self.subTest(ids=ids, values=values):
-                        self.assertEqual(
-                            df.unpivot(ids, values, "var", "val").collect(),
-                            df.unpivot(["id", "str"], ["int", "double"], "var", "val").collect(),
-                        )
+                        with self.assertRaisesRegex(AssertionError, "columns names must be strings"):
+                            df.unpivot(ids, values, "var", "val")
 
         with self.subTest(desc="melt alias"):
             self.assertEqual(


### PR DESCRIPTION
### What changes were proposed in this pull request?
As discussed in https://github.com/apache/spark/pull/37407#discussion_r977818035, method `pyspark.sql.DataFrame.unpivot` should support only column names for `ids` and `values` arguments, to mirror PySpark `GroupedData.pivot`.

### Why are the changes needed?
Simplify and align API with existing PySpark SQL methods.

### Does this PR introduce _any_ user-facing change?
Yes, modifies signature of `pyspark.sql.DataFrame.unpivot`, which has not been released yet.

### How was this patch tested?
Tests `unpivot` with non-string arguments.