### PR TITLE
[SPARK-40885] `Sort` may not take effect when it is the last 'Transform' operator

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -156,7 +156,12 @@ case class CreateDataSourceTableAsSelectCommand(
 
   override def requiredOrdering: Seq[SortOrder] = {
     val options = table.storage.properties
-    V1WritesUtils.getSortOrder(outputColumns, partitionColumns, table.bucketSpec, options)
+    val originSortedColumns = query.outputOrdering.flatMap(_.child match {
+      case attr: Attribute => Some(attr)
+      case _ => None
+    })
+    V1WritesUtils.getSortOrder(originSortedColumns, outputColumns,
+      partitionColumns, table.bucketSpec, options)
   }
 
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.hadoop.fs.{FileSystem, Path}
+
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTablePartition}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
@@ -182,7 +182,12 @@ object V1WritesUtils {
       // columns.
       val sortOrder = (dynamicPartitionColumns ++
         writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns)
-      val residualSort = originSortSet.filterNot(sortOrder.contains)
+      val exprIdSet = sortOrder.flatMap({
+        case a: Attribute => Some(a.exprId)
+        case _ => None
+      }).toSet
+      val residualSort = originSortSet.filterNot(s => (sortOrder.contains()
+        || exprIdSet.contains(s.exprId)))
       (sortOrder ++ residualSort)
         .map(SortOrder(_, Ascending))
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
@@ -180,7 +180,8 @@ object V1WritesUtils {
     } else {
       // We should first sort by dynamic partition columns, then bucket id, and finally sorting
       // columns.
-      val sortOrder = (dynamicPartitionColumns ++ writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns)
+      val sortOrder = (dynamicPartitionColumns ++
+        writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns)
       val residualSort = originSortSet.filterNot(sortOrder.contains)
       (sortOrder ++ residualSort)
         .map(SortOrder(_, Ascending))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
@@ -166,8 +166,8 @@ object V1WritesUtils {
       numStaticPartitionCols: Int = 0): Seq[SortOrder] = {
     require(partitionColumns.size >= numStaticPartitionCols)
 
-    val originSortSet = AttributeSet(originSortColumns)
     val partitionSet = AttributeSet(partitionColumns)
+    val originSortSet = outputColumns.filter(AttributeSet(originSortColumns).contains)
     val dataColumns = outputColumns.filterNot(partitionSet.contains)
     val writerBucketSpec = V1WritesUtils.getWriterBucketSpec(bucketSpec, dataColumns, options)
     val sortColumns = V1WritesUtils.getBucketSortColumns(bucketSpec, dataColumns)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -54,7 +54,12 @@ trait CreateHiveTableAsSelectBase extends V1WriteCommand with V1WritesHiveUtils 
 
   override def requiredOrdering: Seq[SortOrder] = {
     val options = getOptionsWithHiveBucketWrite(tableDesc.bucketSpec)
-    V1WritesUtils.getSortOrder(outputColumns, partitionColumns, tableDesc.bucketSpec, options)
+    val originSortedColumns = query.outputOrdering.flatMap(_.child match {
+      case attr: Attribute => Some(attr)
+      case _ => None
+    })
+    V1WritesUtils.getSortOrder(originSortedColumns, outputColumns,
+      partitionColumns, tableDesc.bucketSpec, options)
   }
 
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -82,7 +82,12 @@ case class InsertIntoHiveTable(
 
   override def requiredOrdering: Seq[SortOrder] = {
     val options = getOptionsWithHiveBucketWrite(table.bucketSpec)
-    V1WritesUtils.getSortOrder(outputColumns, partitionColumns, table.bucketSpec, options)
+    val originSortedColumns = query.outputOrdering.flatMap(_.child match {
+      case attr: Attribute => Some(attr)
+      case _ => None
+    })
+    V1WritesUtils.getSortOrder(originSortedColumns, outputColumns,
+      partitionColumns, table.bucketSpec, options)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

The following codes:
```
      Seq((20, 30, "partition"), (15, 20, "partition"),
        (30, 70, "partition"), (18, 40, "partition"))
        .toDF("id", "sort_col", "p")
        .repartition(1)
        .sortWithinPartitions("p", "sort_col")
        .write
        .partitionBy("p")
        .parquet(f.getAbsolutePath)
```

When the 'Sort'+'partitionBy' operator is used, because 'partitionBy' will generate a new `Sort("partition_col")`, the logical plan is as follows:

```
Sort("p")
  Project("id", "sort_col", "p")
    Sort("p", "sort_col")
      Input
```

However, due to ` org.apache.spark.sql.catalyst.optimizer.EliminateSorts' will prune the operators irrelevant to the output, which will cause 'Sort ("p", "sort_col")' to be pruned, but in fact it should take effect.

This causes Sort to fail in various scenarios, as shown in the following SQL:
```
set spark.hadoop.hive.exec.dynamici.partition=true;
set spark.hadoop.hive.exec.dynamic.partition.mode=nonstrict;

// this sql sort with partition filed (`dt`) and data filed (`name`), but sort with `name` can not work
insert overwrite table sort_table partition(dt) select id,name,dt from test_table order by name,dt;
```

The scenario covered by this issue is that 'Sort' is the last 'Transform' operator of the job. When there are other 'Transform' operators after the 'Sort', the Sort should not be effective.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix bug


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

add new UT.

