### PR TITLE
[SPARK-40792] Helper object to get SQL configs for errors

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -53,6 +53,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.GLOBAL_TEMP_DATABASE
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.SqlConfigKeyUtils
 import org.apache.spark.unsafe.array.ByteArrayMethods
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.CircularBuffer
@@ -83,7 +84,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "value" -> toSQLValue(t, from),
         "sourceType" -> toSQLType(from),
         "targetType" -> toSQLType(to),
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = Array.empty,
       summary = "")
   }
@@ -114,7 +115,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "value" -> value.toPlainString,
         "precision" -> decimalPrecision.toString,
         "scale" -> decimalScale.toString,
-        "config" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "config" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = getQueryContext(context),
       summary = getSummary(context))
   }
@@ -130,7 +131,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "expression" -> toSQLValue(value, from),
         "sourceType" -> toSQLType(from),
         "targetType" -> toSQLType(to),
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = getQueryContext(context),
       summary = getSummary(context))
   }
@@ -144,7 +145,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "expression" -> toSQLValue(s, StringType),
         "sourceType" -> toSQLType(StringType),
         "targetType" -> toSQLType(BooleanType),
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = getQueryContext(context),
       summary = getSummary(context))
   }
@@ -159,7 +160,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "expression" -> toSQLValue(s, StringType),
         "sourceType" -> toSQLType(StringType),
         "targetType" -> toSQLType(to),
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = getQueryContext(context),
       summary = getSummary(context))
   }
@@ -222,7 +223,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
   def divideByZeroError(context: SQLQueryContext): ArithmeticException = {
     new SparkArithmeticException(
       errorClass = "DIVIDE_BY_ZERO",
-      messageParameters = Map("config" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+      messageParameters = Map("config" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = getQueryContext(context),
       summary = getSummary(context))
   }
@@ -244,7 +245,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       messageParameters = Map(
         "indexValue" -> toSQLValue(index, IntegerType),
         "arraySize" -> toSQLValue(numElements, IntegerType),
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = getQueryContext(context),
       summary = getSummary(context))
   }
@@ -258,7 +259,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       messageParameters = Map(
         "indexValue" -> toSQLValue(index, IntegerType),
         "arraySize" -> toSQLValue(numElements, IntegerType),
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = getQueryContext(context),
       summary = getSummary(context))
   }
@@ -267,7 +268,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
     new SparkDateTimeException(
       errorClass = "INVALID_FRACTION_OF_SECOND",
       messageParameters = Map(
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)
       ),
       context = Array.empty,
       summary = "")
@@ -278,7 +279,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "CANNOT_PARSE_TIMESTAMP",
       messageParameters = Map(
         "message" -> e.getMessage,
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = Array.empty,
       summary = "")
   }
@@ -288,7 +289,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "_LEGACY_ERROR_TEMP_2000",
       messageParameters = Map(
         "message" -> e.getMessage,
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = Array.empty,
       summary = "")
   }
@@ -298,7 +299,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "_LEGACY_ERROR_TEMP_2000",
       messageParameters = Map(
         "message" -> message,
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)))
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)))
   }
 
   def ansiIllegalArgumentError(e: Exception): SparkIllegalArgumentException = {
@@ -372,7 +373,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "_LEGACY_ERROR_TEMP_2008",
       messageParameters = Map(
         "url" -> url.toString,
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)))
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)))
   }
 
   def illegalUrlError(url: UTF8String): Throwable = {
@@ -626,7 +627,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "_LEGACY_ERROR_TEMP_2042",
       messageParameters = Map(
         "message" -> e.getMessage,
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = Array.empty,
       summary = "")
   }
@@ -643,7 +644,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       messageParameters = Map(
         "message" -> message,
         "alternative" -> alternative,
-        "config" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+        "config" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = getQueryContext(context),
       summary = getSummary(context))
   }
@@ -1261,7 +1262,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
   def unscaledValueTooLargeForPrecisionError(): SparkArithmeticException = {
     new SparkArithmeticException(
       errorClass = "_LEGACY_ERROR_TEMP_2117",
-      messageParameters = Map("ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+      messageParameters = Map("ansiConfig" -> toSQLConf(SqlConfigKeyUtils.ansiModeConfigKey)),
       context = Array.empty,
       summary = "")
   }
@@ -1376,7 +1377,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "INCONSISTENT_BEHAVIOR_CROSS_VERSION.PARSE_DATETIME_BY_NEW_PARSER",
       messageParameters = Map(
         "datetime" -> toSQLValue(s, StringType),
-        "config" -> toSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key)),
+        "config" -> toSQLConf(SqlConfigKeyUtils.legacyTimeParserPolicyConfigName)),
       e)
   }
 
@@ -1385,7 +1386,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "INCONSISTENT_BEHAVIOR_CROSS_VERSION.DATETIME_PATTERN_RECOGNITION",
       messageParameters = Map(
         "pattern" -> toSQLValue(pattern, StringType),
-        "config" -> toSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key)),
+        "config" -> toSQLConf(SqlConfigKeyUtils.legacyTimeParserPolicyConfigName)),
       e)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SqlConfigKeyUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SqlConfigKeyUtils.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util
+
+import org.apache.spark.sql.internal.SQLConf
+
+object SqlConfigKeyUtils {
+  def ansiModeConfigKey: String = getSqlConfigKey(SQLConf.ANSI_ENABLED.key)
+  def legacyTimeParserPolicyConfigName: String =
+    getSqlConfigKey(SQLConf.LEGACY_TIME_PARSER_POLICY.key)
+
+  /**
+   * Used to find a SQL configuration.
+   *
+   * @param sparkConfigKey Spark configuration key
+   * @return Returns the SQL configuration key.
+   */
+  def getSqlConfigKey(sparkConfigKey: String): String = {
+    sparkConfigKey
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a helper object to get SQL config keys for errors.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Allows injection of vendor specific SQL config keys, e.g. Databricks `ansi_mode` instead of `spark.sql.ansi.enabled`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Careful review and existing unit tests.