### PR TITLE
[SPARK-40917][SQL] Add a dedicated logical plan for `Summary`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -291,6 +291,7 @@ class Analyzer(override val catalogManager: CatalogManager)
       ResolveDeserializer ::
       ResolveNewInstance ::
       ResolveUpCast ::
+      ResolveStatsFunctions ::
       ResolveGroupingAnalytics ::
       ResolvePivot ::
       ResolveUnpivot ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveStatsFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveStatsFunctions.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.SUMMARY
+import org.apache.spark.sql.types._
+
+/**
+ * Resolve StatsFunctions.
+ */
+object ResolveStatsFunctions extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
+    _.containsPattern(SUMMARY), ruleId) {
+
+    case s @ Summary(child, statistics) if s.childrenResolved =>
+      val percentiles = statistics.filter(p => p.endsWith("%"))
+        .map(p => p.stripSuffix("%").toDouble / 100.0)
+
+      var mapExprs = Seq.empty[NamedExpression]
+      child.output.foreach { attr =>
+        if (attr.dataType.isInstanceOf[NumericType] || attr.dataType.isInstanceOf[StringType]) {
+          val name = attr.name
+          val casted: Expression = attr.dataType match {
+            case StringType => Cast(attr, DoubleType, evalMode = EvalMode.TRY)
+            case _ => attr
+          }
+
+          val approxPercentile = if (percentiles.nonEmpty) {
+            Alias(
+              new ApproximatePercentile(
+                casted,
+                Literal(percentiles.toArray),
+                Literal(ApproximatePercentile.DEFAULT_PERCENTILE_ACCURACY)
+              ).toAggregateExpression(),
+              s"__${name}_approx_percentile__")()
+          } else null
+
+          var aggExprs = Seq.empty[Expression]
+          var percentileIndex = 0
+
+          statistics.foreach { stat =>
+            aggExprs :+= Literal(stat)
+
+            stat match {
+              case "count" =>
+                aggExprs :+= Cast(Count(attr).toAggregateExpression(), StringType)
+              case "count_distinct" =>
+                aggExprs :+= Cast(Count(attr).toAggregateExpression(true), StringType)
+              case "approx_count_distinct" =>
+                aggExprs :+= Cast(HyperLogLogPlusPlus(attr).toAggregateExpression(), StringType)
+              case "mean" =>
+                aggExprs :+= Cast(Average(casted).toAggregateExpression(), StringType)
+              case "stddev" =>
+                aggExprs :+= Cast(StddevSamp(casted).toAggregateExpression(), StringType)
+              case "min" =>
+                aggExprs :+= Cast(Min(attr).toAggregateExpression(), StringType)
+              case "max" =>
+                aggExprs :+= Cast(Max(attr).toAggregateExpression(), StringType)
+              case percentile if percentile.endsWith("%") =>
+                aggExprs :+= Cast(new Get(approxPercentile, Literal(percentileIndex)), StringType)
+                percentileIndex += 1
+            }
+          }
+
+          mapExprs :+= Alias(CreateMap(aggExprs), name)()
+        }
+      }
+
+      if (mapExprs.isEmpty) {
+        LocalRelation.fromProduct(
+          output = Seq(AttributeReference("summary", StringType, false)()),
+          data = statistics.map(Tuple1.apply))
+
+      } else {
+        val aggregate = Aggregate(
+          groupingExpressions = Nil,
+          aggregateExpressions = mapExprs,
+          child = child)
+
+        val generate = Generate(
+          generator = Explode(Literal(statistics.toArray)),
+          unrequiredChildIndex = Nil,
+          outer = false,
+          qualifier = None,
+          generatorOutput = Seq(AttributeReference("summary", StringType, false)()),
+          child = aggregate)
+
+        val summaryAttr = Alias(generate.output.last, "summary")()
+        val mapAttrs = generate.output.take(generate.output.size - 1)
+        val statAlias = mapAttrs.map(attr => Alias(ElementAt(attr, summaryAttr), attr.name)())
+
+        Project(
+          projectList = Seq(summaryAttr) ++ statAlias,
+          child = generate)
+      }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveStatsFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveStatsFunctions.scala
@@ -31,7 +31,7 @@ object ResolveStatsFunctions extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
     _.containsPattern(SUMMARY), ruleId) {
 
-    case s @ Summary(child, statistics) if s.childrenResolved =>
+    case s @ UnresolvedSummary(child, statistics) if s.childrenResolved =>
       val percentiles = statistics.filter(p => p.endsWith("%"))
         .map(p => p.stripSuffix("%").toDouble / 100.0)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -2106,7 +2106,7 @@ object AsOfJoin {
 /**
  * A logical plan for summary.
  */
-case class Summary(
+case class UnresolvedSummary(
     child: LogicalPlan,
     statistics: Seq[String]) extends UnaryNode {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -88,6 +88,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.analysis.ResolveHints$ResolveJoinStrategyHints" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveInlineTables" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveLambdaVariables" ::
+      "org.apache.spark.sql.catalyst.analysis.ResolveStatsFunctions" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveTimeZone" ::
       "org.apache.spark.sql.catalyst.analysis.ResolveUnion" ::
       "org.apache.spark.sql.catalyst.analysis.SubstituteUnresolvedOrdinals" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -121,6 +121,9 @@ object TreePattern extends Enumeration  {
   val WINDOW: Value = Value
   val WITH_WINDOW_DEFINITION: Value = Value
 
+  // Stats Function
+  val SUMMARY: Value = Value
+
   // Unresolved expression patterns (Alphabetically ordered)
   val UNRESOLVED_ALIAS: Value = Value
   val UNRESOLVED_ATTRIBUTE: Value = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.expressions.Cast
-import org.apache.spark.sql.catalyst.plans.logical.Summary
+import org.apache.spark.sql.catalyst.plans.logical.UnresolvedSummary
 import org.apache.spark.sql.catalyst.util.QuantileSummaries
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -168,6 +168,6 @@ object StatFunctions extends Logging {
     } else {
       Seq("count", "mean", "stddev", "min", "25%", "50%", "75%", "max")
     }
-    Dataset.ofRows(ds.sparkSession, Summary(ds.logicalPlan, selectedStatistics))
+    Dataset.ofRows(ds.sparkSession, UnresolvedSummary(ds.logicalPlan, selectedStatistics))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a dedicated logical plan for `Summary`


### Why are the changes needed?
to make it more convenient to support `DataFrame.summary` in Connect 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing tests and manually checks