### PR TITLE
[SPARK-41054][UI][CORE] Support RocksDB as KVStore in live UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -71,8 +71,8 @@ private[spark] object Status {
       .booleanConf
       .createWithDefault(false)
 
-  val LOCAL_STORE_DIR = ConfigBuilder("spark.ui.store.path")
-    .doc("Local directory where to cache application information. By default this is " +
+  val LIVE_UI_LOCAL_STORE_DIR = ConfigBuilder("spark.ui.store.path")
+    .doc("Local directory where to cache application information for live UI. By default this is " +
       "not set, meaning all application information will be kept in memory.")
     .version("3.4.0")
     .stringConf

--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -70,4 +70,11 @@ private[spark] object Status {
       .version("3.0.0")
       .booleanConf
       .createWithDefault(false)
+
+  val LOCAL_STORE_DIR = ConfigBuilder("spark.ui.store.path")
+    .doc("Local directory where to cache application information. By default this is " +
+      "not set, meaning all application information will be kept in memory.")
+    .version("3.4.0")
+    .stringConf
+    .createOptional
 }

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -17,17 +17,20 @@
 
 package org.apache.spark.status
 
+import java.io.File
 import java.util.{List => JList}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.HashMap
 
 import org.apache.spark.{JobExecutionStatus, SparkConf, SparkContext}
+import org.apache.spark.internal.config.History.HybridStoreDiskBackend
+import org.apache.spark.internal.config.Status.LIVE_UI_LOCAL_STORE_DIR
 import org.apache.spark.status.api.v1
 import org.apache.spark.storage.FallbackStorage.FALLBACK_BLOCK_MANAGER_ID
 import org.apache.spark.ui.scope._
 import org.apache.spark.util.Utils
-import org.apache.spark.util.kvstore.{InMemoryStore, KVStore}
+import org.apache.spark.util.kvstore.KVStore
 
 /**
  * A wrapper around a KVStore that provides methods for accessing the API data stored within.
@@ -769,7 +772,14 @@ private[spark] object AppStatusStore {
   def createLiveStore(
       conf: SparkConf,
       appStatusSource: Option[AppStatusSource] = None): AppStatusStore = {
-    val store = new ElementTrackingStore(new InMemoryStore(), conf)
+    val storePath = conf.get(LIVE_UI_LOCAL_STORE_DIR).map(new File(_))
+    // For the disk-based KV store of live UI, let's simply make it ROCKSDB only for now,
+    // instead of supporting both LevelDB and RocksDB. RocksDB is built based on LevelDB with
+    // improvements on writes and reads. Furthermore, we can reuse the RocksDBFileManager in
+    // streaming for replicating the local RocksDB file to DFS. The replication in DFS can be
+    // used for Spark history server.
+    val kvStore = KVUtils.createKVStore(storePath, HybridStoreDiskBackend.ROCKSDB, conf)
+    val store = new ElementTrackingStore(kvStore, conf)
     val listener = new AppStatusListener(store, conf, true, appStatusSource)
     new AppStatusStore(store, listener = Some(listener))
   }

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -775,9 +775,7 @@ private[spark] object AppStatusStore {
     val storePath = conf.get(LIVE_UI_LOCAL_STORE_DIR).map(new File(_))
     // For the disk-based KV store of live UI, let's simply make it ROCKSDB only for now,
     // instead of supporting both LevelDB and RocksDB. RocksDB is built based on LevelDB with
-    // improvements on writes and reads. Furthermore, we can reuse the RocksDBFileManager in
-    // streaming for replicating the local RocksDB file to DFS. The replication in DFS can be
-    // used for Spark history server.
+    // improvements on writes and reads.
     val kvStore = KVUtils.createKVStore(storePath, HybridStoreDiskBackend.ROCKSDB, conf)
     val store = new ElementTrackingStore(kvStore, conf)
     val listener = new AppStatusListener(store, conf, true, appStatusSource)

--- a/core/src/main/scala/org/apache/spark/status/KVUtils.scala
+++ b/core/src/main/scala/org/apache/spark/status/KVUtils.scala
@@ -102,7 +102,6 @@ private[spark] object KVUtils extends Logging {
       val dbPath = Files.createDirectories(new File(path, dir).toPath()).toFile()
       Utils.chmod700(dbPath)
 
-
       val metadata = FsHistoryProviderMetadata(
         FsHistoryProvider.CURRENT_LISTING_VERSION,
         AppStatusStore.CURRENT_VERSION,

--- a/core/src/main/scala/org/apache/spark/status/KVUtils.scala
+++ b/core/src/main/scala/org/apache/spark/status/KVUtils.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.status
 
 import java.io.File
+import java.nio.file.Files
 
 import scala.annotation.meta.getter
 import scala.collection.JavaConverters._
@@ -25,9 +26,13 @@ import scala.reflect.{classTag, ClassTag}
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.fusesource.leveldbjni.internal.NativeDB
+import org.rocksdb.RocksDBException
 
 import org.apache.spark.SparkConf
+import org.apache.spark.deploy.history.{FsHistoryProvider, FsHistoryProviderMetadata}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.History
 import org.apache.spark.internal.config.History.HYBRID_STORE_DISK_BACKEND
 import org.apache.spark.internal.config.History.HybridStoreDiskBackend
 import org.apache.spark.internal.config.History.HybridStoreDiskBackend._
@@ -62,10 +67,14 @@ private[spark] object KVUtils extends Logging {
    *                 the store's metadata.
    * @param conf SparkConf use to get `HYBRID_STORE_DISK_BACKEND`
    */
-  def open[M: ClassTag](path: File, metadata: M, conf: SparkConf): KVStore = {
+  def open[M: ClassTag](
+      path: File,
+      metadata: M,
+      conf: SparkConf,
+      diskBackend: Option[HybridStoreDiskBackend.Value] = None): KVStore = {
     require(metadata != null, "Metadata is required.")
 
-    val db = backend(conf) match {
+    val db = diskBackend.getOrElse(backend(conf)) match {
       case LEVELDB => new LevelDB(path, new KVStoreScalaSerializer())
       case ROCKSDB => new RocksDB(path, new KVStoreScalaSerializer())
     }
@@ -78,6 +87,44 @@ private[spark] object KVUtils extends Logging {
     }
 
     db
+  }
+
+  def createKVStore(
+      storePath: Option[File],
+      diskBackend: HybridStoreDiskBackend.Value,
+      conf: SparkConf): KVStore = {
+    storePath.map { path =>
+      val dir = diskBackend match {
+        case LEVELDB => "listing.ldb"
+        case ROCKSDB => "listing.rdb"
+      }
+
+      val dbPath = Files.createDirectories(new File(path, dir).toPath()).toFile()
+      Utils.chmod700(dbPath)
+
+
+      val metadata = FsHistoryProviderMetadata(
+        FsHistoryProvider.CURRENT_LISTING_VERSION,
+        AppStatusStore.CURRENT_VERSION,
+        conf.get(History.HISTORY_LOG_DIR))
+
+      try {
+        open(dbPath, metadata, conf, Some(diskBackend))
+      } catch {
+        // If there's an error, remove the listing database and any existing UI database
+        // from the store directory, since it's extremely likely that they'll all contain
+        // incompatible information.
+        case _: UnsupportedStoreVersionException | _: MetadataMismatchException =>
+          logInfo("Detected incompatible DB versions, deleting...")
+          path.listFiles().foreach(Utils.deleteRecursively)
+          open(dbPath, metadata, conf, Some(diskBackend))
+        case dbExc @ (_: NativeDB.DBException | _: RocksDBException) =>
+          // Get rid of the corrupted data and re-create it.
+          logWarning(s"Failed to load disk store $dbPath :", dbExc)
+          Utils.deleteRecursively(dbPath)
+          open(dbPath, metadata, conf, Some(diskBackend))
+      }
+    }.getOrElse(new InMemoryStore())
   }
 
   /** Turns a KVStoreView into a Scala sequence, applying a filter. */

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1380,6 +1380,15 @@ Apart from these, the following properties are also available, and may be useful
   <td>1.1.1</td>
 </tr>
 <tr>
+  <td><code>spark.ui.store.path</code></td>
+  <td>None</td>
+  <td>
+    Local directory where to cache application information for live UI.
+    By default this is not set, meaning all application information will be kept in memory.
+  </td>
+  <td>3.4.0</td>
+</tr>
+<tr>
   <td><code>spark.ui.killEnabled</code></td>
   <td>true</td>
   <td>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support using RocksDB as the KVStore in live UI. The location of RocksDB can be set via configuration `spark.ui.store.path`. The configuration is optional. The default KV store will still be in memory.

Note: let's make it ROCKSDB only for now instead of supporting both LevelDB and RocksDB. RocksDB is built based on LevelDB with improvements on writes and reads. Furthermore, we can reuse the RocksDBFileManager in streaming for replicating the local RocksDB file to DFS. The replication in DFS can be used for the Spark history server.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The current architecture of Spark live UI and Spark history server(SHS) is too simple to serve large clusters and heavy workloads:

- Spark stores all the live UI date in memory. The size can be a few GBs and affects the driver's stability (OOM). 
- There is a limitation of storing 1000 queries only. Note that we can’t simply increase the limitation under the current Architecture. I did a memory profiling. Storing one query execution detail can take 800KB while storing one task requires 0.3KB. So for 1000 SQL queries with 1000* 2000 tasks, the memory usage for query execution and task data will be 1.4GB. Spark UI stores UI data for jobs/stages/executors as well.  So to store 10k queries, it may take more than 14GB.
- SHS has to parse JSON format event log for the initial start.  The uncompressed event logs can be as big as a few GBs, and the parse can be quite slow. Some users reported they had to wait for more than half an hour.

With RocksDB as KVStore, we can improve the stability of Spark driver and fasten the startup of SHS.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, supporting RocksDB as the KVStore in live UI. The location of RocksDB can be set via configuration `spark.ui.store.path`. The configuration is optional. The default KV store will still be in memory.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT
Preview of the doc change:
<img width="895" alt="image" src="https://user-images.githubusercontent.com/1097932/203184691-b6815990-b7b0-422b-aded-8e1771c0c167.png">
