### PR TITLE
[SPARK-36124][SQL][WIP] Support subqueries with correlation through set operators

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1110,8 +1110,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
       // up to the operator producing the correlated values.
       plan match {
         // Category 1:
-        // ResolvedHint, LeafNode, Repartition, and SubqueryAlias
-        case p @ (_: ResolvedHint | _: LeafNode | _: Repartition | _: SubqueryAlias) =>
+        // ResolvedHint, LeafNode, Repartition, SubqueryAlias, Intersect, Except, Union
+        case p @ (_: ResolvedHint | _: LeafNode | _: Repartition | _: SubqueryAlias |
+                  _: SetOperation | _: Union) =>
           p.children.foreach(child => checkPlan(child, aggregated, canContainOuter))
 
         // Category 2:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds support for subquery decorrelation with UNION, INTERSECT, and EXCEPT on the correlation paths. For example:
```
SELECT t1a, (
  SELECT sum(b) FROM (
    SELECT t2b as b FROM t2 WHERE t2a = t1.t1a
    INTERSECT
    SELECT t3b as b FROM t3 WHERE t3a = t1.t1a
))
FROM t1
```

### Why are the changes needed?
To improve subquery support in Spark.

### Does this PR introduce _any_ user-facing change?
Before this change, queries like this would return an error like: `Decorrelate inner query through Union is not supported.`

After this PR, this query can run successfully.

### How was this patch tested?
Unit tests and (WIP) SQL query tests.