### PR TITLE
[SPARK-40680][CONNECT][BUILD] Avoid hardcoded versions in SBT build

### DIFF
--- a/connector/connect/pom.xml
+++ b/connector/connect/pom.xml
@@ -34,6 +34,7 @@
     <sbt.project.name>connect</sbt.project.name>
     <protobuf.version>3.21.1</protobuf.version>
     <guava.version>31.0.1-jre</guava.version>
+    <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
     <io.grpc.version>1.47.0</io.grpc.version>
     <tomcat.annotations.api.version>6.0.53</tomcat.annotations.api.version>
   </properties>
@@ -123,7 +124,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>failureaccess</artifactId>
-      <version>1.0.1</version>
+      <version>${guava.failureaccess.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -610,11 +610,7 @@ object Core {
 
 
 object SparkConnect {
-
   import BuildCommons.protoVersion
-
-  private val shadePrefix = "org.sparkproject.connect"
-  val shadeJar = taskKey[Unit]("Shade the Jars")
 
   lazy val settings = Seq(
     // Setting version for the protobuf compiler. This has to be propagated to every sub-project
@@ -623,22 +619,35 @@ object SparkConnect {
 
     // For some reason the resolution from the imported Maven build does not work for some
     // of these dependendencies that we need to shade later on.
-    libraryDependencies ++= Seq(
-      "io.grpc" % "protoc-gen-grpc-java" % BuildCommons.gprcVersion asProtocPlugin(),
-      "org.scala-lang" % "scala-library" % "2.12.16" % "provided",
-      "com.google.guava" % "guava" % "31.0.1-jre",
-      "com.google.guava" % "failureaccess" % "1.0.1",
-      "com.google.protobuf" % "protobuf-java" % protoVersion % "protobuf"
-    ),
+    libraryDependencies ++= {
+      val guavaVersion =
+        SbtPomKeys.effectivePom.value.getProperties.get("guava.version").asInstanceOf[String]
+      val guavaFailureaccessVersion =
+        SbtPomKeys.effectivePom.value.getProperties.get(
+          "guava.failureaccess.version").asInstanceOf[String]
+      Seq(
+        "io.grpc" % "protoc-gen-grpc-java" % BuildCommons.gprcVersion asProtocPlugin(),
+        "com.google.guava" % "guava" % guavaVersion,
+        "com.google.guava" % "failureaccess" % guavaFailureaccessVersion,
+        "com.google.protobuf" % "protobuf-java" % protoVersion % "protobuf"
+      )
+    },
 
-    dependencyOverrides ++= Seq(
-      "com.google.guava" % "guava" % "31.0.1-jre",
-      "com.google.guava" % "failureaccess" % "1.0.1",
-      "com.google.protobuf" % "protobuf-java" % protoVersion
-    ),
+    dependencyOverrides ++= {
+      val guavaVersion =
+        SbtPomKeys.effectivePom.value.getProperties.get("guava.version").asInstanceOf[String]
+      val guavaFailureaccessVersion =
+        SbtPomKeys.effectivePom.value.getProperties.get(
+          "guava.failureaccess.version").asInstanceOf[String]
+      Seq(
+        "com.google.guava" % "guava" % guavaVersion,
+        "com.google.guava" % "failureaccess" % guavaFailureaccessVersion,
+        "com.google.protobuf" % "protobuf-java" % protoVersion
+      )
+    },
 
     (Compile / PB.targets) := Seq(
-      PB.gens.java                -> (Compile / sourceManaged).value,
+      PB.gens.java -> (Compile / sourceManaged).value,
       PB.gens.plugin("grpc-java") -> (Compile / sourceManaged).value
     ),
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to read the corresponding versions from POM in SBT build instead of hardcoding the dependency versions.

In addition, this PR removes Scala system libraries in the dependency.

### Why are the changes needed?

To avoid version duplication.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should test it out.