### PR TITLE
[SPARK-40663][SQL][FOLLOWUP] `SparkIllegalArgumentException` should accept `cause`

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -258,9 +258,10 @@ private[spark] class SparkIllegalArgumentException(
     errorClass: String,
     messageParameters: Map[String, String],
     context: Array[QueryContext] = Array.empty,
-    summary: String = "")
+    summary: String = "",
+    cause: Throwable = null)
   extends IllegalArgumentException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters, summary))
+    SparkThrowableHelper.getMessage(errorClass, messageParameters, summary), cause)
   with SparkThrowable {
 
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -367,7 +367,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "_LEGACY_ERROR_TEMP_2008",
       messageParameters = Map(
         "url" -> url.toString,
-        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)))
+        "ansiConfig" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+      cause = e)
   }
 
   def illegalUrlError(url: UTF8String): Throwable = {
@@ -1226,7 +1227,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       stats: String, e: NumberFormatException): SparkIllegalArgumentException = {
     new SparkIllegalArgumentException(
       errorClass = "_LEGACY_ERROR_TEMP_2113",
-      messageParameters = Map("stats" -> stats))
+      messageParameters = Map("stats" -> stats),
+      cause = e)
   }
 
   def statisticNotRecognizedError(stats: String): SparkIllegalArgumentException = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable `SparkIllegalArgumentException` accept `cause` parameter.

### Why are the changes needed?

The original error message generated by `IllegalArgumentException` can accept the `cause` parameter, but `SparkIllegalArgumentException` cannot, so there it some regression was made that we should enable back.

e.g. https://github.com/apache/spark/pull/38123/files#r1014645753


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

```
./build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite*"
```