### PR TITLE
[SPARK-40769][CORE][SQL] Migrate type check failures of aggregate expressions onto error classes

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -330,6 +330,11 @@
           "Cannot use an UnspecifiedFrame. This should have been converted during analysis."
         ]
       },
+      "UNSUPPORTED_INPUT_TYPE" : {
+        "message" : [
+          "The input of <functionName> can't be <dataType> type data."
+        ]
+      },
       "VALUE_OUT_OF_RANGE" : {
         "message" : [
           "The <exprName> must be between <valueRange> (current value = <currentValue>)"
@@ -338,6 +343,12 @@
       "WRONG_NUM_ARGS" : {
         "message" : [
           "The <functionName> requires <expectedNum> parameters but the actual number is <actualNum>."
+        ]
+      },
+      "WRONG_NUM_ARGS_WITH_SUGGESTION" : {
+        "message" : [
+          "The <functionName> requires <expectedNum> parameters but the actual number is <actualNum>.",
+          "If you have to call this function with <legacyNum> parameters, set the legacy configuration <legacyConfKey> to <legacyConfValue>."
         ]
       },
       "WRONG_NUM_ENDPOINTS" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
@@ -66,8 +66,8 @@ case class Count(children: Seq[Expression]) extends DeclarativeAggregate
           "expectedNum" -> " >= 1",
           "actualNum" -> "0",
           "legacyNum" -> "0",
-          "legacyConfKey" -> SQLConf.ALLOW_PARAMETERLESS_COUNT.key,
-          "legacyConfValue" -> true.toString
+          "legacyConfKey" -> toSQLConf(SQLConf.ALLOW_PARAMETERLESS_COUNT.key),
+          "legacyConfValue" -> toSQLConfVal(true.toString)
         )
       )
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Count.scala
@@ -18,9 +18,11 @@
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.TreePattern.{COUNT, TreePattern}
+import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -45,7 +47,8 @@ import org.apache.spark.sql.types._
   group = "agg_funcs",
   since = "1.0.0")
 // scalastyle:on line.size.limit
-case class Count(children: Seq[Expression]) extends DeclarativeAggregate {
+case class Count(children: Seq[Expression]) extends DeclarativeAggregate
+  with QueryErrorsBase {
 
   override def nullable: Boolean = false
 
@@ -56,9 +59,17 @@ case class Count(children: Seq[Expression]) extends DeclarativeAggregate {
 
   override def checkInputDataTypes(): TypeCheckResult = {
     if (children.isEmpty && !SQLConf.get.getConf(SQLConf.ALLOW_PARAMETERLESS_COUNT)) {
-      TypeCheckResult.TypeCheckFailure(s"$prettyName requires at least one argument. " +
-        s"If you have to call the function $prettyName without arguments, set the legacy " +
-        s"configuration `${SQLConf.ALLOW_PARAMETERLESS_COUNT.key}` as true")
+      DataTypeMismatch(
+        errorSubClass = "WRONG_NUM_ARGS_WITH_SUGGESTION",
+        messageParameters = Map(
+          "functionName" -> toSQLId(prettyName),
+          "expectedNum" -> " >= 1",
+          "actualNum" -> "0",
+          "legacyNum" -> "0",
+          "legacyConfKey" -> SQLConf.ALLOW_PARAMETERLESS_COUNT.key,
+          "legacyConfValue" -> true.toString
+        )
+      )
     } else {
       TypeCheckResult.TypeCheckSuccess
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
@@ -92,6 +92,10 @@ private[sql] trait QueryErrorsBase {
     quoteByDefault(conf)
   }
 
+  def toSQLConfVal(conf: String): String = {
+    quoteByDefault(conf)
+  }
+
   def toDSOption(option: String): String = {
     quoteByDefault(option)
   }

--- a/sql/core/src/test/resources/sql-tests/results/count.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/count.sql.out
@@ -152,8 +152,8 @@ org.apache.spark.sql.AnalysisException
     "actualNum" : "0",
     "expectedNum" : " >= 1",
     "functionName" : "`count`",
-    "legacyConfKey" : "spark.sql.legacy.allowParameterlessCount",
-    "legacyConfValue" : "true",
+    "legacyConfKey" : "\"spark.sql.legacy.allowParameterlessCount\"",
+    "legacyConfValue" : "\"true\"",
     "legacyNum" : "0",
     "sqlExpr" : "\"count()\""
   },

--- a/sql/core/src/test/resources/sql-tests/results/count.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/count.sql.out
@@ -147,11 +147,15 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2315",
+  "errorClass" : "DATATYPE_MISMATCH.WRONG_NUM_ARGS_WITH_SUGGESTION",
   "messageParameters" : {
-    "hint" : "",
-    "msg" : "count requires at least one argument. If you have to call the function count without arguments, set the legacy configuration `spark.sql.legacy.allowParameterlessCount` as true",
-    "sqlExpr" : "count()"
+    "actualNum" : "0",
+    "expectedNum" : " >= 1",
+    "functionName" : "`count`",
+    "legacyConfKey" : "spark.sql.legacy.allowParameterlessCount",
+    "legacyConfValue" : "true",
+    "legacyNum" : "0",
+    "sqlExpr" : "\"count()\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -588,7 +588,15 @@ class DataFrameAggregateSuite extends QueryTest
     val error = intercept[AnalysisException] {
       df.select(collect_set($"a"), collect_set($"b"))
     }
-    assert(error.message.contains("collect_set() cannot have map type data"))
+    checkError(
+      exception = error,
+      errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_INPUT_TYPE",
+      parameters = Map(
+        "functionName" -> "`collect_set`",
+        "dataType" -> "\"MAP\"",
+        "sqlExpr" -> "\"collect_set(b)\""
+      )
+    )
   }
 
   test("SPARK-17641: collect functions should not collect null values") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to replace `TypeCheckFailure` by `DataTypeMismatch` in type checks in the aggregate expressions:

- Count
- CollectSet
- CountMinSketchAgg
- HistogramNumeric


### Why are the changes needed?
Migration onto error classes unifies Spark SQL error messages.



### Does this PR introduce _any_ user-facing change?
Yes. The PR changes user-facing error messages.



### How was this patch tested?
Pass GitHub Actions

