### PR TITLE
[SPARK-40821][SQL][SS][FOLLOWUP] Fix available version for new function window_time

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WindowTime.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/WindowTime.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.types._
         A2	2021-01-01 00:00:00	2021-01-01 00:05:00	2021-01-01 00:04:59.999999	1
   """,
   group = "datetime_funcs",
-  since = "3.3.0")
+  since = "3.4.0")
 // scalastyle:on line.size.limit line.contains.tab
 case class WindowTime(windowColumn: Expression)
   extends UnaryExpression

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3788,7 +3788,7 @@ object functions {
    *                     StructType { start: Timestamp, end: Timestamp }
    *
    * @group datetime_funcs
-   * @since 3.3.0
+   * @since 3.4.0
    */
   def window_time(windowColumn: Column): Column = withExpr {
     WindowTime(windowColumn.expr)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the incorrect available version for new function `window_time` to 3.4.0 which is upcoming release for master branch.

### Why are the changes needed?

The version information is incorrect.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A