### PR TITLE
[SPARK-40605][CONNECT][TESTS] Change to use `log4j2.properties` to configure test log output 

### DIFF
--- a/connect/src/test/resources/log4j2.properties
+++ b/connect/src/test/resources/log4j2.properties
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the file target/unit-tests.log
+rootLogger.level = info
+rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
+
+appender.file.type = File
+appender.file.name = File
+appender.file.fileName = target/unit-tests.log
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
+
+# Tests that launch java subprocesses can set the "test.appender" system property to
+# "console" to avoid having the child process's logs overwrite the unit test's
+# log file.
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %t: %m%n%ex
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+logger.jetty.name = org.sparkproject.jetty
+logger.jetty.level = warn

--- a/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connect.planner
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.{SparkFunSuite, TestUtils}
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -57,11 +57,6 @@ trait SparkConnectSessionTest {
 class SparkConnectPlannerSuite extends SparkFunSuite with SparkConnectPlanTest {
 
   protected var spark: SparkSession = null
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    TestUtils.configTestLog4j2("INFO")
-  }
 
   test("Simple Limit") {
     assertThrows[IndexOutOfBoundsException] {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr make `connect` module change to use to use `log4j2.properties` to configure test log output as others modules.


### Why are the changes needed?
You should use `log4j2.properties`  to configure logs



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
