### PR TITLE
[SPARK-41001][CONNECT] Make `userId` optional in SparkRemoteSession

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -285,11 +285,6 @@ class RemoteSparkSession(object):
         else:
             self._user_id = os.getenv("USER", None)
 
-        if self._user_id is None:
-            raise AttributeError(
-                "User ID must be specified either as argument, connection string, or $USER environment variable."
-            )
-
         self._channel = self._builder.to_channel()
         self._stub = grpc_lib.SparkConnectServiceStub(self._channel)
 
@@ -307,7 +302,8 @@ class RemoteSparkSession(object):
         fun.serialized_function = cloudpickle.dumps((function, return_type))
 
         req = pb2.Request()
-        req.user_context.user_id = self._user_id
+        if self._user_id is not None:
+            req.user_context.user_id = self._user_id
         req.plan.command.create_function.CopyFrom(fun)
 
         self._execute_and_fetch(req)

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -358,7 +358,8 @@ class RemoteSparkSession(object):
 
     def _to_pandas(self, plan: pb2.Plan) -> Optional[pandas.DataFrame]:
         req = pb2.Request()
-        req.user_context.user_id = self._user_id
+        if self._user_id is not None:
+            req.user_context.user_id = self._user_id
         req.plan.CopyFrom(plan)
         return self._execute_and_fetch(req)
 
@@ -401,7 +402,8 @@ class RemoteSparkSession(object):
 
     def _analyze(self, plan: pb2.Plan) -> AnalyzeResult:
         req = pb2.Request()
-        req.user_context.user_id = self._user_id
+        if self._user_id:
+            req.user_context.user_id = self._user_id
         req.plan.CopyFrom(plan)
 
         resp = self._stub.AnalyzePlan(req, metadata=self._builder.metadata())

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -268,7 +268,7 @@ class RemoteSparkSession(object):
         ----------
         connection_string: Optional[str]
             Connection string that is used to extract the connection parameters and configure
-            the GRPC connection. Defaults to `sc://localhos`
+            the GRPC connection. Defaults to `sc://localhost`.
         user_id : Optional[str]
             Optional unique user ID that is used to differentiate multiple users and
             isolate their Spark Sessions. If the `user_id` is not set, will default to

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -141,7 +141,7 @@ class ChannelBuilder:
         return self.params.get(ChannelBuilder.PARAM_TOKEN, None)
 
     @property
-    def user_id(self) -> Optional[str]:
+    def userId(self) -> Optional[str]:
         """
         Returns
         -------
@@ -163,7 +163,7 @@ class ChannelBuilder:
         """
         return self.params[key]
 
-    def to_channel(self) -> grpc.Channel:
+    def toChannel(self) -> grpc.Channel:
         """
         Applies the parameters of the connection string and creates a new
         GRPC channel according to the configuration.
@@ -260,32 +260,32 @@ class AnalyzeResult:
 class RemoteSparkSession(object):
     """Conceptually the remote spark session that communicates with the server"""
 
-    def __init__(self, connection_string: str = "sc://localhost", user_id: Optional[str] = None):
+    def __init__(self, connectionString: str = "sc://localhost", userId: Optional[str] = None):
         """
         Creates a new RemoteSparkSession for the Spark Connect interface.
 
         Parameters
         ----------
-        connection_string: Optional[str]
+        connectionString: Optional[str]
             Connection string that is used to extract the connection parameters and configure
             the GRPC connection. Defaults to `sc://localhost`.
-        user_id : Optional[str]
+        userId : Optional[str]
             Optional unique user ID that is used to differentiate multiple users and
             isolate their Spark Sessions. If the `user_id` is not set, will default to
             the $USER environment. Defining the user ID as part of the connection string
             takes precedence.
         """
         # Parse the connection string.
-        self._builder = ChannelBuilder(connection_string)
+        self._builder = ChannelBuilder(connectionString)
         self._user_id = None
-        if self._builder.user_id is not None:
-            self._user_id = self._builder.user_id
-        elif user_id is not None:
-            self._user_id = user_id
+        if self._builder.userId is not None:
+            self._user_id = self._builder.userId
+        elif userId is not None:
+            self._user_id = userId
         else:
             self._user_id = os.getenv("USER", None)
 
-        self._channel = self._builder.to_channel()
+        self._channel = self._builder.toChannel()
         self._stub = grpc_lib.SparkConnectServiceStub(self._channel)
 
         # Create the reader

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -195,7 +195,15 @@ class ChannelBuilderTests(ReusedPySparkTestCase):
         for i in invalid:
             self.assertRaises(AttributeError, ChannelBuilder, i)
 
-        self.assertRaises(AttributeError, ChannelBuilder("sc://host/;token=123").to_channel)
+    def test_sensible_defaults(self):
+        chan = ChannelBuilder("sc://host")
+        self.assertFalse(chan.secure, "Default URL is not secure")
+
+        chan = ChannelBuilder("sc://host/;token=abcs")
+        self.assertTrue(chan.secure, "specifying a token must set the channel to secure")
+
+        chan = ChannelBuilder("sc://host/;use_ssl=abcs")
+        self.assertFalse(chan.secure, "Garbage in, false out")
 
     def test_valid_channel_creation(self):
         chan = ChannelBuilder("sc://host").to_channel()

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -206,14 +206,14 @@ class ChannelBuilderTests(ReusedPySparkTestCase):
         self.assertFalse(chan.secure, "Garbage in, false out")
 
     def test_valid_channel_creation(self):
-        chan = ChannelBuilder("sc://host").to_channel()
+        chan = ChannelBuilder("sc://host").toChannel()
         self.assertIsInstance(chan, grpc.Channel)
 
         # Sets up a channel without tokens because ssl is not used.
-        chan = ChannelBuilder("sc://host/;use_ssl=true;token=abc").to_channel()
+        chan = ChannelBuilder("sc://host/;use_ssl=true;token=abc").toChannel()
         self.assertIsInstance(chan, grpc.Channel)
 
-        chan = ChannelBuilder("sc://host/;use_ssl=true").to_channel()
+        chan = ChannelBuilder("sc://host/;use_ssl=true").toChannel()
         self.assertIsInstance(chan, grpc.Channel)
 
     def test_channel_properties(self):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -75,7 +75,7 @@ class SparkConnectSQLTestCase(ReusedPySparkTestCase):
     @classmethod
     def spark_connect_load_test_data(cls: Any):
         # Setup Remote Spark Session
-        cls.connect = RemoteSparkSession(user_id="test_user")
+        cls.connect = RemoteSparkSession(userId="test_user")
         df = cls.spark.createDataFrame([(x, f"{x}") for x in range(100)], ["id", "name"])
         # Since we might create multiple Spark sessions, we need to create global temporary view
         # that is specifically maintained in the "global_temp" schema.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch provides small changes to the way the `userId` is propagated in the SparkRemoteSession. Previously, the `userId` was a required parameter, this is changed and it's inferred from one of the following configuration options in this order:

1. The `userId` is specified as a parameter to the connection string.
2. The `userId` is specified as a parameter to the `RemoteSparkSession`.
3. If not defined it is inferred from the `$USER`

In addition, since `token` can only be used for secure connections, it will implicitly set the `use_ssl` property of the connection.

### Why are the changes needed?
Usability

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT
