### PR TITLE
[WIP][MINOR] Remove unused import in StatFunctions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -21,14 +21,12 @@ import java.util.Locale
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
-import org.apache.spark.sql.catalyst.expressions.{Cast, ElementAt, EvalMode, GenericInternalRow}
+import org.apache.spark.sql.catalyst.expressions.{Cast, ElementAt, EvalMode}
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.util.QuantileSummaries
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.UTF8String
 
 object StatFunctions extends Logging {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unused import in `StatFunctions.scala`.

### Why are the changes needed?
Cleanup
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/15246973/197441458-a35ee195-96bf-4359-ae1d-f64f981b527e.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.