### PR TITLE
[SPARK-34265][SQL][TESTS][FOLLOW-UP] Add assume for PythonUDF test case in Scala side

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -86,7 +86,7 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-34265: Instrument Python UDF execution using SQL Metrics") {
-
+    assume(shouldTestPythonUDFs)
     val pythonSQLMetrics = List(
       "data sent to Python workers",
       "data returned from Python workers",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `assume` in the Python test added in https://github.com/apache/spark/pull/33559.

### Why are the changes needed?

In some testing environment, Python does not exist. This is consistent with other tests in this file. Otherwise, it'd fails as below:

```
        java.lang.RuntimeException: Python availability: [true], pyspark availability: [false]
      at org.apache.spark.sql.IntegratedUDFTestUtils$.pythonFunc$lzycompute(IntegratedUDFTestUtils.scala:192)
      at org.apache.spark.sql.IntegratedUDFTestUtils$.org$apache$spark$sql$IntegratedUDFTestUtils$$pythonFunc(IntegratedUDFTestUtils.scala:172)
      at org.apache.spark.sql.IntegratedUDFTestUtils$TestPythonUDF$$anon$1.<init>(IntegratedUDFTestUtils.scala:337)
      at org.apache.spark.sql.IntegratedUDFTestUtils$TestPythonUDF.udf$lzycompute(IntegratedUDFTestUtils.scala:334)
      at org.apache.spark.sql.IntegratedUDFTestUtils$TestPythonUDF.udf(IntegratedUDFTestUtils.scala:334)
      at org.apache.spark.sql.IntegratedUDFTestUtils$TestPythonUDF.apply(IntegratedUDFTestUtils.scala:359)
      at org.apache.spark.sql.execution.python.PythonUDFSuite.$anonfun$new$11(PythonUDFSuite.scala:105)
...
```

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually checked. 