### PR TITLE
[SPARK-40606][PS][TEST] Eliminate `to_pandas` warnings in test

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -152,7 +152,7 @@ class BinaryOpsTest(OpsTestBase):
         data = [b"1", b"2", b"3"]
         pser = pd.Series(data)
         psser = ps.Series(data)
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -732,7 +732,7 @@ class BooleanExtensionOpsTest(OpsTestBase):
         data = [True, True, False, None]
         pser = pd.Series(data, dtype="boolean")
         psser = ps.Series(data, dtype="boolean")
-        self.check_extension(pser, psser.to_pandas())
+        self.check_extension(pser, psser._to_pandas())
         self.check_extension(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -166,7 +166,7 @@ class CategoricalOpsTest(OpsTestBase):
         data = [1, "x", "y"]
         pser = pd.Series(data, dtype="category")
         psser = ps.Series(data, dtype="category")
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -239,7 +239,7 @@ class ComplexOpsTest(OpsTestBase):
         pdf, psdf = self.array_pdf, self.array_psdf
         for col in self.array_df_cols:
             pser, psser = pdf[col], psdf[col]
-            self.assert_eq(pser, psser.to_pandas())
+            self.assert_eq(pser, psser._to_pandas())
             self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -176,7 +176,7 @@ class DateOpsTest(OpsTestBase):
         data = [datetime.date(1994, 1, 31), datetime.date(1994, 2, 1), datetime.date(1994, 2, 2)]
         pser = pd.Series(data)
         psser = ps.Series(data)
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -180,7 +180,7 @@ class DatetimeOpsTest(OpsTestBase):
         data = pd.date_range("1994-1-31 10:30:15", periods=3, freq="M")
         pser = pd.Series(data)
         psser = ps.Series(data)
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_null_ops.py
@@ -111,7 +111,7 @@ class NullOpsTest(OpsTestBase):
         data = [None, None, None]
         pser = pd.Series(data)
         psser = ps.Series(data)
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -320,7 +320,7 @@ class NumOpsTest(OpsTestBase):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:
             pser, psser = pdf[col], psdf[col]
-            self.assert_eq(pser, psser.to_pandas())
+            self.assert_eq(pser, psser._to_pandas())
             self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):
@@ -464,7 +464,7 @@ class IntegralExtensionOpsTest(OpsTestBase):
 
     def test_from_to_pandas(self):
         for pser, psser in self.intergral_extension_pser_psser_pairs:
-            self.check_extension(pser, psser.to_pandas())
+            self.check_extension(pser, psser._to_pandas())
             self.check_extension(ps.from_pandas(pser), psser)
 
     def test_isnull(self):
@@ -607,7 +607,7 @@ class FractionalExtensionOpsTest(OpsTestBase):
 
     def test_from_to_pandas(self):
         for pser, psser in self.fractional_extension_pser_psser_pairs:
-            self.check_extension(pser, psser.to_pandas())
+            self.check_extension(pser, psser._to_pandas())
             self.check_extension(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -160,7 +160,7 @@ class StringOpsTest(OpsTestBase):
         data = ["x", "y", "z"]
         pser = pd.Series(data)
         psser = ps.Series(data)
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):
@@ -275,7 +275,7 @@ class StringExtensionOpsTest(StringOpsTest):
         data = ["x", "y", "z", None]
         pser = pd.Series(data, dtype="string")
         psser = ps.Series(data, dtype="string")
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
@@ -139,7 +139,7 @@ class TimedeltaOpsTest(OpsTestBase):
         data = [timedelta(1), timedelta(microseconds=2)]
         pser = pd.Series(data)
         psser = ps.Series(data)
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_udt_ops.py
@@ -126,7 +126,7 @@ class UDTOpsTest(OpsTestBase):
         sparse_vector = SparseVector(len(sparse_values), sparse_values)
         pser = pd.Series([sparse_vector])
         psser = ps.Series([sparse_vector])
-        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(pser, psser._to_pandas())
         self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -380,11 +380,11 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         # here the output is different than pandas in terms of order
         expected = [0, 1, 3, 5, 6, 8, 9]
 
-        self.assert_eq(expected, sorted(psidx.unique().to_pandas()))
-        self.assert_eq(expected, sorted(psidx.unique(level=0).to_pandas()))
+        self.assert_eq(expected, sorted(psidx.unique()._to_pandas()))
+        self.assert_eq(expected, sorted(psidx.unique(level=0)._to_pandas()))
 
         expected = [1, 2, 4, 6, 7, 9, 10]
-        self.assert_eq(expected, sorted((psidx + 1).unique().to_pandas()))
+        self.assert_eq(expected, sorted((psidx + 1).unique()._to_pandas()))
 
         with self.assertRaisesRegex(IndexError, "Too many levels*"):
             psidx.unique(level=1)
@@ -507,7 +507,7 @@ class IndexesTest(ComparisonTestBase, TestUtils):
 
         self.assert_eq(
             midx.symmetric_difference(midx_),
-            midx.to_pandas().symmetric_difference(midx_.to_pandas()),
+            midx._to_pandas().symmetric_difference(midx_._to_pandas()),
         )
 
         with self.assertRaisesRegex(NotImplementedError, "Doesn't support*"):
@@ -1356,7 +1356,7 @@ class IndexesTest(ComparisonTestBase, TestUtils):
             psdf = ps.DataFrame({"a": [-5, -4, -3, -2, -1], "b": [1, 1, 1, 1, 1]})
             psdf["b"] = None
             psmidx = psdf.set_index(["a", "b"]).index
-            pmidx = psmidx.to_pandas()
+            pmidx = psmidx._to_pandas()
             self.assert_eq(psmidx.is_monotonic_increasing, pmidx.is_monotonic_increasing)
             self.assert_eq(psmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
 
@@ -1364,7 +1364,7 @@ class IndexesTest(ComparisonTestBase, TestUtils):
             psdf = ps.DataFrame({"a": [1, 1, 1, 1, 1], "b": ["e", "c", "b", "d", "a"]})
             psdf["a"] = None
             psmidx = psdf.set_index(["a", "b"]).index
-            pmidx = psmidx.to_pandas()
+            pmidx = psmidx._to_pandas()
             self.assert_eq(psmidx.is_monotonic_increasing, pmidx.is_monotonic_increasing)
             self.assert_eq(psmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
 
@@ -1373,7 +1373,7 @@ class IndexesTest(ComparisonTestBase, TestUtils):
             psdf["a"] = None
             psdf["b"] = None
             psmidx = psdf.set_index(["a", "b"]).index
-            pmidx = psmidx.to_pandas()
+            pmidx = psmidx._to_pandas()
             self.assert_eq(psmidx.is_monotonic_increasing, pmidx.is_monotonic_increasing)
             self.assert_eq(psmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
 
@@ -1382,7 +1382,7 @@ class IndexesTest(ComparisonTestBase, TestUtils):
             psdf["a"] = None
             psdf["b"] = None
             psmidx = psdf.set_index(["a", "b"]).index
-            pmidx = psmidx.to_pandas()
+            pmidx = psmidx._to_pandas()
             self.assert_eq(psmidx.is_monotonic_increasing, pmidx.is_monotonic_increasing)
             self.assert_eq(psmidx.is_monotonic_decreasing, pmidx.is_monotonic_decreasing)
 

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
@@ -157,7 +157,7 @@ class DataFramePlotPlotlyTest(PandasOnSparkTestCase, TestUtils):
 
     def test_pie_plot(self):
         def check_pie_plot(psdf):
-            pdf = psdf.to_pandas()
+            pdf = psdf._to_pandas()
             self.assertEqual(
                 psdf.plot(kind="pie", y=psdf.columns[0]),
                 express.pie(pdf, values="a", names=pdf.index),

--- a/python/pyspark/pandas/tests/plot/test_series_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_matplotlib.py
@@ -70,7 +70,7 @@ class SeriesPlotMatplotlibTest(PandasOnSparkTestCase, TestUtils):
 
     @property
     def pdf2(self):
-        return self.psdf2.to_pandas()
+        return self.psdf2._to_pandas()
 
     @staticmethod
     def plot_to_base64(ax):

--- a/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_series_plot_plotly.py
@@ -70,7 +70,7 @@ class SeriesPlotPlotlyTest(PandasOnSparkTestCase, TestUtils):
 
     @property
     def pdf2(self):
-        return self.psdf2.to_pandas()
+        return self.psdf2._to_pandas()
 
     def test_bar_plot(self):
         pdf = self.pdf1
@@ -111,7 +111,7 @@ class SeriesPlotPlotlyTest(PandasOnSparkTestCase, TestUtils):
 
     def test_pie_plot(self):
         psdf = self.psdf1
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         self.assertEqual(
             psdf["a"].plot(kind="pie"),
             express.pie(pdf, values=pdf.columns[0], names=pdf.index),
@@ -134,7 +134,7 @@ class SeriesPlotPlotlyTest(PandasOnSparkTestCase, TestUtils):
         #     },
         #     index=pd.MultiIndex.from_tuples([("x", "y")] * 11),
         # )
-        # pdf = psdf.to_pandas()
+        # pdf = psdf._to_pandas()
         # self.assertEqual(
         #     psdf["a"].plot(kind="pie"), express.pie(pdf, values=pdf.columns[0], names=pdf.index),
         # )

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -723,7 +723,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         self.assert_eq(psdf, pdf)
         self.assert_eq(psdf.columns.names, pdf.columns.names)
-        self.assert_eq(psdf.to_pandas().columns.names, pdf.columns.names)
+        self.assert_eq(psdf._to_pandas().columns.names, pdf.columns.names)
 
     def test_dataframe_multiindex_names_level(self):
         columns = pd.MultiIndex.from_tuples(
@@ -738,7 +738,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         psdf = ps.from_pandas(pdf)
 
         self.assert_eq(psdf.columns.names, pdf.columns.names)
-        self.assert_eq(psdf.to_pandas().columns.names, pdf.columns.names)
+        self.assert_eq(psdf._to_pandas().columns.names, pdf.columns.names)
 
         psdf1 = ps.from_pandas(pdf)
         self.assert_eq(psdf1.columns.names, pdf.columns.names)
@@ -750,13 +750,13 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         self.assert_eq(psdf["X"], pdf["X"])
         self.assert_eq(psdf["X"].columns.names, pdf["X"].columns.names)
-        self.assert_eq(psdf["X"].to_pandas().columns.names, pdf["X"].columns.names)
+        self.assert_eq(psdf["X"]._to_pandas().columns.names, pdf["X"].columns.names)
         self.assert_eq(psdf["X"]["A"], pdf["X"]["A"])
         self.assert_eq(psdf["X"]["A"].columns.names, pdf["X"]["A"].columns.names)
-        self.assert_eq(psdf["X"]["A"].to_pandas().columns.names, pdf["X"]["A"].columns.names)
+        self.assert_eq(psdf["X"]["A"]._to_pandas().columns.names, pdf["X"]["A"].columns.names)
         self.assert_eq(psdf[("X", "A")], pdf[("X", "A")])
         self.assert_eq(psdf[("X", "A")].columns.names, pdf[("X", "A")].columns.names)
-        self.assert_eq(psdf[("X", "A")].to_pandas().columns.names, pdf[("X", "A")].columns.names)
+        self.assert_eq(psdf[("X", "A")]._to_pandas().columns.names, pdf[("X", "A")].columns.names)
         self.assert_eq(psdf[("X", "A", "Z")], pdf[("X", "A", "Z")])
 
     def test_itertuples(self):
@@ -866,7 +866,9 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         with ps.option_context("compute.default_index_type", "distributed"):
             # the index is different.
-            self.assert_eq(psdf.reset_index().to_pandas().reset_index(drop=True), pdf.reset_index())
+            self.assert_eq(
+                psdf.reset_index()._to_pandas().reset_index(drop=True), pdf.reset_index()
+            )
 
     def test_reset_index_with_multiindex_columns(self):
         index = pd.MultiIndex.from_tuples(
@@ -979,14 +981,14 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         df = ps.range(10)
         df.__repr__()
         df["a"] = df["id"]
-        self.assertEqual(df.__repr__(), df.to_pandas().__repr__())
+        self.assertEqual(df.__repr__(), df._to_pandas().__repr__())
 
     def test_repr_html_cache_invalidation(self):
         # If there is any cache, inplace operations should invalidate it.
         df = ps.range(10)
         df._repr_html_()
         df["a"] = df["id"]
-        self.assertEqual(df._repr_html_(), df.to_pandas()._repr_html_())
+        self.assertEqual(df._repr_html_(), df._to_pandas()._repr_html_())
 
     def test_empty_dataframe(self):
         pdf = pd.DataFrame({"a": pd.Series([], dtype="i1"), "b": pd.Series([], dtype="str")})
@@ -2413,7 +2415,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
     def test_to_pandas(self):
         pdf, psdf = self.df_pair
-        self.assert_eq(psdf.to_pandas(), pdf)
+        self.assert_eq(psdf._to_pandas(), pdf)
 
     def test_isin(self):
         pdf = pd.DataFrame(
@@ -2510,7 +2512,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         def check(op, right_psdf=right_psdf, right_pdf=right_pdf):
             k_res = op(left_psdf, right_psdf)
-            k_res = k_res.to_pandas()
+            k_res = k_res._to_pandas()
             k_res = k_res.sort_values(by=list(k_res.columns))
             k_res = k_res.reset_index(drop=True)
             p_res = op(left_pdf, right_pdf)
@@ -2667,7 +2669,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         def check(op, right_psdf=right_psdf, right_pdf=right_pdf):
             k_res = op(left_psdf, right_psdf)
-            k_res = k_res.to_pandas()
+            k_res = k_res._to_pandas()
             k_res = k_res.sort_values(by=list(k_res.columns))
             k_res = k_res.reset_index(drop=True)
             p_res = op(left_pdf, right_pdf)
@@ -6074,8 +6076,8 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         self._test_corrwith(df_bool, df_bool.B)
 
     def _test_corrwith(self, psdf, psobj):
-        pdf = psdf.to_pandas()
-        pobj = psobj.to_pandas()
+        pdf = psdf._to_pandas()
+        pobj = psobj._to_pandas()
         # Regression in pandas 1.5.0 when other is Series and method is "pearson" or "spearman"
         # See https://github.com/pandas-dev/pandas/issues/48826 for the reported issue,
         # and https://github.com/pandas-dev/pandas/pull/46174 for the initial PR that causes.
@@ -6504,7 +6506,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         # string columns
         psdf = ps.DataFrame({"A": ["a", "b", "b", "c"], "B": ["d", "e", "f", "f"]})
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         self.assert_eq(psdf.describe(), pdf.describe().astype(str))
         psdf.A += psdf.A
         pdf.A += pdf.A
@@ -6527,7 +6529,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
                 ],
             }
         )
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         # NOTE: Set `datetime_is_numeric=True` for pandas:
         # FutureWarning: Treating datetime data as categorical rather than numeric in
         # `.describe` is deprecated and will be removed in a future version of pandas.
@@ -6582,7 +6584,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
                 ],
             }
         )
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
             self.assert_eq(
                 psdf.describe().loc[["count", "mean", "min", "max"]],
@@ -6635,7 +6637,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
                 ],
             }
         )
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
             pandas_result = pdf.describe(datetime_is_numeric=True)
             pandas_result.B = pandas_result.B.astype(str)
@@ -6700,7 +6702,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
                 "c": [None, None, None],
             }
         )
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
             pandas_result = pdf.describe(datetime_is_numeric=True)
             pandas_result.b = pandas_result.b.astype(str)
@@ -6741,7 +6743,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
     def test_describe_empty(self):
         # Empty DataFrame
         psdf = ps.DataFrame(columns=["A", "B"])
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         self.assert_eq(
             psdf.describe(),
             pdf.describe().astype(float),
@@ -6749,7 +6751,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         # Explicit empty DataFrame numeric only
         psdf = ps.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         self.assert_eq(
             psdf[psdf.a != psdf.a].describe(),
             pdf[pdf.a != pdf.a].describe(),
@@ -6757,7 +6759,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         # Explicit empty DataFrame string only
         psdf = ps.DataFrame({"a": ["a", "b", "c"], "b": ["q", "w", "e"]})
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         self.assert_eq(
             psdf[psdf.a != psdf.a].describe(),
             pdf[pdf.a != pdf.a].describe().astype(float),
@@ -6770,7 +6772,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
                 "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)],
             }
         )
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         # For timestamp type, we should convert NaT to None in pandas result
         # since pandas API on Spark doesn't support the NaT for object type.
         if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
@@ -6811,7 +6813,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         psdf = ps.DataFrame(
             {"a": [1, 2, 3], "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)]}
         )
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
             pdf_result = pdf[pdf.a != pdf.a].describe(datetime_is_numeric=True)
             pdf_result.b = pdf_result.b.where(pdf_result.b.notnull(), None).astype(str)
@@ -6851,7 +6853,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         # Explicit empty DataFrame numeric & string
         psdf = ps.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         self.assert_eq(
             psdf[psdf.a != psdf.a].describe(),
             pdf[pdf.a != pdf.a].describe(),
@@ -6861,7 +6863,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         psdf = ps.DataFrame(
             {"a": ["a", "b", "c"], "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)]}
         )
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
             pdf_result = pdf[pdf.a != pdf.a].describe(datetime_is_numeric=True)
             self.assert_eq(

--- a/python/pyspark/pandas/tests/test_dataframe_spark_io.py
+++ b/python/pyspark/pandas/tests/test_dataframe_spark_io.py
@@ -57,7 +57,7 @@ class DataFrameSparkIOTest(PandasOnSparkTestCase, TestUtils):
             def check(columns):
                 expected = pd.read_parquet(tmp, columns=columns)
                 actual = ps.read_parquet(tmp, columns=columns)
-                self.assertPandasEqual(expected, actual.to_pandas())
+                self.assertPandasEqual(expected, actual._to_pandas())
 
             check(None)
             check(["i32", "i64"])
@@ -66,7 +66,7 @@ class DataFrameSparkIOTest(PandasOnSparkTestCase, TestUtils):
             # check with pyspark patch.
             expected = pd.read_parquet(tmp)
             actual = ps.read_parquet(tmp)
-            self.assertPandasEqual(expected, actual.to_pandas())
+            self.assertPandasEqual(expected, actual._to_pandas())
 
             # When index columns are known
             pdf = self.test_pdf
@@ -386,13 +386,13 @@ class DataFrameSparkIOTest(PandasOnSparkTestCase, TestUtils):
 
             expected = data.reset_index()[data.columns]
             actual = ps.read_orc(path)
-            self.assertPandasEqual(expected, actual.to_pandas())
+            self.assertPandasEqual(expected, actual._to_pandas())
 
             # columns
             columns = ["i32", "i64"]
             expected = data.reset_index()[columns]
             actual = ps.read_orc(path, columns=columns)
-            self.assertPandasEqual(expected, actual.to_pandas())
+            self.assertPandasEqual(expected, actual._to_pandas())
 
             # index_col
             expected = data.set_index("i32")

--- a/python/pyspark/pandas/tests/test_default_index.py
+++ b/python/pyspark/pandas/tests/test_default_index.py
@@ -35,7 +35,7 @@ class DefaultIndexTest(PandasOnSparkTestCase):
     def test_default_index_distributed(self):
         with ps.option_context("compute.default_index_type", "distributed"):
             sdf = self.spark.range(1000)
-            pdf = ps.DataFrame(sdf).to_pandas()
+            pdf = ps.DataFrame(sdf)._to_pandas()
             self.assertEqual(len(set(pdf.index)), len(pdf))
 
 

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1080,7 +1080,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
             with self.subTest(pdf=pdf):
                 psdf = ps.from_pandas(pdf)
 
-                actual = psdf.groupby("a")["b"].unique().sort_index().to_pandas()
+                actual = psdf.groupby("a")["b"].unique().sort_index()._to_pandas()
                 expect = pdf.groupby("a")["b"].unique().sort_index()
                 self.assert_eq(len(actual), len(expect))
                 for act, exp in zip(actual, expect):
@@ -2367,7 +2367,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         actual = psdf.groupby("d").apply(sum_with_acc_frame)
         actual.columns = ["d", "v"]
         self.assert_eq(
-            actual.to_pandas().sort_index(),
+            actual._to_pandas().sort_index(),
             pdf.groupby("d").apply(sum).sort_index().reset_index(drop=True),
         )
         self.assert_eq(acc.value, 2)
@@ -2378,7 +2378,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
             return np.sum(x)
 
         self.assert_eq(
-            psdf.groupby("d")["v"].apply(sum_with_acc_series).to_pandas().sort_index(),
+            psdf.groupby("d")["v"].apply(sum_with_acc_series)._to_pandas().sort_index(),
             pdf.groupby("d")["v"].apply(sum).sort_index().reset_index(drop=True),
         )
         self.assert_eq(acc.value, 4)

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -138,10 +138,10 @@ class BasicIndexingTest(ComparisonTestBase):
         pdf = self.pdf
 
         df1 = ps.from_pandas(pdf.set_index("month"))
-        self.assertPandasEqual(df1.to_pandas(), pdf.set_index("month"))
+        self.assertPandasEqual(df1._to_pandas(), pdf.set_index("month"))
 
         df2 = ps.from_pandas(pdf.set_index(["year", "month"]))
-        self.assertPandasEqual(df2.to_pandas(), pdf.set_index(["year", "month"]))
+        self.assertPandasEqual(df2._to_pandas(), pdf.set_index(["year", "month"]))
 
     def test_limitations(self):
         df = self.psdf.set_index("month")

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -1512,9 +1512,9 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psser.dot(psdf), pser.dot(pdf))
 
         psser = ps.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).b
-        pser = psser.to_pandas()
+        pser = psser._to_pandas()
         psdf = ps.DataFrame({"c": [7, 8, 9]})
-        pdf = psdf.to_pandas()
+        pdf = psdf._to_pandas()
         self.assert_eq(psser.dot(psdf), pser.dot(pdf))
 
         # SPARK-36968: ps.Series.dot raise "matrices are not aligned" if index is not same
@@ -1881,8 +1881,8 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         self._test_corrwith(self.psdf3, self.psdf4.f)
 
     def _test_corrwith(self, psdf, psobj):
-        pdf = psdf.to_pandas()
-        pobj = psobj.to_pandas()
+        pdf = psdf._to_pandas()
+        pobj = psobj._to_pandas()
         for drop in [True, False]:
             p_corr = pdf.corrwith(pobj, drop=drop)
             ps_corr = psdf.corrwith(psobj, drop=drop)

--- a/python/pyspark/pandas/tests/test_repr.py
+++ b/python/pyspark/pandas/tests/test_repr.py
@@ -38,87 +38,87 @@ class ReprTest(PandasOnSparkTestCase):
     def test_repr_dataframe(self):
         psdf = ps.range(ReprTest.max_display_count)
         self.assertTrue("Showing only the first" not in repr(psdf))
-        self.assert_eq(repr(psdf), repr(psdf.to_pandas()))
+        self.assert_eq(repr(psdf), repr(psdf._to_pandas()))
 
         psdf = ps.range(ReprTest.max_display_count + 1)
         self.assertTrue("Showing only the first" in repr(psdf))
         self.assertTrue(
-            repr(psdf).startswith(repr(psdf.to_pandas().head(ReprTest.max_display_count)))
+            repr(psdf).startswith(repr(psdf._to_pandas().head(ReprTest.max_display_count)))
         )
 
         with option_context("display.max_rows", None):
             psdf = ps.range(ReprTest.max_display_count + 1)
-            self.assert_eq(repr(psdf), repr(psdf.to_pandas()))
+            self.assert_eq(repr(psdf), repr(psdf._to_pandas()))
 
     def test_repr_series(self):
         psser = ps.range(ReprTest.max_display_count).id
         self.assertTrue("Showing only the first" not in repr(psser))
-        self.assert_eq(repr(psser), repr(psser.to_pandas()))
+        self.assert_eq(repr(psser), repr(psser._to_pandas()))
 
         psser = ps.range(ReprTest.max_display_count + 1).id
         self.assertTrue("Showing only the first" in repr(psser))
         self.assertTrue(
-            repr(psser).startswith(repr(psser.to_pandas().head(ReprTest.max_display_count)))
+            repr(psser).startswith(repr(psser._to_pandas().head(ReprTest.max_display_count)))
         )
 
         with option_context("display.max_rows", None):
             psser = ps.range(ReprTest.max_display_count + 1).id
-            self.assert_eq(repr(psser), repr(psser.to_pandas()))
+            self.assert_eq(repr(psser), repr(psser._to_pandas()))
 
         psser = ps.range(ReprTest.max_display_count).id.rename()
         self.assertTrue("Showing only the first" not in repr(psser))
-        self.assert_eq(repr(psser), repr(psser.to_pandas()))
+        self.assert_eq(repr(psser), repr(psser._to_pandas()))
 
         psser = ps.range(ReprTest.max_display_count + 1).id.rename()
         self.assertTrue("Showing only the first" in repr(psser))
         self.assertTrue(
-            repr(psser).startswith(repr(psser.to_pandas().head(ReprTest.max_display_count)))
+            repr(psser).startswith(repr(psser._to_pandas().head(ReprTest.max_display_count)))
         )
 
         with option_context("display.max_rows", None):
             psser = ps.range(ReprTest.max_display_count + 1).id.rename()
-            self.assert_eq(repr(psser), repr(psser.to_pandas()))
+            self.assert_eq(repr(psser), repr(psser._to_pandas()))
 
         psser = ps.MultiIndex.from_tuples(
             [(100 * i, i) for i in range(ReprTest.max_display_count)]
         ).to_series()
         self.assertTrue("Showing only the first" not in repr(psser))
-        self.assert_eq(repr(psser), repr(psser.to_pandas()))
+        self.assert_eq(repr(psser), repr(psser._to_pandas()))
 
         psser = ps.MultiIndex.from_tuples(
             [(100 * i, i) for i in range(ReprTest.max_display_count + 1)]
         ).to_series()
         self.assertTrue("Showing only the first" in repr(psser))
         self.assertTrue(
-            repr(psser).startswith(repr(psser.to_pandas().head(ReprTest.max_display_count)))
+            repr(psser).startswith(repr(psser._to_pandas().head(ReprTest.max_display_count)))
         )
 
         with option_context("display.max_rows", None):
             psser = ps.MultiIndex.from_tuples(
                 [(100 * i, i) for i in range(ReprTest.max_display_count + 1)]
             ).to_series()
-            self.assert_eq(repr(psser), repr(psser.to_pandas()))
+            self.assert_eq(repr(psser), repr(psser._to_pandas()))
 
     def test_repr_indexes(self):
         psidx = ps.range(ReprTest.max_display_count).index
         self.assertTrue("Showing only the first" not in repr(psidx))
-        self.assert_eq(repr(psidx), repr(psidx.to_pandas()))
+        self.assert_eq(repr(psidx), repr(psidx._to_pandas()))
 
         psidx = ps.range(ReprTest.max_display_count + 1).index
         self.assertTrue("Showing only the first" in repr(psidx))
         self.assertTrue(
             repr(psidx).startswith(
-                repr(psidx.to_pandas().to_series().head(ReprTest.max_display_count).index)
+                repr(psidx._to_pandas().to_series().head(ReprTest.max_display_count).index)
             )
         )
 
         with option_context("display.max_rows", None):
             psidx = ps.range(ReprTest.max_display_count + 1).index
-            self.assert_eq(repr(psidx), repr(psidx.to_pandas()))
+            self.assert_eq(repr(psidx), repr(psidx._to_pandas()))
 
         psidx = ps.MultiIndex.from_tuples([(100 * i, i) for i in range(ReprTest.max_display_count)])
         self.assertTrue("Showing only the first" not in repr(psidx))
-        self.assert_eq(repr(psidx), repr(psidx.to_pandas()))
+        self.assert_eq(repr(psidx), repr(psidx._to_pandas()))
 
         psidx = ps.MultiIndex.from_tuples(
             [(100 * i, i) for i in range(ReprTest.max_display_count + 1)]
@@ -126,7 +126,7 @@ class ReprTest(PandasOnSparkTestCase):
         self.assertTrue("Showing only the first" in repr(psidx))
         self.assertTrue(
             repr(psidx).startswith(
-                repr(psidx.to_pandas().to_frame().head(ReprTest.max_display_count).index)
+                repr(psidx._to_pandas().to_frame().head(ReprTest.max_display_count).index)
             )
         )
 
@@ -134,19 +134,19 @@ class ReprTest(PandasOnSparkTestCase):
             psidx = ps.MultiIndex.from_tuples(
                 [(100 * i, i) for i in range(ReprTest.max_display_count + 1)]
             )
-            self.assert_eq(repr(psidx), repr(psidx.to_pandas()))
+            self.assert_eq(repr(psidx), repr(psidx._to_pandas()))
 
     def test_html_repr(self):
         psdf = ps.range(ReprTest.max_display_count)
         self.assertTrue("Showing only the first" not in psdf._repr_html_())
-        self.assertEqual(psdf._repr_html_(), psdf.to_pandas()._repr_html_())
+        self.assertEqual(psdf._repr_html_(), psdf._to_pandas()._repr_html_())
 
         psdf = ps.range(ReprTest.max_display_count + 1)
         self.assertTrue("Showing only the first" in psdf._repr_html_())
 
         with option_context("display.max_rows", None):
             psdf = ps.range(ReprTest.max_display_count + 1)
-            self.assertEqual(psdf._repr_html_(), psdf.to_pandas()._repr_html_())
+            self.assertEqual(psdf._repr_html_(), psdf._to_pandas()._repr_html_())
 
     def test_repr_float_index(self):
         psdf = ps.DataFrame(
@@ -154,14 +154,14 @@ class ReprTest(PandasOnSparkTestCase):
             index=np.random.rand(ReprTest.max_display_count),
         )
         self.assertTrue("Showing only the first" not in repr(psdf))
-        self.assert_eq(repr(psdf), repr(psdf.to_pandas()))
+        self.assert_eq(repr(psdf), repr(psdf._to_pandas()))
         self.assertTrue("Showing only the first" not in repr(psdf.a))
-        self.assert_eq(repr(psdf.a), repr(psdf.a.to_pandas()))
+        self.assert_eq(repr(psdf.a), repr(psdf.a._to_pandas()))
         self.assertTrue("Showing only the first" not in repr(psdf.index))
-        self.assert_eq(repr(psdf.index), repr(psdf.index.to_pandas()))
+        self.assert_eq(repr(psdf.index), repr(psdf.index._to_pandas()))
 
         self.assertTrue("Showing only the first" not in psdf._repr_html_())
-        self.assertEqual(psdf._repr_html_(), psdf.to_pandas()._repr_html_())
+        self.assertEqual(psdf._repr_html_(), psdf._to_pandas()._repr_html_())
 
         psdf = ps.DataFrame(
             {"a": np.random.rand(ReprTest.max_display_count + 1)},

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -982,7 +982,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         with ps.option_context("compute.default_index_type", "distributed"):
             # the index is different.
             self.assert_eq(
-                psser.reset_index().to_pandas().reset_index(drop=True), pser.reset_index()
+                psser.reset_index()._to_pandas().reset_index(drop=True), pser.reset_index()
             )
 
     def test_index_to_series_reset_index(self):
@@ -2866,7 +2866,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             psser = ps.Series([1, 2, np.nan, 4, 5])  # Arrow takes np.nan as null
             psser.loc[3] = np.nan  # Spark takes np.nan as NaN
             kcodes, kuniques = psser.factorize(na_sentinel=None)
-            pcodes, puniques = psser.to_pandas().factorize(sort=True, na_sentinel=None)
+            pcodes, puniques = psser._to_pandas().factorize(sort=True, na_sentinel=None)
             self.assert_eq(pcodes.tolist(), kcodes.to_list())
             self.assert_eq(puniques, kuniques)
 

--- a/python/pyspark/pandas/tests/test_series_datetime.py
+++ b/python/pyspark/pandas/tests/test_series_datetime.py
@@ -52,17 +52,17 @@ class SeriesDateTimeTest(PandasOnSparkTestCase, SQLTestUtils):
         pdf = self.pdf1
         psdf = ps.from_pandas(pdf)
 
-        actual = (psdf["end_date"] - psdf["start_date"] - 1).to_pandas()
+        actual = (psdf["end_date"] - psdf["start_date"] - 1)._to_pandas()
         expected = (pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1
         self.assert_eq(actual, expected)
 
-        actual = (psdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31") - 1).to_pandas()
+        actual = (psdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31") - 1)._to_pandas()
         expected = (pdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31")) // np.timedelta64(
             1, "s"
         ) - 1
         self.assert_eq(actual, expected)
 
-        actual = (pd.Timestamp("2013-3-11 21:45:00") - psdf["start_date"] - 1).to_pandas()
+        actual = (pd.Timestamp("2013-3-11 21:45:00") - psdf["start_date"] - 1)._to_pandas()
         expected = (pd.Timestamp("2013-3-11 21:45:00") - pdf["start_date"]) // np.timedelta64(
             1, "s"
         ) - 1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Eliminate `to_pandas` warnings in test, by changing `to_pandas()` to `_to_pandas()`


### Why are the changes needed?
when a test containing `to_pandas` failed, it may print tons of warnings, for example, in https://github.com/zhengruifeng/spark/actions/runs/3142284988/jobs/5106178199 

it printed this warning from line 1243 to line 3985:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/7322292/192949507-ae1d3677-6ba4-4d80-84b1-44884fb1988b.png">



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
updated tests