### PR TITLE
[MINOR][SQL] Remove redundant field `verboseLayout` from `LogDivertAppender`

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
@@ -298,7 +298,6 @@ public class LogDivertAppender extends AbstractWriterAppender<WriterManager> {
       // the last subAppend call, change the layout to preserve consistency.
       if (isCurrModeVerbose != isVerbose) {
         isVerbose = isCurrModeVerbose;
-        // setLayout(isVerbose, verboseLayout);
       }
     }
 

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
@@ -48,7 +48,6 @@ public class LogDivertAppender extends AbstractWriterAppender<WriterManager> {
   private static final Logger LOG = LogManager.getLogger(LogDivertAppender.class.getName());
   private final OperationManager operationManager;
   private boolean isVerbose;
-  private Layout verboseLayout;
 
   /**
    * A log filter that filters messages coming from the logger with the given names.
@@ -284,7 +283,6 @@ public class LogDivertAppender extends AbstractWriterAppender<WriterManager> {
 
     this.isVerbose = (loggingMode == OperationLog.LoggingLevel.VERBOSE);
     this.operationManager = operationManager;
-    this.verboseLayout = isVerbose ? getLayout() : CLIServiceUtils.verboseLayout;
     addFilter(new NameFilter(loggingMode, operationManager));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove a redundant field `verboseLayout` from `LogDivertAppender`.


### Why are the changes needed?
Remove redundant field,


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions