### PR TITLE
[SPARK-40661][BUILD] Upgrade `jetty-http` from 9.4.48.v20220622 to 9.4.49.v20220914

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -157,7 +157,7 @@ jersey-hk2/2.36//jersey-hk2-2.36.jar
 jersey-server/2.36//jersey-server-2.36.jar
 jetty-sslengine/6.1.26//jetty-sslengine-6.1.26.jar
 jetty-util/6.1.26//jetty-util-6.1.26.jar
-jetty-util/9.4.48.v20220622//jetty-util-9.4.48.v20220622.jar
+jetty-util/9.4.49.v20220914//jetty-util-9.4.49.v20220914.jar
 jetty/6.1.26//jetty-6.1.26.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.11.2//joda-time-2.11.2.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -142,8 +142,8 @@ jersey-container-servlet/2.36//jersey-container-servlet-2.36.jar
 jersey-hk2/2.36//jersey-hk2-2.36.jar
 jersey-server/2.36//jersey-server-2.36.jar
 jettison/1.1//jettison-1.1.jar
-jetty-util-ajax/9.4.48.v20220622//jetty-util-ajax-9.4.48.v20220622.jar
-jetty-util/9.4.48.v20220622//jetty-util-9.4.48.v20220622.jar
+jetty-util-ajax/9.4.49.v20220914//jetty-util-ajax-9.4.49.v20220914.jar
+jetty-util/9.4.49.v20220914//jetty-util-9.4.49.v20220914.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.11.2//joda-time-2.11.2.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <parquet.version>1.12.3</parquet.version>
     <orc.version>1.8.0</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <jetty.version>9.4.49.v20220914</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
     <ivy.version>2.5.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aim to Upgrade `jetty-http` from 9.4.48.v20220622 to 9.4.49.v20220914
#### The v9.4.49.v20220914 should be the last version of the 9. x series.
<img width="624" alt="image" src="https://user-images.githubusercontent.com/15246973/193972198-54e0ac86-6b38-484b-be4b-a3bf87cb6c3b.png">


### Why are the changes needed?
[Release Notes](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.49.v20220914), bring some bug fix:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/15246973/193972233-07b9e5dd-4b31-4440-9f1c-bbebb28d6e3d.png">




### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.