### PR TITLE
[SPARK-41012][SQL] Rename `_LEGACY_ERROR_TEMP_1022` to `ORDER_BY_POS_OUT_OF_RANGE`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -697,6 +697,12 @@
     ],
     "sqlState" : "22005"
   },
+  "ORDER_BY_POS_OUT_OF_RANGE" : {
+    "message" : [
+      "ORDER BY position <index> is not in select list (valid range is [1, <size>])."
+    ],
+    "sqlState" : "42000"
+  },
   "OUT_OF_DECIMAL_TYPE_RANGE" : {
     "message" : [
       "Out of decimal type range: <value>."
@@ -1610,11 +1616,6 @@
   "_LEGACY_ERROR_TEMP_1021" : {
     "message" : [
       "count(<targetString>.*) is not allowed. Please use count(*) or expand the columns manually, e.g. count(col1, col2)."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1022" : {
-    "message" : [
-      "ORDER BY position <index> is not in select list (valid range is [1, <size>])."
     ]
   },
   "_LEGACY_ERROR_TEMP_1023" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -472,7 +472,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
 
   def orderByPositionRangeError(index: Int, size: Int, t: TreeNode[_]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1022",
+      errorClass = "ORDER_BY_POS_OUT_OF_RANGE",
       messageParameters = Map(
         "index" -> index.toString,
         "size" -> size.toString),

--- a/sql/core/src/test/resources/sql-tests/results/order-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/order-by-ordinal.sql.out
@@ -73,7 +73,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1022",
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42000",
   "messageParameters" : {
     "index" : "0",
     "size" : "2"
@@ -95,7 +96,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1022",
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42000",
   "messageParameters" : {
     "index" : "-1",
     "size" : "2"
@@ -117,7 +119,8 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1022",
+  "errorClass" : "ORDER_BY_POS_OUT_OF_RANGE",
+  "sqlState" : "42000",
   "messageParameters" : {
     "index" : "3",
     "size" : "2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename `_LEGACY_ERROR_TEMP_1022` to `ORDER_BY_POS_OUT_OF_RANGE`

### Why are the changes needed?

Error class name should clear/briefly explain the error message.


### Does this PR introduce _any_ user-facing change?

User-facing error class name is changed.

### How was this patch tested?

```
./build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z order-by-ordinal.sql"
```