### PR TITLE
[SPARK-40718][CONNECT] Replace `grpc-netty-shaded` with`grpc-netty`

### DIFF
--- a/connector/connect/pom.xml
+++ b/connector/connect/pom.xml
@@ -134,7 +134,7 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty-shaded</artifactId>
+      <artifactId>grpc-netty</artifactId>
       <version>${io.grpc.version}</version>
     </dependency>
     <dependency>

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import com.google.common.base.Ticker
 import com.google.common.cache.CacheBuilder
 import io.grpc.{Server, Status}
-import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
+import io.grpc.netty.NettyServerBuilder
 import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.stub.StreamObserver
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch replaces the shaded version of Netty in GRPC with the unshaded one since we're shading the result again and want to avoid double shaded package names.


### Why are the changes needed?
Unnecessary double shaded package names.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests will check for compilation break.