### PR TITLE
[SPARK-40932][CORE] Fix issue messages for allGather are overridden

### DIFF
--- a/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala
@@ -176,7 +176,7 @@ private[spark] class BarrierCoordinator(
         logInfo(s"Barrier sync epoch $barrierEpoch from $barrierId received update from Task " +
           s"$taskId, current progress: ${requesters.size}/$numTasks.")
         if (requesters.size == numTasks) {
-          requesters.foreach(_.reply(messages))
+          requesters.foreach(_.reply(messages.clone()))
           // Finished current barrier() call successfully, clean up ContextBarrierState and
           // increase the barrier epoch.
           logInfo(s"Barrier sync epoch $barrierEpoch from $barrierId received all updates from " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

The messages returned by allGather may be overridden by the following barrier APIs, eg,

``` scala
      val messages: Array[String] = context.allGather("ABC")
      context.barrier()
```

the  `messages` may be like Array("", ""), but we're expecting Array("ABC", "ABC") 

The root cause of this issue is the [messages got by allGather](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/BarrierTaskContext.scala#L102) pointing to the [original message](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/BarrierCoordinator.scala#L107) in the local mode. So when the following barrier APIs changed the messages, then the allGather message will be changed accordingly.
Finally, users can't get the correct result.

This PR fixed this issue by sending back the cloned messages.

### Why are the changes needed?

The bug mentioned in this description may block some external SPARK ML libraries which heavily depend on the spark barrier API to do some synchronization. If the barrier mechanism can't guarantee the correctness of the barrier APIs, it will be a disaster for external SPARK ML libraries.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

I added a unit test, with this PR, the unit test can pass
