### PR TITLE
[SPARK-40702][SQL] Fix partition specs in `PartitionsAlreadyExistException`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AlreadyExistException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AlreadyExistException.scala
@@ -79,7 +79,7 @@ class PartitionsAlreadyExistException(message: String) extends AnalysisException
 
   def this(tableName: String, partitionIdents: Seq[InternalRow], partitionSchema: StructType) = {
     this(s"The following partitions already exists in table $tableName:" +
-      partitionIdents.map(_.toSeq(partitionSchema).zip(partitionSchema.map(_.name))
+      partitionIdents.map(id => partitionSchema.map(_.name).zip(id.toSeq(partitionSchema))
         .map( kv => s"${kv._1} -> ${kv._2}").mkString(",")).mkString("\n===\n"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
@@ -111,7 +111,7 @@ class AlterTableAddPartitionSuite
         sql(s"ALTER TABLE $t ADD PARTITION (id=1) LOCATION 'loc'" +
           " PARTITION (id=2) LOCATION 'loc1'")
       }.getMessage
-      assert(errMsg === s"The following partitions already exists in table $t:2 -> id")
+      assert(errMsg === s"The following partitions already exists in table $t:id -> 2")
 
       sql(s"ALTER TABLE $t ADD IF NOT EXISTS PARTITION (id=1) LOCATION 'loc'" +
         " PARTITION (id=2) LOCATION 'loc1'")


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to change formatting of partition specs in `PartitionsAlreadyExistException`. For instance:
```sql
spark-sql> ALTER TABLE t ADD PARTITION (id=1) LOCATION 'loc' PARTITION (id=2) LOCATION 'loc1';
The following partitions already exists in table t:2 -> id
```
After the changes, the error message looks:
```sql
The following partitions already exists in table t:id -> 2
```

### Why are the changes needed?
To be consistent w/ V1 catalogs, and to not confuse Spark SQL users.

### Does this PR introduce _any_ user-facing change?
Yes, it changes user-facing error message.

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *.AlterTableAddPartitionSuite"
```