### PR TITLE
[SPARK-41001] [CONNECT] [DOC] Note: Connection string parameters are case-sensitive.

### DIFF
--- a/connector/connect/docs/client-connection-string.md
+++ b/connector/connect/docs/client-connection-string.md
@@ -20,7 +20,7 @@ scheme is fixed and set to `sc://`. The full URI has to be a
 be parsed properly by most systems. For example, hostnames have to be valid and
 cannot contain arbitrary characters. Configuration parameter are passed in the 
 style of the HTTP URL Path Parameter Syntax. This is similar to the JDBC connection
-strings. The path component must be empty.
+strings. The path component must be empty. All parameters are interpreted **case sensitive**.
 
 ```shell
 sc://hostname:port/;param1=value;param2=value


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding one sentence to the documentation that connection string parameters are case sensitive.

### Why are the changes needed?
Dev Experience

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Doc only