### PR TITLE
[SPARK-41030][BUILD] Upgrade `Apache Ivy` to 2.5.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -109,7 +109,7 @@ htrace-core/3.1.0-incubating//htrace-core-3.1.0-incubating.jar
 httpclient/4.5.13//httpclient-4.5.13.jar
 httpcore/4.4.14//httpcore-4.4.14.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
-ivy/2.5.0//ivy-2.5.0.jar
+ivy/2.5.1//ivy-2.5.1.jar
 jackson-annotations/2.14.0//jackson-annotations-2.14.0.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.14.0//jackson-core-2.14.0.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -97,7 +97,7 @@ httpclient/4.5.13//httpclient-4.5.13.jar
 httpcore/4.4.14//httpcore-4.4.14.jar
 ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
-ivy/2.5.0//ivy-2.5.0.jar
+ivy/2.5.1//ivy-2.5.1.jar
 jackson-annotations/2.14.0//jackson-annotations-2.14.0.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.14.0//jackson-core-2.14.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <jetty.version>9.4.49.v20220914</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
-    <ivy.version>2.5.0</ivy.version>
+    <ivy.version>2.5.1</ivy.version>
     <oro.version>2.0.8</oro.version>
     <!--
     If you changes codahale.metrics.version, you also need to change


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade `Apache Ivy` from 2.5.0 to 2.5.1
[Release  notes](https://ant.apache.org/ivy/history/2.5.1/release-notes.html)

### Why are the changes needed?
[CVE-2022-37865](https://www.cve.org/CVERecord?id=CVE-2022-37865)
and
[CVE-2022-37866](https://nvd.nist.gov/vuln/detail/CVE-2022-37866)
### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA