### PR TITLE
[SPARK-40953][CONNECT][PYTHON] Fix `DataFrame.head` to collect specified number of rows

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -215,8 +215,7 @@ class DataFrame(object):
         return GroupingFrame(self, *cols)
 
     def head(self, n: int) -> Optional["pandas.DataFrame"]:
-        self.limit(n)
-        return self.toPandas()
+        return self.limit(n).toPandas()
 
     # TODO(martin.grund) fix mypu
     def join(self, other: "DataFrame", on: Any, how: Optional[str] = None) -> "DataFrame":


### PR DESCRIPTION
### What changes were proposed in this pull request?
`head` should return `self.limit(n).toPandas()` instead of `self.toPandas()`


### Why are the changes needed?
bugfix


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing tests