### PR TITLE
[SPARK-40632][SQL] Do not inject runtime filter if join condition reference non simple expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.analysis.MultiAlias
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Project}
 import org.apache.spark.sql.types.Metadata
 
 /**
@@ -42,6 +42,14 @@ trait AliasHelper {
         (a.toAttribute, a)
     }
     AttributeMap(aliasMap)
+  }
+
+  protected def getAliasMap(plan: LogicalPlan): AttributeMap[Alias] = {
+    plan match {
+      case p: Project => getAliasMap(p)
+      case a: Aggregate => getAliasMap(a)
+      case _ => AttributeMap.empty[Alias]
+    }
   }
 
   protected def getAliasMap(exprs: Seq[NamedExpression]): AttributeMap[Alias] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `InjectRuntimeFilter` do not inject runtime filter if join condition reference non simple expression.

### Why are the changes needed?

Injecting a runtime filter in this case may affect performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.