### PR TITLE
[CORE] When using the Remote shuffle service, ignore the creation and…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -330,7 +330,9 @@ object SparkEnv extends Logging {
       conf.get(BLOCK_MANAGER_PORT)
     }
 
-    val externalShuffleClient = if (conf.get(config.SHUFFLE_SERVICE_ENABLED)) {
+    val isSortShuffle = shuffleManager
+      .isInstanceOf[org.apache.spark.shuffle.sort.SortShuffleManager]
+    val externalShuffleClient = if (conf.get(config.SHUFFLE_SERVICE_ENABLED) && isSortShuffle) {
       val transConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numUsableCores)
       Some(new ExternalBlockStoreClient(transConf, securityManager,
         securityManager.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT)))


### PR DESCRIPTION
**What changes were proposed in this pull request?**

In elastic resource scheduling (such as k8s), the executor will be quickly recycled. We will use the Remote shuffle service to solve the problem of shuffle data loss, but when spark.shuffle.service.enabled is set to true, BlockManager will register with ExternalShuffle , because the executor has been recycled, the registration will fail, which seriously interferes with the use of the Remote shuffle service. This change ignores the registration of ExternalShuffle when using the Remote shuffle service.


**Why are the changes needed?**
Let the Remote shuffle service work properly.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
Run all unit tests and pass, Remote shuffle service test case: https://github.com/cubefs/shuttle/blob/master/src/test/scala/org/apache/spark/shuffle/Ors2ShuffleManagerTest.scala