### PR TITLE
[SPARK-40651][INFRA] Drop Hadoop2 binary distribtuion from release process

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -324,7 +324,6 @@ if [[ "$1" == "package" ]]; then
   BINARY_PKGS_ARGS["hadoop3"]="-Phadoop-3 $HIVE_PROFILES"
   if ! is_dry_run; then
     BINARY_PKGS_ARGS["without-hadoop"]="-Phadoop-provided"
-    BINARY_PKGS_ARGS["hadoop2"]="-Phadoop-2 $HIVE_PROFILES"
   fi
 
   declare -A BINARY_PKGS_EXTRA


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to drop `Hadoop 2` binary distribution from Apache Spark 3.4 release process.

### Why are the changes needed?

Apache Spark recommends `Hadoop 3`-binary distribution for all Hadoop clusters.

### Does this PR introduce _any_ user-facing change?

Yes, but we provides alternative binary distributions.

### How was this patch tested?

Manually because this is a release script.