### PR TITLE
[SPARK-40933][SQL] Reimplement df.stat.{cov, corr} with built-in sql functions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -109,66 +109,15 @@ object StatFunctions extends Logging {
 
   /** Calculate the Pearson Correlation Coefficient for the given columns */
   def pearsonCorrelation(df: DataFrame, cols: Seq[String]): Double = {
-    val counts = collectStatisticalData(df, cols, "correlation")
-    counts.Ck / math.sqrt(counts.MkX * counts.MkY)
-  }
-
-  /** Helper class to simplify tracking and merging counts. */
-  private class CovarianceCounter extends Serializable {
-    var xAvg = 0.0 // the mean of all examples seen so far in col1
-    var yAvg = 0.0 // the mean of all examples seen so far in col2
-    var Ck = 0.0 // the co-moment after k examples
-    var MkX = 0.0 // sum of squares of differences from the (current) mean for col1
-    var MkY = 0.0 // sum of squares of differences from the (current) mean for col2
-    var count = 0L // count of observed examples
-    // add an example to the calculation
-    def add(x: Double, y: Double): this.type = {
-      val deltaX = x - xAvg
-      val deltaY = y - yAvg
-      count += 1
-      xAvg += deltaX / count
-      yAvg += deltaY / count
-      Ck += deltaX * (y - yAvg)
-      MkX += deltaX * (x - xAvg)
-      MkY += deltaY * (y - yAvg)
-      this
+    require(cols.length == 2,
+      "Currently correlation calculation is supported between two columns.")
+    cols.map(df.resolve).foreach { data =>
+      require(data.dataType.isInstanceOf[NumericType],
+        "Currently correlation calculation for columns with dataType " +
+          s"${data.dataType.catalogString} not supported.")
     }
-    // merge counters from other partitions. Formula can be found at:
-    // http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
-    def merge(other: CovarianceCounter): this.type = {
-      if (other.count > 0) {
-        val totalCount = count + other.count
-        val deltaX = xAvg - other.xAvg
-        val deltaY = yAvg - other.yAvg
-        Ck += other.Ck + deltaX * deltaY * count / totalCount * other.count
-        xAvg = (xAvg * count + other.xAvg * other.count) / totalCount
-        yAvg = (yAvg * count + other.yAvg * other.count) / totalCount
-        MkX += other.MkX + deltaX * deltaX * count / totalCount * other.count
-        MkY += other.MkY + deltaY * deltaY * count / totalCount * other.count
-        count = totalCount
-      }
-      this
-    }
-    // return the sample covariance for the observed examples
-    def cov: Double = Ck / (count - 1)
-  }
-
-  private def collectStatisticalData(df: DataFrame, cols: Seq[String],
-              functionName: String): CovarianceCounter = {
-    require(cols.length == 2, s"Currently $functionName calculation is supported " +
-      "between two columns.")
-    cols.map(name => (name, df.resolve(name))).foreach { case (name, data) =>
-      require(data.dataType.isInstanceOf[NumericType], s"Currently $functionName calculation " +
-        s"for columns with dataType ${data.dataType.catalogString} not supported.")
-    }
-    val columns = cols.map(n => Column(Cast(Column(n).expr, DoubleType)))
-    df.select(columns: _*).queryExecution.toRdd.treeAggregate(new CovarianceCounter)(
-      seqOp = (counter, row) => {
-        counter.add(row.getDouble(0), row.getDouble(1))
-      },
-      combOp = (baseCounter, other) => {
-        baseCounter.merge(other)
-    })
+    val Seq(col1, col2) = cols
+    df.select(corr(col(col1), col(col2))).head.getDouble(0)
   }
 
   /**
@@ -178,8 +127,15 @@ object StatFunctions extends Logging {
    * @return the covariance of the two columns.
    */
   def calculateCov(df: DataFrame, cols: Seq[String]): Double = {
-    val counts = collectStatisticalData(df, cols, "covariance")
-    counts.cov
+    require(cols.length == 2,
+      "Currently covariance calculation is supported between two columns.")
+    cols.map(df.resolve).foreach { data =>
+      require(data.dataType.isInstanceOf[NumericType],
+        "Currently covariance calculation for columns with dataType " +
+          s"${data.dataType.catalogString} not supported.")
+    }
+    val Seq(col1, col2) = cols
+    df.select(covar_samp(col(col1), col(col2))).head.getDouble(0)
   }
 
   /** Generate a table of frequencies for the elements of two columns. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -117,9 +117,11 @@ object StatFunctions extends Logging {
           s"${data.dataType.catalogString} not supported.")
     }
     val Seq(col1, col2) = cols.map(c =>
-      when(isnull(col(c)), lit(0.0)).otherwise(col(c).cast("double")))
-    val row = df.select(corr(col1, col2)).head
-    if (row.isNullAt(0)) Double.NaN else row.getDouble(0)
+      when(isnull(col(c)), lit(0.0))
+        .otherwise(col(c).cast(DoubleType))
+    )
+    df.select(corr(col1, col2))
+      .na.fill(Double.NaN).head.getDouble(0)
   }
 
   /**
@@ -137,9 +139,11 @@ object StatFunctions extends Logging {
           s"${data.dataType.catalogString} not supported.")
     }
     val Seq(col1, col2) = cols.map(c =>
-      when(isnull(col(c)), lit(0.0)).otherwise(col(c).cast("double")))
-    val row = df.select(covar_samp(col1, col2)).head
-    if (row.isNullAt(0)) 0.0 else row.getDouble(0)
+      when(isnull(col(c)), lit(0.0))
+        .otherwise(col(c).cast(DoubleType))
+    )
+    df.select(covar_samp(col1, col2))
+      .na.fill(0.0).head.getDouble(0)
   }
 
   /** Generate a table of frequencies for the elements of two columns. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -116,7 +116,6 @@ object StatFunctions extends Logging {
         "Currently correlation calculation for columns with dataType " +
           s"${data.dataType.catalogString} not supported.")
     }
-    df.queryExecution.toRdd.map(_.getDouble(1))
     val Seq(col1, col2) = cols.map(c =>
       when(isnull(col(c)), lit(0.0)).otherwise(col(c).cast("double")))
     val row = df.select(corr(col1, col2)).head


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make df.stat.{cov, corr} consistent with sql functions


### Why are the changes needed?
it is weird to have two implemetations in SQL


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing UTs