### PR TITLE
[SPARK-40806][SQL] Typo fix: CREATE TABLE -> REPLACE TABLE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3776,7 +3776,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
     val provider = Option(ctx.tableProvider).map(_.multipartIdentifier.getText)
 
     if (provider.isDefined && serdeInfo.isDefined) {
-      operationNotAllowed(s"CREATE TABLE ... USING ... ${serdeInfo.get.describe}", ctx)
+      operationNotAllowed(s"REPLACE TABLE ... USING ... ${serdeInfo.get.describe}", ctx)
     }
 
     val partitioning =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -501,10 +501,10 @@ class DDLParserSuite extends AnalysisTest {
         |USING parquet
         |STORED AS parquet
         """.stripMargin
+    assertUnsupported(createSql, Seq("CREATE TABLE ... USING ... STORED AS"))
+
     val replaceSql = createSql.replaceFirst("CREATE", "REPLACE")
-    Seq(createSql, replaceSql).foreach { sql =>
-      assertUnsupported(sql, Seq("CREATE TABLE ... USING ... STORED AS"))
-    }
+    assertUnsupported(replaceSql, Seq("REPLACE TABLE ... USING ... STORED AS"))
   }
 
   test("create/replace table - using with row format serde") {
@@ -513,10 +513,10 @@ class DDLParserSuite extends AnalysisTest {
         |USING parquet
         |ROW FORMAT SERDE 'customSerde'
         """.stripMargin
+    assertUnsupported(createSql, Seq("CREATE TABLE ... USING ... ROW FORMAT SERDE"))
+
     val replaceSql = createSql.replaceFirst("CREATE", "REPLACE")
-    Seq(createSql, replaceSql).foreach { sql =>
-      assertUnsupported(sql, Seq("CREATE TABLE ... USING ... ROW FORMAT SERDE"))
-    }
+    assertUnsupported(replaceSql, Seq("REPLACE TABLE ... USING ... ROW FORMAT SERDE"))
   }
 
   test("create/replace table - using with row format delimited") {
@@ -525,10 +525,10 @@ class DDLParserSuite extends AnalysisTest {
         |USING parquet
         |ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
         """.stripMargin
+    assertUnsupported(createSql, Seq("CREATE TABLE ... USING ... ROW FORMAT DELIMITED"))
+
     val replaceSql = createSql.replaceFirst("CREATE", "REPLACE")
-    Seq(createSql, replaceSql).foreach { sql =>
-      assertUnsupported(sql, Seq("CREATE TABLE ... USING ... ROW FORMAT DELIMITED"))
-    }
+    assertUnsupported(replaceSql, Seq("REPLACE TABLE ... USING ... ROW FORMAT DELIMITED"))
   }
 
   test("create/replace table - stored by") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aim to typo fix: CREATE TABLE -> REPLACE TABLE in AstBuilder.

### Why are the changes needed?
When i work on [SPARK-40784](https://issues.apache.org/jira/browse/SPARK-40784), i found this issue.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existed UT.