### PR TITLE
[SPARK-40809][SPARK-40780][FOLLOW-UP] Improve filter and alias testing coverage in python client

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -75,6 +75,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertIsNotNone(result)
 
     def test_simple_explain_string(self):
+        read_rel = Read("test_table")
         df = self.connect.read.table(self.tbl_name).limit(10)
         result = df.explain()
         self.assertGreater(len(result), 0)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -75,7 +75,6 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertIsNotNone(result)
 
     def test_simple_explain_string(self):
-        read_rel = Read("test_table")
         df = self.connect.read.table(self.tbl_name).limit(10)
         result = df.explain()
         self.assertGreater(len(result), 0)

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -28,21 +28,11 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
     generation but do not call Spark."""
 
     def test_simple_project(self):
-        def read_table(x):
-            return DataFrame.withPlan(Read(x), self.connect)
-
-        self.connect.set_hook("readTable", read_table)
-
-        plan = self.connect.readTable(self.tbl_name)._plan.collect(self.connect)
+        plan = self.connect.readTable(table_name=self.tbl_name)._plan.collect(self.connect)
         self.assertIsNotNone(plan.root, "Root relation must be set")
         self.assertIsNotNone(plan.root.read)
 
     def test_simple_udf(self):
-        def udf_mock(*args, **kwargs):
-            return "internal_name"
-
-        self.connect.set_hook("register_udf", udf_mock)
-
         u = udf(lambda x: "Martin", StringType())
         self.assertIsNotNone(u)
         expr = u("ThisCol", "ThatCol", "OtherCol")
@@ -51,12 +41,7 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
         self.assertIsNotNone(u_plan)
 
     def test_all_the_plans(self):
-        def read_table(x):
-            return DataFrame.withPlan(Read(x), self.connect)
-
-        self.connect.set_hook("readTable", read_table)
-
-        df = self.connect.readTable(self.tbl_name)
+        df = self.connect.readTable(table_name=self.tbl_name)
         df = df.select(df.col1).filter(df.col2 == 2).sort(df.col3.asc())
         plan = df._plan.collect(self.connect)
         self.assertIsNotNone(plan.root, "Root relation must be set")

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -20,6 +20,8 @@ import functools
 import unittest
 import uuid
 
+from pyspark.sql.connect import DataFrame
+from pyspark.sql.connect.plan import Read
 from pyspark.testing.utils import search_jar
 
 
@@ -59,6 +61,17 @@ class PlanOnlyTestFixture(unittest.TestCase):
     connect: "MockRemoteSession"
 
     @classmethod
+    def _read_table(cls, table_name: str):
+        return DataFrame.withPlan(Read(table_name), cls.connect)
+
+    @classmethod
+    def _udf_mock(cls, *args, **kwargs):
+        return "internal_name"
+
+    @classmethod
     def setUpClass(cls: Any) -> None:
         cls.connect = MockRemoteSession()
         cls.tbl_name = f"tbl{uuid.uuid4()}".replace("-", "")
+
+        cls.connect.set_hook("register_udf", cls._udf_mock)
+        cls.connect.set_hook("readTable", cls._read_table)

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -49,6 +49,9 @@ class MockRemoteSession:
     def set_hook(self, name: str, hook: Any) -> None:
         self.hooks[name] = hook
 
+    def drop_hook(self, name: str) -> None:
+        self.hooks.pop(name)
+
     def __getattr__(self, item: str) -> Any:
         if item not in self.hooks:
             raise LookupError(f"{item} is not defined as a method hook in MockRemoteSession")
@@ -62,7 +65,7 @@ class PlanOnlyTestFixture(unittest.TestCase):
 
     @classmethod
     def _read_table(cls, table_name: str) -> "DataFrame":
-        return DataFrame.withPlan(Read(table_name), cls.connect)
+        return DataFrame.withPlan(Read(table_name), cls.connect)  # type: ignore
 
     @classmethod
     def _udf_mock(cls, *args, **kwargs):
@@ -75,3 +78,8 @@ class PlanOnlyTestFixture(unittest.TestCase):
 
         cls.connect.set_hook("register_udf", cls._udf_mock)
         cls.connect.set_hook("readTable", cls._read_table)
+
+    @classmethod
+    def tearDownClass(cls: Any) -> None:
+        cls.connect.drop_hook("register_udf")
+        cls.connect.drop_hook("readTable")

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -61,7 +61,7 @@ class PlanOnlyTestFixture(unittest.TestCase):
     connect: "MockRemoteSession"
 
     @classmethod
-    def _read_table(cls, table_name: str):
+    def _read_table(cls, table_name: str) -> "DataFrame":
         return DataFrame.withPlan(Read(table_name), cls.connect)
 
     @classmethod

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -68,7 +68,7 @@ class PlanOnlyTestFixture(unittest.TestCase):
         return DataFrame.withPlan(Read(table_name), cls.connect)  # type: ignore
 
     @classmethod
-    def _udf_mock(cls, *args, **kwargs):
+    def _udf_mock(cls, *args, **kwargs) -> str:
         return "internal_name"
 
     @classmethod


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. Refactor `test_connect_plan_only.py` and move common code to base class.
2. Test generated proto plan for `filter` and `alias`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
Improve python client testing coverage.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT
