### PR TITLE
[SPARK-40718][BUILD][CONNECT][FOLLOWUP] Explicitly add Netty related dependencies for the `connect` module

### DIFF
--- a/connector/connect/pom.xml
+++ b/connector/connect/pom.xml
@@ -152,6 +152,24 @@
       <artifactId>grpc-stub</artifactId>
       <version>${io.grpc.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <version>${netty.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+      <version>${netty.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-unix-common</artifactId>
+      <version>${netty.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency> <!-- necessary for Java 9+ -->
       <groupId>org.apache.tomcat</groupId>
       <artifactId>annotations-api</artifactId>

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -203,8 +203,12 @@ metrics-jvm/4.2.10//metrics-jvm-4.2.10.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.80.Final//netty-all-4.1.80.Final.jar
 netty-buffer/4.1.80.Final//netty-buffer-4.1.80.Final.jar
+netty-codec-http/4.1.80.Final//netty-codec-http-4.1.80.Final.jar
+netty-codec-http2/4.1.80.Final//netty-codec-http2-4.1.80.Final.jar
+netty-codec-socks/4.1.80.Final//netty-codec-socks-4.1.80.Final.jar
 netty-codec/4.1.80.Final//netty-codec-4.1.80.Final.jar
 netty-common/4.1.80.Final//netty-common-4.1.80.Final.jar
+netty-handler-proxy/4.1.80.Final//netty-handler-proxy-4.1.80.Final.jar
 netty-handler/4.1.80.Final//netty-handler-4.1.80.Final.jar
 netty-resolver/4.1.80.Final//netty-resolver-4.1.80.Final.jar
 netty-tcnative-classes/2.0.54.Final//netty-tcnative-classes-2.0.54.Final.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -187,8 +187,12 @@ metrics-jvm/4.2.10//metrics-jvm-4.2.10.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.80.Final//netty-all-4.1.80.Final.jar
 netty-buffer/4.1.80.Final//netty-buffer-4.1.80.Final.jar
+netty-codec-http/4.1.80.Final//netty-codec-http-4.1.80.Final.jar
+netty-codec-http2/4.1.80.Final//netty-codec-http2-4.1.80.Final.jar
+netty-codec-socks/4.1.80.Final//netty-codec-socks-4.1.80.Final.jar
 netty-codec/4.1.80.Final//netty-codec-4.1.80.Final.jar
 netty-common/4.1.80.Final//netty-common-4.1.80.Final.jar
+netty-handler-proxy/4.1.80.Final//netty-handler-proxy-4.1.80.Final.jar
 netty-handler/4.1.80.Final//netty-handler-4.1.80.Final.jar
 netty-resolver/4.1.80.Final//netty-resolver-4.1.80.Final.jar
 netty-tcnative-classes/2.0.54.Final//netty-tcnative-classes-2.0.54.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -845,14 +845,6 @@
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
             <artifactId>netty-codec-memcache</artifactId>
           </exclusion>
           <exclusion>
@@ -869,19 +861,11 @@
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec-socks</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
             <artifactId>netty-codec-stomp</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-xml</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
After https://github.com/apache/spark/pull/38179, there are 2 netty version in Spark:

- 4.1.72 for `connect` module
- 4.1.80 for other modules

So this pr explicitly add netty related dependencies for the `connect` module to ensure Spark use unified netty version.

 
### Why are the changes needed?
Ensure Spark use unified netty version.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual test：

run `mvn dependency:tree -pl connector/connect | grep netty`

Before 

```
[INFO] |  +- io.netty:netty-all:jar:4.1.80.Final:provided
[INFO] |  |  +- io.netty:netty-buffer:jar:4.1.80.Final:compile
[INFO] |  |  +- io.netty:netty-codec:jar:4.1.80.Final:compile
[INFO] |  |  +- io.netty:netty-common:jar:4.1.80.Final:compile
[INFO] |  |  +- io.netty:netty-handler:jar:4.1.80.Final:compile
[INFO] |  |  +- io.netty:netty-resolver:jar:4.1.80.Final:provided
[INFO] |  |  +- io.netty:netty-transport:jar:4.1.80.Final:compile
[INFO] |  |  +- io.netty:netty-transport-classes-epoll:jar:4.1.80.Final:provided
[INFO] |  |  \- io.netty:netty-transport-classes-kqueue:jar:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-tcnative-classes:jar:2.0.54.Final:provided
[INFO] |  \- org.apache.arrow:arrow-memory-netty:jar:9.0.0:provided
[INFO] +- io.grpc:grpc-netty:jar:1.47.0:compile
[INFO] |  +- io.netty:netty-codec-http2:jar:4.1.72.Final:compile
[INFO] |  |  \- io.netty:netty-codec-http:jar:4.1.72.Final:compile
[INFO] |  +- io.netty:netty-handler-proxy:jar:4.1.72.Final:runtime
[INFO] |  |  \- io.netty:netty-codec-socks:jar:4.1.72.Final:runtime
[INFO] |  \- io.netty:netty-transport-native-unix-common:jar:4.1.72.Final:runtime
```

After

```
[INFO] |  +- io.netty:netty-all:jar:4.1.80.Final:provided
[INFO] |  |  +- io.netty:netty-resolver:jar:4.1.80.Final:provided
[INFO] |  |  +- io.netty:netty-transport-classes-epoll:jar:4.1.80.Final:provided
[INFO] |  |  \- io.netty:netty-transport-classes-kqueue:jar:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-tcnative-classes:jar:2.0.54.Final:provided
[INFO] |  \- org.apache.arrow:arrow-memory-netty:jar:9.0.0:provided
[INFO] +- io.grpc:grpc-netty:jar:1.47.0:compile
[INFO] +- io.netty:netty-codec-http2:jar:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-common:jar:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-buffer:jar:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-transport:jar:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-codec:jar:4.1.80.Final:provided
[INFO] |  +- io.netty:netty-handler:jar:4.1.80.Final:provided
[INFO] |  \- io.netty:netty-codec-http:jar:4.1.80.Final:provided
[INFO] +- io.netty:netty-handler-proxy:jar:4.1.80.Final:provided
[INFO] |  \- io.netty:netty-codec-socks:jar:4.1.80.Final:provided
[INFO] +- io.netty:netty-transport-native-unix-common:jar:4.1.80.Final:provided
```