### PR TITLE
[SPARK-40537][CONNECT][PYTHON] Reenable MyPy in Spark Connect Python tests

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -72,9 +72,6 @@ disallow_untyped_defs = False
 
 [mypy-pyspark.sql.tests.*]
 disallow_untyped_defs = False
-; TODO(SPARK-40537) reenable mypi support.
-ignore_missing_imports = True
-ignore_errors = True
 
 [mypy-pyspark.sql.pandas.serializers]
 disallow_untyped_defs = False

--- a/python/pyspark/sql/tests/test_connect_basic.py
+++ b/python/pyspark/sql/tests/test_connect_basic.py
@@ -31,11 +31,11 @@ class SparkConnectSQLTestCase(ReusedPySparkTestCase):
     """Parent test fixture class for all Spark Connect related
     test cases."""
 
-    connect = RemoteSparkSession
-    tbl_name = str
+    connect: RemoteSparkSession
+    tbl_name: str
 
     @classmethod
-    def setUpClass(cls: Any) -> None:
+    def setUpClass(cls: Any):
         ReusedPySparkTestCase.setUpClass()
         cls.tempdir = tempfile.NamedTemporaryFile(delete=False)
         cls.hive_available = True
@@ -48,7 +48,7 @@ class SparkConnectSQLTestCase(ReusedPySparkTestCase):
         cls.spark_connect_test_data()
 
     @classmethod
-    def spark_connect_test_data(cls: Any) -> None:
+    def spark_connect_test_data(cls: Any):
         # Setup Remote Spark Session
         cls.tbl_name = f"tbl{uuid.uuid4()}".replace("-", "")
         cls.connect = RemoteSparkSession(user_id="test_user")
@@ -59,13 +59,13 @@ class SparkConnectSQLTestCase(ReusedPySparkTestCase):
 
 
 class SparkConnectTests(SparkConnectSQLTestCase):
-    def test_simple_read(self) -> None:
+    def test_simple_read(self):
         df = self.connect.read.table(self.tbl_name)
         data = df.limit(10).toPandas()
         # Check that the limit is applied
         assert len(data.index) == 10
 
-    def test_simple_udf(self) -> None:
+    def test_simple_udf(self):
         def conv_udf(x) -> str:
             return "Martin"
 
@@ -74,7 +74,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         result = df.select(u(df.id)).toPandas()
         assert result is not None
 
-    def test_simple_explain_string(self) -> None:
+    def test_simple_explain_string(self):
         df = self.connect.read.table(self.tbl_name).limit(10)
         result = df.explain()
         assert len(result) > 0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reenable MyPy tests in Spark Connect tests.

### Why are the changes needed?

To keep the MyPy rules consistent in PySpark codebase.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

CI in this PR should test it out.