### PR TITLE
[SPARK-40729][CORE] Make Spark use `UnsafeFieldAccessor` as default for Java 18+

### DIFF
--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -43,8 +43,8 @@ Scala REPL options:
 # has its own class loader, and any additional classpath specified
 # through spark.driver.extraClassPath is not automatically propagated.
 SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Dscala.usejavacp=true"
-# SPARK-40729:  After Java 18, `MethodHandleAccessor` is used by default
-# instead of `UnsafeFieldAccessor`(`JEP 416: Reimplement Core Reflection with Method Handles`),
+# SPARK-40729: `MethodHandleAccessor` is used by default
+# instead of `UnsafeFieldAccessor` after `JEP 416: Reimplement Core Reflection with Method Handles`,
 # this will lead to the bad case described in SPARK-40729 in the spark-shell,
 # enable the old implementation via `-Djdk.reflect.useDirectMethodHandle=false` as a workaround.
 SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Djdk.reflect.useDirectMethodHandle=false"

--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -43,11 +43,6 @@ Scala REPL options:
 # has its own class loader, and any additional classpath specified
 # through spark.driver.extraClassPath is not automatically propagated.
 SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Dscala.usejavacp=true"
-# SPARK-40729: `MethodHandleAccessor` is used by default
-# instead of `UnsafeFieldAccessor` after `JEP 416: Reimplement Core Reflection with Method Handles`,
-# this will lead to the bad case described in SPARK-40729 in the spark-shell,
-# enable the old implementation via `-Djdk.reflect.useDirectMethodHandle=false` as a workaround.
-SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Djdk.reflect.useDirectMethodHandle=false"
 
 function main() {
   if $cygwin; then

--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -46,7 +46,7 @@ SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Dscala.usejavacp=true"
 # SPARK-40729:  After Java 18, `MethodHandleAccessor` is used by default
 # instead of `UnsafeFieldAccessor`(`JEP 416: Reimplement Core Reflection with Method Handles`),
 # this will lead to the bad case described in SPARK-40729 in the spark-shell,
-# as a workaround enable the old implementation via -Djdk.reflect.useDirectMethodHandle=false.
+# enable the old implementation via `-Djdk.reflect.useDirectMethodHandle=false` as a workaround.
 SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Djdk.reflect.useDirectMethodHandle=false"
 
 function main() {

--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -43,6 +43,11 @@ Scala REPL options:
 # has its own class loader, and any additional classpath specified
 # through spark.driver.extraClassPath is not automatically propagated.
 SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Dscala.usejavacp=true"
+# SPARK-40729:  After Java 18, `MethodHandleAccessor` is used by default
+# instead of `UnsafeFieldAccessor`(`JEP 416: Reimplement Core Reflection with Method Handles`),
+# this will lead to the bad case described in SPARK-40729 in the spark-shell,
+# as a workaround enable the old implementation via -Djdk.reflect.useDirectMethodHandle=false.
+SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Djdk.reflect.useDirectMethodHandle=false"
 
 function main() {
   if $cygwin; then

--- a/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
@@ -40,7 +40,8 @@ public class JavaModuleOptions {
       "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
       "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
-      "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED"};
+      "--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED",
+      "-Djdk.reflect.useDirectMethodHandle=false"};
 
     /**
      * Returns the default Java options related to `--add-opens' and

--- a/pom.xml
+++ b/pom.xml
@@ -2958,7 +2958,8 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
+            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true
+              -Djdk.reflect.useDirectMethodHandle=false</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes

--- a/pom.xml
+++ b/pom.xml
@@ -2958,8 +2958,7 @@
               <include>**/*Suite.java</include>
             </includes>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true
-              -Djdk.reflect.useDirectMethodHandle=false</argLine>
+            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
             <environmentVariables>
               <!--
                 Setting SPARK_DIST_CLASSPATH is a simple way to make sure any child processes
@@ -3012,7 +3011,8 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
+            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true
+              -Djdk.reflect.useDirectMethodHandle=false</argLine>
             <stderr/>
             <environmentVariables>
               <!--

--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,7 @@
       --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
       --add-opens=java.base/sun.security.action=ALL-UNNAMED
       --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+      -Djdk.reflect.useDirectMethodHandle=false
     </extraJavaTestArgs>
   </properties>
   <repositories>
@@ -3011,8 +3012,7 @@
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <junitxml>.</junitxml>
             <filereports>SparkTestSuite.txt</filereports>
-            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true
-              -Djdk.reflect.useDirectMethodHandle=false</argLine>
+            <argLine>-ea -Xmx4g -Xss4m -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=${CodeCacheSize} ${extraJavaTestArgs} -Dio.netty.tryReflectionSetAccessible=true</argLine>
             <stderr/>
             <environmentVariables>
               <!--

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1286,8 +1286,8 @@ object TestSettings {
         "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
         "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
         "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED").mkString(" ")
-      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 " +
-        s"-Djdk.reflect.useDirectMethodHandle=false $extraTestJavaArgs".split(" ").toSeq
+      (s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 " +
+        s"-Djdk.reflect.useDirectMethodHandle=false $extraTestJavaArgs").split(" ").toSeq
     },
     javaOptions ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1285,9 +1285,10 @@ object TestSettings {
         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
         "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
         "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
-        "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED").mkString(" ")
-      (s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 " +
-        s"-Djdk.reflect.useDirectMethodHandle=false $extraTestJavaArgs").split(" ").toSeq
+        "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
+        "-Djdk.reflect.useDirectMethodHandle=false").mkString(" ")
+      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 $extraTestJavaArgs"
+        .split(" ").toSeq
     },
     javaOptions ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1286,8 +1286,8 @@ object TestSettings {
         "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
         "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
         "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED").mkString(" ")
-      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 $extraTestJavaArgs"
-        .split(" ").toSeq
+      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 " +
+        s"-Djdk.reflect.useDirectMethodHandle=false $extraTestJavaArgs".split(" ").toSeq
     },
     javaOptions ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add `-Djdk.reflect.useDirectMethodHandle=false` to `JavaModuleOptions ` and `maven/sbt` `extraJavaTestArgs` to make  Spark use `UnsafeFieldAccessor` as default  with Java 18/19 to avoid the bad case described in SPARK-40729 .

### Why are the changes needed?
After  [JEP 416: Reimplement Core Reflection with Method Handles](https://openjdk.org/jeps/416),  `MethodHandleAccessor` is the default reflection implementation of Java, but in Spark it will cause the bad case mentioned in SPARK-40729,  so add `-Djdk.reflect.useDirectMethodHandle=false` as a workaround for Java 18/19. 

### Does this PR introduce _any_ user-facing change?
No, The new option will not affect Java versions below 18


### How was this patch tested?

- Pass GitHub Actions
- Manual test:

1.  run `repl` module test with Java 18/19

**Before** 

```
- broadcast vars *** FAILED ***
  isContain was true Interpreter output contained 'Exception':
  Welcome to
        ____              __
       / __/__  ___ _____/ /__
      _\ \/ _ \/ _ `/ __/  '_/
     /___/ .__/\_,_/_/ /_/\_\   version 3.4.0-SNAPSHOT
        /_/
           
  Using Scala version 2.12.17 (OpenJDK 64-Bit Server VM, Java 19)
  Type in expressions to have them evaluated.
  Type :help for more information.
  
  scala> 
  scala> array: Array[Int] = Array(0, 0, 0, 0, 0)
  
  scala> broadcastArray: org.apache.spark.broadcast.Broadcast[Array[Int]] = Broadcast(0)
  
  scala> java.lang.InternalError: java.lang.IllegalAccessException: final field has no write access: $Lambda$3029/0x0000000801d80a30.arg$1/putField, from class java.lang.Object (module java.base)
    at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newFieldAccessor(MethodHandleAccessorFactory.java:167)
    at java.base/jdk.internal.reflect.ReflectionFactory.newFieldAccessor(ReflectionFactory.java:145)
    at java.base/java.lang.reflect.Field.acquireOverrideFieldAccessor(Field.java:1184)
    at java.base/java.lang.reflect.Field.getOverrideFieldAccessor(Field.java:1153)
    at java.base/java.lang.reflect.Field.set(Field.java:820)
    at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:406)
    at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:163)
    at org.apache.spark.SparkContext.clean(SparkContext.scala:2502)
    at org.apache.spark.rdd.RDD.$anonfun$map$1(RDD.scala:413)
    at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
    at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
    at org.apache.spark.rdd.RDD.withScope(RDD.scala:405)
    at org.apache.spark.rdd.RDD.map(RDD.scala:412)
    ... 93 elided
  Caused by: java.lang.IllegalAccessException: final field has no write access: $Lambda$3029/0x0000000801d80a30.arg$1/putField, from class java.lang.Object (module java.base)
    at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:955)
    at java.base/java.lang.invoke.MethodHandles$Lookup.unreflectField(MethodHandles.java:3511)
    at java.base/java.lang.invoke.MethodHandles$Lookup.unreflectSetter(MethodHandles.java:3502)
    at java.base/java.lang.invoke.MethodHandleImpl$1.unreflectField(MethodHandleImpl.java:1630)
    at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newFieldAccessor(MethodHandleAccessorFactory.java:145)
    ... 105 more
  
  scala> 
  scala> java.lang.InternalError: java.lang.IllegalAccessException: final field has no write access: $Lambda$3061/0x0000000801e01000.arg$1/putField, from class java.lang.Object (module java.base)
    at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newFieldAccessor(MethodHandleAccessorFactory.java:167)
    at java.base/jdk.internal.reflect.ReflectionFactory.newFieldAccessor(ReflectionFactory.java:145)
    at java.base/java.lang.reflect.Field.acquireOverrideFieldAccessor(Field.java:1184)
    at java.base/java.lang.reflect.Field.getOverrideFieldAccessor(Field.java:1153)
    at java.base/java.lang.reflect.Field.set(Field.java:820)
    at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:406)
    at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:163)
    at org.apache.spark.SparkContext.clean(SparkContext.scala:2502)
    at org.apache.spark.rdd.RDD.$anonfun$map$1(RDD.scala:413)
    at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
    at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
    at org.apache.spark.rdd.RDD.withScope(RDD.scala:405)
    at org.apache.spark.rdd.RDD.map(RDD.scala:412)
    ... 93 elided
  Caused by: java.lang.IllegalAccessException: final field has no write access: $Lambda$3061/0x0000000801e01000.arg$1/putField, from class java.lang.Object (module java.base)
    at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:955)
    at java.base/java.lang.invoke.MethodHandles$Lookup.unreflectField(MethodHandles.java:3511)
    at java.base/java.lang.invoke.MethodHandles$Lookup.unreflectSetter(MethodHandles.java:3502)
    at java.base/java.lang.invoke.MethodHandleImpl$1.unreflectField(MethodHandleImpl.java:1630)
    at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newFieldAccessor(MethodHandleAccessorFactory.java:145)
    ... 105 more
  
  scala>      | 
  scala> :quit (ReplSuite.scala:83)
