### PR TITLE
[WIP][SPARK-40715][SQL] Support selecting shuffled hash join thought LocalMapThreshold is less than advisory partition size

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3950,6 +3950,23 @@ object SQLConf {
     .checkValues(ErrorMessageFormat.values.map(_.toString))
     .createWithDefault(ErrorMessageFormat.PRETTY.toString)
 
+  val ADAPTIVE_SHUFFLE_JOIN_STREAM_PARTITION_THRESHOLD =
+    buildConf("spark.sql.adaptive.shuffleHashJoin.streamPartitionThreshold")
+      .doc("Shuffled hash join is considered to have better performance than SMJ if partition " +
+        "size is larger than this.")
+      .version("3.4.0")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(0L)
+
+  val ADAPTIVE_SHUFFLE_JOIN_LARGE_STREAM_PARTITION_RATIO =
+    buildConf("spark.sql.adaptive.shuffleHashJoin.largeStreamPartitionRatio")
+      .doc(s"The proportion of partitions larger than " +
+        s"${ADAPTIVE_SHUFFLE_JOIN_STREAM_PARTITION_THRESHOLD}")
+      .version("3.4.0")
+      .doubleConf
+      .checkValue(_ >= 0, "The non-empty partition ratio must be positive number.")
+      .createWithDefault(0.8)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3961,7 +3961,7 @@ object SQLConf {
   val ADAPTIVE_SHUFFLE_JOIN_LARGE_STREAM_PARTITION_RATIO =
     buildConf("spark.sql.adaptive.shuffleHashJoin.largeStreamPartitionRatio")
       .doc(s"The proportion of partitions larger than " +
-        s"${ADAPTIVE_SHUFFLE_JOIN_STREAM_PARTITION_THRESHOLD}")
+        s"${ADAPTIVE_SHUFFLE_JOIN_STREAM_PARTITION_THRESHOLD.key}")
       .version("3.4.0")
       .doubleConf
       .checkValue(_ >= 0, "The non-empty partition ratio must be positive number.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3950,23 +3950,6 @@ object SQLConf {
     .checkValues(ErrorMessageFormat.values.map(_.toString))
     .createWithDefault(ErrorMessageFormat.PRETTY.toString)
 
-  val ADAPTIVE_SHUFFLE_JOIN_STREAM_PARTITION_THRESHOLD =
-    buildConf("spark.sql.adaptive.shuffleHashJoin.streamPartitionThreshold")
-      .doc("Shuffled hash join is considered to have better performance than SMJ if partition " +
-        "size is larger than this.")
-      .version("3.4.0")
-      .bytesConf(ByteUnit.BYTE)
-      .createWithDefault(0L)
-
-  val ADAPTIVE_SHUFFLE_JOIN_LARGE_STREAM_PARTITION_RATIO =
-    buildConf("spark.sql.adaptive.shuffleHashJoin.largeStreamPartitionRatio")
-      .doc(s"The proportion of partitions larger than " +
-        s"${ADAPTIVE_SHUFFLE_JOIN_STREAM_PARTITION_THRESHOLD.key}")
-      .version("3.4.0")
-      .doubleConf
-      .checkValue(_ >= 0, "The non-empty partition ratio must be positive number.")
-      .createWithDefault(0.8)
-
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DynamicJoinSelection.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DynamicJoinSelection.scala
@@ -112,8 +112,9 @@ object DynamicJoinSelection extends Rule[LogicalPlan] with JoinSelectionHelper {
         }
 
         def collectShuffleStats(plan: LogicalPlan): Seq[MapOutputStatistics] = plan match {
-          case stage: ShuffleQueryStageExec
-            if stage.isMaterialized && stage.mapStats.isDefined => Seq(stage.mapStats.get)
+          case LogicalQueryStage(_, streamedStage: ShuffleQueryStageExec)
+            if streamedStage.isMaterialized && streamedStage.mapStats.isDefined =>
+            Seq(streamedStage.mapStats.get)
           case _ => plan.children.flatMap(collectShuffleStats)
         }
         val preferShuffleHash =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DynamicJoinSelection.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/DynamicJoinSelection.scala
@@ -59,7 +59,7 @@ object DynamicJoinSelection extends Rule[LogicalPlan] with JoinSelectionHelper {
 
     val newPartitionSpecs = ShufflePartitionsUtil.coalescePartitions(
       Seq(Some(mapStats)) ++ streamedStats.map(Some(_)),
-      Seq(None, None),
+      Seq.fill(streamedStats.length + 1)(None),
       advisoryTargetSize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES),
       minNumPartitions = 0,
       minPartitionSize = 0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2015,50 +2015,50 @@ class AdaptiveQueryExecSuite
   test("SPARK-35264: Support AQE side shuffled hash join formula") {
     withTempView("t1", "t2") {
       def checkJoinStrategy(shouldShuffleHashJoin: Boolean): Unit = {
-        Seq("100", "100000").foreach { size =>
-          withSQLConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> size) {
-            val (origin1, adaptive1) = runAdaptiveAndVerifyResult(
-              "SELECT t1.c1, t2.c1 FROM t1 JOIN t2 ON t1.c1 = t2.c1")
-            assert(findTopLevelSortMergeJoin(origin1).size === 1)
-            if (shouldShuffleHashJoin && size.toInt < 100000) {
-              val shj = findTopLevelShuffledHashJoin(adaptive1)
-              assert(shj.size === 1)
-              assert(shj.head.buildSide == BuildRight)
-            } else {
-              assert(findTopLevelSortMergeJoin(adaptive1).size === 1)
-            }
-          }
+        val (origin1, adaptive1) = runAdaptiveAndVerifyResult(
+          "SELECT t1.c1, t2.c1 FROM t1 JOIN t2 ON t1.c1 = t2.c1")
+        assert(findTopLevelSortMergeJoin(origin1).size === 1)
+        if (shouldShuffleHashJoin) {
+          val shj = findTopLevelShuffledHashJoin(adaptive1)
+          assert(shj.size === 1)
+          assert(shj.head.buildSide == BuildRight)
+        } else {
+          assert(findTopLevelSortMergeJoin(adaptive1).size === 1)
         }
-        // respect user specified join hint
-        val (origin2, adaptive2) = runAdaptiveAndVerifyResult(
-          "SELECT /*+ MERGE(t1) */ t1.c1, t2.c1 FROM t1 JOIN t2 ON t1.c1 = t2.c1")
-        assert(findTopLevelSortMergeJoin(origin2).size === 1)
-        assert(findTopLevelSortMergeJoin(adaptive2).size === 1)
+
+        withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "0") {
+          // respect user specified join hint
+          val (origin2, adaptive2) = runAdaptiveAndVerifyResult(
+            "SELECT /*+ MERGE(t1) */ t1.c1, t2.c1 FROM t1 JOIN t2 ON t1.c1 = t2.c1")
+          assert(findTopLevelSortMergeJoin(origin2).size === 1)
+          assert(findTopLevelSortMergeJoin(adaptive2).size === 1)
+        }
       }
 
       spark.sparkContext.parallelize(
         (1 to 100).map(i => TestData(i, i.toString)), 10)
         .toDF("c1", "c2").createOrReplaceTempView("t1")
       spark.sparkContext.parallelize(
-        (1 to 10).map(i => TestData(i, i.toString)), 5)
+        (1 to 30).map(i => TestData(i, i.toString)), 5)
         .toDF("c1", "c2").createOrReplaceTempView("t2")
 
-      // t1 partition size: [926, 729, 731]
-      // t2 partition size: [318, 120, 0]
+      // left size: 1600B, MapOutputStatistics in ShuffleQueryStageExec [926, 729, 731]
+      // right size: 480B, MapOutputStatistics in ShuffleQueryStageExec [416, 258, 252]
       withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "3",
-        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "450",
+        SQLConf.ADAPTIVE_SHUFFLE_JOIN_STREAM_PARTITION_THRESHOLD.key -> "100",
         SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
-        // check default value
-        checkJoinStrategy(false)
-        withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "400") {
-          checkJoinStrategy(true)
-        }
-        withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "300") {
+        // check default value ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD = 0
           checkJoinStrategy(false)
-        }
-        withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "1000") {
-          checkJoinStrategy(true)
-        }
+          withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "420") {
+            checkJoinStrategy(true)
+          }
+          withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "400") {
+            checkJoinStrategy(false)
+          }
+          withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "500") {
+            checkJoinStrategy(false)
+          }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2046,7 +2046,6 @@ class AdaptiveQueryExecSuite
       // right size: 480B, MapOutputStatistics in ShuffleQueryStageExec [416, 258, 252]
       withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "3",
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "450",
-        SQLConf.ADAPTIVE_SHUFFLE_JOIN_STREAM_PARTITION_THRESHOLD.key -> "100",
         SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
         // check default value ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD = 0
           checkJoinStrategy(false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2042,21 +2042,19 @@ class AdaptiveQueryExecSuite
         (1 to 30).map(i => TestData(i, i.toString)), 5)
         .toDF("c1", "c2").createOrReplaceTempView("t2")
 
-      // left size: 1600B, MapOutputStatistics in ShuffleQueryStageExec [926, 729, 731]
-      // right size: 480B, MapOutputStatistics in ShuffleQueryStageExec [416, 258, 252]
+      // left partition size: [926, 729, 731] after coalesce : [926, 1460]
+      // right partition size: [416, 258, 252] after coalesce : [416, 510]
       withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "3",
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "450",
+        SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "2000",
         SQLConf.PREFER_SORTMERGEJOIN.key -> "true") {
         // check default value ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD = 0
           checkJoinStrategy(false)
-          withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "420") {
-            checkJoinStrategy(true)
-          }
-          withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "400") {
-            checkJoinStrategy(false)
-          }
           withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "500") {
             checkJoinStrategy(false)
+          }
+          withSQLConf(SQLConf.ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD.key -> "800") {
+            checkJoinStrategy(true)
           }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Now preferring shuffled hash join condition:
* `ADVISORY_PARTITION_SIZE_IN_BYTES` <= `ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD`
* All partitions size < `ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD`
but `ADVISORY_PARTITION_SIZE_IN_BYTES` is 64MB by default, so we can not add `SHUFFLE_HASH` hint for the plan which all partitions size are less than `ADVISORY_PARTITION_SIZE_IN_BYTES`.

The new preferring shuffled hash join condition:

* Try to coalesce the join, thinking the side satisfies Shuffled Hash Join condition if all the coalesced partitions are less than `ADAPTIVE_MAX_SHUFFLE_HASH_JOIN_LOCAL_MAP_THRESHOLD`


### Why are the changes needed?

Change more join to shuffled hash join.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Exists UT
