### PR TITLE
[SPARK-40647][CORE] DAGScheduler should fail job until all related running tasks have been killed

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskScheduler.scala
@@ -125,4 +125,14 @@ private[spark] trait TaskScheduler {
    */
   def applicationAttemptId(): Option[String]
 
+  /**
+   * Get all running task ids within the stage.
+   */
+  def runningTaskIdsByStageId(stageId: Int): Option[Set[Long]]
+
+  /**
+   * Determine if a task is running.
+   */
+  def isRunning(taskId: Long): Boolean
+
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -1091,7 +1091,7 @@ private[spark] class TaskSchedulerImpl(
   /**
    * Cleans up the TaskScheduler's state for tracking the given task.
    */
-  private def cleanupTaskState(tid: Long): Unit = {
+  private[scheduler] def cleanupTaskState(tid: Long): Unit = {
     taskIdToTaskSetManager.remove(tid)
     taskIdToExecutorId.remove(tid).foreach { executorId =>
       executorIdToRunningTaskIds.get(executorId).foreach { _.remove(tid) }

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -408,6 +408,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
                 s"${RPC_MESSAGE_MAX_SIZE.key} (%d bytes). Consider increasing " +
                 s"${RPC_MESSAGE_MAX_SIZE.key} or using broadcast variables for large values."
               msg = msg.format(task.taskId, task.index, serializedTask.limit(), maxRpcMessageSize)
+              // Actually this task is not running yet, we can clean up related state here.
+              scheduler.cleanupTaskState(task.taskId)
               taskSetMgr.abort(msg)
             } catch {
               case e: Exception => logError("Exception in error callback", e)

--- a/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ExternalClusterManagerSuite.scala
@@ -103,4 +103,6 @@ private class DummyTaskScheduler extends TaskScheduler {
     decommissionInfo: ExecutorDecommissionInfo): Unit = {}
   override def getExecutorDecommissionState(
     executorId: String): Option[ExecutorDecommissionState] = None
+  override def runningTaskIdsByStageId(stageId: Int): Option[Set[Long]] = None
+  override def isRunning(taskId: Long): Boolean = false
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We consider that Driver should wait for all related running tasks being killed, then it's time to kill the job. To do this, we make following change:
1. add new api `runningTaskIdsByStageId()` and `isRunning()` for `TaskScheduler`
2. add the wait logic between notifying taskKilled and jobFailed


### Why are the changes needed?
The basic motivation is that current logic without waiting for tasks killing will cause some side effects like remaining temporary directory, the details can be seen in [JIRA](https://issues.apache.org/jira/browse/SPARK-40647).


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add an Unit Test.
