### PR TITLE
[SPARK-40409] spark-sql supports reading `ByteType` data of avro serde

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -131,6 +131,9 @@ private[sql] class AvroDeserializer(
       case (INT, DateType) => (updater, ordinal, value) =>
         updater.setInt(ordinal, dateRebaseFunc(value.asInstanceOf[Int]))
 
+      case (INT, ByteType) => (updater, ordinal, value) =>
+        updater.setByte(ordinal, value.asInstanceOf[Int].asInstanceOf[Byte])
+
       case (LONG, LongType) => (updater, ordinal, value) =>
         updater.setLong(ordinal, value.asInstanceOf[Long])
 

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
@@ -94,7 +94,6 @@ class AvroRowReaderSuite
       }
     }
   }
-  
   test("SPARK-40409: read Bytetype data correctly") {
     withTempPath { dir =>
       val catalystSchema = StructType(Seq(StructField("value", ByteType, true)))

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
@@ -95,7 +95,7 @@ class AvroRowReaderSuite
     }
   }
   
-  test("read Bytetype data correctly") {
+  test("SPARK-40409: read Bytetype data correctly") {
     withTempPath { dir =>
       val catalystSchema = StructType(Seq(StructField("value", ByteType, true)))
       val df = spark.createDataFrame(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


When Spark stores byte as an avro type table, the actual avro storage type is Int.

```
val df = sc.parallelize(Seq(("-128").toByte)).toDF
rdd.write.mode("overwrite").format("avro").saveAsTable("byte_avro")
```

Through avro tools, we can find that the actual type of avro is int.

```
java -jar avro-tools-1.11.0.jar getschema hdfs://0.0.0.0:9000/user/hive/warehouse/byte_avro/part-00000-6e901e63-798a-4b43-9d46-f8265773d95a-c000.avro
22/10/01 21:30:46 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
{
  "type" : "record",
  "name" : "topLevelRecord",
  "fields" : [ {
    "name" : "c1",
    "type" : [ "int", "null" ]
  } ]
}
```
However, the hive metadata will record that the field type is byte.

```
CREATE TABLE `byte_avro`(
  `value` int COMMENT '')
ROW FORMAT SERDE
  'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
WITH SERDEPROPERTIES (
  'path'='hdfs://0.0.0.0:9000/user/hive/warehouse/byte_avro1')
STORED AS INPUTFORMAT
  'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
OUTPUTFORMAT
  'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
LOCATION
  'hdfs://0.0.0.0:9000/user/hive/warehouse/byte_avro'
TBLPROPERTIES (
  'spark.sql.create.version'='3.4.0-SNAPSHOT',
  'spark.sql.sources.provider'='avro',
  'spark.sql.sources.schema'='{"type":"struct","fields":[{"name":"value","type":"byte","nullable":true,"metadata":{}}]}',  // here is byte
  'transient_lastDdlTime'='xxx')
```

This will cause an error when reading the Spark.

> spark.sql("select * from byte_avro").show

```
Caused by: org.apache.spark.sql.avro.IncompatibleSchemaException: Cannot convert Avro field 'value' to SQL field 'value' because schema is incompatible (avroType = "int", sqlType = TINYINT)
  at org.apache.spark.sql.avro.AvroDeserializer.newWriter(AvroDeserializer.scala:343)
  at org.apache.spark.sql.avro.AvroDeserializer.$anonfun$getRecordWriter$1(AvroDeserializer.scala:374)
  at scala.collection.immutable.List.map(List.scala:293)
  at org.apache.spark.sql.avro.AvroDeserializer.getRecordWriter(AvroDeserializer.scala:371)
  at org.apache.spark.sql.avro.AvroDeserializer.liftedTree1$1(AvroDeserializer.scala:83)
  ... 27 more
```




### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

add an UT.

