### PR TITLE
[SPARK-40795][BUILD] Exclude redundant jars from spark-protobuf-assembly jar 

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -724,6 +724,20 @@ object SparkProtobuf {
 
     (assembly / logLevel) := Level.Info,
 
+    // Exclude `scala-library` from assembly.
+    (assembly / assemblyPackageScala / assembleArtifact) := false,
+
+    // Exclude `pmml-model-*.jar`, `scala-collection-compat_*.jar`,
+    // `spark-tags_*.jar`, "guava-*.jar" and `unused-1.0.0.jar` from assembly.
+    (assembly / assemblyExcludedJars) := {
+      val cp = (assembly / fullClasspath).value
+      cp filter { v =>
+        val name = v.data.getName
+        name.startsWith("pmml-model-") || name.startsWith("scala-collection-compat_") ||
+          name.startsWith("spark-tags_") || name.startsWith("guava-") || name == "unused-1.0.0.jar"
+      }
+    },
+
     (assembly / assemblyShadeRules) := Seq(
       ShadeRule.rename("com.google.protobuf.**" -> "org.sparkproject.spark-protobuf.protobuf.@1").inAll,
     ),


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add `assemblyPackageScala` and `assemblyExcludedJars` to `SparkProtobuf`  module sbt build options to exclude redundant jars from spark-protobuf-assembly jar.


### Why are the changes needed?
Exclude redundant jars from `spark-protobuf-assembly` jar 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Manual test

run `build/sbt "protobuf/assembly"`

**Before** 

```
[debug] Including from cache: spark-tags_2.12-3.4.0-SNAPSHOT.jar
[debug] Including from cache: unused-1.0.0.jar
[debug] Including from cache: spark-protobuf_2.12-3.4.0-SNAPSHOT.jar
[debug] Including from cache: scala-collection-compat_2.12-2.2.0.jar
[debug] Including from cache: pmml-model-1.4.8.jar
[debug] Including from cache: protobuf-java-3.21.1.jar
[debug] Including from cache: guava-14.0.1.jar
[debug] Including from cache: scala-library-2.12.17.jar
```

**After**

```
[debug] Including: spark-protobuf_2.12-3.4.0-SNAPSHOT.jar
[debug] Including from cache: protobuf-java-3.21.1.jar
```
