### PR TITLE
[SPARK-41095][SQL] Convert unresolved operators to internal errors

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -5107,11 +5107,6 @@
       "Invalid expressions: [<invalidExprSqls>]"
     ]
   },
-  "_LEGACY_ERROR_TEMP_2442" : {
-    "message" : [
-      "unresolved operator <operator>"
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2443" : {
     "message" : [
       "Multiple definitions of observed metrics named '<name>': <plan>"

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -68,6 +68,17 @@ class SparkException(
 }
 
 object SparkException {
+  def internalError(msg: String, context: Array[QueryContext]): SparkException = {
+    val errorClass = "INTERNAL_ERROR"
+    val messageParameters = Map("message" -> msg)
+    new SparkException(
+      message = SparkThrowableHelper.getMessage(errorClass, messageParameters),
+      errorClass = Some(errorClass),
+      messageParameters = messageParameters,
+      cause = null,
+      context = context)
+  }
+
   def internalError(msg: String): SparkException = {
     new SparkException(
       errorClass = "INTERNAL_ERROR",

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -68,22 +68,17 @@ class SparkException(
 }
 
 object SparkException {
-  def internalError(msg: String, context: Array[QueryContext]): SparkException = {
-    val errorClass = "INTERNAL_ERROR"
-    val messageParameters = Map("message" -> msg)
-    new SparkException(
-      message = SparkThrowableHelper.getMessage(errorClass, messageParameters),
-      errorClass = Some(errorClass),
-      messageParameters = messageParameters,
-      cause = null,
-      context = context)
-  }
-
-  def internalError(msg: String): SparkException = {
+  def internalError(msg: String, context: Array[QueryContext], summary: String): SparkException = {
     new SparkException(
       errorClass = "INTERNAL_ERROR",
       messageParameters = Map("message" -> msg),
-      cause = null)
+      cause = null,
+      context,
+      summary)
+  }
+
+  def internalError(msg: String): SparkException = {
+    internalError(msg, context = Array.empty[QueryContext], summary = "")
   }
 
   def internalError(msg: String, cause: Throwable): SparkException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -716,7 +716,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
       case o if !o.resolved =>
         throw SparkException.internalError(
           msg = s"Found the unresolved operator: ${o.simpleString(SQLConf.get.maxToStringFields)}",
-          context = o.origin.getQueryContext)
+          context = o.origin.getQueryContext,
+          summary = o.origin.context.summary)
       case _ =>
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import scala.collection.mutable
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.SubExprUtils._
@@ -713,9 +714,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
     extendedCheckRules.foreach(_(plan))
     plan.foreachUp {
       case o if !o.resolved =>
-        o.failAnalysis(
-          errorClass = "_LEGACY_ERROR_TEMP_2442",
-          messageParameters = Map("operator" -> o.simpleString(SQLConf.get.maxToStringFields)))
+        throw SparkException.internalError(
+          msg = s"Found the unresolved operator: ${o.simpleString(SQLConf.get.maxToStringFields)}",
+          context = o.origin.getQueryContext)
       case _ =>
     }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.scalatest.Assertions._
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -382,10 +383,13 @@ class AnalysisErrorSuite extends AnalysisTest {
     Map("fieldName" -> "`c`", "fields" -> "`aField`, `bField`, `cField`"),
     caseSensitive = false)
 
-  errorTest(
-    "catch all unresolved plan",
-    UnresolvedTestPlan(),
-    "unresolved" :: Nil)
+  checkError(
+    exception = intercept[SparkException] {
+      val analyzer = getAnalyzer
+      analyzer.checkAnalysis(analyzer.execute(UnresolvedTestPlan()))
+    },
+    errorClass = "INTERNAL_ERROR",
+    parameters = Map("message" -> "Found the unresolved operator: 'UnresolvedTestPlan"))
 
   errorTest(
     "union with unequal number of columns",


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to interpret the `unresolved operator` issue as an internal error, and throw `SparkException` w/ the error class `INTERNAL_ERROR`.

### Why are the changes needed?
The issues that leads to `unresolved operator` should be solved earlier w/ proper user-facing errors. If we reach the point when we cannot resolve an operator, we should interpret this as Spark SQL internal error.

### Does this PR introduce _any_ user-facing change?
No, in most regular cases.

### How was this patch tested?
By running the affected and modified test suites:
```
$ PYSPARK_PYTHON=python3 build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
$ build/sbt "test:testOnly *AnalysisErrorSuite"
```