### PR TITLE
[WIP] Try to automatically clean temp RDDs cached by Pandas Indexing

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -123,7 +123,8 @@ case class AdaptiveSparkPlanExec(
       ReplaceHashWithSortAgg,
       RemoveRedundantSorts,
       DisableUnnecessaryBucketedScan,
-      OptimizeSkewedJoin(ensureRequirements)
+      OptimizeSkewedJoin(ensureRequirements),
+      UncachePandasIndexing
     ) ++ context.session.sessionState.adaptiveRulesHolder.queryStagePrepRules
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/UncachePandasIndexing.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/UncachePandasIndexing.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.SparkPlan
+
+object UncachePandasIndexing extends Rule[SparkPlan] {
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    val sc = plan.session.sparkContext
+
+    // TODO: add a config to specify the maximum number of cached RDDs
+    sc.synchronized {
+      val cachedRDDs = sc.persistentRdds.toSeq
+        .filter { case (id, rdd) =>
+          rdd != null &&
+            rdd.name != null &&
+            rdd.name.startsWith("__Pandas_AttachDistributedSequence_")
+        }
+
+      val numCached = cachedRDDs.size
+      if (numCached > 1) {
+        cachedRDDs.sortBy(_._1).take(numCached - 1).foreach { case (id, rdd) =>
+          rdd.unpersist(blocking = false)
+        }
+      }
+    }
+
+    plan
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Try to automatically clean temp RDDs cached by Pandas Indexing

1. specify the name of RDDs which were cached by Pandas Indexing
2. unpersist those RDD if the number exceed the maximum number after each stage


### Why are the changes needed?
to clean cached RDDs ASAP


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
to be added