### PR TITLE
[SPARK-41033][CONNECT][PYTHON] RemoteSparkSession should only accept one `user_id`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -220,6 +220,20 @@ class ChannelBuilderTests(ReusedPySparkTestCase):
         self.assertEqual([("param1", "120 21"), ("x-my-header", "abcd")], md)
 
 
+class RemoteSparkSessionTests(ReusedPySparkTestCase):
+    def test_user_id(self):
+        # SPARK-41033: test `user_id` parameter in RemoteSparkSession.
+        connect = RemoteSparkSession("fake_id")
+        self.assertEqual("fake_id", connect._user_id)
+
+        connect2 = RemoteSparkSession(connection_string="sc://host/;user_id=fake_id2")
+        self.assertEqual("fake_id2", connect2._user_id)
+
+        with self.assertRaises(Exception) as context:
+            RemoteSparkSession("fake_id", "sc://host/;user_id=fake_id2")
+        self.assertTrue("user_id is provided by both" in str(context.exception))
+
+
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_connect_basic import *  # noqa: F401
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We now allow setting up `user_id` in `connection_string`, thus it could cause ambiguity when multiple candidates for `user_id` are provided in both `RemoteSparkSession` constructor and the connector_string.

 This PR proposes that we should enforce only one `user_id` is already provided, either through the constructor or `connection_string` of `RemoteSparkSession`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Reduce ambiguity when seeing multiple candidates for `user_id`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT