### PR TITLE
[SPARK-40556][PS][SQL][WIP] Make `AttachDistributedSequenceExec` a `BinaryExecNode`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AttachDistributedSequenceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AttachDistributedSequenceExec.scala
@@ -63,7 +63,7 @@ case class AttachDistributedSequenceExec(
         val unsafeRowWriter =
           new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1)
 
-        var id = startIndices(partId)
+        var id = startIndices(partId) - 1L
         iter.map { row =>
           // Writes to an UnsafeRow directly
           unsafeRowWriter.reset()
@@ -79,7 +79,7 @@ case class AttachDistributedSequenceExec(
         val unsafeRowWriter =
           new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1)
 
-        var id = 0L
+        var id = -1L
         iter.map { row =>
           // Writes to an UnsafeRow directly
           unsafeRowWriter.reset()


### PR DESCRIPTION
### What changes were proposed in this pull request?
create another child containing only `Literal(true)` to compute the partition sizes


### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
WIP
