### PR TITLE
[SPARK-40616][SQL] Add a warning for insertion of DECIMAL values containing exponent

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2454,6 +2454,14 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
    * Create a double literal for number with an exponent, e.g. 1E-30
    */
   override def visitExponentLiteral(ctx: ExponentLiteralContext): Literal = {
+    val legacyExponentLiteralAsDecimal =
+      conf.getConf(SQLConf.LEGACY_EXPONENT_LITERAL_AS_DECIMAL_ENABLED)
+      if (!legacyExponentLiteralAsDecimal) {
+        logWarning(
+          "In Spark 3.0, numbers written in scientific notation would be parsed " +
+          "as Double. To restore the behavior before Spark 3.0, you can set " +
+          "spark.sql.legacy.exponentLiteralAsDecimal.enabled to true.")
+      }
     numericLiteral(ctx, ctx.getText, /* exponent values don't have a suffix */
       Double.MinValue, Double.MaxValue, DoubleType.simpleString)(_.toDouble)
   }


### PR DESCRIPTION
### **What changes were proposed in this pull request?**

Add a clear warning in spark SQL so that users are aware that a decimal containing an exponent will be converted to double, which may lead to a loss of precision.

The warning message: `In Spark 3.0, numbers written in scientific notation would be parsed as Double. To restore the behavior before Spark 3.0, you can set spark.sql.legacy.exponentLiteralAsDecimal.enabled to true.`

For example, when we want to insert `8.8888888888888888888e9` to a `DECIMAL(20,10)` column of a table, we will be able to see the following warning:

```sql
spark-sql> CREATE TABLE t(c0 DECIMAL(20,10));
spark-sql> INSERT INTO t VALUES (8.8888888888888888888e9);
22/10/07 15:36:04 WARN SparkSqlAstBuilder: In Spark 3.0, numbers written in scientific notation would be parsed as Double. To restore the behavior before Spark 3.0, you can set spark.sql.legacy.exponentLiteralAsDecimal.enabled to true.
spark-sql> select * from t;
8888888888.8888900000
```
The warning will not show up for DECIMAL values without exponent.

### **Why are the changes needed?**

Users may not be aware that numbers written in scientific notation (for example, `1E2`) would be parsed as Double during insertion. Adding a warning to let them be aware of potential precision loss and options of setting one configuration to restore the behavior before Spark 3.0.

### **Does this PR introduce any user-facing change?**

Yes, it adds a warning.

### **How was this patch tested?**
There are no new tests added. All existing tests pass. This change was tested by running the Spark SQL shell with decimal values with and without values containing exponent (For example, see "What changes were proposed in this pull request?
"). We are happy to also add a unit test if it is necessary.
