### PR TITLE
[SPARK-40846][INFRA]  Temporarily pin GA used Java version to pass GA first

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,7 +25,7 @@ on:
       java:
         required: false
         type: string
-        default: 8
+        default: 8.0.345
       branch:
         description: Branch to run the build against
         required: false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -630,8 +630,8 @@ jobs:
       fail-fast: false
       matrix:
         java:
-          - 11.0.16
-          - 17.0.4
+          - 11
+          - 17
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout Spark repository

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -630,8 +630,8 @@ jobs:
       fail-fast: false
       matrix:
         java:
-          - 11
-          - 17
+          - 11.0.16
+          - 17.0.4
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout Spark repository

--- a/.github/workflows/build_java11.yml
+++ b/.github/workflows/build_java11.yml
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'
     with:
-      java: 11
+      java: 11.0.16
       branch: master
       hadoop: hadoop3
       envs: >-

--- a/.github/workflows/build_java17.yml
+++ b/.github/workflows/build_java17.yml
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'
     with:
-      java: 17
+      java: 17.0.4
       branch: master
       hadoop: hadoop3
       envs: >-


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to pin GA used Java version to pass GA test first:

- Java 8 pin to 8.0.345
- Java 11 pin to 11.0.16
- Java 17 pin to 17.0.4

this change should be revert after find the root cause


### Why are the changes needed?
Make  GA passed first.

The following test failed with 8u352/11.0.17/17.0.5:

```
[info] *** 12 TESTS FAILED ***
[error] Failed: Total 6746, Failed 12, Errors 0, Passed 6734, Ignored 5
[error] Failed tests:
[error] 	org.apache.spark.sql.catalyst.expressions.CastWithAnsiOffSuite
[error] 	org.apache.spark.sql.catalyst.util.TimestampFormatterSuite
[error] 	org.apache.spark.sql.catalyst.expressions.CastWithAnsiOnSuite
[error] 	org.apache.spark.sql.catalyst.util.RebaseDateTimeSuite
[error] 	org.apache.spark.sql.catalyst.expressions.TryCastSuite
```



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions