### PR TITLE
[SPARK-40540][SQL][TESTS][FOLLOW-UP] Use a regex for List and ArrayBuffer for 'Struct Star Expansion' test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -1829,8 +1829,11 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
           sql("select a.* from testData2")
         },
         errorClass = "_LEGACY_ERROR_TEMP_1050",
-        parameters = Map("attributes" -> "ArrayBuffer(a)"),
-        context = ExpectedContext(fragment = "a.*", start = 7, stop = 9))
+        errorSubClass = None,
+        sqlState = None,
+        parameters = Map("attributes" -> "(ArrayBuffer|List)\\(a\\)"),
+        matchPVals = true,
+        queryContext = Array(ExpectedContext(fragment = "a.*", start = 7, stop = 9)))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a minor followup of https://github.com/apache/spark/pull/37973 to match the pattern of either `ArrayBuffer` (Scala 2.12) or `List` (Scala 2.13) in "Struct Star Expansion" test case at `SQLQuerySuite.scala`.

### Why are the changes needed?

Currently, the test fails with Scala 2.13 (https://github.com/apache/spark/actions/runs/3146198025/jobs/5114388079):

```
[info] - Struct Star Expansion *** FAILED *** (1 second, 801 milliseconds)
[info]   Map("attributes" -> "List(a)") did not equal Map("attributes" -> "ArrayBuffer(a)") (SparkFunSuite.scala:328)
[info]   Analysis:
[info]   JavaCollectionWrappers$JMapWrapper(attributes: List(a) -> ArrayBuffer(a))
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
[info]   at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
[info]   at org.apache.spark.SparkFunSuite.checkError(SparkFunSuite.scala:328)
[info]   at org.apache.spark.SparkFunSuite.checkError(SparkFunSuite.scala:369)
```

We should also consider Scala 2.13 case.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested:

```scala
scala> "List(a)".matches("(ArrayBuffer|List)\\(a\\)")
res0: Boolean = true

scala> "ArrayBuffer(a)".matches("(ArrayBuffer|List)\\(a\\)")
res1: Boolean = true
```