### PR TITLE
[SPARK-40935][BUILD] Upgrade zstd-jni to 1.5.2-5

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -271,4 +271,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.5.2-4//zstd-jni-1.5.2-4.jar
+zstd-jni/1.5.2-5//zstd-jni-1.5.2-5.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -256,4 +256,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.5.2-4//zstd-jni-1.5.2-4.jar
+zstd-jni/1.5.2-5//zstd-jni-1.5.2-5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -802,7 +802,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.2-4</version>
+        <version>1.5.2-5</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade zstd-jni to 1.5.2-5


### Why are the changes needed?
This version start to support magic less data frames:

- https://github.com/luben/zstd-jni/issues/151
- https://github.com/luben/zstd-jni/pull/235


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions