### PR TITLE
[SPARK-40538][CONNECT][FOLLOW-UP] Fix less than comparison in Spark Connect expression

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -46,7 +46,7 @@ class Expression(object):
     """
 
     __gt__ = _bin_op(">")
-    __lt__ = _bin_op(">")
+    __lt__ = _bin_op("<")
     __add__ = _bin_op("+")
     __sub__ = _bin_op("-")
     __mul__ = _bin_op("*")

--- a/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
@@ -57,6 +57,11 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
         the protobuf structure."""
         df = c.DataFrame.withPlan(p.Read("table"))
 
+        expr = fun.lit(10) < fun.lit(10)
+        expr_plan = expr.to_plan(None)
+        self.assertIsNotNone(expr_plan.unresolved_function)
+        self.assertEqual(expr_plan.unresolved_function.parts[0], "<")
+
         expr = df.id % fun.lit(10) == fun.lit(10)
         expr_plan = expr.to_plan(None)
         self.assertIsNotNone(expr_plan.unresolved_function)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/38270 that changes `__lt__` to use `<` that is less than comparison.

### Why are the changes needed?

To less than comparison to use `<` properly.

### Does this PR introduce _any_ user-facing change?

No, the original change is not released yet.

### How was this patch tested?

Unit test was added.