### PR TITLE
[SPARK-40800][SQL][FOLLOW-UP] Add a config to control whether to always inline one-row relation subquery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -746,7 +746,8 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
     def unapply(plan: LogicalPlan): Option[Seq[NamedExpression]] = {
       // SPARK-40800: always inline expressions to support a broader range of correlated
       // subqueries and avoid expensive domain joins.
-      CollapseProject(EliminateSubqueryAliases(plan), alwaysInline = true) match {
+      val alwaysInline = conf.getConf(SQLConf.ALWAYS_INLINE_ONE_ROW_RELATION_SUBQUERY)
+      CollapseProject(EliminateSubqueryAliases(plan), alwaysInline = alwaysInline) match {
         case Project(projectList, _: OneRowRelation) => Some(stripOuterReferences(projectList))
         case _ => None
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3101,7 +3101,7 @@ object SQLConf {
     buildConf("spark.sql.optimizer.optimizeOneRowRelationSubquery.alwaysInline")
       .internal()
       .doc(s"When true, the optimizer will always inline single row subqueries even if it " +
-        s"causes extra duplication. It only takes effect when " +
+        "causes extra duplication. It only takes effect when " +
         s"${OPTIMIZE_ONE_ROW_RELATION_SUBQUERY.key} is set to true.")
       .version("3.4.0")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3097,6 +3097,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ALWAYS_INLINE_ONE_ROW_RELATION_SUBQUERY =
+    buildConf("spark.sql.optimizer.optimizeOneRowRelationSubquery.alwaysInline")
+      .internal()
+      .doc(s"When true, the optimizer will always inline single row subqueries even if it " +
+        s"causes extra duplication. It only takes effect when " +
+        s"${OPTIMIZE_ONE_ROW_RELATION_SUBQUERY.key} is set to true.")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val TOP_K_SORT_FALLBACK_THRESHOLD =
     buildConf("spark.sql.execution.topKSortFallbackThreshold")
       .doc("In SQL queries with a SORT followed by a LIMIT like " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2470,25 +2470,29 @@ class SubquerySuite extends QueryTest
   test("SPARK-40800: always inline expressions in OptimizeOneRowRelationSubquery") {
     withTempView("t1") {
       sql("CREATE TEMP VIEW t1 AS SELECT ARRAY('a', 'b') a")
-      // Scalar subquery.
-      checkAnswer(sql(
-        """
-          |SELECT (
-          |  SELECT array_sort(a, (i, j) -> rank[i] - rank[j])[0] AS sorted
-          |  FROM (SELECT MAP('a', 1, 'b', 2) rank)
-          |) FROM t1
-          |""".stripMargin),
-        Row("a"))
-      // Lateral subquery.
-      checkAnswer(
-        sql("""
-          |SELECT sorted[0] FROM t1
-          |JOIN LATERAL (
-          |  SELECT array_sort(a, (i, j) -> rank[i] - rank[j]) AS sorted
-          |  FROM (SELECT MAP('a', 1, 'b', 2) rank)
-          |)
-          |""".stripMargin),
-        Row("a"))
+      Seq(true, false).foreach { enabled =>
+        withSQLConf(SQLConf.ALWAYS_INLINE_ONE_ROW_RELATION_SUBQUERY.key -> enabled.toString) {
+          // Scalar subquery.
+          checkAnswer(sql(
+            """
+              |SELECT (
+              |  SELECT array_sort(a, (i, j) -> rank[i] - rank[j])[0] AS sorted
+              |  FROM (SELECT MAP('a', 1, 'b', 2) rank)
+              |) FROM t1
+              |""".stripMargin),
+            Row("a"))
+          // Lateral subquery.
+          checkAnswer(
+            sql("""
+                  |SELECT sorted[0] FROM t1
+                  |JOIN LATERAL (
+                  |  SELECT array_sort(a, (i, j) -> rank[i] - rank[j]) AS sorted
+                  |  FROM (SELECT MAP('a', 1, 'b', 2) rank)
+                  |)
+                  |""".stripMargin),
+            Row("a"))
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is a follow-up for SPARK-40800. It introduces a new Spark config to control the behavior of whether to always inline one-row relation subquery: `spark.sql.optimizer.optimizeOneRowRelationSubquery.alwaysInline` (default: true).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To give users more flexibility to control the correlated subquery performance.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Edited existing unit tests.