### PR TITLE
[SPARK-40919][SQL][TESTS] Fix `AnalysisTest#assertAnalysisErrorClass` to avoid wrong check result when `expectedMessageParameters.size <= 4`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
@@ -184,7 +184,7 @@ trait AnalysisTest extends PlanTest {
       }
 
       if (e.getErrorClass != expectedErrorClass ||
-        !(e.messageParameters == expectedMessageParameters) ||
+        e.messageParameters != expectedMessageParameters ||
         (line >= 0 && e.line.getOrElse(-1) != line) ||
         (pos >= 0) && e.startPosition.getOrElse(-1) != pos) {
         var failMsg = ""
@@ -194,7 +194,7 @@ trait AnalysisTest extends PlanTest {
                |Actual error class: ${e.getErrorClass}
              """.stripMargin
         }
-        if (!(e.messageParameters == expectedMessageParameters)) {
+        if (e.messageParameters != expectedMessageParameters) {
           failMsg +=
             s"""Message parameters should be: ${expectedMessageParameters.mkString("\n  ")}
                |Actual message parameters: ${e.messageParameters.mkString("\n  ")}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
@@ -177,6 +177,10 @@ trait AnalysisTest extends PlanTest {
       caseSensitive: Boolean = true,
       line: Int = -1,
       pos: Int = -1): Unit = {
+
+    def sameMapContents(left: Map[String, String], right: Map[String, String]): Boolean =
+      left.toSeq.sorted == right.toSeq.sorted
+
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
       val analyzer = getAnalyzer
       val e = intercept[AnalysisException] {
@@ -184,7 +188,7 @@ trait AnalysisTest extends PlanTest {
       }
 
       if (e.getErrorClass != expectedErrorClass ||
-        !e.messageParameters.sameElements(expectedMessageParameters) ||
+        !sameMapContents(e.messageParameters, expectedMessageParameters) ||
         (line >= 0 && e.line.getOrElse(-1) != line) ||
         (pos >= 0) && e.startPosition.getOrElse(-1) != pos) {
         var failMsg = ""
@@ -194,7 +198,7 @@ trait AnalysisTest extends PlanTest {
                |Actual error class: ${e.getErrorClass}
              """.stripMargin
         }
-        if (!e.messageParameters.sameElements(expectedMessageParameters)) {
+        if (!sameMapContents(e.messageParameters, expectedMessageParameters)) {
           failMsg +=
             s"""Message parameters should be: ${expectedMessageParameters.mkString("\n  ")}
                |Actual message parameters: ${e.messageParameters.mkString("\n  ")}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
@@ -177,10 +177,6 @@ trait AnalysisTest extends PlanTest {
       caseSensitive: Boolean = true,
       line: Int = -1,
       pos: Int = -1): Unit = {
-
-    def sameMapContents(left: Map[String, String], right: Map[String, String]): Boolean =
-      left.toSeq.sorted == right.toSeq.sorted
-
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
       val analyzer = getAnalyzer
       val e = intercept[AnalysisException] {
@@ -188,7 +184,7 @@ trait AnalysisTest extends PlanTest {
       }
 
       if (e.getErrorClass != expectedErrorClass ||
-        !sameMapContents(e.messageParameters, expectedMessageParameters) ||
+        !(e.messageParameters == expectedMessageParameters) ||
         (line >= 0 && e.line.getOrElse(-1) != line) ||
         (pos >= 0) && e.startPosition.getOrElse(-1) != pos) {
         var failMsg = ""
@@ -198,7 +194,7 @@ trait AnalysisTest extends PlanTest {
                |Actual error class: ${e.getErrorClass}
              """.stripMargin
         }
-        if (!sameMapContents(e.messageParameters, expectedMessageParameters)) {
+        if (!(e.messageParameters == expectedMessageParameters)) {
           failMsg +=
             s"""Message parameters should be: ${expectedMessageParameters.mkString("\n  ")}
                |Actual message parameters: ${e.messageParameters.mkString("\n  ")}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
@@ -184,9 +184,9 @@ trait AnalysisTest extends PlanTest {
       }
 
       if (e.getErrorClass != expectedErrorClass ||
-        e.messageParameters != expectedMessageParameters ||
-        (line >= 0 && e.line.getOrElse(-1) != line) ||
-        (pos >= 0) && e.startPosition.getOrElse(-1) != pos) {
+          e.messageParameters != expectedMessageParameters ||
+          (line >= 0 && e.line.getOrElse(-1) != line) ||
+          (pos >= 0) && e.startPosition.getOrElse(-1) != pos) {
         var failMsg = ""
         if (e.getErrorClass != expectedErrorClass) {
           failMsg +=


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr refactor `AnalysisTest#assertAnalysisErrorClass` method to use `e.messageParameters != expectedMessageParameters` instead of `!e.messageParameters.sameElements(expectedMessageParameters)` to avoid wrong check result when `expectedMessageParameters.size <= 4`


### Why are the changes needed?
Avoid wrong check result of  `AnalysisTest#assertAnalysisErrorClass`  when `expectedMessageParameters.size <= 4`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Manual test:

```scala
Welcome to Scala 2.12.17 (OpenJDK 64-Bit Server VM, Java 1.8.0_352).
Type in expressions for evaluation. Or try :help.

scala> :paste
// Entering paste mode (ctrl-D to finish)

val messageParameters = Map(
      "exprName" -> "`window_duration`",
      "valueRange" -> s"(0, 9223372036854775807]",
      "currentValue" -> "-1000000L",
      "sqlExpr" -> "\"window(2016-01-01 01:01:01, -1000000, 1000000, 0)\""
    )
val expectedMessageParameters =  Map(
      "sqlExpr" -> "\"window(2016-01-01 01:01:01, -1000000, 1000000, 0)\"",
      "exprName" -> "`window_duration`",
      "valueRange" -> s"(0, 9223372036854775807]",
      "currentValue" -> "-1000000L"
    )

val tret = !messageParameters.sameElements(expectedMessageParameters)
val fret = messageParameters != expectedMessageParameters


// Exiting paste mode, now interpreting.

messageParameters: scala.collection.immutable.Map[String,String] = Map(exprName -> `window_duration`, valueRange -> (0, 9223372036854775807], currentValue -> -1000000L, sqlExpr -> "window(2016-01-01 01:01:01, -1000000, 1000000, 0)")
expectedMessageParameters: scala.collection.immutable.Map[String,String] = Map(sqlExpr -> "window(2016-01-01 01:01:01, -1000000, 1000000, 0)", exprName -> `window_duration`, valueRange -> (0, 9223372036854775807], currentValue -> -1000000L)
tret: Boolean = true
fret: Boolean = false
```
