### PR TITLE
[SPARK-41076][BUILD][CONNECT] Upgrade `protobuf` to 3.21.9

### DIFF
--- a/connector/protobuf/pom.xml
+++ b/connector/protobuf/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>spark-protobuf_2.12</artifactId>
   <properties>
     <sbt.project.name>protobuf</sbt.project.name>
-    <protobuf.version>3.21.1</protobuf.version>
+    <protobuf.version>3.21.9</protobuf.version>
   </properties>
   <packaging>jar</packaging>
   <name>Spark Protobuf</name>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade protobuf-java from 3.21.1 to 3.21.9
[Release notes](https://github.com/protocolbuffers/protobuf/releases)

### Why are the changes needed?
[CVE-2022-3171](https://nvd.nist.gov/vuln/detail/CVE-2022-3171)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA
