### PR TITLE
[MINOR][SQL] Skip warning if JOB_SUMMARY_LEVEL is set to NONE for ParquetWrite

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
@@ -94,7 +94,7 @@ case class ParquetWrite(
       conf.setEnum(ParquetOutputFormat.JOB_SUMMARY_LEVEL, JobSummaryLevel.NONE)
     }
 
-    if (ParquetOutputFormat.getJobSummaryLevel(conf) == JobSummaryLevel.NONE
+    if (ParquetOutputFormat.getJobSummaryLevel(conf) != JobSummaryLevel.NONE
       && !classOf[ParquetOutputCommitter].isAssignableFrom(committerClass)) {
       // output summary is requested, but the class is not a Parquet Committer
       logWarning(s"Committer $committerClass is not a ParquetOutputCommitter and cannot" +


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr do the similar change as https://github.com/apache/spark/pull/24808 for `ParquetWrite `




### Why are the changes needed?
The print log condition of Parquet V1 and Parquet V2 should be consistent




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
