### PR TITLE
[SPARK-40897][DOCS] Add some PySpark APIs to References

### DIFF
--- a/python/docs/source/reference/pyspark.rst
+++ b/python/docs/source/reference/pyspark.rst
@@ -262,10 +262,12 @@ Management
     StorageLevel.DISK_ONLY_3
     StorageLevel.MEMORY_AND_DISK
     StorageLevel.MEMORY_AND_DISK_2
+    StorageLevel.MEMORY_AND_DISK_DESER
     StorageLevel.MEMORY_ONLY
     StorageLevel.MEMORY_ONLY_2
     StorageLevel.OFF_HEAP
     TaskContext.attemptNumber
+    TaskContext.cpus
     TaskContext.get
     TaskContext.getLocalProperty
     TaskContext.partitionId
@@ -277,6 +279,7 @@ Management
     BarrierTaskContext.allGather
     BarrierTaskContext.attemptNumber
     BarrierTaskContext.barrier
+    BarrierTaskContext.cpus
     BarrierTaskContext.get
     BarrierTaskContext.getLocalProperty
     BarrierTaskContext.getTaskInfos


### PR DESCRIPTION
### What changes were proposed in this pull request?
add following missing APIs to references:

- StorageLevel.MEMORY_AND_DISK_DESER
- TaskContext.cpus
- BarrierTaskContext.cpus

### Why are the changes needed?
they were missing in Reference


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
manually check, for `BarrierTaskContext.cpus`

```
In [10]: from pyspark import BarrierTaskContext

In [11]: rdd = spark.sparkContext.parallelize([1])

In [12]: rdd.barrier().mapPartitions(lambda _: [BarrierTaskContext.get().cpus()]).collect()
Out[12]: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
```
