### PR TITLE
[SPARK-40865][BUILD] Upgrade jodatime to 2.12.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -147,7 +147,7 @@ jetty-util/6.1.26//jetty-util-6.1.26.jar
 jetty-util/9.4.49.v20220914//jetty-util-9.4.49.v20220914.jar
 jetty/6.1.26//jetty-6.1.26.jar
 jline/2.14.6//jline-2.14.6.jar
-joda-time/2.11.2//joda-time-2.11.2.jar
+joda-time/2.12.0//joda-time-2.12.0.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -132,7 +132,7 @@ jettison/1.1//jettison-1.1.jar
 jetty-util-ajax/9.4.49.v20220914//jetty-util-ajax-9.4.49.v20220914.jar
 jetty-util/9.4.49.v20220914//jetty-util-9.4.49.v20220914.jar
 jline/2.14.6//jline-2.14.6.jar
-joda-time/2.11.2//joda-time-2.11.2.jar
+joda-time/2.12.0//joda-time-2.12.0.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <guava.version>14.0.1</guava.version>
     <janino.version>3.1.7</janino.version>
     <jersey.version>2.36</jersey.version>
-    <joda.version>2.11.2</joda.version>
+    <joda.version>2.12.0</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
     <libthrift.version>0.12.0</libthrift.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade  jodatime to 2.12.0.

### Why are the changes needed?
This version includes:

- Add translations for ca, el, eu, fi, hi, hu, in, iw, ms, nn, ro, sk, sv, zh.
- DateTimeZone data updated to version 2022egtz.

The release notes as following:

- https://www.joda.org/joda-time/changes-report.html#a2.12.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions 