### PR TITLE
[SPARK-39783] Do not parse already qualified identifiers for UNRESOLVED_COLUMN AnalysisException

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3444,13 +3444,13 @@ class Analyzer(override val catalogManager: CatalogManager)
     private def resolveUserSpecifiedColumns(i: InsertIntoStatement): Seq[NamedExpression] = {
       SchemaUtils.checkColumnNameDuplication(
         i.userSpecifiedCols, "in the column list", resolver)
-
       i.userSpecifiedCols.map { col =>
         i.table.resolve(Seq(col), resolver).getOrElse {
           val candidates = i.table.output.map(_.name)
           val orderedCandidates = StringUtils.orderStringsBySimilarity(col, candidates)
+          val qualifiedCandidates = orderedCandidates.map(Seq(_))
           throw QueryCompilationErrors
-            .unresolvedAttributeError("UNRESOLVED_COLUMN", col, orderedCandidates, i.origin)
+            .unresolvedAttributeError("UNRESOLVED_COLUMN", col, qualifiedCandidates, i.origin)
         }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -108,9 +108,11 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
       errorClass: String): Nothing = {
     val missingCol = a.sql
     val candidates = operator.inputSet.toSeq.map(_.qualifiedName)
+    // Because the names are already qualified, do not attempt to parse them again.
     val orderedCandidates = StringUtils.orderStringsBySimilarity(missingCol, candidates)
+    val qualifiedCandidates = orderedCandidates.map(Seq(_))
     throw QueryCompilationErrors.unresolvedAttributeError(
-      errorClass, missingCol, orderedCandidates, a.origin)
+      errorClass, missingCol, qualifiedCandidates, a.origin)
   }
 
   def checkAnalysis(plan: LogicalPlan): Unit = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -182,7 +182,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def unresolvedAttributeError(
       errorClass: String,
       colName: String,
-      candidates: Seq[String],
+      candidates: Seq[Seq[String]],
       origin: Origin): Throwable = {
     val commonParam = Map("objectName" -> toSQLId(colName))
     val proposalParam = if (candidates.isEmpty) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes the error message when referencing a "." separated attribute that does not exist in the table. For example,
```scala
Seq((0)).toDF("the.id").select("the.id").show()
```

would throw an error with the invalid suggestion:
```
org.apache.spark.sql.AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter
 with name `the`.`id` cannot be resolved. Did you mean one of the following? [`the`.`id`];
```

However, it should be showing `the.id` instead of `the`.`id`: 
```
org.apache.spark.sql.AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter
 with name `the`.`id` cannot be resolved. Did you mean one of the following? [`the.id`];
```

The issue is due to to `toSQLId` function that parses the attribute name again, after it has already been qualified. The method splits the name by dots and qualifies each individual part which is incorrect.
 
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fixes a bug in reporting attribute names for the `UNRESOLVED_COLUMN.WITH_SUGGESTION` error.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, the user should see the correct message now when the table contains columns with "." separators.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing unit tests.