### PR TITLE
[SPARK-40906][SQL] `Mode` should copy keys before inserting into Map

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -59,10 +59,10 @@ case class Mode(
   override def update(
       buffer: OpenHashMap[AnyRef, Long],
       input: InternalRow): OpenHashMap[AnyRef, Long] = {
-    val key = child.eval(input).asInstanceOf[AnyRef]
+    val key = child.eval(input)
 
     if (key != null) {
-      buffer.changeValue(key, 1L, _ + 1L)
+      buffer.changeValue(InternalRow.copyValue(key).asInstanceOf[AnyRef], 1L, _ + 1L)
     }
     buffer
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`Mode` should copy keys before inserting into Map


### Why are the changes needed?
the result maybe incorrect:
```
val df = sc.parallelize(Seq.empty[Int], 4)
    .mapPartitionsWithIndex { (idx, iter) =>
         if (idx == 3) {
            Iterator("3", "3", "3", "3", "4")
         } else {
            Iterator("0", "1", "2", "3", "4")
         }
    }.toDF("a")

  df.select(mode(col("a"))).show
+-------+                                                                       
|mode(a)|
+-------+
|      4|
+-------+

```

after this fix:
```
  df.select(mode(col("a"))).show
+-------+                                                                       
|mode(a)|
+-------+
|      3|
+-------+
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added UT
