### PR TITLE
[SPARK-40435][SQL][SS][TESTS][FOLLOWUP] Correct test precondition of `PythonUDFSuite` and `ContinuousSuite`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -234,20 +234,16 @@ case class ExpandExec(
     val i = ctx.freshName("i")
     // these column have to declared before the loop.
     val evaluate = evaluateVariables(outputColumns)
-    val margin =
-      s"""
-         |$evaluate
-         |for (int $i = 0; $i < ${projections.length}; $i ++) {
-         |  switch ($i) {
-         |    ${cases.mkString("\n").trim}
-         |  }
-         |  $numOutput.add(1);
-         |  ${consume(ctx, outputColumns)}
-         |}
+    s"""
+       |$evaluate
+       |for (int $i = 0; $i < ${projections.length}; $i ++) {
+       |  switch ($i) {
+       |    ${cases.mkString("\n").trim}
+       |  }
+       |  $numOutput.add(1);
+       |  ${consume(ctx, outputColumns)}
+       |}
      """.stripMargin
-    println("fuck:")
-    println(margin)
-    margin
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): ExpandExec =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -234,16 +234,20 @@ case class ExpandExec(
     val i = ctx.freshName("i")
     // these column have to declared before the loop.
     val evaluate = evaluateVariables(outputColumns)
-    s"""
-       |$evaluate
-       |for (int $i = 0; $i < ${projections.length}; $i ++) {
-       |  switch ($i) {
-       |    ${cases.mkString("\n").trim}
-       |  }
-       |  $numOutput.add(1);
-       |  ${consume(ctx, outputColumns)}
-       |}
+    val margin =
+      s"""
+         |$evaluate
+         |for (int $i = 0; $i < ${projections.length}; $i ++) {
+         |  switch ($i) {
+         |    ${cases.mkString("\n").trim}
+         |  }
+         |  $numOutput.add(1);
+         |  ${consume(ctx, outputColumns)}
+         |}
      """.stripMargin
+    println("fuck:")
+    println(margin)
+    margin
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): ExpandExec =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -73,7 +73,7 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-39962: Global aggregation of Pandas UDF should respect the column order") {
-    assume(shouldTestPythonUDFs)
+    assume(shouldTestPandasUDFs)
     val df = Seq[(java.lang.Integer, java.lang.Integer)]((1, null)).toDF("a", "b")
 
     val pandasTestUDF = TestGroupedAggPandasUDF(name = "pandas_udf")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -279,7 +279,7 @@ class ContinuousSuite extends ContinuousSuiteBase {
   Seq(TestScalaUDF("udf"), TestPythonUDF("udf"), TestScalarPandasUDF("udf")).foreach { udf =>
     test(s"continuous mode with various UDFs - ${udf.prettyName}") {
       assume(
-        shouldTestPythonUDFs && udf.isInstanceOf[TestScalarPandasUDF] ||
+        shouldTestPandasUDFs && udf.isInstanceOf[TestScalarPandasUDF] ||
         shouldTestPythonUDFs && udf.isInstanceOf[TestPythonUDF] ||
         udf.isInstanceOf[TestScalaUDF])
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/37894 changed the preconditions for the following two tests from `assume(shouldTestGroupedAggPandasUDFs)` to  `assume(shouldTestPythonUDFs)`:

- `SPARK-39962: Global aggregation of Pandas UDF should respect the column order` in `PythonUDFSuite`
- `continuous mode with various UDFs - Scalar Pandas UDF` in `ContinuousSuite`

but this change this change will cause test failure  if `pandas` is not installed, so this pr change the test preconditions from `assume(shouldTestPythonUDFs)` to `assume(shouldTestPandasUDFs)`.

### Why are the changes needed?
Fix test precondition of `PythonUDFSuite` and `ContinuousSuite`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions 
- Manual test, `pandas` is not installed:

```
build/sbt clean "sql/testOnly org.apache.spark.sql.execution.python.PythonUDFSuite"
build/sbt clean "sql/testOnly org.apache.spark.sql.streaming.continuous.ContinuousSuite"
```

**Before**

PythonUDFSuite
```
[info] - SPARK-39962: Global aggregation of Pandas UDF should respect the column order *** FAILED *** (799 milliseconds)
[info]   java.lang.RuntimeException: Python executable [python3] and/or pyspark are unavailable.
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$.pandasGroupedAggFunc$lzycompute(IntegratedUDFTestUtils.scala:236)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$.org$apache$spark$sql$IntegratedUDFTestUtils$$pandasGroupedAggFunc(IntegratedUDFTestUtils.scala:217)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$TestGroupedAggPandasUDF.udf$lzycompute(IntegratedUDFTestUtils.scala:433)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$TestGroupedAggPandasUDF.udf(IntegratedUDFTestUtils.scala:430)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$TestGroupedAggPandasUDF.apply(IntegratedUDFTestUtils.scala:444)
[info]   at org.apache.spark.sql.execution.python.PythonUDFSuite.$anonfun$new$9(PythonUDFSuite.scala:82)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
```

and 

ContinuousSuite
```
[info] - continuous mode with various UDFs - Scalar Pandas UDF *** FAILED *** (715 milliseconds)
[info]   java.lang.RuntimeException: Python executable [python3] and/or pyspark are unavailable.
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$.pandasFunc$lzycompute(IntegratedUDFTestUtils.scala:214)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$.org$apache$spark$sql$IntegratedUDFTestUtils$$pandasFunc(IntegratedUDFTestUtils.scala:194)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$TestScalarPandasUDF$$anon$2.<init>(IntegratedUDFTestUtils.scala:382)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$TestScalarPandasUDF.udf$lzycompute(IntegratedUDFTestUtils.scala:379)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$TestScalarPandasUDF.udf(IntegratedUDFTestUtils.scala:379)
[info]   at org.apache.spark.sql.IntegratedUDFTestUtils$TestScalarPandasUDF.apply(IntegratedUDFTestUtils.scala:404)
[info]   at org.apache.spark.sql.streaming.continuous.ContinuousSuite.$anonfun$new$24(ContinuousSuite.scala:289)
```

**After**

PythonUDFSuite
```
[info] Run completed in 11 seconds, 278 milliseconds.
[info] Total number of tests run: 4
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 4, failed 0, canceled 1, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 72 s (01:12), completed 2022-9-28 15:46:40
```
and

ContinuousSuite
```
[info] Run completed in 33 seconds, 197 milliseconds.
[info] Total number of tests run: 13
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 13, failed 0, canceled 1, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 64 s (01:04), completed 2022-9-28 15:49:45
```
