### PR TITLE
[SPARK-40592][PS] Implement `min_count` in `GroupBy.max`

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -500,15 +500,22 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             accepted_spark_types=(NumericType, BooleanType) if numeric_only else None,
         )
 
-    def max(self, numeric_only: Optional[bool] = False) -> FrameLike:
+    def max(self, numeric_only: Optional[bool] = False, min_count: int = -1) -> FrameLike:
         """
         Compute max of group values.
+
+        .. versionadded:: 3.3.0
 
         Parameters
         ----------
         numeric_only : bool, default False
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data.
+
+            .. versionadded:: 3.4.0
+        min_count : bool, default -1
+            The required number of valid values to perform the operation. If fewer
+            than min_count non-NA values are present the result will be NA.
 
             .. versionadded:: 3.4.0
 
@@ -520,13 +527,13 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         Examples
         --------
         >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
-        ...                    "C": [3, 4, 3, 4], "D": ["a", "b", "b", "a"]})
+        ...                    "C": [3, 4, 3, 4], "D": ["a", "a", "b", "a"]})
 
         >>> df.groupby("A").max().sort_index()
               B  C  D
         A
         1  True  3  b
-        2  True  4  b
+        2  True  4  a
 
         Include only float, int, boolean columns when set numeric_only True.
 
@@ -535,9 +542,36 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         A
         1  True  3
         2  True  4
+
+        >>> df.groupby("D").max().sort_index()
+           A      B  C
+        D
+        a  2   True  4
+        b  1  False  3
+
+        >>> df.groupby("D").max(min_count=3).sort_index()
+             A     B    C
+        D
+        a  2.0  True  4.0
+        b  NaN  None  NaN
         """
+        if not isinstance(min_count, int):
+            raise TypeError("min_count must be integer")
+
+        if min_count > 0:
+
+            def max(col: Column) -> Column:
+                return F.when(
+                    F.count(F.when(~F.isnull(col), F.lit(0))) < min_count, F.lit(None)
+                ).otherwise(F.max(col))
+
+        else:
+
+            def max(col: Column) -> Column:
+                return F.max(col)
+
         return self._reduce_for_stat_function(
-            F.max, accepted_spark_types=(NumericType, BooleanType) if numeric_only else None
+            max, accepted_spark_types=(NumericType, BooleanType) if numeric_only else None
         )
 
     def mean(self, numeric_only: Optional[bool] = True) -> FrameLike:

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1408,8 +1408,10 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
 
     def test_max(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.max())
+        self._test_stat_func(lambda groupby_obj: groupby_obj.max(min_count=2))
         self._test_stat_func(lambda groupby_obj: groupby_obj.max(numeric_only=None))
         self._test_stat_func(lambda groupby_obj: groupby_obj.max(numeric_only=True))
+        self._test_stat_func(lambda groupby_obj: groupby_obj.max(numeric_only=True, min_count=2))
 
     def test_mad(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.mad())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `min_count` in `GroupBy.max`


### Why are the changes needed?
for API coverage


### Does this PR introduce _any_ user-facing change?
yes, new parameter

```
        >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
        ...                    "C": [3, 4, 3, 4], "D": ["a", "a", "b", "a"]})

        >>> df.groupby("D").max().sort_index()
           A      B  C
        D
        a  2   True  4
        b  1  False  3

        >>> df.groupby("D").max(min_count=3).sort_index()
             A     B    C
        D
        a  2.0  True  4.0
        b  NaN  None  NaN
```


### How was this patch tested?
added UT