### PR TITLE
[SPARK-40591][CORE][SQL] Fix data loss caused by ignoreCorruptFiles

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1078,6 +1078,13 @@ package object config {
     .booleanConf
     .createWithDefault(false)
 
+  private[spark] val IGNORE_CORRUPT_FILES_AFTER_RETIES =
+    ConfigBuilder("spark.sql.files.ignoreCorruptFilesAfterRetries")
+      .doc("Max retries before a file is marked as corrupted. This configuration is effective " +
+        s"only when ${IGNORE_CORRUPT_FILES.key} is true")
+      .version("3.4.0")
+      .fallbackConf(TASK_MAX_FAILURES)
+
   private[spark] val IGNORE_MISSING_FILES = ConfigBuilder("spark.files.ignoreMissingFiles")
     .doc("Whether to ignore missing files. If true, the Spark jobs will continue to run when " +
       "encountering missing files and the contents that have been read will still be returned.")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1079,7 +1079,7 @@ package object config {
     .createWithDefault(false)
 
   private[spark] val IGNORE_CORRUPT_FILES_AFTER_RETIES =
-    ConfigBuilder("spark.sql.files.ignoreCorruptFilesAfterRetries")
+    ConfigBuilder("spark.files.ignoreCorruptFilesAfterRetries")
       .doc("Max retries before a file is marked as corrupted. This configuration is effective " +
         s"only when ${IGNORE_CORRUPT_FILES.key} is true")
       .version("3.4.0")

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -557,7 +557,9 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
       assert(e.getCause.getMessage === "Unexpected end of input stream")
       sc.stop()
 
-      val conf = new SparkConf().set(IGNORE_CORRUPT_FILES, true)
+      val conf = new SparkConf()
+        .set(IGNORE_CORRUPT_FILES, true)
+        .set(IGNORE_CORRUPT_FILES_AFTER_RETIES, 1)
       sc = new SparkContext("local", "test", conf)
       // Test HadoopRDD
       assert(sc.textFile(inputFile.toURI.toString).collect().isEmpty)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.catalyst
 
-import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_MISSING_FILES}
+import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_CORRUPT_FILES_AFTER_RETRIES, IGNORE_MISSING_FILES}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.internal.SQLConf
 
@@ -32,11 +32,16 @@ class FileSourceOptions(
   val ignoreCorruptFiles: Boolean = parameters.get(IGNORE_CORRUPT_FILES).map(_.toBoolean)
     .getOrElse(SQLConf.get.ignoreCorruptFiles)
 
+  val ignoreCorruptFilesAfterRetries: Int =
+    parameters.get(IGNORE_CORRUPT_FILES_AFTER_RETRIES).map(_.toInt)
+      .getOrElse(SQLConf.get.ignoreCorruptFilesAfterReties)
+
   val ignoreMissingFiles: Boolean = parameters.get(IGNORE_MISSING_FILES).map(_.toBoolean)
     .getOrElse(SQLConf.get.ignoreMissingFiles)
 }
 
 object FileSourceOptions {
   val IGNORE_CORRUPT_FILES = "ignoreCorruptFiles"
+  val IGNORE_CORRUPT_FILES_AFTER_RETRIES = "ignoreCorruptFilesAfterReties"
   val IGNORE_MISSING_FILES = "ignoreMissingFiles"
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1663,6 +1663,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val IGNORE_CORRUPT_FILES_AFTER_RETIES =
+    buildConf("spark.sql.files.ignoreCorruptFilesAfterRetries")
+      .doc("Max retries before a file is marked as corrupted. This configuration is effective " +
+        s"only when ${IGNORE_CORRUPT_FILES.key} is true and using file-based sources such as " +
+        s"Parquet, JSON and ORC.")
+      .version("3.4.0")
+      .fallbackConf(TASK_MAX_FAILURES)
+
   val IGNORE_MISSING_FILES = buildConf("spark.sql.files.ignoreMissingFiles")
     .doc("Whether to ignore missing files. If true, the Spark jobs will continue to run when " +
       "encountering missing files and the contents that have been read will still be returned. " +
@@ -4130,6 +4138,8 @@ class SQLConf extends Serializable with Logging {
   def filesOpenCostInBytes: Long = getConf(FILES_OPEN_COST_IN_BYTES)
 
   def filesMinPartitionNum: Option[Int] = getConf(FILES_MIN_PARTITION_NUM)
+
+  def ignoreCorruptFilesAfterReties: Int = getConf(IGNORE_CORRUPT_FILES_AFTER_RETIES)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1470,7 +1470,8 @@ abstract class CSVSuite
         assert(e.getCause.getCause.isInstanceOf[EOFException])
         assert(e.getCause.getCause.getMessage === "Unexpected end of input stream")
       }
-      withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
+      withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true",
+        SQLConf.IGNORE_CORRUPT_FILES_AFTER_RETIES.key -> "1") {
         assert(spark.read.csv(inputFile.toURI.toString).collect().isEmpty)
       }
     } finally {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Let's take a look at the case below, the left and the right are visiting the same table and its partitions, and both of them are ignoreCorruptFiles=true. The left side shows that a task skips partial of the data it reads because of encountering 'corrupt data', while the right read this file correctly. As ignoreCorruptFiles coarsely works with RuntimeException and IOException, it can not always represent a positive data corruption.

![image](https://user-images.githubusercontent.com/8326978/192667546-30d20739-a322-4618-8fb7-b0fa24301bcc.png)

What's worse, such kinds of tasks are always marked as successful on the web UI. The same query visiting the same snapshot of data might result in inconsistency silently.

In this PR, we make the ignoreCorruptFiles work with taskAttemptNumber together, that is, only the last attempt will ignore the maybe-corrupted file. Users may want fewer retries in case of performance regressions, so ignoreCorruptFilesAfterRetries is introduced which can be set to less than `spark.task.maxFailures`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix data loss.

Also, the UI now contains failed tasks for both positive and negative data corruption which helps us in bug hunting.


<img width="1467" alt="image" src="https://user-images.githubusercontent.com/8326978/192730245-70cc04d0-6887-40bc-b2ce-01690502cae7.png">


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, it's a bug fix (maybe a UI change like what I said above).

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


- packaged and tested locally,
- new uts,
- existing tests for ignoreCorruptFiles
