### PR TITLE
[SPARK-37945][SQL][FOLLOWUP] Rename the error class `INCORRECT_RUMP_UP_RATE`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -453,7 +453,7 @@
       "Max offset with <rowsPerSecond> rowsPerSecond is <maxSeconds>, but it's <endSeconds> now."
     ]
   },
-  "INCORRECT_RUMP_UP_RATE" : {
+  "INCORRECT_RAMP_UP_RATE" : {
     "message" : [
       "Max offset with <rowsPerSecond> rowsPerSecond is <maxSeconds>, but 'rampUpTimeSeconds' is <rampUpTimeSeconds>."
     ]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2391,7 +2391,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       maxSeconds: Long,
       rampUpTimeSeconds: Long): Throwable = {
     new SparkRuntimeException(
-      errorClass = "INCORRECT_RUMP_UP_RATE",
+      errorClass = "INCORRECT_RAMP_UP_RATE",
       messageParameters = Map(
         "rowsPerSecond" -> rowsPerSecond.toString,
         "maxSeconds" -> maxSeconds.toString,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2387,7 +2387,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
     new SparkException("Foreach writer has been aborted due to a task failure")
   }
 
-  def incorrectRumpUpRate(rowsPerSecond: Long,
+  def incorrectRampUpRate(rowsPerSecond: Long,
       maxSeconds: Long,
       rampUpTimeSeconds: Long): Throwable = {
     new SparkRuntimeException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
@@ -52,7 +52,7 @@ class RateStreamMicroBatchStream(
   private val maxSeconds = Long.MaxValue / rowsPerSecond
 
   if (rampUpTimeSeconds > maxSeconds) {
-    throw QueryExecutionErrors.incorrectRumpUpRate(
+    throw QueryExecutionErrors.incorrectRampUpRate(
       rowsPerSecond, maxSeconds, rampUpTimeSeconds)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProviderSuite.scala
@@ -207,7 +207,7 @@ class RateStreamProviderSuite extends StreamTest {
 
     checkError(
       exception = e,
-      errorClass = "INCORRECT_RUMP_UP_RATE",
+      errorClass = "INCORRECT_RAMP_UP_RATE",
       parameters = Map(
         "rowsPerSecond" -> Long.MaxValue.toString,
         "maxSeconds" -> "1",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProviderSuite.scala
@@ -197,7 +197,7 @@ class RateStreamProviderSuite extends StreamTest {
     }
   }
 
-  testQuietly("microbatch - rump up error") {
+  testQuietly("microbatch - ramp up error") {
     val e = intercept[SparkRuntimeException](
       new RateStreamMicroBatchStream(
         rowsPerSecond = Long.MaxValue,


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to fix a typo by renaming the error class INCORRECT_RUMP_UP_RATE to INCORRECT_RAMP_UP_RATE, and rename the method `incorrectRumpUpRate()` to `incorrectRampUpRate()`.

### Why are the changes needed?
To don't confuse user, and fix the typo.

### Does this PR introduce _any_ user-facing change?
No. The error class hasn't released yet.

### How was this patch tested?
By running the affected tests:
```
$ build/sbt "test:testOnly *RateStreamProviderSuite"
$ build/sbt "core/testOnly *SparkThrowableSuite"
```