### PR TITLE
[SPARK-41056][R] Fix new R_LIBS_SITE behavior introduced in R 4.2

### DIFF
--- a/core/src/test/scala/org/apache/spark/api/r/BaseRRunnerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/r/BaseRRunnerSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.r
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.TestUtils.testCommandAvailable
+import org.apache.spark.internal.config.R.SPARKR_COMMAND
+
+class BaseRRunnerSuite extends SparkFunSuite {
+  test("Retrieve R options from R command") {
+    val rCommand = SPARKR_COMMAND.defaultValue.get
+    assume(testCommandAvailable(rCommand))
+    assert(BaseRRunner.getROptions(rCommand) === "--no-restore"
+      || BaseRRunner.getROptions(rCommand) === "--vanilla")
+  }
+
+  test("Should return the default value if the R command does not exist") {
+    assume(!testCommandAvailable("nonexistent"))
+    assert(BaseRRunner.getROptions("nonexistent") === "--vanilla")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to keep the `R_LIBS_SITE` as was. It has been changed from R 4.2.

### Why are the changes needed?

To keep the behaviour same as the previous. This especially affects the external libraries installed in SparkR worker sides. Especially this can break the user-installed libraries. See the paths below:

**R 4.2**

```r
# R
> Sys.getenv("R_LIBS_SITE")
[1] "/usr/local/lib/R/site-library/:/usr/lib/R/site-library:/usr/lib/R/library'"
# R --vanilla
> Sys.getenv("R_LIBS_SITE")
[1] "/usr/lib/R/site-library"
```

**R 4.1**

```r
# R
> Sys.getenv("R_LIBS_SITE")
[1] "/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library"
# R --vanilla
> Sys.getenv("R_LIBS_SITE")
[1] "/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library"
```

### Does this PR introduce _any_ user-facing change?

Yes. With R 4.2, user-installed libraries won't be found in SparkR workers.

### How was this patch tested?

Manually tested, unittest added. It's difficult to add an e2e tests.

I also manually tested `getROptions` in Scala shall.