### PR TITLE
[SPARK-41071][BUILD] Remove `MaxMetaspaceSize` option from `make-distribution.sh` to make it run successfully

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -161,7 +161,7 @@ fi
 # Build uber fat JAR
 cd "$SPARK_HOME"
 
-export MAVEN_OPTS="${MAVEN_OPTS:--Xss128m -Xmx4g -Xmx4g -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=128m}"
+export MAVEN_OPTS="${MAVEN_OPTS:--Xss128m -Xmx4g -Xmx4g -XX:ReservedCodeCacheSize=128m}"
 
 # Store the command as an array because $MVN variable might have spaces in it.
 # Normal quoting tricks don't work.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Run 

```
dev/make-distribution.sh --tgz -Phadoop-3 -Phadoop-cloud -Pmesos -Pyarn -Pkinesis-asl -Phive-thriftserver -Pspark-ganglia-lgpl -Pkubernetes -Phive  
```

on the master branch fails as follows:

```
[ERROR] ## Exception when compiling 19 sources to /spark-source/connector/avro/target/scala-2.12/classes
java.lang.OutOfMemoryError: Metaspace
java.lang.ClassLoader.defineClass1(Native Method)
java.lang.ClassLoader.defineClass(ClassLoader.java:757)
java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
java.net.URLClassLoader.access$100(URLClassLoader.java:74)
java.net.URLClassLoader$1.run(URLClassLoader.java:369)
java.net.URLClassLoader$1.run(URLClassLoader.java:363)
java.security.AccessController.doPrivileged(Native Method)
java.net.URLClassLoader.findClass(URLClassLoader.java:362)
java.lang.ClassLoader.loadClass(ClassLoader.java:419)
scala_maven.ScalaCompilerLoader.loadClass(ScalaCompilerLoader.java:44)
java.lang.ClassLoader.loadClass(ClassLoader.java:352)
scala.collection.immutable.Set$Set2.$plus(Set.scala:170)
scala.collection.immutable.Set$Set2.$plus(Set.scala:164)
scala.collection.mutable.SetBuilder.$plus$eq(SetBuilder.scala:28)
scala.collection.mutable.SetBuilder.$plus$eq(SetBuilder.scala:24)
scala.collection.TraversableLike$grouper$1$.apply(TraversableLike.scala:467)
scala.collection.TraversableLike$grouper$1$.apply(TraversableLike.scala:455)
scala.collection.mutable.HashMap$$anon$1.$anonfun$foreach$2(HashMap.scala:153)
scala.collection.mutable.HashMap$$anon$1$$Lambda$68804/294594059.apply(Unknown Source)
scala.collection.mutable.HashTable.foreachEntry(HashTable.scala:237)
scala.collection.mutable.HashTable.foreachEntry$(HashTable.scala:230)
scala.collection.mutable.HashMap.foreachEntry(HashMap.scala:44)
scala.collection.mutable.HashMap$$anon$1.foreach(HashMap.scala:153)
scala.collection.TraversableLike.groupBy(TraversableLike.scala:524)
scala.collection.TraversableLike.groupBy$(TraversableLike.scala:454)
scala.collection.AbstractTraversable.groupBy(Traversable.scala:108)
scala.tools.nsc.settings.Warnings.$init$(Warnings.scala:91)
scala.tools.nsc.settings.MutableSettings.<init>(MutableSettings.scala:28)
scala.tools.nsc.Settings.<init>(Settings.scala:19)
scala.tools.nsc.Settings.<init>(Settings.scala:20)
xsbt.CachedCompiler0.<init>(CompilerBridge.scala:79) 
```

So this pr remove `MaxMetaspaceSize` option  from `make-distribution.sh` to make `MaxMetaspaceSize` can use more memory resources and make `make-distribution.sh` run successfully.


### Why are the changes needed?
Make `make-distribution.sh`  run successfully.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test:


```
dev/make-distribution.sh --tgz -Phadoop-3 -Phadoop-cloud -Pmesos -Pyarn -Pkinesis-asl -Phive-thriftserver -Pspark-ganglia-lgpl -Pkubernetes -Phive  
```

- Before: java.lang.OutOfMemoryError: Metaspace
- After: successfully

