### PR TITLE
[SPARK-40665][CONNECT][FOLLOW-UP] Fix `connector/connect/dev/generate_protos.sh`

### DIFF
--- a/connector/connect/dev/generate_protos.sh
+++ b/connector/connect/dev/generate_protos.sh
@@ -16,7 +16,7 @@
 #
 set -ex
 
-SPARK_HOME="$(cd "`dirname $0`"/../..; pwd)"
+SPARK_HOME="$(cd "`dirname $0`"/../../..; pwd)"
 cd "$SPARK_HOME"
 
 pushd connector/connect/src/main


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the path in `connector/connect/dev/generate_protos.sh`


### Why are the changes needed?
```
(spark_dev) ➜  dev git:(master) pwd
/Users/ruifeng.zheng/Dev/spark/connector/connect/dev
(spark_dev) ➜  dev git:(master) ./generate_protos.sh
+++ dirname ./generate_protos.sh
++ cd ./../..
++ pwd
+ SPARK_HOME=/Users/ruifeng.zheng/Dev/spark/connector
+ cd /Users/ruifeng.zheng/Dev/spark/connector
+ pushd connector/connect/src/main
./generate_protos.sh: line 22: pushd: connector/connect/src/main: No such file or directory
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
manually check
