### PR TITLE
[SPARK-40870][INFRA] Upgrade docker actions to cleanup warning

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -299,12 +299,12 @@ jobs:
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./dev/infra/
           push: true

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -40,18 +40,18 @@ jobs:
       - name: Checkout Spark repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./dev/infra/
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade docker actions to cleanup warning


### Why are the changes needed?
- docker/setup-qemu-action from v1 to v2:
  https://github.com/docker/setup-qemu-action/releases/tag/v2.0.0: Cleanup node 12 warning
  https://github.com/docker/setup-qemu-action/releases/tag/v2.1.0: Cleanup set-ouput save-state waring
- docker/setup-buildx-action from v1 to v2:
  https://github.com/docker/setup-buildx-action/releases/tag/v2.0.0: Cleanup node 12 warning
  https://github.com/docker/setup-buildx-action/releases/tag/v2.1.0: Cleanup set-ouput save-state waring
- docker/build-push-action from v2 to v3
  https://github.com/docker/build-push-action/releases/tag/v3.0.0: Cleanup node 12 warning
  https://github.com/docker/build-push-action/releases/tag/v3.2.0: Cleanup set-ouput save-state waring
- docker/login-action from v1 to v2
  https://github.com/docker/login-action/releases/tag/v2.0.0: Cleanup node 12 warning
  https://github.com/docker/login-action/releases/tag/v2.1.0: Cleanup set-ouput save-state waring

### Does this PR introduce _any_ user-facing change?
No, dev only


### How was this patch tested?
CI passed