### PR TITLE
[SPARK-41020][SQL] Rename the error class `_LEGACY_ERROR_TEMP_1019` to `STAR_GROUP_BY_POS`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -912,6 +912,11 @@
     ],
     "sqlState" : "22023"
   },
+  "STAR_GROUP_BY_POS" : {
+    "message" : [
+      "Star (*) is not allowed in a select list when GROUP BY an ordinal position is used."
+    ]
+  },
   "TABLE_OR_VIEW_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create table or view <relationName> because it already exists.",
@@ -1722,11 +1727,6 @@
   "_LEGACY_ERROR_TEMP_1018" : {
     "message" : [
       "<quoted> is a permanent view, which is not supported by streaming reading API such as `DataStreamReader.table` yet."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1019" : {
-    "message" : [
-      "Star (*) is not allowed in select list when GROUP BY ordinal position is used"
     ]
   },
   "_LEGACY_ERROR_TEMP_1020" : {
@@ -5115,7 +5115,7 @@
       "in operator <operator>"
     ]
   },
-  "_LEGACY_ERROR_TEMP_2440" : {
+  "INVALID_EXPRESSION_IN_WHERE" : {
     "message" : [
       "Aggregate/Window/Generate expressions are not valid in where clause of the query.",
       "Expression in where clause: [<condition>]",

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -5115,7 +5115,7 @@
       "in operator <operator>"
     ]
   },
-  "INVALID_EXPRESSION_IN_WHERE" : {
+  "_LEGACY_ERROR_TEMP_2440" : {
     "message" : [
       "Aggregate/Window/Generate expressions are not valid in where clause of the query.",
       "Expression in where clause: [<condition>]",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -443,7 +443,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
 
   def starNotAllowedWhenGroupByOrdinalPositionUsedError(): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1019",
+      errorClass = "STAR_GROUP_BY_POS",
       messageParameters = Map.empty)
   }
 

--- a/sql/core/src/test/resources/sql-tests/results/group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-ordinal.sql.out
@@ -223,7 +223,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1019"
+  "errorClass" : "STAR_GROUP_BY_POS"
 }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to rename the legacy error class `_LEGACY_ERROR_TEMP_1019` to `STAR_GROUP_BY_POS`, and improve the error message format slightly.

### Why are the changes needed?
Proper names of error classes should improve user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "core/testOnly *SparkThrowableSuite"
$ PYSPARK_PYTHON=python3 build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z group-by-ordinal.sql"
```