### PR TITLE
[SPARK-40759][SQL] Migrate type check failures of time window onto error classes

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -215,6 +215,11 @@
           "Null typed values cannot be used as arguments of <functionName>."
         ]
       },
+      "PARAMETER_CONSTRAINT_VIOLATION" : {
+        "message" : [
+          "The <leftExprName>(<leftExprValue>) must be <constraint> the <rightExprName>(<rightExprValue>)"
+        ]
+      },
       "RANGE_FRAME_INVALID_TYPE" : {
         "message" : [
           "The data type <orderSpecType> used in the order specification does not match the data type <valueBoundaryType> which is used in the range frame."
@@ -268,11 +273,6 @@
       "UNEXPECTED_NULL" : {
         "message" : [
           "The <exprName> must not be null"
-        ]
-      },
-      "UNEXPECTED_PARAMETER_CONSTRAINT" : {
-        "message" : [
-          "The <leftExprName>(<leftExprValue>) must be <constraint> the <rightExprName>(<rightExprValue>)"
         ]
       },
       "UNEXPECTED_STATIC_METHOD" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -270,6 +270,11 @@
           "The <exprName> must not be null"
         ]
       },
+      "UNEXPECTED_PARAMETER_CONSTRAINT" : {
+        "message" : [
+          "The <leftExprName>(<leftExprValue>) must be <constraint> the <rightExprName>(<rightExprValue>)"
+        ]
+      },
       "UNEXPECTED_STATIC_METHOD" : {
         "message" : [
           "cannot find a static method <methodName> that matches the argument types in <className>"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -150,8 +150,8 @@ case class TimeWindow(
         return DataTypeMismatch(
           errorSubClass = "PARAMETER_CONSTRAINT_VIOLATION",
           messageParameters = Map(
-            "leftExprName" -> toSQLId("start_time"),
-            "leftExprValue" -> toSQLValue(startTime, LongType),
+            "leftExprName" -> toSQLId("abs(start_time)"),
+            "leftExprValue" -> toSQLValue(startTime.abs, LongType),
             "constraint" -> "<",
             "rightExprName" -> toSQLId("slide_duration"),
             "rightExprValue" -> toSQLValue(slideDuration, LongType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -118,7 +118,7 @@ case class TimeWindow(
         return DataTypeMismatch(
           errorSubClass = "VALUE_OUT_OF_RANGE",
           messageParameters = Map(
-            "exprName" -> "window_duration",
+            "exprName" -> toSQLId("window_duration"),
             "valueRange" -> s"(0, ${Long.MaxValue}]",
             "currentValue" -> toSQLValue(windowDuration, LongType)
           )
@@ -128,7 +128,7 @@ case class TimeWindow(
         return DataTypeMismatch(
           errorSubClass = "VALUE_OUT_OF_RANGE",
           messageParameters = Map(
-            "exprName" -> "slide_duration",
+            "exprName" -> toSQLId("slide_duration"),
             "valueRange" -> s"(0, ${Long.MaxValue}]",
             "currentValue" -> toSQLValue(slideDuration, LongType)
           )
@@ -138,10 +138,10 @@ case class TimeWindow(
         return DataTypeMismatch(
           errorSubClass = "PARAMETER_CONSTRAINT_VIOLATION",
           messageParameters = Map(
-            "leftExprName" -> "slide_duration",
+            "leftExprName" -> toSQLId("slide_duration"),
             "leftExprValue" -> toSQLValue(slideDuration, LongType),
             "constraint" -> "<=",
-            "rightExprName" -> "window_duration",
+            "rightExprName" -> toSQLId("window_duration"),
             "rightExprValue" -> toSQLValue(windowDuration, LongType)
           )
         )
@@ -150,10 +150,10 @@ case class TimeWindow(
         return DataTypeMismatch(
           errorSubClass = "PARAMETER_CONSTRAINT_VIOLATION",
           messageParameters = Map(
-            "leftExprName" -> "start_time",
+            "leftExprName" -> toSQLId("start_time"),
             "leftExprValue" -> toSQLValue(startTime, LongType),
             "constraint" -> "<",
-            "rightExprName" -> "slide_duration",
+            "rightExprName" -> toSQLId("slide_duration"),
             "rightExprValue" -> toSQLValue(slideDuration, LongType)
           )
         )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -136,7 +136,7 @@ case class TimeWindow(
       }
       if (slideDuration > windowDuration) {
         return DataTypeMismatch(
-          errorSubClass = "UNEXPECTED_PARAMETER_CONSTRAINT",
+          errorSubClass = "PARAMETER_CONSTRAINT_VIOLATION",
           messageParameters = Map(
             "leftExprName" -> "slide_duration",
             "leftExprValue" -> toSQLValue(slideDuration, LongType),
@@ -148,7 +148,7 @@ case class TimeWindow(
       }
       if (startTime.abs >= slideDuration) {
         return DataTypeMismatch(
-          errorSubClass = "UNEXPECTED_PARAMETER_CONSTRAINT",
+          errorSubClass = "PARAMETER_CONSTRAINT_VIOLATION",
           messageParameters = Map(
             "leftExprName" -> "start_time",
             "leftExprValue" -> toSQLValue(startTime, LongType),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TimeWindow.scala
@@ -18,13 +18,13 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckFailure
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.trees.TreePattern.{TIME_WINDOW, TreePattern}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_DAY
 import org.apache.spark.sql.catalyst.util.IntervalUtils
-import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryErrorsBase}
 import org.apache.spark.sql.types._
 
 // scalastyle:off line.size.limit line.contains.tab
@@ -71,7 +71,8 @@ case class TimeWindow(
     startTime: Long) extends UnaryExpression
   with ImplicitCastInputTypes
   with Unevaluable
-  with NonSQLExpression {
+  with NonSQLExpression
+  with QueryErrorsBase {
 
   //////////////////////////
   // SQL Constructors
@@ -114,18 +115,48 @@ case class TimeWindow(
     val dataTypeCheck = super.checkInputDataTypes()
     if (dataTypeCheck.isSuccess) {
       if (windowDuration <= 0) {
-        return TypeCheckFailure(s"The window duration ($windowDuration) must be greater than 0.")
+        return DataTypeMismatch(
+          errorSubClass = "VALUE_OUT_OF_RANGE",
+          messageParameters = Map(
+            "exprName" -> "window_duration",
+            "valueRange" -> s"(0, ${Long.MaxValue}]",
+            "currentValue" -> toSQLValue(windowDuration, LongType)
+          )
+        )
       }
       if (slideDuration <= 0) {
-        return TypeCheckFailure(s"The slide duration ($slideDuration) must be greater than 0.")
+        return DataTypeMismatch(
+          errorSubClass = "VALUE_OUT_OF_RANGE",
+          messageParameters = Map(
+            "exprName" -> "slide_duration",
+            "valueRange" -> s"(0, ${Long.MaxValue}]",
+            "currentValue" -> toSQLValue(slideDuration, LongType)
+          )
+        )
       }
       if (slideDuration > windowDuration) {
-        return TypeCheckFailure(s"The slide duration ($slideDuration) must be less than or equal" +
-          s" to the windowDuration ($windowDuration).")
+        return DataTypeMismatch(
+          errorSubClass = "UNEXPECTED_PARAMETER_CONSTRAINT",
+          messageParameters = Map(
+            "leftExprName" -> "slide_duration",
+            "leftExprValue" -> toSQLValue(slideDuration, LongType),
+            "constraint" -> "<=",
+            "rightExprName" -> "window_duration",
+            "rightExprValue" -> toSQLValue(windowDuration, LongType)
+          )
+        )
       }
       if (startTime.abs >= slideDuration) {
-        return TypeCheckFailure(s"The absolute value of start time ($startTime) must be less " +
-          s"than the slideDuration ($slideDuration).")
+        return DataTypeMismatch(
+          errorSubClass = "UNEXPECTED_PARAMETER_CONSTRAINT",
+          messageParameters = Map(
+            "leftExprName" -> "start_time",
+            "leftExprValue" -> toSQLValue(startTime, LongType),
+            "constraint" -> "<",
+            "rightExprName" -> "slide_duration",
+            "rightExprValue" -> toSQLValue(slideDuration, LongType)
+          )
+        )
       }
     }
     dataTypeCheck

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -518,7 +518,7 @@ class AnalysisErrorSuite extends AnalysisTest {
       "valueRange" -> s"(0, 9223372036854775807]",
       "currentValue" -> "-1000000L",
       "sqlExpr" -> "\"window(2016-01-01 01:01:01, -1000000, 1000000, 0)\""
-  )
+    )
   )
 
   errorClassTest(
@@ -555,8 +555,8 @@ class AnalysisErrorSuite extends AnalysisTest {
     Map(
       "exprName" -> "`slide_duration`",
       "valueRange" -> "(0, 9223372036854775807]",
-      "currentValue" -> "0L",
-      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 0, 0)\""
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 0, 0)\"",
+      "currentValue" -> "0L"
     )
   )
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -555,8 +555,8 @@ class AnalysisErrorSuite extends AnalysisTest {
     Map(
       "exprName" -> "`slide_duration`",
       "valueRange" -> "(0, 9223372036854775807]",
-      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 0, 0)\"",
-      "currentValue" -> "0L"
+      "currentValue" -> "0L",
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 0, 0)\""
     )
   )
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -433,67 +433,131 @@ class AnalysisErrorSuite extends AnalysisTest {
     "UNRESOLVED_COLUMN.WITH_SUGGESTION",
     Map("objectName" -> "`bad_column`", "proposal" -> "`a`, `b`, `c`, `d`, `e`"))
 
-  errorTest(
+  errorClassTest(
     "slide duration greater than window in time window",
     testRelation2.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "2 second", "0 second").as("window")),
-      s"The slide duration " :: " must be less than or equal to the windowDuration " :: Nil
+    "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
+    Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 2000000, 0)\"",
+      "leftExprName" -> "`slide_duration`",
+      "leftExprValue" -> "2000000L",
+      "constraint" -> "<=",
+      "rightExprName" -> "`window_duration`",
+      "rightExprValue" -> "1000000L"
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "start time greater than slide duration in time window",
     testRelation.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "1 second", "1 minute").as("window")),
-      "The absolute value of start time " :: " must be less than the slideDuration " :: Nil
+    "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
+    Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 1000000, 60000000)\"",
+      "leftExprName" -> "`start_time`",
+      "leftExprValue" -> "60000000L",
+      "constraint" -> "<",
+      "rightExprName" -> "`slide_duration`",
+      "rightExprValue" -> "1000000L"
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "start time equal to slide duration in time window",
     testRelation.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "1 second", "1 second").as("window")),
-      "The absolute value of start time " :: " must be less than the slideDuration " :: Nil
+    "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
+    Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 1000000, 1000000)\"",
+      "leftExprName" -> "`start_time`",
+      "leftExprValue" -> "1000000L",
+      "constraint" -> "<",
+      "rightExprName" -> "`slide_duration`",
+      "rightExprValue" -> "1000000L"
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "SPARK-21590: absolute value of start time greater than slide duration in time window",
     testRelation.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "1 second", "-1 minute").as("window")),
-    "The absolute value of start time " :: " must be less than the slideDuration " :: Nil
+    "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
+    Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 1000000, -60000000)\"",
+      "leftExprName" -> "`start_time`",
+      "leftExprValue" -> "-60000000L",
+      "constraint" -> "<",
+      "rightExprName" -> "`slide_duration`",
+      "rightExprValue" -> "1000000L"
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "SPARK-21590: absolute value of start time equal to slide duration in time window",
     testRelation.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "1 second", "-1 second").as("window")),
-    "The absolute value of start time " :: " must be less than the slideDuration " :: Nil
+    "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
+    Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 1000000, -1000000)\"",
+      "leftExprName" -> "`start_time`",
+      "leftExprValue" -> "-1000000L",
+      "constraint" -> "<",
+      "rightExprName" -> "`slide_duration`",
+      "rightExprValue" -> "1000000L"
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "negative window duration in time window",
     testRelation.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "-1 second", "1 second", "0 second").as("window")),
-      "The window duration " :: " must be greater than 0." :: Nil
+      "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+    Map(
+      "exprName" -> "`window_duration`",
+      "valueRange" -> s"(0, 9223372036854775807]",
+      "currentValue" -> "-1000000L",
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, -1000000, 1000000, 0)\""
+  )
   )
 
-  errorTest(
+  errorClassTest(
     "zero window duration in time window",
     testRelation.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "0 second", "1 second", "0 second").as("window")),
-      "The window duration " :: " must be greater than 0." :: Nil
+    "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+    Map(
+      "exprName" -> "`window_duration`",
+      "valueRange" -> "(0, 9223372036854775807]",
+      "currentValue" -> "0L",
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 0, 1000000, 0)\""
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "negative slide duration in time window",
     testRelation.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "-1 second", "0 second").as("window")),
-      "The slide duration " :: " must be greater than 0." :: Nil
+    "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+    Map(
+      "exprName" -> "`slide_duration`",
+      "valueRange" -> "(0, 9223372036854775807]",
+      "currentValue" -> "-1000000L",
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, -1000000, 0)\""
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "zero slide duration in time window",
     testRelation.select(
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "0 second", "0 second").as("window")),
-      "The slide duration" :: " must be greater than 0." :: Nil
+    "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
+    Map(
+      "exprName" -> "`slide_duration`",
+      "valueRange" -> "(0, 9223372036854775807]",
+      "currentValue" -> "0L",
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 0, 0)\""
+    )
   )
 
   errorTest(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -514,10 +514,10 @@ class AnalysisErrorSuite extends AnalysisTest {
       TimeWindow(Literal("2016-01-01 01:01:01"), "-1 second", "1 second", "0 second").as("window")),
       "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
     Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, -1000000, 1000000, 0)\"",
       "exprName" -> "`window_duration`",
       "valueRange" -> s"(0, 9223372036854775807]",
-      "currentValue" -> "-1000000L",
-      "sqlExpr" -> "\"window(2016-01-01 01:01:01, -1000000, 1000000, 0)\""
+      "currentValue" -> "-1000000L"
     )
   )
 
@@ -527,10 +527,10 @@ class AnalysisErrorSuite extends AnalysisTest {
       TimeWindow(Literal("2016-01-01 01:01:01"), "0 second", "1 second", "0 second").as("window")),
     "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
     Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 0, 1000000, 0)\"",
       "exprName" -> "`window_duration`",
       "valueRange" -> "(0, 9223372036854775807]",
-      "currentValue" -> "0L",
-      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 0, 1000000, 0)\""
+      "currentValue" -> "0L"
     )
   )
 
@@ -540,10 +540,10 @@ class AnalysisErrorSuite extends AnalysisTest {
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "-1 second", "0 second").as("window")),
     "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
     Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, -1000000, 0)\"",
       "exprName" -> "`slide_duration`",
       "valueRange" -> "(0, 9223372036854775807]",
-      "currentValue" -> "-1000000L",
-      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, -1000000, 0)\""
+      "currentValue" -> "-1000000L"
     )
   )
 
@@ -553,10 +553,10 @@ class AnalysisErrorSuite extends AnalysisTest {
       TimeWindow(Literal("2016-01-01 01:01:01"), "1 second", "0 second", "0 second").as("window")),
     "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE",
     Map(
+      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 0, 0)\"",
       "exprName" -> "`slide_duration`",
       "valueRange" -> "(0, 9223372036854775807]",
-      "currentValue" -> "0L",
-      "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 0, 0)\""
+      "currentValue" -> "0L"
     )
   )
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -455,7 +455,7 @@ class AnalysisErrorSuite extends AnalysisTest {
     "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
     Map(
       "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 1000000, 60000000)\"",
-      "leftExprName" -> "`start_time`",
+      "leftExprName" -> "`abs(start_time)`",
       "leftExprValue" -> "60000000L",
       "constraint" -> "<",
       "rightExprName" -> "`slide_duration`",
@@ -470,7 +470,7 @@ class AnalysisErrorSuite extends AnalysisTest {
     "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
     Map(
       "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 1000000, 1000000)\"",
-      "leftExprName" -> "`start_time`",
+      "leftExprName" -> "`abs(start_time)`",
       "leftExprValue" -> "1000000L",
       "constraint" -> "<",
       "rightExprName" -> "`slide_duration`",
@@ -485,8 +485,8 @@ class AnalysisErrorSuite extends AnalysisTest {
     "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
     Map(
       "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 1000000, -60000000)\"",
-      "leftExprName" -> "`start_time`",
-      "leftExprValue" -> "-60000000L",
+      "leftExprName" -> "`abs(start_time)`",
+      "leftExprValue" -> "60000000L",
       "constraint" -> "<",
       "rightExprName" -> "`slide_duration`",
       "rightExprValue" -> "1000000L"
@@ -500,8 +500,8 @@ class AnalysisErrorSuite extends AnalysisTest {
     "DATATYPE_MISMATCH.PARAMETER_CONSTRAINT_VIOLATION",
     Map(
       "sqlExpr" -> "\"window(2016-01-01 01:01:01, 1000000, 1000000, -1000000)\"",
-      "leftExprName" -> "`start_time`",
-      "leftExprValue" -> "-1000000L",
+      "leftExprName" -> "`abs(start_time)`",
+      "leftExprValue" -> "1000000L",
       "constraint" -> "<",
       "rightExprName" -> "`slide_duration`",
       "rightExprValue" -> "1000000L"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr replace `TypeCheckFailure` by `DataTypeMismatch` in type checks in the time window expressions:


### Why are the changes needed?
Migration onto error classes unifies Spark SQL error messages.


### Does this PR introduce _any_ user-facing change?
Yes. The PR changes user-facing error messages.




### How was this patch tested?

- Pass GitHub Actions
- Manual test:

```
build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.analysis.AnalysisErrorSuite" -Pscala-2.13
```
passed