### PR TITLE
[SPARK-39725][BUILD][3.3] Upgrade `jetty` to 9.4.48.v20220622

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -146,7 +146,7 @@ jersey-hk2/2.36//jersey-hk2-2.36.jar
 jersey-server/2.36//jersey-server-2.36.jar
 jetty-sslengine/6.1.26//jetty-sslengine-6.1.26.jar
 jetty-util/6.1.26//jetty-util-6.1.26.jar
-jetty-util/9.4.46.v20220331//jetty-util-9.4.46.v20220331.jar
+jetty-util/9.4.48.v20220622//jetty-util-9.4.48.v20220622.jar
 jetty/6.1.26//jetty-6.1.26.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.10.13//joda-time-2.10.13.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -133,8 +133,8 @@ jersey-container-servlet/2.36//jersey-container-servlet-2.36.jar
 jersey-hk2/2.36//jersey-hk2-2.36.jar
 jersey-server/2.36//jersey-server-2.36.jar
 jettison/1.1//jettison-1.1.jar
-jetty-util-ajax/9.4.46.v20220331//jetty-util-ajax-9.4.46.v20220331.jar
-jetty-util/9.4.46.v20220331//jetty-util-9.4.46.v20220331.jar
+jetty-util-ajax/9.4.48.v20220622//jetty-util-ajax-9.4.48.v20220622.jar
+jetty-util/9.4.48.v20220622//jetty-util-9.4.48.v20220622.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.10.13//joda-time-2.10.13.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.2</parquet.version>
     <orc.version>1.7.6</orc.version>
-    <jetty.version>9.4.46.v20220331</jetty.version>
+    <jetty.version>9.4.48.v20220622</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
     <ivy.version>2.5.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade jetty from 9.4.46.v20220331 to 9.4.48.v20220622
[Relase notes](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.48.v20220622)
### Why are the changes needed?
[CVE-2022-2047](https://nvd.nist.gov/vuln/detail/CVE-2022-2047)
and
[CVE-2022-2048](https://nvd.nist.gov/vuln/detail/CVE-2022-2048) This is a 7.5 HIGH

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass Github actions