### PR TITLE
[SPARK-40229][PS][TEST][FOLLOWUP] Add `openpyxl` to `requirements.txt`

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -13,6 +13,7 @@ matplotlib<3.3.0
 
 # PySpark test dependencies
 unittest-xml-reporting
+openpyxl
 
 # PySpark test dependencies (optional)
 coverage


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of https://github.com/apache/spark/pull/37671.

### Why are the changes needed?

Since https://github.com/apache/spark/pull/37671 added `openpyxl` for PySpark test environments and re-enabled `test_to_excel` test, we need to add it to `requirements.txt` as PySpark test dependency explicitly.

### Does this PR introduce _any_ user-facing change?

No. This is a test dependency.

### How was this patch tested?

Manually.