### PR TITLE
[SPARK-41060][K8S] Fix generating driver and executor Config Maps

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -101,7 +101,7 @@ private[spark] class BasicExecutorFeatureStep(
 
   override def configurePod(pod: SparkPod): SparkPod = {
     val name = s"$executorPodNamePrefix-exec-${kubernetesConf.executorId}"
-    val configMapName = KubernetesClientUtils.configMapNameExecutor
+    val configMapName = KubernetesClientUtils.configMapNameExecutor()
     val confFilesMap = KubernetesClientUtils
       .buildSparkConfDirFilesMap(configMapName, kubernetesConf.sparkConf, Map.empty)
     val keyToPaths = KubernetesClientUtils.buildKeyToPathObjects(confFilesMap)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -102,7 +102,7 @@ private[spark] class Client(
 
   def run(): Unit = {
     val resolvedDriverSpec = builder.buildFromFeatures(conf, kubernetesClient)
-    val configMapName = KubernetesClientUtils.configMapNameDriver
+    val configMapName = KubernetesClientUtils.configMapNameDriver()
     val confFilesMap = KubernetesClientUtils.buildSparkConfDirFilesMap(configMapName,
       conf.sparkConf, resolvedDriverSpec.systemProperties)
     val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -179,4 +179,3 @@ private[spark] object KubernetesClientUtils extends Logging {
     confFiles
   }
 }
-

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -36,14 +36,14 @@ import org.apache.spark.internal.Logging
 private[spark] object KubernetesClientUtils extends Logging {
 
   // Config map name can be KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH chars at max.
-  def configMapName(prefix: String): String = {
+  private def configMapName(prefix: String): String = {
     val suffix = "-conf-map"
     s"${prefix.take(KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH - suffix.length)}$suffix"
   }
 
-  val configMapNameExecutor: String = configMapName(s"spark-exec-${KubernetesUtils.uniqueID()}")
+  def configMapNameExecutor(): String = configMapName(s"spark-exec-${KubernetesUtils.uniqueID()}")
 
-  val configMapNameDriver: String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
+  def configMapNameDriver(): String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
 
   private def buildStringFromPropertiesMap(configMapName: String,
       propertiesMap: Map[String, String]): String = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -179,3 +179,4 @@ private[spark] object KubernetesClientUtils extends Logging {
     confFiles
   }
 }
+

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -76,7 +76,7 @@ private[spark] class KubernetesClusterSchedulerBackend(
   }
 
   private def setUpExecutorConfigMap(driverPod: Option[Pod]): Unit = {
-    val configMapName = KubernetesClientUtils.configMapNameExecutor
+    val configMapName = KubernetesClientUtils.configMapNameExecutor()
     val resolvedExecutorProperties =
       Map(KUBERNETES_NAMESPACE.key -> namespace)
     val confFilesMap = KubernetesClientUtils

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -486,18 +486,12 @@ class KubernetesSuite extends SparkFunSuite
 
     Eventually.eventually(patienceTimeout, patienceInterval) {
       expectedDriverLogOnCompletion.foreach { e =>
-        if (kubernetesTestComponents.kubernetesClient
+        // scalastyle:off println
+        println(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(driverPod.getMetadata.getName)
-          .getLog
-          .contains(e)) {
-          // scalastyle:off println
-          println(kubernetesTestComponents.kubernetesClient
-            .pods()
-            .withName(driverPod.getMetadata.getName)
-            .getLog)
-          // scalastyle:on println
-        }
+          .getLog)
+        // scalastyle:on println
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(driverPod.getMetadata.getName)
@@ -506,18 +500,12 @@ class KubernetesSuite extends SparkFunSuite
           s"The application did not complete, driver log did not contain str ${e}")
       }
       expectedExecutorLogOnCompletion.foreach { e =>
-        if (kubernetesTestComponents.kubernetesClient
+        // scalastyle:off println
+        println(kubernetesTestComponents.kubernetesClient
           .pods()
-          .withName(execPod.get.getMetadata.getName)
-          .getLog
-          .contains(e)) {
-          // scalastyle:off println
-          println(kubernetesTestComponents.kubernetesClient
-            .pods()
-            .withName(driverPod.getMetadata.getName)
-            .getLog)
-          // scalastyle:on println
-        }
+          .withName(driverPod.getMetadata.getName)
+          .getLog)
+        // scalastyle:on println
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(execPod.get.getMetadata.getName)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -486,12 +486,18 @@ class KubernetesSuite extends SparkFunSuite
 
     Eventually.eventually(patienceTimeout, patienceInterval) {
       expectedDriverLogOnCompletion.foreach { e =>
-        // scalastyle:off println
-        println(kubernetesTestComponents.kubernetesClient
+        if (kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(driverPod.getMetadata.getName)
-          .getLog)
-        // scalastyle:on println
+          .getLog
+          .contains(e)) {
+          // scalastyle:off println
+          println(kubernetesTestComponents.kubernetesClient
+            .pods()
+            .withName(driverPod.getMetadata.getName)
+            .getLog)
+          // scalastyle:on println
+        }
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(driverPod.getMetadata.getName)
@@ -500,12 +506,18 @@ class KubernetesSuite extends SparkFunSuite
           s"The application did not complete, driver log did not contain str ${e}")
       }
       expectedExecutorLogOnCompletion.foreach { e =>
-        // scalastyle:off println
-        println(kubernetesTestComponents.kubernetesClient
+        if (kubernetesTestComponents.kubernetesClient
           .pods()
-          .withName(driverPod.getMetadata.getName)
-          .getLog)
-        // scalastyle:on println
+          .withName(execPod.get.getMetadata.getName)
+          .getLog
+          .contains(e)) {
+          // scalastyle:off println
+          println(kubernetesTestComponents.kubernetesClient
+            .pods()
+            .withName(driverPod.getMetadata.getName)
+            .getLog)
+          // scalastyle:on println
+        }
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(execPod.get.getMetadata.getName)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -486,6 +486,12 @@ class KubernetesSuite extends SparkFunSuite
 
     Eventually.eventually(patienceTimeout, patienceInterval) {
       expectedDriverLogOnCompletion.foreach { e =>
+        // scalastyle:off println
+        println(kubernetesTestComponents.kubernetesClient
+          .pods()
+          .withName(driverPod.getMetadata.getName)
+          .getLog)
+        // scalastyle:on println
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(driverPod.getMetadata.getName)
@@ -494,6 +500,12 @@ class KubernetesSuite extends SparkFunSuite
           s"The application did not complete, driver log did not contain str ${e}")
       }
       expectedExecutorLogOnCompletion.foreach { e =>
+        // scalastyle:off println
+        println(kubernetesTestComponents.kubernetesClient
+          .pods()
+          .withName(driverPod.getMetadata.getName)
+          .getLog)
+        // scalastyle:on println
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(execPod.get.getMetadata.getName)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -486,12 +486,6 @@ class KubernetesSuite extends SparkFunSuite
 
     Eventually.eventually(patienceTimeout, patienceInterval) {
       expectedDriverLogOnCompletion.foreach { e =>
-        // scalastyle:off println
-        println(kubernetesTestComponents.kubernetesClient
-          .pods()
-          .withName(driverPod.getMetadata.getName)
-          .getLog)
-        // scalastyle:on println
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(driverPod.getMetadata.getName)
@@ -500,12 +494,6 @@ class KubernetesSuite extends SparkFunSuite
           s"The application did not complete, driver log did not contain str ${e}")
       }
       expectedExecutorLogOnCompletion.foreach { e =>
-        // scalastyle:off println
-        println(kubernetesTestComponents.kubernetesClient
-          .pods()
-          .withName(driverPod.getMetadata.getName)
-          .getLog)
-        // scalastyle:on println
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
           .withName(execPod.get.getMetadata.getName)


### PR DESCRIPTION
### What changes were proposed in this pull request?
There's a problem with submitting spark jobs to K8s cluster: the library generates and reuses the same name for config maps (for drivers and executors). Ideally, for each job 2 config maps should be created: for a driver and an executor. However, the library creates only one driver config map for all jobs (in some cases it generates only one executor map for all jobs in the same manner). So, if I run 5 jobs, then only one driver config map will be generated and used for every job. During those runs we experience issues when deleting pods from the cluster: executors pods are endlessly created and immediately terminated overloading cluster resources.

This problem occurs because of the **KubernetesClientUtils** class in which we have **configMapNameExecutor** and **configMapNameDriver** as constants. It seems to be incorrect and should be urgently fixed. I've prepared some changes for review to fix the issue (turned the constants into the methods) (tested in the cluster of our project).


### Why are the changes needed?
To make the spark submitter generate new names for driver and executor config maps to let jobs complete successfully, not overloading cluster resources.


### Does this PR introduce _any_ user-facing change?
Executors pods should stop being generated and terminated endlessly.


### How was this patch tested?
Modified the unit tests in the module. Tested with the unit tests and by submitting jobs to the K8S cluster of our project.