### PR TITLE
[SPARK-36290][SQL] Pull out complex join condition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -146,7 +146,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
         operatorOptimizationRuleSet: _*) ::
       Batch("Push extra predicate through join", fixedPoint,
         PushExtraPredicateThroughJoin,
-        PushDownPredicates) :: Nil
+        PushDownPredicates) ::
+      Batch("Pull out complex join condition", Once,
+        PullOutComplexJoinCondition) :: Nil
     }
 
     val batches = (
@@ -289,7 +291,6 @@ abstract class Optimizer(catalogManager: CatalogManager)
       ReplaceExpressions,
       RewriteNonCorrelatedExists,
       PullOutGroupingExpressions,
-      PullOutComplexJoinCondition,
       ComputeCurrentTime,
       ReplaceCurrentLike(catalogManager),
       SpecialDatetimeValues,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -289,6 +289,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       ReplaceExpressions,
       RewriteNonCorrelatedExists,
       PullOutGroupingExpressions,
+      PullOutComplexJoinCondition,
       ComputeCurrentTime,
       ReplaceCurrentLike(catalogManager),
       SpecialDatetimeValues,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutComplexJoinCondition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutComplexJoinCondition.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, PredicateHelper}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.JOIN
+
+/**
+ * This rule ensures that [[Join]] keys doesn't contain complex expressions in the
+ * optimization phase.
+ *
+ * Complex expressions are pulled out to a [[Project]] node under [[Join]] and are
+ * referenced in join condition.
+ *
+ * {{{
+ *   SELECT * FROM t1 JOIN t2 ON t1.a + 10 = t2.x ==>
+ *   Project [a#0, b#1, x#2, y#3]
+ *   +- Join Inner, ((spark_catalog.default.t1.a + 10)#8 = x#2)
+ *      :- Project [a#0, b#1, (a#0 + 10) AS (spark_catalog.default.t1.a + 10)#8]
+ *      :  +- Filter isnotnull((a#0 + 10))
+ *      :     +- Relation default.t1[a#0,b#1] parquet
+ *      +- Filter isnotnull(x#2)
+ *         +- Relation default.t2[x#2,y#3] parquet
+ * }}}
+ */
+object PullOutComplexJoinCondition extends Rule[LogicalPlan] with PredicateHelper {
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(_.containsPattern(JOIN)) {
+    case j @ Join(left, right, _, Some(condition), _) if j.resolved =>
+      val complexExps = splitConjunctivePredicates(condition).flatMap {
+        case p: Expression => p.children.filter(e => !e.foldable && e.children.nonEmpty)
+        case _ => Nil
+      }
+
+      val leftComplexExpMap = complexExps.filter(canEvaluate(_, left))
+        .map(e => e.canonicalized -> Alias(e, e.sql.take(20))()).toMap
+      val rightComplexExpMap = complexExps.filter(canEvaluate(_, right))
+        .map(e => e.canonicalized -> Alias(e, e.sql.take(20))()).toMap
+      val allComplexExpMap = leftComplexExpMap ++ rightComplexExpMap
+
+      if (allComplexExpMap.nonEmpty) {
+        val newCondition = condition.transformDown {
+          case e: Expression if e.children.nonEmpty && allComplexExpMap.contains(e.canonicalized) =>
+            allComplexExpMap.get(e.canonicalized).map(_.toAttribute).getOrElse(e)
+        }
+        val newLeft = Project(left.output ++ leftComplexExpMap.values, left)
+        val newRight = Project(right.output ++ rightComplexExpMap.values, right)
+        Project(j.output, j.copy(left = newLeft, right = newRight, condition = Some(newCondition)))
+      } else {
+        j
+      }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullOutComplexJoinConditionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PullOutComplexJoinConditionSuite.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{Alias, Substring, Upper}
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+
+class PullOutComplexJoinConditionSuite extends PlanTest {
+
+  private object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Pull out complex join condition", Once,
+        PullOutComplexJoinCondition,
+        CollapseProject) :: Nil
+  }
+
+  private val testRelation = LocalRelation($"a".string, $"b".int, $"c".int)
+  private val testRelation1 = LocalRelation($"d".string, $"e".int)
+  private val x = testRelation.subquery("x")
+  private val y = testRelation1.subquery("y")
+
+  test("Pull out join keys evaluation(String expressions)") {
+    Seq(Upper("y.d".attr), Substring("y.d".attr, 1, 5)).foreach { udf =>
+      val originalQuery = x.join(y, condition = Option($"a" === udf)).select($"a", $"e")
+      val correctAnswer = x.select($"a", $"b", $"c")
+        .join(y.select($"d", $"e", Alias(udf, udf.sql)()),
+          condition = Option($"a" === s"`${udf.sql}`".attr)).select($"a", $"e")
+
+      comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+    }
+  }
+
+  test("Pull out join condition contains other predicates") {
+    val udf = Substring("y.d".attr, 1, 5)
+    val originalQuery =
+      x.join(y, condition = Option($"a" === udf && $"b" > $"e")).select($"a", $"e")
+    val correctAnswer = x.select($"a", $"b", $"c")
+      .join(y.select($"d", $"e", Alias(udf, udf.sql)()),
+        condition = Option($"a" === s"`${udf.sql}`".attr && $"b" > $"e")).select($"a", $"e")
+
+    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+  }
+
+  test("Pull out EqualNullSafe join condition") {
+    val udf = "x.b".attr + 1
+
+    val originalQuery = x.join(y, condition = Option(udf <=> $"e")).select($"a", $"e")
+    val correctAnswer = x.select($"a", $"b", $"c", Alias(udf, udf.sql)())
+      .join(y.select($"d", $"e"), condition = Option(s"`${udf.sql}`".attr <=> s"e".attr))
+      .select($"a", $"e")
+
+    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+  }
+
+  test("Pull out non-equality join conditions") {
+    val udf = "x.b".attr + 1
+    val originalQuery = x.join(y, condition = Option(udf > $"e")).select($"a", $"e")
+
+    val correctAnswer = x.select($"a", $"b", $"c", Alias(udf, udf.sql)())
+      .join(y.select($"d", $"e"), condition = Option(s"`${udf.sql}`".attr > s"e".attr))
+      .select($"a", $"e")
+
+    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+  }
+
+  test("Negative case: all children are Attributes") {
+    val originalQuery = x.join(y, condition = Option($"a" === $"d"))
+
+    comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
+  }
+
+  test("Negative case: contains Literal") {
+    val originalQuery = x.join(y, condition = Option($"a" === "string"))
+
+    comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Similar to [`PullOutGroupingExpressions`](https://github.com/wangyum/spark/blob/7fd3f8f9ec55b364525407213ba1c631705686c5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutGroupingExpressions.scala#L48). This PR adds a new rule(`PullOutComplexJoinCondition`) to pull out complex join condition. 

### Why are the changes needed?

Pull out complex join condition has following advantage:
1. Reduce the number of complex expression evaluations from 3 to 2 times if it is SortMergeJoin..
2. Infer more additional filters, sometimes can avoid data skew. For example: https://github.com/apache/spark/pull/28642
3. Avoid other rules also need to handle complex condition. For example: https://github.com/apache/spark/blob/dee7396204e2f6e7346e220867953fc74cd4253d/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushPartialAggregationThroughJoin.scala#L325-L327

For example:
```sql
CREATE TABLE t1 (item_id BIGINT, event_type STRING, dt STRING) USING parquet PARTITIONED BY (dt);
CREATE TABLE t2 (item_id BIGINT, cal_dt DATE) using parquet;
set spark.sql.autoBroadcastJoinThreshold=-1;

SELECT a.item_id,
       a.event_type
FROM   t1 a
       INNER JOIN (SELECT DISTINCT cal_dt,
                                   item_id
                   FROM   t2) b
               ON a.item_id = b.item_id
                  AND To_date(a.dt, 'yyyyMMdd') = b.cal_dt
WHERE To_date(a.dt, 'yyyyMMdd') = date '2022-10-01';
```

Before this PR:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Project [item_id#28L, event_type#29]
   +- SortMergeJoin [cast(gettimestamp(dt#30, yyyyMMdd, TimestampType, Some(America/Los_Angeles), false) as date), item_id#28L], [cal_dt#32, item_id#31L], Inner
      :- Sort [cast(gettimestamp(dt#30, yyyyMMdd, TimestampType, Some(America/Los_Angeles), false) as date) ASC NULLS FIRST, item_id#28L ASC NULLS FIRST], false, 0
      :  +- Exchange hashpartitioning(cast(gettimestamp(dt#30, yyyyMMdd, TimestampType, Some(America/Los_Angeles), false) as date), item_id#28L, 5), ENSURE_REQUIREMENTS, [plan_id=78]
      :     +- Filter isnotnull(item_id#28L)
      :        +- FileScan parquet spark_catalog.default.t1[item_id#28L,event_type#29,dt#30]
      +- Sort [cal_dt#32 ASC NULLS FIRST, item_id#31L ASC NULLS FIRST], false, 0
         +- HashAggregate(keys=[cal_dt#32, item_id#31L], functions=[])
            +- Exchange hashpartitioning(cal_dt#32, item_id#31L, 5), ENSURE_REQUIREMENTS, [plan_id=74]
               +- HashAggregate(keys=[cal_dt#32, item_id#31L], functions=[])
                  +- Filter (isnotnull(item_id#31L) AND isnotnull(cal_dt#32))
                     +- FileScan parquet spark_catalog.default.t2[item_id#31L,cal_dt#32]
```

After this PR:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Project [item_id#28L, event_type#29]
   +- SortMergeJoin [CAST(gettimestamp(a.#37, item_id#28L], [cal_dt#32, item_id#31L], Inner
      :- Sort [CAST(gettimestamp(a.#37 ASC NULLS FIRST, item_id#28L ASC NULLS FIRST], false, 0
      :  +- Exchange hashpartitioning(CAST(gettimestamp(a.#37, item_id#28L, 5), ENSURE_REQUIREMENTS, [plan_id=78]
      :     +- Project [item_id#28L, event_type#29, cast(gettimestamp(dt#30, yyyyMMdd, TimestampType, Some(America/Los_Angeles), false) as date) AS CAST(gettimestamp(a.#37]
      :        +- Filter isnotnull(item_id#28L)
      :           +- FileScan parquet spark_catalog.default.t1[item_id#28L,event_type#29,dt#30]
      +- Sort [cal_dt#32 ASC NULLS FIRST, item_id#31L ASC NULLS FIRST], false, 0
         +- HashAggregate(keys=[cal_dt#32, item_id#31L], functions=[])
            +- Exchange hashpartitioning(cal_dt#32, item_id#31L, 5), ENSURE_REQUIREMENTS, [plan_id=74]
               +- HashAggregate(keys=[cal_dt#32, item_id#31L], functions=[])
                  +- Filter (((cal_dt#32 = 2022-10-01) AND isnotnull(item_id#31L)) AND isnotnull(cal_dt#32))
                     +- FileScan parquet spark_catalog.default.t2[item_id#31L,cal_dt#32]
```

Performance evaluation:

Spark | Job Duration(min)
-- | --
Vanilla | [38](https://issues.apache.org/jira/secure/attachment/13050013/default%28join%20order%20will%20change%29.png)
Pull out complex join condition and disable `spark.sql.constraintPropagation.enabled` | [3.6](https://issues.apache.org/jira/secure/attachment/13050016/Pull%20out%20complex%20join%20condition.png)
Pull out complex join condition and enable `spark.sql.constraintPropagation.enabled` | [1.8](https://issues.apache.org/jira/secure/attachment/13050026/Pull%20out%20complex%20join%20condition%20and%20infer%20more%20filters.png)



### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.