### PR TITLE
[SPARK-40696][INFRA][FOLLOWUP] Add packages write permisson for parent workflows

### DIFF
--- a/.github/workflows/build_ansi.yml
+++ b/.github/workflows/build_ansi.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_branch32.yml
+++ b/.github/workflows/build_branch32.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_branch33.yml
+++ b/.github/workflows/build_branch33.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_coverage.yml
+++ b/.github/workflows/build_coverage.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_hadoop2.yml
+++ b/.github/workflows/build_hadoop2.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_java11.yml
+++ b/.github/workflows/build_java11.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_java17.yml
+++ b/.github/workflows/build_java17.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -26,5 +26,7 @@ on:
 
 jobs:
   call-build-and-test:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml

--- a/.github/workflows/build_scala213.yml
+++ b/.github/workflows/build_scala213.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add packages write permisson for parent workflows


### Why are the changes needed?
To avoid the issue like:
> The workflow is not valid. .github/workflows/build_main.yml (Line: 28, Col: 3): Error calling workflow 'apache/spark/.github/workflows/build_and_test.yml@6eedb0eaa72008858b77d8d36fde0938b0962922'. The nested job 'Base image build' is requesting 'packages: write', but is only allowed 'packages: none'.

https://github.com/apache/spark/actions/runs/3202259476/workflow



### Does this PR introduce _any_ user-facing change?
No, dev only


### How was this patch tested?
see master merge results.