### PR TITLE
[SPARK-33349][K8S] Reset the executor pods watcher when we receive a version changed from k8s

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -501,6 +501,14 @@ private[spark] object Config extends Logging {
       .booleanConf
       .createWithDefault(true)
 
+  val KUBERNETES_EXECUTOR_ENABLE_WATCHER_AUTO_RESET =
+    ConfigBuilder("spark.kubernetes.executor.enableApiWatcherAutoReset")
+      .doc("If Spark ExecutorPodsWatcher closed caused by client too old resource version. " +
+        "We should reset executor watcher connection.")
+      .version("3.4.0")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
 
   val KUBERNETES_EXECUTOR_API_POLLING_INTERVAL =
     ConfigBuilder("spark.kubernetes.executor.apiPollingInterval")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsWatchSnapshotSource.scala
@@ -98,7 +98,8 @@ class ExecutorPodsWatchSnapshotSource(
 
     override def onClose(e: WatcherException): Unit = {
       if (e != null && e.isHttpGone) {
-        logDebug(s"Got HTTP Gone code, resource version changed in k8s api: $e")
+        logDebug(s"Got HTTP Gone code, should be reset watcher connection, " +
+          s"resource version changed in k8s api: $e")
         reset(this)
       } else {
         logWarning("Kubernetes client has been closed (this is expected if the application is" +


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is committed to solving the problem of [33349](https://issues.apache.org/jira/browse/SPARK-33349).  When spark apps encounter too old resource version from k8s, executor pods watcher will be close unexpected. After watcher closed, executors snapshotsStore can not continue update, this means app unable to get executors pod status in time. Thus, we should be restart watcher after abnormal shutdown. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Running spark-submit to a k8s cluster
