### PR TITLE
[SPARK-40643][PS] Implement `min_count` in `GroupBy.last`

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -409,6 +409,8 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         """
         Compute first of group values.
 
+        .. versionadded:: 3.3.0
+
         Parameters
         ----------
         numeric_only : bool, default False
@@ -484,15 +486,22 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             accepted_spark_types=(NumericType, BooleanType) if numeric_only else None,
         )
 
-    def last(self, numeric_only: Optional[bool] = False) -> FrameLike:
+    def last(self, numeric_only: Optional[bool] = False, min_count: int = -1) -> FrameLike:
         """
         Compute last of group values.
+
+        .. versionadded:: 3.3.0
 
         Parameters
         ----------
         numeric_only : bool, default False
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data.
+
+            .. versionadded:: 3.4.0
+        min_count : int, default -1
+            The required number of valid values to perform the operation. If fewer
+            than ``min_count`` non-NA values are present the result will be NA.
 
             .. versionadded:: 3.4.0
 
@@ -504,13 +513,13 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         Examples
         --------
         >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
-        ...                    "C": [3, 3, 4, 4], "D": ["a", "b", "b", "a"]})
+        ...                    "C": [3, 3, 4, 4], "D": ["a", "a", "a", "b"]})
         >>> df
            A      B  C  D
         0  1   True  3  a
-        1  2  False  3  b
-        2  1  False  4  b
-        3  2   True  4  a
+        1  2  False  3  a
+        2  1  False  4  a
+        3  2   True  4  b
 
         >>> df.groupby("A").last().sort_index()
                B  C  D
@@ -525,9 +534,36 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         A
         1  False  4
         2   True  4
+
+        >>> df.groupby("D").last().sort_index()
+           A      B  C
+        D
+        a  1  False  4
+        b  2   True  4
+
+        >>> df.groupby("D").last(min_count=3).sort_index()
+             A      B    C
+        D
+        a  1.0  False  4.0
+        b  NaN   None  NaN
         """
+        if not isinstance(min_count, int):
+            raise TypeError("min_count must be integer")
+
+        if min_count > 0:
+
+            def last(col: Column) -> Column:
+                return F.when(
+                    F.count(F.when(~F.isnull(col), F.lit(0))) < min_count, F.lit(None)
+                ).otherwise(F.last(col, ignorenulls=True))
+
+        else:
+
+            def last(col: Column) -> Column:
+                return F.last(col, ignorenulls=True)
+
         return self._reduce_for_stat_function(
-            lambda col: F.last(col, ignorenulls=True),
+            last,
             accepted_spark_types=(NumericType, BooleanType) if numeric_only else None,
         )
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -513,13 +513,13 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         Examples
         --------
         >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
-        ...                    "C": [3, 3, 4, 4], "D": ["a", "a", "a", "b"]})
+        ...                    "C": [3, 3, 4, 4], "D": ["a", "a", "b", "a"]})
         >>> df
            A      B  C  D
         0  1   True  3  a
         1  2  False  3  a
-        2  1  False  4  a
-        3  2   True  4  b
+        2  1  False  4  b
+        3  2   True  4  a
 
         >>> df.groupby("A").last().sort_index()
                B  C  D
@@ -538,14 +538,14 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         >>> df.groupby("D").last().sort_index()
            A      B  C
         D
-        a  1  False  4
-        b  2   True  4
+        a  2   True  4
+        b  1  False  4
 
         >>> df.groupby("D").last(min_count=3).sort_index()
-             A      B    C
+             A     B    C
         D
-        a  1.0  False  4.0
-        b  NaN   None  NaN
+        a  2.0  True  4.0
+        b  NaN  None  NaN
         """
         if not isinstance(min_count, int):
             raise TypeError("min_count must be integer")
@@ -887,7 +887,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             It takes no effect since only numeric columns can be support here.
 
             .. versionadded:: 3.4.0
-        min_count: int, default 0
+        min_count : int, default 0
             The required number of valid values to perform the operation.
             If fewer than min_count non-NA values are present the result will be NA.
 
@@ -1279,7 +1279,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data.
 
-        min_count: int, default 0
+        min_count : int, default 0
             The required number of valid values to perform the operation.
             If fewer than min_count non-NA values are present the result will be NA.
 

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1464,6 +1464,23 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         self._test_stat_func(lambda groupby_obj: groupby_obj.last(numeric_only=None))
         self._test_stat_func(lambda groupby_obj: groupby_obj.last(numeric_only=True))
 
+        pdf = pd.DataFrame(
+            {
+                "A": [1, 2, 1, 2],
+                "B": [-1.5, np.nan, -3.2, 0.1],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(pdf.groupby("A").last().sort_index(), psdf.groupby("A").last().sort_index())
+        self.assert_eq(
+            pdf.groupby("A").last(min_count=1).sort_index(),
+            psdf.groupby("A").last(min_count=1).sort_index(),
+        )
+        self.assert_eq(
+            pdf.groupby("A").last(min_count=2).sort_index(),
+            psdf.groupby("A").last(min_count=2).sort_index(),
+        )
+
     def test_nth(self):
         for n in [0, 1, 2, 128, -1, -2, -128]:
             self._test_stat_func(lambda groupby_obj: groupby_obj.nth(n))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `min_count` in `GroupBy.last`


### Why are the changes needed?
for API coverage


### Does this PR introduce _any_ user-facing change?
yes, new parameter
```
        >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
        ...                    "C": [3, 3, 4, 4], "D": ["a", "a", "a", "b"]})

        >>> df.groupby("D").last().sort_index()
           A      B  C
        D
        a  1  False  4
        b  2   True  4
        >>> df.groupby("D").last(min_count=3).sort_index()
             A      B    C
        D
        a  1.0  False  4.0
        b  NaN   None  NaN

```

### How was this patch tested?
added UT