### PR TITLE
[SPARK-40803][CORE] Look up config items on codec creation.

### DIFF
--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -132,9 +132,9 @@ class LZ4CompressionCodec(conf: SparkConf) extends CompressionCodec {
   @transient private[this] lazy val xxHashFactory: XXHashFactory = XXHashFactory.fastestInstance()
 
   private[this] val defaultSeed: Int = 0x9747b28c // LZ4BlockOutputStream.DEFAULT_SEED
+  private[this] val blockSize = conf.get(IO_COMPRESSION_LZ4_BLOCKSIZE).toInt
 
   override def compressedOutputStream(s: OutputStream): OutputStream = {
-    val blockSize = conf.get(IO_COMPRESSION_LZ4_BLOCKSIZE).toInt
     val syncFlush = false
     new LZ4BlockOutputStream(
       s,
@@ -191,9 +191,9 @@ class SnappyCompressionCodec(conf: SparkConf) extends CompressionCodec {
   } catch {
     case e: Error => throw new IllegalArgumentException(e)
   }
+  private[this] val blockSize = conf.get(IO_COMPRESSION_SNAPPY_BLOCKSIZE).toInt
 
   override def compressedOutputStream(s: OutputStream): OutputStream = {
-    val blockSize = conf.get(IO_COMPRESSION_SNAPPY_BLOCKSIZE).toInt
     new SnappyOutputStream(s, blockSize)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This moves look up of the `IO_COMPRESSION_LZ4_BLOCKSIZE` and `IO_COMPRESSION_SNAPPY_BLOCKSIZE` to the constructor instead of the method `compressedOutputStream`. This is already how it done for `IO_COMPRESSION_ZSTD_BUFFERSIZE` in `ZStdCompressionCodec`.


### Why are the changes needed?
The cost of looking up the config is often insignificant, but there are cases like a large shuffle with high number of partitions and therefore lots of small streams where the overhead becomes measurable (seen as high as a couple of % of executor cpu time).


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing unit tests.

