### PR TITLE
[SPARK-40880][SQL] Reimplement `summary` with dataframe operations

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -273,21 +273,22 @@ object StatFunctions extends Logging {
             aggColumns += lit(stats)
 
             stats.toLowerCase(Locale.ROOT) match {
-              case "count" =>
-                aggColumns += count(rawColumn).cast("string")
-              case "count_distinct" =>
-                aggColumns += count_distinct(rawColumn).cast("string")
-              case "approx_count_distinct" =>
-                aggColumns += approx_count_distinct(rawColumn).cast("string")
-              case "mean" => aggColumns += avg(numColumn).cast("string")
-              case "stddev" =>
-                aggColumns += stddev(numColumn).cast("string")
-              case "min" =>
-                aggColumns += min(rawColumn).cast("string")
-              case "max" =>
-                aggColumns += max(rawColumn).cast("string")
+              case "count" => aggColumns += count(rawColumn)
+
+              case "count_distinct" => aggColumns += count_distinct(rawColumn)
+
+              case "approx_count_distinct" => aggColumns += approx_count_distinct(rawColumn)
+
+              case "mean" => aggColumns += avg(numColumn)
+
+              case "stddev" => aggColumns += stddev(numColumn)
+
+              case "min" => aggColumns += min(rawColumn)
+
+              case "max" => aggColumns += max(rawColumn)
+
               case percentile if percentile.endsWith("%") =>
-                aggColumns += get(percentilesCol, lit(percentileIndex)).cast("string")
+                aggColumns += get(percentilesCol, lit(percentileIndex))
                 percentileIndex += 1
 
               case _ => throw QueryExecutionErrors.statisticNotRecognizedError(stats)
@@ -295,7 +296,7 @@ object StatFunctions extends Logging {
           }
 
           // map { "count" -> "1024", "min" -> "1.0", ... }
-          mapColumns += map(aggColumns.result(): _*).as(field.name)
+          mapColumns += map(aggColumns.map(_.cast("string")): _*).as(field.name)
           columnNames += field.name
 
         case _ =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reimplement `summary` with dataframe operations

### Why are the changes needed?
1, do not truncate the sql plan any more;
2, enable sql optimization like column pruning:

``` 
scala> val df = spark.range(0, 3, 1, 10).withColumn("value", lit("str"))
df: org.apache.spark.sql.DataFrame = [id: bigint, value: string]

scala> df.summary("max", "50%").show
+-------+---+-----+
|summary| id|value|
+-------+---+-----+
|    max|  2|  str|
|    50%|  1| null|
+-------+---+-----+


scala> df.summary("max", "50%").select("id").show
+---+
| id|
+---+
|  2|
|  1|
+---+


scala> df.summary("max", "50%").select("id").queryExecution.optimizedPlan
res4: org.apache.spark.sql.catalyst.plans.logical.LogicalPlan =
Project [element_at(id#367, summary#376, None, false) AS id#371]
+- Generate explode([max,50%]), false, [summary#376]
   +- Aggregate [map(max, cast(max(id#153L) as string), 50%, cast(percentile_approx(id#153L, [0.5], 10000, 0, 0)[0] as string)) AS id#367]
      +- Range (0, 3, step=1, splits=Some(10))


```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing UTs and manually check