### PR TITLE
[SPARK-40928][INFRA] Upgrade setup-python to v4

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -232,7 +232,7 @@ jobs:
         distribution: temurin
         java-version: ${{ matrix.java }}
     - name: Install Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       # We should install one Python that is higher then 3+ for SQL and Yarn because:
       # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
       # - Yarn has a Python specific test too, for example, YarnClusterSuite.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade actions/setup-python to v4


### Why are the changes needed?
- https://github.com/actions/setup-python/releases/tag/v3.0.0: upgrade to node 16
- https://github.com/actions/setup-python/releases/tag/v4.3.0: cleanup setoutput warning

### Does this PR introduce _any_ user-facing change?
No, dev only


### How was this patch tested?
CI passed
