### PR TITLE
[SPARK-40682][SQL][TESTS] Set `spark.driver.maxResultSize` to 3g in `SqlBasedBenchmark`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/SqlBasedBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/SqlBasedBenchmark.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.benchmark
 
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.internal.config.MAX_RESULT_SIZE
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.SaveMode.Overwrite
@@ -41,6 +42,7 @@ trait SqlBasedBenchmark extends BenchmarkBase with SQLHelper {
       .config(SQLConf.SHUFFLE_PARTITIONS.key, 1)
       .config(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, 1)
       .config(UI_ENABLED.key, false)
+      .config(MAX_RESULT_SIZE.key, "3g")
       .getOrCreate()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `spark.driver.maxResultSize` to `3g` from the default value, `1g`,  in `SqlBasedBenchmark`.

### Why are the changes needed?

Apache Spark benchmark is using `4g` JVM memory. We can utilize it for `spark.driver.maxResultSize` in some cases after this PR.

### Does this PR introduce _any_ user-facing change?

No. This is a test case and unblocks only the cases which failed before.

### How was this patch tested?

N/A