### PR TITLE
[SPARK-40609][SQL] Casts types according to bucket info for Equality expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -79,6 +79,7 @@ object AnsiTypeCoercion extends TypeCoercionBase {
     new AnsiCombinedTypeCoercionRule(
       InConversion ::
       PromoteStrings ::
+      EqualityTypeCasts ::
       DecimalPrecision ::
       FunctionArgumentConversion ::
       ConcatCoercion ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -762,12 +762,13 @@ abstract class TypeCoercionBase {
       exprs.map(_.dataType).forall {
         case _: IntegralType => true
         case DecimalType.Fixed(_, 0) => true
+        case _ => false
       }
     }
 
     override val transform: PartialFunction[Expression, Expression] = {
       case b @ Equality(left: Attribute, right: Attribute)
-          if left.dataType != right.dataType && isIntegralTypes(b.children) =>
+          if b.childrenResolved && left.dataType != right.dataType && isIntegralTypes(b.children) =>
         // The result type is:
         // 1. The attribute data type with larger bucket number.
         // 2. The attribute data type with larger default size if it is not bucketed attribute.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -175,6 +175,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$ConcatCoercion" ::
       "org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$Division" ::
       "org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$EltCoercion" ::
+      "org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$EqualityTypeCasts" ::
       "org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$FunctionArgumentConversion" ::
       "org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$IfCoercion" ::
       "org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$ImplicitTypeCasts" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercionSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.analysis.AnsiTypeCoercion._
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.EvalMode.TRY
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -1045,5 +1046,13 @@ class AnsiTypeCoercionSuite extends TypeCoercionSuiteBase {
       ruleTest(
         AnsiTypeCoercion.GetDateFieldOperations, operation(ts), operation(Cast(ts, DateType)))
     }
+  }
+
+  test("SPARK-40609: Casts types according to bucket info for Equality expression") {
+    ruleTest(TypeCoercion.EqualityTypeCasts,
+      EqualTo(AttributeReference("l", IntegerType, metadata = bucketMetadata(200))(),
+        AttributeReference("r", LongType)()),
+      EqualTo(AttributeReference("l", IntegerType, metadata = bucketMetadata(200))(),
+        Cast(AttributeReference("r", LongType)(), IntegerType, evalMode = TRY)))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -22,9 +22,11 @@ import java.time.{Duration, LocalDateTime, Period}
 
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion._
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.EvalMode.TRY
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.internal.SQLConf
@@ -1739,6 +1741,55 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
         }
       }
     }
+  }
+
+  test("SPARK-40609: Casts types according to bucket info for Equality expression") {
+    def metadata(bucketNum: Int): Metadata = {
+      new MetadataBuilder()
+        .putLong(BucketSpec.toString(), bucketNum).build()
+    }
+    // Bucket exist
+    ruleTest(TypeCoercion.EqualityTypeCasts,
+      EqualTo(
+        AttributeReference("l", IntegerType, metadata = metadata(100))(),
+        AttributeReference("r", LongType, metadata = metadata(50))()),
+      EqualTo(
+        AttributeReference("l", IntegerType, metadata = metadata(100))(),
+        Cast(AttributeReference("r", LongType, metadata = metadata(50))(), IntegerType,
+          evalMode = TRY)))
+
+    ruleTest(TypeCoercion.EqualityTypeCasts,
+      EqualNullSafe(
+        AttributeReference("l", DecimalType(18, 0), metadata = metadata(100))(),
+        AttributeReference("r", LongType, metadata = metadata(50))()),
+      EqualNullSafe(
+        AttributeReference("l", DecimalType(18, 0), metadata = metadata(100))(),
+        Cast(AttributeReference("r", LongType, metadata = metadata(50))(), DecimalType(18, 0),
+          evalMode = TRY)))
+
+    ruleTest(TypeCoercion.EqualityTypeCasts,
+      EqualTo(
+        AttributeReference("l", IntegerType, metadata = metadata(100))(),
+        AttributeReference("r", LongType)()),
+      EqualTo(
+        AttributeReference("l", IntegerType, metadata = metadata(100))(),
+        Cast(AttributeReference("r", LongType)(), IntegerType, evalMode = TRY)))
+
+    // Bucket does not exist
+    ruleTest(TypeCoercion.EqualityTypeCasts,
+      EqualTo(AttributeReference("l", IntegerType)(),
+        AttributeReference("r", LongType)()),
+      EqualTo(
+        Cast(AttributeReference("l", IntegerType)(), LongType, evalMode = TRY),
+        AttributeReference("r", LongType)()))
+
+
+    ruleTest(TypeCoercion.EqualityTypeCasts,
+      EqualTo(AttributeReference("l", DecimalType(10, 0))(),
+        AttributeReference("r", DecimalType(20, 0))()),
+      EqualTo(
+        Cast(AttributeReference("l", DecimalType(10, 0))(), DecimalType(20, 0), evalMode = TRY),
+      AttributeReference("r", DecimalType(20, 0))()))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -38,6 +38,7 @@ import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, OverwriteByExpression}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources.{DataSourceUtils, HadoopFsRelation, LogicalRelation}
@@ -1080,9 +1081,10 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
         spark.sql("INSERT OVERWRITE TABLE tbl2 SELECT COL1, COL2, COL3 FROM view1")
         val identifier = TableIdentifier("tbl2")
         val location = spark.sessionState.catalog.getTableMetadata(identifier).location.toString
+        val bucketMetadata = new MetadataBuilder().putLong(BucketSpec.toString(), 3).build()
         val expectedSchema = StructType(Seq(
           StructField("COL1", LongType, true),
-          StructField("COL3", IntegerType, true),
+          StructField("COL3", IntegerType, true, bucketMetadata),
           StructField("COL2", IntegerType, true)))
         assert(spark.read.parquet(location).schema == expectedSchema)
         checkAnswer(spark.table("tbl2"), df)


### PR DESCRIPTION
### What changes were proposed in this pull request?

It will invalidate the bucket scan if add a cast to bucket column. In fact, sometimes we can avoid adding this cast if it is an equality expression and both sides are integral types.

This PR adds a new type coercion rule(`EqualityTypeCasts`) to support casting types according to bucket info for Equality expressions. For example:
```sql
CREATE TABLE t1(l bigint) USING parquet CLUSTERED BY (l) INTO 200 buckets;
CREATE TABLE t2(dec decimal(18, 0)) USING parquet CLUSTERED BY (dec) INTO 200 buckets;

SET spark.sql.autoBroadcastJoinThreshold=-1;
SELECT * FROM t1 JOIN t2 ON t1.l = t2.dec;
```

Before this PR:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortMergeJoin [cast(l#10L as decimal(20,0))], [cast(dec#11 as decimal(20,0))], Inner
   :- Sort [cast(l#10L as decimal(20,0)) ASC NULLS FIRST], false, 0
   :  +- Exchange hashpartitioning(cast(l#10L as decimal(20,0)), 5), ENSURE_REQUIREMENTS, [plan_id=38]
   :     +- Filter isnotnull(l#10L)
   :        +- FileScan parquet spark_catalog.default.t1[l#10L]
   +- Sort [cast(dec#11 as decimal(20,0)) ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(cast(dec#11 as decimal(20,0)), 5), ENSURE_REQUIREMENTS, [plan_id=42]
         +- Filter isnotnull(dec#11)
            +- FileScan parquet spark_catalog.default.t2[dec#11]
```
After this PR:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortMergeJoin [l#10L], [try_cast(dec#11 as bigint)], Inner
   :- Sort [l#10L ASC NULLS FIRST], false, 0
   :  +- Filter isnotnull(l#10L)
   :     +- FileScan parquet spark_catalog.default.t1[l#10L]
   +- Sort [try_cast(dec#11 as bigint) ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(try_cast(dec#11 as bigint), 200), ENSURE_REQUIREMENTS, [plan_id=38]
         +- Filter isnotnull(dec#11)
            +- FileScan parquet spark_catalog.default.t2[dec#11]
```


### Why are the changes needed?

Reduce shuffle to improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.