### PR TITLE
[SPARK-40644][PYTHON] Show the versions of dependencies in PySpark REPL

### DIFF
--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -63,10 +63,32 @@ print(
 """
     % sc.version
 )
-print(
-    "Using Python version %s (%s, %s)"
-    % (platform.python_version(), platform.python_build()[0], platform.python_build()[1])
-)
+
+
+def _create_version_string() -> str:
+    version_str = "Using Python version %s (%s, %s)" % (
+        platform.python_version(),
+        platform.python_build()[0],
+        platform.python_build()[1],
+    )
+
+    try:
+        from importlib.metadata import version
+
+        versions = []
+        for pkg in ["py4j", "pandas", "numpy", "scipy", "pyarrow", "grpcio", "protobuf"]:
+            try:
+                versions.append("%s=%s" % (pkg, version(pkg)))
+            except Exception:
+                versions.append("%s=NotFound" % pkg)
+        version_str += " with packages [%s]" % (", ".join(versions))
+    except Exception:
+        pass
+
+    return version_str
+
+
+print(_create_version_string())
 print("Spark context Web UI available at %s" % (sc.uiWebUrl))
 print("Spark context available as 'sc' (master = %s, app id = %s)." % (sc.master, sc.applicationId))
 print("SparkSession available as 'spark'.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Show the versions of dependencies in PySpark REPL

### Why are the changes needed?
version information is pretty useful, show it at the start of PySpark REPL, so contributors and users do not need to check them manually


### Does this PR introduce _any_ user-facing change?
yes

before:
```
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.4.0-SNAPSHOT
      /_/

Using Python version 3.9.13 (main, Aug 25 2022 18:24:45)
Spark context Web UI available at http://192.168.0.111:4040
Spark context available as 'sc' (master = local[*], app id = local-1664852808945).
SparkSession available as 'spark'.
```

after:
case 1:
```
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.4.0-SNAPSHOT
      /_/

Using Python version 3.9.13 (main, Aug 25 2022 18:24:45) with packages [py4j=0.10.9.7, pandas=1.5.0, numpy=1.23.3, scipy=1.9.1, pyarrow=9.0.0, grpcio=NotFound, protobuf=4.21.6]
Spark context Web UI available at http://192.168.0.113:4040
Spark context available as 'sc' (master = local[*], app id = local-1664428927644).
SparkSession available as 'spark'.
```

case2 (after install `grpcio`):
```
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.4.0-SNAPSHOT
      /_/

Using Python version 3.9.13 (main, Aug 25 2022 18:24:45) with packages [py4j=0.10.9.7, pandas=1.5.0, numpy=1.23.3, scipy=1.9.1, pyarrow=9.0.0, grpcio=1.48.1, protobuf=4.21.6]
Spark context Web UI available at http://192.168.0.113:4040
Spark context available as 'sc' (master = local[*], app id = local-1664429292180).
SparkSession available as 'spark'.
```


### How was this patch tested?
manually check in different envs