### PR TITLE
[SPARK-40705][SQL] Handle case of using mutable array when converting Row to JSON for Scala 2.13

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Row.scala
@@ -584,6 +584,8 @@ trait Row extends Serializable {
       case (i: CalendarInterval, _) => JString(i.toString)
       case (a: Array[_], ArrayType(elementType, _)) =>
         iteratorToJsonArray(a.iterator, elementType)
+      case (a: mutable.ArraySeq[_], ArrayType(elementType, _)) =>
+        iteratorToJsonArray(a.iterator, elementType)
       case (s: Seq[_], ArrayType(elementType, _)) =>
         iteratorToJsonArray(s.iterator, elementType)
       case (m: Map[String @unchecked, _], MapType(StringType, valueType, _)) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
@@ -32,8 +32,8 @@ class RowTest extends AnyFunSpec with Matchers {
 
   val schema = StructType(
     StructField("col1", StringType) ::
-      StructField("col2", StringType) ::
-      StructField("col3", IntegerType) :: Nil)
+    StructField("col2", StringType) ::
+    StructField("col3", IntegerType) :: Nil)
   val values = Array("value1", "value2", 1)
   val valuesWithoutCol3 = Array[Any](null, "value2", null)
 
@@ -70,12 +70,18 @@ class RowTest extends AnyFunSpec with Matchers {
     }
 
     it("getValuesMap() retrieves values of multiple fields as a Map(field -> value)") {
-      val expected = Map("col1" -> "value1", "col2" -> "value2")
+      val expected = Map(
+        "col1" -> "value1",
+        "col2" -> "value2"
+      )
       sampleRow.getValuesMap(List("col1", "col2")) shouldBe expected
     }
 
     it("getValuesMap() retrieves null value on non AnyVal Type") {
-      val expected = Map("col1" -> null, "col2" -> "value2")
+      val expected = Map(
+        "col1" -> null,
+        "col2" -> "value2"
+      )
       sampleRowWithoutCol3.getValuesMap[String](List("col1", "col2")) shouldBe expected
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
I encountered an issue using Spark while reading JSON files based on a schema it throws every time an exception related to conversion of types.

>Note: This issue can be reproduced only with Scala `2.13`, I'm not having this issue with `2.12`

````
Failed to convert value ArraySeq(1, 2, 3) (class of class scala.collection.mutable.ArraySeq$ofRef}) with the type of ArrayType(StringType,true) to JSON.
java.lang.IllegalArgumentException: Failed to convert value ArraySeq(1, 2, 3) (class of class scala.collection.mutable.ArraySeq$ofRef}) with the type of ArrayType(StringType,true) to JSON.
````

If I add ArraySeq to the matching cases, the test that I added passed successfully 
![image](https://user-images.githubusercontent.com/28459763/194669557-2f13032f-126f-4c2e-bc6d-1a4cfd0a009d.png)

With the current code source, the test fails and we have this following error
![image](https://user-images.githubusercontent.com/28459763/194669654-19cefb13-180c-48ac-9206-69d8f672f64c.png)


### Why are the changes needed?
If the person is using Scala 2.13, they can't parse an array. Which means they need to fallback to 2.12 to keep the project functioning 

### How was this patch tested?
I added a sample unit test for the case, but I can add more if you want to.