### PR TITLE
[MINOR][SQL] Replace `new SparkException(errorClass = "INTERNAL_ERROR", ...)` by `SparkException.internalError`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -495,11 +495,9 @@ object QueryExecution {
    */
   private[sql] def toInternalError(msg: String, e: Throwable): Throwable = e match {
     case e @ (_: java.lang.NullPointerException | _: java.lang.AssertionError) =>
-      new SparkException(
-        errorClass = "INTERNAL_ERROR",
-        messageParameters = Map("message" -> (msg +
-          " Please, fill a bug report in, and provide the full stack trace.")),
-        cause = e)
+      SparkException.internalError(
+        msg + " Please, fill a bug report in, and provide the full stack trace.",
+        e)
     case e: Throwable =>
       e
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to replace `new SparkException(errorClass = "INTERNAL_ERROR", ...)` with `SparkException.internalError`

### Why are the changes needed?
The changes improve the error framework.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.