### PR TITLE
[SPARK-42438][SQL] Improve constraint propagation using multiTransform

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1420,7 +1420,7 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
       conditionOpt: Option[Expression]): ExpressionSet = {
     val baseConstraints = left.constraints.union(right.constraints)
       .union(ExpressionSet(conditionOpt.map(splitConjunctivePredicates).getOrElse(Nil)))
-    baseConstraints.union(inferAdditionalConstraints(baseConstraints))
+    inferConstraints(baseConstraints)
   }
 
   private def inferNewFilter(plan: LogicalPlan, constraints: ExpressionSet): LogicalPlan = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -479,7 +479,7 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
  * 4) Unwrap '=', '<=>' if one side is a boolean literal
  */
 object SimplifyBinaryComparison
-  extends Rule[LogicalPlan] with PredicateHelper with ConstraintHelper {
+  extends Rule[LogicalPlan] with PredicateHelper {
 
   private def canSimplifyComparison(
       left: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -59,7 +59,8 @@ trait ConstraintHelper extends SQLConfHelper {
   lazy val constraintInferenceLimit = conf.getConf(SQLConf.CONSTRAINT_INFERENCE_LIMIT)
 
   /**
-   * Infers an additional set of constraints from a given set of equality constraints.
+   * Infers an additional set of constraints from a given set of equality constraints and returns
+   * them with the original constraint set.
    * For e.g., if an operator has constraints of the form (`a = 5`, `a = b`), this returns an
    * additional constraint of the form `b = 5`.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -882,6 +882,28 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val CONSTRAINT_PROJECTION_LIMIT =
+    buildConf("spark.sql.constraintPropagation.projectionLimit")
+      .doc("If defined then the maximum number of original and projected constraints during " +
+        "constraint propagation.")
+      .internal()
+      .version("3.5.0")
+      .intConf
+      .checkValue(_ >= 0,
+        "The value of spark.sql.constraintPropagation.projectionLimit must not be negative.")
+      .createOptional
+
+  val CONSTRAINT_INFERENCE_LIMIT =
+    buildConf("spark.sql.constraintPropagation.inferenceLimit")
+      .doc("If defined then the maximum number of inferred constraints during constraint " +
+        "propagation.")
+      .internal()
+      .version("3.5.0")
+      .intConf
+      .checkValue(_ >= 0,
+        "The value of spark.sql.constraintPropagation.inferenceLimit must not be negative.")
+      .createOptional
+
   val PROPAGATE_DISTINCT_KEYS_ENABLED =
     buildConf("spark.sql.optimizer.propagateDistinctKeys.enabled")
       .internal()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -547,4 +547,18 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
       )
     }
   }
+
+  test("constraint projection test") {
+    val r = LocalRelation ($"c".int).where($"c" + $"c" > 10)
+      .select($"c".as ("c1"), $"c".as("c2") )
+    val analyzed = r.analyze
+    println(analyzed.constraints)
+
+    val r1 = LocalRelation($"c1".int).where($"c1" + $"c1" > 10).as("r1")
+    val r2 = LocalRelation($"c2".int).as("r2")
+    val rr = r1.join(r2, Inner, Some($"r1.c1" === $"r2.c2"))
+
+    val analyzed2 = rr.analyze
+    println(analyzed2.constraints)
+  }
 }

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
@@ -213,7 +213,7 @@ Output [4]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23, cs_sold_date
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#24), dynamicpruningexpression(cs_sold_date_sk#24 IN dynamicpruning#19)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
 
 (37) ColumnarToRow [codegen id : 15]
@@ -221,7 +221,7 @@ Input [4]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23, cs_sold_date_
 
 (38) Filter [codegen id : 15]
 Input [4]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23, cs_sold_date_sk#24]
-Condition : (isnotnull(cs_bill_customer_sk#21) AND isnotnull(cs_item_sk#22))
+Condition : (isnotnull(cs_item_sk#22) AND isnotnull(cs_bill_customer_sk#21))
 
 (39) ReusedExchange [Reuses operator id: 59]
 Output [1]: [d_date_sk#25]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/simplified.txt
@@ -94,7 +94,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                             WholeStageCodegen (15)
                               Project [cs_bill_customer_sk,cs_item_sk,cs_quantity]
                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                  Filter [cs_bill_customer_sk,cs_item_sk]
+                                  Filter [cs_item_sk,cs_bill_customer_sk]
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/explain.txt
@@ -90,7 +90,7 @@ Output [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_quantity#16, cs_sold_date
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#17), dynamicpruningexpression(cs_sold_date_sk#17 IN dynamicpruning#13)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
 
 (11) ColumnarToRow [codegen id : 2]
@@ -98,7 +98,7 @@ Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_quantity#16, cs_sold_date_
 
 (12) Filter [codegen id : 2]
 Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_quantity#16, cs_sold_date_sk#17]
-Condition : (isnotnull(cs_bill_customer_sk#14) AND isnotnull(cs_item_sk#15))
+Condition : (isnotnull(cs_item_sk#15) AND isnotnull(cs_bill_customer_sk#14))
 
 (13) BroadcastExchange
 Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_quantity#16, cs_sold_date_sk#17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/simplified.txt
@@ -49,7 +49,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                       InputAdapter
                                         BroadcastExchange #5
                                           WholeStageCodegen (2)
-                                            Filter [cs_bill_customer_sk,cs_item_sk]
+                                            Filter [cs_item_sk,cs_bill_customer_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
@@ -213,7 +213,7 @@ Output [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24, cs_sold_da
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#25), dynamicpruningexpression(cs_sold_date_sk#25 IN dynamicpruning#20)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_net_profit:decimal(7,2)>
 
 (37) ColumnarToRow [codegen id : 15]
@@ -221,7 +221,7 @@ Input [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24, cs_sold_dat
 
 (38) Filter [codegen id : 15]
 Input [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24, cs_sold_date_sk#25]
-Condition : (isnotnull(cs_bill_customer_sk#22) AND isnotnull(cs_item_sk#23))
+Condition : (isnotnull(cs_item_sk#23) AND isnotnull(cs_bill_customer_sk#22))
 
 (39) ReusedExchange [Reuses operator id: 59]
 Output [1]: [d_date_sk#26]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/simplified.txt
@@ -94,7 +94,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                             WholeStageCodegen (15)
                               Project [cs_bill_customer_sk,cs_item_sk,cs_net_profit]
                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                  Filter [cs_bill_customer_sk,cs_item_sk]
+                                  Filter [cs_item_sk,cs_bill_customer_sk]
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_net_profit,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/explain.txt
@@ -90,7 +90,7 @@ Output [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_net_profit#16, cs_sold_da
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#17), dynamicpruningexpression(cs_sold_date_sk#17 IN dynamicpruning#13)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_net_profit:decimal(7,2)>
 
 (11) ColumnarToRow [codegen id : 2]
@@ -98,7 +98,7 @@ Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_net_profit#16, cs_sold_dat
 
 (12) Filter [codegen id : 2]
 Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_net_profit#16, cs_sold_date_sk#17]
-Condition : (isnotnull(cs_bill_customer_sk#14) AND isnotnull(cs_item_sk#15))
+Condition : (isnotnull(cs_item_sk#15) AND isnotnull(cs_bill_customer_sk#14))
 
 (13) BroadcastExchange
 Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_net_profit#16, cs_sold_date_sk#17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/simplified.txt
@@ -49,7 +49,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                       InputAdapter
                                         BroadcastExchange #5
                                           WholeStageCodegen (2)
-                                            Filter [cs_bill_customer_sk,cs_item_sk]
+                                            Filter [cs_item_sk,cs_bill_customer_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_net_profit,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
@@ -213,7 +213,7 @@ Output [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24, cs_sold_date
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#25), dynamicpruningexpression(cs_sold_date_sk#25 IN dynamicpruning#26)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
 
 (37) ColumnarToRow [codegen id : 15]
@@ -221,7 +221,7 @@ Input [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24, cs_sold_date_
 
 (38) Filter [codegen id : 15]
 Input [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24, cs_sold_date_sk#25]
-Condition : (isnotnull(cs_bill_customer_sk#22) AND isnotnull(cs_item_sk#23))
+Condition : (isnotnull(cs_item_sk#23) AND isnotnull(cs_bill_customer_sk#22))
 
 (39) ReusedExchange [Reuses operator id: 64]
 Output [1]: [d_date_sk#27]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/simplified.txt
@@ -94,7 +94,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                             WholeStageCodegen (15)
                               Project [cs_bill_customer_sk,cs_item_sk,cs_quantity]
                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                  Filter [cs_bill_customer_sk,cs_item_sk]
+                                  Filter [cs_item_sk,cs_bill_customer_sk]
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/explain.txt
@@ -90,7 +90,7 @@ Output [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_quantity#16, cs_sold_date
 Batched: true
 Location: InMemoryFileIndex []
 PartitionFilters: [isnotnull(cs_sold_date_sk#17), dynamicpruningexpression(cs_sold_date_sk#17 IN dynamicpruning#18)]
-PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
+PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
 
 (11) ColumnarToRow [codegen id : 2]
@@ -98,7 +98,7 @@ Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_quantity#16, cs_sold_date_
 
 (12) Filter [codegen id : 2]
 Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_quantity#16, cs_sold_date_sk#17]
-Condition : (isnotnull(cs_bill_customer_sk#14) AND isnotnull(cs_item_sk#15))
+Condition : (isnotnull(cs_item_sk#15) AND isnotnull(cs_bill_customer_sk#14))
 
 (13) BroadcastExchange
 Input [4]: [cs_bill_customer_sk#14, cs_item_sk#15, cs_quantity#16, cs_sold_date_sk#17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/simplified.txt
@@ -49,7 +49,7 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                       InputAdapter
                                         BroadcastExchange #5
                                           WholeStageCodegen (2)
-                                            Filter [cs_bill_customer_sk,cs_item_sk]
+                                            Filter [cs_item_sk,cs_bill_customer_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR refectors constaint propagation using `TreeNode.multiTransform()`:
- It improves the performance of `LogicalPlan.getAllValidConstraints()` because constraint pruning (based on the node output set) happens during the projection in `getAllValidConstraints()`.
- Adds new `spark.sql.constraintPropagation.projectionLimit` and `spark.sql.constraintPropagation.inferenceLimit` configs to limit the number of constraints generated. These limits can be useful in some usecases where otherwise constraint propagation needs to be disabled entirelly (`spark.sql.constraintPropagation.enabled=false`) due to huge number of constraints.

### Why are the changes needed?
Improvement.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing and new UTs.
