### PR TITLE
[SPARK-40815][SQL][FOLLOW-UP] Disable DelegateSymlinkTextInputFormat tests for JDK 9+

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -205,7 +205,7 @@ private[spark] object HiveUtils extends Logging {
         "table scan in order to fix the issue of empty splits")
       .version("3.4.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   /**
    * The version of the hive client that will be used to communicate with the metastore.  Note that

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -205,7 +205,7 @@ private[spark] object HiveUtils extends Logging {
         "table scan in order to fix the issue of empty splits")
       .version("3.4.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   /**
    * The version of the hive client that will be used to communicate with the metastore.  Note that

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSerDeReadWriteSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSerDeReadWriteSuite.scala
@@ -226,7 +226,8 @@ class HiveSerDeReadWriteSuite extends QueryTest with SQLTestUtils with TestHiveS
     }
   }
 
-  test("SPARK-40815: DelegateSymlinkTextInputFormat serialization") {
+  // Ignored due to JDK 11 failures reported in https://github.com/apache/spark/pull/38277.
+  ignore("SPARK-40815: DelegateSymlinkTextInputFormat serialization") {
     def assertSerDe(split: DelegateSymlinkTextInputFormat.DelegateSymlinkTextInputSplit): Unit = {
       val buf = new ByteArrayOutputStream()
       val out = new DataOutputStream(buf)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSerDeReadWriteSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSerDeReadWriteSuite.scala
@@ -261,7 +261,8 @@ class HiveSerDeReadWriteSuite extends QueryTest with SQLTestUtils with TestHiveS
     )
   }
 
-  test("SPARK-40815: Read SymlinkTextInputFormat") {
+  // Ignored due to JDK 11 failures reported in https://github.com/apache/spark/pull/38277.
+  ignore("SPARK-40815: Read SymlinkTextInputFormat") {
     withTable("t") {
       withTempDir { root =>
         val dataPath = new File(root, "data")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSerDeReadWriteSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSerDeReadWriteSuite.scala
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 
+import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.ql.io.{DelegateSymlinkTextInputFormat, SymlinkTextInputFormat}
 import org.apache.hadoop.mapred.FileSplit;
@@ -226,8 +227,10 @@ class HiveSerDeReadWriteSuite extends QueryTest with SQLTestUtils with TestHiveS
     }
   }
 
-  // Ignored due to JDK 11 failures reported in https://github.com/apache/spark/pull/38277.
-  ignore("SPARK-40815: DelegateSymlinkTextInputFormat serialization") {
+  test("SPARK-40815: DelegateSymlinkTextInputFormat serialization") {
+    // Ignored due to JDK 11 failures reported in https://github.com/apache/spark/pull/38277.
+    assume(!SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9))
+
     def assertSerDe(split: DelegateSymlinkTextInputFormat.DelegateSymlinkTextInputSplit): Unit = {
       val buf = new ByteArrayOutputStream()
       val out = new DataOutputStream(buf)
@@ -262,8 +265,10 @@ class HiveSerDeReadWriteSuite extends QueryTest with SQLTestUtils with TestHiveS
     )
   }
 
-  // Ignored due to JDK 11 failures reported in https://github.com/apache/spark/pull/38277.
-  ignore("SPARK-40815: Read SymlinkTextInputFormat") {
+  test("SPARK-40815: Read SymlinkTextInputFormat") {
+    // Ignored due to JDK 11 failures reported in https://github.com/apache/spark/pull/38277.
+    assume(!SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9))
+
     withTable("t") {
       withTempDir { root =>
         val dataPath = new File(root, "data")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR is a follow-up for https://github.com/apache/spark/pull/38277. 

This change is required due to test failures in JDK 11 and JDK 17. The patch disables the unit test for JDK 9+. 
This is a temporary measure while I am debugging and working on the fix for higher versions of JDK.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fixes the test failure in JDK 11.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

N/A.