### PR TITLE
[SPARK-41077][CONNECT][PYTHON][REFACTORING] Rename `ColumnRef` to `Column` in Python client implementation

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
 
 def _bin_op(
     name: str, doc: str = "binary function", reverse: bool = False
-) -> Callable[["ColumnRef", Any], "Expression"]:
-    def _(self: "ColumnRef", other: Any) -> "Expression":
+) -> Callable[["Column", Any], "Expression"]:
+    def _(self: "Column", other: Any) -> "Expression":
         if isinstance(other, get_args(PrimitiveType)):
             other = LiteralExpression(other)
         if not reverse:
@@ -163,15 +163,15 @@ class LiteralExpression(Expression):
         return f"Literal({self._value})"
 
 
-class ColumnRef(Expression):
+class Column(Expression):
     """Represents a column reference. There is no guarantee that this column
     actually exists. In the context of this project, we refer by its name and
     treat it as an unresolved attribute. Attributes that have the same fully
     qualified name are identical"""
 
     @classmethod
-    def from_qualified_name(cls, name: str) -> "ColumnRef":
-        return ColumnRef(name)
+    def from_qualified_name(cls, name: str) -> "Column":
+        return Column(name)
 
     def __init__(self, name: str) -> None:
         super().__init__()
@@ -198,7 +198,7 @@ class ColumnRef(Expression):
 
 
 class SortOrder(Expression):
-    def __init__(self, col: ColumnRef, ascending: bool = True, nullsLast: bool = True) -> None:
+    def __init__(self, col: Column, ascending: bool = True, nullsLast: bool = True) -> None:
         super().__init__()
         self.ref = col
         self.ascending = ascending

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -31,7 +31,7 @@ import pandas
 
 import pyspark.sql.connect.plan as plan
 from pyspark.sql.connect.column import (
-    ColumnRef,
+    Column,
     Expression,
     LiteralExpression,
 )
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from pyspark.sql.connect.typing import ColumnOrString, ExpressionOrString
     from pyspark.sql.connect.client import RemoteSparkSession
 
-ColumnOrName = Union[ColumnRef, str]
+ColumnOrName = Union[Column, str]
 
 
 class GroupingFrame(object):
@@ -52,9 +52,9 @@ class GroupingFrame(object):
     MeasuresType = Union[Sequence[Tuple["ExpressionOrString", str]], Dict[str, str]]
     OptMeasuresType = Optional[MeasuresType]
 
-    def __init__(self, df: "DataFrame", *grouping_cols: Union[ColumnRef, str]) -> None:
+    def __init__(self, df: "DataFrame", *grouping_cols: Union[Column, str]) -> None:
         self._df = df
-        self._grouping_cols = [x if isinstance(x, ColumnRef) else df[x] for x in grouping_cols]
+        self._grouping_cols = [x if isinstance(x, Column) else df[x] for x in grouping_cols]
 
     def agg(self, exprs: Optional[MeasuresType] = None) -> "DataFrame":
 
@@ -76,18 +76,18 @@ class GroupingFrame(object):
         )
         return res
 
-    def _map_cols_to_dict(self, fun: str, cols: List[Union[ColumnRef, str]]) -> Dict[str, str]:
+    def _map_cols_to_dict(self, fun: str, cols: List[Union[Column, str]]) -> Dict[str, str]:
         return {x if isinstance(x, str) else x.name(): fun for x in cols}
 
-    def min(self, *cols: Union[ColumnRef, str]) -> "DataFrame":
+    def min(self, *cols: Union[Column, str]) -> "DataFrame":
         expr = self._map_cols_to_dict("min", list(cols))
         return self.agg(expr)
 
-    def max(self, *cols: Union[ColumnRef, str]) -> "DataFrame":
+    def max(self, *cols: Union[Column, str]) -> "DataFrame":
         expr = self._map_cols_to_dict("max", list(cols))
         return self.agg(expr)
 
-    def sum(self, *cols: Union[ColumnRef, str]) -> "DataFrame":
+    def sum(self, *cols: Union[Column, str]) -> "DataFrame":
         expr = self._map_cols_to_dict("sum", list(cols))
         return self.agg(expr)
 
@@ -129,7 +129,7 @@ class DataFrame(object):
     def alias(self, alias: str) -> "DataFrame":
         return DataFrame.withPlan(plan.SubqueryAlias(self._plan, alias), session=self._session)
 
-    def approxQuantile(self, col: ColumnRef, probabilities: Any, relativeError: Any) -> "DataFrame":
+    def approxQuantile(self, col: Column, probabilities: Any, relativeError: Any) -> "DataFrame":
         ...
 
     def colRegex(self, regex: str) -> "DataFrame":
@@ -206,7 +206,7 @@ class DataFrame(object):
             self._session,
         )
 
-    def describe(self, cols: List[ColumnRef]) -> Any:
+    def describe(self, cols: List[Column]) -> Any:
         ...
 
     def dropDuplicates(self, subset: Optional[List[str]] = None) -> "DataFrame":
@@ -250,7 +250,7 @@ class DataFrame(object):
 
     def drop(self, *cols: "ColumnOrString") -> "DataFrame":
         all_cols = self.columns
-        dropped = set([c.name() if isinstance(c, ColumnRef) else self[c].name() for c in cols])
+        dropped = set([c.name() if isinstance(c, Column) else self[c].name() for c in cols])
         dropped_cols = filter(lambda x: x in dropped, all_cols)
         return DataFrame.withPlan(plan.Project(self._plan, *dropped_cols), session=self._session)
 
@@ -320,11 +320,11 @@ class DataFrame(object):
         """
         return self.limit(num).collect()
 
-    # TODO: extend `on` to also be type List[ColumnRef].
+    # TODO: extend `on` to also be type List[Column].
     def join(
         self,
         other: "DataFrame",
-        on: Optional[Union[str, List[str], ColumnRef]] = None,
+        on: Optional[Union[str, List[str], Column]] = None,
         how: Optional[str] = None,
     ) -> "DataFrame":
         if self._plan is None:
@@ -566,16 +566,16 @@ class DataFrame(object):
             p = p._child
         return None
 
-    def __getattr__(self, name: str) -> "ColumnRef":
+    def __getattr__(self, name: str) -> "Column":
         return self[name]
 
-    def __getitem__(self, name: str) -> "ColumnRef":
+    def __getitem__(self, name: str) -> "Column":
         # Check for alias
         alias = self._get_alias()
         if alias is not None:
-            return ColumnRef(alias)
+            return Column(alias)
         else:
-            return ColumnRef(name)
+            return Column(name)
 
     def _print_plan(self) -> str:
         if self._plan:

--- a/python/pyspark/sql/connect/function_builder.py
+++ b/python/pyspark/sql/connect/function_builder.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Optional, Any, Iterable, Union
 import pyspark.sql.connect.proto as proto
 import pyspark.sql.types
 from pyspark.sql.connect.column import (
-    ColumnRef,
+    Column,
     Expression,
     ScalarFunctionExpression,
 )
@@ -45,7 +45,7 @@ def _build(name: str, *args: "ExpressionOrString") -> ScalarFunctionExpression:
     -------
     :class:`ScalarFunctionExpression`
     """
-    cols = [x if isinstance(x, Expression) else ColumnRef.from_qualified_name(x) for x in args]
+    cols = [x if isinstance(x, Expression) else Column.from_qualified_name(x) for x in args]
     return ScalarFunctionExpression(name, *cols)
 
 

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -14,15 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.connect.column import ColumnRef, LiteralExpression
+from pyspark.sql.connect.column import Column, LiteralExpression
 
 from typing import Any
 
 # TODO(SPARK-40538) Add support for the missing PySpark functions.
 
 
-def col(x: str) -> ColumnRef:
-    return ColumnRef(x)
+def col(x: str) -> Column:
+    return Column(x)
 
 
 def lit(x: Any) -> LiteralExpression:

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -28,7 +28,7 @@ from typing import (
 
 import pyspark.sql.connect.proto as proto
 from pyspark.sql.connect.column import (
-    ColumnRef,
+    Column,
     Expression,
     SortOrder,
 )
@@ -64,7 +64,7 @@ class LogicalPlan(object):
         if type(col) is str:
             return self.unresolved_attr(col)
         else:
-            return cast(ColumnRef, col).to_plan(session)
+            return cast(Column, col).to_plan(session)
 
     def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         ...
@@ -360,7 +360,7 @@ class Sort(LogicalPlan):
     def __init__(
         self,
         child: Optional["LogicalPlan"],
-        columns: List[Union[SortOrder, ColumnRef, str]],
+        columns: List[Union[SortOrder, Column, str]],
         is_global: bool,
     ) -> None:
         super().__init__(child)
@@ -368,7 +368,7 @@ class Sort(LogicalPlan):
         self.is_global = is_global
 
     def col_to_sort_field(
-        self, col: Union[SortOrder, ColumnRef, str], session: "RemoteSparkSession"
+        self, col: Union[SortOrder, Column, str], session: "RemoteSparkSession"
     ) -> proto.Sort.SortField:
         if isinstance(col, SortOrder):
             sf = proto.Sort.SortField()
@@ -387,7 +387,7 @@ class Sort(LogicalPlan):
         else:
             sf = proto.Sort.SortField()
             # Check string
-            if isinstance(col, ColumnRef):
+            if isinstance(col, Column):
                 sf.expression.CopyFrom(col.to_plan(session))
             else:
                 sf.expression.CopyFrom(self.unresolved_attr(col))
@@ -478,7 +478,7 @@ class Aggregate(LogicalPlan):
     def __init__(
         self,
         child: Optional["LogicalPlan"],
-        grouping_cols: List[ColumnRef],
+        grouping_cols: List[Column],
         measures: OptMeasuresType,
     ) -> None:
         super().__init__(child)
@@ -532,7 +532,7 @@ class Join(LogicalPlan):
         self,
         left: Optional["LogicalPlan"],
         right: "LogicalPlan",
-        on: Optional[Union[str, List[str], ColumnRef]],
+        on: Optional[Union[str, List[str], Column]],
         how: Optional[str],
     ) -> None:
         super().__init__(left)

--- a/python/pyspark/sql/connect/typing/__init__.pyi
+++ b/python/pyspark/sql/connect/typing/__init__.pyi
@@ -17,12 +17,12 @@
 
 from typing_extensions import Protocol
 from typing import Union
-from pyspark.sql.connect.column import ScalarFunctionExpression, Expression, ColumnRef
+from pyspark.sql.connect.column import ScalarFunctionExpression, Expression, Column
 from pyspark.sql.connect.function_builder import UserDefinedFunction
 
 ExpressionOrString = Union[str, Expression]
 
-ColumnOrString = Union[str, ColumnRef]
+ColumnOrString = Union[str, Column]
 
 class FunctionBuilderCallable(Protocol):
     def __call__(self, *_: ExpressionOrString) -> ScalarFunctionExpression: ...

--- a/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
@@ -36,11 +36,11 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
         df = self.connect.with_plan(p.Read("table"))
 
         c1 = df.col_name
-        self.assertIsInstance(c1, col.ColumnRef)
+        self.assertIsInstance(c1, col.Column)
         c2 = df["col_name"]
-        self.assertIsInstance(c2, col.ColumnRef)
+        self.assertIsInstance(c2, col.Column)
         c3 = fun.col("col_name")
-        self.assertIsInstance(c3, col.ColumnRef)
+        self.assertIsInstance(c3, col.Column)
 
         # All Protos should be identical
         cp1 = c1.to_plan(None)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Connect python client uses `ColumnRef` to represent columns in API (e.g. `df.name`). Current PySpark uses `Class Column` for the same thing. In this case, we can align Connect with PySpark, which can help existing PySpark users to reuse their code for Spark Connect python client as much as possible (minimize the code change).


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is to help existing PySpark users to reuse their code for Spark Connect python client as much as possible (minimize the code change).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT