### PR TITLE
[SPARK-40871][INFRA] Upgrade actions/github-script to v6 and fix notify workflow

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -36,7 +36,7 @@ jobs:
       checks: write
     steps:
       - name: "Notify test workflow"
-        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # pin@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -80,7 +80,7 @@ jobs:
               status = 'completed'
               const conclusion = 'action_required'
 
-              github.checks.create({
+              github.rest.checks.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name: name,
@@ -132,7 +132,7 @@ jobs:
                 + '/actions/runs/'
                 + run_id
 
-              github.checks.create({
+              github.rest.checks.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name: name,

--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -32,7 +32,7 @@ jobs:
       checks: write
     steps:
       - name: "Update build status"
-        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # pin@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade actions/github-scripts from v3 to v6 and fix notify workflow


### Why are the changes needed?
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. 

- Since github-script V5,  change from `github.*` to `github.rest.*`, but `request`, `paginate` are unchanged.
  see also https://github.com/actions/github-script#breaking-changes-in-v5
- Since github-script V6, upgrade node12 to node16


### Does this PR introduce _any_ user-facing change?
No, dev only


### How was this patch tested?
- Due to `pull_request_target`, the current PR is not in effect, we can only do test on local : set default branch to V6, and submit the PR https://github.com/Yikun/spark/pull/181

Notify works well:
<img width="850" alt="image" src="https://user-images.githubusercontent.com/1736354/197310102-6c709716-8a99-422d-8d38-3f770b6925f0.png">

Update status set to failed as expeceted:
<img width="898" alt="image" src="https://user-images.githubusercontent.com/1736354/197310119-30332769-0553-4ffa-816c-97a5ec0b3c27.png">

And `See test results` set right.
https://github.com/Yikun/spark/pull/181/checks?check_run_id=9029035780
