### PR TITLE
[WIP][SPARK-40648][YARN][TESTS][3.2] Add @ExtendedLevelDBTest to LevelDB relevant tests in the yarn module

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleAlternateNameConfigSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleAlternateNameConfigSuite.scala
@@ -24,12 +24,13 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.spark._
 import org.apache.spark.internal.config._
 import org.apache.spark.network.yarn.{YarnShuffleService, YarnTestAccessor}
-import org.apache.spark.tags.ExtendedYarnTest
+import org.apache.spark.tags.{ExtendedLevelDBTest, ExtendedYarnTest}
 
 /**
  * SPARK-34828: Integration test for the external shuffle service with an alternate name and
  * configs (by using a configuration overlay)
  */
+@ExtendedLevelDBTest
 @ExtendedYarnTest
 class YarnShuffleAlternateNameConfigSuite extends YarnShuffleIntegrationSuite {
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnShuffleIntegrationSuite.scala
@@ -33,11 +33,12 @@ import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Network._
 import org.apache.spark.network.shuffle.ShuffleTestAccessor
 import org.apache.spark.network.yarn.{YarnShuffleService, YarnTestAccessor}
-import org.apache.spark.tags.ExtendedYarnTest
+import org.apache.spark.tags.{ExtendedLevelDBTest, ExtendedYarnTest}
 
 /**
  * Integration test for the external shuffle service with a yarn mini-cluster
  */
+@ExtendedLevelDBTest
 @ExtendedYarnTest
 class YarnShuffleIntegrationSuite extends BaseYarnClusterSuite {
 
@@ -86,6 +87,7 @@ class YarnShuffleIntegrationSuite extends BaseYarnClusterSuite {
 /**
  * Integration test for the external shuffle service with auth on.
  */
+@ExtendedLevelDBTest
 @ExtendedYarnTest
 class YarnShuffleAuthSuite extends YarnShuffleIntegrationSuite {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-40490 make  the test case related to `YarnShuffleIntegrationSuite` starts to verify the `registeredExecFile` reload test scenario again，so this pr add `@ExtendedLevelDBTest` to `LevelDB` relevant tests in the `yarn` module so that the `MacOs/Apple Silicon` can skip the tests through `-Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest`.


### Why are the changes needed?
According to convention, Add `@ExtendedLevelDBTest` to LevelDB relevant tests to make `yarn` module can skip these tests through `-Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest` on `MacOs/Apple Silicon`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual test on `MacOs/Apple Silicon`

```
build/sbt clean "yarn/testOnly *YarnShuffleIntegrationSuite*" -Pyarn -Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest
build/sbt clean "yarn/testOnly *YarnShuffleAuthSuite*" -Pyarn -Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest
build/sbt clean "yarn/testOnly *YarnShuffleAlternateNameConfigSuite*" -Pyarn -Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest

```

**Before**

```

```

**After**

```

```