### PR TITLE
[SPARK-40674][CONNECT][PYTHON][TESTS] Use uniitest's asserts instead of built-in assert

### DIFF
--- a/python/pyspark/sql/tests/test_connect_basic.py
+++ b/python/pyspark/sql/tests/test_connect_basic.py
@@ -63,7 +63,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         df = self.connect.read.table(self.tbl_name)
         data = df.limit(10).toPandas()
         # Check that the limit is applied
-        assert len(data.index) == 10
+        self.assertEqual(len(data.index), 10)
 
     def test_simple_udf(self) -> None:
         def conv_udf(x) -> str:
@@ -72,12 +72,12 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         u = udf(conv_udf)
         df = self.connect.read.table(self.tbl_name)
         result = df.select(u(df.id)).toPandas()
-        assert result is not None
+        self.assertIsNotNone(result)
 
     def test_simple_explain_string(self) -> None:
         df = self.connect.read.table(self.tbl_name).limit(10)
         result = df.explain()
-        assert len(result) > 0
+        self.assertGreater(len(result), 0)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/test_connect_column_expressions.py
@@ -27,19 +27,20 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
         df = c.DataFrame.withPlan(p.Read("table"))
 
         c1 = df.col_name
-        assert isinstance(c1, col.ColumnRef)
+        self.assertIsInstance(c1, col.ColumnRef)
         c2 = df["col_name"]
-        assert isinstance(c2, col.ColumnRef)
+        self.assertIsInstance(c2, col.ColumnRef)
         c3 = fun.col("col_name")
-        assert isinstance(c3, col.ColumnRef)
+        self.assertIsInstance(c3, col.ColumnRef)
 
         # All Protos should be identical
         cp1 = c1.to_plan(None)
         cp2 = c2.to_plan(None)
         cp3 = c3.to_plan(None)
 
-        assert cp1 is not None
-        assert cp1 == cp2 == cp3
+        self.assertIsNotNone(cp1)
+        self.assertEqual(cp1, cp2)
+        self.assertEqual(cp2, cp3)
 
     def test_column_literals(self):
         df = c.DataFrame.withPlan(p.Read("table"))

--- a/python/pyspark/sql/tests/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/test_connect_plan_only.py
@@ -48,7 +48,7 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
         expr = u("ThisCol", "ThatCol", "OtherCol")
         self.assertTrue(isinstance(expr, UserDefinedFunction))
         u_plan = expr.to_plan(self.connect)
-        assert u_plan is not None
+        self.assertIsNotNone(u_plan)
 
     def test_all_the_plans(self):
         def read_table(x):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use unittest' assert API instead of Python's built-in assert in Spark Connect tests.

### Why are the changes needed?

For better error message when a test fails, and consisten codebase.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should verify it.