### PR TITLE
[SPARK-40781][CORE] Explain exit code 137 as killed due to OOM

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ExecutorExitCode.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorExitCode.scala
@@ -45,8 +45,8 @@ object ExecutorExitCode {
    */
   val HEARTBEAT_FAILURE = 56
 
-  /** Executor is killed due to out of memory issue */
-  val KILLED_DUE_TO_OOM = 137
+  /** Executor is killed by SIGKILL */
+  val KILLED_DUE_TO_SIGKILL = 137
 
   def explainExitCode(exitCode: Int): String = {
     exitCode match {
@@ -62,8 +62,8 @@ object ExecutorExitCode {
         "ExternalBlockStore failed to create a local temporary directory."
       case HEARTBEAT_FAILURE =>
         "Unable to send heartbeats to driver."
-      case KILLED_DUE_TO_OOM =>
-        "Killed due to out of memory."
+      case KILLED_DUE_TO_SIGKILL =>
+        "Killed due to SIGKILL. It might be caused by oom killer or other external processes."
       case _ =>
         "Unknown executor exit code (" + exitCode + ")" + (
           if (exitCode > 128) {

--- a/core/src/main/scala/org/apache/spark/executor/ExecutorExitCode.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorExitCode.scala
@@ -45,6 +45,9 @@ object ExecutorExitCode {
    */
   val HEARTBEAT_FAILURE = 56
 
+  /** Executor is killed due to out of memory issue */
+  val KILLED_DUE_TO_OOM = 137
+
   def explainExitCode(exitCode: Int): String = {
     exitCode match {
       case UNCAUGHT_EXCEPTION => "Uncaught exception"
@@ -59,6 +62,8 @@ object ExecutorExitCode {
         "ExternalBlockStore failed to create a local temporary directory."
       case HEARTBEAT_FAILURE =>
         "Unable to send heartbeats to driver."
+      case KILLED_DUE_TO_OOM =>
+        "Killed due to out of memory."
       case _ =>
         "Unknown executor exit code (" + exitCode + ")" + (
           if (exitCode > 128) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Explain exit code 137 as killed due to SIGKILL. This is used in `Yarn` and `Standalone` when creating ExecutorExited as loss reason. 

In `Standalone`, it's most likely caused by oom killer due to OOM. 
In  `Yarn`, it's caused by nodemanager due to memory issue. https://aws.amazon.com/premiumsupport/knowledge-center/container-killed-on-request-137-emr/#:~:text=When%20a%20container%20(Spark%20executor,in%20narrow%20and%20wide%20transformations.

### Why are the changes needed?
Reduce the efforts of users to search the meaning of exit code.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested.