### PR TITLE
[SPARK-40823][CONNECT][FOLLOW-UP] Fix test_connect_column_expressions.py

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
@@ -77,7 +77,7 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
             ProtoExpression.UnresolvedAttribute,
         )
         self.assertEqual(
-            mod_fun.unresolved_function.arguments[0].unresolved_attribute.parts, ["id"]
+            mod_fun.unresolved_function.arguments[0].unresolved_attribute.unparsed_identifier, "id"
         )
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix  test_connect_column_expressions.py


### Why are the changes needed?
master is broken

```
ERROR [0.006s]: test_column_expressions (pyspark.sql.tests.connect.test_connect_column_expressions.SparkConnectColumnExpressionSuite)
Test a more complex combination of expressions and their translation into
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/sql/tests/connect/test_connect_column_expressions.py", line 80, in test_column_expressions
    mod_fun.unresolved_function.arguments[0].unresolved_attribute.parts, ["id"]
AttributeError: parts
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
test locally
