### PR TITLE
[SPARK-40815][SQL][FOLLOW-UP] Fix record reader in DelegateSymlinkTextInputFormat to avoid Hive ExecMapper.getDone() check

### DIFF
--- a/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/DelegateSymlinkTextInputFormat.java
+++ b/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/DelegateSymlinkTextInputFormat.java
@@ -99,6 +99,11 @@ public class DelegateSymlinkTextInputFormat extends SymlinkTextInputFormat {
     DelegateSymlinkTextInputSplit delegateSplit = (DelegateSymlinkTextInputSplit) split;
     InputSplit targetSplit = ((SymlinkTextInputSplit) delegateSplit.getSplit()).getTargetSplit();
 
+    // SPARK-40815: the code is derived from
+    // https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/io/SymlinkTextInputFormat.java
+    // However, we use the TextInputFormat record reader directly without HiveRecordReader to avoid
+    // ExecMapper.getDone() checks.
+
     // The target data is in TextInputFormat.
     TextInputFormat inputFormat = new TextInputFormat();
     inputFormat.configure(job);

--- a/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/DelegateSymlinkTextInputFormat.java
+++ b/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/DelegateSymlinkTextInputFormat.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapred.TextInputFormat;
 
 /**
  * Delegate for SymlinkTextInputFormat, created to address SPARK-40815.
@@ -95,8 +96,13 @@ public class DelegateSymlinkTextInputFormat extends SymlinkTextInputFormat {
   @Override
   public RecordReader<LongWritable, Text> getRecordReader(
       InputSplit split, JobConf job, Reporter reporter) throws IOException {
-    InputSplit targetSplit = ((DelegateSymlinkTextInputSplit) split).getSplit();
-    return super.getRecordReader(targetSplit, job, reporter);
+    DelegateSymlinkTextInputSplit delegateSplit = (DelegateSymlinkTextInputSplit) split;
+    InputSplit targetSplit = ((SymlinkTextInputSplit) delegateSplit.getSplit()).getTargetSplit();
+
+    // The target data is in TextInputFormat.
+    TextInputFormat inputFormat = new TextInputFormat();
+    inputFormat.configure(job);
+    return inputFormat.getRecordReader(targetSplit, job, reporter);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Follow-up for https://github.com/apache/spark/pull/38504.

This PR fixes an issue where a unit test for SymlinkTextInputFormat would fail in JDK 11. The fix is to return the record reader directly instead of wrapping it with `HiveRecordReader`.

The issue could be reproduced by running a test right before SPARK-40815 tests with JDK 11 and appears to be related to `ExecMapper.getDone()` (https://github.com/apache/hive/blob/branch-2.3/ql/src/java/org/apache/hadoop/hive/ql/io/HiveRecordReader.java#L76). This check is for a static variable that is set when the map job is done to limit results. Note that there is no synchronisation around `getDone()` or `setDone()`, it is just a static mutable variable.

Once that is set, the record reader returns 0 records. I don't know why it works in JDK 8 but not in JDK 11 but my current suspicion is something related to class loader in JDK similar to this patch: https://github.com/apache/hive/commit/a234475faa2cab2606f2a74eb9ca071f006998e2 (maybe this is the fix but I was not able to verify).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Re-enables the test and fixes an issue with DelegateSymlinkTextInputFormat returning 0 records. Note that this is still an issue with SymlinkTextInputFormat as this needs to be addressed in Hive.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I re-enabled the unit tests that used to fail in JDK 11 and extended a test to cover LIMIT.