### PR TITLE
[SPARK-37555][TEST][FOLLOWUP] Increase timeout of CLI test `spark-sql should pass last unclosed comment to backend`

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -626,7 +626,7 @@ class CliSuite extends SparkFunSuite {
   }
 
   test("SPARK-37555: spark-sql should pass last unclosed comment to backend") {
-    runCliWithin(2.minute)(
+    runCliWithin(5.minute)(
       // Only unclosed comment.
       "/* SELECT /*+ HINT() 4; */;".stripMargin -> "Syntax error at or near ';'",
       // Unclosed nested bracketed comment.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix flaky test  `spark-sql should pass last unclosed comment to backend`,
it's timeout should be caused by unstable GA env, so I increase timeout time for the test


### Why are the changes needed?
Fix flaky test.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not need
