### PR TITLE
[SPARK-40830][SQL] Provide groupByKey shortcuts for groupBy.as

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1929,7 +1929,7 @@ class Dataset[T] private[sql](
    *       this Dataset with that function.
    *
    * @group typedrel
-   * @since 3.4.0
+   * @since 3.5.0
    */
   def groupByKey[K: Encoder](column: Column, columns: Column*): KeyValueGroupedDataset[K, T] =
     groupBy(column +: columns: _*).as[K, T]
@@ -1945,7 +1945,7 @@ class Dataset[T] private[sql](
    *       this Dataset with that function.
    *
    * @group typedrel
-   * @since 3.4.0
+   * @since 3.5.0
    */
   def groupByKey[K: Encoder](column: String, columns: String*): KeyValueGroupedDataset[K, T] =
     groupBy(column, columns: _*).as[K, T]
@@ -1987,7 +1987,7 @@ class Dataset[T] private[sql](
    *       this Dataset with that function.
    *
    * @group typedrel
-   * @since 3.4.0
+   * @since 3.5.0
    */
   @scala.annotation.varargs
   def groupByKey[K](encoder: Encoder[K], column: Column, columns: Column*):
@@ -2005,7 +2005,7 @@ class Dataset[T] private[sql](
    *       this Dataset with that function.
    *
    * @group typedrel
-   * @since 3.4.0
+   * @since 3.5.0
    */
   @scala.annotation.varargs
   def groupByKey[K](encoder: Encoder[K],

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1931,8 +1931,8 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 3.4.0
    */
-  def groupByKey[K: Encoder](columns: Column*): KeyValueGroupedDataset[K, T] =
-    groupBy(columns: _*).as[K, T]
+  def groupByKey[K: Encoder](column: Column, columns: Column*): KeyValueGroupedDataset[K, T] =
+    groupBy(column +: columns: _*).as[K, T]
 
   /**
    * (Scala-specific)
@@ -1947,8 +1947,8 @@ class Dataset[T] private[sql](
    * @group typedrel
    * @since 3.4.0
    */
-  def groupByKey[K: Encoder](col1: String, columns: String*): KeyValueGroupedDataset[K, T] =
-    groupBy(col1, columns: _*).as[K, T]
+  def groupByKey[K: Encoder](column: String, columns: String*): KeyValueGroupedDataset[K, T] =
+    groupBy(column, columns: _*).as[K, T]
 
   /**
    * (Scala-specific)
@@ -1990,8 +1990,9 @@ class Dataset[T] private[sql](
    * @since 3.4.0
    */
   @scala.annotation.varargs
-  def groupByKey[K](encoder: Encoder[K], columns: Column*) : KeyValueGroupedDataset[K, T] =
-    groupBy(columns: _*).as(encoderFor(encoder), exprEnc)
+  def groupByKey[K](encoder: Encoder[K], column: Column, columns: Column*):
+      KeyValueGroupedDataset[K, T] =
+    groupBy(column +: columns: _*).as(encoderFor(encoder), exprEnc)
 
   /**
    * (Java-specific)
@@ -2008,9 +2009,9 @@ class Dataset[T] private[sql](
    */
   @scala.annotation.varargs
   def groupByKey[K](encoder: Encoder[K],
-                    col1: String,
+                    column: String,
                     columns: String*): KeyValueGroupedDataset[K, T] =
-    groupBy(col1, columns: _*).as(encoderFor(encoder), exprEnc)
+    groupBy(column, columns: _*).as(encoderFor(encoder), exprEnc)
 
   /**
    * (Java-specific)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1920,13 +1920,44 @@ class Dataset[T] private[sql](
 
   /**
    * (Scala-specific)
+   * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key columns.
+   *
+   * @see `org.apache.spark.sql.Dataset.groupByKey(T => K)`
+   *
+   * @note Calling this method should be preferred to `groupByKey(T => K)` because the
+   *       Catalyst query planner cannot exploit existing partitioning and ordering of
+   *       this Dataset with that function.
+   *
+   * @group typedrel
+   * @since 3.4.0
+   */
+  def groupByKey[K: Encoder](columns: Column*): KeyValueGroupedDataset[K, T] =
+    groupBy(columns: _*).as[K, T]
+
+  /**
+   * (Scala-specific)
+   * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key columns.
+   *
+   * @see `org.apache.spark.sql.Dataset.groupByKey(T => K)`
+   *
+   * @note Calling this method should be preferred to `groupByKey(T => K)` because the
+   *       Catalyst query planner cannot exploit existing partitioning and ordering of
+   *       this Dataset with that function.
+   *
+   * @group typedrel
+   * @since 3.4.0
+   */
+  def groupByKey[K: Encoder](col1: String, columns: String*): KeyValueGroupedDataset[K, T] =
+    groupBy(col1, columns: _*).as[K, T]
+
+  /**
+   * (Scala-specific)
    * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key `func`.
    *
-   * @see `org.apache.spark.sql.Dataset.groupBy(*Column)`
-   * @see `org.apache.spark.sql.Dataset.groupBy(String, *String)`
-   * @see `org.apache.spark.sql.RelationalGroupedDataset.as()`
+   * @see `org.apache.spark.sql.Dataset.groupByKey(Column*)`
+   * @see `org.apache.spark.sql.Dataset.groupByKey(String, String*)`
    *
-   * @note Calling `groupBy(Column*).as[K, T]` or `groupByKey(String, String*).as[K, T]` should be
+   * @note Calling `groupByKey(Column*)` or `groupByKey(String, String*)` should be
    *       preferred to this method because the Catalyst query planner cannot exploit
    *       existing partitioning and ordering of this Dataset with this function.
    *
@@ -1947,14 +1978,49 @@ class Dataset[T] private[sql](
 
   /**
    * (Java-specific)
+   * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key columns.
+   *
+   * @see `org.apache.spark.sql.Dataset.groupByKey(MapFunction[T, K])`
+   *
+   * @note Calling this method should be preferred to `groupByKey(MapFunction[T, K])` because the
+   *       Catalyst query planner cannot exploit existing partitioning and ordering of
+   *       this Dataset with that function.
+   *
+   * @group typedrel
+   * @since 3.4.0
+   */
+  @scala.annotation.varargs
+  def groupByKey[K](encoder: Encoder[K], columns: Column*) : KeyValueGroupedDataset[K, T] =
+    groupBy(columns: _*).as(encoderFor(encoder), exprEnc)
+
+  /**
+   * (Java-specific)
+   * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key columns.
+   *
+   * @see `org.apache.spark.sql.Dataset.groupByKey(MapFunction[T, K])`
+   *
+   * @note Calling this method should be preferred to `groupByKey(MapFunction[T, K])` because the
+   *       Catalyst query planner cannot exploit existing partitioning and ordering of
+   *       this Dataset with that function.
+   *
+   * @group typedrel
+   * @since 3.4.0
+   */
+  @scala.annotation.varargs
+  def groupByKey[K](encoder: Encoder[K],
+                    col1: String,
+                    columns: String*): KeyValueGroupedDataset[K, T] =
+    groupBy(col1, columns: _*).as(encoderFor(encoder), exprEnc)
+
+  /**
+   * (Java-specific)
    * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key `func`.
    *
-   * @see `org.apache.spark.sql.Dataset.groupBy(*Column)`
-   * @see `org.apache.spark.sql.Dataset.groupBy(String, *String)`
-   * @see `org.apache.spark.sql.RelationalGroupedDataset.as()`
+   * @see `org.apache.spark.sql.Dataset.groupByKey(Encoder, Column*)`
+   * @see `org.apache.spark.sql.Dataset.groupByKey(Encoder, String, String*)`
    *
-   * @note Calling `groupBy(Column*).as[K, T]` or `groupByKey(String, String*).as[K, T]` should be
-   *       preferred to this method because the Catalyst query planner cannot exploit
+   * @note Calling `groupByKey(Encoder, Column*)` or `groupByKey(Encoder, String, String*)` should
+   *       be preferred to this method because the Catalyst query planner cannot exploit
    *       existing partitioning and ordering of this Dataset with this function.
    *
    * @group typedrel

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1922,6 +1922,14 @@ class Dataset[T] private[sql](
    * (Scala-specific)
    * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key `func`.
    *
+   * @see `org.apache.spark.sql.Dataset.groupBy(*Column)`
+   * @see `org.apache.spark.sql.Dataset.groupBy(String, *String)`
+   * @see `org.apache.spark.sql.RelationalGroupedDataset.as()`
+   *
+   * @note Calling `groupBy(Column*).as[K, T]` or `groupByKey(String, String*).as[K, T]` should be
+   *       preferred to this method because the Catalyst query planner cannot exploit
+   *       existing partitioning and ordering of this Dataset with this function.
+   *
    * @group typedrel
    * @since 2.0.0
    */
@@ -1940,6 +1948,14 @@ class Dataset[T] private[sql](
   /**
    * (Java-specific)
    * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key `func`.
+   *
+   * @see `org.apache.spark.sql.Dataset.groupBy(*Column)`
+   * @see `org.apache.spark.sql.Dataset.groupBy(String, *String)`
+   * @see `org.apache.spark.sql.RelationalGroupedDataset.as()`
+   *
+   * @note Calling `groupBy(Column*).as[K, T]` or `groupByKey(String, String*).as[K, T]` should be
+   *       preferred to this method because the Catalyst query planner cannot exploit
+   *       existing partitioning and ordering of this Dataset with this function.
    *
    * @group typedrel
    * @since 2.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1928,6 +1928,11 @@ class Dataset[T] private[sql](
    *       Catalyst query planner cannot exploit existing partitioning and ordering of
    *       this Dataset with that function.
    *
+   * {{{
+   *   ds.groupByKey[Int]($"age").flatMapGroups(...)
+   *   ds.groupByKey[(String, String)]($"department", $"gender").flatMapGroups(...)
+   * }}}
+   *
    * @group typedrel
    * @since 3.5.0
    */
@@ -1943,6 +1948,11 @@ class Dataset[T] private[sql](
    * @note Calling this method should be preferred to `groupByKey(T => K)` because the
    *       Catalyst query planner cannot exploit existing partitioning and ordering of
    *       this Dataset with that function.
+   *
+   * {{{
+   *   ds.groupByKey[Int]($"age").flatMapGroups(...)
+   *   ds.groupByKey[(String, String)]($"department", $"gender").flatMapGroups(...)
+   * }}}
    *
    * @group typedrel
    * @since 3.5.0
@@ -1978,51 +1988,7 @@ class Dataset[T] private[sql](
 
   /**
    * (Java-specific)
-   * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key columns.
-   *
-   * @see `org.apache.spark.sql.Dataset.groupByKey(MapFunction[T, K])`
-   *
-   * @note Calling this method should be preferred to `groupByKey(MapFunction[T, K])` because the
-   *       Catalyst query planner cannot exploit existing partitioning and ordering of
-   *       this Dataset with that function.
-   *
-   * @group typedrel
-   * @since 3.5.0
-   */
-  @scala.annotation.varargs
-  def groupByKey[K](encoder: Encoder[K], column: Column, columns: Column*):
-      KeyValueGroupedDataset[K, T] =
-    groupBy(column +: columns: _*).as(encoderFor(encoder), exprEnc)
-
-  /**
-   * (Java-specific)
-   * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key columns.
-   *
-   * @see `org.apache.spark.sql.Dataset.groupByKey(MapFunction[T, K])`
-   *
-   * @note Calling this method should be preferred to `groupByKey(MapFunction[T, K])` because the
-   *       Catalyst query planner cannot exploit existing partitioning and ordering of
-   *       this Dataset with that function.
-   *
-   * @group typedrel
-   * @since 3.5.0
-   */
-  @scala.annotation.varargs
-  def groupByKey[K](encoder: Encoder[K],
-                    column: String,
-                    columns: String*): KeyValueGroupedDataset[K, T] =
-    groupBy(column, columns: _*).as(encoderFor(encoder), exprEnc)
-
-  /**
-   * (Java-specific)
    * Returns a [[KeyValueGroupedDataset]] where the data is grouped by the given key `func`.
-   *
-   * @see `org.apache.spark.sql.Dataset.groupByKey(Encoder, Column*)`
-   * @see `org.apache.spark.sql.Dataset.groupByKey(Encoder, String, String*)`
-   *
-   * @note Calling `groupByKey(Encoder, Column*)` or `groupByKey(Encoder, String, String*)` should
-   *       be preferred to this method because the Catalyst query planner cannot exploit
-   *       existing partitioning and ordering of this Dataset with this function.
    *
    * @group typedrel
    * @since 2.0.0

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -320,6 +320,20 @@ public class JavaDatasetSuite implements Serializable {
 
     Assert.assertEquals(asSet("1a", "3foobar"), toSet(mapped.collectAsList()));
 
+    KeyValueGroupedDataset<Integer, String> colGrouped =
+      ds.groupByKey(Encoders.INT(), length(col("value")));
+
+    Dataset<String> colMapped = colGrouped.mapGroups(
+      (MapGroupsFunction<Integer, String, String>) (key, values) -> {
+        StringBuilder sb = new StringBuilder(key.toString());
+        while (values.hasNext()) {
+          sb.append(values.next());
+        }
+        return sb.toString();
+      }, Encoders.STRING());
+
+    Assert.assertEquals(toSet(mapped.collectAsList()), toSet(colMapped.collectAsList()));
+
     Dataset<String> flatMapped = grouped.flatMapGroups(
         (FlatMapGroupsFunction<Integer, String, String>) (key, values) -> {
           StringBuilder sb = new StringBuilder(key.toString());

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -320,20 +320,6 @@ public class JavaDatasetSuite implements Serializable {
 
     Assert.assertEquals(asSet("1a", "3foobar"), toSet(mapped.collectAsList()));
 
-    KeyValueGroupedDataset<Integer, String> colGrouped =
-      ds.groupByKey(Encoders.INT(), length(col("value")));
-
-    Dataset<String> colMapped = colGrouped.mapGroups(
-      (MapGroupsFunction<Integer, String, String>) (key, values) -> {
-        StringBuilder sb = new StringBuilder(key.toString());
-        while (values.hasNext()) {
-          sb.append(values.next());
-        }
-        return sb.toString();
-      }, Encoders.STRING());
-
-    Assert.assertEquals(toSet(mapped.collectAsList()), toSet(colMapped.collectAsList()));
-
     Dataset<String> flatMapped = grouped.flatMapGroups(
         (FlatMapGroupsFunction<Integer, String, String>) (key, values) -> {
           StringBuilder sb = new StringBuilder(key.toString());


### PR DESCRIPTION
### What changes were proposed in this pull request?
This documents that `groupBy(...).as[...]` should be preferred over `groupByKey(...)`.

It further provides shortcuts for `groupBy(...).as[...]` that make it easier to use column-based `groupByKey`.

### Why are the changes needed?

Calling `Dataset.groupBy(...).as[K, T]` should be preferred over calling `Dataset.groupByKey(...)` whenever possible. The former allows Catalyst to exploit existing partitioning and ordering of the Dataset, while the latter hides from Catalyst which columns are used to create the keys.

_When the dataset is already partitioned and ordered by the grouping columns, `Dataset.groupByKey(...)` will repartition and order the entire dataset again._

Example:

Calling `ds.groupByKey(_.id)` hides from Catalyst that column `id` is the grouping key, while `ds.groupBy($"id").as[Int, V]` tells Catalyst that `ds` is to be grouped by (partitioned and ordered by) column `id`.

The new column-based `groupByKey` methods make it easier for users to find a way to express the grouping by expressions. Looking at the `Dataset` API, the user finds `groupByKey` with `Column`. The existing `groupBy` method returns a `RelationalGroupedDataset`, which provides the `as[K, V]` method, which allows for the same semantics, but is difficult to find.

The new column-based `groupByKey` methods further do not require the user to specify the type `V` of the original `Dataset[V]`, as `groupByKey` has access to the type / encoder:

    ds.groupBy($"id").as[Int, V]

vs.

    ds.groupByKey[Int]($"id")

### Does this PR introduce _any_ user-facing change?

**Note: This breaks compilation when function name is used with existing `groupByKey`:**

Was:

    groupByKey(identity)

Now:

    groupByKey(identity(_))

It adds these methods:

Scala:
- `Dataset.groupByKey[K](Column, Column*)`
- `Dataset.groupByKey[K](String, String*)`

Java-specific methods cannot be added without introducing ambiguity. The compiler cannot work out which method is meant to be called.

### How was this patch tested?
Adds tests to `DatasetSuite`.