### PR TITLE
[SPARK-41034][CONNECT][PYTHON] Connect DataFrame should require a RemoteSparkSession

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 import uuid
-from typing import cast, get_args, TYPE_CHECKING, Optional, Callable, Any
+from typing import cast, get_args, TYPE_CHECKING, Callable, Any
 
 import decimal
 import datetime
@@ -76,7 +76,7 @@ class Expression(object):
     def __init__(self) -> None:
         pass
 
-    def to_plan(self, session: Optional["RemoteSparkSession"]) -> "proto.Expression":
+    def to_plan(self, session: "RemoteSparkSession") -> "proto.Expression":
         ...
 
     def __str__(self) -> str:
@@ -93,7 +93,7 @@ class LiteralExpression(Expression):
         super().__init__()
         self._value = value
 
-    def to_plan(self, session: Optional["RemoteSparkSession"]) -> "proto.Expression":
+    def to_plan(self, session: "RemoteSparkSession") -> "proto.Expression":
         """Converts the literal expression to the literal in proto.
 
         TODO(SPARK-40533) This method always assumes the largest type and can thus
@@ -181,7 +181,7 @@ class ColumnRef(Expression):
         """Returns the qualified name of the column reference."""
         return self._unparsed_identifier
 
-    def to_plan(self, session: Optional["RemoteSparkSession"]) -> proto.Expression:
+    def to_plan(self, session: "RemoteSparkSession") -> proto.Expression:
         """Returns the Proto representation of the expression."""
         expr = proto.Expression()
         expr.unresolved_attribute.unparsed_identifier = self._unparsed_identifier
@@ -207,7 +207,7 @@ class SortOrder(Expression):
     def __str__(self) -> str:
         return str(self.ref) + " ASC" if self.ascending else " DESC"
 
-    def to_plan(self, session: Optional["RemoteSparkSession"]) -> proto.Expression:
+    def to_plan(self, session: "RemoteSparkSession") -> proto.Expression:
         return self.ref.to_plan(session)
 
 
@@ -221,7 +221,7 @@ class ScalarFunctionExpression(Expression):
         self._args = args
         self._op = op
 
-    def to_plan(self, session: Optional["RemoteSparkSession"]) -> proto.Expression:
+    def to_plan(self, session: "RemoteSparkSession") -> proto.Expression:
         fun = proto.Expression()
         fun.unresolved_function.parts.append(self._op)
         fun.unresolved_function.arguments.extend([x.to_plan(session) for x in self._args])

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -100,21 +100,23 @@ class DataFrame(object):
     of the DataFrame with the changes applied.
     """
 
-    def __init__(self, data: Optional[List[Any]] = None, schema: Optional[StructType] = None):
+    def __init__(
+        self,
+        session: "RemoteSparkSession",
+        data: Optional[List[Any]] = None,
+        schema: Optional[StructType] = None,
+    ):
         """Creates a new data frame"""
         self._schema = schema
         self._plan: Optional[plan.LogicalPlan] = None
         self._cache: Dict[str, Any] = {}
-        self._session: Optional["RemoteSparkSession"] = None
+        self._session: "RemoteSparkSession" = session
 
     @classmethod
-    def withPlan(
-        cls, plan: plan.LogicalPlan, session: Optional["RemoteSparkSession"] = None
-    ) -> "DataFrame":
+    def withPlan(cls, plan: plan.LogicalPlan, session: "RemoteSparkSession") -> "DataFrame":
         """Main initialization method used to construct a new data frame with a child plan."""
-        new_frame = DataFrame()
+        new_frame = DataFrame(session=session)
         new_frame._plan = plan
-        new_frame._session = session
         return new_frame
 
     def select(self, *cols: ColumnOrName) -> "DataFrame":

--- a/python/pyspark/sql/connect/function_builder.py
+++ b/python/pyspark/sql/connect/function_builder.py
@@ -87,7 +87,7 @@ class UserDefinedFunction(Expression):
             self._args = []
         self._func_name = None
 
-    def to_plan(self, session: Optional["RemoteSparkSession"]) -> proto.Expression:
+    def to_plan(self, session: "RemoteSparkSession") -> proto.Expression:
         if session is None:
             raise Exception("CAnnot create UDF without remote Session.")
         # Needs to materialize the UDF to the server

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -57,7 +57,7 @@ class LogicalPlan(object):
         return exp
 
     def to_attr_or_expression(
-        self, col: "ColumnOrString", session: Optional["RemoteSparkSession"]
+        self, col: "ColumnOrString", session: "RemoteSparkSession"
     ) -> proto.Expression:
         """Returns either an instance of an unresolved attribute or the serialized
         expression value of the column."""
@@ -66,7 +66,7 @@ class LogicalPlan(object):
         else:
             return cast(ColumnRef, col).to_plan(session)
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         ...
 
     def _verify(self, session: "RemoteSparkSession") -> bool:
@@ -81,9 +81,7 @@ class LogicalPlan(object):
 
         return test_plan == plan
 
-    def to_proto(
-        self, session: Optional["RemoteSparkSession"] = None, debug: bool = False
-    ) -> proto.Plan:
+    def to_proto(self, session: "RemoteSparkSession", debug: bool = False) -> proto.Plan:
         """
         Generates connect proto plan based on this LogicalPlan.
 
@@ -126,7 +124,7 @@ class DataSource(LogicalPlan):
         self.schema = schema
         self.options = options
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         plan = proto.Relation()
         if self.format is not None:
             plan.read.data_source.format = self.format
@@ -157,7 +155,7 @@ class Read(LogicalPlan):
         super().__init__(None)
         self.table_name = table_name
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         plan = proto.Relation()
         plan.read.named_table.unparsed_identifier = self.table_name
         return plan
@@ -201,7 +199,7 @@ class Project(LogicalPlan):
                     f"Only Expressions or String can be used for projections: '{c}'."
                 )
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         proj_exprs = []
         for c in self._raw_columns:
@@ -240,7 +238,7 @@ class Filter(LogicalPlan):
         super().__init__(child)
         self.filter = filter
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         plan = proto.Relation()
         plan.filter.input.CopyFrom(self._child.plan(session))
@@ -268,7 +266,7 @@ class Limit(LogicalPlan):
         super().__init__(child)
         self.limit = limit
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         plan = proto.Relation()
         plan.limit.input.CopyFrom(self._child.plan(session))
@@ -296,7 +294,7 @@ class Offset(LogicalPlan):
         super().__init__(child)
         self.offset = offset
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         plan = proto.Relation()
         plan.offset.input.CopyFrom(self._child.plan(session))
@@ -330,7 +328,7 @@ class Deduplicate(LogicalPlan):
         self.all_columns_as_keys = all_columns_as_keys
         self.column_names = column_names
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         plan = proto.Relation()
         plan.deduplicate.all_columns_as_keys = self.all_columns_as_keys
@@ -370,7 +368,7 @@ class Sort(LogicalPlan):
         self.is_global = is_global
 
     def col_to_sort_field(
-        self, col: Union[SortOrder, ColumnRef, str], session: Optional["RemoteSparkSession"]
+        self, col: Union[SortOrder, ColumnRef, str], session: "RemoteSparkSession"
     ) -> proto.Sort.SortField:
         if isinstance(col, SortOrder):
             sf = proto.Sort.SortField()
@@ -397,7 +395,7 @@ class Sort(LogicalPlan):
             sf.nulls = proto.Sort.SortNulls.SORT_NULLS_LAST
             return sf
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         plan = proto.Relation()
         plan.sort.input.CopyFrom(self._child.plan(session))
@@ -437,7 +435,7 @@ class Sample(LogicalPlan):
         self.with_replacement = with_replacement
         self.seed = seed
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         plan = proto.Relation()
         plan.sample.input.CopyFrom(self._child.plan(session))
@@ -487,9 +485,7 @@ class Aggregate(LogicalPlan):
         self.grouping_cols = grouping_cols
         self.measures = measures if measures is not None else []
 
-    def _convert_measure(
-        self, m: MeasureType, session: Optional["RemoteSparkSession"]
-    ) -> proto.Expression:
+    def _convert_measure(self, m: MeasureType, session: "RemoteSparkSession") -> proto.Expression:
         exp, fun = m
         proto_expr = proto.Expression()
         measure = proto_expr.unresolved_function
@@ -500,7 +496,7 @@ class Aggregate(LogicalPlan):
             measure.arguments.append(cast(Expression, exp).to_plan(session))
         return proto_expr
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         groupings = [x.to_plan(session) for x in self.grouping_cols]
 
@@ -570,7 +566,7 @@ class Join(LogicalPlan):
             )
         self.how = join_type
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         rel = proto.Relation()
         rel.join.left.CopyFrom(self.left.plan(session))
         rel.join.right.CopyFrom(self.right.plan(session))
@@ -614,7 +610,7 @@ class UnionAll(LogicalPlan):
         self.other = other
         self.by_name = by_name
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         rel = proto.Relation()
         rel.set_op.left_input.CopyFrom(self._child.plan(session))
@@ -658,7 +654,7 @@ class SubqueryAlias(LogicalPlan):
         super().__init__(child)
         self._alias = alias
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         rel = proto.Relation()
         rel.subquery_alias.alias = self._alias
         return rel
@@ -684,7 +680,7 @@ class SQL(LogicalPlan):
         super().__init__(None)
         self._query = query
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         rel = proto.Relation()
         rel.sql.query = self._query
         return rel
@@ -719,7 +715,7 @@ class Range(LogicalPlan):
         self._step = step
         self._num_partitions = num_partitions
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         rel = proto.Relation()
         rel.range.start = self._start
         rel.range.end = self._end

--- a/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
@@ -25,7 +25,6 @@ from pyspark.testing.sqlutils import have_pandas, pandas_requirement_message
 
 if have_pandas:
     from pyspark.sql.connect.proto import Expression as ProtoExpression
-    import pyspark.sql.connect as c
     import pyspark.sql.connect.plan as p
     import pyspark.sql.connect.column as col
     import pyspark.sql.connect.functions as fun
@@ -34,7 +33,7 @@ if have_pandas:
 @unittest.skipIf(not have_pandas, cast(str, pandas_requirement_message))
 class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
     def test_simple_column_expressions(self):
-        df = c.DataFrame.withPlan(p.Read("table"))
+        df = self.connect.with_plan(p.Read("table"))
 
         c1 = df.col_name
         self.assertIsInstance(c1, col.ColumnRef)
@@ -79,7 +78,7 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
             lit.to_plan(None)
 
     def test_column_literals(self):
-        df = c.DataFrame.withPlan(p.Read("table"))
+        df = self.connect.with_plan(p.Read("table"))
         lit_df = df.select(fun.lit(10))
         self.assertIsNotNone(lit_df._plan.to_proto(None))
 
@@ -138,7 +137,7 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
     def test_column_expressions(self):
         """Test a more complex combination of expressions and their translation into
         the protobuf structure."""
-        df = c.DataFrame.withPlan(p.Read("table"))
+        df = self.connect.with_plan(p.Read("table"))
 
         expr = fun.lit(10) < fun.lit(10)
         expr_plan = expr.to_plan(None)

--- a/python/pyspark/sql/tests/connect/test_connect_select_ops.py
+++ b/python/pyspark/sql/tests/connect/test_connect_select_ops.py
@@ -30,7 +30,7 @@ if have_pandas:
 class SparkConnectToProtoSuite(PlanOnlyTestFixture):
     def test_select_with_columns_and_strings(self):
         df = self.connect.with_plan(Read("table"))
-        self.assertIsNotNone(df.select(col("name"))._plan.to_proto())
+        self.assertIsNotNone(df.select(col("name"))._plan.to_proto(self.connect))
         self.assertIsNotNone(df.select("name"))
         self.assertIsNotNone(df.select("name", "name2"))
         self.assertIsNotNone(df.select(col("name"), col("name2")))
@@ -49,7 +49,9 @@ class SparkConnectToProtoSuite(PlanOnlyTestFixture):
             ("leftanti", proto.Join.JoinType.JOIN_TYPE_LEFT_ANTI),
             ("leftsemi", proto.Join.JoinType.JOIN_TYPE_LEFT_SEMI),
         ]:
-            joined_df = df_left.join(df_right, on=col("name"), how=join_type_str)._plan.to_proto()
+            joined_df = df_left.join(df_right, on=col("name"), how=join_type_str)._plan.to_proto(
+                self.connect
+            )
             self.assertEqual(joined_df.root.join.join_type, join_type)
 
 

--- a/python/pyspark/sql/tests/connect/test_connect_select_ops.py
+++ b/python/pyspark/sql/tests/connect/test_connect_select_ops.py
@@ -21,7 +21,6 @@ from pyspark.testing.connectutils import PlanOnlyTestFixture
 from pyspark.testing.sqlutils import have_pandas, pandas_requirement_message
 
 if have_pandas:
-    from pyspark.sql.connect import DataFrame
     from pyspark.sql.connect.functions import col
     from pyspark.sql.connect.plan import Read
     import pyspark.sql.connect.proto as proto
@@ -30,7 +29,7 @@ if have_pandas:
 @unittest.skipIf(not have_pandas, cast(str, pandas_requirement_message))
 class SparkConnectToProtoSuite(PlanOnlyTestFixture):
     def test_select_with_columns_and_strings(self):
-        df = DataFrame.withPlan(Read("table"))
+        df = self.connect.with_plan(Read("table"))
         self.assertIsNotNone(df.select(col("name"))._plan.to_proto())
         self.assertIsNotNone(df.select("name"))
         self.assertIsNotNone(df.select("name", "name2"))
@@ -39,8 +38,8 @@ class SparkConnectToProtoSuite(PlanOnlyTestFixture):
         self.assertIsNotNone(df.select("*"))
 
     def test_join_with_join_type(self):
-        df_left = DataFrame.withPlan(Read("table"))
-        df_right = DataFrame.withPlan(Read("table"))
+        df_left = self.connect.with_plan(Read("table"))
+        df_right = self.connect.with_plan(Read("table"))
         for (join_type_str, join_type) in [
             (None, proto.Join.JoinType.JOIN_TYPE_INNER),
             ("inner", proto.Join.JoinType.JOIN_TYPE_INNER),

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -24,6 +24,7 @@ if have_pandas:
     from pyspark.sql.connect import DataFrame
     from pyspark.sql.connect.plan import Read, Range, SQL
     from pyspark.testing.utils import search_jar
+    from pyspark.sql.connect.plan import LogicalPlan
 
     connect_jar = search_jar("connector/connect", "spark-connect-assembly-", "spark-connect")
 else:
@@ -92,6 +93,10 @@ class PlanOnlyTestFixture(unittest.TestCase):
         return DataFrame.withPlan(SQL(query), cls.connect)  # type: ignore
 
     @classmethod
+    def _with_plan(cls, plan: LogicalPlan) -> "DataFrame":
+        return DataFrame.withPlan(plan, cls.connect)  # type: ignore
+
+    @classmethod
     def setUpClass(cls: Any) -> None:
         cls.connect = MockRemoteSession()
         cls.tbl_name = "test_connect_plan_only_table_1"
@@ -100,6 +105,7 @@ class PlanOnlyTestFixture(unittest.TestCase):
         cls.connect.set_hook("readTable", cls._read_table)
         cls.connect.set_hook("range", cls._session_range)
         cls.connect.set_hook("sql", cls._session_sql)
+        cls.connect.set_hook("with_plan", cls._with_plan)
 
     @classmethod
     def tearDownClass(cls: Any) -> None:
@@ -107,3 +113,4 @@ class PlanOnlyTestFixture(unittest.TestCase):
         cls.connect.drop_hook("readTable")
         cls.connect.drop_hook("range")
         cls.connect.drop_hook("sql")
+        cls.connect.drop_hook("with_plan")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Connect have marked the session parameter everywhere as `Optional`.  This seems to be only useful for testing where test case can ignore the session parameter when it is not applicable. 

However:
1. There are PySpark DataFrame API that returns SparkSession which is not optional. If Connect keep it as optional then we will have diff on such API.
2. Optional suggests `None` check which seems to not be necessary at many places (or forget to check `None` etc.)

This PR proposes to remove the `Optional` on the session from API interface.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  4. If you fix a bug, you can clarify why it is a bug.
-->
Maintainability 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT