### PR TITLE
[SPARK-40721][CORE] Use `||` instead of `|` in `TimSort`

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/TimSort.java
+++ b/core/src/main/java/org/apache/spark/util/collection/TimSort.java
@@ -788,7 +788,7 @@ class TimSort<K, Buffer> {
           if (--len1 == 1)
             break outer;
           minGallop--;
-        } while (count1 >= MIN_GALLOP | count2 >= MIN_GALLOP);
+        } while (count1 >= MIN_GALLOP || count2 >= MIN_GALLOP);
         if (minGallop < 0)
           minGallop = 0;
         minGallop += 2;  // Penalize for leaving gallop mode
@@ -910,7 +910,7 @@ class TimSort<K, Buffer> {
           if (--len1 == 0)
             break outer;
           minGallop--;
-        } while (count1 >= MIN_GALLOP | count2 >= MIN_GALLOP);
+        } while (count1 >= MIN_GALLOP || count2 >= MIN_GALLOP);
         if (minGallop < 0)
           minGallop = 0;
         minGallop += 2;  // Penalize for leaving gallop mode


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr changes `while (count1 >= MIN_GALLOP | count2 >= MIN_GALLOP)` in `TimSort` to `while (count1 >= MIN_GALLOP || count2 >= MIN_GALLOP)`.



### Why are the changes needed?
The or operation of 2 boolean expressions should use `||`.
When `||` is used, if the first expression is true, the second expression does't need to be calculated. When `|` is used, 2 expressions must be calculated.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions