### PR TITLE
[MINOR][CONNECT] Fix file name in docs

### DIFF
--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -69,4 +69,4 @@ To use the release version of Spark Connect:
 When contributing a new client please be aware that we strive to have a common
 user experience across all languages. Please follow the below guidelines:
 
-* [Connection string configuration](docs/client_connection_string.md)
+* [Connection string configuration](docs/client-connection-string.md)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the filename in doc: `client_connection_string.md` -> `client-connection-string.md`.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
github CI