### PR TITLE
[SPARK-40695][INFRA] Add permisson for notify and status update job

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -31,6 +31,9 @@ jobs:
   notify:
     name: Notify test workflow
     runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      checks: write
     steps:
       - name: "Notify test workflow"
         uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # pin@v3

--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -27,6 +27,9 @@ jobs:
   update:
     name: Update build status
     runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      checks: write
     steps:
       - name: "Update build status"
         uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # pin@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch add permisson for notify and status update job


### Why are the changes needed?
Notify test workflow job:
- GET /repos/:owner/:repo/actions/workflows/:id/runs?&branch=:branch: [actions:read](https://docs.github.com/en/rest/actions/workflows#get-a-workflow)
- GET /repos/:owner/:repo/commits/:ref/check-runs: [checks:read](https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference)
- github.checks.create: [checks:write](https://docs.github.com/en/rest/checks/runs#create-a-check-run)

Update build status job: 
- GET /repos/:owner/:repo/pulls?state=:state: https://docs.github.com/en/rest/pulls/pulls#list-pull-request no permission needed
- GET /repos/{owner}/{repo}/commits/{ref}/check-runs: [checks:read](https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference)
- GET /repos/{owner}/{repo}/actions/runs/{run_id}: [actions:read](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)
- PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}: [checks:write](https://docs.github.com/en/rest/checks/runs#update-a-check-run)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
test it after merged
