### PR TITLE
[SPARK-41039][BUILD] Upgrade `scala-parallel-collections` to 1.0.4 for Scala 2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
         <artifactId>scala-parallel-collections_${scala.binary.version}</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
       </dependency>
       --><!-- #endif scala-2.13 -->
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `scala-parallel-collections` from 1.0.3 to 1.0.4 for Scala 2.13


### Why are the changes needed?
`scala-parallel-collections` started from version 1.0.4 to verify the compatibility of [Java 17 through CI](https://github.com/scala/scala-parallel-collections/pull/187), the release notes and full change as follows:

- https://github.com/scala/scala-parallel-collections/releases/tag/v1.0.4
- https://github.com/scala/scala-parallel-collections/compare/v1.0.3...v1.0.4


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Manually check Scala UTs with Scala 2.13 and this pr, passed


