### PR TITLE
[SPARK-40766][BUILD] Upgrade the guava defined in `plugins.sbt` used by `checkstyle` to `31.0.1-jre`

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,8 +22,8 @@ addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")
 // please check pom.xml in the root of the source tree too.
 libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "9.3"
 
-// checkstyle uses guava 23.0.
-libraryDependencies += "com.google.guava" % "guava" % "23.0"
+// checkstyle uses guava 31.0.1-jre.
+libraryDependencies += "com.google.guava" % "guava" % "31.0.1-jre"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-40071 upgrade checkstyle to 9.3, but checkstyle 9.3 uses guava 31.0.1-jre:

https://github.com/checkstyle/checkstyle/blob/5c1903792f8432243cc8ae5cd79a03a004d3c09c/pom.xml#L250-L253

<img width="455" alt="image" src="https://user-images.githubusercontent.com/1475305/195262034-95036047-f37d-46a2-84e2-8975be3ab261.png">

So this pr upgrade it.


### Why are the changes needed?
Upgrade matched dependencies for `checkstyle`.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions