### PR TITLE
[SPARK-40642][DOC] doc for String memory size since java>=9

### DIFF
--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -95,10 +95,13 @@ than the "raw" data inside their fields. This is due to several reasons:
 * Each distinct Java object has an "object header", which is about 16 bytes and contains information
   such as a pointer to its class. For an object with very little data in it (say one `Int` field), this
   can be bigger than the data.
-* Java `String`s have about 40 bytes of overhead over the raw string data (since they store it in an
+* Before Java 9, `String`s have about 40 bytes of overhead over the raw string data (since they store it in an
   array of `Char`s and keep extra data such as the length), and store each character
   as *two* bytes due to `String`'s internal usage of UTF-16 encoding. Thus a 10-character string can
   easily consume 60 bytes.
+  Since Java 9 (JEP 254), `String`s have about 44 bytes of overhead, but most latin1 string are encoded in UTF-8. 
+  Thus a latin1 10-character string can consume 54 bytes.
+  
 * Common collection classes, such as `HashMap` and `LinkedList`, use linked data structures, where
   there is a "wrapper" object for each entry (e.g. `Map.Entry`). This object not only has a header,
   but also pointers (typically 8 bytes each) to the next object in the list.


### PR DESCRIPTION
The doc is wrong for java >= 9 as described here https://openjdk.org/jeps/254
( in detailed here https://issues.apache.org/jira/browse/SPARK-40642 ) 
