### PR TITLE
[SPARK-40976][BUILD] Upgrade sbt to 1.7.3

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -97,7 +97,7 @@ if (!(Test-Path $tools)) {
 # ========================== SBT
 Push-Location $tools
 
-$sbtVer = "1.7.2"
+$sbtVer = "1.7.3"
 Start-FileDownload "https://github.com/sbt/sbt/releases/download/v$sbtVer/sbt-$sbtVer.zip" "sbt.zip"
 
 # extract

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 # Please update the version in appveyor-install-dependencies.ps1 together.
-sbt.version=1.7.2
+sbt.version=1.7.3


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to re-upgrade sbt to 1.7.3 due to SPARK-40996 has solved the issue of `dev/sbt-checkstyle` execution failure.




### Why are the changes needed?
The release note as follows, this version just updates sbt underlying Coursier from 2.1.0-M2 to 2.1.0-M7-18-g67daad6a9:

- https://github.com/sbt/sbt/releases/tag/v1.7.3


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Manual test: Run `dev/sbt-checkstyle` with this pr

```
Checkstyle checks passed.
```