### PR TITLE
[SPARK-40598][PS] Fix plotting features work properly with pandas 1.5.0.

### DIFF
--- a/python/pyspark/pandas/plot/matplotlib.py
+++ b/python/pyspark/pandas/plot/matplotlib.py
@@ -50,6 +50,8 @@ _all_kinds = PlotAccessor._all_kinds  # type: ignore[attr-defined]
 
 
 class PandasOnSparkBarPlot(PandasBarPlot, TopNPlotBase):
+    _kind = "bar"
+
     def __init__(self, data, **kwargs):
         super().__init__(self.get_top_n(data), **kwargs)
 
@@ -59,6 +61,8 @@ class PandasOnSparkBarPlot(PandasBarPlot, TopNPlotBase):
 
 
 class PandasOnSparkBoxPlot(PandasBoxPlot, BoxPlotBase):
+    _kind = "box"
+
     def boxplot(
         self,
         ax,
@@ -354,6 +358,8 @@ class PandasOnSparkBoxPlot(PandasBoxPlot, BoxPlotBase):
 
 
 class PandasOnSparkHistPlot(PandasHistPlot, HistogramPlotBase):
+    _kind = "hist"
+
     def _args_adjust(self):
         if is_list_like(self.bottom):
             self.bottom = np.array(self.bottom)
@@ -413,6 +419,8 @@ class PandasOnSparkHistPlot(PandasHistPlot, HistogramPlotBase):
 
 
 class PandasOnSparkPiePlot(PandasPiePlot, TopNPlotBase):
+    _kind = "pie"
+
     def __init__(self, data, **kwargs):
         super().__init__(self.get_top_n(data), **kwargs)
 
@@ -422,6 +430,8 @@ class PandasOnSparkPiePlot(PandasPiePlot, TopNPlotBase):
 
 
 class PandasOnSparkAreaPlot(PandasAreaPlot, SampledPlotBase):
+    _kind = "area"
+
     def __init__(self, data, **kwargs):
         super().__init__(self.get_sampled(data), **kwargs)
 
@@ -431,6 +441,8 @@ class PandasOnSparkAreaPlot(PandasAreaPlot, SampledPlotBase):
 
 
 class PandasOnSparkLinePlot(PandasLinePlot, SampledPlotBase):
+    _kind = "line"
+
     def __init__(self, data, **kwargs):
         super().__init__(self.get_sampled(data), **kwargs)
 
@@ -440,6 +452,8 @@ class PandasOnSparkLinePlot(PandasLinePlot, SampledPlotBase):
 
 
 class PandasOnSparkBarhPlot(PandasBarhPlot, TopNPlotBase):
+    _kind = "barh"
+
     def __init__(self, data, **kwargs):
         super().__init__(self.get_top_n(data), **kwargs)
 
@@ -449,6 +463,8 @@ class PandasOnSparkBarhPlot(PandasBarhPlot, TopNPlotBase):
 
 
 class PandasOnSparkScatterPlot(PandasScatterPlot, TopNPlotBase):
+    _kind = "scatter"
+
     def __init__(self, data, x, y, **kwargs):
         super().__init__(self.get_top_n(data), x, y, **kwargs)
 
@@ -458,6 +474,8 @@ class PandasOnSparkScatterPlot(PandasScatterPlot, TopNPlotBase):
 
 
 class PandasOnSparkKdePlot(PandasKdePlot, KdePlotBase):
+    _kind = "kde"
+
     def _compute_plot_data(self):
         self.data = KdePlotBase.prepare_kde_data(self.data)
 
@@ -707,7 +725,7 @@ def plot_frame(
     y=None,
     kind="line",
     ax=None,
-    subplots=None,
+    subplots=False,
     sharex=None,
     sharey=False,
     layout=None,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to fix the plotting functions working properly with pandas 1.5.0.

This includes two fixes:
- Fix the `PandasOnSpark*Plot` to get name of plot in the string format properly.
- Fix the default value of `subplots` parameter from `plot_frame` to match with latest pandas. (`None` -> `False`)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

#### 1. get `_kind` from pandas class no longer possible.

We're leverage the pandas plotting classes to implement for `matplotlib` implementation, and get the class name from pandas like:
```python
>>> from pandas.plotting._matplotlib.core import AreaPlot
>>> AreaPlot._kind
'area'
```
However, since pandas 1.5.0, they convert the member variable `_kind` into `@property`, so we cannot bring the name of class properly from pandas class as below:
```python
>>> from pandas.plotting._matplotlib.core import AreaPlot
AreaPlot._kind
>>> AreaPlot._kind
<property object at 0x7fe520d749a0>
```

#### 2. `subplots` parameter no longer allow the type other than `Iterable` or `bool`.

We internally set the default value for `subplots` as `None`, but from pandas 1.5.0 only allows `Iterable` or `bool`, so the plotting function is not work properly as below:

```python
>>> psdf.plot(kind="bar")
Traceback (most recent call last):
...
ValueError: subplots should be a bool or an iterable
```

With this fixes, it work properly with pandas 1.5.0 as below:

**<For Series and DataFrame plot>**

**Before**:
```python
>>> from pyspark.pandas.config import set_option
>>> set_option("plotting.backend", "matplotlib")
>>> import pyspark.pandas as ps
>>> psdf = ps.range(10)
>>> psdf.plot(kind="bar")
Traceback (most recent call last):
...
KeyError: 'bar'
```

**After**:
```python
>>> from pyspark.pandas.config import set_option
>>> set_option("plotting.backend", "matplotlib")
>>> import pyspark.pandas as ps
>>> psdf = ps.range(10)
>>> psdf.plot(kind="bar")
<AxesSubplot:>
```

**<For DataFrame plot>**

**Before**:
```python
>>> from pyspark.pandas.config import set_option
>>> set_option("plotting.backend", "matplotlib")
>>> import pyspark.pandas as ps
>>> psdf = ps.range(10)
>>> psdf.plot(kind="bar")
Traceback (most recent call last):
...
ValueError: subplots should be a bool or an iterable
```

**After**:
```python
>>> from pyspark.pandas.config import set_option
>>> set_option("plotting.backend", "matplotlib")
>>> import pyspark.pandas as ps
>>> psdf = ps.range(10)
>>> psdf.plot(kind="bar")
<AxesSubplot:>
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually tested with pandas 1.5.0.
