### PR TITLE
[SPARK-40631][PS] Implement `min_count` in `GroupBy.first`

### DIFF
--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1450,6 +1450,14 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         self.assert_eq(
             pdf.groupby("A").first().sort_index(), psdf.groupby("A").first().sort_index()
         )
+        self.assert_eq(
+            pdf.groupby("A").first(min_count=1).sort_index(),
+            psdf.groupby("A").first(min_count=1).sort_index(),
+        )
+        self.assert_eq(
+            pdf.groupby("A").first(min_count=2).sort_index(),
+            psdf.groupby("A").first(min_count=2).sort_index(),
+        )
 
     def test_last(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.last())


### PR DESCRIPTION

### What changes were proposed in this pull request?
Implement `min_count` in `GroupBy.first`


### Why are the changes needed?
for API coverage

### Does this PR introduce _any_ user-facing change?
new parameter supported

```
        >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
        ...                    "C": [3, 3, 4, 4], "D": ["a", "b", "a", "a"]})

        >>> df.groupby("D").first().sort_index()
           A      B  C
        D
        a  1   True  3
        b  2  False  3
        >>> df.groupby("D").first(min_count=3).sort_index()
             A     B    C
        D
        a  1.0  True  3.0
        b  NaN  None  NaN

```


### How was this patch tested?
added UT
