### PR TITLE
[Minor][Docs][SQL] Fix typo in Doc for emptyDataset: change returns to since

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -294,7 +294,7 @@ class SparkSession private(
   /**
    * Creates a new [[Dataset]] of type T containing zero elements.
    *
-   * @return 2.0.0
+   * @since 2.0.0
    */
   def emptyDataset[T: Encoder]: Dataset[T] = {
     val encoder = implicitly[Encoder[T]]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Doc fix for emptyDataset: change returns to since.

### Why are the changes needed?

Fix doc.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.