### PR TITLE
[SPARK-40696][INFRA] Add packages write permisson for infra image

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -276,6 +276,8 @@ jobs:
       fromJson(needs.precondition.outputs.required).sparkr == 'true') &&
       inputs.branch == 'master'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -34,6 +34,8 @@ jobs:
   main:
     if: github.repository == 'apache/spark'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v2


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch add the write permission for infra image related jobs.



### Why are the changes needed?
In princinple, the default github action token permissons already [contains enough permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), but looks like it failed due to some reason recently (but I haven't noticed any github official changes log yet and apache infra notification)


### Does this PR introduce _any_ user-facing change?
No, dev only

### How was this patch tested?
- CI passed.
- After merge, the master job recover.
