### PR TITLE
[SPARK-40872] Fallback to original shuffle block when a push-merged shuffle chunk is zero-size

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
@@ -285,6 +285,8 @@ private class PushBasedFetchHelper(
    * 2. There is a failure when fetching remote shuffle chunks.
    * 3. There is a failure when processing SuccessFetchResult which is for a shuffle chunk
    *    (local or remote).
+   * 4. There is a zero-size buffer when processing SuccessFetchResult for a shuffle chunk
+   *    (local or remote).
    */
   def initiateFallbackFetchForPushMergedBlock(
       blockId: BlockId,

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -828,8 +828,8 @@ final class ShuffleBlockFetcherIterator(
                   case ce: ClosedByInterruptException =>
                     logError("Failed to create input stream from local block, " +
                       ce.getMessage)
-                  case e: IOException => logError(
-                    "Failed to create input stream from local block", e)
+                  case e: IOException =>
+                    logError("Failed to create input stream from local block", e)
                 }
                 buf.release()
                 if (blockId.isShuffleChunk) {

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -799,6 +799,9 @@ final class ShuffleBlockFetcherIterator(
             val msg = s"Received a zero-size buffer for block $blockId from $address " +
               s"(expectedApproxSize = $size, isNetworkReqDone=$isNetworkReqDone)"
             if (blockId.isShuffleChunk) {
+              // Zero-size block may come from nodes with hardware failures, For shuffle chunks,
+              // the original shuffle blocks that belong to that zero-size shuffle chunk is
+              // available and we can opt to fallback immediately.
               logWarning(msg)
               pushBasedFetchHelper.initiateFallbackFetchForPushMergedBlock(blockId, address)
               // Set result to null to trigger another iteration of the while loop to get either.

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -806,7 +806,6 @@ final class ShuffleBlockFetcherIterator(
               pushBasedFetchHelper.initiateFallbackFetchForPushMergedBlock(blockId, address)
               // Set result to null to trigger another iteration of the while loop to get either.
               result = null
-              null
             } else {
               throwFetchFailedException(blockId, mapIndex, address, new IOException(msg))
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When push-based shuffle is enabled, a zero-size buf error may occur when fetching shuffle chunks from bad nodes, especially when memory is full. In this case, we can fall back to original shuffle blocks.


### Why are the changes needed?
When the reduce task obtains the shuffle chunk with a zero-size buf, we let it fall back to original shuffle block. After verification, these blocks can be read successfully without shuffle retry.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT