### PR TITLE
[MINOR][BUILD] Add `dist`dir to  `fileset` of`maven-clean-plugin` 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3085,6 +3085,9 @@
               <fileset>
                 <directory>spark-warehouse</directory>
               </fileset>
+              <fileset>
+                <directory>dist</directory>
+              </fileset>
             </filesets>
           </configuration>
         </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add add `dist` to  `fileset` of`maven-clean-plugin` to make `mvn clean` can delete the `dist` dir which created by `dev/make-distribution.sh`.


### Why are the changes needed?
`dev/make-distribution.sh` will create a dist dir but no one cleaned it up.

 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Local test to confirm that `dist` dir can be cleaned
