### PR TITLE
[SPARK-40712][BUILD] Upgrade `sbt-assembly` plugin to 1.2.0

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -946,7 +946,6 @@ object YARN {
 }
 
 object Assembly {
-  import sbtassembly.AssemblyUtils._
   import sbtassembly.AssemblyPlugin.autoImport._
 
   val hadoopVersion = taskKey[String]("The version of hadoop that spark is compiled against.")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "9.3"
 // checkstyle uses guava 23.0.
 libraryDependencies += "com.google.guava" % "guava" % "23.0"
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `sbt-assembly` plugin from `0.15.0` to `1.2.0`


### Why are the changes needed?
`sbt-assembly` 1.2.0 no longer supports sbt 0.13, the release notes as follows:

- https://github.com/sbt/sbt-assembly/releases/tag/v1.0.0
- https://github.com/sbt/sbt-assembly/releases/tag/v1.1.0
- https://github.com/sbt/sbt-assembly/releases/tag/v1.2.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions