### PR TITLE
[SPARK-40913][INFRA] Pin `pytest==7.1.3`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -556,7 +556,7 @@ jobs:
         #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
         # Jinja2 3.0.0+ causes error when building with Sphinx.
         #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-        python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.920' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==22.6.0'
+        python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.920' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==22.6.0'
         python3.9 -m pip install 'pandas-stubs==1.2.0.53'
     - name: Install dependencies for Python code generation check
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pin pytest==7.1.3


### Why are the changes needed?

`pytest-mypy-plugins==1.9.3` depends on `pytest [required: >=6.0.0]`, [pytest 7.2.0](https://pypi.org/project/pytest/) is released just now

I guess it breaks the python linter

```
Traceback (most recent call last):
  File "/usr/local/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/usr/local/lib/python3.9/dist-packages/_pytest/config/__init__.py", line 190, in console_main
    code = main()
  File "/usr/local/lib/python3.9/dist-packages/_pytest/config/__init__.py", line 148, in main
    config = _prepareconfig(args, plugins)
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI,  but can not reproduce locally