### PR TITLE
[SPARK-38505][SQL] Make partial aggregation adaptive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -335,6 +335,18 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
   }
 
   /**
+   * Returns a Seq containing the result until the condition specified by `f`.
+   * The condition is recursively applied to this node and all of its children.
+   */
+  def collectUntil(f: BaseType => Boolean): Seq[BaseType] = {
+    if (f(this)) {
+      Nil
+    } else {
+      Seq(this) ++ children.foldLeft(Seq.empty[BaseType]) { (l, r) => l ++ r.collectUntil(f) }
+    }
+  }
+
+  /**
    * Finds and returns the first [[TreeNode]] of the tree for which the given partial function
    * is defined (pre-order), and applies the partial function to it.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3216,6 +3216,18 @@ object SQLConf {
       .checkValue(bit => bit >= 10 && bit <= 30, "The bit value must be in [10, 30].")
       .createWithDefault(16)
 
+  val ADAPTIVE_PARTIAL_AGGREGATION_THRESHOLD =
+    buildConf("spark.sql.aggregate.adaptivePartialAggregationThreshold")
+      .internal()
+      .doc("Minimum number of processed rows before partial aggregation can be skipped. " +
+        "By setting this value to 0 adaptive partial aggregation can be disabled.")
+      .version("3.3.0")
+      .intConf
+      .checkValue(threshold => threshold >= 0 && threshold < (1 << 16),
+        "The threshold value must be bigger than or equal to 0 and less than " +
+          s"1 << ${FAST_HASH_AGGREGATE_MAX_ROWS_CAPACITY_BIT.key}.")
+      .createWithDefault(60000)
+
   val AVRO_COMPRESSION_CODEC = buildConf("spark.sql.avro.compression.codec")
     .doc("Compression codec used in writing of AVRO files. Supported codecs: " +
       "uncompressed, deflate, snappy, bzip2, xz and zstandard. Default codec is snappy.")
@@ -4389,6 +4401,8 @@ class SQLConf extends Serializable with Logging {
 
   def streamingSessionWindowMergeSessionInLocalPartition: Boolean =
     getConf(STREAMING_SESSION_WINDOW_MERGE_SESSIONS_IN_LOCAL_PARTITION)
+
+  def adaptivePartialAggregationThreshold: Int = getConf(ADAPTIVE_PARTIAL_AGGREGATION_THRESHOLD)
 
   def datetimeJava8ApiEnabled: Boolean = getConf(DATETIME_JAVA8API_ENABLED)
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.java
@@ -227,6 +227,10 @@ public final class UnsafeFixedWidthAggregationMap {
     return map.getAvgHashProbesPerKey();
   }
 
+  public int getNumKeys() {
+    return map.numKeys();
+  }
+
   /**
    * Sorts the map's records in place, spill them to disk, and returns an [[UnsafeKVExternalSorter]]
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashMapGenerator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashMapGenerator.scala
@@ -75,6 +75,8 @@ abstract class HashMapGenerator(
        |
        |${generateRowIterator()}
        |
+       |${generateGetNumKeys()}
+       |
        |${generateClose()}
        |}
      """.stripMargin
@@ -132,6 +134,14 @@ abstract class HashMapGenerator(
     """
        |public void close() {
        |  batch.close();
+       |}
+     """.stripMargin
+  }
+
+  protected final def generateGetNumKeys(): String = {
+    s"""
+       |public int getNumKeys() {
+       |  return batch.numRows();
        |}
      """.stripMargin
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptiveHashAggregateExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/AdaptiveHashAggregateExecSuite.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.aggregate
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.{ProjectExec, RangeExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
+import org.apache.spark.sql.execution.metric.SQLMetricsTestUtils
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class AdaptiveHashAggregateExecSuite extends QueryTest
+  with SharedSparkSession
+  with SQLMetricsTestUtils
+  with AdaptiveSparkPlanHelper {
+  import testImplicits._
+
+  test("Partial aggregation adaptive") {
+    Seq(0, 1, 10).foreach { partialAggThreshold =>
+      withSQLConf(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_THRESHOLD.key -> s"$partialAggThreshold") {
+        val agg = testData2.groupBy("a").sum("b")
+        val hashAggregate = agg.queryExecution.sparkPlan.asInstanceOf[HashAggregateExec]
+        val partialHashAggregate = hashAggregate.child.asInstanceOf[HashAggregateExec]
+
+        assert(hashAggregate.requiredChildDistributionExpressions.isDefined)
+        assert(!hashAggregate.isAdaptivePartialAggregationEnabled)
+
+        assert(partialHashAggregate.requiredChildDistributionExpressions.isEmpty)
+        if (partialAggThreshold > 0) {
+          assert(partialHashAggregate.isAdaptivePartialAggregationEnabled)
+        } else {
+          assert(!partialHashAggregate.isAdaptivePartialAggregationEnabled)
+        }
+
+        val nodeIds = Set(6L)
+        val metrics = getSparkPlanMetrics(agg, 2, nodeIds, true).get
+        nodeIds.foreach { nodeId =>
+          val outputRows = metrics(nodeId)._2("number of output rows").toString
+
+          if (partialAggThreshold == 1) {
+            assert(outputRows.toLong === 6)
+            val skippedRows =
+              metrics(nodeId)._2("number of skipped partial aggregate rows").toString
+            assert(skippedRows.toLong === 4)
+          } else {
+            assert(outputRows.toLong === 4)
+          }
+        }
+
+        checkAnswer(agg, Seq(Row(1, 3), Row(2, 3), Row(3, 3)))
+      }
+    }
+  }
+
+  test("HashAggregateExec's children contains Join") {
+    withSQLConf(SQLConf.ADAPTIVE_PARTIAL_AGGREGATION_THRESHOLD.key -> "1") {
+      val agg = testData2.join(testData, $"a" === $"key").groupBy("a").sum("b")
+
+      val hashAggregate = agg.queryExecution.sparkPlan.asInstanceOf[HashAggregateExec]
+      val partialHashAggregate = hashAggregate.child.asInstanceOf[HashAggregateExec]
+
+      assert(!hashAggregate.requiredChildDistributionExpressions.isEmpty)
+      assert(!hashAggregate.isAdaptivePartialAggregationEnabled)
+
+      assert(partialHashAggregate.requiredChildDistributionExpressions.isEmpty)
+      assert(!partialHashAggregate.isAdaptivePartialAggregationEnabled)
+    }
+  }
+
+  test("Test collectUntil") {
+    withTempView("v1", "v2") {
+      // HashAggregate(keys=[a#2L], functions=[sum(b#15L)], output=[a#2L, sum(b)#19L])
+      // +- HashAggregate(keys=[a#2L], functions=[partial_sum(b#15L)], output=[a#2L, sum#23L])
+      //    +- Project [a#2L, b#15L]
+      //       +- BroadcastHashJoin [a#2L], [a#14L], Inner, BuildLeft, false
+      //          :- HashAggregate(keys=[a#2L], functions=[], output=[a#2L])
+      //          :  +- HashAggregate(keys=[a#2L], functions=[], output=[a#2L])
+      //          :     +- Project [id#0L AS a#2L]
+      //          :        +- Range (0, 2, step=1, splits=2)
+      //          +- Project [id#12L AS a#14L, id#12L AS b#15L]
+      //             +- Range (0, 2, step=1, splits=2)
+      spark.range(2)
+        .selectExpr("id AS a", "id AS b")
+        .groupBy("a").sum("b")
+        .createTempView("v1")
+
+      spark.range(2)
+        .selectExpr("id AS a", "id AS b")
+        .createTempView("v2")
+
+      val df = sql("SELECT v1.a, sum(v2.b) FROM v1 join v2 ON v1.a = v2.a GROUP BY v1.a")
+      val plan = df.queryExecution.sparkPlan
+
+      assert(plan.collectUntil(_.isInstanceOf[HashAggregateExec]).isEmpty)
+      assert(plan.collectUntil(_.isInstanceOf[ProjectExec]).size === 2)
+      assert(plan.collectUntil(_.isInstanceOf[BroadcastHashJoinExec]).size === 3)
+      assert(
+        plan.collectUntil(_.isInstanceOf[RangeExec]).size === plan.collect { case p => p }.size - 2)
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `HashAggregateExec` adaptively skip partial aggregation to avoid spilling if partial aggregation do not reduce the number of output rows too much. 

By setting `spark.sql.aggregate.adaptivePartialAggregationThreshold` to 0 this feature can be disabled.

### Why are the changes needed?

Improve partial aggregation phase performance and we can implement these 2 features after this PR:
1. SPARK-36245: Partial deduplicate the right side of left semi/anti join
2. SPARK-38506: Push partial aggregation through join

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and TPC-H 5T benchmark test.

SQL | Before this PR(Seconds) | After this PR(Seconds)
-- | -- | --
q15 | 66  | 51
q17 | 86 | 80
q18 | 129 | 122
