### PR TITLE
[SPARK-40764][SQL] Extract partitioning from children's output expressions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/AliasAwareOutputExpression.scala
@@ -16,8 +16,10 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, PartitioningCollection, UnknownPartitioning}
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
+import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
 
 /**
  * A trait that provides functionality to handle aliases in the `outputExpressions`.
@@ -29,7 +31,33 @@ trait AliasAwareOutputExpression extends UnaryExecNode {
     case a @ Alias(child, _) => child.canonicalized -> a.toAttribute
   }.toMap
 
+  private lazy val (attributeAliases, nonAttributeAliases) = child.collect {
+    case a: AliasAwareOutputExpression => a.outputExpressions.collect { case a: Alias => a }
+    case r: ReusedExchangeExec => r.getTagValue(ReuseExchangeAndSubquery.ORIGIN_EXCHANGE).map {
+      _.collect {
+        case a: AliasAwareOutputExpression => a.outputExpressions.collect { case a: Alias => a }
+      }.flatten
+    }.getOrElse(Nil)
+  }.flatten.partition(_.child.isInstanceOf[Attribute])
+
+  private lazy val nonAttributeAliasesMap =
+    nonAttributeAliases.map(a => a.toAttribute.canonicalized -> a.child).toMap
+
+  private lazy val attributeAliasesMap =
+    attributeAliases.map(a => a.child.canonicalized -> a.toAttribute).toMap
+
   protected def hasAlias: Boolean = aliasMap.nonEmpty
+
+  protected def extractFromChildren(exp: Expression): Expression = {
+    exp.transformDown {
+      case a: Attribute => nonAttributeAliasesMap.getOrElse(a.canonicalized, a)
+    }.transformDown {
+      case a: Attribute => a
+      case e: Expression => e.transformDown {
+        case a: Attribute => attributeAliasesMap.getOrElse(a.canonicalized, a)
+      }
+    }
+  }
 
   protected def normalizeExpression(exp: Expression): Expression = {
     exp.transformDown {
@@ -47,7 +75,10 @@ trait AliasAwareOutputPartitioning extends AliasAwareOutputExpression {
     val normalizedOutputPartitioning = if (hasAlias) {
       child.outputPartitioning match {
         case e: Expression =>
-          normalizeExpression(e).asInstanceOf[Partitioning]
+          val newOutputPartitioning = normalizeExpression(e).asInstanceOf[Partitioning]
+          val extractedOutputPartitioning =
+            normalizeExpression(extractFromChildren(e)).asInstanceOf[Partitioning]
+          PartitioningCollection(Seq(newOutputPartitioning, extractedOutputPartitioning))
         case other => other
       }
     } else {
@@ -57,7 +88,7 @@ trait AliasAwareOutputPartitioning extends AliasAwareOutputExpression {
     flattenPartitioning(normalizedOutputPartitioning).filter {
       case hashPartitioning: HashPartitioning => hashPartitioning.references.subsetOf(outputSet)
       case _ => true
-    } match {
+    }.distinct match {
       case Seq() => UnknownPartitioning(child.outputPartitioning.numPartitions)
       case Seq(singlePartitioning) => singlePartitioning
       case seqWithMultiplePartitionings => PartitioningCollection(seqWithMultiplePartitionings)
@@ -83,7 +114,13 @@ trait AliasAwareOutputOrdering extends AliasAwareOutputExpression {
 
   final override def outputOrdering: Seq[SortOrder] = {
     if (hasAlias) {
-      orderingExpressions.map(normalizeExpression(_).asInstanceOf[SortOrder])
+      orderingExpressions.map { sortOrder =>
+        val newSortOrder = normalizeExpression(sortOrder).asInstanceOf[SortOrder]
+        val extractedSortOrder =
+          normalizeExpression(extractFromChildren(sortOrder)).asInstanceOf[SortOrder]
+        newSortOrder.copy(sameOrderExpressions = newSortOrder.sameOrderExpressions :+
+          extractedSortOrder.child)
+      }
     } else {
       orderingExpressions
     }

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/explain.txt
@@ -1,22 +1,22 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * Filter (69)
-   +- * HashAggregate (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin Inner (65)
-               :- Window (60)
-               :  +- * Sort (59)
-               :     +- Exchange (58)
-               :        +- * Project (57)
-               :           +- * Filter (56)
-               :              +- * SortMergeJoin FullOuter (55)
-               :                 :- * Sort (27)
-               :                 :  +- Exchange (26)
-               :                 :     +- * HashAggregate (25)
-               :                 :        +- * HashAggregate (24)
-               :                 :           +- * Project (23)
-               :                 :              +- * SortMergeJoin Inner (22)
+TakeOrderedAndProject (66)
++- * Filter (65)
+   +- * HashAggregate (64)
+      +- * HashAggregate (63)
+         +- * Project (62)
+            +- * SortMergeJoin Inner (61)
+               :- Window (56)
+               :  +- * Sort (55)
+               :     +- Exchange (54)
+               :        +- * Project (53)
+               :           +- * Filter (52)
+               :              +- * SortMergeJoin FullOuter (51)
+               :                 :- * Sort (25)
+               :                 :  +- Exchange (24)
+               :                 :     +- * HashAggregate (23)
+               :                 :        +- * HashAggregate (22)
+               :                 :           +- * Project (21)
+               :                 :              +- * SortMergeJoin Inner (20)
                :                 :                 :- * Sort (15)
                :                 :                 :  +- Exchange (14)
                :                 :                 :     +- * Project (13)
@@ -32,43 +32,39 @@ TakeOrderedAndProject (70)
                :                 :                 :                                :  +- * ColumnarToRow (2)
                :                 :                 :                                :     +- Scan parquet spark_catalog.default.web_sales (1)
                :                 :                 :                                +- ReusedExchange (4)
-               :                 :                 +- * Sort (21)
-               :                 :                    +- Exchange (20)
-               :                 :                       +- * Project (19)
-               :                 :                          +- Window (18)
-               :                 :                             +- * Sort (17)
-               :                 :                                +- ReusedExchange (16)
-               :                 +- * Sort (54)
-               :                    +- Exchange (53)
-               :                       +- * HashAggregate (52)
-               :                          +- * HashAggregate (51)
-               :                             +- * Project (50)
-               :                                +- * SortMergeJoin Inner (49)
-               :                                   :- * Sort (42)
-               :                                   :  +- Exchange (41)
-               :                                   :     +- * Project (40)
-               :                                   :        +- Window (39)
-               :                                   :           +- * Sort (38)
-               :                                   :              +- Exchange (37)
-               :                                   :                 +- * HashAggregate (36)
-               :                                   :                    +- Exchange (35)
-               :                                   :                       +- * HashAggregate (34)
-               :                                   :                          +- * Project (33)
-               :                                   :                             +- * BroadcastHashJoin Inner BuildRight (32)
-               :                                   :                                :- * Filter (30)
-               :                                   :                                :  +- * ColumnarToRow (29)
-               :                                   :                                :     +- Scan parquet spark_catalog.default.store_sales (28)
-               :                                   :                                +- ReusedExchange (31)
-               :                                   +- * Sort (48)
-               :                                      +- Exchange (47)
-               :                                         +- * Project (46)
-               :                                            +- Window (45)
-               :                                               +- * Sort (44)
-               :                                                  +- ReusedExchange (43)
-               +- * Project (64)
-                  +- Window (63)
-                     +- * Sort (62)
-                        +- ReusedExchange (61)
+               :                 :                 +- * Project (19)
+               :                 :                    +- Window (18)
+               :                 :                       +- * Sort (17)
+               :                 :                          +- ReusedExchange (16)
+               :                 +- * Sort (50)
+               :                    +- Exchange (49)
+               :                       +- * HashAggregate (48)
+               :                          +- * HashAggregate (47)
+               :                             +- * Project (46)
+               :                                +- * SortMergeJoin Inner (45)
+               :                                   :- * Sort (40)
+               :                                   :  +- Exchange (39)
+               :                                   :     +- * Project (38)
+               :                                   :        +- Window (37)
+               :                                   :           +- * Sort (36)
+               :                                   :              +- Exchange (35)
+               :                                   :                 +- * HashAggregate (34)
+               :                                   :                    +- Exchange (33)
+               :                                   :                       +- * HashAggregate (32)
+               :                                   :                          +- * Project (31)
+               :                                   :                             +- * BroadcastHashJoin Inner BuildRight (30)
+               :                                   :                                :- * Filter (28)
+               :                                   :                                :  +- * ColumnarToRow (27)
+               :                                   :                                :     +- Scan parquet spark_catalog.default.store_sales (26)
+               :                                   :                                +- ReusedExchange (29)
+               :                                   +- * Project (44)
+               :                                      +- Window (43)
+               :                                         +- * Sort (42)
+               :                                            +- ReusedExchange (41)
+               +- * Project (60)
+                  +- Window (59)
+                     +- * Sort (58)
+                        +- ReusedExchange (57)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -86,7 +82,7 @@ Input [3]: [ws_item_sk#1, ws_sales_price#2, ws_sold_date_sk#3]
 Input [3]: [ws_item_sk#1, ws_sales_price#2, ws_sold_date_sk#3]
 Condition : isnotnull(ws_item_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 75]
+(4) ReusedExchange [Reuses operator id: 71]
 Output [2]: [d_date_sk#5, d_date#6]
 
 (5) BroadcastHashJoin [codegen id : 2]
@@ -156,47 +152,39 @@ Arguments: [row_number() windowspecdefinition(ws_item_sk#14, d_date#13 ASC NULLS
 Output [3]: [item_sk#10 AS item_sk#16, sumws#11 AS sumws#17, rk#15]
 Input [5]: [item_sk#10, d_date#13, sumws#11, ws_item_sk#14, rk#15]
 
-(20) Exchange
-Input [3]: [item_sk#16, sumws#17, rk#15]
-Arguments: hashpartitioning(item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(21) Sort [codegen id : 12]
-Input [3]: [item_sk#16, sumws#17, rk#15]
-Arguments: [item_sk#16 ASC NULLS FIRST], false, 0
-
-(22) SortMergeJoin [codegen id : 13]
+(20) SortMergeJoin [codegen id : 12]
 Left keys [1]: [item_sk#10]
 Right keys [1]: [item_sk#16]
 Join type: Inner
 Join condition: (rk#12 >= rk#15)
 
-(23) Project [codegen id : 13]
+(21) Project [codegen id : 12]
 Output [4]: [item_sk#10, d_date#6, sumws#11, sumws#17]
 Input [7]: [item_sk#10, d_date#6, sumws#11, rk#12, item_sk#16, sumws#17, rk#15]
 
-(24) HashAggregate [codegen id : 13]
+(22) HashAggregate [codegen id : 12]
 Input [4]: [item_sk#10, d_date#6, sumws#11, sumws#17]
 Keys [3]: [item_sk#10, d_date#6, sumws#11]
 Functions [1]: [partial_sum(sumws#17)]
 Aggregate Attributes [2]: [sum#18, isEmpty#19]
 Results [5]: [item_sk#10, d_date#6, sumws#11, sum#20, isEmpty#21]
 
-(25) HashAggregate [codegen id : 13]
+(23) HashAggregate [codegen id : 12]
 Input [5]: [item_sk#10, d_date#6, sumws#11, sum#20, isEmpty#21]
 Keys [3]: [item_sk#10, d_date#6, sumws#11]
 Functions [1]: [sum(sumws#17)]
 Aggregate Attributes [1]: [sum(sumws#17)#22]
 Results [3]: [item_sk#10, d_date#6, sum(sumws#17)#22 AS cume_sales#23]
 
-(26) Exchange
+(24) Exchange
 Input [3]: [item_sk#10, d_date#6, cume_sales#23]
-Arguments: hashpartitioning(item_sk#10, d_date#6, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Arguments: hashpartitioning(item_sk#10, d_date#6, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(27) Sort [codegen id : 14]
+(25) Sort [codegen id : 13]
 Input [3]: [item_sk#10, d_date#6, cume_sales#23]
 Arguments: [item_sk#10 ASC NULLS FIRST, d_date#6 ASC NULLS FIRST], false, 0
 
-(28) Scan parquet spark_catalog.default.store_sales
+(26) Scan parquet spark_catalog.default.store_sales
 Output [3]: [ss_item_sk#24, ss_sales_price#25, ss_sold_date_sk#26]
 Batched: true
 Location: InMemoryFileIndex []
@@ -204,228 +192,220 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#26), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_sales_price:decimal(7,2)>
 
-(29) ColumnarToRow [codegen id : 16]
+(27) ColumnarToRow [codegen id : 15]
 Input [3]: [ss_item_sk#24, ss_sales_price#25, ss_sold_date_sk#26]
 
-(30) Filter [codegen id : 16]
+(28) Filter [codegen id : 15]
 Input [3]: [ss_item_sk#24, ss_sales_price#25, ss_sold_date_sk#26]
 Condition : isnotnull(ss_item_sk#24)
 
-(31) ReusedExchange [Reuses operator id: 75]
+(29) ReusedExchange [Reuses operator id: 71]
 Output [2]: [d_date_sk#27, d_date#28]
 
-(32) BroadcastHashJoin [codegen id : 16]
+(30) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_sold_date_sk#26]
 Right keys [1]: [d_date_sk#27]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 16]
+(31) Project [codegen id : 15]
 Output [3]: [ss_item_sk#24, ss_sales_price#25, d_date#28]
 Input [5]: [ss_item_sk#24, ss_sales_price#25, ss_sold_date_sk#26, d_date_sk#27, d_date#28]
 
-(34) HashAggregate [codegen id : 16]
+(32) HashAggregate [codegen id : 15]
 Input [3]: [ss_item_sk#24, ss_sales_price#25, d_date#28]
 Keys [2]: [ss_item_sk#24, d_date#28]
 Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#25))]
 Aggregate Attributes [1]: [sum#29]
 Results [3]: [ss_item_sk#24, d_date#28, sum#30]
 
-(35) Exchange
+(33) Exchange
 Input [3]: [ss_item_sk#24, d_date#28, sum#30]
-Arguments: hashpartitioning(ss_item_sk#24, d_date#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(ss_item_sk#24, d_date#28, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(36) HashAggregate [codegen id : 17]
+(34) HashAggregate [codegen id : 16]
 Input [3]: [ss_item_sk#24, d_date#28, sum#30]
 Keys [2]: [ss_item_sk#24, d_date#28]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#25))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#25))#31]
 Results [4]: [ss_item_sk#24 AS item_sk#32, d_date#28, MakeDecimal(sum(UnscaledValue(ss_sales_price#25))#31,17,2) AS sumss#33, ss_item_sk#24]
 
-(37) Exchange
+(35) Exchange
 Input [4]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24]
-Arguments: hashpartitioning(ss_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: hashpartitioning(ss_item_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(38) Sort [codegen id : 18]
+(36) Sort [codegen id : 17]
 Input [4]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24]
 Arguments: [ss_item_sk#24 ASC NULLS FIRST, d_date#28 ASC NULLS FIRST], false, 0
 
-(39) Window
+(37) Window
 Input [4]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24]
 Arguments: [row_number() windowspecdefinition(ss_item_sk#24, d_date#28 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#34], [ss_item_sk#24], [d_date#28 ASC NULLS FIRST]
 
-(40) Project [codegen id : 19]
+(38) Project [codegen id : 18]
 Output [4]: [item_sk#32, d_date#28, sumss#33, rk#34]
 Input [5]: [item_sk#32, d_date#28, sumss#33, ss_item_sk#24, rk#34]
 
-(41) Exchange
+(39) Exchange
 Input [4]: [item_sk#32, d_date#28, sumss#33, rk#34]
-Arguments: hashpartitioning(item_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: hashpartitioning(item_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(42) Sort [codegen id : 20]
+(40) Sort [codegen id : 19]
 Input [4]: [item_sk#32, d_date#28, sumss#33, rk#34]
 Arguments: [item_sk#32 ASC NULLS FIRST], false, 0
 
-(43) ReusedExchange [Reuses operator id: 37]
+(41) ReusedExchange [Reuses operator id: 35]
 Output [4]: [item_sk#32, d_date#35, sumss#33, ss_item_sk#36]
 
-(44) Sort [codegen id : 24]
+(42) Sort [codegen id : 23]
 Input [4]: [item_sk#32, d_date#35, sumss#33, ss_item_sk#36]
 Arguments: [ss_item_sk#36 ASC NULLS FIRST, d_date#35 ASC NULLS FIRST], false, 0
 
-(45) Window
+(43) Window
 Input [4]: [item_sk#32, d_date#35, sumss#33, ss_item_sk#36]
 Arguments: [row_number() windowspecdefinition(ss_item_sk#36, d_date#35 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#37], [ss_item_sk#36], [d_date#35 ASC NULLS FIRST]
 
-(46) Project [codegen id : 25]
+(44) Project [codegen id : 24]
 Output [3]: [item_sk#32 AS item_sk#38, sumss#33 AS sumss#39, rk#37]
 Input [5]: [item_sk#32, d_date#35, sumss#33, ss_item_sk#36, rk#37]
 
-(47) Exchange
-Input [3]: [item_sk#38, sumss#39, rk#37]
-Arguments: hashpartitioning(item_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(48) Sort [codegen id : 26]
-Input [3]: [item_sk#38, sumss#39, rk#37]
-Arguments: [item_sk#38 ASC NULLS FIRST], false, 0
-
-(49) SortMergeJoin [codegen id : 27]
+(45) SortMergeJoin [codegen id : 25]
 Left keys [1]: [item_sk#32]
 Right keys [1]: [item_sk#38]
 Join type: Inner
 Join condition: (rk#34 >= rk#37)
 
-(50) Project [codegen id : 27]
+(46) Project [codegen id : 25]
 Output [4]: [item_sk#32, d_date#28, sumss#33, sumss#39]
 Input [7]: [item_sk#32, d_date#28, sumss#33, rk#34, item_sk#38, sumss#39, rk#37]
 
-(51) HashAggregate [codegen id : 27]
+(47) HashAggregate [codegen id : 25]
 Input [4]: [item_sk#32, d_date#28, sumss#33, sumss#39]
 Keys [3]: [item_sk#32, d_date#28, sumss#33]
 Functions [1]: [partial_sum(sumss#39)]
 Aggregate Attributes [2]: [sum#40, isEmpty#41]
 Results [5]: [item_sk#32, d_date#28, sumss#33, sum#42, isEmpty#43]
 
-(52) HashAggregate [codegen id : 27]
+(48) HashAggregate [codegen id : 25]
 Input [5]: [item_sk#32, d_date#28, sumss#33, sum#42, isEmpty#43]
 Keys [3]: [item_sk#32, d_date#28, sumss#33]
 Functions [1]: [sum(sumss#39)]
 Aggregate Attributes [1]: [sum(sumss#39)#44]
 Results [3]: [item_sk#32, d_date#28, sum(sumss#39)#44 AS cume_sales#45]
 
-(53) Exchange
+(49) Exchange
 Input [3]: [item_sk#32, d_date#28, cume_sales#45]
-Arguments: hashpartitioning(item_sk#32, d_date#28, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Arguments: hashpartitioning(item_sk#32, d_date#28, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(54) Sort [codegen id : 28]
+(50) Sort [codegen id : 26]
 Input [3]: [item_sk#32, d_date#28, cume_sales#45]
 Arguments: [item_sk#32 ASC NULLS FIRST, d_date#28 ASC NULLS FIRST], false, 0
 
-(55) SortMergeJoin [codegen id : 29]
+(51) SortMergeJoin [codegen id : 27]
 Left keys [2]: [item_sk#10, d_date#6]
 Right keys [2]: [item_sk#32, d_date#28]
 Join type: FullOuter
 Join condition: None
 
-(56) Filter [codegen id : 29]
+(52) Filter [codegen id : 27]
 Input [6]: [item_sk#10, d_date#6, cume_sales#23, item_sk#32, d_date#28, cume_sales#45]
 Condition : isnotnull(CASE WHEN isnotnull(item_sk#10) THEN item_sk#10 ELSE item_sk#32 END)
 
-(57) Project [codegen id : 29]
+(53) Project [codegen id : 27]
 Output [4]: [CASE WHEN isnotnull(item_sk#10) THEN item_sk#10 ELSE item_sk#32 END AS item_sk#46, CASE WHEN isnotnull(d_date#6) THEN d_date#6 ELSE d_date#28 END AS d_date#47, cume_sales#23 AS web_sales#48, cume_sales#45 AS store_sales#49]
 Input [6]: [item_sk#10, d_date#6, cume_sales#23, item_sk#32, d_date#28, cume_sales#45]
 
-(58) Exchange
+(54) Exchange
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
-Arguments: hashpartitioning(item_sk#46, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Arguments: hashpartitioning(item_sk#46, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(59) Sort [codegen id : 30]
+(55) Sort [codegen id : 28]
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Arguments: [item_sk#46 ASC NULLS FIRST, d_date#47 ASC NULLS FIRST], false, 0
 
-(60) Window
+(56) Window
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Arguments: [row_number() windowspecdefinition(item_sk#46, d_date#47 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#50], [item_sk#46], [d_date#47 ASC NULLS FIRST]
 
-(61) ReusedExchange [Reuses operator id: 58]
+(57) ReusedExchange [Reuses operator id: 54]
 Output [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 
-(62) Sort [codegen id : 60]
+(58) Sort [codegen id : 56]
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Arguments: [item_sk#46 ASC NULLS FIRST, d_date#47 ASC NULLS FIRST], false, 0
 
-(63) Window
+(59) Window
 Input [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Arguments: [row_number() windowspecdefinition(item_sk#46, d_date#47 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rk#51], [item_sk#46], [d_date#47 ASC NULLS FIRST]
 
-(64) Project [codegen id : 61]
+(60) Project [codegen id : 57]
 Output [4]: [item_sk#46 AS item_sk#52, web_sales#48 AS web_sales#53, store_sales#49 AS store_sales#54, rk#51]
 Input [5]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, rk#51]
 
-(65) SortMergeJoin [codegen id : 62]
+(61) SortMergeJoin [codegen id : 58]
 Left keys [1]: [item_sk#46]
 Right keys [1]: [item_sk#52]
 Join type: Inner
 Join condition: (rk#50 >= rk#51)
 
-(66) Project [codegen id : 62]
+(62) Project [codegen id : 58]
 Output [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_sales#53, store_sales#54]
 Input [9]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, rk#50, item_sk#52, web_sales#53, store_sales#54, rk#51]
 
-(67) HashAggregate [codegen id : 62]
+(63) HashAggregate [codegen id : 58]
 Input [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_sales#53, store_sales#54]
 Keys [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Functions [2]: [partial_max(web_sales#53), partial_max(store_sales#54)]
 Aggregate Attributes [2]: [max#55, max#56]
 Results [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, max#57, max#58]
 
-(68) HashAggregate [codegen id : 62]
+(64) HashAggregate [codegen id : 58]
 Input [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, max#57, max#58]
 Keys [4]: [item_sk#46, d_date#47, web_sales#48, store_sales#49]
 Functions [2]: [max(web_sales#53), max(store_sales#54)]
 Aggregate Attributes [2]: [max(web_sales#53)#59, max(store_sales#54)#60]
 Results [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, max(web_sales#53)#59 AS web_cumulative#61, max(store_sales#54)#60 AS store_cumulative#62]
 
-(69) Filter [codegen id : 62]
+(65) Filter [codegen id : 58]
 Input [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_cumulative#61, store_cumulative#62]
 Condition : ((isnotnull(web_cumulative#61) AND isnotnull(store_cumulative#62)) AND (web_cumulative#61 > store_cumulative#62))
 
-(70) TakeOrderedAndProject
+(66) TakeOrderedAndProject
 Input [6]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_cumulative#61, store_cumulative#62]
 Arguments: 100, [item_sk#46 ASC NULLS FIRST, d_date#47 ASC NULLS FIRST], [item_sk#46, d_date#47, web_sales#48, store_sales#49, web_cumulative#61, store_cumulative#62]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (75)
-+- * Project (74)
-   +- * Filter (73)
-      +- * ColumnarToRow (72)
-         +- Scan parquet spark_catalog.default.date_dim (71)
+BroadcastExchange (71)
++- * Project (70)
+   +- * Filter (69)
+      +- * ColumnarToRow (68)
+         +- Scan parquet spark_catalog.default.date_dim (67)
 
 
-(71) Scan parquet spark_catalog.default.date_dim
+(67) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#5, d_date#6, d_month_seq#63]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_month_seq:int>
 
-(72) ColumnarToRow [codegen id : 1]
+(68) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#5, d_date#6, d_month_seq#63]
 
-(73) Filter [codegen id : 1]
+(69) Filter [codegen id : 1]
 Input [3]: [d_date_sk#5, d_date#6, d_month_seq#63]
 Condition : (((isnotnull(d_month_seq#63) AND (d_month_seq#63 >= 1212)) AND (d_month_seq#63 <= 1223)) AND isnotnull(d_date_sk#5))
 
-(74) Project [codegen id : 1]
+(70) Project [codegen id : 1]
 Output [2]: [d_date_sk#5, d_date#6]
 Input [3]: [d_date_sk#5, d_date#6, d_month_seq#63]
 
-(75) BroadcastExchange
+(71) BroadcastExchange
 Input [2]: [d_date_sk#5, d_date#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:2 Hosting operator id = 28 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#4
+Subquery:2 Hosting operator id = 26 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#4
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/simplified.txt
@@ -1,5 +1,5 @@
 TakeOrderedAndProject [item_sk,d_date,web_sales,store_sales,web_cumulative,store_cumulative]
-  WholeStageCodegen (62)
+  WholeStageCodegen (58)
     Filter [web_cumulative,store_cumulative]
       HashAggregate [item_sk,d_date,web_sales,store_sales,max,max] [max(web_sales),max(store_sales),web_cumulative,store_cumulative,max,max]
         HashAggregate [item_sk,d_date,web_sales,store_sales,web_sales,store_sales] [max,max,max,max]
@@ -7,20 +7,20 @@ TakeOrderedAndProject [item_sk,d_date,web_sales,store_sales,web_cumulative,store
             SortMergeJoin [item_sk,item_sk,rk,rk]
               InputAdapter
                 Window [item_sk,d_date]
-                  WholeStageCodegen (30)
+                  WholeStageCodegen (28)
                     Sort [item_sk,d_date]
                       InputAdapter
                         Exchange [item_sk] #1
-                          WholeStageCodegen (29)
+                          WholeStageCodegen (27)
                             Project [item_sk,item_sk,d_date,d_date,cume_sales,cume_sales]
                               Filter [item_sk,item_sk]
                                 SortMergeJoin [item_sk,d_date,item_sk,d_date]
                                   InputAdapter
-                                    WholeStageCodegen (14)
+                                    WholeStageCodegen (13)
                                       Sort [item_sk,d_date]
                                         InputAdapter
                                           Exchange [item_sk,d_date] #2
-                                            WholeStageCodegen (13)
+                                            WholeStageCodegen (12)
                                               HashAggregate [item_sk,d_date,sumws,sum,isEmpty] [sum(sumws),cume_sales,sum,isEmpty]
                                                 HashAggregate [item_sk,d_date,sumws,sumws] [sum,isEmpty,sum,isEmpty]
                                                   Project [item_sk,d_date,sumws,sumws]
@@ -61,46 +61,42 @@ TakeOrderedAndProject [item_sk,d_date,web_sales,store_sales,web_cumulative,store
                                                                                                 InputAdapter
                                                                                                   ReusedExchange [d_date_sk,d_date] #6
                                                       InputAdapter
-                                                        WholeStageCodegen (12)
-                                                          Sort [item_sk]
+                                                        WholeStageCodegen (11)
+                                                          Project [item_sk,sumws,rk]
                                                             InputAdapter
-                                                              Exchange [item_sk] #7
-                                                                WholeStageCodegen (11)
-                                                                  Project [item_sk,sumws,rk]
+                                                              Window [ws_item_sk,d_date]
+                                                                WholeStageCodegen (10)
+                                                                  Sort [ws_item_sk,d_date]
                                                                     InputAdapter
-                                                                      Window [ws_item_sk,d_date]
-                                                                        WholeStageCodegen (10)
-                                                                          Sort [ws_item_sk,d_date]
-                                                                            InputAdapter
-                                                                              ReusedExchange [item_sk,d_date,sumws,ws_item_sk] #4
+                                                                      ReusedExchange [item_sk,d_date,sumws,ws_item_sk] #4
                                   InputAdapter
-                                    WholeStageCodegen (28)
+                                    WholeStageCodegen (26)
                                       Sort [item_sk,d_date]
                                         InputAdapter
-                                          Exchange [item_sk,d_date] #8
-                                            WholeStageCodegen (27)
+                                          Exchange [item_sk,d_date] #7
+                                            WholeStageCodegen (25)
                                               HashAggregate [item_sk,d_date,sumss,sum,isEmpty] [sum(sumss),cume_sales,sum,isEmpty]
                                                 HashAggregate [item_sk,d_date,sumss,sumss] [sum,isEmpty,sum,isEmpty]
                                                   Project [item_sk,d_date,sumss,sumss]
                                                     SortMergeJoin [item_sk,item_sk,rk,rk]
                                                       InputAdapter
-                                                        WholeStageCodegen (20)
+                                                        WholeStageCodegen (19)
                                                           Sort [item_sk]
                                                             InputAdapter
-                                                              Exchange [item_sk] #9
-                                                                WholeStageCodegen (19)
+                                                              Exchange [item_sk] #8
+                                                                WholeStageCodegen (18)
                                                                   Project [item_sk,d_date,sumss,rk]
                                                                     InputAdapter
                                                                       Window [ss_item_sk,d_date]
-                                                                        WholeStageCodegen (18)
+                                                                        WholeStageCodegen (17)
                                                                           Sort [ss_item_sk,d_date]
                                                                             InputAdapter
-                                                                              Exchange [ss_item_sk] #10
-                                                                                WholeStageCodegen (17)
+                                                                              Exchange [ss_item_sk] #9
+                                                                                WholeStageCodegen (16)
                                                                                   HashAggregate [ss_item_sk,d_date,sum] [sum(UnscaledValue(ss_sales_price)),item_sk,sumss,sum]
                                                                                     InputAdapter
-                                                                                      Exchange [ss_item_sk,d_date] #11
-                                                                                        WholeStageCodegen (16)
+                                                                                      Exchange [ss_item_sk,d_date] #10
+                                                                                        WholeStageCodegen (15)
                                                                                           HashAggregate [ss_item_sk,d_date,ss_sales_price] [sum,sum]
                                                                                             Project [ss_item_sk,ss_sales_price,d_date]
                                                                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -112,24 +108,20 @@ TakeOrderedAndProject [item_sk,d_date,web_sales,store_sales,web_cumulative,store
                                                                                                 InputAdapter
                                                                                                   ReusedExchange [d_date_sk,d_date] #6
                                                       InputAdapter
-                                                        WholeStageCodegen (26)
-                                                          Sort [item_sk]
+                                                        WholeStageCodegen (24)
+                                                          Project [item_sk,sumss,rk]
                                                             InputAdapter
-                                                              Exchange [item_sk] #12
-                                                                WholeStageCodegen (25)
-                                                                  Project [item_sk,sumss,rk]
+                                                              Window [ss_item_sk,d_date]
+                                                                WholeStageCodegen (23)
+                                                                  Sort [ss_item_sk,d_date]
                                                                     InputAdapter
-                                                                      Window [ss_item_sk,d_date]
-                                                                        WholeStageCodegen (24)
-                                                                          Sort [ss_item_sk,d_date]
-                                                                            InputAdapter
-                                                                              ReusedExchange [item_sk,d_date,sumss,ss_item_sk] #10
+                                                                      ReusedExchange [item_sk,d_date,sumss,ss_item_sk] #9
               InputAdapter
-                WholeStageCodegen (61)
+                WholeStageCodegen (57)
                   Project [item_sk,web_sales,store_sales,rk]
                     InputAdapter
                       Window [item_sk,d_date]
-                        WholeStageCodegen (60)
+                        WholeStageCodegen (56)
                           Sort [item_sk,d_date]
                             InputAdapter
                               ReusedExchange [item_sk,d_date,web_sales,store_sales] #1

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -1370,7 +1370,9 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
         """.stripMargin)
       spark.sql("CREATE TABLE date_dim(d_date_sk INT, d_date DATE) using parquet")
 
-      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      withSQLConf(
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
         val df = sql(
           """
             |WITH web_tv


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extract partitionings from children's output expressions:
1. It first transform the current partitioning with non attribute aliases.
2. Then transform the transformed partitioning with attribute aliases.
3. Then normalize it.

For example:
```sql
CREATE TABLE t1(value string) using parquet;
CREATE TABLE t2(value string) using parquet;
set spark.sql.autoBroadcastJoinThreshold=-1;

SELECT upper(tmp.value),                  
       max(tmp.value)                     
FROM   (SELECT value,                     
               upper(value) AS upper_value
        FROM   t1) tmp                    
       JOIN t2                            
         ON tmp.upper_value = t2.value    
GROUP  BY upper(tmp.value);
```

Before this PR:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortAggregate(key=[_groupingexpression#238], functions=[max(value#229)], output=[upper(value)#233, max(value)#234])
   +- Sort [_groupingexpression#238 ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(_groupingexpression#238, 5), ENSURE_REQUIREMENTS, [plan_id=127]
         +- SortAggregate(key=[_groupingexpression#238], functions=[partial_max(value#229)], output=[_groupingexpression#238, max#240])
            +- Sort [_groupingexpression#238 ASC NULLS FIRST], false, 0
               +- Project [value#229, upper(value#229) AS _groupingexpression#238]
                  +- SortMergeJoin [upper_value#228], [value#230], Inner
                     :- Sort [upper_value#228 ASC NULLS FIRST], false, 0
                     :  +- Exchange hashpartitioning(upper_value#228, 5), ENSURE_REQUIREMENTS, [plan_id=117]
                     :     +- Project [value#229, upper(value#229) AS upper_value#228]
                     :        +- Filter isnotnull(upper(value#229))
                     :           +- FileScan parquet spark_catalog.default.t1[value#229]
                     +- Sort [value#230 ASC NULLS FIRST], false, 0
                        +- Exchange hashpartitioning(value#230, 5), ENSURE_REQUIREMENTS, [plan_id=118]
                           +- Filter isnotnull(value#230)
                              +- FileScan parquet spark_catalog.default.t2[value#230]
```

After this PR:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortAggregate(key=[_groupingexpression#238], functions=[max(value#229)], output=[upper(value)#233, max(value)#234])
   +- SortAggregate(key=[_groupingexpression#238], functions=[partial_max(value#229)], output=[_groupingexpression#238, max#240])
      +- Project [value#229, upper(value#229) AS _groupingexpression#238]
         +- SortMergeJoin [upper_value#228], [value#230], Inner
            :- Sort [upper_value#228 ASC NULLS FIRST], false, 0
            :  +- Exchange hashpartitioning(upper_value#228, 5), ENSURE_REQUIREMENTS, [plan_id=117]
            :     +- Project [value#229, upper(value#229) AS upper_value#228]
            :        +- Filter isnotnull(upper(value#229))
            :           +- FileScan parquet spark_catalog.default.t1[value#229]
            +- Sort [value#230 ASC NULLS FIRST], false, 0
               +- Exchange hashpartitioning(value#230, 5), ENSURE_REQUIREMENTS, [plan_id=118]
                  +- Filter isnotnull(value#230)
                     +- FileScan parquet spark_catalog.default.t2[value#230]
```

### Why are the changes needed?

Extract partitionings to reduce shuffle exchange.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and benchmark test.

SQL | Before this PR(Seconds) | After this PR(Seconds)
-- | -- | --
TPC-DS q51a | 120  | 114