### PR TITLE
[SPARK-40601][PYTHON] Assert identical key size when cogrouping groups

### DIFF
--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -366,10 +366,6 @@ class PandasCogroupedOps:
     """
 
     def __init__(self, gd1: "GroupedData", gd2: "GroupedData"):
-        gel1 = gd1._jgd.groupingExprs().length()
-        gel2 = gd2._jgd.groupingExprs().length()
-        assert gel1 == gel2, f"Cogroup keys must have same size: {gel1} != {gel2}"
-
         self._gd1 = gd1
         self._gd2 = gd2
 

--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -368,7 +368,7 @@ class PandasCogroupedOps:
     def __init__(self, gd1: "GroupedData", gd2: "GroupedData"):
         gel1 = gd1._jgd.groupingExprs().length()
         gel2 = gd2._jgd.groupingExprs().length()
-        assert gel1 == gel2, f"group keys must have same size: {gel1} != {gel2}"
+        assert gel1 == gel2, f"Cogroup keys must have same size: {gel1} != {gel2}"
 
         self._gd1 = gd1
         self._gd2 = gd2

--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -366,6 +366,10 @@ class PandasCogroupedOps:
     """
 
     def __init__(self, gd1: "GroupedData", gd2: "GroupedData"):
+        gel1 = gd1._jgd.groupingExprs().length()
+        gel2 = gd2._jgd.groupingExprs().length()
+        assert gel1 == gel2, f"group keys must have same size: {gel1} != {gel2}"
+
         self._gd1 = gd1
         self._gd2 = gd2
 

--- a/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
@@ -125,6 +125,22 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
 
         assert_frame_equal(expected, result)
 
+    def test_different_group_key_cardinality(self):
+        left = self.data1
+        right = self.data2
+
+        with QuietTest(self.sc):
+            with self.assertRaisesRegex(
+                    AssertionError,
+                    "group keys must have same size: 2 != 1",
+            ):
+                (
+                    left.groupby("id", "k")
+                        .cogroup(right.groupby("id"))
+                        .applyInPandas(lambda l, r: l, "id long, k int, v int")
+                        .collect()
+                )
+
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
         left = self.data1
         right = self.data2

--- a/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
@@ -137,8 +137,6 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
                 (
                     left.groupby("id", "k")
                         .cogroup(right.groupby("id"))
-                        .applyInPandas(lambda l, r: l, "id long, k int, v int")
-                        .collect()
                 )
 
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):

--- a/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
@@ -132,7 +132,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 AssertionError,
-                "group keys must have same size: 2 != 1",
+                "Cogroup keys must have same size: 2 != 1",
             ):
                 (left.groupby("id", "k").cogroup(right.groupby("id")))
 

--- a/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/test_pandas_cogrouped_map.py
@@ -131,13 +131,10 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
 
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
-                    AssertionError,
-                    "group keys must have same size: 2 != 1",
+                AssertionError,
+                "group keys must have same size: 2 != 1",
             ):
-                (
-                    left.groupby("id", "k")
-                        .cogroup(right.groupby("id"))
-                )
+                (left.groupby("id", "k").cogroup(right.groupby("id")))
 
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
         left = self.data1

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -594,6 +594,9 @@ class RelationalGroupedDataset protected[sql](
       expr: PythonUDF): DataFrame = {
     require(expr.evalType == PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF,
       "Must pass a cogrouped map udf")
+    require(this.groupingExprs.length == r.groupingExprs.length,
+      "Cogroup keys must have same size: " +
+        s"${this.groupingExprs.length} != ${r.groupingExprs.length}")
     require(expr.dataType.isInstanceOf[StructType],
       s"The returnType of the udf must be a ${StructType.simpleString}")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -30,11 +30,12 @@ import scala.util.Random
 import org.scalatest.matchers.should.Matchers._
 
 import org.apache.spark.SparkException
+import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobEnd}
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, EqualTo, ExpressionSet, GreaterThan, Literal, Uuid}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, EqualTo, ExpressionSet, GreaterThan, Literal, PythonUDF, Uuid}
 import org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, LeafNode, LocalRelation, LogicalPlan, OneRowRelation, Statistics}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -2793,6 +2794,35 @@ class DataFrameSuite extends QueryTest
       errorClass = "UNRESOLVED_COLUMN",
       errorSubClass = Some("WITH_SUGGESTION"),
       parameters = Map("objectName" -> "`d`", "proposal" -> "`a`, `b`, `c`"))
+  }
+
+  test("SPARK-40601: flatMapCoGroupsInPandas should fail with different number of keys") {
+    val df1 = Seq((1, 2, "A1"), (2, 1, "A2")).toDF("key1", "key2", "value")
+    val df2 = df1.filter($"value" === "A2")
+
+    val flatMapCoGroupsInPandasUDF = PythonUDF("flagMapCoGroupsInPandasUDF", null,
+      StructType(Seq(StructField("x", LongType), StructField("y", LongType))),
+      Seq.empty,
+      PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF,
+      true)
+
+    // the number of keys must match
+    val exception1 = intercept[IllegalArgumentException] {
+      df1.groupBy($"key1", $"key2").flatMapCoGroupsInPandas(
+        df2.groupBy($"key2"), flatMapCoGroupsInPandasUDF)
+    }
+    assert(exception1.getMessage.contains("Cogroup keys must have same size: 2 != 1"))
+    val exception2 = intercept[IllegalArgumentException] {
+      df1.groupBy($"key1").flatMapCoGroupsInPandas(
+        df2.groupBy($"key1", $"key2"), flatMapCoGroupsInPandasUDF)
+    }
+    assert(exception2.getMessage.contains("Cogroup keys must have same size: 1 != 2"))
+
+    // but different keys are allowed
+    val actual = df1.groupBy($"key1").flatMapCoGroupsInPandas(
+      df2.groupBy($"key2"), flatMapCoGroupsInPandasUDF)
+    // can't evaluate the DataFrame as there is no PythonFunction given
+    assert(actual != null)
   }
 
   test("emptyDataFrame should be foldable") {


### PR DESCRIPTION
Cogrouping two grouped DataFrames in PySpark that have different group key cardinalities raises an error that is not very descriptive:

```python
left.groupby("id", "k")
    .cogroup(right.groupby("id"))
```

```
py4j.protocol.Py4JJavaError: An error occurred while calling o726.collectToPython.
: java.lang.IndexOutOfBoundsException: 1
	at scala.collection.mutable.ResizableArray.apply(ResizableArray.scala:46)
	at scala.collection.mutable.ResizableArray.apply$(ResizableArray.scala:45)
	at scala.collection.mutable.ArrayBuffer.apply(ArrayBuffer.scala:49)
	at org.apache.spark.sql.catalyst.plans.physical.HashShuffleSpec.$anonfun$createPartitioning$5(partitioning.scala:650)
...
org.apache.spark.sql.execution.exchange.EnsureRequirements.$anonfun$ensureDistributionAndOrdering$14(EnsureRequirements.scala:159)
```

### What changes were proposed in this pull request?
Assert identical size of groupby keys and provide a meaningful error on cogroup.

### Why are the changes needed?
The error does not provide information on how to solve the problem.

### Does this PR introduce _any_ user-facing change?
Yes, raises an `AssertionError: group keys must have same size` instead.

### How was this patch tested?
Adds test `test_different_group_key_cardinality` to `pyspark.sql.tests.test_pandas_cogrouped_map`.