### PR TITLE
[WIP][SPARK-40761][SQL] Migrate type check failures of percentile expressions onto error classes

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -3678,5 +3678,35 @@
     "message" : [
       "Failed to merge incompatible data types ${leftCatalogString} and ${rightCatalogString}"
     ]
+  },
+  "_LEGACY_ERROR_TEMP_2126" : {
+    "message" : [
+      "The accuracy or percentage provided must be a constant literal"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_2127" : {
+    "message" : [
+      "The accuracy provided must be a literal between (0, <maxValue>] (current value = <accuracy>)"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_2128" : {
+    "message" : [
+      "Percentage value must not be null"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_2129" : {
+    "message" : [
+      "All percentage values must be between 0.0 and 1.0 (current = <percentages>)"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_2130" : {
+    "message" : [
+      "The percentage(s) must be a constant literal, but got <expression>"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_2131" : {
+    "message" : [
+      "Percentage(s) must be between 0.0 and 1.0, but got <expression>"
+    ]
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -21,7 +21,7 @@ import java.util
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckFailure, TypeCheckSuccess}
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.{BinaryLike, TernaryLike, UnaryLike}
 import org.apache.spark.sql.catalyst.util._
@@ -83,15 +83,20 @@ abstract class PercentileBase
     if (defaultCheck.isFailure) {
       defaultCheck
     } else if (!percentageExpression.foldable) {
+      import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
       // percentageExpression must be foldable
-      TypeCheckFailure("The percentage(s) must be a constant literal, " +
-        s"but got $percentageExpression")
+      DataTypeMismatch(
+        errorSubClass = "_LEGACY_ERROR_TEMP_2130",
+        messageParameters = Map("expression" -> percentageExpression.toString)
+      )
     } else if (percentages == null) {
-      TypeCheckFailure("Percentage value must not be null")
+      DataTypeMismatch(errorSubClass = "_LEGACY_ERROR_TEMP_2128")
     } else if (percentages.exists(percentage => percentage < 0.0 || percentage > 1.0)) {
       // percentages(s) must be in the range [0.0, 1.0]
-      TypeCheckFailure("Percentage(s) must be between 0.0 and 1.0, " +
-        s"but got $percentageExpression")
+      DataTypeMismatch(
+        errorSubClass = "_LEGACY_ERROR_TEMP_2131",
+        messageParameters = Map("expression" -> percentageExpression.toString)
+      )
     } else {
       TypeCheckSuccess
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -83,7 +83,6 @@ abstract class PercentileBase
     if (defaultCheck.isFailure) {
       defaultCheck
     } else if (!percentageExpression.foldable) {
-      import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
       // percentageExpression must be foldable
       DataTypeMismatch(
         errorSubClass = "_LEGACY_ERROR_TEMP_2130",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -278,7 +278,8 @@ class ApproximatePercentileSuite extends SparkFunSuite {
 
       assert(
         wrongPercentage.checkInputDataTypes() match {
-          case DataTypeMismatch(msg, _) if msg.equals("_LEGACY_ERROR_TEMP_2129") => true
+          case DataTypeMismatch(errorSubClass, _) =>
+            errorSubClass.equals("_LEGACY_ERROR_TEMP_2129")
           case _ => false
       })
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -21,7 +21,7 @@ import java.sql.Date
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckFailure
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
@@ -219,7 +219,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
 
     assertEqual(
       wrongAccuracy.checkInputDataTypes(),
-      TypeCheckFailure("The accuracy or percentage provided must be a constant literal")
+      DataTypeMismatch(errorSubClass = "_LEGACY_ERROR_TEMP_2126")
     )
 
     val wrongPercentage = new ApproximatePercentile(
@@ -229,7 +229,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
 
     assertEqual(
       wrongPercentage.checkInputDataTypes(),
-      TypeCheckFailure("The accuracy or percentage provided must be a constant literal")
+      DataTypeMismatch(errorSubClass = "_LEGACY_ERROR_TEMP_2126")
     )
   }
 
@@ -240,8 +240,11 @@ class ApproximatePercentileSuite extends SparkFunSuite {
       accuracyExpression = Literal(-1))
     assertEqual(
       wrongAccuracy.checkInputDataTypes(),
-      TypeCheckFailure(s"The accuracy provided must be a literal between (0, ${Int.MaxValue}]" +
-        " (current value = -1)"))
+      DataTypeMismatch(
+        errorSubClass = "_LEGACY_ERROR_TEMP_2127",
+        messageParameters = Map("maxValue" -> Int.MaxValue.toString, "accuracy" -> "-1")
+      )
+    )
 
     val correctPercentageExpressions = Seq(
       Literal(0.1f, FloatType),
@@ -275,7 +278,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
 
       assert(
         wrongPercentage.checkInputDataTypes() match {
-          case TypeCheckFailure(msg) if msg.contains("must be between 0.0 and 1.0") => true
+          case DataTypeMismatch(msg, _) if msg.equals("_LEGACY_ERROR_TEMP_2129") => true
           case _ => false
       })
     }
@@ -320,7 +323,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assert(new ApproximatePercentile(
       AttributeReference("a", DoubleType)(),
       percentageExpression = Literal(null, DoubleType)).checkInputDataTypes() ===
-      TypeCheckFailure("Percentage value must not be null"))
+      DataTypeMismatch( errorSubClass = "_LEGACY_ERROR_TEMP_2128"))
 
     val nullPercentageExprs =
       Seq(CreateArray(Seq(null).map(Literal(_))), CreateArray(Seq(0.1D, null).map(Literal(_))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
@@ -209,8 +209,11 @@ class PercentileSuite extends SparkFunSuite {
     invalidPercentages.foreach { percentage =>
       val percentile2 = new Percentile(child, percentage)
       assertEqual(percentile2.checkInputDataTypes(),
-        TypeCheckFailure(s"Percentage(s) must be between 0.0 and 1.0, " +
-          s"but got ${percentage.simpleString(100)}"))
+        DataTypeMismatch(
+          errorSubClass = "_LEGACY_ERROR_TEMP_2131",
+          messageParameters = Map("expression" -> percentage.simpleString(100))
+        )
+      )
     }
 
     val nonFoldablePercentage = Seq(NonFoldableLiteral(0.5),
@@ -219,8 +222,11 @@ class PercentileSuite extends SparkFunSuite {
     nonFoldablePercentage.foreach { percentage =>
       val percentile3 = new Percentile(child, percentage)
       assertEqual(percentile3.checkInputDataTypes(),
-        TypeCheckFailure(s"The percentage(s) must be a constant literal, " +
-          s"but got ${percentage}"))
+        DataTypeMismatch(
+          errorSubClass = "_LEGACY_ERROR_TEMP_2130",
+          messageParameters = Map("expression" -> percentage.toString)
+        )
+      )
     }
 
     val invalidDataTypes = Seq(ByteType, ShortType, IntegerType, LongType, FloatType,
@@ -261,7 +267,7 @@ class PercentileSuite extends SparkFunSuite {
     assert(new Percentile(
       AttributeReference("a", DoubleType)(),
       percentageExpression = Literal(null, DoubleType)).checkInputDataTypes() ===
-      TypeCheckFailure("Percentage value must not be null"))
+      DataTypeMismatch(errorSubClass = "_LEGACY_ERROR_TEMP_2128"))
 
     val nullPercentageExprs =
       Seq(CreateArray(Seq(null).map(Literal(_))), CreateArray(Seq(0.1D, null).map(Literal(_))))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr replace `TypeCheckFailure` by `DataTypeMismatch` in type checks in the percentile expressions, includes `ApproximatePercentile.scala` and `percentiles.scala`

### Why are the changes needed?
Migration onto error classes unifies Spark SQL error messages.

### Does this PR introduce _any_ user-facing change?
Yes. The PR changes user-facing error messages.

### How was this patch tested?
- Pass GitHub Actions