### PR TITLE
[MINOR][DOCS] Fix links in the sql-pyspark-pandas-with-arrow

### DIFF
--- a/docs/sql-pyspark-pandas-with-arrow.md
+++ b/docs/sql-pyspark-pandas-with-arrow.md
@@ -19,4 +19,4 @@ license: |
   limitations under the License.
 ---
 
-The Arrow usage guide is now archived on [this page](https://spark.apache.org/docs/latest/api/python/user_guide/arrow_pandas.html).
+The Arrow usage guide is now archived on [this page](https://spark.apache.org/docs/latest/api/python/user_guide/sql/arrow_pandas.html).


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix links in the sql-pyspark-pandas-with-arrow.

### Why are the changes needed?
https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html
<img width="696" alt="image" src="https://user-images.githubusercontent.com/15246973/200457446-250e8c9b-3712-4e79-b6e9-6bdabf322206.png">

when click [this page](https://spark.apache.org/docs/latest/api/python/user_guide/arrow_pandas.html), will jump to https://spark.apache.org/docs/latest/api/python/user_guide/arrow_pandas.html, as follow:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/15246973/200457489-2561b9df-3107-4e19-960d-881f31851f82.png">


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually verified.
