### PR TITLE
[SPARK-40869][K8S] Resource name prefix should not start with a hyphen

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -256,6 +256,7 @@ private[spark] object KubernetesConf {
       .toLowerCase(Locale.ROOT)
       .replaceAll("[^a-z0-9\\-]", "-")
       .replaceAll("-+", "-")
+      .replaceAll("^-", "")
   }
 
   def getAppNameLabel(appName: String): String = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -250,4 +250,8 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(KubernetesConf.getAppNameLabel("a" * 62 + "-aaa") === "a" * 62)
     assert(KubernetesConf.getAppNameLabel("-" + "a" * 63) === "a" * 62)
   }
+
+  test("SPARK-40869: KubernetesConf.getResourceNamePrefix creates invalid name prefixes") {
+    assert(KubernetesConf.getResourceNamePrefix("_hello_").startsWith("hello"))
+  }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -251,7 +251,7 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(KubernetesConf.getAppNameLabel("-" + "a" * 63) === "a" * 62)
   }
 
-  test("SPARK-40869: KubernetesConf.getResourceNamePrefix creates invalid name prefixes") {
+  test("SPARK-40869: Resource name prefix should not start with a hyphen") {
     assert(KubernetesConf.getResourceNamePrefix("_hello_").startsWith("hello"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Strip leading - from resource name prefix


### Why are the changes needed?
leading - are not allowed for resource name prefix (especially spark.kubernetes.executor.podNamePrefix)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test