### PR TITLE
[SPARK-40946][SQL] Add a new DataSource V2 interface SupportsPushDownClusterKeys

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownClusterKeys.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownClusterKeys.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.expressions.Expression;
+
+/**
+ * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
+ * push down all the join or aggregate keys to data sources. A return value true indicates
+ * that data source will return input partitions (via planInputPartitions} following the
+ * clustering keys. Otherwise, a false return value indicates the data source doesn't make
+ * such a guarantee, even though it may still report a partitioning that may or may not
+ * be compatible with the given clustering keys, and it's Spark's responsibility to group
+ * the input partitions whether it can be applied.
+ *
+ * @since 3.4.0
+ */
+@Evolving
+public interface SupportsPushDownClusterKeys extends ScanBuilder {
+
+  /**
+   * Pushes down cluster keys to the data source.
+   */
+  boolean pushClusterKeys(Expression[] expressions);
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDeleteFromTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDeleteFromTable.scala
@@ -39,15 +39,15 @@ object RewriteDeleteFromTable extends RewriteRowLevelCommand {
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     case d @ DeleteFromTable(aliasedTable, cond) if d.resolved =>
       EliminateSubqueryAliases(aliasedTable) match {
-        case DataSourceV2Relation(_: TruncatableTable, _, _, _, _) if cond == TrueLiteral =>
+        case DataSourceV2Relation(_: TruncatableTable, _, _, _, _, _) if cond == TrueLiteral =>
           // don't rewrite as the table supports truncation
           d
 
-        case r @ DataSourceV2Relation(t: SupportsRowLevelOperations, _, _, _, _) =>
+        case r @ DataSourceV2Relation(t: SupportsRowLevelOperations, _, _, _, _, _) =>
           val table = buildOperationTable(t, DELETE, CaseInsensitiveStringMap.empty())
           buildReplaceDataPlan(r, table, cond)
 
-        case DataSourceV2Relation(_: SupportsDeleteV2, _, _, _, _) =>
+        case DataSourceV2Relation(_: SupportsDeleteV2, _, _, _, _, _) =>
           // don't rewrite as the table supports deletes only with filters
           d
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -387,7 +387,7 @@ object GroupBasedRowLevelOperation {
   type ReturnType = (ReplaceData, Expression, LogicalPlan)
 
   def unapply(plan: LogicalPlan): Option[ReturnType] = plan match {
-    case rd @ ReplaceData(DataSourceV2Relation(table, _, _, _, _), cond, query, _, _) =>
+    case rd @ ReplaceData(DataSourceV2Relation(table, _, _, _, _, _), cond, query, _, _) =>
       val readRelation = findReadRelation(table, query)
       readRelation.map((rd, cond, _))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -211,7 +211,7 @@ case class ReplaceData(
 
   lazy val operation: RowLevelOperation = {
     EliminateSubqueryAliases(table) match {
-      case DataSourceV2Relation(RowLevelOperationTable(_, operation), _, _, _, _) =>
+      case DataSourceV2Relation(RowLevelOperationTable(_, operation), _, _, _, _, _) =>
         operation
       case _ =>
         throw new AnalysisException(s"Cannot retrieve row-level operation from $table")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -37,13 +37,16 @@ import org.apache.spark.util.Utils
  * @param options The options for this table operation. It's used to create fresh
  *                [[org.apache.spark.sql.connector.read.ScanBuilder]] and
  *                [[org.apache.spark.sql.connector.write.WriteBuilder]].
+ * @param partitionGroupedByClusterKeys if the partitions in this relation is grouped
+ *                                      by clustered keys
  */
 case class DataSourceV2Relation(
     table: Table,
     output: Seq[AttributeReference],
     catalog: Option[CatalogPlugin],
     identifier: Option[Identifier],
-    options: CaseInsensitiveStringMap)
+    options: CaseInsensitiveStringMap,
+    var partitionGroupedByClusterKeys: Boolean = false)
   extends LeafNode with MultiInstanceRelation with NamedRelation with ExposesMetadataColumns {
 
   import DataSourceV2Implicits._

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -281,7 +281,7 @@ abstract class InMemoryBaseTable(
     override def pushClusterKeys(expressions: Array[Expression]): Boolean = {
       joinKeys = (joinKeys ++ expressions).distinct
       joinKeys.map(_.asInstanceOf[NamedReference]).foreach(key =>
-        if (getPartitionColumns.contains(key)) {
+        if (partition.nonEmpty && getPartitionColumns.contains(key)) {
           return true
         }
       )

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3923,7 +3923,7 @@ class Dataset[T] private[sql](
         fr.inputFiles
       case r: HiveTableRelation =>
         r.tableMeta.storage.locationUri.map(_.toString).toArray
-      case DataSourceV2ScanRelation(DataSourceV2Relation(table: FileTable, _, _, _, _),
+      case DataSourceV2ScanRelation(DataSourceV2Relation(table: FileTable, _, _, _, _, _),
           _, _, _, _) =>
         table.fileIndex.inputFiles
     }.flatten

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -181,7 +181,7 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
         isSameName(ident.qualifier :+ ident.name) &&
           isSameName(v1Ident.catalog.toSeq ++ v1Ident.database :+ v1Ident.table)
 
-      case SubqueryAlias(ident, DataSourceV2Relation(_, _, Some(catalog), Some(v2Ident), _)) =>
+      case SubqueryAlias(ident, DataSourceV2Relation(_, _, Some(catalog), Some(v2Ident), _, _)) =>
         isSameName(ident.qualifier :+ ident.name) &&
           isSameName(catalog.name() +: v2Ident.namespace() :+ v2Ident.name())
 
@@ -345,7 +345,7 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
         case _ => false
       }
 
-      case DataSourceV2Relation(fileTable: FileTable, _, _, _, _) =>
+      case DataSourceV2Relation(fileTable: FileTable, _, _, _, _, _) =>
         refreshFileIndexIfNecessary(fileTable.fileIndex, fs, qualifiedPath)
 
       case _ => false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FallBackFileSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FallBackFileSourceV2.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, File
 class FallBackFileSourceV2(sparkSession: SparkSession) extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
     case i @ InsertIntoStatement(
-        d @ DataSourceV2Relation(table: FileTable, _, _, _, _), _, _, _, _, _) =>
+        d @ DataSourceV2Relation(table: FileTable, _, _, _, _, _), _, _, _, _, _) =>
       val v1FileFormat = table.fallbackFileFormat.newInstance()
       val relation = HadoopFsRelation(
         table.fileIndex,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -21,9 +21,9 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, NamedExpression, SchemaPruning}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
-import org.apache.spark.sql.connector.expressions.SortOrder
+import org.apache.spark.sql.connector.expressions.{Expression => V2Expression, SortOrder}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownClusterKeys, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources
@@ -113,6 +113,15 @@ object PushDownUtils {
         s.pushTableSample(
           sample.lowerBound, sample.upperBound, sample.withReplacement, sample.seed)
       case _ => false
+    }
+  }
+
+  def pushClusterKeys(scanBuilder: ScanBuilder, keys: Seq[V2Expression]): Boolean = {
+    scanBuilder match {
+      case s: SupportsPushDownClusterKeys =>
+        s.pushClusterKeys(keys.toArray)
+      case _ =>
+        false
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -569,7 +569,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
 
   private def pushDownJoinKeys(plan: LogicalPlan, keys: Seq[NamedReference]): Unit = {
     var pushed = false
-    def pushJoinKeys(plan: LogicalPlan) {
+    def pushJoinKeys(plan: LogicalPlan): Unit = {
       plan match {
         case PhysicalOperation(_, _, sHolder: ScanBuilderHolder) =>
           val tableContainsKeys = keys.map(_.describe()).forall(sHolder.output.map(_.name).contains)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -19,13 +19,13 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.expressions.{aggregate, Alias, And, Attribute, AttributeMap, AttributeReference, AttributeSet, Cast, Expression, IntegerLiteral, Literal, NamedExpression, PredicateHelper, ProjectionOverSchema, SortOrder, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{aggregate, Alias, And, Attribute, AttributeMap, AttributeReference, AttributeSet, BinaryComparison, Cast, Expression, IntegerLiteral, Literal, NamedExpression, PredicateHelper, ProjectionOverSchema, SortOrder, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.optimizer.CollapseProject
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, LeafNode, Limit, LimitAndOffset, LocalLimit, LogicalPlan, Offset, OffsetAndLimit, Project, Sample, Sort}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LeafNode, Limit, LimitAndOffset, LocalLimit, LogicalPlan, Offset, OffsetAndLimit, Project, Sample, Sort}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
+import org.apache.spark.sql.connector.expressions.{FieldReference, NamedReference, SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, CountStar, Max, Min, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, V1Scan}
@@ -42,6 +42,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       createScanBuilder,
       pushDownSample,
       pushDownFilters,
+      pushDownJoinKey,
       pushDownAggregates,
       pushDownLimitAndOffset,
       buildScanWithPushedAggregate,
@@ -521,6 +522,73 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       } else {
         offset
       }
+  }
+
+  def pushDownJoinKey(plan: LogicalPlan): LogicalPlan = plan.transform {
+    case join: Join =>
+      val joinKeys = splitConjunctivePredicates(join.condition.get)
+      val conditions = joinKeys.map(_.asInstanceOf[BinaryComparison])
+
+      var leftKeys = Seq[NamedReference]()
+      conditions.map(condition =>
+        condition.left match {
+          case attr: AttributeReference =>
+            if (join.left.outputSet.contains(attr)) {
+              leftKeys = leftKeys :+ getFieldReference(condition.left)
+            } else {
+              leftKeys = leftKeys :+ getFieldReference(condition.right)
+            }
+          case _ =>
+        }
+      )
+      if (leftKeys.nonEmpty) {
+        pushDownJoinKeys(join.left, leftKeys)
+      }
+
+      var rightKeys = Seq[NamedReference]()
+      conditions.map(condition =>
+        condition.right match {
+          case attr: AttributeReference =>
+            if (join.right.outputSet.contains(attr)) {
+              rightKeys = rightKeys :+ getFieldReference(condition.right)
+            } else {
+              rightKeys = rightKeys :+ getFieldReference(condition.left)
+            }
+          case _ =>
+        }
+      )
+      if (rightKeys.nonEmpty) {
+        pushDownJoinKeys(join.right, rightKeys)
+      }
+      join
+  }
+
+  private def getFieldReference(expr: Expression): NamedReference = {
+    FieldReference.apply(expr.asInstanceOf[AttributeReference].name)
+  }
+
+  private def pushDownJoinKeys(plan: LogicalPlan, keys: Seq[NamedReference]): Unit = {
+    var pushed = false
+    def pushJoinKeys(plan: LogicalPlan) {
+      plan match {
+        case PhysicalOperation(_, _, sHolder: ScanBuilderHolder) =>
+          val tableContainsKeys = keys.map(_.describe()).forall(sHolder.output.map(_.name).contains)
+          if (tableContainsKeys) {
+            val groupedByClusterKeys = PushDownUtils.pushClusterKeys(sHolder.builder, keys)
+            sHolder.relation.partitionGroupedByClusterKeys = groupedByClusterKeys
+            pushed = true
+          }
+        case join: Join =>
+          if (!pushed) {
+            pushJoinKeys(join.left)
+          }
+          if (!pushed) {
+            pushJoinKeys(join.right)
+          }
+        case _ =>
+      }
+    }
+    pushJoinKeys(plan)
   }
 
   private def getWrappedScan(scan: Scan, sHolder: ScanBuilderHolder): Scan = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.connector.catalog.InMemoryBaseTable
 import org.apache.spark.sql.connector.expressions.FieldReference
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
-import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2Relation}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.internal.SQLConf.{PARTITION_OVERWRITE_MODE, PartitionOverwriteMode, V2_SESSION_CATALOG_IMPLEMENTATION}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -19,8 +19,10 @@ package org.apache.spark.sql.connector
 
 import java.sql.Timestamp
 import java.time.{Duration, LocalDate, Period}
+
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.MICROSECONDS
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{CannotReplaceMissingTableException, NoSuchDatabaseException, NoSuchNamespaceException, TableAlreadyExistsException}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2446,7 +2446,7 @@ class DataSourceV2SQLSuiteV1Filter extends DataSourceV2SQLSuite with AlterTableT
     val executed = df.queryExecution.executedPlan
     val joinKeys = collect(executed) {
       case BatchScanExec(_, scan: InMemoryBaseTable#InMemoryBatchScan, _, _, _, _) =>
-        scan.joinKeys
+        scan.pushedJoinKeys
     }
 
     assert(joinKeys.size == 2)
@@ -2481,7 +2481,7 @@ class DataSourceV2SQLSuiteV1Filter extends DataSourceV2SQLSuite with AlterTableT
     val executed = df.queryExecution.executedPlan
     val joinKeys = collect(executed) {
       case BatchScanExec(_, scan: InMemoryBaseTable#InMemoryBatchScan, _, _, _, _) =>
-        scan.joinKeys
+        scan.pushedJoinKeys
     }
 
     assert(joinKeys.size == 4)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1369,7 +1369,7 @@ class ParquetV2PartitionDiscoverySuite extends ParquetPartitionDiscoverySuite {
       (1 to 10).map(i => (i, i.toString)).toDF("a", "b").write.parquet(dir.getCanonicalPath)
       val queryExecution = spark.read.parquet(dir.getCanonicalPath).queryExecution
       queryExecution.analyzed.collectFirst {
-        case DataSourceV2Relation(fileTable: FileTable, _, _, _, _) =>
+        case DataSourceV2Relation(fileTable: FileTable, _, _, _, _, _) =>
           assert(fileTable.fileIndex.partitionSpec() === PartitionSpec.emptySpec)
       }.getOrElse {
         fail(s"Expecting a matching DataSourceV2Relation, but got:\n$queryExecution")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
@@ -730,7 +730,7 @@ class FileStreamSinkV2Suite extends FileStreamSinkSuite {
     // Verify that MetadataLogFileIndex is being used and the correct partitioning schema has
     // been inferred
     val table = df.queryExecution.analyzed.collect {
-      case DataSourceV2Relation(table: FileTable, _, _, _, _) => table
+      case DataSourceV2Relation(table: FileTable, _, _, _, _, _) => table
     }
     assert(table.size === 1)
     assert(table.head.fileIndex.isInstanceOf[MetadataLogFileIndex])


### PR DESCRIPTION


### What changes were proposed in this pull request?
```
/**
 * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
 * push down all the join or aggregate keys to data sources. A return value true indicates
 * that data source will return input partitions (via planInputPartitions} following the
 * clustering keys. Otherwise, a false return value indicates the data source doesn't make
 * such a guarantee, even though it may still report a partitioning that may or may not
 * be compatible with the given clustering keys, and it's Spark's responsibility to group
 * the input partitions whether it can be applied.
 *
 * @since 3.4.0
 */
@Evolving
public interface SupportsPushDownClusterKeys extends ScanBuilder {
```


### Why are the changes needed?
Pass down the information of join keys to v2 data sources so the data sources can decide how to combine the input splits according to the joins keys.


### Does this PR introduce _any_ user-facing change?
Yes, new interface `SupportsPushDownClusterKeys`


### How was this patch tested?
new tests
