### PR TITLE
[SPARK-40676][BUILD] Upgrade `scalatest` related test dependencies to 3.2.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,9 +196,9 @@
     <!-- Please don't upgrade the version to 4.10+, it depends on JDK 11 -->
     <antlr4.version>4.9.3</antlr4.version>
     <jpam.version>1.1</jpam.version>
-    <selenium.version>4.2.2</selenium.version>
-    <htmlunit-driver.version>3.62.0</htmlunit-driver.version>
-    <htmlunit.version>2.62.0</htmlunit.version>
+    <selenium.version>4.4.0</selenium.version>
+    <htmlunit-driver.version>3.64.0</htmlunit-driver.version>
+    <htmlunit.version>2.64.0</htmlunit.version>
     <maven-antrun.version>1.8</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.5.0</commons-cli.version>
@@ -400,7 +400,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
+      <artifactId>scalacheck-1-17_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -410,7 +410,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>selenium-4-2_${scala.binary.version}</artifactId>
+      <artifactId>selenium-4-4_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1151,25 +1151,25 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.2.13</version>
+        <version>3.2.14</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
-        <version>3.2.13.0</version>
+        <artifactId>scalacheck-1-17_${scala.binary.version}</artifactId>
+        <version>3.2.14.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
-        <version>3.2.13.0</version>
+        <version>3.2.14.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>selenium-4-2_${scala.binary.version}</artifactId>
-        <version>3.2.13.0</version>
+        <artifactId>selenium-4-4_${scala.binary.version}</artifactId>
+        <version>3.2.14.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `scalatest` related test dependencies to 3.2.14:

- scalatest: upgrade scalatest to 3.2.14
- scalatestplus
   - scalacheck: upgrade to `scalacheck-1-17` 3.2.14.0
   - mockito: upgrade to `mockito-4-6` to 3.2.14.0
   - selenium: uprade to `selenium-4-4` to 3.2.14.0 and `selenium-java` to 4.4, `htmlunit-driver` to 3.64.0, `htmlunit` to 2.64.0


### Why are the changes needed?
The release notes as follows:

- scalatest:https://github.com/scalatest/scalatest/releases/tag/release-3.2.14
- scalatestplus
   - scalacheck-1-17: https://github.com/scalatest/scalatestplus-scalacheck/releases/tag/release-3.2.14.0-for-scalacheck-1.17
   - mockito-4-6: https://github.com/scalatest/scalatestplus-mockito/releases/tag/release-3.2.14.0-for-mockito-4.6
   - selenium-4-4: https://github.com/scalatest/scalatestplus-selenium/releases/tag/release-3.2.14.0-for-selenium-4.4


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Manual test:

```
build/sbt -Dguava.version=31.1-jre -Dspark.test.webdriver.chrome.driver=/path/to/chromedriver -Dtest.default.exclude.tags="" -Phive -Phive-thriftserver "core/testOnly org.apache.spark.deploy.history.RocksDBBackendChromeUIHistoryServerSuite"
```

```
[info] RocksDBBackendChromeUIHistoryServerSuite:
Starting ChromeDriver 105.0.5195.52 (412c95e518836d8a7d97250d62b29c2ae6a26a85-refs/branch-heads/5195@{#853}) on port 58104
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
[info] - ajax rendered relative links are prefixed with uiRoot (spark.ui.proxyBase) (2 seconds, 216 milliseconds)
[info] Run completed in 7 seconds, 816 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 111 s (01:51), completed 2022-10-6 17:14:20
```