### PR TITLE
[SPARK-40907][PS][SQL] `PandasMode` should copy keys before inserting into Map

### DIFF
--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -6044,6 +6044,19 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         with self.assertRaises(ValueError):
             psdf.mode(axis=2)
 
+        def f(index, iterator):
+            return ["3", "3", "3", "3", "4"] if index == 3 else ["0", "1", "2", "3", "4"]
+
+        rdd = self.spark.sparkContext.parallelize(
+            [
+                1,
+            ],
+            4,
+        ).mapPartitionsWithIndex(f)
+        df = self.spark.createDataFrame(rdd, schema="string")
+        psdf = df.pandas_api()
+        self.assert_eq(psdf.mode(), psdf._to_pandas().mode())
+
     def test_abs(self):
         pdf = pd.DataFrame({"a": [-2, -1, 0, 1]})
         psdf = ps.from_pandas(pdf)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -121,10 +121,12 @@ case class PandasMode(
   override def update(
       buffer: OpenHashMap[AnyRef, Long],
       input: InternalRow): OpenHashMap[AnyRef, Long] = {
-    val key = child.eval(input).asInstanceOf[AnyRef]
+    val key = child.eval(input)
 
-    if (key != null || !ignoreNA) {
-      buffer.changeValue(key, 1L, _ + 1L)
+    if (key != null) {
+      buffer.changeValue(InternalRow.copyValue(key).asInstanceOf[AnyRef], 1L, _ + 1L)
+    } else if (!ignoreNA) {
+      buffer.changeValue(null, 1L, _ + 1L)
     }
     buffer
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `PandasMode` copy keys before inserting into Map


### Why are the changes needed?
correctness issue similar to https://github.com/apache/spark/pull/38383, make it a separate PR since it is dedicated for Pandas API

```
In [24]: def f(index, iterator): return ['3', '3', '3', '3', '4'] if index == 3 else ['0', '1', '2', '3', '4']

In [25]: rdd = sc.parallelize([1, ], 4).mapPartitionsWithIndex(f)

In [26]: df = spark.createDataFrame(rdd, schema='string')

In [27]: psdf = df.pandas_api()

In [28]: psdf.mode()
Out[28]: 
  value
0     4

In [29]: psdf._to_pandas().mode()
Out[29]: 
  value
0     3
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added UT