### PR TITLE
[MINOR][DOCS] Clarify that VarianceThresholdSelector uses sample variance

### DIFF
--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -1875,7 +1875,7 @@ for more details on the API.
 ## VarianceThresholdSelector
 
 `VarianceThresholdSelector` is a selector that removes low-variance features. Features with a
- variance not greater than the `varianceThreshold` will be removed. If not set, `varianceThreshold`
+ (sample) variance not greater than the `varianceThreshold` will be removed. If not set, `varianceThreshold`
  defaults to 0, which means only features with variance 0 (i.e. features that have the same value in all samples)
  will be removed.
 
@@ -1895,7 +1895,7 @@ id | features
  6 | [8.0, 9.0, 6.0, 0.0, 0.0, 0.0]
 ~~~
 
-The variance for the 6 features are 16.67, 0.67, 8.17, 10.17,
+The sample variances for the 6 features are 16.67, 0.67, 8.17, 10.17,
 5.07, and 11.47 respectively. If we use `VarianceThresholdSelector` with
 `varianceThreshold = 8.0`, then the features with variance <= 8.0 are removed:
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/VarianceThresholdSelector.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/VarianceThresholdSelector.scala
@@ -56,7 +56,7 @@ private[feature] trait VarianceThresholdSelectorParams extends Params
 
 /**
  * Feature selector that removes all low-variance features. Features with a
- * variance not greater than the threshold will be removed. The default is to keep
+ * (sample) variance not greater than the threshold will be removed. The default is to keep
  * all features with non-zero variance, i.e. remove the features that have the
  * same value in all samples.
  */

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -7015,7 +7015,7 @@ class VarianceThresholdSelector(
 ):
     """
     Feature selector that removes all low-variance features. Features with a
-    variance not greater than the threshold will be removed. The default is to keep
+    (sample) variance not greater than the threshold will be removed. The default is to keep
     all features with non-zero variance, i.e. remove the features that have the
     same value in all samples.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Note that the VarianceThresholdSelector uses sample variance, not population variance, in docs.

### Why are the changes needed?

"Variance" is otherwise ambiguous in docs.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A