### PR TITLE
[SPARK-34079][SQL][FOLLOWUP] Improve the readability and simplify the code for MergeScalarSubqueries

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/MergeScalarSubqueries.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/MergeScalarSubqueries.scala
@@ -357,8 +357,8 @@ object MergeScalarSubqueries extends Rule[LogicalPlan] {
       Aggregate.supportsObjectHashAggregate(aggregateExpressions))
     supportsHashAggregates.head && supportsHashAggregates.last ||
       supportsHashAggregates.head == supportsHashAggregates.last &&
-        supportsObjectHashAggregates.head && supportsObjectHashAggregates.last ||
-          supportsObjectHashAggregates.head == supportsObjectHashAggregates.last
+        (supportsObjectHashAggregates.head && supportsObjectHashAggregates.last ||
+          supportsObjectHashAggregates.head == supportsObjectHashAggregates.last)
   }
 
   // Second traversal replaces `ScalarSubqueryReference`s to either

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/MergeScalarSubqueries.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/MergeScalarSubqueries.scala
@@ -392,7 +392,7 @@ object MergeScalarSubqueries extends Rule[LogicalPlan] {
  * Temporal reference to a cached subquery.
  *
  * @param subqueryIndex A subquery index in the cache.
- * @param headerIndex A index in the output of merged subquery.
+ * @param headerIndex An index in the output of merged subquery.
  * @param dataType The dataType of origin scalar subquery.
  */
 case class ScalarSubqueryReference(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Recently, I read the `MergeScalarSubqueries` because it is a feature used for improve performance.
I fount the parameters of ScalarSubqueryReference is hard to understand, so I want add some comments on it.

Additionally, the private method `supportedAggregateMerge` of `MergeScalarSubqueries` looks redundant, this PR wants simplify the code.


### Why are the changes needed?
Improve the readability and simplify the code for `MergeScalarSubqueries`.


### Does this PR introduce _any_ user-facing change?
'No'.
Just improve the readability and simplify the code for `MergeScalarSubqueries`.


### How was this patch tested?
Exists tests.
