### PR TITLE
[SPARK-40779][PS][TEST] Fix `corrwith` to work properly with different anchor.

### DIFF
--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -1868,7 +1868,10 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
 
         df_bool = ps.DataFrame({"A": [True, True, False, False], "B": [True, False, False, True]})
         ser_bool = ps.Series([True, True, False, True])
-        self._test_corrwith(df_bool, ser_bool)
+        # Regression in pandas 1.5.0
+        # See https://github.com/pandas-dev/pandas/issues/49141 for the reported issue,
+        # and https://github.com/pandas-dev/pandas/pull/46174 for the initial PR that causes.
+        # self._test_corrwith(df_bool, ser_bool)
 
         self._test_corrwith(self.psdf1, self.psdf1)
         self._test_corrwith(self.psdf1, self.psdf2)
@@ -1876,7 +1879,10 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         self._test_corrwith(self.psdf3, self.psdf4)
 
         self._test_corrwith(self.psdf1, self.psdf1.a)
-        self._test_corrwith(self.psdf1, self.psdf2.b)
+        # Regression in pandas 1.5.0
+        # See https://github.com/pandas-dev/pandas/issues/49141 for the reported issue,
+        # and https://github.com/pandas-dev/pandas/pull/46174 for the initial PR that causes.
+        # self._test_corrwith(self.psdf1, self.psdf2.b)
         self._test_corrwith(self.psdf2, self.psdf3.c)
         self._test_corrwith(self.psdf3, self.psdf4.f)
 

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -1866,11 +1866,11 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         self._test_corrwith((df1 + 1), df2.B)
         self._test_corrwith((df1 + 1), (df2.B + 2))
 
-        df_bool = ps.DataFrame({"A": [True, True, False, False], "B": [True, False, False, True]})
-        ser_bool = ps.Series([True, True, False, True])
         # Regression in pandas 1.5.0
         # See https://github.com/pandas-dev/pandas/issues/49141 for the reported issue,
         # and https://github.com/pandas-dev/pandas/pull/46174 for the initial PR that causes.
+        # df_bool = ps.DataFrame({"A": [True, True, False, False], "B": [True, False, False, True]})
+        # ser_bool = ps.Series([True, True, False, True])
         # self._test_corrwith(df_bool, ser_bool)
 
         self._test_corrwith(self.psdf1, self.psdf1)

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -1869,9 +1869,13 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         # Regression in pandas 1.5.0
         # See https://github.com/pandas-dev/pandas/issues/49141 for the reported issue,
         # and https://github.com/pandas-dev/pandas/pull/46174 for the initial PR that causes.
-        # df_bool = ps.DataFrame({"A": [True, True, False, False], "B": [True, False, False, True]})
-        # ser_bool = ps.Series([True, True, False, True])
-        # self._test_corrwith(df_bool, ser_bool)
+        df_bool = ps.DataFrame({"A": [True, True, False, False], "B": [True, False, False, True]})
+        ser_bool = ps.Series([True, True, False, True])
+        if LooseVersion(pd.__version__) >= LooseVersion("1.5.0"):
+            expected = ps.Series([0.5773502691896257, 0.5773502691896257], index=["B", "A"])
+            self.assert_eq(df_bool.corrwith(ser_bool), expected, almost=True)
+        else:
+            self._test_corrwith(df_bool, ser_bool)
 
         self._test_corrwith(self.psdf1, self.psdf1)
         self._test_corrwith(self.psdf1, self.psdf2)
@@ -1882,7 +1886,12 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         # Regression in pandas 1.5.0
         # See https://github.com/pandas-dev/pandas/issues/49141 for the reported issue,
         # and https://github.com/pandas-dev/pandas/pull/46174 for the initial PR that causes.
-        # self._test_corrwith(self.psdf1, self.psdf2.b)
+        if LooseVersion(pd.__version__) >= LooseVersion("1.5.0"):
+            expected = ps.Series([-0.08827348295047496, 0.4413674147523748], index=["b", "a"])
+            self.assert_eq(self.psdf1.corrwith(self.psdf2.b), expected, almost=True)
+        else:
+            self._test_corrwith(self.psdf1, self.psdf2.b)
+
         self._test_corrwith(self.psdf2, self.psdf3.c)
         self._test_corrwith(self.psdf3, self.psdf4.f)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to disable some tests for DataFrame.corrwith since there is regression in pandas 1.5.0.

We should re-enable it after fixing in future pandas release.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There is bug in pandas for DataFrame.corrwith for some cases, we should skip it for now.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

The existing CI should pass