### PR TITLE
[SPARK-40634][BUILD] Upgrade joda-time to 2.11.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -160,7 +160,7 @@ jetty-util/6.1.26//jetty-util-6.1.26.jar
 jetty-util/9.4.48.v20220622//jetty-util-9.4.48.v20220622.jar
 jetty/6.1.26//jetty-6.1.26.jar
 jline/2.14.6//jline-2.14.6.jar
-joda-time/2.10.14//joda-time-2.10.14.jar
+joda-time/2.11.2//joda-time-2.11.2.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -145,7 +145,7 @@ jettison/1.1//jettison-1.1.jar
 jetty-util-ajax/9.4.48.v20220622//jetty-util-ajax-9.4.48.v20220622.jar
 jetty-util/9.4.48.v20220622//jetty-util-9.4.48.v20220622.jar
 jline/2.14.6//jline-2.14.6.jar
-joda-time/2.10.14//joda-time-2.10.14.jar
+joda-time/2.11.2//joda-time-2.11.2.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
     <guava.version>14.0.1</guava.version>
     <janino.version>3.1.7</janino.version>
     <jersey.version>2.36</jersey.version>
-    <joda.version>2.10.14</joda.version>
+    <joda.version>2.11.2</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
     <libthrift.version>0.12.0</libthrift.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade joda-time from 2.10.14 to 2.11.2.


### Why are the changes needed?
The new version brings some bug fix, the release notes as follows:

- https://www.joda.org/joda-time/changes-report.html#a2.11.0
- https://www.joda.org/joda-time/changes-report.html#a2.11.1
- https://www.joda.org/joda-time/changes-report.html#a2.11.2


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions
