### PR TITLE
[MINOR][DOCS][PYTHON] Fix the truncation of API reference in several DataTypes

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -350,21 +350,21 @@ class FloatType(FractionalType, metaclass=DataTypeSingleton):
 
 
 class ByteType(IntegralType):
-    """Byte data type, i.e. a signed integer in a single byte."""
+    """Byte data type, i.e.\  a signed integer in a single byte."""
 
     def simpleString(self) -> str:
         return "tinyint"
 
 
 class IntegerType(IntegralType):
-    """Int data type, i.e. a signed 32-bit integer."""
+    """Int data type, i.e.\  a signed 32-bit integer."""
 
     def simpleString(self) -> str:
         return "int"
 
 
 class LongType(IntegralType):
-    """Long data type, i.e. a signed 64-bit integer.
+    """Long data type, i.e.\  a signed 64-bit integer.
 
     If the values are beyond the range of [-9223372036854775808, 9223372036854775807],
     please use :class:`DecimalType`.
@@ -434,7 +434,7 @@ class DayTimeIntervalType(AtomicType):
 
 
 class ShortType(IntegralType):
-    """Short data type, i.e. a signed 16-bit integer."""
+    """Short data type, i.e.\  a signed 16-bit integer."""
 
     def simpleString(self) -> str:
         return "smallint"


### PR DESCRIPTION
### What changes were proposed in this pull request?
The documentation under https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/data_types.html chops off the stubs on periods with a subsequent space. This leads to weird stubs when "i.e." is used. This PR escapes the subsequent spaces.
![image](https://user-images.githubusercontent.com/2806328/197775658-60a86497-61b0-41ab-a90f-1452667ebc2a.png)


### Why are the changes needed?
see above.

### Does this PR introduce _any_ user-facing change?
This changes the documentation under https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/data_types.html

### How was this patch tested?
manual build