### PR TITLE
[SPARK-40801][BUILD][3.2] Upgrade `Apache commons-text` to 1.10

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -51,7 +51,7 @@ commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.4.1//commons-math3-3.4.1.jar
 commons-net/3.1//commons-net-3.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.6//commons-text-1.6.jar
+commons-text/1.10.0//commons-text-1.10.0.jar
 compress-lzf/1.0.3//compress-lzf-1.0.3.jar
 core/1.1.2//core-1.1.2.jar
 curator-client/2.7.1//curator-client-2.7.1.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -42,7 +42,7 @@ commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.4.1//commons-math3-3.4.1.jar
 commons-net/3.1//commons-net-3.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.6//commons-text-1.6.jar
+commons-text/1.10.0//commons-text-1.10.0.jar
 compress-lzf/1.0.3//compress-lzf-1.0.3.jar
 core/1.1.2//core-1.1.2.jar
 curator-client/2.13.0//curator-client-2.13.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.6</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION

### What changes were proposed in this pull request?
Upgrade Apache commons-text from 1.6 to 1.10.0


### Why are the changes needed?
[CVE-2022-42889](https://nvd.nist.gov/vuln/detail/CVE-2022-42889) 
this is a [9.8 CRITICAL](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2022-42889&vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.1&source=NIST)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA
