### PR TITLE
[SPARK-41025][SS] Introduce ValidateOffsetRange/ComparableOffset to support offset range validation

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ComparableOffset.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ComparableOffset.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.streaming;
+
+/**
+ * Mixed-in interface to notice to Spark that the offset instance is comparable with another
+ * offset instance. Both DSv1 Offset and DSv2 Offset are eligible to extend this interface.
+ *
+ * @see ValidateOffsetRange
+ * @since 3.4.0
+ */
+public interface ComparableOffset {
+  /**
+   * The result of comparison between two offsets.
+   * <p>
+   * - EQUAL: two offsets are equal<br/>
+   * - GREATER: this offset is greater than the other offset<br/>
+   * - LESS: this offset is less than the other offset<br/>
+   * - UNDETERMINED: can't determine which is greater<br/>
+   *   e.g. greater for some parts but less for some other parts<br/>
+   * - NOT_COMPARABLE: both are not comparable offsets e.g. different types
+   */
+  enum CompareResult {
+    EQUAL,
+    GREATER,
+    LESS,
+    UNDETERMINED,
+    NOT_COMPARABLE
+  }
+
+  /**
+   * Compare this offset with given offset.
+   *
+   * @see CompareResult
+   */
+  CompareResult compareTo(ComparableOffset other);
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ValidateOffsetRange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ValidateOffsetRange.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.streaming;
+
+/**
+ * Mixed-in interface for streaming source class to notice to Spark that this source wants to
+ * validate the range of offset (start, end). Both DSv1 and DSv2 streaming source are eligible to
+ * extend this interface.
+ *
+ * The Offset class for this source should implement {@link ComparableOffset} to allow Spark to
+ * perform validation.
+ *
+ * @see ComparableOffset
+ * @since 3.4.0
+ */
+public interface ValidateOffsetRange {
+  /**
+   * Whether to validate offset range. Default implementation always returns true.
+   *
+   * Data sources wanting to "selectively" validate the range should override this method to
+   * control the return value. (e.g. failOnLoss option in Kafka data source)
+   *
+   * @return true if Spark should validate the offset range, false otherwise.
+   */
+  default boolean shouldValidate() { return true; }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ValidateOffsetRange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/ValidateOffsetRange.java
@@ -20,7 +20,8 @@ package org.apache.spark.sql.connector.read.streaming;
 /**
  * Mixed-in interface for streaming source class to notice to Spark that this source wants to
  * validate the range of offset (start, end). Both DSv1 and DSv2 streaming source are eligible to
- * extend this interface.
+ * extend this interface. Note that deserializeOffset is already a part of DSv2 streaming source,
+ * hence DSv1 streaming source only needs to implement the method.
  *
  * The Offset class for this source should implement {@link ComparableOffset} to allow Spark to
  * perform validation.
@@ -38,4 +39,11 @@ public interface ValidateOffsetRange {
    * @return true if Spark should validate the offset range, false otherwise.
    */
   default boolean shouldValidate() { return true; }
+
+  /**
+   * Deserialize a JSON string into an Offset of the implementation-defined offset type.
+   *
+   * @throws IllegalArgumentException if the JSON does not encode a valid offset for this reader
+   */
+  Offset deserializeOffset(String json);
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2014,6 +2014,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val STREAMING_OFFSET_RANGE_ASSERTION_ENABLED =
+    buildConf("spark.sql.streaming.microbatch.assertOffsetRange.enabled")
+      .internal()
+      .doc("When true, microbatch execution will perform assertion for offset range (start, end)" +
+        " during batch planning.")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(true)
 
   val VARIABLE_SUBSTITUTE_ENABLED =
     buildConf("spark.sql.variable.substitute")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -31,7 +31,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.read.streaming
-import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimit, ReadMaxFiles, SupportsAdmissionControl, SupportsTriggerAvailableNow}
+import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimit, ReadMaxFiles, SupportsAdmissionControl, SupportsTriggerAvailableNow, ValidateOffsetRange}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources.{DataSource, InMemoryFileIndex, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf
@@ -51,6 +51,7 @@ class FileStreamSource(
     options: Map[String, String])
   extends SupportsAdmissionControl
   with SupportsTriggerAvailableNow
+  with ValidateOffsetRange
   with Source
   with Logging {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSource.scala
@@ -215,6 +215,10 @@ class FileStreamSource(
     maxFilesPerBatch.map(ReadLimit.maxFiles).getOrElse(super.getDefaultReadLimit)
   }
 
+  override def deserializeOffset(json: String): streaming.Offset = {
+    FileStreamSourceOffset(json)
+  }
+
   /**
    * For test only. Run `func` with the internal lock to make sure when `func` is running,
    * the current offset won't be changed and no new batch will be emitted.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceOffset.scala
@@ -22,14 +22,24 @@ import scala.util.control.Exception._
 import org.json4s.NoTypeHints
 import org.json4s.jackson.Serialization
 
+import org.apache.spark.sql.connector.read.streaming.ComparableOffset
+import org.apache.spark.sql.connector.read.streaming.ComparableOffset.CompareResult
+
 /**
  * Offset for the [[FileStreamSource]].
  *
  * @param logOffset  Position in the [[FileStreamSourceLog]]
  */
-case class FileStreamSourceOffset(logOffset: Long) extends Offset {
+case class FileStreamSourceOffset(logOffset: Long) extends Offset with ComparableOffset {
   override def json: String = {
     Serialization.write(this)(FileStreamSourceOffset.format)
+  }
+
+  override def compareTo(other: ComparableOffset): ComparableOffset.CompareResult = {
+    other match {
+      case o: FileStreamSourceOffset => LongOffset.compareOffsetValues(logOffset, o.logOffset)
+      case _ => CompareResult.NOT_COMPARABLE
+    }
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceOffset.scala
@@ -49,15 +49,18 @@ object FileStreamSourceOffset {
   def apply(offset: Offset): FileStreamSourceOffset = {
     offset match {
       case f: FileStreamSourceOffset => f
-      case SerializedOffset(str) =>
-        catching(classOf[NumberFormatException]).opt {
-          FileStreamSourceOffset(str.toLong)
-        }.getOrElse {
-          Serialization.read[FileStreamSourceOffset](str)
-        }
+      case SerializedOffset(str) => apply(str)
       case _ =>
         throw new IllegalArgumentException(
           s"Invalid conversion from offset of ${offset.getClass} to FileStreamSourceOffset")
+    }
+  }
+
+  def apply(json: String): FileStreamSourceOffset = {
+    catching(classOf[NumberFormatException]).opt {
+      FileStreamSourceOffset(json.toLong)
+    }.getOrElse {
+      Serialization.read[FileStreamSourceOffset](json)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability}
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory, Scan, ScanBuilder}
-import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream, Offset => OffsetV2, SparkDataStream}
+import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream, Offset => OffsetV2, SparkDataStream, ValidateOffsetRange}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.SimpleTableProvider
 import org.apache.spark.sql.types.StructType
@@ -151,7 +151,10 @@ case class MemoryStream[A : Encoder](
     id: Int,
     sqlContext: SQLContext,
     numPartitions: Option[Int] = None)
-  extends MemoryStreamBase[A](sqlContext) with MicroBatchStream with Logging {
+  extends MemoryStreamBase[A](sqlContext)
+  with MicroBatchStream
+  with ValidateOffsetRange
+  with Logging {
 
   protected val output = logicalPlan.output
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamMicroBatchStream.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
-import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset}
+import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset, ValidateOffsetRange}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -41,7 +41,7 @@ class RateStreamMicroBatchStream(
     numPartitions: Int = 1,
     options: CaseInsensitiveStringMap,
     checkpointLocation: String)
-  extends MicroBatchStream with Logging {
+  extends MicroBatchStream with ValidateOffsetRange with Logging {
   import RateStreamProvider._
 
   private[sources] val clock = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketMicroBatchStream.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
-import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset}
+import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset, ValidateOffsetRange}
 import org.apache.spark.sql.execution.streaming.LongOffset
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -39,7 +39,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * multiple reasons, including no support for fault recovery.
  */
 class TextSocketMicroBatchStream(host: String, port: Int, numPartitions: Int)
-  extends MicroBatchStream with Logging {
+  extends MicroBatchStream with ValidateOffsetRange with Logging {
 
   @GuardedBy("this")
   private var socket: Socket = null


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce new interface `ValidateOffsetRange`/`ComparableOffset`.

> ValidateOffsetRange

A mix-in of streaming SparkDataStream interface to indicate MicroBatchExecution to perform offset range validation. Sources which want to perform the validation "conditionally" should override the method `shouldValidate`.

```
public interface ValidateOffsetRange {
  default boolean shouldValidate() { return true; }
}
```

> ComparableOffset

A mix-in of streaming Offset interface to implement comparison between two offset instances. The new interface can be mixed-in with both DSv1 streaming Offset and DSv2 streaming Offset.

```
public interface ComparableOffset {
  enum CompareResult {
    EQUAL,
    GREATER,
    LESS,
    UNDETERMINED,
    NOT_COMPARABLE
  }

  CompareResult compareTo(ComparableOffset other);
}
```

When the source implements ValidateOffsetRange and requests MicroBatchExecution to do the validation, the offset instance must implement ComparableOffset. Otherwise MicroBatchExecution will throw error.

This PR also implements this interface for streaming offset in built-in data sources. For Kafka data source, the validation will be disabled when failOnLoss option is enabled, because failOnLoss allows the error case.

### Why are the changes needed?

Currently, Spark doesn't do any assertion against offsets and data source implementation is full of responsibility to validate the offset. It seems more useful to provide the offset validation by Spark rather than just documenting the responsibility and let data source implementation do the duty.

This offset validation is more important since we have Trigger.AvailableNow which gradually increases the offset and terminates when the offset is equal to the desired offset. A bug in data source may stall the query progress or even data duplication.

### Does this PR introduce _any_ user-facing change?

No for end users.

### How was this patch tested?

New UTs