### PR TITLE
[SPARK-40645][CONNECT] Throw exception for Collect() and recommend to use toPandas()

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -141,7 +141,7 @@ class RemoteSparkSession(object):
     def sql(self, sql_string: str) -> "DataFrame":
         return DataFrame.withPlan(SQL(sql_string), self)
 
-    def to_pandas(self, plan: pb2.Plan) -> pandas.DataFrame:
+    def _to_pandas(self, plan: pb2.Plan) -> pandas.DataFrame:
         req = pb2.Request()
         req.user_context.user_id = self._user_id
         req.plan.CopyFrom(plan)

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -141,7 +141,7 @@ class RemoteSparkSession(object):
     def sql(self, sql_string: str) -> "DataFrame":
         return DataFrame.withPlan(SQL(sql_string), self)
 
-    def toPandas(self, plan: pb2.Plan) -> pandas.DataFrame:
+    def _toPandas(self, plan: pb2.Plan) -> pandas.DataFrame:
         req = pb2.Request()
         req.user_context.user_id = self._user_id
         req.plan.CopyFrom(plan)

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -141,7 +141,7 @@ class RemoteSparkSession(object):
     def sql(self, sql_string: str) -> "DataFrame":
         return DataFrame.withPlan(SQL(sql_string), self)
 
-    def collect(self, plan: pb2.Plan) -> pandas.DataFrame:
+    def toPandas(self, plan: pb2.Plan) -> pandas.DataFrame:
         req = pb2.Request()
         req.user_context.user_id = self._user_id
         req.plan.CopyFrom(plan)

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -141,7 +141,7 @@ class RemoteSparkSession(object):
     def sql(self, sql_string: str) -> "DataFrame":
         return DataFrame.withPlan(SQL(sql_string), self)
 
-    def _toPandas(self, plan: pb2.Plan) -> pandas.DataFrame:
+    def to_pandas(self, plan: pb2.Plan) -> pandas.DataFrame:
         req = pb2.Request()
         req.user_context.user_id = self._user_id
         req.plan.CopyFrom(plan)

--- a/python/pyspark/sql/connect/data_frame.py
+++ b/python/pyspark/sql/connect/data_frame.py
@@ -231,7 +231,7 @@ class DataFrame(object):
 
     def toPandas(self) -> pandas.DataFrame:
         query = self._plan.collect(self._session)
-        return self._session._toPandas(query)
+        return self._session.to_pandas(query)
 
     def explain(self) -> str:
         query = self._plan.collect(self._session)

--- a/python/pyspark/sql/connect/data_frame.py
+++ b/python/pyspark/sql/connect/data_frame.py
@@ -231,7 +231,7 @@ class DataFrame(object):
 
     def toPandas(self) -> pandas.DataFrame:
         query = self._plan.collect(self._session)
-        return self._session.toPandas(query)
+        return self._session._toPandas(query)
 
     def explain(self) -> str:
         query = self._plan.collect(self._session)

--- a/python/pyspark/sql/connect/data_frame.py
+++ b/python/pyspark/sql/connect/data_frame.py
@@ -27,6 +27,8 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import pandas
+
 import pyspark.sql.connect.plan as plan
 from pyspark.sql.connect.column import (
     ColumnOrString,
@@ -225,11 +227,11 @@ class DataFrame(object):
         return ""
 
     def collect(self):
-        query = self._plan.collect(self._session)
-        return self._session.collect(query)
+        raise NotImplementedError("Please use toPandas().")
 
-    def toPandas(self):
-        return self.collect()
+    def toPandas(self) -> pandas.DataFrame:
+        query = self._plan.collect(self._session)
+        return self._session.toPandas(query)
 
     def explain(self) -> str:
         query = self._plan.collect(self._session)

--- a/python/pyspark/sql/connect/data_frame.py
+++ b/python/pyspark/sql/connect/data_frame.py
@@ -231,7 +231,7 @@ class DataFrame(object):
 
     def toPandas(self) -> pandas.DataFrame:
         query = self._plan.collect(self._session)
-        return self._session.to_pandas(query)
+        return self._session._to_pandas(query)
 
     def explain(self) -> str:
         query = self._plan.collect(self._session)

--- a/python/pyspark/sql/tests/connect/test_spark_connect.py
+++ b/python/pyspark/sql/tests/connect/test_spark_connect.py
@@ -57,7 +57,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
     def test_simple_read(self) -> None:
         """Tests that we can access the Spark Connect GRPC service locally."""
         df = self.connect.read.table(self.tbl_name)
-        data = df.limit(10).collect()
+        data = df.limit(10).toPandas()
         # Check that the limit is applied
         assert len(data.index) == 10
 
@@ -67,7 +67,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
         u = udf(conv_udf)
         df = self.connect.read.table(self.tbl_name)
-        result = df.select(u(df.id)).collect()
+        result = df.select(u(df.id)).toPandas()
         assert result is not None
 
     def test_simple_explain_string(self) -> None:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Current connect `Collect()` return Pandas DataFrame, which does not match with PySpark DataFrame API which returns a `List[Row]`: https://github.com/apache/spark/blob/ceb8527413288b4d5c54d3afd76d00c9e26817a1/python/pyspark/sql/connect/data_frame.py#L227
https://github.com/apache/spark/blob/ceb8527413288b4d5c54d3afd76d00c9e26817a1/python/pyspark/sql/dataframe.py#L1119

The underlying implementation has been generating Pandas DataFrame though. In this case, we can choose to use to `toPandas()` and throw exception for `Collect()` to recommend to use `toPandas()`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The goal of the connect project is still to align with existing data frame API as much as possible. In this case, given that `Collect()` is not compatible in existing python client, we can choose to disable it for now.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT
