### PR TITLE
[SPARK-40991][PYTHON] Update `cloudpickle` to v2.2.0

### DIFF
--- a/python/pyspark/cloudpickle/__init__.py
+++ b/python/pyspark/cloudpickle/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-
 from pyspark.cloudpickle.cloudpickle import *  # noqa
 from pyspark.cloudpickle.cloudpickle_fast import CloudPickler, dumps, dump  # noqa
 
@@ -8,4 +5,4 @@ from pyspark.cloudpickle.cloudpickle_fast import CloudPickler, dumps, dump  # no
 # expose their Pickler subclass at top-level under the  "Pickler" name.
 Pickler = CloudPickler
 
-__version__ = '2.0.0'
+__version__ = '2.2.0'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `cloudpickle` to `v2.2.0` for Apache Spark 3.4.0.

### Why are the changes needed?

SPARK-37457 updated `cloudpickle` v2.0.0 at Apache Spark 3.3.0.

To bring the latest bug fixes.
- https://github.com/cloudpipe/cloudpickle/releases/tag/v2.2.0
- https://github.com/cloudpipe/cloudpickle/releases/tag/2.1.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.