### PR TITLE
[SPARK-40797] [BUILD] Force import groups on a single line.

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -19,6 +19,7 @@ align = none
 align.openParenDefnSite = false
 align.openParenCallSite = false
 align.tokens = []
+importSelectors = "singleLine"
 optIn = {
   configStyleArguments = false
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When using the scalafmt.conf file as provided by the project repository to organize and optimize imports there is a case in which un-desired behavior appears.

If the import group does not fit on a single line, Scalafmt will by default try to bin-pack and then break out over mulitple lines.

For example:

    import org.apache.spark.sql.catalyst.analysis.{UnresolvedAlias, UnresolvedAttribute, UnresolvedFunction, UnresolvedRelation, UnresolvedStar}

will become

    import org.apache.spark.sql.catalyst.analysis.{
      UnresolvedAlias,
      UnresolvedAttributed,
      ...
    }

In previous code reviews this has been marked as departing from the consistency of the Spark code base. This patch enables an option in Scalafmt to force the import group on a single line even if it exceeds the max line length.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->


### Why are the changes needed?
Code consistency.

### Does this PR introduce _any_ user-facing change?
No

