### PR TITLE
[SPARK-40801][BUILD] Upgrade `Apache commons-text` to 1.10

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -52,7 +52,7 @@ commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-net/3.1//commons-net-3.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.9//commons-text-1.9.jar
+commons-text/1.10.0//commons-text-1.10.0.jar
 compress-lzf/1.1//compress-lzf-1.1.jar
 curator-client/2.7.1//curator-client-2.7.1.jar
 curator-framework/2.7.1//curator-framework-2.7.1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -49,7 +49,7 @@ commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.9//commons-text-1.9.jar
+commons-text/1.10.0//commons-text-1.10.0.jar
 compress-lzf/1.1//compress-lzf-1.1.jar
 curator-client/2.13.0//curator-client-2.13.0.jar
 curator-framework/2.13.0//curator-framework-2.13.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -604,7 +604,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.9</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache commons-text from 1.9 to 1.10.0

### Why are the changes needed?
[CVE-2022-42889](https://nvd.nist.gov/vuln/detail/CVE-2022-42889) 


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass github action 
