### PR TITLE
[SPARK-40725][INFRA] Add `mypy-protobuf` to dev/requirements

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -49,3 +49,4 @@ black==22.6.0
 # Spark Connect
 grpcio==1.48.1
 protobuf==4.21.6
+mypy-protobuf


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `mypy-protobuf` to dev/requirements


### Why are the changes needed?
`connector/connect/dev/generate_protos.sh` requires this package:
```
DEBUG   /buf.alpha.registry.v1alpha1.GenerateService/GeneratePlugins    {"duration": "14.25µs", "http.path": "/buf.alpha.registry.v1alpha1.GenerateService/GeneratePlugins", "http.url": "https://api.buf.build/buf.alpha.registry.v1alpha1.GenerateService/GeneratePlugins", "http.host": "api.buf.build", "http.method": "POST", "http.user_agent": "connect-go/0.4.0-dev (go1.19.2)"}
DEBUG   command {"duration": "9.238333ms"}
Failure: plugin mypy: could not find protoc plugin for name mypy
```


### Does this PR introduce _any_ user-facing change?
No, only for contributors

### How was this patch tested?
manually check