### PR TITLE
[SPARK-41004][CONNECT][TESTS] Check error classes in InterceptorRegistrySuite

### DIFF
--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/service/InterceptorRegistrySuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/service/InterceptorRegistrySuite.scala
@@ -114,9 +114,14 @@ class InterceptorRegistrySuite extends SharedSparkSession {
       Connect.CONNECT_GRPC_INTERCEPTOR_CLASSES.key ->
         "org.apache.spark.sql.connect.service.TestingInterceptorNoTrivialCtor") {
       val sb = NettyServerBuilder.forPort(9999)
-      assertThrows[SparkException] {
-        SparkConnectInterceptorRegistry.chainInterceptors(sb)
-      }
+      checkError(
+        exception = intercept[SparkException] {
+          SparkConnectInterceptorRegistry.chainInterceptors(sb)
+        },
+        errorClass = "CONNECT.INTERCEPTOR_CTOR_MISSING",
+        parameters = Map(
+          "cls" -> "org.apache.spark.sql.connect.service.TestingInterceptorNoTrivialCtor")
+      )
     }
   }
 
@@ -124,17 +129,26 @@ class InterceptorRegistrySuite extends SharedSparkSession {
     withSparkConf(
       Connect.CONNECT_GRPC_INTERCEPTOR_CLASSES.key ->
         "org.apache.spark.sql.connect.service.TestingInterceptorNoTrivialCtor") {
-      assertThrows[SparkException] {
-        SparkConnectInterceptorRegistry.createConfiguredInterceptors
-      }
+      checkError(
+        exception = intercept[SparkException] {
+          SparkConnectInterceptorRegistry.createConfiguredInterceptors
+        },
+        errorClass = "CONNECT.INTERCEPTOR_CTOR_MISSING",
+        parameters = Map(
+          "cls" -> "org.apache.spark.sql.connect.service.TestingInterceptorNoTrivialCtor")
+      )
     }
 
     withSparkConf(
       Connect.CONNECT_GRPC_INTERCEPTOR_CLASSES.key ->
         "org.apache.spark.sql.connect.service.TestingInterceptorInstantiationError") {
-      assertThrows[SparkException] {
-        SparkConnectInterceptorRegistry.createConfiguredInterceptors
-      }
+      checkError(
+        exception = intercept[SparkException] {
+          SparkConnectInterceptorRegistry.createConfiguredInterceptors
+        },
+        errorClass = "CONNECT.INTERCEPTOR_RUNTIME_ERROR",
+        parameters = Map("msg" -> "Bad Error")
+      )
     }
   }
 

--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/service/InterceptorRegistrySuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/service/InterceptorRegistrySuite.scala
@@ -119,9 +119,8 @@ class InterceptorRegistrySuite extends SharedSparkSession {
           SparkConnectInterceptorRegistry.chainInterceptors(sb)
         },
         errorClass = "CONNECT.INTERCEPTOR_CTOR_MISSING",
-        parameters = Map(
-          "cls" -> "org.apache.spark.sql.connect.service.TestingInterceptorNoTrivialCtor")
-      )
+        parameters =
+          Map("cls" -> "org.apache.spark.sql.connect.service.TestingInterceptorNoTrivialCtor"))
     }
   }
 
@@ -134,9 +133,8 @@ class InterceptorRegistrySuite extends SharedSparkSession {
           SparkConnectInterceptorRegistry.createConfiguredInterceptors
         },
         errorClass = "CONNECT.INTERCEPTOR_CTOR_MISSING",
-        parameters = Map(
-          "cls" -> "org.apache.spark.sql.connect.service.TestingInterceptorNoTrivialCtor")
-      )
+        parameters =
+          Map("cls" -> "org.apache.spark.sql.connect.service.TestingInterceptorNoTrivialCtor"))
     }
 
     withSparkConf(
@@ -147,8 +145,7 @@ class InterceptorRegistrySuite extends SharedSparkSession {
           SparkConnectInterceptorRegistry.createConfiguredInterceptors
         },
         errorClass = "CONNECT.INTERCEPTOR_RUNTIME_ERROR",
-        parameters = Map("msg" -> "Bad Error")
-      )
+        parameters = Map("msg" -> "Bad Error"))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to replace 'intercept' with 'Check error classes' in InterceptorRegistrySuite, include:
1. CONNECT.INTERCEPTOR_CTOR_MISSING
2. CONNECT.INTERCEPTOR_RUNTIME_ERROR

### Why are the changes needed?
The changes improve the error framework.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suite:
```
$./build/sbt "connect/testOnly *InterceptorRegistrySuite"
```