### PR TITLE
[SPARK-40521][SQL] Return only exists partitions in `PartitionsAlreadyExistException` from Hive's create partition

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableAddPartitionSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableAddPartitionSuiteBase.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution.command
 import java.time.{Duration, Period}
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.catalyst.analysis.PartitionsAlreadyExistException
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -164,23 +163,6 @@ trait AlterTableAddPartitionSuiteBase extends QueryTest with DDLCommandTestUtils
       }.getMessage
       assert(errMsg.contains("Partition spec is invalid. " +
         "The spec (part0) must match the partition spec (part0, part1)"))
-    }
-  }
-
-  test("partition already exists") {
-    withNamespaceAndTable("ns", "tbl") { t =>
-      sql(s"CREATE TABLE $t (id bigint, data string) $defaultUsing PARTITIONED BY (id)")
-      sql(s"ALTER TABLE $t ADD PARTITION (id=2) LOCATION 'loc1'")
-
-      val errMsg = intercept[PartitionsAlreadyExistException] {
-        sql(s"ALTER TABLE $t ADD PARTITION (id=1) LOCATION 'loc'" +
-          " PARTITION (id=2) LOCATION 'loc1'")
-      }.getMessage
-      assert(errMsg.contains("The following partitions already exists"))
-
-      sql(s"ALTER TABLE $t ADD IF NOT EXISTS PARTITION (id=1) LOCATION 'loc'" +
-        " PARTITION (id=2) LOCATION 'loc1'")
-      checkPartitions(t, Map("id" -> "1"), Map("id" -> "2"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.catalyst.analysis.PartitionsAlreadyExistException
 import org.apache.spark.sql.execution.command
 
 /**
@@ -97,6 +98,24 @@ class AlterTableAddPartitionSuite
         sql(s"ALTER TABLE $t ADD PARTITION (id=2, part=3)")
         checkCachedRelation(v2, Seq(Row(0, 0), Row(0, 1), Row(1, 2), Row(2, 3)))
       }
+    }
+  }
+
+  // TODO: Move this test to the common trait as soon as it is migrated on checkError()
+  test("partition already exists") {
+    withNamespaceAndTable("ns", "tbl") { t =>
+      sql(s"CREATE TABLE $t (id bigint, data string) $defaultUsing PARTITIONED BY (id)")
+      sql(s"ALTER TABLE $t ADD PARTITION (id=2) LOCATION 'loc1'")
+
+      val errMsg = intercept[PartitionsAlreadyExistException] {
+        sql(s"ALTER TABLE $t ADD PARTITION (id=1) LOCATION 'loc'" +
+          " PARTITION (id=2) LOCATION 'loc1'")
+      }.getMessage
+      assert(errMsg === s"The following partitions already exists in table $t:2 -> id")
+
+      sql(s"ALTER TABLE $t ADD IF NOT EXISTS PARTITION (id=1) LOCATION 'loc'" +
+        " PARTITION (id=2) LOCATION 'loc1'")
+      checkPartitions(t, Map("id" -> "1"), Map("id" -> "2"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to modify Hive catalog implementation of create partition in the case when Hive reports that some of partitions exist already. In that case, Spark will check existence of all input partitions one-by-one and return **only existing** partitions in `PartitionAlreadyExistsException`.

### Why are the changes needed?
1. To do not confuse Spark SQL users about existing partitions.
2. To be consistent with other catalogs V2 and V1 In-Memory.

### Does this PR introduce _any_ user-facing change?
Yes, it changes user-facing error message.

Before:
```
spark-sql> CREATE TABLE t (id bigint, data string) USING HIVE PARTITIONED BY (id);
spark-sql> ALTER TABLE t ADD PARTITION (id=2) LOCATION 'loc1';
spark-sql> ALTER TABLE t ADD PARTITION (id=1) LOCATION 'loc' PARTITION (id=2) LOCATION 'loc1';
The following partitions already exists in table 't' database 'default':
Map(id -> 1)
===
Map(id -> 2)
```
The error shows an existent and a non-existent partitions.

After:
```
...
spark-sql> ALTER TABLE t ADD PARTITION (id=1) LOCATION 'loc' PARTITION (id=2) LOCATION 'loc1';
The following partitions already exists in table 't' database 'default':
Map(id -> 2)
```
The error contains only existent partitions that cause issues.

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *.AlterTableAddPartitionSuite"
```