### PR TITLE
[SPARK-39375][CONNECT][FOLLOW-UP] Refactor Read to UnresolvedRelation

### DIFF
--- a/connector/connect/src/main/protobuf/spark/connect/relations.proto
+++ b/connector/connect/src/main/protobuf/spark/connect/relations.proto
@@ -31,7 +31,7 @@ option java_package = "org.apache.spark.connect.proto";
 message Relation {
   RelationCommon common = 1;
   oneof rel_type {
-    Read read = 2;
+    UnresolvedRelation unresolved_relation = 2;
     Project project = 3;
     Filter filter = 4;
     Join join = 5;
@@ -60,16 +60,9 @@ message SQL {
   string query = 1;
 }
 
-// Relation that reads from a file / table or other data source. Does not have additional
-// inputs.
-message Read {
-  oneof read_type {
-    NamedTable named_table = 1;
-  }
-
-  message NamedTable {
-    repeated string parts = 1;
-  }
+// An unresolved relation. Does not have additional inputs.
+message UnresolvedRelation {
+  repeated string name_parts = 1;
 }
 
 // Projection of a bag of expressions for a given input relation.

--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -37,10 +37,10 @@ trait SparkConnectPlanTest {
   def readRel: proto.Relation =
     proto.Relation
       .newBuilder()
-      .setRead(
-        proto.Read
+      .setUnresolvedRelation(
+        proto.UnresolvedRelation
           .newBuilder()
-          .setNamedTable(proto.Read.NamedTable.newBuilder().addParts("table"))
+          .addNameParts("table")
           .build())
       .build()
 }
@@ -81,24 +81,25 @@ class SparkConnectPlannerSuite extends SparkFunSuite with SparkConnectPlanTest {
   }
 
   test("Simple Read") {
-    val read = proto.Read.newBuilder().build()
+    val read = proto.UnresolvedRelation.newBuilder().build()
     // Invalid read without Table name.
-    intercept[InvalidPlanInput](transform(proto.Relation.newBuilder.setRead(read).build()))
+    intercept[InvalidPlanInput](
+      transform(proto.Relation.newBuilder.setUnresolvedRelation(read).build()))
     val readWithTable = read.toBuilder
-      .setNamedTable(proto.Read.NamedTable.newBuilder.addParts("name").build())
+      .addNameParts("name")
       .build()
-    val res = transform(proto.Relation.newBuilder.setRead(readWithTable).build())
+    val res = transform(proto.Relation.newBuilder.setUnresolvedRelation(readWithTable).build())
     assert(res !== null)
     assert(res.nodeName == "UnresolvedRelation")
   }
 
   test("Simple Project") {
-    val readWithTable = proto.Read.newBuilder()
-      .setNamedTable(proto.Read.NamedTable.newBuilder.addParts("name").build())
+    val readWithTable = proto.UnresolvedRelation.newBuilder()
+      .addNameParts("name")
       .build()
     val project =
       proto.Project.newBuilder()
-        .setInput(proto.Relation.newBuilder().setRead(readWithTable).build())
+        .setInput(proto.Relation.newBuilder().setUnresolvedRelation(readWithTable).build())
         .addExpressions(
           proto.Expression.newBuilder()
             .setUnresolvedStar(UnresolvedStar.newBuilder().build()).build()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Refactor proto from `Read` to `UnresolvedRelation`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
UnresolvedRelation has its own proto. In the future we will add a proto for DataSource. We can decouple these two plans in connect.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT