### PR TITLE
[SPARK-40922][PYTHON] Document multiple path support in `pyspark.pandas.read_csv`

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -213,7 +213,7 @@ def range(
 
 
 def read_csv(
-    path: str,
+    path: Union[str, List[str]],
     sep: str = ",",
     header: Union[str, int, None] = "infer",
     names: Optional[Union[str, List[str]]] = None,
@@ -234,8 +234,8 @@ def read_csv(
 
     Parameters
     ----------
-    path : str
-        The path string storing the CSV file to be read.
+    path : str or list
+        path(s) of the CSV file(s) to be read.
     sep : str, default ‘,’
         Delimiter to use. Non empty string.
     header : int, default ‘infer’

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -235,7 +235,7 @@ def read_csv(
     Parameters
     ----------
     path : str or list
-        path(s) of the CSV file(s) to be read.
+        Path(s) of the CSV file(s) to be read.
     sep : str, default ‘,’
         Delimiter to use. Non empty string.
     header : int, default ‘infer’
@@ -296,6 +296,10 @@ def read_csv(
     Examples
     --------
     >>> ps.read_csv('data.csv')  # doctest: +SKIP
+
+    Load multiple CSV files as a single DataFrame:
+
+    >>> ps.read_csv(['data-01.csv', 'data-02.csv'])  # doctest: +SKIP
     """
     # For latin-1 encoding is same as iso-8859-1, that's why its mapped to iso-8859-1.
     encoding_mapping = {"latin-1": "iso-8859-1"}


### PR DESCRIPTION
### What changes were proposed in this pull request?

as discussed in https://issues.apache.org/jira/browse/SPARK-40922: 

> The path argument of `pyspark.pandas.read_csv(path, ...)` currently has type annotation `str` and is documented as
>
>       path : str
>           The path string storing the CSV file to be read.
>The implementation however uses `pyspark.sql.DataFrameReader.csv(path, ...)` which does support multiple paths:
>
>        path : str or list
>            string, or list of strings, for input path(s),
>            or RDD of Strings storing CSV rows.
>

This PR updates the type annotation and documentation of `path` argument of `pyspark.pandas.read_csv`

### Why are the changes needed?

Loading multiple CSV files at once is a useful feature to have and should be documented 

### Does this PR introduce _any_ user-facing change?
it documents and existing feature

### How was this patch tested?
No need for tests (so far): only type annotations and docblocks were changed