### PR TITLE
[SPARK-40997][K8S] K8s resource name prefix should start w/ alphanumeric

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -250,12 +250,17 @@ private[spark] object KubernetesConf {
     s"spark-${UUID.randomUUID().toString.replaceAll("-", "")}"
 
   def getResourceNamePrefix(appName: String): String = {
+    // Most resource types require a name that can be used as a DNS subdomain name, the name must
+    // contain only lowercase alphanumeric characters, '-' or '.', and start with an alphanumeric
+    // character.
+    // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
     val id = KubernetesUtils.uniqueID()
     s"$appName-$id"
       .trim
       .toLowerCase(Locale.ROOT)
       .replaceAll("[^a-z0-9\\-]", "-")
       .replaceAll("-+", "-")
+      .stripPrefix("-")
   }
 
   def getAppNameLabel(appName: String): String = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -250,4 +250,11 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(KubernetesConf.getAppNameLabel("a" * 62 + "-aaa") === "a" * 62)
     assert(KubernetesConf.getAppNameLabel("-" + "a" * 63) === "a" * 62)
   }
+
+  test("SPARK-40997: K8s resource name prefix should start w/ alphanumeric") {
+    assert(!KubernetesConf.getResourceNamePrefix("-hello-").startsWith("-"))
+    // scalastyle:off nonascii
+    assert(!KubernetesConf.getResourceNamePrefix("测试").startsWith("-"))
+    // scalastyle:on nonascii
+  }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -252,9 +252,10 @@ class KubernetesConfSuite extends SparkFunSuite {
   }
 
   test("SPARK-40997: K8s resource name prefix should start w/ alphanumeric") {
-    assert(!KubernetesConf.getResourceNamePrefix("-hello-").startsWith("-"))
     // scalastyle:off nonascii
-    assert(!KubernetesConf.getResourceNamePrefix("测试").startsWith("-"))
+    Seq("-hello-", "测试").foreach { appName =>
     // scalastyle:on nonascii
+      assert(KubernetesConf.getResourceNamePrefix(appName).matches("^[a-z0-9][a-z0-9\\-]*"))
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Ensure string generated by `KubernetesConf#getResourceNamePrefix` always start w/ alphanumeric

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
According to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names, the most resource names should start with an alphanumeric character.

Currently, the `KubernetesConf#getResourceNamePrefix` does not ensure the return value always start w/ alphanumeric, for example, if user set `spark.app.name=测试`, will cause the following error.

```
2022-11-02 19:46:05 [ERROR] [kubernetes-executor-snapshots-subscribers-1] org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl#98 - Going to stop due to IllegalArgumentException
java.lang.IllegalArgumentException: '-9ea12a8438298333' in spark.kubernetes.executor.podNamePrefix is invalid. must conform https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names and the value length <= 237
	at org.apache.spark.internal.config.TypedConfigBuilder.$anonfun$checkValue$1(ConfigBuilder.scala:108) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.internal.config.TypedConfigBuilder.$anonfun$transform$1(ConfigBuilder.scala:101) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at scala.Option.map(Option.scala:230) ~[scala-library-2.12.15.jar:?]
	at org.apache.spark.internal.config.OptionalConfigEntry.readFrom(ConfigEntry.scala:239) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.internal.config.OptionalConfigEntry.readFrom(ConfigEntry.scala:214) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.SparkConf.get(SparkConf.scala:261) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.deploy.k8s.KubernetesConf.get(KubernetesConf.scala:70) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.deploy.k8s.KubernetesExecutorConf.<init>(KubernetesConf.scala:156) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.deploy.k8s.KubernetesConf$.createExecutorConf(KubernetesConf.scala:246) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$requestNewExecutors$1(ExecutorPodsAllocator.scala:394) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:158) ~[scala-library-2.12.15.jar:?]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.requestNewExecutors(ExecutorPodsAllocator.scala:387) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$onNewSnapshots$35(ExecutorPodsAllocator.scala:351) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$onNewSnapshots$35$adapted(ExecutorPodsAllocator.scala:344) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62) ~[scala-library-2.12.15.jar:?]
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55) ~[scala-library-2.12.15.jar:?]
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49) ~[scala-library-2.12.15.jar:?]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.onNewSnapshots(ExecutorPodsAllocator.scala:344) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$start$3(ExecutorPodsAllocator.scala:122) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$start$3$adapted(ExecutorPodsAllocator.scala:122) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl$SnapshotsSubscriber.org$apache$spark$scheduler$cluster$k8s$ExecutorPodsSnapshotsStoreImpl$SnapshotsSubscriber$$processSnapshotsInternal(ExecutorPodsSnapshotsStoreImpl.scala:138) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl$SnapshotsSubscriber.processSnapshots(ExecutorPodsSnapshotsStoreImpl.scala:126) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl$$anon$1.run(ExecutorPodsSnapshotsStoreImpl.scala:90) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_345]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_345]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_345]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[?:1.8.0_345]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_345]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_345]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_345]
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT added.