### PR TITLE
[SPARK-40619][SQL][TESTS] Add explicitly gc for `HivePartitionFilteringSuite`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -39,6 +39,12 @@ import org.apache.spark.util.Utils
 class HivePartitionFilteringSuite(version: String)
     extends HiveVersionSuite(version) with BeforeAndAfterAll with SQLHelper {
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    // SPARK-40619: explicitly call gc to avoid OutOfMemoryError as far as possible.
+    System.gc()
+  }
+
   private val tryDirectSqlKey = HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname
   private val fallbackKey = SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FALLBACK_ON_EXCEPTION.key
   private val pruningFastFallback = SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FAST_FALLBACK.key


### PR DESCRIPTION
### What changes were proposed in this pull request?
Similar as SPARK-39869, this pr add explicitly `System.gc()` before each case for `HivePartitionFilteringSuite` to avoid OutOfMemoryError as far as possible.


### Why are the changes needed?
Fix flaky test.

```
2022-09-29T16:23:50.4263170Z [info] org.apache.spark.sql.hive.client.HivePartitionFilteringSuites *** ABORTED *** (26 minutes, 32 seconds)
2022-09-29T16:23:50.4340944Z [info]   java.lang.reflect.InvocationTargetException:
2022-09-29T16:23:50.4341736Z [info]   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
2022-09-29T16:23:50.4342537Z [info]   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
2022-09-29T16:23:50.4343543Z [info]   at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2022-09-29T16:23:50.4344319Z [info]   at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
2022-09-29T16:23:50.4345108Z [info]   at org.apache.spark.sql.hive.client.IsolatedClientLoader.createClient(IsolatedClientLoader.scala:315)
2022-09-29T16:23:50.4346070Z [info]   at org.apache.spark.sql.hive.client.HiveClientBuilder$.buildClient(HiveClientBuilder.scala:50)
2022-09-29T16:23:50.4347512Z [info]   at org.apache.spark.sql.hive.client.HiveVersionSuite.buildClient(HiveVersionSuite.scala:48)
2022-09-29T16:23:50.4348463Z [info]   at org.apache.spark.sql.hive.client.HivePartitionFilteringSuite.init(HivePartitionFilteringSuite.scala:73)
2022-09-29T16:23:50.4349656Z [info]   at org.apache.spark.sql.hive.client.HivePartitionFilteringSuite.beforeAll(HivePartitionFilteringSuite.scala:118)
2022-09-29T16:23:50.4350533Z [info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
2022-09-29T16:23:50.4351500Z [info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
2022-09-29T16:23:50.4352219Z [info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
2022-09-29T16:23:50.4353147Z [info]   at org.apache.spark.SparkFunSuite.run(SparkFunSuite.scala:66)
2022-09-29T16:23:50.4353841Z [info]   at org.scalatest.Suite.callExecuteOnSuite$1(Suite.scala:1178)
2022-09-29T16:23:50.4354737Z [info]   at org.scalatest.Suite.$anonfun$runNestedSuites$1(Suite.scala:1225)
2022-09-29T16:23:50.4355475Z [info]   at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
2022-09-29T16:23:50.4356464Z [info]   at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
2022-09-29T16:23:50.4357212Z [info]   at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
2022-09-29T16:23:50.4358108Z [info]   at org.scalatest.Suite.runNestedSuites(Suite.scala:1223)
2022-09-29T16:23:50.4358777Z [info]   at org.scalatest.Suite.runNestedSuites$(Suite.scala:1156)
2022-09-29T16:23:50.4359870Z [info]   at org.apache.spark.sql.hive.client.HivePartitionFilteringSuites.runNestedSuites(HivePartitionFilteringSuites.scala:24)
2022-09-29T16:23:50.4360679Z [info]   at org.scalatest.Suite.run(Suite.scala:1111)
2022-09-29T16:23:50.4361498Z [info]   at org.scalatest.Suite.run$(Suite.scala:1096)
2022-09-29T16:23:50.4362487Z [info]   at org.apache.spark.sql.hive.client.HivePartitionFilteringSuites.run(HivePartitionFilteringSuites.scala:24)
2022-09-29T16:23:50.4363571Z [info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
2022-09-29T16:23:50.4364320Z [info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:516)
2022-09-29T16:23:50.4365208Z [info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:413)
2022-09-29T16:23:50.4365870Z [info]   at java.util.concurrent.FutureTask.run(FutureTask.java:266)
2022-09-29T16:23:50.4366831Z [info]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2022-09-29T16:23:50.4368396Z [info]   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2022-09-29T16:23:50.4368925Z [info]   at java.lang.Thread.run(Thread.java:750)
2022-09-29T16:23:50.4369387Z [info]   Cause: java.lang.OutOfMemoryError: Metaspace
2022-09-29T16:23:50.4369882Z [info]   at java.lang.ClassLoader.defineClass1(Native Method)
2022-09-29T16:23:50.4370399Z [info]   at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
2022-09-29T16:23:50.4370965Z [info]   at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
2022-09-29T16:23:50.4371538Z [info]   at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
2022-09-29T16:23:50.4372072Z [info]   at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
2022-09-29T16:23:50.4372586Z [info]   at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
2022-09-29T16:23:50.4373083Z [info]   at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
2022-09-29T16:23:50.4373604Z [info]   at java.security.AccessController.doPrivileged(Native Method)
2022-09-29T16:23:50.4374148Z [info]   at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
2022-09-29T16:23:50.4374670Z [info]   at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
2022-09-29T16:23:50.4375323Z [info]   at org.apache.spark.sql.hive.client.IsolatedClientLoader$$anon$1.doLoadClass(IsolatedClientLoader.scala:269)
2022-09-29T16:23:50.4376066Z [info]   at org.apache.spark.sql.hive.client.IsolatedClientLoader$$anon$1.loadClass(IsolatedClientLoader.scala:258)
2022-09-29T16:23:50.4376672Z [info]   at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
2022-09-29T16:23:50.4377204Z [info]   at org.apache.hadoop.hive.conf.HiveConf.<clinit>(HiveConf.java:150)
2022-09-29T16:23:50.4377825Z [info]   at org.apache.spark.sql.hive.client.HiveClientImpl$.newHiveConf(HiveClientImpl.scala:1284)
2022-09-29T16:23:50.4378489Z [info]   at org.apache.spark.sql.hive.client.HiveClientImpl.newState(HiveClientImpl.scala:171)
2022-09-29T16:23:50.4379144Z [info]   at org.apache.spark.sql.hive.client.HiveClientImpl.<init>(HiveClientImpl.scala:136)
2022-09-29T16:23:50.4379774Z [info]   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
2022-09-29T16:23:50.4380475Z [info]   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
2022-09-29T16:23:50.4381298Z [info]   at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2022-09-29T16:23:50.4381965Z [info]   at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
2022-09-29T16:23:50.4382648Z [info]   at org.apache.spark.sql.hive.client.IsolatedClientLoader.createClient(IsolatedClientLoader.scala:315)
2022-09-29T16:23:50.4383383Z [info]   at org.apache.spark.sql.hive.client.HiveClientBuilder$.buildClient(HiveClientBuilder.scala:50)
2022-09-29T16:23:50.4384079Z [info]   at org.apache.spark.sql.hive.client.HiveVersionSuite.buildClient(HiveVersionSuite.scala:48)
2022-09-29T16:23:50.4384868Z [info]   at org.apache.spark.sql.hive.client.HivePartitionFilteringSuite.init(HivePartitionFilteringSuite.scala:73)
2022-09-29T16:23:50.4385686Z [info]   at org.apache.spark.sql.hive.client.HivePartitionFilteringSuite.beforeAll(HivePartitionFilteringSuite.scala:118)
2022-09-29T16:23:50.4386560Z [info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
2022-09-29T16:23:50.4387139Z [info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
2022-09-29T16:23:50.4387696Z [info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
2022-09-29T16:23:50.4388245Z [info]   at org.apache.spark.SparkFunSuite.run(SparkFunSuite.scala:66)
2022-09-29T16:23:50.4388781Z [info]   at org.scalatest.Suite.callExecuteOnSuite$1(Suite.scala:1178)
2022-09-29T16:23:50.4389309Z [info]   at org.scalatest.Suite.$anonfun$runNestedSuites$1(Suite.scala:1225) 
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions