### PR TITLE
[SPARK-40590][TEST] Fix `ps.read_parquet` when `pandas_metadata` is `True`

### DIFF
--- a/python/pyspark/pandas/tests/test_dataframe_spark_io.py
+++ b/python/pyspark/pandas/tests/test_dataframe_spark_io.py
@@ -99,7 +99,7 @@ class DataFrameSparkIOTest(PandasOnSparkTestCase, TestUtils):
             expected3 = expected2.set_index("index", append=True)
             # There is a bug in `to_parquet` from pandas 1.5.0 when writing MultiIndex.
             # See https://github.com/pandas-dev/pandas/issues/48848 for the reported issue.
-            if LooseVersion(pd.__version__) >= LooseVersion("1.5.0"):
+            if LooseVersion(pd.__version__) == LooseVersion("1.5.0"):
                 expected_psdf = ps.read_parquet(path2, pandas_metadata=True).set_index(
                     "index", append=True
                 )

--- a/python/pyspark/pandas/tests/test_dataframe_spark_io.py
+++ b/python/pyspark/pandas/tests/test_dataframe_spark_io.py
@@ -18,6 +18,7 @@
 import unittest
 import glob
 import os
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -96,11 +97,18 @@ class DataFrameSparkIOTest(PandasOnSparkTestCase, TestUtils):
             self.assert_eq(ps.read_parquet(path2, pandas_metadata=True), expected2)
 
             expected3 = expected2.set_index("index", append=True)
+            # There is a bug in `to_parquet` from pandas 1.5.0 when writing MultiIndex.
+            # See https://github.com/pandas-dev/pandas/issues/48848 for the reported issue.
+            if LooseVersion(pd.__version__) >= LooseVersion("1.5.0"):
+                expected_psdf = ps.read_parquet(path2, pandas_metadata=True).set_index(
+                    "index", append=True
+                )
+            else:
+                path3 = "{}/file3.parquet".format(tmp)
+                expected3.to_parquet(path3)
+                expected_psdf = ps.read_parquet(path3, pandas_metadata=True)
 
-            path3 = "{}/file3.parquet".format(tmp)
-            expected3.to_parquet(path3)
-
-            self.assert_eq(ps.read_parquet(path3, pandas_metadata=True), expected3)
+            self.assert_eq(expected_psdf, expected3)
 
     def test_parquet_write(self):
         with self.temp_dir() as tmp:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to fix the `ps.read_parquet` test since the `pd.to_parquet` is broken when the index is `MultiIndex` from pandas 1.5.0.

We leverage the `pd.to_parquet` in the test, so the test failed with pandas 1.5.0 as below (`MultiIndex` is not respected):
```python
DataFrame shape mismatch
[left]:  (20, 5)
[right]: (20, 4)

Left:
    i32  i64     f  bhello     index
0     0    0   0.0      yo  0.617492
1     1    1   1.0  people  0.823826
2     2    2   2.0  people  0.443275
3     0    3   3.0   hello  0.639776
4     1    4   4.0      yo  0.393410
5     2    0   5.0      yo  0.898860
6     0    1   6.0  people  0.725236
7     1    2   7.0      yo  0.933009
8     2    3   8.0      yo  0.663381
9     0    4   9.0   hello  0.471077
10    1    0  10.0   hello  0.562182
11    2    1  11.0  people  0.734902
12    0    2  12.0      yo  0.956519
13    1    3  13.0   hello  0.860517
14    2    4  14.0  people  0.012749
15    0    0  15.0  people  0.561815
16    1    1  16.0  people  0.389130
17    2    2  17.0   hello  0.930301
18    0    3  18.0   hello  0.835025
19    1    4  19.0      yo  0.212191
i32         int32
i64         int64
f         float64
bhello     object
index     float64
dtype: object

Right:
             i32  i64     f  bhello
   index                           
0  0.617492    0    0   0.0      yo
1  0.823826    1    1   1.0  people
2  0.443275    2    2   2.0  people
3  0.639776    0    3   3.0   hello
4  0.393410    1    4   4.0      yo
5  0.898860    2    0   5.0      yo
6  0.725236    0    1   6.0  people
7  0.933009    1    2   7.0      yo
8  0.663381    2    3   8.0      yo
9  0.471077    0    4   9.0   hello
10 0.562182    1    0  10.0   hello
11 0.734902    2    1  11.0  people
12 0.956519    0    2  12.0      yo
13 0.860517    1    3  13.0   hello
14 0.012749    2    4  14.0  people
15 0.561815    0    0  15.0  people
16 0.389130    1    1  16.0  people
17 0.930301    2    2  17.0   hello
18 0.835025    0    3  18.0   hello
19 0.212191    1    4  19.0      yo
i32         int32
i64         int64
f         float64
bhello     object
dtype: object
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We should make the all test passing with pandas 1.5.0.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually test with pandas 1.5.0.