### PR TITLE
[SPARK-41042][SQL] Rename `PARSE_CHAR_MISSING_LENGTH` to `DATATYPE_MISSING_SIZE`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -392,6 +392,12 @@
       }
     }
   },
+  "DATATYPE_MISSING_SIZE" : {
+    "message" : [
+      "DataType <type> requires a length parameter, for example <type>(10). Please specify the length."
+    ],
+    "sqlState" : "42000"
+  },
   "DATETIME_OVERFLOW" : {
     "message" : [
       "Datetime operation overflow: <operation>."
@@ -772,12 +778,6 @@
     "message" : [
       "Out of decimal type range: <value>."
     ]
-  },
-  "PARSE_CHAR_MISSING_LENGTH" : {
-    "message" : [
-      "DataType <type> requires a length parameter, for example <type>(10). Please specify the length."
-    ],
-    "sqlState" : "42000"
   },
   "PARSE_EMPTY_STATEMENT" : {
     "message" : [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -299,7 +299,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def charTypeMissingLengthError(dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {
     new ParseException(
-      errorClass = "PARSE_CHAR_MISSING_LENGTH",
+      errorClass = "DATATYPE_MISSING_SIZE",
       messageParameters = Map("type" -> toSQLType(dataType)),
       ctx)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
@@ -271,17 +271,17 @@ class ErrorParserSuite extends AnalysisTest {
     // special handling on char and varchar
     checkError(
       exception = parseException("SELECT cast('a' as CHAR)"),
-      errorClass = "PARSE_CHAR_MISSING_LENGTH",
+      errorClass = "DATATYPE_MISSING_SIZE",
       parameters = Map("type" -> "\"CHAR\""),
       context = ExpectedContext(fragment = "CHAR", start = 19, stop = 22))
     checkError(
       exception = parseException("SELECT cast('a' as Varchar)"),
-      errorClass = "PARSE_CHAR_MISSING_LENGTH",
+      errorClass = "DATATYPE_MISSING_SIZE",
       parameters = Map("type" -> "\"VARCHAR\""),
       context = ExpectedContext(fragment = "Varchar", start = 19, stop = 25))
     checkError(
       exception = parseException("SELECT cast('a' as Character)"),
-      errorClass = "PARSE_CHAR_MISSING_LENGTH",
+      errorClass = "DATATYPE_MISSING_SIZE",
       parameters = Map("type" -> "\"CHARACTER\""),
       context = ExpectedContext(fragment = "Character", start = 19, stop = 27))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename `PARSE_CHAR_MISSING_LENGTH` to `DATATYPE_MISSING_SIZE`


### Why are the changes needed?

The error class name is specific to `CHAR`, but we get <type> as a parameter in this error class.

The error class should cover more general and have clear name, such as the future types beyond `CHAR`.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

```
./build/sbt “sql/testOnly org.apache.spark.sql.SQLQueryTestSuite*”
```