### PR TITLE
[MINOR][CORE][SQL][FOLLOWUP] Add missing s prefix to enable string interpolation

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1883,7 +1883,7 @@ private[spark] class DAGScheduler(
           if (ignoreStageFailure) {
             logInfo(s"Ignoring fetch failure from $task of $failedStage attempt " +
               s"${task.stageAttemptId} when count spark.stage.maxConsecutiveAttempts " +
-              "as executor ${bmAddress.executorId} is decommissioned and " +
+              s"as executor ${bmAddress.executorId} is decommissioned and " +
               s" ${config.STAGE_IGNORE_DECOMMISSION_FETCH_FAILURE.key}=true")
           } else {
             failedStage.failedAttemptIds.add(task.stageAttemptId)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -641,7 +641,7 @@ private[spark] class TaskSchedulerImpl(
                     if (!unschedulableTaskSetToExpiryTime.contains(taskSet)) {
                       logInfo("Notifying ExecutorAllocationManager to allocate more executors to" +
                         " schedule the unschedulable task before aborting" +
-                        " stage ${taskSet.stageId}.")
+                        s" stage ${taskSet.stageId}.")
                       dagScheduler.unschedulableTaskSetAdded(taskSet.taskSet.stageId,
                         taskSet.taskSet.stageAttemptId)
                       updateUnschedulableTaskSetTimeoutAndStartAbortTimer(taskSet, taskIndex)

--- a/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
@@ -395,7 +395,7 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
 
       // Fake tasks with different taskIds.
       val taskDescriptions = (1 to numTasks).map {
-        taskId => new TaskDescription(taskId, 2, "1", "TASK ${taskId}", 19,
+        taskId => new TaskDescription(taskId, 2, "1", s"TASK $taskId", 19,
           1, mutable.Map.empty, mutable.Map.empty, mutable.Map.empty, new Properties, 1,
           Map(GPU -> new ResourceInformation(GPU, Array("0", "1"))), data)
       }
@@ -483,7 +483,7 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
 
       // Fake tasks with different taskIds.
       val taskDescriptions = (1 to numTasks).map {
-        taskId => new TaskDescription(taskId, 2, "1", "TASK ${taskId}", 19,
+        taskId => new TaskDescription(taskId, 2, "1", s"TASK $taskId", 19,
           1, mutable.Map.empty, mutable.Map.empty, mutable.Map.empty, new Properties, 1,
           Map(GPU -> new ResourceInformation(GPU, Array("0", "1"))), data)
       }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GeneralizedLinearRegressionSuite.scala
@@ -1686,7 +1686,7 @@ class GeneralizedLinearRegressionSuite extends MLTest with DefaultReadWriteTest 
         .setFeaturesCol("features")
       val model = trainer.fit(dataset)
       val actual = model.summary.aic
-      assert(actual ~= expected(idx) absTol 1e-4, "Model mismatch: GLM with regParam = $regParam.")
+      assert(actual ~= expected(idx) absTol 1e-4, s"Model mismatch: GLM with regParam = $regParam.")
       idx += 1
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
@@ -629,14 +629,14 @@ object DecisionTreeSuite extends SparkFunSuite {
       case (Some(aNode), Some(bNode)) => checkEqual(aNode, bNode)
       case (None, None) =>
       case _ =>
-        fail("Only one instance has leftNode defined. (a.leftNode: ${a.leftNode}," +
-          " b.leftNode: ${b.leftNode})")
+        fail(s"Only one instance has leftNode defined. (a.leftNode: ${a.leftNode}," +
+          s" b.leftNode: ${b.leftNode})")
     }
     (a.rightNode, b.rightNode) match {
       case (Some(aNode: Node), Some(bNode: Node)) => checkEqual(aNode, bNode)
       case (None, None) =>
-      case _ => fail("Only one instance has rightNode defined. (a.rightNode: ${a.rightNode}, " +
-        "b.rightNode: ${b.rightNode})")
+      case _ => fail(s"Only one instance has rightNode defined. (a.rightNode: ${a.rightNode}, " +
+        s"b.rightNode: ${b.rightNode})")
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds missing `s` prefix to enable string interpolation. Complements #38297.

### Why are the changes needed?
Strings will not contain substituted values but variable names.

### Does this PR introduce _any_ user-facing change?
Log messages will change.

### How was this patch tested?
Not tested.