### PR TITLE
[SPARK-41051][CORE] Optimize ProcfsMetrics file acquisition

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -170,7 +170,7 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
     try {
       val pidDir = new File(procfsDir, pid.toString)
       def openReader(): BufferedReader = {
-        val f = new File(new File(procfsDir, pid.toString), procfsStatFile)
+        val f = new File(pidDir, procfsStatFile)
         new BufferedReader(new InputStreamReader(new FileInputStream(f), UTF_8))
       }
       Utils.tryWithResource(openReader) { in =>


### PR DESCRIPTION
What changes were proposed in this pull request?
Reuse variables from declared procfs files instead of duplicate code

Why are the changes needed?
The cost of looking up the config is often insignificant, but there
reduce some duplicate code

Does this PR introduce any user-facing change?
No.

How was this patch tested?
Existing unit tests.

Closes #41051 from sus/[SPARK-41051](https://issues.apache.org/jira/browse/SPARK-41051).