### PR TITLE
[SPARK-40823][CONNECT][TESTS][FOLLOW-UP] Fix test_column_expressions test case not to use parts

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
@@ -82,7 +82,7 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
             ProtoExpression.UnresolvedAttribute,
         )
         self.assertEqual(
-            mod_fun.unresolved_function.arguments[0].unresolved_attribute.parts, ["id"]
+            mod_fun.unresolved_function.arguments[0].unresolved_attribute.unparsed_identifier, "id"
         )
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/38264. There was a logical conflict with https://github.com/apache/spark/commit/a9da92498f0968eab21590845abbf1987ee9f1cd

### Why are the changes needed?

To make the tests pass.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually checked:

```bash
./python/run-tests --testnames 'pyspark.sql.tests.connect.test_connect_column_expressions'
Running PySpark tests. Output is in /.../spark/python/unit-tests.log
Will test against the following Python executables: ['python3.9']
Will test the following Python tests: ['pyspark.sql.tests.connect.test_connect_column_expressions']
python3.9 python_implementation is CPython
python3.9 version is: Python 3.9.5
Starting test(python3.9): pyspark.sql.tests.connect.test_connect_column_expressions (temp output: /Users/hyukjin.kwon/workspace/forked/spark/python/target/d3211937-d4e1-4492-a1f4-e0905117bfcb/python3.9__pyspark.sql.tests.connect.test_connect_column_expressions__uyrxnduc.log)
Finished test(python3.9): pyspark.sql.tests.connect.test_connect_column_expressions (0s)
Tests passed in 0 seconds
```