### PR TITLE
[SPARK-40860][INFRA] Change `set-output` to `GITHUB_EVENT`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
     - name: Generate matrix
       id: set-matrix
-      run: echo "::set-output name=matrix::["`seq -s, 1 $SPARK_BENCHMARK_NUM_SPLITS`"]"
+      run: echo "matrix=["`seq -s, 1 $SPARK_BENCHMARK_NUM_SPLITS`"]" >> $GITHUB_OUTPUT
 
   # Any TPC-DS related updates on this job need to be applied to tpcds-1g job of build_and_test.yml as well
   tpcds-1g-gen:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -103,16 +103,15 @@ jobs:
               \"k8s-integration-tests\" : \"true\",
             }"
           echo $precondition # For debugging
-          # GitHub Actions set-output doesn't take newlines
-          # https://github.community/t/set-output-truncates-multiline-strings/16852/3
-          precondition="${precondition//$'\n'/'%0A'}"
-          echo "::set-output name=required::$precondition"
+          # Remove `\n` to avoid "Invalid format" error
+          precondition="${precondition//$'\n'/}}"
+          echo "required=$precondition" >> $GITHUB_OUTPUT
         else
           # This is usually set by scheduled jobs.
           precondition='${{ inputs.jobs }}'
           echo $precondition # For debugging
-          precondition="${precondition//$'\n'/'%0A'}"
-          echo "::set-output name=required::$precondition"
+          precondition="${precondition//$'\n'/}"
+          echo "required=$precondition" >> $GITHUB_OUTPUT
         fi
     - name: Generate infra image URL
       id: infra-image-outputs
@@ -121,7 +120,7 @@ jobs:
         REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
         IMG_NAME="apache-spark-ci-image:${{ inputs.branch }}-${{ github.run_id }}"
         IMG_URL="ghcr.io/$REPO_OWNER/$IMG_NAME"
-        echo ::set-output name=image_url::$IMG_URL
+        echo "image_url=$IMG_URL" >> $GITHUB_OUTPUT
 
   # Build: build Spark and run the tests for specified modules.
   build:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change `set-output` to `GITHUB_OUTPUT`.


### Why are the changes needed?
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Does this PR introduce _any_ user-facing change?
No, dev only


### How was this patch tested?
- CI passed
- Also do a local test on benchmark: https://github.com/Yikun/spark/actions/runs/3294384181/jobs/5431945626