### PR TITLE
[SPARK-39876][FOLLOW-UP][SQL] Add parser and Dataset tests for SQL UNPIVOT

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1137,7 +1137,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
       Unpivot(
         None,
         Some(unpivotColumns.map(Seq(_))),
-        Some(unpivotAliases),
+        // None when all elements are None
+        Some(unpivotAliases).filter(_.exists(_.isDefined)),
         variableColumnName,
         valueColumnNames,
         query
@@ -1151,7 +1152,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
       Unpivot(
         None,
         Some(unpivotColumns),
-        Some(unpivotAliases),
+        // None when all elements are None
+        Some(unpivotAliases).filter(_.exists(_.isDefined)),
         variableColumnName,
         valueColumnNames,
         query

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1471,7 +1471,10 @@ case class Unpivot(
     copy(child = newChild)
 
   def canBeCoercioned: Boolean = values.exists(_.nonEmpty) &&
-    values.exists(_.forall(_.forall(_.resolved)))
+    values.exists(_.forall(_.forall(_.resolved))) &&
+    // when no ids are given, values must be Attributes (column names) to allow detecting ids
+    // coercion will add aliases, would disallow detecting ids, so defer coercion after id detection
+    ids.exists(_.forall(_.resolved))
 
   def valuesTypeCoercioned: Boolean = canBeCoercioned &&
     // all inner values at position idx must have the same data type

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/UnpivotParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/UnpivotParserSuite.scala
@@ -163,5 +163,33 @@ class UnpivotParserSuite extends AnalysisTest {
     }
   }
 
-  // TODO: include and exclude nulls
+  test("unpivot - exclude nulls") {
+    assertEqual(
+      "SELECT * FROM t UNPIVOT EXCLUDE NULLS (val FOR col in (a, b))",
+      Unpivot(
+        None,
+        Some(Seq(Seq(UnresolvedAlias($"a")), Seq(UnresolvedAlias($"b")))),
+        None,
+        "col",
+        Seq("val"),
+        table("t"))
+        .where(coalesce($"val").isNotNull)
+        .select(star())
+    )
+  }
+
+  test("unpivot - include nulls") {
+    assertEqual(
+      "SELECT * FROM t UNPIVOT INCLUDE NULLS (val FOR col in (a, b))",
+      Unpivot(
+        None,
+        Some(Seq(Seq(UnresolvedAlias($"a")), Seq(UnresolvedAlias($"b")))),
+        None,
+        "col",
+        Seq("val"),
+        table("t"))
+        .select(star())
+    )
+  }
+
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/UnpivotParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/UnpivotParserSuite.scala
@@ -42,8 +42,7 @@ class UnpivotParserSuite extends AnalysisTest {
         None,
         "col",
         Seq("val"),
-        table("t")
-      )
+        table("t"))
         .where(coalesce($"val").isNotNull)
         .select(star())
     )
@@ -63,8 +62,7 @@ class UnpivotParserSuite extends AnalysisTest {
             Some(Seq(Some("A"), None)),
             "col",
             Seq("val"),
-            table("t")
-          )
+            table("t"))
             .where(coalesce($"val").isNotNull)
             .select(star())
         )
@@ -81,8 +79,7 @@ class UnpivotParserSuite extends AnalysisTest {
         None,
         "col",
         Seq("val1", "val2"),
-        table("t")
-      )
+        table("t"))
         .where(coalesce($"val1", $"val2").isNotNull)
         .select(star())
     )
@@ -105,8 +102,7 @@ class UnpivotParserSuite extends AnalysisTest {
             Some(Seq(Some("first"), None)),
             "col",
             Seq("val1", "val2"),
-            table("t")
-          )
+            table("t"))
             .where(coalesce($"val1", $"val2").isNotNull)
             .select(star())
         )
@@ -139,8 +135,7 @@ class UnpivotParserSuite extends AnalysisTest {
             None,
             "col",
             Seq("val"),
-            table("t")
-          )
+            table("t"))
             .where(coalesce($"val").isNotNull)
             .subquery("up")
             .select(star("up"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/UnpivotParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/UnpivotParserSuite.scala
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser
+
+import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Unpivot}
+
+class UnpivotParserSuite extends AnalysisTest {
+
+  import CatalystSqlParser._
+  import org.apache.spark.sql.catalyst.dsl.expressions._
+  import org.apache.spark.sql.catalyst.dsl.plans._
+
+  private def assertEqual(sqlCommand: String, plan: LogicalPlan): Unit = {
+    comparePlans(parsePlan(sqlCommand), plan, checkAnalysis = false)
+  }
+
+  private def intercept(sqlCommand: String, errorClass: Option[String], messages: String*): Unit =
+    interceptParseException(parsePlan)(sqlCommand, messages: _*)(errorClass)
+
+  test("unpivot - single value") {
+    assertEqual(
+      "SELECT * FROM t UNPIVOT (val FOR col in (a, b))",
+      Unpivot(
+        None,
+        Some(Seq(Seq(UnresolvedAlias($"a")), Seq(UnresolvedAlias($"b")))),
+        Some(Seq(None, None)),
+        "col",
+        Seq("val"),
+        table("t")
+      )
+        .where(coalesce($"val").isNotNull)
+        .select(star())
+    )
+  }
+
+  test("unpivot - single value with alias") {
+    Seq(
+      "SELECT * FROM t UNPIVOT (val FOR col in (a A, b))",
+      "SELECT * FROM t UNPIVOT (val FOR col in (a AS A, b))"
+    ).foreach { sql =>
+      withClue(sql) {
+        assertEqual(
+          sql,
+          Unpivot(
+            None,
+            Some(Seq(Seq(UnresolvedAlias($"a")), Seq(UnresolvedAlias($"b")))),
+            Some(Seq(Some("A"), None)),
+            "col",
+            Seq("val"),
+            table("t")
+          )
+            .where(coalesce($"val").isNotNull)
+            .select(star())
+        )
+      }
+    }
+  }
+
+  test("unpivot - multiple values") {
+    assertEqual(
+      "SELECT * FROM t UNPIVOT ((val1, val2) FOR col in ((a, b), (c, d)))",
+      Unpivot(
+        None,
+        Some(Seq(Seq($"a", $"b").map(UnresolvedAlias(_)), Seq($"c", $"d").map(UnresolvedAlias(_)))),
+        Some(Seq(None, None)),
+        "col",
+        Seq("val1", "val2"),
+        table("t")
+      )
+        .where(coalesce($"val1", $"val2").isNotNull)
+        .select(star())
+    )
+  }
+
+  test("unpivot - multiple values with alias") {
+    Seq(
+      "SELECT * FROM t UNPIVOT ((val1, val2) FOR col in ((a, b) first, (c, d)))",
+      "SELECT * FROM t UNPIVOT ((val1, val2) FOR col in ((a, b) AS first, (c, d)))"
+    ).foreach { sql =>
+      withClue(sql) {
+        assertEqual(
+          sql,
+          Unpivot(
+            None,
+            Some(Seq(
+              Seq($"a", $"b").map(UnresolvedAlias(_)),
+              Seq($"c", $"d").map(UnresolvedAlias(_))
+            )),
+            Some(Seq(Some("first"), None)),
+            "col",
+            Seq("val1", "val2"),
+            table("t")
+          )
+            .where(coalesce($"val1", $"val2").isNotNull)
+            .select(star())
+        )
+      }
+    }
+  }
+
+  test("unpivot - multiple values with inner alias") {
+    Seq(
+      "SELECT * FROM t UNPIVOT ((val1, val2) FOR col in ((a A, b), (c, d)))",
+      "SELECT * FROM t UNPIVOT ((val1, val2) FOR col in ((a AS A, b), (c, d)))"
+    ).foreach { sql =>
+      withClue(sql) {
+        intercept(sql, Some("PARSE_SYNTAX_ERROR"), "Syntax error at or near ")
+      }
+    }
+  }
+
+  test("unpivot - alias") {
+    Seq(
+      "SELECT up.* FROM t UNPIVOT (val FOR col in (a, b)) up",
+      "SELECT up.* FROM t UNPIVOT (val FOR col in (a, b)) AS up"
+    ).foreach { sql =>
+      withClue(sql) {
+        assertEqual(
+          sql,
+          Unpivot(
+            None,
+            Some(Seq(Seq(UnresolvedAlias($"a")), Seq(UnresolvedAlias($"b")))),
+            Some(Seq(None, None)),
+            "col",
+            Seq("val"),
+            table("t")
+          )
+            .where(coalesce($"val").isNotNull)
+            .subquery("up")
+            .select(star("up"))
+        )
+      }
+    }
+  }
+
+  test("unpivot - no unpivot value names") {
+    intercept(
+      "SELECT * FROM t UNPIVOT (() FOR col in ((a, b), (c, d)))",
+      Some("PARSE_SYNTAX_ERROR"), "Syntax error at or near "
+    )
+  }
+
+  test("unpivot - no unpivot columns") {
+    Seq(
+      "SELECT * FROM t UNPIVOT (val FOR col in ())",
+      "SELECT * FROM t UNPIVOT ((val1, val2) FOR col in ())",
+      "SELECT * FROM t UNPIVOT ((val1, val2) FOR col in (()))"
+    ).foreach { sql =>
+      withClue(sql) {
+        intercept(sql, Some("PARSE_SYNTAX_ERROR"), "Syntax error at or near ")
+      }
+    }
+  }
+
+  // TODO: include and exclude nulls
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/UnpivotParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/UnpivotParserSuite.scala
@@ -39,7 +39,7 @@ class UnpivotParserSuite extends AnalysisTest {
       Unpivot(
         None,
         Some(Seq(Seq(UnresolvedAlias($"a")), Seq(UnresolvedAlias($"b")))),
-        Some(Seq(None, None)),
+        None,
         "col",
         Seq("val"),
         table("t")
@@ -78,7 +78,7 @@ class UnpivotParserSuite extends AnalysisTest {
       Unpivot(
         None,
         Some(Seq(Seq($"a", $"b").map(UnresolvedAlias(_)), Seq($"c", $"d").map(UnresolvedAlias(_)))),
-        Some(Seq(None, None)),
+        None,
         "col",
         Seq("val1", "val2"),
         table("t")
@@ -136,7 +136,7 @@ class UnpivotParserSuite extends AnalysisTest {
           Unpivot(
             None,
             Some(Seq(Seq(UnresolvedAlias($"a")), Seq(UnresolvedAlias($"b")))),
-            Some(Seq(None, None)),
+            None,
             "col",
             Seq("val"),
             table("t")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds more tests for the SQL `UNPIVOT` clause. https://github.com/apache/spark/pull/37407#discussion_r988768918

### Why are the changes needed?
Better test coverage.

### Does this PR introduce _any_ user-facing change?
No, only more tests and fixing one issue. SQL `UNPIVOT` has not been released yet.

### How was this patch tested?
In `UnpivotParserSuite` and `DatasetUnpivotSuite`.