### PR TITLE
[SPARK-40796][BUILD][FOLLOW-UP] Make Python code generation check only in master(3.4)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -608,7 +608,7 @@ jobs:
     - name: Python linter
       run: PYTHON_EXECUTABLE=python3.9 ./dev/lint-python
     - name: Python code generation check
-      run: PATH=$PATH:$HOME/buf/bin PYTHON_EXECUTABLE=python3.9 ./dev/check-codegen-python.py
+      run: if test -f ./dev/check-codegen-python.py; then PATH=$PATH:$HOME/buf/bin PYTHON_EXECUTABLE=python3.9 ./dev/check-codegen-python.py; fi
     - name: R linter
       run: ./dev/lint-r
     - name: JS linter


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make Python code generation check only in master(3.4)


### Why are the changes needed?
`linter` is also triggered in 3.2 and 3.3

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI
