### PR TITLE
[SPARK-41074][DOC] Add option `--upgrade` in dependency installation command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ See also https://issues.apache.org/jira/browse/SPARK-35375.
 -->
 Run the following command from $SPARK_HOME:
 ```sh
-$ sudo pip install -r dev/requirements.txt
+$ sudo pip install --upgrade -r dev/requirements.txt
 ```
 
 ### R API Documentation (Optional)

--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -130,7 +130,7 @@ If you are using Conda, the development environment can be set as follows.
     # Python 3.7+ is required
     conda create --name pyspark-dev-env python=3.9
     conda activate pyspark-dev-env
-    pip install -r dev/requirements.txt
+    pip install --upgrade -r dev/requirements.txt
 
 Once it is set up, make sure you switch to `pyspark-dev-env` before starting the development:
 
@@ -147,7 +147,7 @@ With Python 3.7+, pip can be used as below to install and set up the development
 
 .. code-block:: bash
 
-    pip install -r dev/requirements.txt
+    pip install --upgrade -r dev/requirements.txt
 
 Now, you can start developing and `running the tests <testing.rst>`_.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add option `--upgrade` in dependency installation command

### Why are the changes needed?

for the packages whose version are not pinned, `pip install -r dev/requirements.txt` can not upgrade them

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
manually check