### PR TITLE
[SPARK-40587][CONNECT] Support SELECT * in an explicit way in connect proto

### DIFF
--- a/connect/src/main/protobuf/spark/connect/expressions.proto
+++ b/connect/src/main/protobuf/spark/connect/expressions.proto
@@ -156,7 +156,7 @@ message Expression {
     string expression = 1;
   }
 
-  // represent * (e.g. SELECT *)
+  // UnresolvedStar is used to expand all the fields of a relation or struct.
   message UnresolvedStar {
   }
 }

--- a/connect/src/main/protobuf/spark/connect/expressions.proto
+++ b/connect/src/main/protobuf/spark/connect/expressions.proto
@@ -34,6 +34,7 @@ message Expression {
     UnresolvedAttribute unresolved_attribute = 2;
     UnresolvedFunction unresolved_function = 3;
     ExpressionString expression_string = 4;
+    UnresolvedStar unresolved_star = 5;
   }
 
   message Literal {
@@ -155,4 +156,7 @@ message Expression {
     string expression = 1;
   }
 
+  // represent * (e.g. SELECT *)
+  message UnresolvedStar {
+  }
 }

--- a/connect/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connect/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -96,7 +96,9 @@ class SparkConnectPlanner(plan: proto.Relation, session: SparkSession) {
       rel: proto.Project,
       common: Option[proto.RelationCommon]): LogicalPlan = {
     val baseRel = transformRelation(rel.getInput)
-    val projection = if (rel.getExpressionsCount == 0) {
+    // TODO: support the target field for *.
+    val projection =
+      if (rel.getExpressionsCount == 1&& rel.getExpressions(0).hasUnresolvedStar) {
       Seq(UnresolvedStar(Option.empty))
     } else {
       rel.getExpressionsList.asScala.map(transformExpression).map(UnresolvedAlias(_))

--- a/connect/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connect/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -98,7 +98,7 @@ class SparkConnectPlanner(plan: proto.Relation, session: SparkSession) {
     val baseRel = transformRelation(rel.getInput)
     // TODO: support the target field for *.
     val projection =
-      if (rel.getExpressionsCount == 1&& rel.getExpressions(0).hasUnresolvedStar) {
+      if (rel.getExpressionsCount == 1 && rel.getExpressions(0).hasUnresolvedStar) {
       Seq(UnresolvedStar(Option.empty))
     } else {
       rel.getExpressionsList.asScala.map(transformExpression).map(UnresolvedAlias(_))

--- a/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.{SparkFunSuite, TestUtils}
 import org.apache.spark.connect.proto
+import org.apache.spark.connect.proto.Expression.UnresolvedStar
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
@@ -94,6 +95,22 @@ class SparkConnectPlannerSuite extends SparkFunSuite with SparkConnectPlanTest {
     val res = transform(proto.Relation.newBuilder.setRead(readWithTable).build())
     assert(res !== null)
     assert(res.nodeName == "UnresolvedRelation")
+  }
+
+  test("Simple Project") {
+    val readWithTable = proto.Read.newBuilder()
+      .setNamedTable(proto.Read.NamedTable.newBuilder.addParts("name").build())
+      .build()
+    val project =
+      proto.Project.newBuilder()
+        .setInput(proto.Relation.newBuilder().setRead(readWithTable).build())
+        .addExpressions(
+          proto.Expression.newBuilder()
+            .setUnresolvedStar(UnresolvedStar.newBuilder().build()).build()
+        ).build()
+    val res = transform(proto.Relation.newBuilder.setProject(project).build())
+    assert(res !== null)
+    assert(res.nodeName == "Project")
   }
 
   test("Simple Sort") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support `SELECT *` in an explicit way by connect proto.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Current proto uses empty project list for `SELECT *`. However, this is an implicit way that it is hard to differentiate `not set` and `set but empty` (the latter is invalid plan). For longer term proto compatibility, we should always use explicit fields for passing through information.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT
