### PR TITLE
[SPARK-40770][PYTHON] Improved error messages for applyInPandas for schema mismatch

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -189,51 +189,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             fn=merge_pandas,
             error_class=PythonException,
             error_message_regex="Column names of the returned pandas.DataFrame "
-            "do not match specified schema.  Unexpected: add, more  Schema: id, k, v, v2\n",
-        )
-
-        # with very large schema, missing and unexpected is limited to 5
-        # and the schema is abbreviated in the error message
-        schema = "id long, k long, mean double, " + ", ".join(
-            f"column_with_long_column_name_{no} integer" for no in range(35)
-        )
-        self._test_merge_error(
-            fn=lambda lft, rgt: pd.DataFrame(
-                [
-                    (
-                        lft.id,
-                        lft.k,
-                        lft.v.mean(),
-                    )
-                    + tuple(lft.v.mean() for _ in range(7))
-                ],
-                columns=["id", "k", "mean"] + [f"extra_column_{no} integer" for no in range(7)],
-            ),
-            output_schema=schema,
-            error_class=PythonException,
-            error_message_regex="Column names of the returned pandas\\.DataFrame "
-            "do not match specified schema\\.  "
-            "Missing \\(first 5 of 35\\): column_with_long_column_name_0,"
-            " column_with_long_column_name_1, column_with_long_column_name_10,"
-            " column_with_long_column_name_11, column_with_long_column_name_12  "
-            "Unexpected \\(first 5 of 7\\): extra_column_0 integer, extra_column_1 integer,"
-            " extra_column_2 integer, extra_column_3 integer, extra_column_4 integer  "
-            "Schema: id, k, mean, column_with_long_column_name_0, column_with_long_column_name_1,"
-            " column_with_long_column_name_2, column_with_long_column_name_3,"
-            " column_with_long_column_name_4, column_with_long_column_name_5,"
-            " column_with_long_column_name_6, column_with_long_column_name_7,"
-            " column_with_long_column_name_8, column_with_long_column_name_9,"
-            " column_with_long_column_name_10, column_with_long_column_name_11,"
-            " column_with_long_column_name_12, column_with_long_column_name_13,"
-            " column_with_long_column_name_14, column_with_\\.\\.\\.g_column_name_19,"
-            " column_with_long_column_name_20, column_with_long_column_name_21,"
-            " column_with_long_column_name_22, column_with_long_column_name_23,"
-            " column_with_long_column_name_24, column_with_long_column_name_25,"
-            " column_with_long_column_name_26, column_with_long_column_name_27,"
-            " column_with_long_column_name_28, column_with_long_column_name_29,"
-            " column_with_long_column_name_30, column_with_long_column_name_31,"
-            " column_with_long_column_name_32, column_with_long_column_name_33,"
-            " column_with_long_column_name_34\n",
+            "do not match specified schema.  Unexpected: add, more\n",
         )
 
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
@@ -250,41 +206,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             fn=merge_pandas,
             error_class=PythonException,
             error_message_regex="Number of columns of the returned pandas.DataFrame "
-            "doesn't match specified schema.  Expected: 4  Actual: 6  Schema: id, k, v, v2\n",
-        )
-
-        # with very large schema the schema is abbreviated in the error message
-        schema = "id long, k long, mean double, " + ", ".join(
-            f"column_with_long_column_name_{no} integer" for no in range(35)
-        )
-
-        def fn(lft, _):
-            # remove column names from lft DataFrame
-            lft.columns = range(lft.columns.size)
-            return lft
-
-        self._test_merge_error(
-            fn=fn,
-            output_schema=schema,
-            error_class=PythonException,
-            error_message_regex="Number of columns of the returned pandas\\.DataFrame "
-            "doesn't match specified schema\\.  Expected: 38  Actual: 3  "
-            "Schema: id, k, mean, column_with_long_column_name_0, column_with_long_column_name_1,"
-            " column_with_long_column_name_2, column_with_long_column_name_3,"
-            " column_with_long_column_name_4, column_with_long_column_name_5,"
-            " column_with_long_column_name_6, column_with_long_column_name_7,"
-            " column_with_long_column_name_8, column_with_long_column_name_9,"
-            " column_with_long_column_name_10, column_with_long_column_name_11,"
-            " column_with_long_column_name_12, column_with_long_column_name_13,"
-            " column_with_long_column_name_14, column_with_\\.\\.\\.g_column_name_19,"
-            " column_with_long_column_name_20, column_with_long_column_name_21,"
-            " column_with_long_column_name_22, column_with_long_column_name_23,"
-            " column_with_long_column_name_24, column_with_long_column_name_25,"
-            " column_with_long_column_name_26, column_with_long_column_name_27,"
-            " column_with_long_column_name_28, column_with_long_column_name_29,"
-            " column_with_long_column_name_30, column_with_long_column_name_31,"
-            " column_with_long_column_name_32, column_with_long_column_name_33,"
-            " column_with_long_column_name_34\n",
+            "doesn't match specified schema.  Expected: 4  Actual: 6\n",
         )
 
     def test_apply_in_pandas_returning_empty_dataframe(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -44,11 +44,10 @@ if have_pyarrow:
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
 )
 class CogroupedMapInPandasTests(ReusedSQLTestCase):
-    @classmethod
     @property
-    def data1(cls):
+    def data1(self):
         return (
-            cls.spark.range(10)
+            self.spark.range(10)
             .toDF("id")
             .withColumn("ks", array([lit(i) for i in range(20, 30)]))
             .withColumn("k", explode(col("ks")))
@@ -56,11 +55,10 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             .drop("ks")
         )
 
-    @classmethod
     @property
-    def data2(cls):
+    def data2(self):
         return (
-            cls.spark.range(10)
+            self.spark.range(10)
             .toDF("id")
             .withColumn("ks", array([lit(i) for i in range(20, 30)]))
             .withColumn("k", explode(col("ks")))
@@ -460,6 +458,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
         output_schema="id long, k int, v int, v2 int",
         expected=None,
     ):
+        # Test fn with and without key argument
         with self.subTest("without key"):
             self.__test_merge(left, right, by, fn, output_schema, expected)
         with self.subTest("with key"):
@@ -475,6 +474,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
         output_schema="id long, k int, v int, v2 int",
         expected=None,
     ):
+        # Test fn as is, cf. _test_merge
         left = self.data1 if left is None else left
         right = self.data2 if right is None else right
 
@@ -507,6 +507,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
         fn=lambda lft, rgt: pd.merge(lft, rgt, on=["id", "k"]),
         output_schema="id long, k int, v int, v2 int",
     ):
+        # Test fn with and without key argument
         with self.subTest("without key"):
             self.__test_merge_error(
                 left=left,
@@ -539,6 +540,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
         fn=lambda lft, rgt: pd.merge(lft, rgt, on=["id", "k"]),
         output_schema="id long, k int, v int, v2 int",
     ):
+        # Test fn as is, cf. _test_merge_error
         with QuietTest(self.sc):
             with self.assertRaisesRegex(error_class, error_message_regex):
                 self.__test_merge(left, right, by, fn, output_schema)

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -305,15 +305,15 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
                 # sometimes we see ValueErrors
                 with self.subTest(convert="string to double"):
                     expected = (
-                        "ValueError: Exception thrown when converting pandas\\.Series \\(object\\) "
-                        "with name 'k' to Arrow Array \\(double\\)\\."
+                        r"ValueError: Exception thrown when converting pandas.Series \(object\) "
+                        r"with name 'k' to Arrow Array \(double\)."
                     )
                     if safely:
                         expected = expected + (
                             " It can be caused by overflows or other "
-                            "unsafe conversions warned by Arrow\\. Arrow safe type check "
+                            "unsafe conversions warned by Arrow. Arrow safe type check "
                             "can be disabled by using SQL config "
-                            "`spark\\.sql\\.execution\\.pandas\\.convertToArrowArraySafely`\\."
+                            "`spark.sql.execution.pandas.convertToArrowArraySafely`."
                         )
                     self._test_merge_error(
                         fn=lambda lft, rgt: pd.DataFrame({"id": [1], "k": ["2.0"]}),
@@ -325,8 +325,8 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
                 # sometimes we see TypeErrors
                 with self.subTest(convert="double to string"):
                     expected = (
-                        "TypeError: Exception thrown when converting pandas\\.Series \\(float64\\) "
-                        "with name 'k' to Arrow Array \\(string\\)\\.\n"
+                        r"TypeError: Exception thrown when converting pandas.Series \(float64\) "
+                        r"with name 'k' to Arrow Array \(string\).\n"
                     )
                     self._test_merge_error(
                         fn=lambda lft, rgt: pd.DataFrame({"id": [1], "k": [2.0]}),

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -189,7 +189,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             fn=merge_pandas,
             error_class=PythonException,
             error_message_regex="Column names of the returned pandas.DataFrame "
-            "do not match specified schema. Unexpected: add, more Schema: id, k, v, v2\n",
+            "do not match specified schema.  Unexpected: add, more  Schema: id, k, v, v2\n",
         )
 
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
@@ -206,7 +206,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             fn=merge_pandas,
             error_class=PythonException,
             error_message_regex="Number of columns of the returned pandas.DataFrame "
-            "doesn't match specified schema. Expected: 4 Actual: 6 Schema: id, k, v, v2\n",
+            "doesn't match specified schema.  Expected: 4  Actual: 6  Schema: id, k, v, v2\n",
         )
 
     def test_apply_in_pandas_returning_empty_dataframe(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -189,7 +189,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             fn=merge_pandas,
             error_class=PythonException,
             error_message_regex="Column names of the returned pandas.DataFrame "
-            "do not match specified schema. Unexpected: add, more",
+            "do not match specified schema. Unexpected: add, more Schema: id, k, v, v2\n",
         )
 
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
@@ -206,7 +206,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             fn=merge_pandas,
             error_class=PythonException,
             error_message_regex="Number of columns of the returned pandas.DataFrame "
-            "doesn't match specified schema. Expected: 4 Actual: 6",
+            "doesn't match specified schema. Expected: 4 Actual: 6 Schema: id, k, v, v2\n",
         )
 
     def test_apply_in_pandas_returning_empty_dataframe(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -43,7 +43,7 @@ if have_pyarrow:
     not have_pandas or not have_pyarrow,
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
 )
-class CogroupedMapInPandasTests(ReusedSQLTestCase):
+class CogroupedApplyInPandasTests(ReusedSQLTestCase):
     @property
     def data1(self):
         return (

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -189,7 +189,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             fn=merge_pandas,
             error_class=PythonException,
             error_message_regex="Column names of the returned pandas.DataFrame "
-            "do not match specified schema.  Unexpected: add, more\n",
+            "do not match specified schema. Unexpected: add, more.\n",
         )
 
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
@@ -206,7 +206,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             fn=merge_pandas,
             error_class=PythonException,
             error_message_regex="Number of columns of the returned pandas.DataFrame "
-            "doesn't match specified schema.  Expected: 4  Actual: 6\n",
+            "doesn't match specified schema. Expected: 4 Actual: 6\n",
         )
 
     def test_apply_in_pandas_returning_empty_dataframe(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -458,12 +458,14 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
         output_schema="id long, k int, v int, v2 int",
         expected=None,
     ):
+        def fn_with_key(_, lft, rgt):
+            return fn(lft, rgt)
+
         # Test fn with and without key argument
         with self.subTest("without key"):
             self.__test_merge(left, right, by, fn, output_schema, expected)
         with self.subTest("with key"):
-            f = lambda key, lft, rgt: fn(lft, rgt)
-            self.__test_merge(left, right, by, f, output_schema, expected)
+            self.__test_merge(left, right, by, fn_with_key, output_schema, expected)
 
     def __test_merge(
         self,
@@ -507,6 +509,9 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
         fn=lambda lft, rgt: pd.merge(lft, rgt, on=["id", "k"]),
         output_schema="id long, k int, v int, v2 int",
     ):
+        def fn_with_key(_, lft, rgt):
+            return fn(lft, rgt)
+
         # Test fn with and without key argument
         with self.subTest("without key"):
             self.__test_merge_error(
@@ -519,12 +524,11 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
                 error_message_regex=error_message_regex,
             )
         with self.subTest("with key"):
-            f = lambda key, lft, rgt: fn(lft, rgt)
             self.__test_merge_error(
                 left=left,
                 right=right,
                 by=by,
-                fn=f,
+                fn=fn_with_key,
                 output_schema=output_schema,
                 error_class=error_class,
                 error_message_regex=error_message_regex,

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -209,7 +209,7 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             "doesn't match specified schema. Expected: 4 Actual: 6",
         )
 
-    def test_apply_in_pandas_returning_empty_dataframe_without_columns(self):
+    def test_apply_in_pandas_returning_empty_dataframe(self):
         def merge_pandas(lft, rgt):
             if 0 in lft["id"] and lft["id"][0] % 2 == 0:
                 return pd.DataFrame()
@@ -218,56 +218,6 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             return pd.merge(lft, rgt, on=["id", "k"])
 
         self._test_merge_empty(fn=merge_pandas)
-
-    def test_apply_in_pandas_returning_empty_dataframe_with_column_names(self):
-        def merge_pandas(lft, rgt):
-            if 0 in lft["id"] and lft["id"][0] % 2 == 0:
-                return pd.DataFrame(columns=["id", "k", "v", "v2"])
-            if 0 in rgt["id"] and rgt["id"][0] % 3 == 0:
-                return pd.DataFrame(columns=["id", "k", "v", "v2"])
-            return pd.merge(lft, rgt, on=["id", "k"])
-
-        self._test_merge_empty(fn=merge_pandas)
-
-    def test_apply_in_pandas_returning_empty_dataframe_with_wrong_column_names(self):
-        def merge_pandas(lft, rgt):
-            if 0 in lft["id"] and lft["id"][0] % 2 == 0:
-                return pd.DataFrame(columns=["id", "k", "x"])
-            if 0 in rgt["id"] and rgt["id"][0] % 3 == 0:
-                return pd.DataFrame(columns=["id", "k", "x"])
-            return pd.merge(lft, rgt, on=["id", "k"])
-
-        self._test_merge_error(
-            fn=merge_pandas,
-            error_class=PythonException,
-            error_message_regex="Column names of the returned pandas.DataFrame "
-            "do not match specified schema. Missing: v, v2 Unexpected: x",
-        )
-
-    def test_apply_in_pandas_returning_empty_dataframe_without_column_names(self):
-        def merge_pandas(lft, rgt):
-            if 0 in lft["id"] and lft["id"][0] % 2 == 0:
-                return pd.DataFrame(columns=[0, 1, 2, 3])
-            if 0 in rgt["id"] and rgt["id"][0] % 3 == 0:
-                return pd.DataFrame(columns=[0, 1, 2, 3])
-            return pd.merge(lft, rgt, on=["id", "k"])
-
-        self._test_merge_empty(fn=merge_pandas)
-
-    def test_apply_in_pandas_returning_empty_dataframe_without_column_names_and_wrong_amount(self):
-        def merge_pandas(lft, rgt):
-            if 0 in lft["id"] and lft["id"][0] % 2 == 0:
-                return pd.DataFrame(columns=[0, 1, 2])
-            if 0 in rgt["id"] and rgt["id"][0] % 3 == 0:
-                return pd.DataFrame(columns=[0, 1, 2])
-            return pd.merge(lft, rgt, on=["id", "k"])
-
-        self._test_merge_error(
-            fn=merge_pandas,
-            error_class=PythonException,
-            error_message_regex="Number of columns of the returned pandas.DataFrame doesn't "
-            "match specified schema. Expected: 4 Actual: 3",
-        )
 
     def test_mixed_scalar_udfs_followed_by_cogrouby_apply(self):
         df = self.spark.range(0, 10).toDF("v1")

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -192,6 +192,50 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             "do not match specified schema.  Unexpected: add, more  Schema: id, k, v, v2\n",
         )
 
+        # with very large schema, missing and unexpected is limited to 5
+        # and the schema is abbreviated in the error message
+        schema = "id long, k long, mean double, " + ", ".join(
+            f"column_with_long_column_name_{no} integer" for no in range(35)
+        )
+        self._test_merge_error(
+            fn=lambda lft, rgt: pd.DataFrame(
+                [
+                    (
+                        lft.id,
+                        lft.k,
+                        lft.v.mean(),
+                    )
+                    + tuple(lft.v.mean() for _ in range(7))
+                ],
+                columns=["id", "k", "mean"] + [f"extra_column_{no} integer" for no in range(7)],
+            ),
+            output_schema=schema,
+            error_class=PythonException,
+            error_message_regex="Column names of the returned pandas\\.DataFrame "
+            "do not match specified schema\\.  "
+            "Missing \\(first 5 of 35\\): column_with_long_column_name_0,"
+            " column_with_long_column_name_1, column_with_long_column_name_10,"
+            " column_with_long_column_name_11, column_with_long_column_name_12  "
+            "Unexpected \\(first 5 of 7\\): extra_column_0 integer, extra_column_1 integer,"
+            " extra_column_2 integer, extra_column_3 integer, extra_column_4 integer  "
+            "Schema: id, k, mean, column_with_long_column_name_0, column_with_long_column_name_1,"
+            " column_with_long_column_name_2, column_with_long_column_name_3,"
+            " column_with_long_column_name_4, column_with_long_column_name_5,"
+            " column_with_long_column_name_6, column_with_long_column_name_7,"
+            " column_with_long_column_name_8, column_with_long_column_name_9,"
+            " column_with_long_column_name_10, column_with_long_column_name_11,"
+            " column_with_long_column_name_12, column_with_long_column_name_13,"
+            " column_with_long_column_name_14, column_with_\\.\\.\\.g_column_name_19,"
+            " column_with_long_column_name_20, column_with_long_column_name_21,"
+            " column_with_long_column_name_22, column_with_long_column_name_23,"
+            " column_with_long_column_name_24, column_with_long_column_name_25,"
+            " column_with_long_column_name_26, column_with_long_column_name_27,"
+            " column_with_long_column_name_28, column_with_long_column_name_29,"
+            " column_with_long_column_name_30, column_with_long_column_name_31,"
+            " column_with_long_column_name_32, column_with_long_column_name_33,"
+            " column_with_long_column_name_34\n",
+        )
+
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
         def merge_pandas(lft, rgt):
             if 0 in lft["id"] and lft["id"][0] % 2 == 0:
@@ -207,6 +251,40 @@ class CogroupedMapInPandasTests(ReusedSQLTestCase):
             error_class=PythonException,
             error_message_regex="Number of columns of the returned pandas.DataFrame "
             "doesn't match specified schema.  Expected: 4  Actual: 6  Schema: id, k, v, v2\n",
+        )
+
+        # with very large schema the schema is abbreviated in the error message
+        schema = "id long, k long, mean double, " + ", ".join(
+            f"column_with_long_column_name_{no} integer" for no in range(35)
+        )
+
+        def fn(lft, _):
+            # remove column names from lft DataFrame
+            lft.columns = range(lft.columns.size)
+            return lft
+
+        self._test_merge_error(
+            fn=fn,
+            output_schema=schema,
+            error_class=PythonException,
+            error_message_regex="Number of columns of the returned pandas\\.DataFrame "
+            "doesn't match specified schema\\.  Expected: 38  Actual: 3  "
+            "Schema: id, k, mean, column_with_long_column_name_0, column_with_long_column_name_1,"
+            " column_with_long_column_name_2, column_with_long_column_name_3,"
+            " column_with_long_column_name_4, column_with_long_column_name_5,"
+            " column_with_long_column_name_6, column_with_long_column_name_7,"
+            " column_with_long_column_name_8, column_with_long_column_name_9,"
+            " column_with_long_column_name_10, column_with_long_column_name_11,"
+            " column_with_long_column_name_12, column_with_long_column_name_13,"
+            " column_with_long_column_name_14, column_with_\\.\\.\\.g_column_name_19,"
+            " column_with_long_column_name_20, column_with_long_column_name_21,"
+            " column_with_long_column_name_22, column_with_long_column_name_23,"
+            " column_with_long_column_name_24, column_with_long_column_name_25,"
+            " column_with_long_column_name_26, column_with_long_column_name_27,"
+            " column_with_long_column_name_28, column_with_long_column_name_29,"
+            " column_with_long_column_name_30, column_with_long_column_name_31,"
+            " column_with_long_column_name_32, column_with_long_column_name_33,"
+            " column_with_long_column_name_34\n",
         )
 
     def test_apply_in_pandas_returning_empty_dataframe(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -301,6 +301,24 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 # stats returns three columns while here we set schema with two columns
                 df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
 
+    def test_apply_in_pandas_returning_wrong_columns(self):
+        df = self.data
+
+        def stats(key, pdf):
+            v = pdf.v
+            # returning three columns
+            res = pd.DataFrame([key + (v.mean(), v.std())])
+            return res
+
+        with QuietTest(self.sc):
+            with self.assertRaisesRegex(
+                PythonException,
+                "Number of columns of the returned pandas.DataFrame doesn't match "
+                "specified schema. Expected: 2 Actual: 3",
+            ):
+                # stats returns three columns while here we set schema with two columns
+                df.groupby("id").applyInPandas(stats, schema="id integer, m double, n string").collect()
+
     def test_apply_in_pandas_returning_empty_dataframe(self):
         df = self.data
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -684,8 +684,8 @@ class GroupedApplyInPandasTests(ReusedSQLTestCase):
             .orderBy("id")
             .collect()
         )
-        for r in result:
-            self.assertListEqual(expected[r[0]], r[1])
+
+        self.assertListEqual([Row(id=key, result=val) for key, val in expected.items()], result)
 
     def test_grouped_over_window_with_key(self):
 
@@ -751,8 +751,7 @@ class GroupedApplyInPandasTests(ReusedSQLTestCase):
             .collect()
         )
 
-        for r in result:
-            self.assertListEqual(expected[r[0]], r[1])
+        self.assertListEqual([Row(id=key, result=val) for key, val in expected.items()], result)
 
     def test_case_insensitive_grouping_column(self):
         # SPARK-31915: case-insensitive grouping column should work.

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -308,7 +308,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             with self.assertRaisesRegex(
                 PythonException,
                 "Column names of the returned pandas.DataFrame do not match specified schema.  "
-                "Missing: mean  Unexpected: median, std  Schema: id, mean\n",
+                "Missing: mean  Unexpected: median, std\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame(
@@ -316,85 +316,15 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                     )
                 )
 
-            # with very large schema, missing and unexpected is limited to 5
-            # and the schema is abbreviated in the error message
-            with self.assertRaisesRegex(
-                PythonException,
-                "Column names of the returned pandas\\.DataFrame do not match specified schema\\.  "
-                "Missing \\(first 5 of 35\\): column_with_long_column_name_0,"
-                " column_with_long_column_name_1, column_with_long_column_name_10,"
-                " column_with_long_column_name_11, column_with_long_column_name_12  "
-                "Unexpected \\(first 5 of 7\\): extra_column_0 integer, extra_column_1 integer,"
-                " extra_column_2 integer, extra_column_3 integer, extra_column_4 integer  "
-                "Schema: id, mean, column_with_long_column_name_0, column_with_long_column_name_1,"
-                " column_with_long_column_name_2, column_with_long_column_name_3,"
-                " column_with_long_column_name_4, column_with_long_column_name_5,"
-                " column_with_long_column_name_6, column_with_long_column_name_7,"
-                " column_with_long_column_name_8, column_with_long_column_name_9,"
-                " column_with_long_column_name_10, column_with_long_column_name_11,"
-                " column_with_long_column_name_12, column_with_long_column_name_13,"
-                " column_with_long_column_name_14, column_with_lon\\.\\.\\.g_column_name_19,"
-                " column_with_long_column_name_20, column_with_long_column_name_21,"
-                " column_with_long_column_name_22, column_with_long_column_name_23,"
-                " column_with_long_column_name_24, column_with_long_column_name_25,"
-                " column_with_long_column_name_26, column_with_long_column_name_27,"
-                " column_with_long_column_name_28, column_with_long_column_name_29,"
-                " column_with_long_column_name_30, column_with_long_column_name_31,"
-                " column_with_long_column_name_32, column_with_long_column_name_33,"
-                " column_with_long_column_name_34\n",
-            ):
-                # the schema will be cut off at 1024 characters, this will be slightly longer
-                schema = "id long, mean double, " + ", ".join(
-                    f"column_with_long_column_name_{no} integer" for no in range(35)
-                )
-                self._test_apply_in_pandas(
-                    lambda key, pdf: pd.DataFrame(
-                        [key + (pdf.v.mean(),) + tuple(pdf.v.mean() for _ in range(7))],
-                        columns=["id", "mean"] + [f"extra_column_{no} integer" for no in range(7)],
-                    ),
-                    output_schema=schema,
-                )
-
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 PythonException,
                 "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema.  Expected: 2  Actual: 3  Schema: id, mean\n",
+                "specified schema.  Expected: 2  Actual: 3\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
-                )
-
-            # with very large schema the schema is abbreviated in the error message
-            with self.assertRaisesRegex(
-                PythonException,
-                "Number of columns of the returned pandas\\.DataFrame "
-                "doesn't match specified schema\\.  Expected: 37  Actual: 2  "
-                "Schema: id, mean, column_with_long_column_name_0, column_with_long_column_name_1,"
-                " column_with_long_column_name_2, column_with_long_column_name_3,"
-                " column_with_long_column_name_4, column_with_long_column_name_5,"
-                " column_with_long_column_name_6, column_with_long_column_name_7,"
-                " column_with_long_column_name_8, column_with_long_column_name_9,"
-                " column_with_long_column_name_10, column_with_long_column_name_11,"
-                " column_with_long_column_name_12, column_with_long_column_name_13,"
-                " column_with_long_column_name_14, column_with_lon\\.\\.\\.g_column_name_19,"
-                " column_with_long_column_name_20, column_with_long_column_name_21,"
-                " column_with_long_column_name_22, column_with_long_column_name_23,"
-                " column_with_long_column_name_24, column_with_long_column_name_25,"
-                " column_with_long_column_name_26, column_with_long_column_name_27,"
-                " column_with_long_column_name_28, column_with_long_column_name_29,"
-                " column_with_long_column_name_30, column_with_long_column_name_31,"
-                " column_with_long_column_name_32, column_with_long_column_name_33,"
-                " column_with_long_column_name_34\n",
-            ):
-                # the schema will be cut off at 1024 characters, this will be slightly longer
-                schema = "id long, mean double, " + ", ".join(
-                    f"column_with_long_column_name_{no} integer" for no in range(35)
-                )
-                self._test_apply_in_pandas(
-                    lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(),)]),
-                    output_schema=schema,
                 )
 
     def test_apply_in_pandas_returning_empty_dataframe(self):
@@ -661,7 +591,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 with self.assertRaisesRegex(
                     PythonException,
                     "RuntimeError: Column names of the returned pandas.DataFrame do not match "
-                    "specified schema.  Missing: id  Unexpected: iid  Schema: id, v\n",
+                    "specified schema.  Missing: id  Unexpected: iid\n",
                 ):
                     grouped_df.apply(column_name_typo).collect()
                 with self.assertRaisesRegex(Exception, "[D|d]ecimal.*got.*date"):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -307,8 +307,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 PythonException,
-                "Column names of the returned pandas.DataFrame do not match specified schema.  "
-                "Missing: mean  Unexpected: median, std\n",
+                "Column names of the returned pandas.DataFrame do not match specified schema. "
+                "Missing: mean. Unexpected: median, std.\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame(
@@ -321,7 +321,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             with self.assertRaisesRegex(
                 PythonException,
                 "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema.  Expected: 2  Actual: 3\n",
+                "specified schema. Expected: 2 Actual: 3\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
@@ -591,7 +591,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 with self.assertRaisesRegex(
                     PythonException,
                     "RuntimeError: Column names of the returned pandas.DataFrame do not match "
-                    "specified schema.  Missing: id  Unexpected: iid\n",
+                    "specified schema. Missing: id. Unexpected: iid.\n",
                 ):
                     grouped_df.apply(column_name_typo).collect()
                 with self.assertRaisesRegex(Exception, "[D|d]ecimal.*got.*date"):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -327,28 +327,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                     lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
                 )
 
-    def test_apply_in_pandas_returning_empty_dataframe_without_columns(self):
+    def test_apply_in_pandas_returning_empty_dataframe(self):
         self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame())
-
-    def test_apply_in_pandas_returning_empty_dataframe_with_column_names(self):
-        self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame(columns=["mean", "id"]))
-
-    def test_apply_in_pandas_returning_empty_dataframe_with_wrong_column_names(self):
-        self._test_apply_in_pandas_returning_empty_dataframe_error(
-            pd.DataFrame(columns=["id", "median", "std"]),
-            "Column names of the returned pandas.DataFrame "
-            "do not match specified schema. Missing: mean Unexpected: median, std",
-        )
-
-    def test_apply_in_pandas_returning_empty_dataframe_with_no_column_names(self):
-        self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame(columns=[0, 1]))
-
-    def test_apply_in_pandas_returning_empty_dataframe_with_no_column_names_and_wrong_amount(self):
-        self._test_apply_in_pandas_returning_empty_dataframe_error(
-            pd.DataFrame(columns=[0, 1, 2]),
-            "Number of columns of the returned pandas.DataFrame "
-            "doesn't match specified schema. Expected: 2 Actual: 3",
-        )
 
     def test_datatype_string(self):
         df = self.data

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -307,7 +307,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 PythonException,
-                "Column names of the returned pandas.DataFrame do not match specified schema.  "
+                "Column names of the returned pandas\\.DataFrame do not match specified schema\\.  "
                 "Missing: mean  Unexpected: median, std  Schema: id, mean\n",
             ):
                 self._test_apply_in_pandas(
@@ -316,15 +316,85 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                     )
                 )
 
+            # with very large schema, missing and unexpected is limited to 5
+            # and the schema is abbreviated in the error message
+            with self.assertRaisesRegex(
+                PythonException,
+                "Column names of the returned pandas\\.DataFrame do not match specified schema\\.  "
+                "Missing \\(first 5 of 35\\): column_with_long_column_name_0,"
+                " column_with_long_column_name_1, column_with_long_column_name_10,"
+                " column_with_long_column_name_11, column_with_long_column_name_12  "
+                "Unexpected \\(first 5 of 7\\): extra_column_0 integer, extra_column_1 integer,"
+                " extra_column_2 integer, extra_column_3 integer, extra_column_4 integer  "
+                "Schema: id, mean, column_with_long_column_name_0, column_with_long_column_name_1,"
+                " column_with_long_column_name_2, column_with_long_column_name_3,"
+                " column_with_long_column_name_4, column_with_long_column_name_5,"
+                " column_with_long_column_name_6, column_with_long_column_name_7,"
+                " column_with_long_column_name_8, column_with_long_column_name_9,"
+                " column_with_long_column_name_10, column_with_long_column_name_11,"
+                " column_with_long_column_name_12, column_with_long_column_name_13,"
+                " column_with_long_column_name_14, column_with_lon\\.\\.\\.g_column_name_19,"
+                " column_with_long_column_name_20, column_with_long_column_name_21,"
+                " column_with_long_column_name_22, column_with_long_column_name_23,"
+                " column_with_long_column_name_24, column_with_long_column_name_25,"
+                " column_with_long_column_name_26, column_with_long_column_name_27,"
+                " column_with_long_column_name_28, column_with_long_column_name_29,"
+                " column_with_long_column_name_30, column_with_long_column_name_31,"
+                " column_with_long_column_name_32, column_with_long_column_name_33,"
+                " column_with_long_column_name_34\n",
+            ):
+                # the schema will be cut off at 1024 characters, this will be slightly longer
+                schema = "id long, mean double, " + ", ".join(
+                    f"column_with_long_column_name_{no} integer" for no in range(35)
+                )
+                self._test_apply_in_pandas(
+                    lambda key, pdf: pd.DataFrame(
+                        [key + (pdf.v.mean(),) + tuple(pdf.v.mean() for _ in range(7))],
+                        columns=["id", "mean"] + [f"extra_column_{no} integer" for no in range(7)],
+                    ),
+                    output_schema=schema,
+                )
+
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 PythonException,
-                "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema.  Expected: 2  Actual: 3  Schema: id, mean\n",
+                "Number of columns of the returned pandas\\.DataFrame doesn't match "
+                "specified schema\\.  Expected: 2  Actual: 3  Schema: id, mean\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
+                )
+
+            # with very large schema the schema is abbreviated in the error message
+            with self.assertRaisesRegex(
+                PythonException,
+                "Number of columns of the returned pandas\\.DataFrame "
+                "doesn't match specified schema\\.  Expected: 37  Actual: 2  "
+                "Schema: id, mean, column_with_long_column_name_0, column_with_long_column_name_1,"
+                " column_with_long_column_name_2, column_with_long_column_name_3,"
+                " column_with_long_column_name_4, column_with_long_column_name_5,"
+                " column_with_long_column_name_6, column_with_long_column_name_7,"
+                " column_with_long_column_name_8, column_with_long_column_name_9,"
+                " column_with_long_column_name_10, column_with_long_column_name_11,"
+                " column_with_long_column_name_12, column_with_long_column_name_13,"
+                " column_with_long_column_name_14, column_with_lon\\.\\.\\.g_column_name_19,"
+                " column_with_long_column_name_20, column_with_long_column_name_21,"
+                " column_with_long_column_name_22, column_with_long_column_name_23,"
+                " column_with_long_column_name_24, column_with_long_column_name_25,"
+                " column_with_long_column_name_26, column_with_long_column_name_27,"
+                " column_with_long_column_name_28, column_with_long_column_name_29,"
+                " column_with_long_column_name_30, column_with_long_column_name_31,"
+                " column_with_long_column_name_32, column_with_long_column_name_33,"
+                " column_with_long_column_name_34\n",
+            ):
+                # the schema will be cut off at 1024 characters, this will be slightly longer
+                schema = "id long, mean double, " + ", ".join(
+                    f"column_with_long_column_name_{no} integer" for no in range(35)
+                )
+                self._test_apply_in_pandas(
+                    lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(),)]),
+                    output_schema=schema,
                 )
 
     def test_apply_in_pandas_returning_empty_dataframe(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -307,7 +307,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 PythonException,
-                "Column names of the returned pandas\\.DataFrame do not match specified schema\\.  "
+                "Column names of the returned pandas.DataFrame do not match specified schema.  "
                 "Missing: mean  Unexpected: median, std  Schema: id, mean\n",
             ):
                 self._test_apply_in_pandas(
@@ -359,8 +359,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 PythonException,
-                "Number of columns of the returned pandas\\.DataFrame doesn't match "
-                "specified schema\\.  Expected: 2  Actual: 3  Schema: id, mean\n",
+                "Number of columns of the returned pandas.DataFrame doesn't match "
+                "specified schema.  Expected: 2  Actual: 3  Schema: id, mean\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
@@ -408,15 +408,15 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 # sometimes we see ValueErrors
                 with self.subTest(convert="string to double"):
                     expected = (
-                        "ValueError: Exception thrown when converting pandas\\.Series \\(object\\) "
-                        "with name 'mean' to Arrow Array \\(double\\)\\."
+                        r"ValueError: Exception thrown when converting pandas.Series \(object\) "
+                        r"with name 'mean' to Arrow Array \(double\)."
                     )
                     if safely:
                         expected = expected + (
                             " It can be caused by overflows or other "
-                            "unsafe conversions warned by Arrow\\. Arrow safe type check "
+                            "unsafe conversions warned by Arrow. Arrow safe type check "
                             "can be disabled by using SQL config "
-                            "`spark\\.sql\\.execution\\.pandas\\.convertToArrowArraySafely`\\."
+                            "`spark.sql.execution.pandas.convertToArrowArraySafely`."
                         )
                     with self.assertRaisesRegex(PythonException, expected + "\n"):
                         self._test_apply_in_pandas(
@@ -428,8 +428,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 with self.subTest(convert="double to string"):
                     with self.assertRaisesRegex(
                         PythonException,
-                        "TypeError: Exception thrown when converting pandas\\.Series \\(float64\\) "
-                        "with name 'mean' to Arrow Array \\(string\\)\\.\n",
+                        r"TypeError: Exception thrown when converting pandas.Series \(float64\) "
+                        r"with name 'mean' to Arrow Array \(string\).\n",
                     ):
                         self._test_apply_in_pandas(
                             lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(),)]),

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -73,7 +73,7 @@ if have_pyarrow:
     not have_pandas or not have_pyarrow,
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
 )
-class GroupedMapInPandasTests(ReusedSQLTestCase):
+class GroupedApplyInPandasTests(ReusedSQLTestCase):
     @property
     def data(self):
         return (
@@ -289,17 +289,17 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         return pd.DataFrame([key + (pdf.v.mean(),)])
 
     def test_apply_in_pandas_returning_column_names(self):
-        self._test_apply_in_pandas(GroupedMapInPandasTests.stats_with_column_names)
+        self._test_apply_in_pandas(GroupedApplyInPandasTests.stats_with_column_names)
 
     def test_apply_in_pandas_returning_no_column_names(self):
-        self._test_apply_in_pandas(GroupedMapInPandasTests.stats_with_no_column_names)
+        self._test_apply_in_pandas(GroupedApplyInPandasTests.stats_with_no_column_names)
 
     def test_apply_in_pandas_returning_column_names_sometimes(self):
         def stats(key, pdf):
             if key[0] % 2:
-                return GroupedMapInPandasTests.stats_with_column_names(key, pdf)
+                return GroupedApplyInPandasTests.stats_with_column_names(key, pdf)
             else:
-                return GroupedMapInPandasTests.stats_with_no_column_names(key, pdf)
+                return GroupedApplyInPandasTests.stats_with_no_column_names(key, pdf)
 
         self._test_apply_in_pandas(stats)
 
@@ -681,6 +681,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             df.groupby("group", window("ts", "5 days"))
             .applyInPandas(f, df.schema)
             .select("id", "result")
+            .orderBy("id")
             .collect()
         )
         for r in result:
@@ -746,6 +747,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             df.groupby("group", window("ts", "5 days"))
             .applyInPandas(f, df.schema)
             .select("id", "result")
+            .orderBy("id")
             .collect()
         )
 
@@ -781,7 +783,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
 
         def stats(key, pdf):
             if key[0] % 2 == 0:
-                return GroupedMapInPandasTests.stats_with_no_column_names(key, pdf)
+                return GroupedApplyInPandasTests.stats_with_no_column_names(key, pdf)
             return empty_df
 
         result = (

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -74,11 +74,10 @@ if have_pyarrow:
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
 )
 class GroupedMapInPandasTests(ReusedSQLTestCase):
-    @classmethod
     @property
-    def data(cls):
+    def data(self):
         return (
-            cls.spark.range(10)
+            self.spark.range(10)
             .toDF("id")
             .withColumn("vs", array([lit(i) for i in range(20, 30)]))
             .withColumn("v", explode(col("vs")))
@@ -750,9 +749,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         )
         self.assertEqual(row.asDict(), Row(column=1, score=0.5).asDict())
 
-    @classmethod
-    def _test_apply_in_pandas(cls, f):
-        df = cls.data
+    def _test_apply_in_pandas(self, f):
+        df = self.data
 
         result = (
             df.groupby("id")

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -269,98 +269,121 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         expected = expected.assign(norm=expected.norm.astype("float64"))
         assert_frame_equal(expected, result)
 
-    def test_apply_in_pandas_not_returning_pandas_dataframe(self):
+    def _do_test_apply_in_pandas(self, f):
         df = self.data
-
-        def stats(key, _):
-            return key
-
-        with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                PythonException,
-                "Return type of the user-defined function should be pandas.DataFrame, "
-                "but is <class 'tuple'>",
-            ):
-                df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
-
-    def test_apply_in_pandas_returning_wrong_number_of_columns(self):
-        df = self.data
-
-        def stats(key, pdf):
-            v = pdf.v
-            # returning three columns
-            res = pd.DataFrame([key + (v.mean(), v.std())])
-            return res
-
-        with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                PythonException,
-                "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema. Expected: 2 Actual: 3",
-            ):
-                # stats returns three columns while here we set schema with two columns
-                df.groupby("id").applyInPandas(stats, schema="id integer, m double").collect()
-
-    def test_apply_in_pandas_returning_wrong_columns(self):
-        df = self.data
-
-        def stats(key, pdf):
-            v = pdf.v
-            # returning three columns
-            res = pd.DataFrame([key + (v.mean(), v.std())])
-            return res
-
-        with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                PythonException,
-                "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema. Expected: 2 Actual: 3",
-            ):
-                # stats returns three columns while here we set schema with two columns
-                df.groupby("id").applyInPandas(stats, schema="id integer, m double, n string").collect()
-
-    def test_apply_in_pandas_returning_empty_dataframe(self):
-        df = self.data
-
-        def odd_means(key, pdf):
-            if key[0] % 2 == 0:
-                return pd.DataFrame([])
-            else:
-                return pd.DataFrame([key + (pdf.v.mean(),)])
-
-        expected_ids = {row[0] for row in self.data.collect() if row[0] % 2 != 0}
 
         result = (
             df.groupby("id")
-            .applyInPandas(odd_means, schema="id integer, m double")
-            .sort("id", "m")
+            .applyInPandas(f, schema="id integer, mean double")
+            .sort("id", "mean")
+            .collect()
+        )
+        expected = df.select("id").distinct().withColumn("mean", lit(24.5)).collect()
+
+        self.assertEqual(expected, result)
+
+    def test_apply_in_pandas_not_returning_pandas_dataframe(self):
+        with QuietTest(self.sc):
+            with self.assertRaisesRegex(
+                    PythonException,
+                    "Return type of the user-defined function should be pandas.DataFrame, "
+                    "but is <class 'tuple'>",
+            ):
+                self._do_test_apply_in_pandas(lambda key, pdf: key)
+
+    @staticmethod
+    def stats_with_column_names(key, pdf):
+        # order of column can be different to applyInPandas schema when column names are given
+        return pd.DataFrame([(pdf.v.mean(), ) + key], columns=["mean", "id"])
+
+    @staticmethod
+    def stats_with_no_column_names(key, pdf):
+        # columns must be in order of applyInPandas schema when no columns given
+        return pd.DataFrame([key + (pdf.v.mean(), )])
+
+    def test_apply_in_pandas_returning_column_names(self):
+        self._do_test_apply_in_pandas(GroupedMapInPandasTests.stats_with_column_names)
+
+    def test_apply_in_pandas_returning_no_column_names(self):
+        self._do_test_apply_in_pandas(GroupedMapInPandasTests.stats_with_no_column_names)
+
+    def test_apply_in_pandas_returning_column_names_sometimes(self):
+        def stats(key, pdf):
+            if key[0] % 2:
+                return GroupedMapInPandasTests.stats_with_column_names(key, pdf)
+            else:
+                return GroupedMapInPandasTests.stats_with_no_column_names(key, pdf)
+
+        self._do_test_apply_in_pandas(stats)
+
+    def test_apply_in_pandas_returning_wrong_column_names(self):
+        with QuietTest(self.sc):
+            with self.assertRaisesRegex(
+                PythonException,
+                "Column names of the returned pandas.DataFrame do not match specified schema. "
+                "Missing: mean Unexpected: median, std",
+            ):
+                self._do_test_apply_in_pandas(
+                    lambda key, pdf: pd.DataFrame([key + (pdf.v.median(), pdf.v.std())],
+                                                  columns=["id", "median", "std"]))
+
+    def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
+        with QuietTest(self.sc):
+            with self.assertRaisesRegex(
+                    PythonException,
+                    "Number of columns of the returned pandas.DataFrame doesn't match "
+                    "specified schema. Expected: 2 Actual: 3",
+            ):
+                self._do_test_apply_in_pandas(
+                    lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())]))
+
+    def _do_test_apply_in_pandas_returning_empty_dataframe(self, empty_df):
+        """ Tests some returned DataFrames are empty. """
+        df = self.data
+
+        def stats(key, pdf):
+            if key[0] % 2 == 0:
+                return GroupedMapInPandasTests.stats_with_no_column_names(key, pdf)
+            return empty_df
+
+        result = (
+            df.groupby("id")
+            .applyInPandas(stats, schema="id integer, mean double")
+            .sort("id", "mean")
             .collect()
         )
 
         actual_ids = {row[0] for row in result}
+        expected_ids = {row[0] for row in self.data.collect() if row[0] % 2 == 0}
         self.assertSetEqual(expected_ids, actual_ids)
-
         self.assertEqual(len(expected_ids), len(result))
         for row in result:
             self.assertEqual(24.5, row[1])
 
-    def test_apply_in_pandas_returning_empty_dataframe_and_wrong_number_of_columns(self):
-        df = self.data
-
-        def odd_means(key, pdf):
-            if key[0] % 2 == 0:
-                return pd.DataFrame([], columns=["id"])
-            else:
-                return pd.DataFrame([key + (pdf.v.mean(),)])
-
+    def _do_test_apply_in_pandas_returning_empty_dataframe_error(self, empty_df, error):
         with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                PythonException,
-                "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema. Expected: 2 Actual: 1",
-            ):
-                # stats returns one column for even keys while here we set schema with two columns
-                df.groupby("id").applyInPandas(odd_means, schema="id integer, m double").collect()
+            with self.assertRaisesRegex(PythonException, error):
+                self._do_test_apply_in_pandas_returning_empty_dataframe(empty_df)
+
+    def test_apply_in_pandas_returning_empty_dataframe_with_column_names(self):
+        self._do_test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame(columns=["mean", "id"]))
+
+    def test_apply_in_pandas_returning_empty_dataframe_with_wrong_column_names(self):
+        self._do_test_apply_in_pandas_returning_empty_dataframe_error(
+            pd.DataFrame(columns=["id", "median", "std"]),
+            "Column names of the returned pandas.DataFrame "
+            "do not match specified schema. Missing: mean Unexpected: median, std"
+        )
+
+    def test_apply_in_pandas_returning_empty_dataframe_without_column_names(self):
+        self._do_test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame())
+
+    def test_apply_in_pandas_returning_empty_dataframe_without_column_names_and_wrong_amount(self):
+        self._do_test_apply_in_pandas_returning_empty_dataframe_error(
+            pd.DataFrame(columns=[0, 1, 2]),
+            "Number of columns of the returned pandas.DataFrame "
+            "doesn't match specified schema. Expected: 2 Actual: 3"
+        )
 
     def test_datatype_string(self):
         df = self.data
@@ -584,7 +607,10 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
 
         with self.sql_conf({"spark.sql.execution.pandas.convertToArrowArraySafely": False}):
             with QuietTest(self.sc):
-                with self.assertRaisesRegex(Exception, "KeyError: 'id'"):
+                with self.assertRaisesRegex(
+                        PythonException,
+                        "RuntimeError: Column names of the returned pandas.DataFrame do not match "
+                        "specified schema. Missing: id Unexpected: iid"):
                     grouped_df.apply(column_name_typo).collect()
                 with self.assertRaisesRegex(Exception, "[D|d]ecimal.*got.*date"):
                     grouped_df.apply(invalid_positional_types).collect()

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -328,10 +328,11 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                     lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
                 )
 
+    def test_apply_in_pandas_returning_empty_dataframe_without_columns(self):
+        self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame())
+
     def test_apply_in_pandas_returning_empty_dataframe_with_column_names(self):
-        self._test_apply_in_pandas_returning_empty_dataframe(
-            pd.DataFrame(columns=["mean", "id"])
-        )
+        self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame(columns=["mean", "id"]))
 
     def test_apply_in_pandas_returning_empty_dataframe_with_wrong_column_names(self):
         self._test_apply_in_pandas_returning_empty_dataframe_error(
@@ -340,10 +341,10 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             "do not match specified schema. Missing: mean Unexpected: median, std",
         )
 
-    def test_apply_in_pandas_returning_empty_dataframe_without_column_names(self):
-        self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame())
+    def test_apply_in_pandas_returning_empty_dataframe_with_no_column_names(self):
+        self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame(columns=[0, 1]))
 
-    def test_apply_in_pandas_returning_empty_dataframe_without_column_names_and_wrong_amount(self):
+    def test_apply_in_pandas_returning_empty_dataframe_with_no_column_names_and_wrong_amount(self):
         self._test_apply_in_pandas_returning_empty_dataframe_error(
             pd.DataFrame(columns=[0, 1, 2]),
             "Number of columns of the returned pandas.DataFrame "
@@ -774,9 +775,9 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
 
         result = (
             df.groupby("id")
-                .applyInPandas(stats, schema="id long, mean double")
-                .sort("id", "mean")
-                .collect()
+            .applyInPandas(stats, schema="id long, mean double")
+            .sort("id", "mean")
+            .collect()
         )
 
         actual_ids = {row[0] for row in result}

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -307,8 +307,8 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 PythonException,
-                "Column names of the returned pandas.DataFrame do not match specified schema. "
-                "Missing: mean Unexpected: median, std Schema: id, mean\n",
+                "Column names of the returned pandas.DataFrame do not match specified schema.  "
+                "Missing: mean  Unexpected: median, std  Schema: id, mean\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame(
@@ -321,7 +321,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             with self.assertRaisesRegex(
                 PythonException,
                 "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema. Expected: 2 Actual: 3 Schema: id, mean\n",
+                "specified schema.  Expected: 2  Actual: 3  Schema: id, mean\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
@@ -555,7 +555,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 with self.assertRaisesRegex(
                     PythonException,
                     "RuntimeError: Column names of the returned pandas.DataFrame do not match "
-                    "specified schema. Missing: id Unexpected: iid Schema: id, v\n",
+                    "specified schema.  Missing: id  Unexpected: iid  Schema: id, v\n",
                 ):
                     grouped_df.apply(column_name_typo).collect()
                 with self.assertRaisesRegex(Exception, "[D|d]ecimal.*got.*date"):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -308,7 +308,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             with self.assertRaisesRegex(
                 PythonException,
                 "Column names of the returned pandas.DataFrame do not match specified schema. "
-                "Missing: mean Unexpected: median, std",
+                "Missing: mean Unexpected: median, std Schema: id, mean\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame(
@@ -321,7 +321,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
             with self.assertRaisesRegex(
                 PythonException,
                 "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema. Expected: 2 Actual: 3",
+                "specified schema. Expected: 2 Actual: 3 Schema: id, mean\n",
             ):
                 self._test_apply_in_pandas(
                     lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
@@ -555,7 +555,7 @@ class GroupedMapInPandasTests(ReusedSQLTestCase):
                 with self.assertRaisesRegex(
                     PythonException,
                     "RuntimeError: Column names of the returned pandas.DataFrame do not match "
-                    "specified schema. Missing: id Unexpected: iid",
+                    "specified schema. Missing: id Unexpected: iid Schema: id, v\n",
                 ):
                     grouped_df.apply(column_name_typo).collect()
                 with self.assertRaisesRegex(Exception, "[D|d]ecimal.*got.*date"):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map_with_state.py
@@ -53,7 +53,7 @@ if have_pyarrow:
     not have_pandas or not have_pyarrow,
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
 )
-class GroupedMapInPandasWithStateTests(ReusedSQLTestCase):
+class GroupedApplyInPandasWithStateTests(ReusedSQLTestCase):
     @classmethod
     def conf(cls):
         cfg = SparkConf()

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -472,7 +472,10 @@ class ArrowTests(ReusedSQLTestCase):
                 exception = context.exception
                 self.assertTrue(hasattr(exception, "args"))
                 self.assertEqual(len(exception.args), 1)
-                self.assertRegex(exception.args[0], "with name 'decimal128\\(38, 18\\)'")
+                self.assertRegex(
+                    exception.args[0],
+                    "with name '7_date_t' " "to Arrow Array \\(decimal128\\(38, 18\\)\\)",
+                )
 
                 # the inner exception provides us with the incorrect types
                 exception = exception.__context__

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -465,8 +465,20 @@ class ArrowTests(ReusedSQLTestCase):
         wrong_schema = StructType(fields)
         with self.sql_conf({"spark.sql.execution.pandas.convertToArrowArraySafely": False}):
             with QuietTest(self.sc):
-                with self.assertRaisesRegex(Exception, "[D|d]ecimal.*got.*date"):
+                with self.assertRaises(Exception) as context:
                     self.spark.createDataFrame(pdf, schema=wrong_schema)
+
+                # the exception provides us with the column that is incorrect
+                exception = context.exception
+                self.assertTrue(hasattr(exception, "args"))
+                self.assertEqual(len(exception.args), 1)
+                self.assertRegex(exception.args[0], "with name 'decimal128\\(38, 18\\)'")
+
+                # the inner exception provides us with the incorrect types
+                exception = exception.__context__
+                self.assertTrue(hasattr(exception, "args"))
+                self.assertEqual(len(exception.args), 1)
+                self.assertRegex(exception.args[0], "[D|d]ecimal.*got.*date")
 
     def test_createDataFrame_with_names(self):
         pdf = self.create_pandas_data_frame()

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -171,9 +171,9 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
             extra = sorted(list(column_names.difference(field_names)))
             raise RuntimeError(
                 "Column names of the returned pandas.DataFrame do not match specified schema."
-                "{}{} Schema: {}".format(
-                    (" Missing: " + (", ".join(missing))) if missing else "",
-                    (" Unexpected: " + (", ".join(extra))) if extra else "",
+                "{}{}  Schema: {}".format(
+                    ("  Missing: " + (", ".join(missing))) if missing else "",
+                    ("  Unexpected: " + (", ".join(extra))) if extra else "",
                     ", ".join(field.name for field in return_type.fields),
                 )
             )
@@ -181,8 +181,8 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
         elif len(result.columns) != len(return_type):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
-                "doesn't match specified schema. "
-                "Expected: {} Actual: {} Schema: {}".format(
+                "doesn't match specified schema.  "
+                "Expected: {}  Actual: {}  Schema: {}".format(
                     len(return_type),
                     len(result.columns),
                     ", ".join(field.name for field in return_type.fields),

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -167,49 +167,22 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
             and any(isinstance(name, str) for name in result.columns)
             and column_names != field_names
         ):
-            limit = 5
-
-            # limit missing columns to at most $limit
             missing = sorted(list(field_names.difference(column_names)))
-            if len(missing) > limit:
-                missing = f"  Missing (first {limit} of {len(missing)}): " + ", ".join(
-                    missing[:limit]
-                )
-            elif missing:
-                missing = "  Missing: " + (", ".join(missing))
-            else:
-                missing = ""
+            missing = ("  Missing: " + (", ".join(missing))) if missing else ""
 
-            # limit unexpected columns to at most $limit
             extra = sorted(list(column_names.difference(field_names)))
-            if len(extra) > limit:
-                extra = f"  Unexpected (first {limit} of {len(extra)}): " + ", ".join(extra[:limit])
-            elif extra:
-                extra = "  Unexpected: " + (", ".join(extra))
-            else:
-                extra = ""
-
-            # limit schema in error message to 1024 characters, insert ... in the middle
-            schema = ", ".join(field.name for field in return_type.fields)
-            if len(schema) > 1024:
-                schema = schema[:510] + "..." + schema[-511:]
+            extra = ("  Unexpected: " + (", ".join(extra))) if extra else ""
 
             raise RuntimeError(
                 "Column names of the returned pandas.DataFrame do not match specified schema."
-                "{}{}  Schema: {}".format(missing, extra, schema)
+                "{}{}".format(missing, extra)
             )
         # otherwise the number of columns of result have to match the return type
         elif len(result.columns) != len(return_type):
-            schema = ", ".join(field.name for field in return_type.fields)
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema.  "
-                "Expected: {}  Actual: {}  Schema: {}".format(
-                    len(return_type),
-                    len(result.columns),
-                    # limit schema in error message to 1024 characters, insert ... in the middle
-                    schema if len(schema) <= 1024 else schema[:510] + "..." + schema[-511:],
-                )
+                "Expected: {}  Actual: {}".format(len(return_type), len(result.columns))
             )
 
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -179,7 +179,7 @@ def wrap_cogrouped_map_pandas_udf(f, return_type, argspec):
     return lambda kl, vl, kr, vr: [(wrapped(kl, vl, kr, vr), to_arrow_type(return_type))]
 
 
-def wrap_grouped_map_pandas_udf(f, return_type, argspec):
+def wrap_grouped_map_pandas_udf(f, return_type, argspec, runner_conf):
     def wrapped(key_series, value_series):
         import pandas as pd
 
@@ -194,16 +194,36 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec):
                 "Return type of the user-defined function should be "
                 "pandas.DataFrame, but is {}".format(type(result))
             )
-        # the number of columns of result have to match the return type
-        # but it is fine for result to have no columns at all if it is empty
-        if not (
-            len(result.columns) == len(return_type) or len(result.columns) == 0 and result.empty
-        ):
-            raise RuntimeError(
-                "Number of columns of the returned pandas.DataFrame "
-                "doesn't match specified schema. "
-                "Expected: {} Actual: {}".format(len(return_type), len(result.columns))
-            )
+
+        # check the schema of the result only if it is not empty or has columns
+        if not result.empty or len(result.columns) != 0:
+            # if any column name of the result is a string
+            # the column names of the result have to match the return type
+            #   see create_array in pyspark.sql.pandas.serializers.ArrowStreamPandasSerializer
+            field_names = set([field.name for field in return_type.fields])
+            column_names = set(result.columns)
+            if (
+                assign_cols_by_name(runner_conf)
+                and any(isinstance(name, str) for name in result.columns)
+                and column_names != field_names
+            ):
+                missing = sorted(list(field_names.difference(column_names)))
+                extra = sorted(list(column_names.difference(field_names)))
+                raise RuntimeError(
+                    "Column names of the returned pandas.DataFrame do not match specified schema."
+                    "{}{}".format(
+                        (" Missing: " + (", ".join(missing))) if missing else "",
+                        (" Unexpected: " + (", ".join(extra))) if extra else "",
+                    )
+                )
+            # otherwise the number of columns of result have to match the return type
+            elif len(result.columns) != len(return_type):
+                raise RuntimeError(
+                    "Number of columns of the returned pandas.DataFrame "
+                    "doesn't match specified schema. "
+                    "Expected: {} Actual: {}".format(len(return_type), len(result.columns))
+                )
+
         return result
 
     return lambda k, v: [(wrapped(k, v), to_arrow_type(return_type))]
@@ -396,7 +416,7 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
         return arg_offsets, wrap_batch_iter_udf(func, return_type)
     elif eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
         argspec = getfullargspec(chained_func)  # signature was lost when wrapping it
-        return arg_offsets, wrap_grouped_map_pandas_udf(func, return_type, argspec)
+        return arg_offsets, wrap_grouped_map_pandas_udf(func, return_type, argspec, runner_conf)
     elif eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE:
         return arg_offsets, wrap_grouped_map_pandas_udf_with_state(func, return_type)
     elif eval_type == PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF:
@@ -410,6 +430,16 @@ def read_single_udf(pickleSer, infile, eval_type, runner_conf, udf_index):
         return arg_offsets, wrap_udf(func, return_type)
     else:
         raise ValueError("Unknown eval type: {}".format(eval_type))
+
+
+# Used by SQL_GROUPED_MAP_PANDAS_UDF and SQL_SCALAR_PANDAS_UDF when returning StructType
+def assign_cols_by_name(runner_conf):
+    return (
+        runner_conf.get(
+            "spark.sql.legacy.execution.pandas.groupedMap.assignColumnsByName", "true"
+        ).lower()
+        == "true"
+    )
 
 
 def read_udfs(pickleSer, infile, eval_type):
@@ -444,16 +474,9 @@ def read_udfs(pickleSer, infile, eval_type):
             runner_conf.get("spark.sql.execution.pandas.convertToArrowArraySafely", "false").lower()
             == "true"
         )
-        # Used by SQL_GROUPED_MAP_PANDAS_UDF and SQL_SCALAR_PANDAS_UDF when returning StructType
-        assign_cols_by_name = (
-            runner_conf.get(
-                "spark.sql.legacy.execution.pandas.groupedMap.assignColumnsByName", "true"
-            ).lower()
-            == "true"
-        )
 
         if eval_type == PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF:
-            ser = CogroupUDFSerializer(timezone, safecheck, assign_cols_by_name)
+            ser = CogroupUDFSerializer(timezone, safecheck, assign_cols_by_name(runner_conf))
         elif eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE:
             arrow_max_records_per_batch = runner_conf.get(
                 "spark.sql.execution.arrow.maxRecordsPerBatch", 10000
@@ -463,7 +486,7 @@ def read_udfs(pickleSer, infile, eval_type):
             ser = ApplyInPandasWithStateSerializer(
                 timezone,
                 safecheck,
-                assign_cols_by_name,
+                assign_cols_by_name(runner_conf),
                 state_object_schema,
                 arrow_max_records_per_batch,
             )
@@ -478,7 +501,7 @@ def read_udfs(pickleSer, infile, eval_type):
                 or eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
             )
             ser = ArrowStreamPandasUDFSerializer(
-                timezone, safecheck, assign_cols_by_name, df_for_struct
+                timezone, safecheck, assign_cols_by_name(runner_conf), df_for_struct
             )
     else:
         ser = BatchedSerializer(CPickleSerializer(), 100)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -167,25 +167,48 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
             and any(isinstance(name, str) for name in result.columns)
             and column_names != field_names
         ):
+            limit = 5
+
+            # limit missing columns to at most $limit
             missing = sorted(list(field_names.difference(column_names)))
+            if len(missing) > limit:
+                missing = f"  Missing (first {limit} of {len(missing)}): " + ", ".join(
+                    missing[:limit]
+                )
+            elif missing:
+                missing = "  Missing: " + (", ".join(missing))
+            else:
+                missing = ""
+
+            # limit unexpected columns to at most $limit
             extra = sorted(list(column_names.difference(field_names)))
+            if len(extra) > limit:
+                extra = f"  Unexpected (first {limit} of {len(extra)}): " + ", ".join(extra[:limit])
+            elif extra:
+                extra = "  Unexpected: " + (", ".join(extra))
+            else:
+                extra = ""
+
+            # limit schema in error message to 1024 characters, insert ... in the middle
+            schema = ", ".join(field.name for field in return_type.fields)
+            if len(schema) > 1024:
+                schema = schema[:510] + "..." + schema[-511:]
+
             raise RuntimeError(
                 "Column names of the returned pandas.DataFrame do not match specified schema."
-                "{}{}  Schema: {}".format(
-                    ("  Missing: " + (", ".join(missing))) if missing else "",
-                    ("  Unexpected: " + (", ".join(extra))) if extra else "",
-                    ", ".join(field.name for field in return_type.fields),
-                )
+                "{}{}  Schema: {}".format(missing, extra, schema)
             )
         # otherwise the number of columns of result have to match the return type
         elif len(result.columns) != len(return_type):
+            schema = ", ".join(field.name for field in return_type.fields)
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema.  "
                 "Expected: {}  Actual: {}  Schema: {}".format(
                     len(return_type),
                     len(result.columns),
-                    ", ".join(field.name for field in return_type.fields),
+                    # limit schema in error message to 1024 characters, insert ... in the middle
+                    schema if len(schema) <= 1024 else schema[:510] + "..." + schema[-511:],
                 )
             )
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -171,9 +171,10 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
             extra = sorted(list(column_names.difference(field_names)))
             raise RuntimeError(
                 "Column names of the returned pandas.DataFrame do not match specified schema."
-                "{}{}".format(
+                "{}{} Schema: {}".format(
                     (" Missing: " + (", ".join(missing))) if missing else "",
                     (" Unexpected: " + (", ".join(extra))) if extra else "",
+                    ", ".join(field.name for field in return_type.fields),
                 )
             )
         # otherwise the number of columns of result have to match the return type
@@ -181,7 +182,11 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
                 "doesn't match specified schema. "
-                "Expected: {} Actual: {}".format(len(return_type), len(result.columns))
+                "Expected: {} Actual: {} Schema: {}".format(
+                    len(return_type),
+                    len(result.columns),
+                    ", ".join(field.name for field in return_type.fields),
+                )
             )
 
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -168,10 +168,10 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
             and column_names != field_names
         ):
             missing = sorted(list(field_names.difference(column_names)))
-            missing = ("  Missing: " + (", ".join(missing))) if missing else ""
+            missing = f" Missing: {', '.join(missing)}." if missing else ""
 
             extra = sorted(list(column_names.difference(field_names)))
-            extra = ("  Unexpected: " + (", ".join(extra))) if extra else ""
+            extra = f" Unexpected: {', '.join(extra)}." if extra else ""
 
             raise RuntimeError(
                 "Column names of the returned pandas.DataFrame do not match specified schema."
@@ -181,8 +181,8 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
         elif len(result.columns) != len(return_type):
             raise RuntimeError(
                 "Number of columns of the returned pandas.DataFrame "
-                "doesn't match specified schema.  "
-                "Expected: {}  Actual: {}".format(len(return_type), len(result.columns))
+                "doesn't match specified schema. "
+                "Expected: {} Actual: {}".format(len(return_type), len(result.columns))
             )
 
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -214,6 +214,8 @@ def verify_pandas_result(result, return_type, assign_cols_by_name):
 
 
 def wrap_cogrouped_map_pandas_udf(f, return_type, argspec, runner_conf):
+    _assign_cols_by_name = assign_cols_by_name(runner_conf)
+
     def wrapped(left_key_series, left_value_series, right_key_series, right_value_series):
         import pandas as pd
 
@@ -226,13 +228,16 @@ def wrap_cogrouped_map_pandas_udf(f, return_type, argspec, runner_conf):
             key_series = left_key_series if not left_df.empty else right_key_series
             key = tuple(s[0] for s in key_series)
             result = f(key, left_df, right_df)
-        verify_pandas_result(result, return_type, assign_cols_by_name(runner_conf))
+        verify_pandas_result(result, return_type, _assign_cols_by_name)
+
         return result
 
     return lambda kl, vl, kr, vr: [(wrapped(kl, vl, kr, vr), to_arrow_type(return_type))]
 
 
 def wrap_grouped_map_pandas_udf(f, return_type, argspec, runner_conf):
+    _assign_cols_by_name = assign_cols_by_name(runner_conf)
+
     def wrapped(key_series, value_series):
         import pandas as pd
 
@@ -241,7 +246,8 @@ def wrap_grouped_map_pandas_udf(f, return_type, argspec, runner_conf):
         elif len(argspec.args) == 2:
             key = tuple(s[0] for s in key_series)
             result = f(key, pd.concat(value_series, axis=1))
-        verify_pandas_result(result, return_type, assign_cols_by_name(runner_conf))
+        verify_pandas_result(result, return_type, _assign_cols_by_name)
+
         return result
 
     return lambda k, v: [(wrapped(k, v), to_arrow_type(return_type))]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the error messages when a Python method provided to `DataFrame.groupby(...).applyInPandas` / `DataFrame.groupby(...).cogroup(...).applyInPandas` returns a Pandas DataFrame that does not match the expected schema.

With
```Python
gdf = spark.range(2).join(spark.range(3).withColumnRenamed("id", "val")).groupby("id")
```

**Mismatching column names, matching number of columns:**
```Python
gdf.applyInPandas(lambda pdf: pdf.rename(columns={"val": "v"}), "id long, val long").show()
# was: KeyError: 'val'
# now: RuntimeError: Column names of the returned pandas.DataFrame do not match specified schema.
#      Missing: val  Unexpected: v
```

**Mismatching column names, different number of columns:**
```Python
gdf.applyInPandas(lambda pdf: pdf.assign(foo=[3, 3, 3]).rename(columns={"val": "v"}), "id long, val long").show()
# was: RuntimeError: Number of columns of the returned pandas.DataFrame doesn't match specified schema.
#      Expected: 2 Actual: 3
# now: RuntimeError: Column names of the returned pandas.DataFrame do not match specified schema.
#      Missing: val  Unexpected: foo, v
```

**Expected schema matches but has duplicates (`id`) so that number of columns match:**
```Python
gdf.applyInPandas(lambda pdf: pdf.rename(columns={"val": "v"}), "id long, id long").show()
# was: java.lang.IllegalArgumentException: not all nodes and buffers were consumed.
#      nodes: [ArrowFieldNode [length=3, nullCount=0]]
#      buffers: [ArrowBuf[304], address:139860828549160, length:0, ArrowBuf[305], address:139860828549160, length:24]
# now: RuntimeError: Column names of the returned pandas.DataFrame do not match specified schema.
#      Unexpected: v 
```

**In case the returned Pandas DataFrame contains no column names (none of the column labels is a string):**
```Python
gdf.applyInPandas(lambda pdf: pdf.assign(foo=[3, 3, 3]).rename(columns={"id": 0, "val": 1, "foo": 2}), "id long, val long").show()
# was: RuntimeError: Number of columns of the returned pandas.DataFrame doesn't match specified schema.
#      Expected: 2 Actual: 3
# now: RuntimeError: Number of columns of the returned pandas.DataFrame doesn't match specified schema.
#      Expected: 2  Actual: 3
```

**Mismatching types (ValueError and TypeError):**
```Python
gdf.applyInPandas(lambda pdf: pdf, "id int, val string").show()
# was: pyarrow.lib.ArrowTypeError: Expected a string or bytes dtype, got int64
# now: pyarrow.lib.ArrowTypeError: Expected a string or bytes dtype, got int64
#      The above exception was the direct cause of the following exception:
#      TypeError: Exception thrown when converting pandas.Series (int64) with name 'val' to Arrow Array (string).


gdf.applyInPandas(lambda pdf: pdf.assign(val=pdf["val"].apply(str)), "id int, val double").show()
# was: pyarrow.lib.ArrowInvalid: Could not convert '0' with type str: tried to convert to double
# now: pyarrow.lib.ArrowInvalid: Could not convert '0' with type str: tried to convert to double
#      The above exception was the direct cause of the following exception:
#      ValueError: Exception thrown when converting pandas.Series (object) with name 'val' to Arrow Array (double).

with self.sql_conf({"spark.sql.execution.pandas.convertToArrowArraySafely": True}):
  gdf.applyInPandas(lambda pdf: pdf.assign(val=pdf["val"].apply(str)), "id int, val double").show()
# was: ValueError: Exception thrown when converting pandas.Series (object) to Arrow Array (double).
#      It can be caused by overflows or other unsafe conversions warned by Arrow. Arrow safe type check can be disabled
#      by using SQL config `spark.sql.execution.pandas.convertToArrowArraySafely`.
# now: ValueError: Exception thrown when converting pandas.Series (object) with name 'val' to Arrow Array (double).
#      It can be caused by overflows or other unsafe conversions warned by Arrow. Arrow safe type check can be disabled
#      by using SQL config `spark.sql.execution.pandas.convertToArrowArraySafely`.
```

### Why are the changes needed?
Existing errors are generic (`KeyError`) or meaningless (`not all nodes and buffers were consumed`). The errors should help users in spotting the mismatching columns by naming them.

The schema of the returned Pandas DataFrames can only be checked during processing the DataFrame, so such errors are very expensive. Therefore, they should be expressive.

### Does this PR introduce _any_ user-facing change?
This only changes error messages, not behaviour.

### How was this patch tested?
Tests all cases of schema mismatch for `GroupedData.applyInPandas` and `PandasCogroupedOps.applyInPandas`.