### PR TITLE
[SPARK-40694][INFRA] Add permission to recover label job

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -30,6 +30,9 @@ jobs:
   label:
     name: Label pull requests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     # In order to get back the negated matches like in the old config,
     # we need the actinons/labeler concept of `all` and `any` which matches


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add permission to recover label job

### Why are the changes needed?

I notice that some apache projects [added the `permissons` explictly](https://github.com/apache/beam/blob/master/.github/workflows/label_prs.yml#L26-L28), it doesn't be impacted by github action flaky.

In princinple, the default github action token permissons already [contains enough permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), but looks like it failed due to some reason recently (but I didn't notice any github official changes log yet and apache infra notification)



### Does this PR introduce _any_ user-facing change?
No, dev only


### How was this patch tested?
Frankly, we couldn't test it before merge because it not happened in fork repo, and also `pull_request_target` is only work after this merge.

But local test can help us to make sure it works in some level: https://github.com/Yikun/spark/pull/176

<img width="847" alt="image" src="https://user-images.githubusercontent.com/1736354/194446431-7b48f092-7e1a-4ad8-a658-aaf9418c2fcb.png">
