### PR TITLE
[SPARK-40648][YARN][TESTS] Add `@ExtendedLevelDBTest` to `LevelDB` relevant tests in the `yarn` module

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleAlternateNameConfigSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleAlternateNameConfigSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark._
 import org.apache.spark.internal.config._
 import org.apache.spark.network.shuffledb.DBBackend
 import org.apache.spark.network.yarn.{YarnShuffleService, YarnTestAccessor}
-import org.apache.spark.tags.ExtendedYarnTest
+import org.apache.spark.tags.{ExtendedLevelDBTest, ExtendedYarnTest}
 
 /**
  * SPARK-34828: Integration test for the external shuffle service with an alternate name and
@@ -77,6 +77,7 @@ abstract class YarnShuffleAlternateNameConfigSuite extends YarnShuffleIntegratio
     }
   }
 }
+@ExtendedLevelDBTest
 @ExtendedYarnTest
 class YarnShuffleAlternateNameConfigWithLevelDBBackendSuite
   extends YarnShuffleAlternateNameConfigSuite {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.internal.config.Network._
 import org.apache.spark.network.shuffle.ShuffleTestAccessor
 import org.apache.spark.network.shuffledb.DBBackend
 import org.apache.spark.network.yarn.{YarnShuffleService, YarnTestAccessor}
-import org.apache.spark.tags.ExtendedYarnTest
+import org.apache.spark.tags.{ExtendedLevelDBTest, ExtendedYarnTest}
 
 /**
  * Integration test for the external shuffle service with a yarn mini-cluster
@@ -87,6 +87,7 @@ abstract class YarnShuffleIntegrationSuite extends BaseYarnClusterSuite {
   }
 }
 
+@ExtendedLevelDBTest
 @ExtendedYarnTest
 class YarnShuffleIntegrationWithLevelDBBackendSuite
   extends YarnShuffleIntegrationSuite {
@@ -118,6 +119,7 @@ abstract class YarnShuffleAuthSuite extends YarnShuffleIntegrationSuite {
   }
 }
 
+@ExtendedLevelDBTest
 @ExtendedYarnTest
 class YarnShuffleAuthWithLevelDBBackendSuite extends YarnShuffleAuthSuite {
   override protected def dbBackend: DBBackend = DBBackend.LEVELDB


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-40490 make  the test case related to `YarnShuffleIntegrationSuite` starts to verify the `registeredExecFile` reload test scenario again，so this pr add `@ExtendedLevelDBTest` to `LevelDB` relevant tests in the `yarn` module so that the `MacOs/Apple Silicon` can skip the tests through `-Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest`.


### Why are the changes needed?
According to convention, Add `@ExtendedLevelDBTest` to LevelDB relevant tests to make `yarn` module can skip these tests through `-Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest` on `MacOs/Apple Silicon`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual test on `MacOs/Apple Silicon`

```
mvn clean install -pl resource-managers/yarn -Pyarn -am -DskipTests
mvn clean install -pl resource-managers/yarn -Pyarn -Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest
```

**Before**

```
*** RUN ABORTED ***
  java.lang.UnsatisfiedLinkError: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /Users/yangjie01/SourceCode/git/spark-source/resource-managers/yarn/target/tmp/libleveldbjni-64-1-7057248091178764836.8: dlopen(/Users/yangjie01/SourceCode/git/spark-source/resource-managers/yarn/target/tmp/libleveldbjni-64-1-7057248091178764836.8, 1): no suitable image found.  Did find:
	/Users/yangjie01/SourceCode/git/spark-source/resource-managers/yarn/target/tmp/libleveldbjni-64-1-7057248091178764836.8: no matching architecture in universal wrapper
	/Users/yangjie01/SourceCode/git/spark-source/resource-managers/yarn/target/tmp/libleveldbjni-64-1-7057248091178764836.8: no matching architecture in universal wrapper]
  at org.fusesource.hawtjni.runtime.Library.doLoad(Library.java:182)
  at org.fusesource.hawtjni.runtime.Library.load(Library.java:140)
  at org.fusesource.leveldbjni.JniDBFactory.<clinit>(JniDBFactory.java:48)
  at org.apache.spark.network.util.LevelDBProvider.initLevelDB(LevelDBProvider.java:48)
  at org.apache.spark.network.util.DBProvider.initDB(DBProvider.java:40)
  at org.apache.spark.network.shuffle.ExternalShuffleBlockResolver.<init>(ExternalShuffleBlockResolver.java:131)
  at org.apache.spark.network.shuffle.ExternalShuffleBlockResolver.<init>(ExternalShuffleBlockResolver.java:100)
  at org.apache.spark.network.shuffle.ExternalBlockHandler.<init>(ExternalBlockHandler.java:90)
  at org.apache.spark.network.yarn.YarnShuffleService.serviceInit(YarnShuffleService.java:276)
  at org.apache.hadoop.service.AbstractService.init(AbstractService.java:164)
  ...
```

**After**

```
Run completed in 9 minutes, 46 seconds.
Total number of tests run: 164
Suites: completed 23, aborted 0
Tests: succeeded 164, failed 0, canceled 1, ignored 0, pending 0
All tests passed.
```