### PR TITLE
[SPARK-40804][SQL] Missing handling a catalog name in destination tables in RenameTableExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameTableExec.scala
@@ -45,7 +45,8 @@ case class RenameTableExec(
 
     // If new identifier consists of a table name only, the table should be renamed in place.
     // Such behavior matches to the v1 implementation of table renaming in Spark and other DBMSs.
-    val qualifiedNewIdent = if (newIdent.namespace.isEmpty) {
+    // Handling length=2 case is for where newIdent is specified as catalog.db.table.
+    val qualifiedNewIdent = if (newIdent.namespace.isEmpty || newIdent.namespace.length == 2) {
       Identifier.of(oldIdent.namespace, newIdent.name)
     } else newIdent
     catalog.renameTable(oldIdent, qualifiedNewIdent)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -65,6 +65,18 @@ trait AlterTableRenameSuiteBase extends QueryTest with DDLCommandTestUtils {
     }
   }
 
+  test("include catalog in the destination table") {
+    withNamespaceAndTable("ns", "dst_tbl", catalog) { dst =>
+      val src = dst.replace("dst", "src")
+      sql(s"CREATE TABLE $src (c0 INT) $defaultUsing")
+      sql(s"INSERT INTO $src SELECT 0")
+
+      sql(s"ALTER TABLE $src RENAME TO $catalog.ns.dst_tbl")
+      checkTables("ns", "dst_tbl")
+      QueryTest.checkAnswer(sql(s"SELECT c0 FROM $dst"), Seq(Row(0)))
+    }
+  }
+
   test("SPARK-33786: Cache's storage level should be respected when a table name is altered") {
     withNamespaceAndTable("ns", "dst_tbl") { dst =>
       val src = dst.replace("dst", "src")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameSuiteBase.scala
@@ -65,18 +65,6 @@ trait AlterTableRenameSuiteBase extends QueryTest with DDLCommandTestUtils {
     }
   }
 
-  test("include catalog in the destination table") {
-    withNamespaceAndTable("ns", "dst_tbl", catalog) { dst =>
-      val src = dst.replace("dst", "src")
-      sql(s"CREATE TABLE $src (c0 INT) $defaultUsing")
-      sql(s"INSERT INTO $src SELECT 0")
-
-      sql(s"ALTER TABLE $src RENAME TO $catalog.ns.dst_tbl")
-      checkTables("ns", "dst_tbl")
-      QueryTest.checkAnswer(sql(s"SELECT c0 FROM $dst"), Seq(Row(0)))
-    }
-  }
-
   test("SPARK-33786: Cache's storage level should be respected when a table name is altered") {
     withNamespaceAndTable("ns", "dst_tbl") { dst =>
       val src = dst.replace("dst", "src")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenameSuite.scala
@@ -35,13 +35,25 @@ class AlterTableRenameSuite extends command.AlterTableRenameSuiteBase with Comma
     }
   }
 
-  test("include catalog in the destination table") {
+  test("include the same catalog name in the destination table") {
     withNamespaceAndTable("ns", "dst_tbl", catalog) { dst =>
       val src = dst.replace("dst", "src")
       sql(s"CREATE TABLE $src (c0 INT) $defaultUsing")
       sql(s"INSERT INTO $src SELECT 0")
 
       sql(s"ALTER TABLE $src RENAME TO $catalog.ns.dst_tbl")
+      checkTables("ns", "dst_tbl")
+    }
+  }
+
+  test("include the different catalog name in the destination table") {
+    withNamespaceAndTable("ns", "dst_tbl") { dst =>
+      val src = dst.replace("dst", "src")
+      val newDst = dst.replace("test_catalog", "another_test_catalog")
+      sql(s"CREATE TABLE $src (c0 INT) $defaultUsing")
+      sql(s"INSERT INTO $src SELECT 0")
+
+      sql(s"ALTER TABLE $src RENAME TO $newDst")
       checkTables("ns", "dst_tbl")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableRenameSuite.scala
@@ -34,4 +34,15 @@ class AlterTableRenameSuite extends command.AlterTableRenameSuiteBase with Comma
       }
     }
   }
+
+  test("include catalog in the destination table") {
+    withNamespaceAndTable("ns", "dst_tbl", catalog) { dst =>
+      val src = dst.replace("dst", "src")
+      sql(s"CREATE TABLE $src (c0 INT) $defaultUsing")
+      sql(s"INSERT INTO $src SELECT 0")
+
+      sql(s"ALTER TABLE $src RENAME TO $catalog.ns.dst_tbl")
+      checkTables("ns", "dst_tbl")
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently `RenameTableExec` only handles an empty namespace for destination tables as the following current spec:

(3.3.0 is picked up) https://github.com/apache/spark/blob/v3.3.0/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameTableExec.scala#L48

```
# L48
    val qualifiedNewIdent = if (newIdent.namespace.isEmpty) {
      Identifier.of(oldIdent.namespace, newIdent.name)
    } else newIdent
```

This part doesn't handle the case where a destination table is specified catalog.db.table. If catalog.db.table is passed to `ALTER TABLE <src> RENAME TO <dst>` query, there's a difference of handling namespaces between source and destination tables. Specifically, source tables can be correctly handled as `[db]` for its namespace, but destination tables are handled as `[catalog, db]` for its namespace.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This change provide handling destination names that include catalog name as `catalog.db.table`.  
For example, Apache Iceberg is expected to handle the destination table as catalog.db.table in the document; [https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table--rename-to](https://iceberg.apache.org/docs/latest/spark-ddl/#alter-table--rename-to.)


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. Keep the compatibility with the current spec.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

An unit test is added. The test checks whether renaming table name is successful or not if dst for ALTER TABLE RENAME TO has catalog name as `ALTER TABLE src RENAME TO catalog.db.table`.

(New) test results:

```
Run starting. Expected test count is: 11
AlterTableRenameSuite:
23:18:19.594 WARN org.apache.hadoop.util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
- ALTER TABLE .. RENAME using V2 catalog V2 command: rename a table in a database/namespace
- ALTER TABLE .. RENAME using V2 catalog V2 command: table to rename does not exist
- ALTER TABLE .. RENAME using V2 catalog V2 command: omit namespace in the destination table
- ALTER TABLE .. RENAME using V2 catalog V2 command: SPARK-33786: Cache's storage level should be respected when a table name is altered
- ALTER TABLE .. RENAME using V2 catalog V2 command: rename cached table
- ALTER TABLE .. RENAME using V2 catalog V2 command: rename without explicitly specifying database
- ALTER TABLE .. RENAME using V2 catalog V2 command: SPARK-37963: preserve partition info
- ALTER TABLE .. RENAME using V2 catalog V2 command: SPARK-38587: use formatted names
- ALTER TABLE .. RENAME using V2 catalog V2 command: destination namespace is different
- ALTER TABLE .. RENAME using V2 catalog V2 command: include the same catalog name in the destination table
- ALTER TABLE .. RENAME using V2 catalog V2 command: include the different catalog name in the destination table

Run completed in 22 seconds, 377 milliseconds.
Total number of tests run: 11
Suites: completed 2, aborted 0
Tests: succeeded 11, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57.484 s
[INFO] Finished at: 2022-10-17T23:18:35+09:00
[INFO] ------------------------------------------------------------------------

Process finished with exit code 0
```