### PR TITLE
[SPARK-40717][CONNECT][TESTS][FOLLOW-UP] Assert analyzed plan in column alias test case

### DIFF
--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -99,6 +99,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
       transform(connectTestRelation.select("id".protoAttr.as("id2")))
     }
     val sparkPlan = sparkTestRelation.select($"id".as("id2"))
+    comparePlans(connectPlan.analyze, sparkPlan.analyze, false)
   }
 
   test("Aggregate with more than 1 grouping expressions") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/38174 which mistakenly missed to assert the analyzed plans.

### Why are the changes needed?

To make sure the test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?
Unittest fixed.