```

**After**

```
Run completed in 1 minute, 12 seconds.
Total number of tests run: 44
Suites: completed 7, aborted 0
Tests: succeeded 44, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

2. test spark-shell with Java 18/19:

**Before**

```
bin/spark-shell --master local
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
22/10/11 19:13:08 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
22/10/11 19:13:08 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.
Spark context Web UI available at http://localhost:4041
Spark context available as 'sc' (master = local, app id = local-1665486788733).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.4.0-SNAPSHOT
      /_/
         
Using Scala version 2.12.17 (OpenJDK 64-Bit Server VM, Java 18.0.2.1)
Type in expressions to have them evaluated.
Type :help for more information.

scala> :paste
// Entering paste mode (ctrl-D to finish)

var array = new Array[Int](5)
val broadcastArray = sc.broadcast(array)
sc.parallelize(0 to 4).map(x => broadcastArray.value(x)).collect()
array(0) = 5
sc.parallelize(0 to 4).map(x => broadcastArray.value(x)).collect()

// Exiting paste mode, now interpreting.

java.lang.InternalError: java.lang.IllegalAccessException: final field has no write access: $Lambda$2396/0x00000008015b2e70.arg$1/putField, from class java.lang.Object (module java.base)
  at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newFieldAccessor(MethodHandleAccessorFactory.java:167)
  at java.base/jdk.internal.reflect.ReflectionFactory.newFieldAccessor(ReflectionFactory.java:176)
  at java.base/java.lang.reflect.Field.acquireOverrideFieldAccessor(Field.java:1184)
  at java.base/java.lang.reflect.Field.getOverrideFieldAccessor(Field.java:1153)
  at java.base/java.lang.reflect.Field.set(Field.java:820)
  at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:406)
  at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:163)
  at org.apache.spark.SparkContext.clean(SparkContext.scala:2502)
  at org.apache.spark.rdd.RDD.$anonfun$map$1(RDD.scala:413)
  at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
  at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
  at org.apache.spark.rdd.RDD.withScope(RDD.scala:405)
  at org.apache.spark.rdd.RDD.map(RDD.scala:412)
  ... 43 elided
Caused by: java.lang.IllegalAccessException: final field has no write access: $Lambda$2396/0x00000008015b2e70.arg$1/putField, from class java.lang.Object (module java.base)
  at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:955)
  at java.base/java.lang.invoke.MethodHandles$Lookup.unreflectField(MethodHandles.java:3494)
  at java.base/java.lang.invoke.MethodHandles$Lookup.unreflectSetter(MethodHandles.java:3485)
  at java.base/java.lang.invoke.MethodHandleImpl$1.unreflectField(MethodHandleImpl.java:1637)
  at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newFieldAccessor(MethodHandleAccessorFactory.jav
```

**After**  

```
bin/spark-shell --master local
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
22/10/11 19:11:21 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
22/10/11 19:11:21 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.
Spark context Web UI available at http://localhost:4041
Spark context available as 'sc' (master = local, app id = local-1665486681920).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.4.0-SNAPSHOT
      /_/
         
Using Scala version 2.12.17 (OpenJDK 64-Bit Server VM, Java 18.0.2.1)
Type in expressions to have them evaluated.
Type :help for more information.

scala> :paste
// Entering paste mode (ctrl-D to finish)

var array = new Array[Int](5)
val broadcastArray = sc.broadcast(array)
sc.parallelize(0 to 4).map(x => broadcastArray.value(x)).collect()
array(0) = 5
sc.parallelize(0 to 4).map(x => broadcastArray.value(x)).collect()

// Exiting paste mode, now interpreting.

array: Array[Int] = Array(5, 0, 0, 0, 0)
broadcastArray: org.apache.spark.broadcast.Broadcast[Array[Int]] = Broadcast(0)
res0: Array[Int] = Array(5, 0, 0, 0, 0)
```