### PR TITLE
[SPARK-40583][DOCS] Fixing artifactId name in `cloud-integration.md`

### DIFF
--- a/docs/cloud-integration.md
+++ b/docs/cloud-integration.md
@@ -105,7 +105,7 @@ is set to the chosen version of Spark:
   ...
   <dependency>
     <groupId>org.apache.spark</groupId>
-    <artifactId>hadoop-cloud_{{site.SCALA_BINARY_VERSION}}</artifactId>
+    <artifactId>spark-hadoop-cloud_{{site.SCALA_BINARY_VERSION}}</artifactId>
     <version>${spark.version}</version>
     <scope>provided</scope>
   </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
I am changing the name of the artifactId that enables the integration with several cloud infrastructures.

### Why are the changes needed?
The name of the package is wrong and it does not exist.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
It is not needed.