### PR TITLE
[SPARK-41024][BUILD] Upgrade scala-maven-plugin to 4.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
       errors building different Hadoop versions.
       See: SPARK-36547, SPARK-38394.
        -->
-    <scala-maven-plugin.version>4.7.1</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.7.2</scala-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade scala-maven-plugin to 4.7.2



### Why are the changes needed?
This version set `-release` instead of `-target` to clean up a deprecation compilation warning for Scala 2.13.9

- https://github.com/davidB/scala-maven-plugin/pull/648

The all change from 4.7.1 as follows:

- https://github.com/davidB/scala-maven-plugin/compare/4.7.1...4.7.2


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions