### PR TITLE
[SPARK-40640][CORE] SparkHadoopUtil to set origin of hadoop/hive config options

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -425,7 +425,7 @@ private[spark] object SparkHadoopUtil extends Logging {
    * Source for configuration options set by spark when another source is
    * not explicitly declared.
    */
-  private[deploy] val SOURCE_SPARK = "Set by Spark"
+  private[spark] val SOURCE_SPARK = "Set by Spark"
 
   /**
    * Source for configuration options with `spark.hadoop.` prefix copied
@@ -524,19 +524,12 @@ private[spark] object SparkHadoopUtil extends Logging {
     if (keyId != null && accessKey != null) {
       // source prefix string; will have environment variable added
       val source = SOURCE_SPARK + " on " + InetAddress.getLocalHost.toString + " from "
-      hadoopConf.set("fs.s3.awsAccessKeyId", keyId, source +
-        ENV_VAR_AWS_ACCESS_KEY)
-      hadoopConf.set("fs.s3n.awsAccessKeyId", keyId, source +
-        ENV_VAR_AWS_ACCESS_KEY)
-      hadoopConf.set("fs.s3a.access.key", keyId, source +
-        ENV_VAR_AWS_ACCESS_KEY)
-      hadoopConf.set("fs.s3.awsSecretAccessKey", accessKey, source +
-        ENV_VAR_AWS_SECRET_KEY)
-      hadoopConf.set("fs.s3n.awsSecretAccessKey", accessKey, source +
-        ENV_VAR_AWS_SECRET_KEY)
-      hadoopConf.set("fs.s3a.secret.key", accessKey, source +
-        ENV_VAR_AWS_SECRET_KEY)
-
+      hadoopConf.set("fs.s3.awsAccessKeyId", keyId, source + ENV_VAR_AWS_ACCESS_KEY)
+      hadoopConf.set("fs.s3n.awsAccessKeyId", keyId, source + ENV_VAR_AWS_ACCESS_KEY)
+      hadoopConf.set("fs.s3a.access.key", keyId, source + ENV_VAR_AWS_ACCESS_KEY)
+      hadoopConf.set("fs.s3.awsSecretAccessKey", accessKey, source + ENV_VAR_AWS_SECRET_KEY)
+      hadoopConf.set("fs.s3n.awsSecretAccessKey", accessKey, source + ENV_VAR_AWS_SECRET_KEY)
+      hadoopConf.set("fs.s3a.secret.key", accessKey, source + ENV_VAR_AWS_SECRET_KEY)
 
       // look for session token if the other variables were set
       if (sessionToken != null) {
@@ -611,7 +604,7 @@ private[spark] object SparkHadoopUtil extends Logging {
   def propertySources(hadoopConf: Configuration, key: String): String = {
     val sources = hadoopConf.getPropertySources(key)
     if (sources != null && sources.nonEmpty) {
-      sources.mkString("," )
+      sources.mkString(",")
     } else {
       ""
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -512,7 +512,7 @@ private[spark] object SparkHadoopUtil extends Logging {
   private def appendSparkHiveConfigs(conf: SparkConf, hadoopConf: Configuration): Unit = {
     // Copy any "spark.hive.foo=bar" spark properties into conf as "hive.foo=bar"
     for ((key, value) <- conf.getAll if key.startsWith("spark.hive.")) {
-      hadoopConf.set(key.substring("spark.".length), value, "spark.hive propagation")
+      hadoopConf.set(key.substring("spark.".length), value, "Set by Spark from keys starting with 'spark.hive'")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -485,7 +485,7 @@ private[spark] object SparkHadoopUtil extends Logging {
   private def appendSparkHadoopConfigs(conf: SparkConf, hadoopConf: Configuration): Unit = {
     // Copy any "spark.hadoop.foo=bar" spark properties into conf as "foo=bar"
     for ((key, value) <- conf.getAll if key.startsWith("spark.hadoop.")) {
-      hadoopConf.set(key.substring("spark.hadoop.".length), value, "spark.hadoop propagation")
+      hadoopConf.set(key.substring("spark.hadoop.".length), value, "Set by Spark from keys starting with 'spark.hadoop'")
     }
     val launcher = "spark launch"
     if (conf.getOption("spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version").isEmpty) {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -478,7 +478,7 @@ private[spark] object SparkHadoopUtil extends Logging {
 
   private def appendHiveConfigs(hadoopConf: Configuration): Unit = {
     hiveConfKeys.foreach { kv =>
-      hadoopConf.set(kv.getKey, kv.getValue, "hive-site.xml")
+      hadoopConf.set(kv.getKey, kv.getValue, "Set by Spark from hive-site.xml")
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -443,7 +443,7 @@ private[spark] object SparkHadoopUtil extends Logging {
       val envSecretKey = "AWS_SECRET_ACCESS_KEY"
       val accessKey = System.getenv(envSecretKey)
       if (keyId != null && accessKey != null) {
-        val source = "Spark set from "
+        val source = "Set by Spark from "
         hadoopConf.set("fs.s3.awsAccessKeyId", keyId, source + envKeyId)
         hadoopConf.set("fs.s3n.awsAccessKeyId", keyId, source + envKeyId)
         hadoopConf.set("fs.s3a.access.key", keyId, source + envKeyId)

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -39,8 +39,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
     assertConfigMatches(hadoopConf, "orc.filterPushdown", "true", SOURCE_SPARK_HADOOP)
     assertConfigMatches(hadoopConf, "fs.s3a.downgrade.syncable.exceptions", "true",
       SET_TO_DEFAULT_VALUES)
-    assertConfigMatches(hadoopConf, "fs.s3a.endpoint", "s3.amazonaws.com",
-      SET_TO_DEFAULT_VALUES)
+    assertConfigMatches(hadoopConf, "fs.s3a.endpoint", "s3.amazonaws.com", SET_TO_DEFAULT_VALUES)
   }
 
   /**
@@ -94,8 +93,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
     val hadoopConf = new Configuration(false)
     sc.set("spark.hive.hiveoption", "value")
     new SparkHadoopUtil().appendS3AndSparkHadoopHiveConfigurations(sc, hadoopConf)
-    assertConfigMatches(hadoopConf, "hive.hiveoption", "value",
-      SOURCE_SPARK_HIVE)
+    assertConfigMatches(hadoopConf, "hive.hiveoption", "value", SOURCE_SPARK_HIVE)
   }
 
   /**
@@ -170,8 +168,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
     val v = hadoopConf.get(key)
     // get the source list
     val origin = SparkHadoopUtil.propertySources(hadoopConf, key)
-    assert(origin.nonEmpty,
-      s"Sources are missing for '$key' with value '$v'")
+    assert(origin.nonEmpty, s"Sources are missing for '$key' with value '$v'")
     assert(origin.contains(expectedSource),
       s"Expected source $key with value $v: and source $origin to contain $expectedSource")
   }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -24,9 +24,9 @@ import org.apache.spark.internal.config.BUFFER_SIZE
 
 class SparkHadoopUtilSuite extends SparkFunSuite {
 
-  private val launch = "spark launch"
-  private val hadoopPropagation = "spark.hadoop propagation"
-  private val hivePropagation = "spark.hive propagation"
+  private val launch = "Set by Spark to default values"
+  private val hadoopPropagation = "Set by Spark from keys starting with 'spark.hadoop'"
+  private val hivePropagation = "Set by Spark from keys starting with 'spark.hive'"
 
   /**
    * Verify that spark.hadoop options are propagated, and that
@@ -46,7 +46,6 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
    * An empty S3A endpoint will be overridden just as a null value
    * would.
    */
-
   test("appendSparkHadoopConfigs with S3A endpoint set to empty string") {
     val sc = new SparkConf()
     val hadoopConf = new Configuration(false)
@@ -155,10 +154,10 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
     expectedSource: String): Unit = {
     val v = hadoopConf.get(key)
     // get the possibly null source list
-    val sources = hadoopConf.getPropertySources(key)
-    assert(sources != null && sources.length > 0,
+    val origin = new SparkHadoopUtil().extractOrigin(hadoopConf, key, null)
+    assert(origin != null,
       s"Sources are missing for '$key' with value '$v'")
-    assert(sources(0) ===  expectedSource,
+    assert(origin ===  expectedSource,
       s"Expected source $key with value $v: to contain $expectedSource")
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -22,7 +22,7 @@ import java.net.InetAddress
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
-import org.apache.spark.deploy.SparkHadoopUtil.{ENV_VAR_AWS_ACCESS_KEY, ENV_VAR_AWS_SECRET_KEY, ENV_VAR_AWS_SESSION_TOKEN, SET_TO_DEFAULT_VALUES, SOURCE_SPARK_HADOOP, SOURCE_SPARK_HIVE}
+import org.apache.spark.deploy.SparkHadoopUtil.{SET_TO_DEFAULT_VALUES, SOURCE_SPARK_HADOOP, SOURCE_SPARK_HIVE}
 import org.apache.spark.internal.config.BUFFER_SIZE
 
 class SparkHadoopUtilSuite extends SparkFunSuite {
@@ -36,8 +36,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
     val hadoopConf = new Configuration(false)
     sc.set("spark.hadoop.orc.filterPushdown", "true")
     new SparkHadoopUtil().appendSparkHadoopConfigs(sc, hadoopConf)
-    assertConfigMatches(hadoopConf, "orc.filterPushdown", "true",
-      SOURCE_SPARK_HADOOP)
+    assertConfigMatches(hadoopConf, "orc.filterPushdown", "true", SOURCE_SPARK_HADOOP)
     assertConfigMatches(hadoopConf, "fs.s3a.downgrade.syncable.exceptions", "true",
       SET_TO_DEFAULT_VALUES)
     assertConfigMatches(hadoopConf, "fs.s3a.endpoint", "s3.amazonaws.com",
@@ -90,7 +89,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
   /**
    * spark.hive.* is passed to the hadoop config as hive.*.
    */
-  test("spark.hive propagation") {
+  test("SPARK-40640: spark.hive propagation") {
     val sc = new SparkConf()
     val hadoopConf = new Configuration(false)
     sc.set("spark.hive.hiveoption", "value")
@@ -111,12 +110,9 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
   }
 
   test("SPARK-40640: aws credentials from environment variables") {
-    val env = new java.util.HashMap[String, String]
-    env.put(ENV_VAR_AWS_ACCESS_KEY, "access-key")
-    env.put(ENV_VAR_AWS_SECRET_KEY, "secret-key")
-    env.put(ENV_VAR_AWS_SESSION_TOKEN, "session-token")
     val hadoopConf = new Configuration(false)
-    SparkHadoopUtil.appendS3CredentialsFromEnvironment(hadoopConf, env)
+    SparkHadoopUtil.appendS3CredentialsFromEnvironment(hadoopConf,
+      "access-key", "secret-key", "session-token")
     val source = "Set by Spark on " + InetAddress.getLocalHost + " from "
     assertConfigMatches(hadoopConf, "fs.s3a.access.key", "access-key", source)
     assertConfigMatches(hadoopConf, "fs.s3a.secret.key", "secret-key", source)
@@ -124,12 +120,8 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
   }
 
   test("SPARK-19739: S3 session token propagation requires access and secret keys") {
-    val env = new java.util.HashMap[String, String]
-    // only set the session token, not the access/secret key,
-    // and verify that it was not passed down
-    env.put(ENV_VAR_AWS_SESSION_TOKEN, "session-token")
     val hadoopConf = new Configuration(false)
-    SparkHadoopUtil.appendS3CredentialsFromEnvironment(hadoopConf, env)
+    SparkHadoopUtil.appendS3CredentialsFromEnvironment(hadoopConf, null, null, "session-token")
     assertConfigValue(hadoopConf, "fs.s3a.session.token", null)
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkHadoopUtilSuite.scala
@@ -157,7 +157,7 @@ class SparkHadoopUtilSuite extends SparkFunSuite {
     // get the possibly null source list
     val sources = hadoopConf.getPropertySources(key)
     assert(sources != null && sources.length > 0,
-      s"Expected source for $key with value $v")
+      s"Sources are missing for '$key' with value '$v'")
     assert(sources(0) ===  expectedSource,
       s"Expected source $key with value $v: to contain $expectedSource")
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -47,6 +47,7 @@ import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.deploy.SparkHadoopUtil.SOURCE_SPARK
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -1299,8 +1300,7 @@ private[hive] object HiveClientImpl extends Logging {
     // 3: we set all entries in config to this hiveConf.
     val confMap = (hadoopConf.iterator().asScala.map(kv => kv.getKey -> kv.getValue) ++
       sparkConf.getAll.toMap ++ extraConfig).toMap
-    val fromSpark = "Set by Spark"
-    confMap.foreach { case (k, v) => hiveConf.set(k, v, fromSpark) }
+    confMap.foreach { case (k, v) => hiveConf.set(k, v, SOURCE_SPARK) }
     SQLConf.get.redactOptions(confMap).foreach { case (k, v) =>
       logDebug(s"Applying Hadoop/Hive/Spark and extra properties to Hive Conf:$k=$v")
     }
@@ -1318,7 +1318,7 @@ private[hive] object HiveClientImpl extends Logging {
     if (hiveConf.get("hive.execution.engine") == "tez") {
       logWarning("Detected HiveConf hive.execution.engine is 'tez' and will be reset to 'mr'" +
         " to disable useless hive logic")
-      hiveConf.set("hive.execution.engine", "mr", fromSpark)
+      hiveConf.set("hive.execution.engine", "mr", SOURCE_SPARK)
     }
     hiveConf
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -47,7 +47,6 @@ import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.spark.{SparkConf, SparkException}
-import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -1300,8 +1299,6 @@ private[hive] object HiveClientImpl extends Logging {
     // 3: we set all entries in config to this hiveConf.
     val confMap = (hadoopConf.iterator().asScala.map(kv => kv.getKey -> kv.getValue) ++
       sparkConf.getAll.toMap ++ extraConfig).toMap
-    val sparkHadoopUtil = new SparkHadoopUtil()
-
     val fromSpark = "Set by Spark"
     confMap.foreach { case (k, v) => hiveConf.set(k, v, fromSpark) }
     SQLConf.get.redactOptions(confMap).foreach { case (k, v) =>


### PR DESCRIPTION


### What changes were proposed in this pull request?

The options passed from spark conf, hive-site.xml, AWS env vars now all record this in their source attribute of the entries.

The Configuration Writable methods do not propagate this, so it is not as useful cluster-wide than it could be. It does help with some of the basic troubleshooting.


### Why are the changes needed?
 
Helps when troubleshooting where options make their way down. These can be examined
and logged later.

For example, my cloudstore diagnosticss JAR can do this in its storediag command
and in an s3a AWS credential provider. I may add some of that logging
at debug to the ASF hadoop implementations.

https://github.com/steveloughran/cloudstore

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Not *really*. It's a very low level diagnostics feature in the Hadoop configuration classes.

### How was this patch tested?

New tests added; existing tests enhanced.
