### PR TITLE
[MINOR][SQL] Wrap `given` in backticks to fix compilation warning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -101,15 +101,16 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
         "pivotType" -> pivotCol.dataType.catalogString))
   }
 
+  // Wrap `given` in backticks due to it will become a keyword in Scala 3.
   def unpivotRequiresAttributes(
-      given: String,
+      `given`: String,
       empty: String,
       expressions: Seq[NamedExpression]): Throwable = {
     val nonAttributes = expressions.filterNot(_.isInstanceOf[Attribute]).map(toSQLExpr)
     new AnalysisException(
       errorClass = "UNPIVOT_REQUIRES_ATTRIBUTES",
       messageParameters = Map(
-        "given" -> given,
+        "given" -> `given`,
         "empty" -> empty,
         "expressions" -> nonAttributes.mkString(", ")))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
A minor change to fix the a Scala related compilation warning

```
[WARNING] /spark-source/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala:105: [deprecation @  | origin= | version=2.13.7] Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3.
```

### Why are the changes needed?
Fix a Scala related compilation warning.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Action
