### PR TITLE
[SPARK-40802][SQL] Resolve JDBCRelation's schema with preparing the statement

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -45,7 +45,6 @@ object JDBCRDD extends Logging {
    * schema.
    *
    * @param options - JDBC options that contains url, table and other information.
-   *
    * @return A StructType giving the table's Catalyst schema.
    * @throws java.sql.SQLException if the table specification is garbage.
    * @throws java.sql.SQLException if the table contains an unsupported type.
@@ -62,19 +61,7 @@ object JDBCRDD extends Logging {
       query: String, options: JDBCOptions, dialect: JdbcDialect): StructType = {
     val conn: Connection = dialect.createConnectionFactory(options)(-1)
     try {
-      val statement = conn.prepareStatement(query)
-      try {
-        statement.setQueryTimeout(options.queryTimeout)
-        val rs = statement.executeQuery()
-        try {
-          JdbcUtils.getSchema(rs, dialect, alwaysNullable = true,
-            isTimestampNTZ = options.inferTimestampNTZType)
-        } finally {
-          rs.close()
-        }
-      } finally {
-        statement.close()
-      }
+      dialect.getQueryOutputSchema(conn, query, options)
     } finally {
       conn.close()
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -35,11 +35,17 @@ import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
 import org.apache.spark.sql.connector.catalog.index.TableIndex
 import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, NamedReference}
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
-import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DecimalType, ShortType, StringType}
+import org.apache.spark.sql.types.{BooleanType, ByteType, DataType, DecimalType, ShortType, StringType, StructType}
 
 private[sql] object H2Dialect extends JdbcDialect {
   override def canHandle(url: String): Boolean =
     url.toLowerCase(Locale.ROOT).startsWith("jdbc:h2")
+
+  override def getQueryOutputSchema(
+      conn: Connection,
+      query: String,
+      options: JDBCOptions): StructType =
+    JdbcUtils.getQueryOutputSchemaWithExecuteQuery(conn, query, options, this)
 
   private val distinctUnsupportedAggregateFunctions =
     Set("COVAR_POP", "COVAR_SAMP", "CORR", "REGR_INTERCEPT", "REGR_R2", "REGR_SLOPE", "REGR_SXY")

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -85,6 +85,9 @@ abstract class JdbcDialect extends Serializable with Logging {
    */
   def canHandle(url : String): Boolean
 
+  def getQueryOutputSchema(conn: Connection, query: String, options: JDBCOptions): StructType =
+    JdbcUtils.getQueryOutputSchemaWithGetMetaData(conn, query, options, this)
+
   /**
    * Get the custom datatype mapping for the given jdbc meta information.
    * @param sqlType The sql type (see java.sql.Types)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.SQLException
+import java.sql.{Connection, SQLException}
 import java.util.Locale
 
 import scala.util.control.NonFatal
@@ -26,6 +26,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException
 import org.apache.spark.sql.connector.expressions.Expression
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -38,6 +39,12 @@ private object MsSqlServerDialect extends JdbcDialect {
     val GEOMETRY = -157
     val GEOGRAPHY = -158
   }
+
+  override def getQueryOutputSchema(
+      conn: Connection,
+      query: String,
+      options: JDBCOptions): StructType =
+    JdbcUtils.getQueryOutputSchemaWithExecuteQuery(conn, query, options, this)
 
   override def canHandle(url: String): Boolean =
     url.toLowerCase(Locale.ROOT).startsWith("jdbc:sqlserver")

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -32,12 +32,18 @@ import org.apache.spark.sql.connector.catalog.index.TableIndex
 import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, NamedReference}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
-import org.apache.spark.sql.types.{BooleanType, DataType, FloatType, LongType, MetadataBuilder}
+import org.apache.spark.sql.types.{BooleanType, DataType, FloatType, LongType, MetadataBuilder, StructType}
 
 private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
 
   override def canHandle(url : String): Boolean =
     url.toLowerCase(Locale.ROOT).startsWith("jdbc:mysql")
+
+  override def getQueryOutputSchema(
+      conn: Connection,
+      query: String,
+      options: JDBCOptions): StructType =
+    JdbcUtils.getQueryOutputSchemaWithExecuteQuery(conn, query, options, this)
 
   private val distinctUnsupportedAggregateFunctions =
     Set("VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.execution.streaming.state.RenameReturnsFalseFileSyst
 import org.apache.spark.sql.functions.{lit, lower, struct, sum, udf}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.EXCEPTION
-import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
+import org.apache.spark.sql.jdbc.{H2Dialect, JdbcDialect, JdbcDialects}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DataType, DecimalType, LongType, MetadataBuilder, StructType}
 import org.apache.spark.util.Utils
@@ -499,6 +499,13 @@ class QueryExecutionErrorsSuite
 
     val testH2DialectUnrecognizedSQLType = new JdbcDialect {
       override def canHandle(url: String): Boolean = url.startsWith("jdbc:h2")
+
+      // The mocked H2Dialect should use the same implementation to H2Dialect
+      override def getQueryOutputSchema(
+          conn: Connection,
+          query: String,
+          options: JDBCOptions): StructType =
+        H2Dialect.getQueryOutputSchema(conn, query, options)
 
       override def getCatalystType(sqlType: Int, typeName: String, size: Int,
         md: MetadataBuilder): Option[DataType] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1899,14 +1899,11 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     when(mockRsmd.isSigned(anyInt())).thenReturn(false)
     when(mockRsmd.isNullable(anyInt())).thenReturn(java.sql.ResultSetMetaData.columnNoNulls)
 
-    val mockRs = mock(classOf[java.sql.ResultSet])
-    when(mockRs.getMetaData).thenReturn(mockRsmd)
-
     val mockDialect = mock(classOf[JdbcDialect])
     when(mockDialect.getCatalystType(anyInt(), anyString(), anyInt(), any[MetadataBuilder]))
       .thenReturn(None)
 
-    val schema = JdbcUtils.getSchema(mockRs, mockDialect)
+    val schema = JdbcUtils.getSchema(mockRsmd, mockDialect)
     val fields = schema.fields
     assert(fields.length === 1)
     assert(fields(0).dataType === StringType)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR changed to resolve the JDBC Relation schema with PreparedStatement.executeQuery() instead of PreparedStatement.getMetaData(). The main changes are:
1. Add a new function: getQueryOutputSchema() to JdbcDialect. By default, it will use getMetaData() to resolve schema.
2. For 3 JDBC dialects: H2Dialect, MsSqlServerDialect and MySqlDialect, override this function to use executeQuery() to resolve the schema because they doesn't support getMetaData() well.
3. Add 2 utility functions to JdbcUtils for the 2 ways to resolving schema.

### Why are the changes needed?
1. getMetaData() is better performance compared with executeQuery() because
   getMetaData() only needs to compile the Query, but executeQuery() needs to execute the query.
2. Move the schema resolution to JdbcDialect, make it possible to resolve schema differently for each database.
    In the future, spark can support some non-SELECT query such as CALL PROC, etc.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested with existing test cases