### PR TITLE
[SPARK-40868][SQL] Avoid introducing too many partitions when bucketed scan disabled by sql planner

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1423,6 +1423,12 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val AUTO_BUCKETED_SCAN_MAX_PARTITIONS =
+    buildConf("spark.sql.sources.bucketing.autoBucketedScan.max.partitions")
+      .doc("The maximum partition number allowed if one bucket table is disabled by planner.")
+      .version("3.4.0")
+      .fallbackConf(BUCKETING_MAX_BUCKETS)
+
   val CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING =
     buildConf("spark.sql.optimizer.canChangeCachedPlanOutputPartitioning")
       .internal()
@@ -4442,6 +4448,8 @@ class SQLConf extends Serializable with Logging {
   def bucketingMaxBuckets: Int = getConf(SQLConf.BUCKETING_MAX_BUCKETS)
 
   def autoBucketedScanEnabled: Boolean = getConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED)
+
+  def autoBucketedScanMaxPartitions: Int = getConf(SQLConf.AUTO_BUCKETED_SCAN_MAX_PARTITIONS)
 
   def v2BucketingEnabled: Boolean = getConf(SQLConf.V2_BUCKETING_ENABLED)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DisableUnnecessaryBucketedScanSuite.scala
@@ -290,7 +290,7 @@ abstract class DisableUnnecessaryBucketedScanSuite
       withSQLConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED.key -> "true",
         SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "4",
         SQLConf.FILES_MAX_PARTITION_BYTES.key -> "128") {
-        spark.range(0, 500).toDF("k").write.bucketBy(5, "k").saveAsTable("t1")
+        spark.range(0, 1000).toDF("k").write.bucketBy(5, "k").saveAsTable("t1")
 
         val query = "SELECT k FROM t1"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

For bucket tables with huge size, lots of partitions maybe generated if bucketed scan disabled by sql planner. 

We can add one limit(default as BUCKETING_MAX_BUCKETS) to reduce the partitions for non-bucketed scan.

### Why are the changes needed?
Avoid too many tasks introduced in single stage.

Before
![image](https://user-images.githubusercontent.com/7522130/197170079-35ee13f2-1d6c-425b-bfdd-5c4ac3c8297c.png)

After
![image](https://user-images.githubusercontent.com/7522130/197170156-556f839b-8fde-4f29-862b-5a6d90bd0a8e.png)

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
UT