### PR TITLE
fix runtime filter do not execute when no stats

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -192,8 +192,13 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     // filter to each small task might be more costly than scanning them itself. Thus, we use max
     // rather than sum here.
     val maxScanSize = maxScanByteSize(filterApplicationSide)
-    maxScanSize >=
-      conf.getConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD)
+    if (conf.runtimeFilterEnabledWhenOnStats) {
+      maxScanSize <= 0 || maxScanSize >=
+        conf.getConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD)
+    } else {
+      maxScanSize >=
+        conf.getConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD)
+    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -426,6 +426,14 @@ object SQLConf {
       .version("3.4.0")
       .booleanConf
       .createWithDefault(true)
+  
+  val RUNTIME_FILTER__ENABLED_WHEN_NO_STATS =
+    buildConf("spark.sql.optimizer.runtimeFilter.enabled.whenNoStats")
+      .doc("When true and there is no statistical data, maxScanSize is not " +
+        "used as a judgment condition for using the runtime filter.")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(false)
 
   val PLANNED_WRITE_ENABLED = buildConf("spark.sql.optimizer.plannedWrite.enabled")
     .internal()
@@ -4108,6 +4116,9 @@ class SQLConf extends Serializable with Logging {
 
   def runtimeRowLevelOperationGroupFilterEnabled: Boolean =
     getConf(RUNTIME_ROW_LEVEL_OPERATION_GROUP_FILTER_ENABLED)
+  
+  def runtimeFilterEnabledWhenOnStats: Boolean =
+    getConf(RUNTIME_FILTER__ENABLED_WHEN_NO_STATS)
 
   def stateStoreProviderClass: String = getConf(STATE_STORE_PROVIDER_CLASS)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This RP makes the Row-level Runtime Filtering work without stats.


### Why are the changes needed?
At present, Row-level Runtime Filtering will judge whether maxScanSize meets the requirements for performing Row-level Runtime Filtering. When there is no stats in the catalogTable, maxScanSize is equal to 0, which makes it unable to meet the requirements for performing Row-level Runtime Filtering, resulting in Row-level Runtime Filtering not being enabled. By adding the RUNTIME_FILTER__ENABLED_WHEN_NO_STATS parameter, when RUNTIME_FILTER__ENABLED_WHEN_NO_STATS is true, even if maxScanSize is equal to 0 but other conditions can satisfy Row-level Runtime Filtering will still be executed. Avoid Row-level Runtime Filtering not enabled because catalogTable has no stats.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test.
