### PR TITLE
[SPARK-40761][SQL] Migrate type check failures of percentile expressions onto error classes

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -168,6 +168,16 @@
           "The <functionName> accepts only arrays of pair structs, but <childExpr> is of <childType>."
         ]
       },
+      "MUST_BE_CONSTANT" : {
+        "message" : [
+          "The <exprName> must be a constant literal (current value = <currentValue>)"
+        ]
+      },
+      "MUST_NOT_NULL" : {
+        "message" : [
+          "The <exprName> must not be null"
+        ]
+      },
       "NON_FOLDABLE_INPUT" : {
         "message" : [
           "the input should be a foldable string expression and not null; however, got <inputExpr>."
@@ -231,6 +241,11 @@
       "UNSPECIFIED_FRAME" : {
         "message" : [
           "Cannot use an UnspecifiedFrame. This should have been converted during analysis."
+        ]
+      },
+      "VALUE_OUT_OF_RANGE" : {
+        "message" : [
+          "The <exprName> must be between <valueRange> (current value = <currentValue>)"
         ]
       },
       "WRONG_NUM_PARAMS" : {
@@ -950,45 +965,6 @@
       "2. use Java UDF APIs, e.g. `udf(new UDF1[String, Integer] { override def call(s: String): Integer = s.length() }, IntegerType)`, if input types are all non primitive",
       "3. set \"spark.sql.legacy.allowUntypedScalaUDF\" to \"true\" and use this API with caution"
     ]
-  },
-  "INVALID_PERCENTAGES" : {
-    "message" : [
-      "The percentage(s) "
-    ],
-    "subClass" : {
-      "MUST_NOT_NULL" : {
-        "message" : [
-          "must not be null"
-        ]
-      },
-      "MUST_CONSTANT" : {
-        "message" : [
-          "must be a constant literal (current value = <currentValue>)"
-        ]
-      },
-      "VALUE_OUT_OF_RANGE" : {
-        "message" : [
-          "must be between 0.0 and 1.0 (current value = <currentValue>)"
-        ]
-      }
-    }
-  },
-  "INVALID_ACCURACY" : {
-    "message" : [
-      "The accuracy "
-    ],
-    "subClass" : {
-      "MUST_CONSTANT" : {
-        "message" : [
-          "must be a constant literal (current value = <currentValue>)"
-        ]
-      },
-      "VALUE_OUT_OF_RANGE" : {
-        "message" : [
-          "must be a literal between (0, <maxValue>] (current value = <currentValue>)"
-        ]
-      }
-    }
   },
   "_LEGACY_ERROR_TEMP_0001" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -173,11 +173,6 @@
           "The <exprName> must be a constant literal (current value = <currentValue>)"
         ]
       },
-      "MUST_NOT_NULL" : {
-        "message" : [
-          "The <exprName> must not be null"
-        ]
-      },
       "NON_FOLDABLE_INPUT" : {
         "message" : [
           "the input should be a foldable string expression and not null; however, got <inputExpr>."
@@ -236,6 +231,11 @@
       "UNEXPECTED_INPUT_TYPE" : {
         "message" : [
           "parameter <paramIndex> requires <requiredType> type, however, <inputSql> is of <inputType> type."
+        ]
+      },
+      "UNEXPECTED_NULL" : {
+        "message" : [
+          "The <exprName> must not be null"
         ]
       },
       "UNSPECIFIED_FRAME" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -170,7 +170,7 @@
       },
       "NON_FOLDABLE_INPUT" : {
         "message" : [
-          "the <inputName> should be a foldable <inputType> expression and not null; however, got <inputExpr>."
+          "the input <inputName> should be a foldable <inputType> expression; however, got <inputExpr>."
         ]
       },
       "NON_STRING_TYPE" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -951,6 +951,45 @@
       "3. set \"spark.sql.legacy.allowUntypedScalaUDF\" to \"true\" and use this API with caution"
     ]
   },
+  "INVALID_PERCENTAGES" : {
+    "message" : [
+      "The percentage(s) "
+    ],
+    "subClass" : {
+      "MUST_NOT_NULL" : {
+        "message" : [
+          "must not be null"
+        ]
+      },
+      "MUST_CONSTANT" : {
+        "message" : [
+          "must be a constant literal (current value = <currentValue>)"
+        ]
+      },
+      "VALUE_OUT_OF_RANGE" : {
+        "message" : [
+          "must be between 0.0 and 1.0 (current value = <currentValue>)"
+        ]
+      }
+    }
+  },
+  "INVALID_ACCURACY" : {
+    "message" : [
+      "The accuracy "
+    ],
+    "subClass" : {
+      "MUST_CONSTANT" : {
+        "message" : [
+          "must be a constant literal (current value = <currentValue>)"
+        ]
+      },
+      "VALUE_OUT_OF_RANGE" : {
+        "message" : [
+          "must be a literal between (0, <maxValue>] (current value = <currentValue>)"
+        ]
+      }
+    }
+  },
   "_LEGACY_ERROR_TEMP_0001" : {
     "message" : [
       "Invalid InsertIntoContext"

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -168,14 +168,9 @@
           "The <functionName> accepts only arrays of pair structs, but <childExpr> is of <childType>."
         ]
       },
-      "MUST_BE_CONSTANT" : {
-        "message" : [
-          "The <exprName> must be a constant literal (current value = <currentValue>)"
-        ]
-      },
       "NON_FOLDABLE_INPUT" : {
         "message" : [
-          "the input should be a foldable string expression and not null; however, got <inputExpr>."
+          "the <inputName> should be a foldable <inputType> expression and not null; however, got <inputExpr>."
         ]
       },
       "NON_STRING_TYPE" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -120,18 +120,20 @@ case class ApproximatePercentile(
       defaultCheck
     } else if (!percentageExpression.foldable) {
       DataTypeMismatch(
-        errorSubClass = "MUST_BE_CONSTANT",
+        errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "exprName" -> "percentage(s)",
-          "currentValue" -> percentageExpression.toString
+          "inputName" -> "percentage(s)",
+          "inputType" -> "double",
+          "inputExpr" -> percentageExpression.toString
         )
       )
     } else if (!accuracyExpression.foldable) {
       DataTypeMismatch(
-        errorSubClass = "MUST_BE_CONSTANT",
+        errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "exprName" -> "accuracy",
-          "currentValue" -> accuracyExpression.toString
+          "inputName" -> "accuracy",
+          "inputType" -> "int",
+          "inputExpr" -> accuracyExpression.toString
         )
       )
     } else if (accuracy <= 0 || accuracy > Int.MaxValue) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -156,7 +156,7 @@ case class ApproximatePercentile(
         messageParameters = Map(
           "exprName" -> "percentage",
           "valueRange" -> "[0.0, 1.0]",
-          "currentValue" -> toSQLValue(percentages, DoubleType)
+          "currentValue" -> percentages.map(toSQLValue(_, DoubleType)).mkString(",")
         )
       )
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -120,29 +120,41 @@ case class ApproximatePercentile(
       defaultCheck
     } else if (!percentageExpression.foldable) {
       DataTypeMismatch(
-        errorSubClass = "INVALID_PERCENTAGES.MUST_CONSTANT",
-        messageParameters = Map("currentValue" -> percentageExpression.toString
+        errorSubClass = "MUST_BE_CONSTANT",
+        messageParameters = Map(
+          "exprName" -> "percentage(s)",
+          "currentValue" -> percentageExpression.toString
         )
       )
     } else if (!accuracyExpression.foldable) {
       DataTypeMismatch(
-        errorSubClass = "INVALID_ACCURACY.MUST_CONSTANT",
-        messageParameters = Map("currentValue" -> accuracyExpression.toString)
+        errorSubClass = "MUST_BE_CONSTANT",
+        messageParameters = Map(
+          "exprName" -> "accuracy",
+          "currentValue" -> accuracyExpression.toString
+        )
       )
     } else if (accuracy <= 0 || accuracy > Int.MaxValue) {
       DataTypeMismatch(
-        errorSubClass = "INVALID_ACCURACY.VALUE_OUT_OF_RANGE",
+        errorSubClass = "VALUE_OUT_OF_RANGE",
         messageParameters = Map(
-          "maxValue" -> Int.MaxValue.toString,
+          "exprName" -> "accuracy",
+          "valueRange" -> s"(0, ${Int.MaxValue}]",
           "currentValue" -> accuracy.toString
         )
       )
     } else if (percentages == null) {
-      DataTypeMismatch(errorSubClass = "INVALID_PERCENTAGES.MUST_NOT_NULL")
+      DataTypeMismatch(
+        errorSubClass = "MUST_NOT_NULL",
+        messageParameters = Map("exprName" -> "percentage(s)"))
     } else if (percentages.exists(percentage => percentage < 0.0D || percentage > 1.0D)) {
       DataTypeMismatch(
-        errorSubClass = "INVALID_PERCENTAGES.VALUE_OUT_OF_RANGE",
-        messageParameters = Map("currentValue" -> percentages.mkString(", "))
+        errorSubClass = "VALUE_OUT_OF_RANGE",
+        messageParameters = Map(
+          "exprName" -> "percentage(s)",
+          "valueRange" -> "[0.0, 1.0]",
+          "currentValue" -> percentages.mkString(", ")
+        )
       )
     } else {
       TypeCheckSuccess

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -143,7 +143,7 @@ case class ApproximatePercentile(
         messageParameters = Map(
           "exprName" -> "accuracy",
           "valueRange" -> s"(0, ${Int.MaxValue}]",
-          "currentValue" -> accuracy.toString
+          "currentValue" -> toSQLValue(accuracy)
         )
       )
     } else if (percentages == null) {
@@ -156,7 +156,7 @@ case class ApproximatePercentile(
         messageParameters = Map(
           "exprName" -> "percentage",
           "valueRange" -> "[0.0, 1.0]",
-          "currentValue" -> percentages.mkString(", ")
+          "currentValue" -> toSQLValue(percentages)
         )
       )
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -143,7 +143,7 @@ case class ApproximatePercentile(
         messageParameters = Map(
           "exprName" -> "accuracy",
           "valueRange" -> s"(0, ${Int.MaxValue}]",
-          "currentValue" -> toSQLValue(accuracy)
+          "currentValue" -> toSQLValue(accuracy, LongType)
         )
       )
     } else if (percentages == null) {
@@ -156,7 +156,7 @@ case class ApproximatePercentile(
         messageParameters = Map(
           "exprName" -> "percentage",
           "valueRange" -> "[0.0, 1.0]",
-          "currentValue" -> toSQLValue(percentages)
+          "currentValue" -> toSQLValue(percentages, DoubleType)
         )
       )
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -145,7 +145,7 @@ case class ApproximatePercentile(
       )
     } else if (percentages == null) {
       DataTypeMismatch(
-        errorSubClass = "MUST_NOT_NULL",
+        errorSubClass = "UNEXPECTED_NULL",
         messageParameters = Map("exprName" -> "percentage(s)"))
     } else if (percentages.exists(percentage => percentage < 0.0D || percentage > 1.0D)) {
       DataTypeMismatch(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -21,7 +21,7 @@ import java.util
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckFailure, TypeCheckSuccess}
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.{BinaryLike, TernaryLike, UnaryLike}
 import org.apache.spark.sql.catalyst.util._
@@ -84,14 +84,18 @@ abstract class PercentileBase
       defaultCheck
     } else if (!percentageExpression.foldable) {
       // percentageExpression must be foldable
-      TypeCheckFailure("The percentage(s) must be a constant literal, " +
-        s"but got $percentageExpression")
+      DataTypeMismatch(
+        errorSubClass = "INVALID_PERCENTAGES.MUST_CONSTANT",
+        messageParameters = Map("currentValue" -> percentageExpression.toString)
+      )
     } else if (percentages == null) {
-      TypeCheckFailure("Percentage value must not be null")
+      DataTypeMismatch(errorSubClass = "INVALID_PERCENTAGES.MUST_NOT_NULL")
     } else if (percentages.exists(percentage => percentage < 0.0 || percentage > 1.0)) {
       // percentages(s) must be in the range [0.0, 1.0]
-      TypeCheckFailure("Percentage(s) must be between 0.0 and 1.0, " +
-        s"but got $percentageExpression")
+      DataTypeMismatch(
+        errorSubClass = "INVALID_PERCENTAGES.VALUE_OUT_OF_RANGE",
+        messageParameters = Map("currentValue" -> percentageExpression.toString)
+      )
     } else {
       TypeCheckSuccess
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -92,7 +92,7 @@ abstract class PercentileBase
       )
     } else if (percentages == null) {
       DataTypeMismatch(
-        errorSubClass = "MUST_NOT_NULL",
+        errorSubClass = "UNEXPECTED_NULL",
         messageParameters = Map("exprName" -> "percentage(s)")
       )
     } else if (percentages.exists(percentage => percentage < 0.0 || percentage > 1.0)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -104,7 +104,7 @@ abstract class PercentileBase
         messageParameters = Map(
           "exprName" -> "percentage",
           "valueRange" -> "[0.0, 1.0]",
-          "currentValue" -> toSQLExpr(percentageExpression)
+          "currentValue" -> toSQLValue(percentageExpression)
         )
       )
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.trees.{BinaryLike, TernaryLike, UnaryLike}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -87,23 +88,23 @@ abstract class PercentileBase
       DataTypeMismatch(
         errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "inputName" -> "percentage(s)",
-          "inputType" -> "double",
-          "inputExpr" -> percentageExpression.toString)
+          "inputName" -> "percentage",
+          "inputType" -> toSQLType(percentageExpression.dataType),
+          "inputExpr" -> toSQLExpr(percentageExpression))
       )
     } else if (percentages == null) {
       DataTypeMismatch(
         errorSubClass = "UNEXPECTED_NULL",
-        messageParameters = Map("exprName" -> "percentage(s)")
+        messageParameters = Map("exprName" -> "percentage")
       )
     } else if (percentages.exists(percentage => percentage < 0.0 || percentage > 1.0)) {
       // percentages(s) must be in the range [0.0, 1.0]
       DataTypeMismatch(
         errorSubClass = "VALUE_OUT_OF_RANGE",
         messageParameters = Map(
-          "exprName" -> "percentage(s)",
+          "exprName" -> "percentage",
           "valueRange" -> "[0.0, 1.0]",
-          "currentValue" -> percentageExpression.toString
+          "currentValue" -> toSQLExpr(percentageExpression)
         )
       )
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -85,16 +85,25 @@ abstract class PercentileBase
     } else if (!percentageExpression.foldable) {
       // percentageExpression must be foldable
       DataTypeMismatch(
-        errorSubClass = "INVALID_PERCENTAGES.MUST_CONSTANT",
-        messageParameters = Map("currentValue" -> percentageExpression.toString)
+        errorSubClass = "MUST_BE_CONSTANT",
+        messageParameters = Map(
+          "exprName" -> "percentage(s)",
+          "currentValue" -> percentageExpression.toString)
       )
     } else if (percentages == null) {
-      DataTypeMismatch(errorSubClass = "INVALID_PERCENTAGES.MUST_NOT_NULL")
+      DataTypeMismatch(
+        errorSubClass = "MUST_NOT_NULL",
+        messageParameters = Map("exprName" -> "percentage(s)")
+      )
     } else if (percentages.exists(percentage => percentage < 0.0 || percentage > 1.0)) {
       // percentages(s) must be in the range [0.0, 1.0]
       DataTypeMismatch(
-        errorSubClass = "INVALID_PERCENTAGES.VALUE_OUT_OF_RANGE",
-        messageParameters = Map("currentValue" -> percentageExpression.toString)
+        errorSubClass = "VALUE_OUT_OF_RANGE",
+        messageParameters = Map(
+          "exprName" -> "percentage(s)",
+          "valueRange" -> "[0.0, 1.0]",
+          "currentValue" -> percentageExpression.toString
+        )
       )
     } else {
       TypeCheckSuccess

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -104,7 +104,7 @@ abstract class PercentileBase
         messageParameters = Map(
           "exprName" -> "percentage",
           "valueRange" -> "[0.0, 1.0]",
-          "currentValue" -> toSQLValue(percentageExpression)
+          "currentValue" -> toSQLValue(percentageExpression, DoubleType)
         )
       )
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -104,7 +104,7 @@ abstract class PercentileBase
         messageParameters = Map(
           "exprName" -> "percentage",
           "valueRange" -> "[0.0, 1.0]",
-          "currentValue" -> toSQLValue(percentageExpression, DoubleType)
+          "currentValue" -> percentages.map(toSQLValue(_, DoubleType)).mkString(",")
         )
       )
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -85,10 +85,11 @@ abstract class PercentileBase
     } else if (!percentageExpression.foldable) {
       // percentageExpression must be foldable
       DataTypeMismatch(
-        errorSubClass = "MUST_BE_CONSTANT",
+        errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "exprName" -> "percentage(s)",
-          "currentValue" -> percentageExpression.toString)
+          "inputName" -> "percentage(s)",
+          "inputType" -> "double",
+          "inputExpr" -> percentageExpression.toString)
       )
     } else if (percentages == null) {
       DataTypeMismatch(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -188,7 +188,10 @@ case class SchemaOfCsv(
     } else {
       DataTypeMismatch(
         errorSubClass = "NON_FOLDABLE_INPUT",
-        messageParameters = Map("inputExpr" -> toSQLExpr(child)))
+        messageParameters = Map(
+          "inputName" -> "input",
+          "inputType" -> "string",
+          "inputExpr" -> toSQLExpr(child)))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/csvExpressions.scala
@@ -185,13 +185,17 @@ case class SchemaOfCsv(
   override def checkInputDataTypes(): TypeCheckResult = {
     if (child.foldable && csv != null) {
       super.checkInputDataTypes()
-    } else {
+    } else if (!child.foldable) {
       DataTypeMismatch(
         errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "inputName" -> "input",
-          "inputType" -> "string",
+          "inputName" -> "csv",
+          "inputType" -> toSQLType(child.dataType),
           "inputExpr" -> toSQLExpr(child)))
+    } else {
+      DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_NULL",
+        messageParameters = Map("exprName" -> "csv"))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -797,7 +797,10 @@ case class SchemaOfJson(
     } else {
       DataTypeMismatch(
         errorSubClass = "NON_FOLDABLE_INPUT",
-        messageParameters = Map("inputExpr" -> toSQLExpr(child)))
+        messageParameters = Map(
+          "inputName" -> "input",
+          "inputType" -> "string",
+          "inputExpr" -> toSQLExpr(child)))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -794,13 +794,17 @@ case class SchemaOfJson(
   override def checkInputDataTypes(): TypeCheckResult = {
     if (child.foldable && json != null) {
       super.checkInputDataTypes()
-    } else {
+    } else if (!child.foldable) {
       DataTypeMismatch(
         errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "inputName" -> "input",
-          "inputType" -> "string",
+          "inputName" -> "json",
+          "inputType" -> toSQLType(child.dataType),
           "inputExpr" -> toSQLExpr(child)))
+    } else {
+      DataTypeMismatch(
+        errorSubClass = "UNEXPECTED_NULL",
+        messageParameters = Map("exprName" -> "json"))
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -221,10 +221,11 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assertEqual(
       wrongAccuracy.checkInputDataTypes(),
       DataTypeMismatch(
-        errorSubClass = "MUST_BE_CONSTANT",
+        errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "exprName" -> "accuracy",
-          "currentValue" -> accuracyExpression.toString
+          "inputName" -> "accuracy",
+          "inputType" -> "int",
+          "inputExpr" -> accuracyExpression.toString
         )
       )
     )
@@ -237,10 +238,11 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assertEqual(
       wrongPercentage.checkInputDataTypes(),
       DataTypeMismatch(
-        errorSubClass = "MUST_BE_CONSTANT",
+        errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "exprName" -> "percentage(s)",
-          "currentValue" -> attribute.toString
+          "inputName" -> "percentage(s)",
+          "inputType" -> "double",
+          "inputExpr" -> attribute.toString
         )
       )
     )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -261,7 +261,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
         messageParameters = Map(
           "exprName" -> "accuracy",
           "valueRange" -> s"(0, ${Int.MaxValue}]",
-          "currentValue" -> "-1")
+          "currentValue" -> "-1L")
       )
     )
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -221,8 +221,11 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assertEqual(
       wrongAccuracy.checkInputDataTypes(),
       DataTypeMismatch(
-        errorSubClass = "INVALID_ACCURACY.MUST_CONSTANT",
-        messageParameters = Map("currentValue" -> accuracyExpression.toString)
+        errorSubClass = "MUST_BE_CONSTANT",
+        messageParameters = Map(
+          "exprName" -> "accuracy",
+          "currentValue" -> accuracyExpression.toString
+        )
       )
     )
 
@@ -234,8 +237,11 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assertEqual(
       wrongPercentage.checkInputDataTypes(),
       DataTypeMismatch(
-        errorSubClass = "INVALID_PERCENTAGES.MUST_CONSTANT",
-        messageParameters = Map("currentValue" -> attribute.toString)
+        errorSubClass = "MUST_BE_CONSTANT",
+        messageParameters = Map(
+          "exprName" -> "percentage(s)",
+          "currentValue" -> attribute.toString
+        )
       )
     )
   }
@@ -248,8 +254,11 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assertEqual(
       wrongAccuracy.checkInputDataTypes(),
       DataTypeMismatch(
-        errorSubClass = "INVALID_ACCURACY.VALUE_OUT_OF_RANGE",
-        messageParameters = Map("maxValue" -> Int.MaxValue.toString, "currentValue" -> "-1")
+        errorSubClass = "VALUE_OUT_OF_RANGE",
+        messageParameters = Map(
+          "exprName" -> "accuracy",
+          "valueRange" -> s"(0, ${Int.MaxValue}]",
+          "currentValue" -> "-1")
       )
     )
 
@@ -286,7 +295,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
       assert(
         wrongPercentage.checkInputDataTypes() match {
           case DataTypeMismatch(errorSubClass, _) =>
-            errorSubClass.equals("INVALID_PERCENTAGES.VALUE_OUT_OF_RANGE")
+            errorSubClass.equals("VALUE_OUT_OF_RANGE")
           case _ => false
       })
     }
@@ -331,7 +340,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assert(new ApproximatePercentile(
       AttributeReference("a", DoubleType)(),
       percentageExpression = Literal(null, DoubleType)).checkInputDataTypes() ===
-      DataTypeMismatch(errorSubClass = "INVALID_PERCENTAGES.MUST_NOT_NULL"))
+      DataTypeMismatch(errorSubClass = "MUST_NOT_NULL", Map("exprName" -> "percentage(s)")))
 
     val nullPercentageExprs =
       Seq(CreateArray(Seq(null).map(Literal(_))), CreateArray(Seq(0.1D, null).map(Literal(_))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -340,7 +340,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assert(new ApproximatePercentile(
       AttributeReference("a", DoubleType)(),
       percentageExpression = Literal(null, DoubleType)).checkInputDataTypes() ===
-      DataTypeMismatch(errorSubClass = "MUST_NOT_NULL", Map("exprName" -> "percentage(s)")))
+      DataTypeMismatch(errorSubClass = "UNEXPECTED_NULL", Map("exprName" -> "percentage(s)")))
 
     val nullPercentageExprs =
       Seq(CreateArray(Seq(null).map(Literal(_))), CreateArray(Seq(0.1D, null).map(Literal(_))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentileSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, BoundReference, Cast, CreateArray, DecimalLiteral, GenericInternalRow, Literal}
+import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.{PercentileDigest, PercentileDigestSerializer}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.util.{ArrayData, QuantileSummaries}
@@ -224,8 +225,8 @@ class ApproximatePercentileSuite extends SparkFunSuite {
         errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
           "inputName" -> "accuracy",
-          "inputType" -> "int",
-          "inputExpr" -> accuracyExpression.toString
+          "inputType" -> toSQLType(accuracyExpression.dataType),
+          "inputExpr" -> toSQLExpr(accuracyExpression)
         )
       )
     )
@@ -240,9 +241,9 @@ class ApproximatePercentileSuite extends SparkFunSuite {
       DataTypeMismatch(
         errorSubClass = "NON_FOLDABLE_INPUT",
         messageParameters = Map(
-          "inputName" -> "percentage(s)",
-          "inputType" -> "double",
-          "inputExpr" -> attribute.toString
+          "inputName" -> "percentage",
+          "inputType" -> toSQLType(attribute.dataType),
+          "inputExpr" -> toSQLExpr(attribute)
         )
       )
     )
@@ -342,7 +343,7 @@ class ApproximatePercentileSuite extends SparkFunSuite {
     assert(new ApproximatePercentile(
       AttributeReference("a", DoubleType)(),
       percentageExpression = Literal(null, DoubleType)).checkInputDataTypes() ===
-      DataTypeMismatch(errorSubClass = "UNEXPECTED_NULL", Map("exprName" -> "percentage(s)")))
+      DataTypeMismatch(errorSubClass = "UNEXPECTED_NULL", Map("exprName" -> "percentage")))
 
     val nullPercentageExprs =
       Seq(CreateArray(Seq(null).map(Literal(_))), CreateArray(Seq(0.1D, null).map(Literal(_))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.TypeCheckResult._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types._
@@ -212,9 +213,9 @@ class PercentileSuite extends SparkFunSuite {
         DataTypeMismatch(
           errorSubClass = "VALUE_OUT_OF_RANGE",
           messageParameters = Map(
-            "exprName" -> "percentage(s)",
+            "exprName" -> "percentage",
             "valueRange" -> "[0.0, 1.0]",
-            "currentValue" -> percentage.simpleString(100)
+            "currentValue" -> toSQLExpr(percentage)
           )
         )
       )
@@ -229,9 +230,9 @@ class PercentileSuite extends SparkFunSuite {
         DataTypeMismatch(
           errorSubClass = "NON_FOLDABLE_INPUT",
           messageParameters = Map(
-            "inputName" -> "percentage(s)",
-            "inputType" -> "double",
-            "inputExpr" -> percentage.toString)
+            "inputName" -> "percentage",
+            "inputType" -> toSQLType(percentage.dataType),
+            "inputExpr" -> toSQLExpr(percentage))
         )
       )
     }
@@ -274,7 +275,7 @@ class PercentileSuite extends SparkFunSuite {
     assert(new Percentile(
       AttributeReference("a", DoubleType)(),
       percentageExpression = Literal(null, DoubleType)).checkInputDataTypes() ===
-      DataTypeMismatch(errorSubClass = "UNEXPECTED_NULL", Map("exprName" -> "percentage(s)")))
+      DataTypeMismatch(errorSubClass = "UNEXPECTED_NULL", Map("exprName" -> "percentage")))
 
     val nullPercentageExprs =
       Seq(CreateArray(Seq(null).map(Literal(_))), CreateArray(Seq(0.1D, null).map(Literal(_))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
@@ -273,7 +273,7 @@ class PercentileSuite extends SparkFunSuite {
     assert(new Percentile(
       AttributeReference("a", DoubleType)(),
       percentageExpression = Literal(null, DoubleType)).checkInputDataTypes() ===
-      DataTypeMismatch(errorSubClass = "MUST_NOT_NULL", Map("exprName" -> "percentage(s)")))
+      DataTypeMismatch(errorSubClass = "UNEXPECTED_NULL", Map("exprName" -> "percentage(s)")))
 
     val nullPercentageExprs =
       Seq(CreateArray(Seq(null).map(Literal(_))), CreateArray(Seq(0.1D, null).map(Literal(_))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
@@ -210,8 +210,12 @@ class PercentileSuite extends SparkFunSuite {
       val percentile2 = new Percentile(child, percentage)
       assertEqual(percentile2.checkInputDataTypes(),
         DataTypeMismatch(
-          errorSubClass = "INVALID_PERCENTAGES.VALUE_OUT_OF_RANGE",
-          messageParameters = Map("currentValue" -> percentage.simpleString(100))
+          errorSubClass = "VALUE_OUT_OF_RANGE",
+          messageParameters = Map(
+            "exprName" -> "percentage(s)",
+            "valueRange" -> "[0.0, 1.0]",
+            "currentValue" -> percentage.simpleString(100)
+          )
         )
       )
     }
@@ -223,9 +227,12 @@ class PercentileSuite extends SparkFunSuite {
       val percentile3 = new Percentile(child, percentage)
       assertEqual(percentile3.checkInputDataTypes(),
         DataTypeMismatch(
-          errorSubClass = "INVALID_PERCENTAGES.MUST_CONSTANT",
-          messageParameters = Map("currentValue" -> percentage.toString))
+          errorSubClass = "MUST_BE_CONSTANT",
+          messageParameters = Map(
+            "exprName" -> "percentage(s)",
+            "currentValue" -> percentage.toString)
         )
+      )
     }
 
     val invalidDataTypes = Seq(ByteType, ShortType, IntegerType, LongType, FloatType,
@@ -266,7 +273,7 @@ class PercentileSuite extends SparkFunSuite {
     assert(new Percentile(
       AttributeReference("a", DoubleType)(),
       percentageExpression = Literal(null, DoubleType)).checkInputDataTypes() ===
-      DataTypeMismatch(errorSubClass = "INVALID_PERCENTAGES.MUST_NOT_NULL"))
+      DataTypeMismatch(errorSubClass = "MUST_NOT_NULL", Map("exprName" -> "percentage(s)")))
 
     val nullPercentageExprs =
       Seq(CreateArray(Seq(null).map(Literal(_))), CreateArray(Seq(0.1D, null).map(Literal(_))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
@@ -215,7 +215,7 @@ class PercentileSuite extends SparkFunSuite {
           messageParameters = Map(
             "exprName" -> "percentage",
             "valueRange" -> "[0.0, 1.0]",
-            "currentValue" -> toSQLExpr(percentage)
+            "currentValue" -> toSQLValue(percentage)
           )
         )
       )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PercentileSuite.scala
@@ -227,10 +227,11 @@ class PercentileSuite extends SparkFunSuite {
       val percentile3 = new Percentile(child, percentage)
       assertEqual(percentile3.checkInputDataTypes(),
         DataTypeMismatch(
-          errorSubClass = "MUST_BE_CONSTANT",
+          errorSubClass = "NON_FOLDABLE_INPUT",
           messageParameters = Map(
-            "exprName" -> "percentage(s)",
-            "currentValue" -> percentage.toString)
+            "inputName" -> "percentage(s)",
+            "inputType" -> "double",
+            "inputExpr" -> percentage.toString)
         )
       )
     }

--- a/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
@@ -113,6 +113,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
   "messageParameters" : {
     "inputExpr" : "\"NULL\"",
+    "inputName" : "input",
+    "inputType" : "string",
     "sqlExpr" : "\"schema_of_csv(NULL)\""
   },
   "queryContext" : [ {
@@ -143,6 +145,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
   "messageParameters" : {
     "inputExpr" : "\"csvField\"",
+    "inputName" : "input",
+    "inputType" : "string",
     "sqlExpr" : "\"schema_of_csv(csvField)\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/csv-functions.sql.out
@@ -110,11 +110,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_NULL",
   "messageParameters" : {
-    "inputExpr" : "\"NULL\"",
-    "inputName" : "input",
-    "inputType" : "string",
+    "exprName" : "csv",
     "sqlExpr" : "\"schema_of_csv(NULL)\""
   },
   "queryContext" : [ {
@@ -145,8 +143,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
   "messageParameters" : {
     "inputExpr" : "\"csvField\"",
-    "inputName" : "input",
-    "inputType" : "string",
+    "inputName" : "csv",
+    "inputType" : "\"STRING\"",
     "sqlExpr" : "\"schema_of_csv(csvField)\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/json-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/json-functions.sql.out
@@ -430,11 +430,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_NULL",
   "messageParameters" : {
-    "inputExpr" : "\"NULL\"",
-    "inputName" : "input",
-    "inputType" : "string",
+    "exprName" : "json",
     "sqlExpr" : "\"schema_of_json(NULL)\""
   },
   "queryContext" : [ {
@@ -465,8 +463,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
   "messageParameters" : {
     "inputExpr" : "\"jsonField\"",
-    "inputName" : "input",
-    "inputType" : "string",
+    "inputName" : "json",
+    "inputType" : "\"STRING\"",
     "sqlExpr" : "\"schema_of_json(jsonField)\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/json-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/json-functions.sql.out
@@ -433,6 +433,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
   "messageParameters" : {
     "inputExpr" : "\"NULL\"",
+    "inputName" : "input",
+    "inputType" : "string",
     "sqlExpr" : "\"schema_of_json(NULL)\""
   },
   "queryContext" : [ {
@@ -463,6 +465,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
   "messageParameters" : {
     "inputExpr" : "\"jsonField\"",
+    "inputName" : "input",
+    "inputType" : "string",
     "sqlExpr" : "\"schema_of_json(jsonField)\""
   },
   "queryContext" : [ {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr replace `TypeCheckFailure` by `DataTypeMismatch` in type checks in the percentile expressions, includes `ApproximatePercentile.scala` and `percentiles.scala`

### Why are the changes needed?
Migration onto error classes unifies Spark SQL error messages.

### Does this PR introduce _any_ user-facing change?
Yes. The PR changes user-facing error messages.

### How was this patch tested?
- Pass GitHub Actions