### PR TITLE
[MINOR][CONNECT] Remove `.gitignore` file from `connect` module

### DIFF
--- a/connector/connect/.gitignore
+++ b/connector/connect/.gitignore
@@ -1,2 +1,0 @@
-# Ignore generated proto files.
-src/main/gen


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr remove `.gitignore` file from `connect` module.


### Why are the changes needed?

- `generated proto files` will be generated in `generated-sources` directory instead of `src/main/gen` directory, so  the content of this configuration file is invalid
- For the scala module, it is better to use the unified `.gitignore` in the root directory 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions