### PR TITLE
[SPARK-40765][SQL] Optimize redundant fs operation in `CommandUtils#calculateSingleLocationSize#getPathSize` method

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -113,12 +113,12 @@ object CommandUtils extends Logging {
     // countFileSize to count the table size.
     val stagingDir = sessionState.conf.getConfString("hive.exec.stagingdir", ".hive-staging")
 
-    def getDataSize(fs: FileSystem, fileStatus: FileStatus): Long = {
+    def getPathSize(fs: FileSystem, fileStatus: FileStatus): Long = {
       val size = if (fileStatus.isDirectory) {
         fs.listStatus(fileStatus.getPath)
           .map { status =>
             if (isDataPath(status.getPath, stagingDir)) {
-              getDataSize(fs, status)
+              getPathSize(fs, status)
             } else {
               0L
             }
@@ -126,6 +126,7 @@ object CommandUtils extends Logging {
       } else {
         fileStatus.getLen
       }
+
       size
     }
 
@@ -134,7 +135,7 @@ object CommandUtils extends Logging {
       val path = new Path(p)
       try {
         val fs = path.getFileSystem(sessionState.newHadoopConf())
-        getDataSize(fs, fs.getFileStatus(path))
+        getPathSize(fs, fs.getFileStatus(path))
       } catch {
         case NonFatal(e) =>
           logWarning(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -22,7 +22,7 @@ import java.net.URI
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
-import org.apache.hadoop.fs.{FileSystem, Path, PathFilter}
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, PathFilter}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
@@ -113,13 +113,12 @@ object CommandUtils extends Logging {
     // countFileSize to count the table size.
     val stagingDir = sessionState.conf.getConfString("hive.exec.stagingdir", ".hive-staging")
 
-    def getPathSize(fs: FileSystem, path: Path): Long = {
-      val fileStatus = fs.getFileStatus(path)
+    def getDataSize(fs: FileSystem, fileStatus: FileStatus): Long = {
       val size = if (fileStatus.isDirectory) {
-        fs.listStatus(path)
+        fs.listStatus(fileStatus.getPath)
           .map { status =>
             if (isDataPath(status.getPath, stagingDir)) {
-              getPathSize(fs, status.getPath)
+              getDataSize(fs, status)
             } else {
               0L
             }
@@ -127,7 +126,6 @@ object CommandUtils extends Logging {
       } else {
         fileStatus.getLen
       }
-
       size
     }
 
@@ -136,7 +134,7 @@ object CommandUtils extends Logging {
       val path = new Path(p)
       try {
         val fs = path.getFileSystem(sessionState.newHadoopConf())
-        getPathSize(fs, path)
+        getDataSize(fs, fs.getFileStatus(path))
       } catch {
         case NonFatal(e) =>
           logWarning(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change the 2nd input parameter from `Path` to `FileStatus` to avoid redundant `fs.getFileStatus(path)` in each recursive call.


### Why are the changes needed?
Reduce one dfs operation in each recursive call.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass Github Actions