### PR TITLE
[SPARK-38774][PS][FOLLOW-UP] Make parameter name in `Series.autocorr` consistent with Pandas

### DIFF
--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -3240,7 +3240,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self._test_autocorr(pdf)
 
         psser = ps.from_pandas(pdf["s1"])
-        with self.assertRaisesRegex(TypeError, r"periods should be an int; however, got"):
+        with self.assertRaisesRegex(TypeError, r"lag should be an int; however, got"):
             psser.autocorr(1.0)
 
     def _test_autocorr(self, pdf):


### PR DESCRIPTION
### What changes were proposed in this pull request?
in `Series.autocorr`, rename `periods` as `lag`


### Why are the changes needed?
when implementing the `Series.autocorr` in my first PS PR https://github.com/apache/spark/pull/36048 , I wrongly follow the parameter name `min_periods` in `Series.corr`, it should be `lag` to be the same with [Pandas](https://pandas.pydata.org/docs/reference/api/pandas.Series.autocorr.html)


### Does this PR introduce _any_ user-facing change?
no, since 3.4 is not released


### How was this patch tested?
existing UTs