### PR TITLE
[SPARK-40912][CORE]Overhead of Exceptions in KryoDeserializationStream 

### DIFF
--- a/core/benchmarks/KryoBenchmark-jdk11-results.txt
+++ b/core/benchmarks/KryoBenchmark-jdk11-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1036-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       259            264           3          3.9         259.3       1.0X
-basicTypes: Long with unsafe:true                      288            305          16          3.5         287.9       0.9X
-basicTypes: Float with unsafe:true                     291            299           7          3.4         290.6       0.9X
-basicTypes: Double with unsafe:true                    289            291           3          3.5         289.1       0.9X
-Array: Int with unsafe:true                              3              3           0        321.7           3.1      83.4X
-Array: Long with unsafe:true                             5              5           1        216.0           4.6      56.0X
-Array: Float with unsafe:true                            3              3           0        317.1           3.2      82.2X
-Array: Double with unsafe:true                           5              5           0        215.4           4.6      55.9X
-Map of string->Double  with unsafe:true                 37             37           0         27.2          36.7       7.1X
-basicTypes: Int with unsafe:false                      306            312           8          3.3         306.1       0.8X
-basicTypes: Long with unsafe:false                     330            334           5          3.0         329.8       0.8X
-basicTypes: Float with unsafe:false                    304            306           2          3.3         303.5       0.9X
-basicTypes: Double with unsafe:false                   311            316           9          3.2         310.6       0.8X
-Array: Int with unsafe:false                            21             21           1         48.1          20.8      12.5X
-Array: Long with unsafe:false                           30             31           1         33.1          30.2       8.6X
-Array: Float with unsafe:false                           8              8           1        127.9           7.8      33.2X
-Array: Double with unsafe:false                         14             14           0         73.7          13.6      19.1X
-Map of string->Double  with unsafe:false                39             40           1         25.5          39.3       6.6X
+basicTypes: Int with unsafe:true                       269            272           2          3.7         269.0       1.0X
+basicTypes: Long with unsafe:true                      296            301           9          3.4         295.8       0.9X
+basicTypes: Float with unsafe:true                     300            301           1          3.3         299.6       0.9X
+basicTypes: Double with unsafe:true                    291            292           1          3.4         291.3       0.9X
+Array: Int with unsafe:true                              3              3           0        325.9           3.1      87.7X
+Array: Long with unsafe:true                             5              5           0        216.1           4.6      58.1X
+Array: Float with unsafe:true                            3              3           0        319.8           3.1      86.0X
+Array: Double with unsafe:true                           5              5           0        219.1           4.6      58.9X
+Map of string->Double  with unsafe:true                 38             38           0         26.2          38.1       7.1X
+basicTypes: Int with unsafe:false                      314            319           9          3.2         313.8       0.9X
+basicTypes: Long with unsafe:false                     335            337           1          3.0         335.4       0.8X
+basicTypes: Float with unsafe:false                    309            310           1          3.2         309.2       0.9X
+basicTypes: Double with unsafe:false                   320            323           2          3.1         320.0       0.8X
+Array: Int with unsafe:false                            18             19           0         54.2          18.4      14.6X
+Array: Long with unsafe:false                           30             30           1         33.8          29.5       9.1X
+Array: Float with unsafe:false                           8              8           0        126.0           7.9      33.9X
+Array: Double with unsafe:false                         14             14           0         72.5          13.8      19.5X
+Map of string->Double  with unsafe:false                40             40           1         24.9          40.1       6.7X
 
 

--- a/core/benchmarks/KryoBenchmark-jdk11-results.txt
+++ b/core/benchmarks/KryoBenchmark-jdk11-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       301            319          11          3.3         301.5       1.0X
-basicTypes: Long with unsafe:true                      337            351           9          3.0         337.2       0.9X
-basicTypes: Float with unsafe:true                     327            335           6          3.1         327.5       0.9X
-basicTypes: Double with unsafe:true                    321            336          10          3.1         321.0       0.9X
-Array: Int with unsafe:true                              4              5           1        245.2           4.1      73.9X
-Array: Long with unsafe:true                             7              8           1        147.6           6.8      44.5X
-Array: Float with unsafe:true                            4              5           1        250.4           4.0      75.5X
-Array: Double with unsafe:true                           7              8           1        144.1           6.9      43.4X
-Map of string->Double  with unsafe:true                 42             46           4         23.8          42.0       7.2X
-basicTypes: Int with unsafe:false                      347            357          10          2.9         347.4       0.9X
-basicTypes: Long with unsafe:false                     378            394          10          2.6         378.1       0.8X
-basicTypes: Float with unsafe:false                    346            359           9          2.9         345.6       0.9X
-basicTypes: Double with unsafe:false                   350            372          20          2.9         350.3       0.9X
-Array: Int with unsafe:false                            22             24           2         46.0          21.8      13.9X
-Array: Long with unsafe:false                           34             37           3         29.1          34.3       8.8X
-Array: Float with unsafe:false                          10             10           1        103.5           9.7      31.2X
-Array: Double with unsafe:false                         16             17           1         61.2          16.3      18.5X
-Map of string->Double  with unsafe:false                44             48           4         22.7          44.1       6.8X
+basicTypes: Int with unsafe:true                       259            264           3          3.9         259.3       1.0X
+basicTypes: Long with unsafe:true                      288            305          16          3.5         287.9       0.9X
+basicTypes: Float with unsafe:true                     291            299           7          3.4         290.6       0.9X
+basicTypes: Double with unsafe:true                    289            291           3          3.5         289.1       0.9X
+Array: Int with unsafe:true                              3              3           0        321.7           3.1      83.4X
+Array: Long with unsafe:true                             5              5           1        216.0           4.6      56.0X
+Array: Float with unsafe:true                            3              3           0        317.1           3.2      82.2X
+Array: Double with unsafe:true                           5              5           0        215.4           4.6      55.9X
+Map of string->Double  with unsafe:true                 37             37           0         27.2          36.7       7.1X
+basicTypes: Int with unsafe:false                      306            312           8          3.3         306.1       0.8X
+basicTypes: Long with unsafe:false                     330            334           5          3.0         329.8       0.8X
+basicTypes: Float with unsafe:false                    304            306           2          3.3         303.5       0.9X
+basicTypes: Double with unsafe:false                   311            316           9          3.2         310.6       0.8X
+Array: Int with unsafe:false                            21             21           1         48.1          20.8      12.5X
+Array: Long with unsafe:false                           30             31           1         33.1          30.2       8.6X
+Array: Float with unsafe:false                           8              8           1        127.9           7.8      33.2X
+Array: Double with unsafe:false                         14             14           0         73.7          13.6      19.1X
+Map of string->Double  with unsafe:false                39             40           1         25.5          39.3       6.6X
 
 

--- a/core/benchmarks/KryoBenchmark-jdk17-results.txt
+++ b/core/benchmarks/KryoBenchmark-jdk17-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1036-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       360            392          31          2.8         359.9       1.0X
-basicTypes: Long with unsafe:true                      400            415          13          2.5         399.6       0.9X
-basicTypes: Float with unsafe:true                     401            413           8          2.5         400.5       0.9X
-basicTypes: Double with unsafe:true                    418            423           4          2.4         418.2       0.9X
-Array: Int with unsafe:true                              4              5           1        247.5           4.0      89.1X
-Array: Long with unsafe:true                             7              8           1        148.6           6.7      53.5X
-Array: Float with unsafe:true                            4              5           1        263.5           3.8      94.8X
-Array: Double with unsafe:true                           6              8           1        155.9           6.4      56.1X
-Map of string->Double  with unsafe:true                 46             50           2         21.7          46.1       7.8X
-basicTypes: Int with unsafe:false                      436            447          13          2.3         435.6       0.8X
-basicTypes: Long with unsafe:false                     453            482          20          2.2         453.2       0.8X
-basicTypes: Float with unsafe:false                    435            458          28          2.3         435.0       0.8X
-basicTypes: Double with unsafe:false                   451            471          22          2.2         450.8       0.8X
-Array: Int with unsafe:false                            22             27           2         45.0          22.2      16.2X
-Array: Long with unsafe:false                           39             43           4         25.5          39.2       9.2X
-Array: Float with unsafe:false                          10             12           1        104.3           9.6      37.5X
-Array: Double with unsafe:false                         18             20           1         54.7          18.3      19.7X
-Map of string->Double  with unsafe:false                48             51           2         20.9          47.9       7.5X
+basicTypes: Int with unsafe:true                       268            270           2          3.7         267.8       1.0X
+basicTypes: Long with unsafe:true                      292            294           2          3.4         291.6       0.9X
+basicTypes: Float with unsafe:true                     290            294           3          3.5         289.7       0.9X
+basicTypes: Double with unsafe:true                    297            300           2          3.4         297.1       0.9X
+Array: Int with unsafe:true                              3              3           0        365.5           2.7      97.9X
+Array: Long with unsafe:true                             4              5           0        242.5           4.1      64.9X
+Array: Float with unsafe:true                            3              3           0        364.5           2.7      97.6X
+Array: Double with unsafe:true                           4              5           0        238.0           4.2      63.7X
+Map of string->Double  with unsafe:true                 37             38           1         26.9          37.2       7.2X
+basicTypes: Int with unsafe:false                      304            306           1          3.3         304.4       0.9X
+basicTypes: Long with unsafe:false                     332            335           2          3.0         332.4       0.8X
+basicTypes: Float with unsafe:false                    301            305           3          3.3         301.0       0.9X
+basicTypes: Double with unsafe:false                   308            310           2          3.2         308.2       0.9X
+Array: Int with unsafe:false                            20             21           0         49.7          20.1      13.3X
+Array: Long with unsafe:false                           31             31           1         32.2          31.1       8.6X
+Array: Float with unsafe:false                           8              8           0        122.6           8.2      32.8X
+Array: Double with unsafe:false                         13             14           0         74.5          13.4      20.0X
+Map of string->Double  with unsafe:false                39             39           1         25.8          38.8       6.9X
 
 

--- a/core/benchmarks/KryoBenchmark-jdk17-results.txt
+++ b/core/benchmarks/KryoBenchmark-jdk17-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1031-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       263            265           2          3.8         262.5       1.0X
-basicTypes: Long with unsafe:true                      294            295           1          3.4         293.6       0.9X
-basicTypes: Float with unsafe:true                     280            282           1          3.6         279.7       0.9X
-basicTypes: Double with unsafe:true                    283            286           2          3.5         282.7       0.9X
-Array: Int with unsafe:true                              3              3           0        337.9           3.0      88.7X
-Array: Long with unsafe:true                             5              5           0        210.7           4.7      55.3X
-Array: Float with unsafe:true                            3              3           0        338.4           3.0      88.8X
-Array: Double with unsafe:true                           5              5           0        210.8           4.7      55.4X
-Map of string->Double  with unsafe:true                 38             38           0         26.5          37.7       7.0X
-basicTypes: Int with unsafe:false                      304            306           1          3.3         304.4       0.9X
-basicTypes: Long with unsafe:false                     330            333           3          3.0         329.5       0.8X
-basicTypes: Float with unsafe:false                    301            303           1          3.3         301.3       0.9X
-basicTypes: Double with unsafe:false                   309            312           2          3.2         308.7       0.9X
-Array: Int with unsafe:false                            21             21           0         48.3          20.7      12.7X
-Array: Long with unsafe:false                           31             32           1         31.9          31.4       8.4X
-Array: Float with unsafe:false                           8              8           0        120.7           8.3      31.7X
-Array: Double with unsafe:false                         14             14           1         71.4          14.0      18.7X
-Map of string->Double  with unsafe:false                40             40           1         25.0          40.0       6.6X
+basicTypes: Int with unsafe:true                       360            392          31          2.8         359.9       1.0X
+basicTypes: Long with unsafe:true                      400            415          13          2.5         399.6       0.9X
+basicTypes: Float with unsafe:true                     401            413           8          2.5         400.5       0.9X
+basicTypes: Double with unsafe:true                    418            423           4          2.4         418.2       0.9X
+Array: Int with unsafe:true                              4              5           1        247.5           4.0      89.1X
+Array: Long with unsafe:true                             7              8           1        148.6           6.7      53.5X
+Array: Float with unsafe:true                            4              5           1        263.5           3.8      94.8X
+Array: Double with unsafe:true                           6              8           1        155.9           6.4      56.1X
+Map of string->Double  with unsafe:true                 46             50           2         21.7          46.1       7.8X
+basicTypes: Int with unsafe:false                      436            447          13          2.3         435.6       0.8X
+basicTypes: Long with unsafe:false                     453            482          20          2.2         453.2       0.8X
+basicTypes: Float with unsafe:false                    435            458          28          2.3         435.0       0.8X
+basicTypes: Double with unsafe:false                   451            471          22          2.2         450.8       0.8X
+Array: Int with unsafe:false                            22             27           2         45.0          22.2      16.2X
+Array: Long with unsafe:false                           39             43           4         25.5          39.2       9.2X
+Array: Float with unsafe:false                          10             12           1        104.3           9.6      37.5X
+Array: Double with unsafe:false                         18             20           1         54.7          18.3      19.7X
+Map of string->Double  with unsafe:false                48             51           2         20.9          47.9       7.5X
 
 

--- a/core/benchmarks/KryoBenchmark-results.txt
+++ b/core/benchmarks/KryoBenchmark-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1031-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       248            252           5          4.0         248.1       1.0X
-basicTypes: Long with unsafe:true                      281            284           3          3.6         280.7       0.9X
-basicTypes: Float with unsafe:true                     266            268           2          3.8         265.9       0.9X
-basicTypes: Double with unsafe:true                    265            270           3          3.8         265.3       0.9X
-Array: Int with unsafe:true                              3              3           0        346.2           2.9      85.9X
-Array: Long with unsafe:true                             5              5           0        216.0           4.6      53.6X
-Array: Float with unsafe:true                            3              3           0        341.4           2.9      84.7X
-Array: Double with unsafe:true                           5              5           0        217.8           4.6      54.0X
-Map of string->Double  with unsafe:true                 35             35           0         28.9          34.6       7.2X
-basicTypes: Int with unsafe:false                      283            285           1          3.5         283.4       0.9X
-basicTypes: Long with unsafe:false                     302            302           1          3.3         301.6       0.8X
-basicTypes: Float with unsafe:false                    276            278           3          3.6         275.6       0.9X
-basicTypes: Double with unsafe:false                   281            282           1          3.6         280.8       0.9X
-Array: Int with unsafe:false                            21             21           0         48.6          20.6      12.1X
-Array: Long with unsafe:false                           30             30           0         33.3          30.0       8.3X
-Array: Float with unsafe:false                           8              8           0        126.6           7.9      31.4X
-Array: Double with unsafe:false                         15             15           0         68.2          14.7      16.9X
-Map of string->Double  with unsafe:false                36             37           0         27.4          36.4       6.8X
+basicTypes: Int with unsafe:true                       281            289           7          3.6         280.6       1.0X
+basicTypes: Long with unsafe:true                      311            330          10          3.2         310.5       0.9X
+basicTypes: Float with unsafe:true                     305            317           9          3.3         304.9       0.9X
+basicTypes: Double with unsafe:true                    304            324           9          3.3         304.1       0.9X
+Array: Int with unsafe:true                              5              6           1        202.6           4.9      56.8X
+Array: Long with unsafe:true                             9             10           1        113.1           8.8      31.7X
+Array: Float with unsafe:true                            5              6           1        189.7           5.3      53.2X
+Array: Double with unsafe:true                           9             10           1        117.2           8.5      32.9X
+Map of string->Double  with unsafe:true                 47             49           2         21.3          47.0       6.0X
+basicTypes: Int with unsafe:false                      328            345          11          3.1         327.7       0.9X
+basicTypes: Long with unsafe:false                     362            370           6          2.8         362.0       0.8X
+basicTypes: Float with unsafe:false                    324            342          25          3.1         323.6       0.9X
+basicTypes: Double with unsafe:false                   336            343           6          3.0         335.6       0.8X
+Array: Int with unsafe:false                            24             26           1         42.0          23.8      11.8X
+Array: Long with unsafe:false                           37             39           2         26.8          37.3       7.5X
+Array: Float with unsafe:false                          10             12           1         96.6          10.3      27.1X
+Array: Double with unsafe:false                         19             20           1         53.6          18.7      15.0X
+Map of string->Double  with unsafe:false                46             50           2         21.5          46.5       6.0X
 
 

--- a/core/benchmarks/KryoBenchmark-results.txt
+++ b/core/benchmarks/KryoBenchmark-results.txt
@@ -2,27 +2,27 @@
 Benchmark Kryo Unsafe vs safe Serialization
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1036-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Benchmark Kryo Unsafe vs safe Serialization:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-basicTypes: Int with unsafe:true                       281            289           7          3.6         280.6       1.0X
-basicTypes: Long with unsafe:true                      311            330          10          3.2         310.5       0.9X
-basicTypes: Float with unsafe:true                     305            317           9          3.3         304.9       0.9X
-basicTypes: Double with unsafe:true                    304            324           9          3.3         304.1       0.9X
-Array: Int with unsafe:true                              5              6           1        202.6           4.9      56.8X
-Array: Long with unsafe:true                             9             10           1        113.1           8.8      31.7X
-Array: Float with unsafe:true                            5              6           1        189.7           5.3      53.2X
-Array: Double with unsafe:true                           9             10           1        117.2           8.5      32.9X
-Map of string->Double  with unsafe:true                 47             49           2         21.3          47.0       6.0X
-basicTypes: Int with unsafe:false                      328            345          11          3.1         327.7       0.9X
-basicTypes: Long with unsafe:false                     362            370           6          2.8         362.0       0.8X
-basicTypes: Float with unsafe:false                    324            342          25          3.1         323.6       0.9X
-basicTypes: Double with unsafe:false                   336            343           6          3.0         335.6       0.8X
-Array: Int with unsafe:false                            24             26           1         42.0          23.8      11.8X
-Array: Long with unsafe:false                           37             39           2         26.8          37.3       7.5X
-Array: Float with unsafe:false                          10             12           1         96.6          10.3      27.1X
-Array: Double with unsafe:false                         19             20           1         53.6          18.7      15.0X
-Map of string->Double  with unsafe:false                46             50           2         21.5          46.5       6.0X
+basicTypes: Int with unsafe:true                       239            258          15          4.2         239.4       1.0X
+basicTypes: Long with unsafe:true                      277            302          18          3.6         276.5       0.9X
+basicTypes: Float with unsafe:true                     296            304           8          3.4         295.6       0.8X
+basicTypes: Double with unsafe:true                    281            308          13          3.6         281.0       0.9X
+Array: Int with unsafe:true                              5              6           1        201.1           5.0      48.1X
+Array: Long with unsafe:true                             7              8           1        141.6           7.1      33.9X
+Array: Float with unsafe:true                            5              5           1        218.4           4.6      52.3X
+Array: Double with unsafe:true                           7              8           1        136.6           7.3      32.7X
+Map of string->Double  with unsafe:true                 43             47           4         23.2          43.1       5.6X
+basicTypes: Int with unsafe:false                      295            316          13          3.4         294.7       0.8X
+basicTypes: Long with unsafe:false                     310            329          13          3.2         310.0       0.8X
+basicTypes: Float with unsafe:false                    283            290           7          3.5         283.0       0.8X
+basicTypes: Double with unsafe:false                   294            325          17          3.4         293.8       0.8X
+Array: Int with unsafe:false                            23             25           2         44.1          22.7      10.6X
+Array: Long with unsafe:false                           34             37           2         29.1          34.4       7.0X
+Array: Float with unsafe:false                          10             11           1        104.8           9.5      25.1X
+Array: Double with unsafe:false                         17             19           2         60.0          16.7      14.4X
+Map of string->Double  with unsafe:false                40             46           3         24.7          40.4       5.9X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-jdk11-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk11-results.txt
@@ -2,21 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1030-azure
+OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-Benchmark of kryo asIterator on deserialization stream:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                   12             13           1          0.8        1233.5       1.0X
-Colletion of int with 10 elements, useIterator: true                  27             27           0          0.4        2651.9       0.5X
-Colletion of int with 100 elements, useIterator: true                154            155           1          0.1       15437.2       0.1X
-Colletion of string with 1 elements, useIterator: true                14             15           0          0.7        1419.7       0.9X
-Colletion of string with 10 elements, useIterator: true               37             38           0          0.3        3747.1       0.3X
-Colletion of string with 100 elements, useIterator: true             254            255           3          0.0       25369.2       0.0X
-Colletion of int with 1 elements, useIterator: false                  12             12           0          0.9        1164.4       1.1X
-Colletion of int with 10 elements, useIterator: false                 26             26           0          0.4        2578.0       0.5X
-Colletion of int with 100 elements, useIterator: false               159            159           0          0.1       15892.6       0.1X
-Colletion of string with 1 elements, useIterator: false               13             14           1          0.8        1306.8       0.9X
-Colletion of string with 10 elements, useIterator: false              35             36           2          0.3        3483.2       0.4X
-Colletion of string with 100 elements, useIterator: false            237            238           0          0.0       23706.8       0.1X
+Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------
+Colletion of int with 1 elements, useIterator: true                       13             13           1          0.8        1273.5       1.0X
+Colletion of int with 10 elements, useIterator: true                      28             28           1          0.4        2759.4       0.5X
+Colletion of int with 100 elements, useIterator: true                    168            168           0          0.1       16812.1       0.1X
+Colletion of string with 1 elements, useIterator: true                    15             15           0          0.7        1470.5       0.9X
+Colletion of string with 10 elements, useIterator: true                   40             41           0          0.2        4032.9       0.3X
+Colletion of string with 100 elements, useIterator: true                 277            278           0          0.0       27721.6       0.0X
+Colletion of Array[int] with 1 elements, useIterator: true                14             15           1          0.7        1432.8       0.9X
+Colletion of Array[int] with 10 elements, useIterator: true               36             37           1          0.3        3613.0       0.4X
+Colletion of Array[int] with 100 elements, useIterator: true             262            266           4          0.0       26233.9       0.0X
+Colletion of int with 1 elements, useIterator: false                      12             12           0          0.9        1163.9       1.1X
+Colletion of int with 10 elements, useIterator: false                     23             23           0          0.4        2288.4       0.6X
+Colletion of int with 100 elements, useIterator: false                   125            126           0          0.1       12548.6       0.1X
+Colletion of string with 1 elements, useIterator: false                   14             14           1          0.7        1357.0       0.9X
+Colletion of string with 10 elements, useIterator: false                  34             35           2          0.3        3448.7       0.4X
+Colletion of string with 100 elements, useIterator: false                236            238           3          0.0       23580.2       0.1X
+Colletion of Array[int] with 1 elements, useIterator: false               13             13           1          0.8        1257.8       1.0X
+Colletion of Array[int] with 10 elements, useIterator: false              31             32           0          0.3        3102.0       0.4X
+Colletion of Array[int] with 100 elements, useIterator: false            215            216           0          0.0       21515.9       0.1X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-jdk11-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk11-results.txt
@@ -1,0 +1,22 @@
+================================================================================================
+Benchmark of kryo asIterator on deserialization stream
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1023-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Benchmark of kryo asIterator on deserialization stream:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------
+Colletion of int with 1 elements, useIterator: true                   98             98           0          0.1        9763.9       1.0X
+Colletion of int with 10 elements, useIterator: true                 113            114           0          0.1       11311.5       0.9X
+Colletion of int with 100 elements, useIterator: true                239            239           1          0.0       23856.3       0.4X
+Colletion of string with 1 elements, useIterator: true               100            100           0          0.1        9996.3       1.0X
+Colletion of string with 10 elements, useIterator: true              128            128           0          0.1       12772.8       0.8X
+Colletion of string with 100 elements, useIterator: true             379            380           0          0.0       37937.0       0.3X
+Colletion of int with 1 elements, useIterator: false                  11             12           0          0.9        1137.9       8.6X
+Colletion of int with 10 elements, useIterator: false                 24             24           0          0.4        2384.4       4.1X
+Colletion of int with 100 elements, useIterator: false               138            138           0          0.1       13768.9       0.7X
+Colletion of string with 1 elements, useIterator: false               13             13           0          0.8        1271.8       7.7X
+Colletion of string with 10 elements, useIterator: false              35             36           0          0.3        3524.1       2.8X
+Colletion of string with 100 elements, useIterator: false            244            244           0          0.0       24395.8       0.4X
+
+

--- a/core/benchmarks/KryoIteratorBenchmark-jdk11-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk11-results.txt
@@ -2,21 +2,21 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1023-azure
+OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1030-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark of kryo asIterator on deserialization stream:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                   98             98           0          0.1        9763.9       1.0X
-Colletion of int with 10 elements, useIterator: true                 113            114           0          0.1       11311.5       0.9X
-Colletion of int with 100 elements, useIterator: true                239            239           1          0.0       23856.3       0.4X
-Colletion of string with 1 elements, useIterator: true               100            100           0          0.1        9996.3       1.0X
-Colletion of string with 10 elements, useIterator: true              128            128           0          0.1       12772.8       0.8X
-Colletion of string with 100 elements, useIterator: true             379            380           0          0.0       37937.0       0.3X
-Colletion of int with 1 elements, useIterator: false                  11             12           0          0.9        1137.9       8.6X
-Colletion of int with 10 elements, useIterator: false                 24             24           0          0.4        2384.4       4.1X
-Colletion of int with 100 elements, useIterator: false               138            138           0          0.1       13768.9       0.7X
-Colletion of string with 1 elements, useIterator: false               13             13           0          0.8        1271.8       7.7X
-Colletion of string with 10 elements, useIterator: false              35             36           0          0.3        3524.1       2.8X
-Colletion of string with 100 elements, useIterator: false            244            244           0          0.0       24395.8       0.4X
+Colletion of int with 1 elements, useIterator: true                   12             13           1          0.8        1233.5       1.0X
+Colletion of int with 10 elements, useIterator: true                  27             27           0          0.4        2651.9       0.5X
+Colletion of int with 100 elements, useIterator: true                154            155           1          0.1       15437.2       0.1X
+Colletion of string with 1 elements, useIterator: true                14             15           0          0.7        1419.7       0.9X
+Colletion of string with 10 elements, useIterator: true               37             38           0          0.3        3747.1       0.3X
+Colletion of string with 100 elements, useIterator: true             254            255           3          0.0       25369.2       0.0X
+Colletion of int with 1 elements, useIterator: false                  12             12           0          0.9        1164.4       1.1X
+Colletion of int with 10 elements, useIterator: false                 26             26           0          0.4        2578.0       0.5X
+Colletion of int with 100 elements, useIterator: false               159            159           0          0.1       15892.6       0.1X
+Colletion of string with 1 elements, useIterator: false               13             14           1          0.8        1306.8       0.9X
+Colletion of string with 10 elements, useIterator: false              35             36           2          0.3        3483.2       0.4X
+Colletion of string with 100 elements, useIterator: false            237            238           0          0.0       23706.8       0.1X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-jdk11-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk11-results.txt
@@ -2,27 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1036-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                       13             13           1          0.8        1273.5       1.0X
-Colletion of int with 10 elements, useIterator: true                      28             28           1          0.4        2759.4       0.5X
-Colletion of int with 100 elements, useIterator: true                    168            168           0          0.1       16812.1       0.1X
-Colletion of string with 1 elements, useIterator: true                    15             15           0          0.7        1470.5       0.9X
-Colletion of string with 10 elements, useIterator: true                   40             41           0          0.2        4032.9       0.3X
-Colletion of string with 100 elements, useIterator: true                 277            278           0          0.0       27721.6       0.0X
-Colletion of Array[int] with 1 elements, useIterator: true                14             15           1          0.7        1432.8       0.9X
-Colletion of Array[int] with 10 elements, useIterator: true               36             37           1          0.3        3613.0       0.4X
-Colletion of Array[int] with 100 elements, useIterator: true             262            266           4          0.0       26233.9       0.0X
-Colletion of int with 1 elements, useIterator: false                      12             12           0          0.9        1163.9       1.1X
-Colletion of int with 10 elements, useIterator: false                     23             23           0          0.4        2288.4       0.6X
-Colletion of int with 100 elements, useIterator: false                   125            126           0          0.1       12548.6       0.1X
-Colletion of string with 1 elements, useIterator: false                   14             14           1          0.7        1357.0       0.9X
-Colletion of string with 10 elements, useIterator: false                  34             35           2          0.3        3448.7       0.4X
-Colletion of string with 100 elements, useIterator: false                236            238           3          0.0       23580.2       0.1X
-Colletion of Array[int] with 1 elements, useIterator: false               13             13           1          0.8        1257.8       1.0X
-Colletion of Array[int] with 10 elements, useIterator: false              31             32           0          0.3        3102.0       0.4X
-Colletion of Array[int] with 100 elements, useIterator: false            215            216           0          0.0       21515.9       0.1X
+Colletion of int with 1 elements, useIterator: true                       13             13           0          0.8        1262.3       1.0X
+Colletion of int with 10 elements, useIterator: true                      30             30           1          0.3        2974.4       0.4X
+Colletion of int with 100 elements, useIterator: true                    190            191           2          0.1       18981.4       0.1X
+Colletion of string with 1 elements, useIterator: true                    15             15           0          0.7        1497.9       0.8X
+Colletion of string with 10 elements, useIterator: true                   43             44           1          0.2        4338.8       0.3X
+Colletion of string with 100 elements, useIterator: true                 308            309           1          0.0       30800.1       0.0X
+Colletion of Array[int] with 1 elements, useIterator: true                14             15           0          0.7        1411.7       0.9X
+Colletion of Array[int] with 10 elements, useIterator: true               38             39           0          0.3        3798.4       0.3X
+Colletion of Array[int] with 100 elements, useIterator: true             283            284           0          0.0       28301.9       0.0X
+Colletion of int with 1 elements, useIterator: false                      11             12           0          0.9        1146.7       1.1X
+Colletion of int with 10 elements, useIterator: false                     23             23           0          0.4        2256.0       0.6X
+Colletion of int with 100 elements, useIterator: false                   126            126           1          0.1       12550.7       0.1X
+Colletion of string with 1 elements, useIterator: false                   13             14           0          0.7        1341.3       0.9X
+Colletion of string with 10 elements, useIterator: false                  35             36           1          0.3        3536.6       0.4X
+Colletion of string with 100 elements, useIterator: false                243            244           0          0.0       24332.6       0.1X
+Colletion of Array[int] with 1 elements, useIterator: false               13             13           0          0.8        1262.6       1.0X
+Colletion of Array[int] with 10 elements, useIterator: false              32             32           0          0.3        3155.6       0.4X
+Colletion of Array[int] with 100 elements, useIterator: false            219            220           0          0.0       21932.1       0.1X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-jdk17-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk17-results.txt
@@ -3,26 +3,26 @@ Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                      113            114           1          0.1       11274.8       1.0X
-Colletion of int with 10 elements, useIterator: true                     125            126           0          0.1       12547.7       0.9X
-Colletion of int with 100 elements, useIterator: true                    243            244           1          0.0       24324.0       0.5X
-Colletion of string with 1 elements, useIterator: true                   112            112           0          0.1       11207.8       1.0X
-Colletion of string with 10 elements, useIterator: true                  135            135           0          0.1       13459.3       0.8X
-Colletion of string with 100 elements, useIterator: true                 350            351           1          0.0       35010.5       0.3X
-Colletion of Array[int] with 1 elements, useIterator: true               112            113           1          0.1       11235.7       1.0X
-Colletion of Array[int] with 10 elements, useIterator: true              132            132           1          0.1       13167.5       0.9X
-Colletion of Array[int] with 100 elements, useIterator: true             334            334           1          0.0       33351.4       0.3X
-Colletion of int with 1 elements, useIterator: false                      14             14           0          0.7        1364.5       8.3X
-Colletion of int with 10 elements, useIterator: false                     24             25           0          0.4        2414.8       4.7X
-Colletion of int with 100 elements, useIterator: false                   132            132           0          0.1       13171.3       0.9X
-Colletion of string with 1 elements, useIterator: false                   15             15           0          0.7        1504.1       7.5X
-Colletion of string with 10 elements, useIterator: false                  36             37           1          0.3        3633.5       3.1X
-Colletion of string with 100 elements, useIterator: false                242            242           1          0.0       24161.7       0.5X
-Colletion of Array[int] with 1 elements, useIterator: false               15             15           0          0.7        1457.2       7.7X
-Colletion of Array[int] with 10 elements, useIterator: false              32             33           0          0.3        3222.4       3.5X
-Colletion of Array[int] with 100 elements, useIterator: false            219            219           0          0.0       21873.1       0.5X
+Colletion of int with 1 elements, useIterator: true                       22             25           2          0.5        2160.1       1.0X
+Colletion of int with 10 elements, useIterator: true                      37             41           2          0.3        3742.8       0.6X
+Colletion of int with 100 elements, useIterator: true                    192            199           5          0.1       19184.5       0.1X
+Colletion of string with 1 elements, useIterator: true                    24             26           1          0.4        2384.5       0.9X
+Colletion of string with 10 elements, useIterator: true                   51             58           3          0.2        5092.8       0.4X
+Colletion of string with 100 elements, useIterator: true                 338            355          12          0.0       33833.5       0.1X
+Colletion of Array[int] with 1 elements, useIterator: true                24             28           5          0.4        2372.5       0.9X
+Colletion of Array[int] with 10 elements, useIterator: true               48             53           3          0.2        4841.6       0.4X
+Colletion of Array[int] with 100 elements, useIterator: true             341            356           8          0.0       34118.0       0.1X
+Colletion of int with 1 elements, useIterator: false                      21             25           3          0.5        2103.1       1.0X
+Colletion of int with 10 elements, useIterator: false                     37             42           3          0.3        3729.3       0.6X
+Colletion of int with 100 elements, useIterator: false                   171            181          10          0.1       17105.7       0.1X
+Colletion of string with 1 elements, useIterator: false                   24             27           2          0.4        2410.6       0.9X
+Colletion of string with 10 elements, useIterator: false                  52             57           3          0.2        5213.2       0.4X
+Colletion of string with 100 elements, useIterator: false                343            354           8          0.0       34284.3       0.1X
+Colletion of Array[int] with 1 elements, useIterator: false               23             26           2          0.4        2339.2       0.9X
+Colletion of Array[int] with 10 elements, useIterator: false              46             53           7          0.2        4637.8       0.5X
+Colletion of Array[int] with 100 elements, useIterator: false            302            326          12          0.0       30210.0       0.1X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-jdk17-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk17-results.txt
@@ -1,0 +1,22 @@
+================================================================================================
+Benchmark of kryo asIterator on deserialization stream
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1030-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Benchmark of kryo asIterator on deserialization stream:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------
+Colletion of int with 1 elements, useIterator: true                   23             25           2          0.4        2260.0       1.0X
+Colletion of int with 10 elements, useIterator: true                  42             45           2          0.2        4178.2       0.5X
+Colletion of int with 100 elements, useIterator: true                231            241           8          0.0       23114.4       0.1X
+Colletion of string with 1 elements, useIterator: true                25             27           2          0.4        2514.1       0.9X
+Colletion of string with 10 elements, useIterator: true               59             64           4          0.2        5862.3       0.4X
+Colletion of string with 100 elements, useIterator: true             394            404          10          0.0       39353.0       0.1X
+Colletion of int with 1 elements, useIterator: false                  23             25           1          0.4        2289.3       1.0X
+Colletion of int with 10 elements, useIterator: false                 39             42           3          0.3        3887.0       0.6X
+Colletion of int with 100 elements, useIterator: false               189            197           5          0.1       18899.6       0.1X
+Colletion of string with 1 elements, useIterator: false               24             27           3          0.4        2415.1       0.9X
+Colletion of string with 10 elements, useIterator: false              53             56           3          0.2        5329.9       0.4X
+Colletion of string with 100 elements, useIterator: false            330            340           6          0.0       32998.7       0.1X
+
+

--- a/core/benchmarks/KryoIteratorBenchmark-jdk17-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk17-results.txt
@@ -2,21 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1030-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
-Benchmark of kryo asIterator on deserialization stream:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                   23             25           2          0.4        2260.0       1.0X
-Colletion of int with 10 elements, useIterator: true                  42             45           2          0.2        4178.2       0.5X
-Colletion of int with 100 elements, useIterator: true                231            241           8          0.0       23114.4       0.1X
-Colletion of string with 1 elements, useIterator: true                25             27           2          0.4        2514.1       0.9X
-Colletion of string with 10 elements, useIterator: true               59             64           4          0.2        5862.3       0.4X
-Colletion of string with 100 elements, useIterator: true             394            404          10          0.0       39353.0       0.1X
-Colletion of int with 1 elements, useIterator: false                  23             25           1          0.4        2289.3       1.0X
-Colletion of int with 10 elements, useIterator: false                 39             42           3          0.3        3887.0       0.6X
-Colletion of int with 100 elements, useIterator: false               189            197           5          0.1       18899.6       0.1X
-Colletion of string with 1 elements, useIterator: false               24             27           3          0.4        2415.1       0.9X
-Colletion of string with 10 elements, useIterator: false              53             56           3          0.2        5329.9       0.4X
-Colletion of string with 100 elements, useIterator: false            330            340           6          0.0       32998.7       0.1X
+OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------
+Colletion of int with 1 elements, useIterator: true                      113            114           1          0.1       11274.8       1.0X
+Colletion of int with 10 elements, useIterator: true                     125            126           0          0.1       12547.7       0.9X
+Colletion of int with 100 elements, useIterator: true                    243            244           1          0.0       24324.0       0.5X
+Colletion of string with 1 elements, useIterator: true                   112            112           0          0.1       11207.8       1.0X
+Colletion of string with 10 elements, useIterator: true                  135            135           0          0.1       13459.3       0.8X
+Colletion of string with 100 elements, useIterator: true                 350            351           1          0.0       35010.5       0.3X
+Colletion of Array[int] with 1 elements, useIterator: true               112            113           1          0.1       11235.7       1.0X
+Colletion of Array[int] with 10 elements, useIterator: true              132            132           1          0.1       13167.5       0.9X
+Colletion of Array[int] with 100 elements, useIterator: true             334            334           1          0.0       33351.4       0.3X
+Colletion of int with 1 elements, useIterator: false                      14             14           0          0.7        1364.5       8.3X
+Colletion of int with 10 elements, useIterator: false                     24             25           0          0.4        2414.8       4.7X
+Colletion of int with 100 elements, useIterator: false                   132            132           0          0.1       13171.3       0.9X
+Colletion of string with 1 elements, useIterator: false                   15             15           0          0.7        1504.1       7.5X
+Colletion of string with 10 elements, useIterator: false                  36             37           1          0.3        3633.5       3.1X
+Colletion of string with 100 elements, useIterator: false                242            242           1          0.0       24161.7       0.5X
+Colletion of Array[int] with 1 elements, useIterator: false               15             15           0          0.7        1457.2       7.7X
+Colletion of Array[int] with 10 elements, useIterator: false              32             33           0          0.3        3222.4       3.5X
+Colletion of Array[int] with 100 elements, useIterator: false            219            219           0          0.0       21873.1       0.5X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-jdk17-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-jdk17-results.txt
@@ -2,27 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1036-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                       22             25           2          0.5        2160.1       1.0X
-Colletion of int with 10 elements, useIterator: true                      37             41           2          0.3        3742.8       0.6X
-Colletion of int with 100 elements, useIterator: true                    192            199           5          0.1       19184.5       0.1X
-Colletion of string with 1 elements, useIterator: true                    24             26           1          0.4        2384.5       0.9X
-Colletion of string with 10 elements, useIterator: true                   51             58           3          0.2        5092.8       0.4X
-Colletion of string with 100 elements, useIterator: true                 338            355          12          0.0       33833.5       0.1X
-Colletion of Array[int] with 1 elements, useIterator: true                24             28           5          0.4        2372.5       0.9X
-Colletion of Array[int] with 10 elements, useIterator: true               48             53           3          0.2        4841.6       0.4X
-Colletion of Array[int] with 100 elements, useIterator: true             341            356           8          0.0       34118.0       0.1X
-Colletion of int with 1 elements, useIterator: false                      21             25           3          0.5        2103.1       1.0X
-Colletion of int with 10 elements, useIterator: false                     37             42           3          0.3        3729.3       0.6X
-Colletion of int with 100 elements, useIterator: false                   171            181          10          0.1       17105.7       0.1X
-Colletion of string with 1 elements, useIterator: false                   24             27           2          0.4        2410.6       0.9X
-Colletion of string with 10 elements, useIterator: false                  52             57           3          0.2        5213.2       0.4X
-Colletion of string with 100 elements, useIterator: false                343            354           8          0.0       34284.3       0.1X
-Colletion of Array[int] with 1 elements, useIterator: false               23             26           2          0.4        2339.2       0.9X
-Colletion of Array[int] with 10 elements, useIterator: false              46             53           7          0.2        4637.8       0.5X
-Colletion of Array[int] with 100 elements, useIterator: false            302            326          12          0.0       30210.0       0.1X
+Colletion of int with 1 elements, useIterator: true                       14             15           0          0.7        1418.2       1.0X
+Colletion of int with 10 elements, useIterator: true                      26             26           1          0.4        2565.9       0.6X
+Colletion of int with 100 elements, useIterator: true                    137            138           1          0.1       13720.7       0.1X
+Colletion of string with 1 elements, useIterator: true                    16             16           0          0.6        1572.0       0.9X
+Colletion of string with 10 elements, useIterator: true                   38             38           0          0.3        3782.3       0.4X
+Colletion of string with 100 elements, useIterator: true                 252            253           0          0.0       25193.4       0.1X
+Colletion of Array[int] with 1 elements, useIterator: true                15             16           0          0.6        1547.7       0.9X
+Colletion of Array[int] with 10 elements, useIterator: true               34             35           1          0.3        3389.1       0.4X
+Colletion of Array[int] with 100 elements, useIterator: true             227            229           1          0.0       22733.2       0.1X
+Colletion of int with 1 elements, useIterator: false                      14             14           0          0.7        1376.0       1.0X
+Colletion of int with 10 elements, useIterator: false                     24             25           0          0.4        2426.0       0.6X
+Colletion of int with 100 elements, useIterator: false                   132            132           0          0.1       13204.7       0.1X
+Colletion of string with 1 elements, useIterator: false                   15             16           0          0.7        1517.3       0.9X
+Colletion of string with 10 elements, useIterator: false                  37             38           1          0.3        3700.8       0.4X
+Colletion of string with 100 elements, useIterator: false                252            253           0          0.0       25234.5       0.1X
+Colletion of Array[int] with 1 elements, useIterator: false               15             15           0          0.7        1466.1       1.0X
+Colletion of Array[int] with 10 elements, useIterator: false              32             33           0          0.3        3237.5       0.4X
+Colletion of Array[int] with 100 elements, useIterator: false            217            218           1          0.0       21706.8       0.1X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-results.txt
@@ -1,0 +1,22 @@
+================================================================================================
+Benchmark of kryo asIterator on deserialization stream
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1023-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Benchmark of kryo asIterator on deserialization stream:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------
+Colletion of int with 1 elements, useIterator: true                   84             85           1          0.1        8353.1       1.0X
+Colletion of int with 10 elements, useIterator: true                 101            102           1          0.1       10107.5       0.8X
+Colletion of int with 100 elements, useIterator: true                243            244           1          0.0       24297.7       0.3X
+Colletion of string with 1 elements, useIterator: true                85             85           1          0.1        8476.6       1.0X
+Colletion of string with 10 elements, useIterator: true              111            112           1          0.1       11070.8       0.8X
+Colletion of string with 100 elements, useIterator: true             338            339           1          0.0       33820.9       0.2X
+Colletion of int with 1 elements, useIterator: false                  11             11           1          0.9        1082.5       7.7X
+Colletion of int with 10 elements, useIterator: false                 22             23           1          0.4        2229.2       3.7X
+Colletion of int with 100 elements, useIterator: false               119            120           1          0.1       11935.5       0.7X
+Colletion of string with 1 elements, useIterator: false               12             12           1          0.8        1198.8       7.0X
+Colletion of string with 10 elements, useIterator: false              31             32           1          0.3        3149.1       2.7X
+Colletion of string with 100 elements, useIterator: false            210            211           1          0.0       21042.6       0.4X
+
+

--- a/core/benchmarks/KryoIteratorBenchmark-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-results.txt
@@ -2,27 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1036-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                       29             30           1          0.3        2869.7       1.0X
-Colletion of int with 10 elements, useIterator: true                      37             39           2          0.3        3736.9       0.8X
-Colletion of int with 100 elements, useIterator: true                    159            168           8          0.1       15889.2       0.2X
-Colletion of string with 1 elements, useIterator: true                    30             32           1          0.3        2996.6       1.0X
-Colletion of string with 10 elements, useIterator: true                   49             51           2          0.2        4900.9       0.6X
-Colletion of string with 100 elements, useIterator: true                 280            288           5          0.0       28012.7       0.1X
-Colletion of Array[int] with 1 elements, useIterator: true                29             31           2          0.3        2891.7       1.0X
-Colletion of Array[int] with 10 elements, useIterator: true               45             49           3          0.2        4492.9       0.6X
-Colletion of Array[int] with 100 elements, useIterator: true             258            264           5          0.0       25848.7       0.1X
-Colletion of int with 1 elements, useIterator: false                      27             29           2          0.4        2736.7       1.0X
-Colletion of int with 10 elements, useIterator: false                     33             35           2          0.3        3311.4       0.9X
-Colletion of int with 100 elements, useIterator: false                   130            136           4          0.1       13026.5       0.2X
-Colletion of string with 1 elements, useIterator: false                   29             30           1          0.3        2892.4       1.0X
-Colletion of string with 10 elements, useIterator: false                  45             50           4          0.2        4530.8       0.6X
-Colletion of string with 100 elements, useIterator: false                263            269           4          0.0       26286.1       0.1X
-Colletion of Array[int] with 1 elements, useIterator: false               28             30           1          0.4        2796.8       1.0X
-Colletion of Array[int] with 10 elements, useIterator: false              42             45           3          0.2        4242.5       0.7X
-Colletion of Array[int] with 100 elements, useIterator: false            246            251           4          0.0       24612.0       0.1X
+Colletion of int with 1 elements, useIterator: true                       22             24           2          0.4        2228.3       1.0X
+Colletion of int with 10 elements, useIterator: true                      30             33           3          0.3        2970.4       0.8X
+Colletion of int with 100 elements, useIterator: true                    142            147           3          0.1       14249.2       0.2X
+Colletion of string with 1 elements, useIterator: true                    23             26           2          0.4        2308.2       1.0X
+Colletion of string with 10 elements, useIterator: true                   40             43           3          0.3        3997.5       0.6X
+Colletion of string with 100 elements, useIterator: true                 256            263           7          0.0       25550.7       0.1X
+Colletion of Array[int] with 1 elements, useIterator: true                22             24           1          0.5        2209.9       1.0X
+Colletion of Array[int] with 10 elements, useIterator: true               38             40           1          0.3        3755.1       0.6X
+Colletion of Array[int] with 100 elements, useIterator: true             240            251           9          0.0       23978.8       0.1X
+Colletion of int with 1 elements, useIterator: false                      21             23           1          0.5        2126.5       1.0X
+Colletion of int with 10 elements, useIterator: false                     27             29           2          0.4        2671.3       0.8X
+Colletion of int with 100 elements, useIterator: false                   114            118           3          0.1       11413.3       0.2X
+Colletion of string with 1 elements, useIterator: false                   22             24           2          0.4        2243.3       1.0X
+Colletion of string with 10 elements, useIterator: false                  38             41           2          0.3        3830.4       0.6X
+Colletion of string with 100 elements, useIterator: false                242            258          11          0.0       24223.8       0.1X
+Colletion of Array[int] with 1 elements, useIterator: false               22             23           1          0.5        2211.3       1.0X
+Colletion of Array[int] with 10 elements, useIterator: false              36             38           2          0.3        3566.2       0.6X
+Colletion of Array[int] with 100 elements, useIterator: false            221            225           5          0.0       22054.1       0.1X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-results.txt
@@ -2,21 +2,27 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1030-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-Benchmark of kryo asIterator on deserialization stream:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                   12             12           1          0.9        1173.9       1.0X
-Colletion of int with 10 elements, useIterator: true                  24             24           1          0.4        2374.7       0.5X
-Colletion of int with 100 elements, useIterator: true                138            139           1          0.1       13811.4       0.1X
-Colletion of string with 1 elements, useIterator: true                13             14           1          0.8        1305.1       0.9X
-Colletion of string with 10 elements, useIterator: true               35             35           1          0.3        3450.0       0.3X
-Colletion of string with 100 elements, useIterator: true             235            236           0          0.0       23529.7       0.0X
-Colletion of int with 1 elements, useIterator: false                  11             11           1          0.9        1088.1       1.1X
-Colletion of int with 10 elements, useIterator: false                 22             22           1          0.5        2190.0       0.5X
-Colletion of int with 100 elements, useIterator: false               123            123           0          0.1       12265.0       0.1X
-Colletion of string with 1 elements, useIterator: false               12             12           1          0.8        1189.7       1.0X
-Colletion of string with 10 elements, useIterator: false              33             33           1          0.3        3257.0       0.4X
-Colletion of string with 100 elements, useIterator: false            219            220           1          0.0       21891.7       0.1X
+OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1031-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Benchmark of kryo asIterator on deserialization stream:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------
+Colletion of int with 1 elements, useIterator: true                       29             30           1          0.3        2869.7       1.0X
+Colletion of int with 10 elements, useIterator: true                      37             39           2          0.3        3736.9       0.8X
+Colletion of int with 100 elements, useIterator: true                    159            168           8          0.1       15889.2       0.2X
+Colletion of string with 1 elements, useIterator: true                    30             32           1          0.3        2996.6       1.0X
+Colletion of string with 10 elements, useIterator: true                   49             51           2          0.2        4900.9       0.6X
+Colletion of string with 100 elements, useIterator: true                 280            288           5          0.0       28012.7       0.1X
+Colletion of Array[int] with 1 elements, useIterator: true                29             31           2          0.3        2891.7       1.0X
+Colletion of Array[int] with 10 elements, useIterator: true               45             49           3          0.2        4492.9       0.6X
+Colletion of Array[int] with 100 elements, useIterator: true             258            264           5          0.0       25848.7       0.1X
+Colletion of int with 1 elements, useIterator: false                      27             29           2          0.4        2736.7       1.0X
+Colletion of int with 10 elements, useIterator: false                     33             35           2          0.3        3311.4       0.9X
+Colletion of int with 100 elements, useIterator: false                   130            136           4          0.1       13026.5       0.2X
+Colletion of string with 1 elements, useIterator: false                   29             30           1          0.3        2892.4       1.0X
+Colletion of string with 10 elements, useIterator: false                  45             50           4          0.2        4530.8       0.6X
+Colletion of string with 100 elements, useIterator: false                263            269           4          0.0       26286.1       0.1X
+Colletion of Array[int] with 1 elements, useIterator: false               28             30           1          0.4        2796.8       1.0X
+Colletion of Array[int] with 10 elements, useIterator: false              42             45           3          0.2        4242.5       0.7X
+Colletion of Array[int] with 100 elements, useIterator: false            246            251           4          0.0       24612.0       0.1X
 
 

--- a/core/benchmarks/KryoIteratorBenchmark-results.txt
+++ b/core/benchmarks/KryoIteratorBenchmark-results.txt
@@ -2,21 +2,21 @@
 Benchmark of kryo asIterator on deserialization stream
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1023-azure
+OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1030-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark of kryo asIterator on deserialization stream:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------
-Colletion of int with 1 elements, useIterator: true                   84             85           1          0.1        8353.1       1.0X
-Colletion of int with 10 elements, useIterator: true                 101            102           1          0.1       10107.5       0.8X
-Colletion of int with 100 elements, useIterator: true                243            244           1          0.0       24297.7       0.3X
-Colletion of string with 1 elements, useIterator: true                85             85           1          0.1        8476.6       1.0X
-Colletion of string with 10 elements, useIterator: true              111            112           1          0.1       11070.8       0.8X
-Colletion of string with 100 elements, useIterator: true             338            339           1          0.0       33820.9       0.2X
-Colletion of int with 1 elements, useIterator: false                  11             11           1          0.9        1082.5       7.7X
-Colletion of int with 10 elements, useIterator: false                 22             23           1          0.4        2229.2       3.7X
-Colletion of int with 100 elements, useIterator: false               119            120           1          0.1       11935.5       0.7X
-Colletion of string with 1 elements, useIterator: false               12             12           1          0.8        1198.8       7.0X
-Colletion of string with 10 elements, useIterator: false              31             32           1          0.3        3149.1       2.7X
-Colletion of string with 100 elements, useIterator: false            210            211           1          0.0       21042.6       0.4X
+Colletion of int with 1 elements, useIterator: true                   12             12           1          0.9        1173.9       1.0X
+Colletion of int with 10 elements, useIterator: true                  24             24           1          0.4        2374.7       0.5X
+Colletion of int with 100 elements, useIterator: true                138            139           1          0.1       13811.4       0.1X
+Colletion of string with 1 elements, useIterator: true                13             14           1          0.8        1305.1       0.9X
+Colletion of string with 10 elements, useIterator: true               35             35           1          0.3        3450.0       0.3X
+Colletion of string with 100 elements, useIterator: true             235            236           0          0.0       23529.7       0.0X
+Colletion of int with 1 elements, useIterator: false                  11             11           1          0.9        1088.1       1.1X
+Colletion of int with 10 elements, useIterator: false                 22             22           1          0.5        2190.0       0.5X
+Colletion of int with 100 elements, useIterator: false               123            123           0          0.1       12265.0       0.1X
+Colletion of string with 1 elements, useIterator: false               12             12           1          0.8        1189.7       1.0X
+Colletion of string with 10 elements, useIterator: false              33             33           1          0.3        3257.0       0.4X
+Colletion of string with 100 elements, useIterator: false            219            220           1          0.0       21891.7       0.1X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-jdk11-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-jdk11-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                 9790          12432         370          0.0    19579752.2       1.0X
-KryoPool:false                                               14512          17607         653          0.0    29023660.8       0.7X
+KryoPool:true                                                 9148          11202         527          0.0    18296526.5       1.0X
+KryoPool:false                                               12156          15383         488          0.0    24311513.7       0.8X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-jdk11-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-jdk11-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1036-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                 9148          11202         527          0.0    18296526.5       1.0X
-KryoPool:false                                               12156          15383         488          0.0    24311513.7       0.8X
+KryoPool:true                                                 8338          10560         NaN          0.0    16675730.9       1.0X
+KryoPool:false                                               12586          14541         329          0.0    25172974.1       0.7X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-jdk17-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-jdk17-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1031-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                 8306          11121         875          0.0    16611043.7       1.0X
-KryoPool:false                                               11855          15605         NaN          0.0    23709932.2       0.7X
+KryoPool:true                                                11647          15707         985          0.0    23294917.4       1.0X
+KryoPool:false                                               16482          20654         NaN          0.0    32964347.5       0.7X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-jdk17-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-jdk17-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1036-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                11647          15707         985          0.0    23294917.4       1.0X
-KryoPool:false                                               16482          20654         NaN          0.0    32964347.5       0.7X
+KryoPool:true                                                 8230          11345         772          0.0    16459043.1       1.0X
+KryoPool:false                                               12819          15714         NaN          0.0    25637323.3       0.6X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1031-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                 7751           9409         NaN          0.0    15501889.2       1.0X
-KryoPool:false                                               11350          14163         177          0.0    22700046.8       0.7X
+KryoPool:true                                                10935          13675         NaN          0.0    21869677.2       1.0X
+KryoPool:false                                               16385          19406         NaN          0.0    32770253.9       0.7X
 
 

