### PR TITLE
[SPARK-40677][CONNECT][BUILD] Shade more dependency to be able to run separately

### DIFF
--- a/connector/connect/pom.xml
+++ b/connector/connect/pom.xml
@@ -243,6 +243,17 @@
               <include>com.google.guava:*</include>
               <include>io.grpc:*:</include>
               <include>com.google.protobuf:*</include>
+
+              <!--
+                The dependencies below are not added in SBT because SBT add them all
+                as assembly build.
+              -->
+              <include>com.google.android:annotations</include>
+              <include>com.google.api.grpc:proto-google-common-proto</include>
+              <include>io.perfmark:perfmark-api</include>
+              <include>org.codehaus.mojo:animal-sniffer-annotations</include>
+              <include>com.google.errorprone:error_prone_annotations</include>
+              <include>com.google.j2objc:j2objc-annotations</include>
             </includes>
           </artifactSet>
           <relocations>
@@ -270,6 +281,31 @@
             <relocation>
               <pattern>io.grpc</pattern>
               <shadedPattern>${spark.shade.packageName}.connect.grpc</shadedPattern>
+            </relocation>
+
+            <relocation>
+              <pattern>com.google.android</pattern>
+              <shadedPattern>${spark.shade.packageName}.connect.android</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.api.grpc</pattern>
+              <shadedPattern>${spark.shade.packageName}.connect.api</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>io.perfmark</pattern>
+              <shadedPattern>${spark.shade.packageName}.connect.perfmark</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.codehaus.mojo</pattern>
+              <shadedPattern>${spark.shade.packageName}.connect.mojo</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.errorprone</pattern>
+              <shadedPattern>${spark.shade.packageName}.connect.errorprone</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.com.google.j2objc</pattern>
+              <shadedPattern>${spark.shade.packageName}.connect.j2objc</shadedPattern>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the following dependencies shaded:

```
com.google.android:annotations
com.google.api.grpc:proto-google-common-proto
io.perfmark:perfmark-api
org.codehaus.mojo:animal-sniffer-annotations
com.google.errorprone:error_prone_annotations
com.google.j2objc:j2objc-annotations
```

Before https://github.com/apache/spark/pull/38109, it worked because related dependences pulled together but now we don't as Spark Connect would be a single jar. This issue has existed from the very first place.

### Why are the changes needed?

Otherwise, the tests fails if you build Spark Connect with Maven. SBT does not have the issue because it does the assemply with all dependencies.

### Does this PR introduce _any_ user-facing change?

No, the codes are not released out yet.

### How was this patch tested?

Manually tested via Maven:

```bash
./build/mvn clean package
./python/run-tests --testnames 'pyspark.sql.tests.test_connect_basic'
```