### PR TITLE
[SPARK-40719][SQL] `CTAS` should respect `TBLPROPERTIES` during execution

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -237,7 +237,7 @@ case class CreateDataSourceTableAsSelectCommand(
       className = table.provider.get,
       partitionColumns = table.partitionColumnNames,
       bucketSpec = table.bucketSpec,
-      options = table.storage.properties ++ pathOption,
+      options = table.properties ++ table.storage.properties ++ pathOption,
       catalogTable = if (tableExists) Some(table) else None)
 
     try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -230,6 +230,16 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-40719: CTAS should respect TBLPROPERTIES during query execution") {
+    withTable("t") {
+      withTempDir { dir =>
+        sql(s"CREATE TABLE t USING PARQUET LOCATION '$dir' " +
+          "TBLPROPERTIES (parquet.compression 'zstd') AS SELECT 1")
+        assert(dir.listFiles().exists(f => f.isFile && f.getName.contains("zstd")))
+      }
+    }
+  }
 }
 
 trait DDLSuiteBase extends SQLTestUtils {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to propagate table properties during CTAS query executions.

### Why are the changes needed?

Currently, `CREATE TABLE ... USING ... TBLPROPERTIES (...) AS` ignores table properties while `CREATE TABLE ... STORED AS ... TBLPROPERTIES (...) AS` respect them.

```sql
spark-sql> CREATE TABLE t1 STORED AS PARQUET TBLPROPERTIES (parquet.compression 'zstd') AS SELECT 1;
spark-sql> CREATE TABLE t2 USING PARQUET TBLPROPERTIES (parquet.compression 'zstd') AS SELECT 1;
```

```
$ ls spark-warehouse/t1
_SUCCESS
part-00000-c28a99f0-a88f-448d-a60d-e8204bf2f3a7-c000.zstd.parquet

$ ls spark-warehouse/t2
_SUCCESS
part-00000-3c5853d0-308d-4571-86c3-3e1a31eacfe6-c000.snappy.parquet
```

### Does this PR introduce _any_ user-facing change?

Yes, 

### How was this patch tested?

Pass the CI with the newly added test case.