--- a/core/benchmarks/KryoSerializerBenchmark-results.txt
+++ b/core/benchmarks/KryoSerializerBenchmark-results.txt
@@ -2,11 +2,11 @@
 Benchmark KryoPool vs old"pool of 1" implementation
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1036-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Benchmark KryoPool vs old"pool of 1" implementation:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-KryoPool:true                                                10935          13675         NaN          0.0    21869677.2       1.0X
-KryoPool:false                                               16385          19406         NaN          0.0    32770253.9       0.7X
+KryoPool:true                                                 9955          12622         NaN          0.0    19910361.3       1.0X
+KryoPool:false                                               15141          17852         NaN          0.0    30282157.2       0.7X
 
 

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -344,7 +344,7 @@ class KryoDeserializationStream(
     override protected def getNext(): Any = {
       if (KryoDeserializationStream.this.hasNext) {
         try {
-          return readValue[Any]()
+          return readObject[Any]()
         } catch {
           case eof: EOFException =>
         }

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -526,7 +526,7 @@ class ExternalAppendOnlyMap[K, V, C](
     }
 
     override def next(): (K, C) = {
-      if (batchIterator == null) {
+      if (!hasNext) {
         throw new NoSuchElementException
       }
       readNextItem()

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -505,13 +505,13 @@ class ExternalAppendOnlyMap[K, V, C](
      * If no more pairs are left, return null.
      */
     private def readNextItem(): (K, C) = {
-      val next = batchIterator.next()
+      val item = batchIterator.next()
       objectsRead += 1
       if (objectsRead == serializerBatchSize) {
         objectsRead = 0
         batchIterator = nextBatchIterator()
       }
-      next
+      item
     }
 
     override def hasNext: Boolean = {

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -460,13 +460,13 @@ class ExternalAppendOnlyMap[K, V, C](
     // An intermediate stream that reads from exactly one batch
     // This guards against pre-fetching and other arbitrary behavior of higher level streams
     private var deserializeStream: DeserializationStream = null
-    private var nextItem: (K, C) = null
+    private var batchIterator: Iterator[(K, C)] = null
     private var objectsRead = 0
 
     /**
      * Construct a stream that reads only from the next batch.
      */
-    private def nextBatchStream(): DeserializationStream = {
+    private def nextBatchIterator(): Iterator[(K, C)] = {
       // Note that batchOffsets.length = numBatches + 1 since we did a scan above; check whether
       // we're still in a valid batch.
       if (batchIndex < batchOffsets.length - 1) {
@@ -489,7 +489,8 @@ class ExternalAppendOnlyMap[K, V, C](
 
         val bufferedStream = new BufferedInputStream(ByteStreams.limit(fileStream, end - start))
         val wrappedStream = serializerManager.wrapStream(blockId, bufferedStream)
-        ser.deserializeStream(wrappedStream)
+        deserializeStream = ser.deserializeStream(wrappedStream)
+        deserializeStream.asKeyValueIterator.asInstanceOf[Iterator[(K, C)]]
       } else {
         // No more batches left
         cleanup()
@@ -504,44 +505,31 @@ class ExternalAppendOnlyMap[K, V, C](
      * If no more pairs are left, return null.
      */
     private def readNextItem(): (K, C) = {
-      try {
-        val k = deserializeStream.readKey().asInstanceOf[K]
-        val c = deserializeStream.readValue().asInstanceOf[C]
-        val item = (k, c)
-        objectsRead += 1
-        if (objectsRead == serializerBatchSize) {
-          objectsRead = 0
-          deserializeStream = nextBatchStream()
-        }
-        item
-      } catch {
-        case e: EOFException =>
-          cleanup()
-          null
+      val next = batchIterator.next()
+      objectsRead += 1
+      if (objectsRead == serializerBatchSize) {
+        objectsRead = 0
+        batchIterator = nextBatchIterator()
       }
+      next
     }
 
     override def hasNext: Boolean = {
-      if (nextItem == null) {
-        if (deserializeStream == null) {
-          // In case of deserializeStream has not been initialized
-          deserializeStream = nextBatchStream()
-          if (deserializeStream == null) {
-            return false
-          }
+      if (batchIterator == null) {
+        // In case of batchIterator has not been initialized
+        batchIterator = nextBatchIterator()
+        if (batchIterator == null) {
+          return false
         }
-        nextItem = readNextItem()
       }
-      nextItem != null
+      batchIterator.hasNext
     }
 
     override def next(): (K, C) = {
-      if (!hasNext) {
+      if (batchIterator == null) {
         throw new NoSuchElementException
       }
-      val item = nextItem
-      nextItem = null
-      item
+      readNextItem()
     }
 
     private def cleanup(): Unit = {

--- a/core/src/test/scala/org/apache/spark/serializer/KryoIteratorBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoIteratorBenchmark.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.serializer
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+import scala.reflect.ClassTag
+import scala.util.Random
+
+import org.apache.spark.SparkConf
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.internal.config._
+import org.apache.spark.internal.config.Kryo._
+import org.apache.spark.serializer.KryoTest._
+
+/**
+ * Benchmark for kryo asIterator on a deserialization stream". To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> <spark core test jar>
+ *   2. build/sbt "core/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "core/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/KryoSerializerBenchmark-results.txt".
+ * }}}
+ */
+object KryoIteratorBenchmark extends BenchmarkBase {
+  val N = 10000
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val name = "Benchmark of kryo asIterator on deserialization stream"
+    runBenchmark(name) {
+      val benchmark = new Benchmark(name, N, 10, output = output)
+      Seq(true, false).map(useIterator => run(useIterator, benchmark))
+      benchmark.run()
+    }
+  }
+
+  private def run(useIterator: Boolean, benchmark: Benchmark): Unit = {
+    val ser = createSerializer()
+
+    def roundTrip[T: ClassTag](
+        elements: Array[T],
+        useIterator: Boolean,
+        ser: SerializerInstance): Int = {
+      val serialized: Array[Byte] = {
+        val baos = new ByteArrayOutputStream()
+        val serStream = ser.serializeStream(baos)
+        var i = 0
+        while (i < elements.length) {
+          serStream.writeObject(elements(i))
+          i += 1
+        }
+        serStream.close()
+        baos.toByteArray
+      }
+
+      val deserStream = ser.deserializeStream(new ByteArrayInputStream(serialized))
+      if (useIterator) {
+        if (deserStream.asIterator.toArray.length == elements.length) 1 else 0
+      } else {
+        val res = new Array[T](elements.length)
+        var i = 0
+        while (i < elements.length) {
+          res(i) = deserStream.readValue()
+          i += 1
+        }
+        deserStream.close()
+        if (res.length == elements.length) 1 else 0
+      }
+    }
+
+    def createCase[T: ClassTag](name: String, elementCount: Int, createElement: => T): Unit = {
+      val elements = Array.fill[T](elementCount)(createElement)
+
+      benchmark.addCase(
+        s"Colletion of $name with $elementCount elements, useIterator: $useIterator") { _ =>
+        var sum = 0L
+        var i = 0
+        while (i < N) {
+          sum += roundTrip(elements, useIterator, ser)
+          i += 1
+        }
+        sum
+      }
+    }
+
+    createCase("int", 1, Random.nextInt)
+    createCase("int", 10, Random.nextInt)
+    createCase("int", 100, Random.nextInt)
+    createCase("string", 1, Random.nextString(5))
+    createCase("string", 10, Random.nextString(5))
+    createCase("string", 100, Random.nextString(5))
+  }
+
+  def createSerializer(): SerializerInstance = {
+    val conf = new SparkConf()
+    conf.set(SERIALIZER, "org.apache.spark.serializer.KryoSerializer")
+    conf.set(KRYO_USER_REGISTRATORS, Seq(classOf[MyRegistrator].getName))
+
+    new KryoSerializer(conf).newInstance()
+  }
+}

--- a/core/src/test/scala/org/apache/spark/serializer/KryoIteratorBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoIteratorBenchmark.scala
@@ -105,6 +105,9 @@ object KryoIteratorBenchmark extends BenchmarkBase {
     createCase("string", 1, Random.nextString(5))
     createCase("string", 10, Random.nextString(5))
     createCase("string", 100, Random.nextString(5))
+    createCase("Array[int]", 1, Array.fill(10)(Random.nextInt))
+    createCase("Array[int]", 10, Array.fill(10)(Random.nextInt))
+    createCase("Array[int]", 100, Array.fill(10)(Random.nextInt))
   }
 
   def createSerializer(): SerializerInstance = {

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.serializer
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, EOFException}
 import java.nio.ByteBuffer
 import java.util.concurrent.Executors
 
@@ -615,6 +615,9 @@ class KryoSerializerAutoResetDisabledSuite extends SparkFunSuite with SharedSpar
     assert(serialized.length > 2)
     val trucated = serialized.take(2).toArray
     val deserializationStream = serInstance.deserializeStream(new ByteArrayInputStream(trucated))
+    intercept[EOFException](
+      serInstance.deserializeStream(new ByteArrayInputStream(trucated)).readValue()
+    )
     assert(deserializationStream.asIterator.toSeq == Seq())
   }
 }

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
@@ -253,10 +253,10 @@ abstract class BaseReceivedBlockHandlerSuite(enableEncryption: Boolean)
       isBlockManagerBasedBlockHandler: Boolean): Unit = {
     // ByteBufferBlock-MEMORY_ONLY
     testRecordcount(isBlockManagerBasedBlockHandler, StorageLevel.MEMORY_ONLY,
-      ByteBufferBlock(ByteBuffer.wrap(new Array(0))), blockManager, None)
+      ByteBufferBlock(ByteBuffer.wrap(Array.tabulate(100)(i => i.toByte))), blockManager, None)
     // ByteBufferBlock-MEMORY_ONLY_SER
     testRecordcount(isBlockManagerBasedBlockHandler, StorageLevel.MEMORY_ONLY_SER,
-      ByteBufferBlock(ByteBuffer.wrap(new Array(0))), blockManager, None)
+      ByteBufferBlock(ByteBuffer.wrap(Array.tabulate(100)(i => i.toByte))), blockManager, None)
     // ArrayBufferBlock-MEMORY_ONLY
     testRecordcount(isBlockManagerBasedBlockHandler, StorageLevel.MEMORY_ONLY,
       ArrayBufferBlock(ArrayBuffer.fill(25)(0)), blockManager, Some(25))

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
@@ -253,10 +253,10 @@ abstract class BaseReceivedBlockHandlerSuite(enableEncryption: Boolean)
       isBlockManagerBasedBlockHandler: Boolean): Unit = {
     // ByteBufferBlock-MEMORY_ONLY
     testRecordcount(isBlockManagerBasedBlockHandler, StorageLevel.MEMORY_ONLY,
-      ByteBufferBlock(ByteBuffer.wrap(Array.tabulate(100)(i => i.toByte))), blockManager, None)
+      ByteBufferBlock(ByteBuffer.wrap(new Array(0))), blockManager, None)
     // ByteBufferBlock-MEMORY_ONLY_SER
     testRecordcount(isBlockManagerBasedBlockHandler, StorageLevel.MEMORY_ONLY_SER,
-      ByteBufferBlock(ByteBuffer.wrap(Array.tabulate(100)(i => i.toByte))), blockManager, None)
+      ByteBufferBlock(ByteBuffer.wrap(new Array(0))), blockManager, None)
     // ArrayBufferBlock-MEMORY_ONLY
     testRecordcount(isBlockManagerBasedBlockHandler, StorageLevel.MEMORY_ONLY,
       ArrayBufferBlock(ArrayBuffer.fill(25)(0)), blockManager, Some(25))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR avoid exceptions in the implementation of KryoDeserializationStream.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Using an exceptions for end of stream is slow, especially for small streams. It also problematic as it the exception caught in the KryoDeserializationStream could also be caused by corrupt data which would just be ignored in the current implementation.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes, it changes so some method on KryoDeserializationStream no longer raises EOFException.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This PR only changes KryoDeserializationStream as a proof of concept. If this is the direction we want to go we should probably change DerserializationStream isntead so that the interface is consistent.
