### PR TITLE
[SPARK-41086][SQL] Consolidate SecondArgumentXXX error to INVALID_PARAMETER_VALUE

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -900,12 +900,6 @@
     ],
     "sqlState" : "42000"
   },
-  "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER" : {
-    "message" : [
-      "The second argument of <functionName> function needs to be an integer."
-    ],
-    "sqlState" : "22023"
-  },
   "STAR_GROUP_BY_POS" : {
     "message" : [
       "Star (*) is not allowed in a select list when GROUP BY an ordinal position is used."
@@ -2109,11 +2103,6 @@
       "Unsupported component type <clz> in arrays."
     ]
   },
-  "_LEGACY_ERROR_TEMP_1104" : {
-    "message" : [
-      "The second argument should be a double literal."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_1105" : {
     "message" : [
       "Field name should be String Literal, but it's <extraction>."
@@ -2631,11 +2620,6 @@
   "_LEGACY_ERROR_TEMP_1209" : {
     "message" : [
       "Ambiguous reference to fields <fields>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1210" : {
-    "message" : [
-      "The second argument in <funcName> should be a boolean literal."
     ]
   },
   "_LEGACY_ERROR_TEMP_1211" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -801,7 +801,8 @@ abstract class TypeCoercionBase {
           Cast(r, IntegerType, ansiEnabled = true).eval().asInstanceOf[Int]
         } catch {
           case e: NumberFormatException =>
-            throw QueryCompilationErrors.secondArgumentOfFunctionIsNotIntegerError("date_add", e)
+            throw QueryCompilationErrors.secondArgumentOfFunctionIsNotIntegerError(
+              "date_add", r.sql, e)
         }
         DateAdd(l, Literal(days))
       case DateSub(l, r) if r.dataType == StringType && r.foldable =>
@@ -809,7 +810,8 @@ abstract class TypeCoercionBase {
           Cast(r, IntegerType, ansiEnabled = true).eval().asInstanceOf[Int]
         } catch {
           case e: NumberFormatException =>
-            throw QueryCompilationErrors.secondArgumentOfFunctionIsNotIntegerError("date_sub", e)
+            throw QueryCompilationErrors.secondArgumentOfFunctionIsNotIntegerError(
+              "date_sub", r.sql, e)
         }
         DateSub(l, Literal(days))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -123,6 +123,6 @@ object FirstLast {
   def validateIgnoreNullExpr(exp: Expression, funcName: String): Boolean = exp match {
     case Literal(b: Boolean, BooleanType) => b
     case _ => throw QueryCompilationErrors.secondArgumentInFunctionIsNotBooleanLiteralError(
-      funcName)
+      funcName, exp.sql)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
@@ -148,6 +148,7 @@ object HyperLogLogPlusPlus {
     case Literal(d: Double, DoubleType) => d
     case Literal(dec: Decimal, _) => dec.toDouble
     case _ =>
-      throw QueryCompilationErrors.secondArgumentNotDoubleLiteralError
+      throw QueryCompilationErrors.secondArgumentNotDoubleLiteralError(
+        "approx_count_distinct", exp.sql)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2084,10 +2084,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       messageParameters = Map("fields" -> fields))
   }
 
-  def secondArgumentInFunctionIsNotBooleanLiteralError(funcName: String): Throwable = {
+  def secondArgumentInFunctionIsNotBooleanLiteralError(
+      funcName: String, parameter: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1210",
-      messageParameters = Map("funcName" -> funcName))
+      errorClass = "INVALID_PARAMETER_VALUE",
+      messageParameters =
+        Map("parameter" -> parameter, "functionName" -> funcName, "expected" -> "Boolean"))
   }
 
   def joinConditionMissingOrTrivialError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1085,10 +1085,11 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       messageParameters = Map("clz" -> clz.toString))
   }
 
-  def secondArgumentNotDoubleLiteralError(): Throwable = {
+  def secondArgumentNotDoubleLiteralError(functionName: String, parameter: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1104",
-      messageParameters = Map.empty)
+      errorClass = "INVALID_PARAMETER_VALUE",
+      messageParameters =
+        Map("parameter" -> parameter, "functionName" -> functionName, "expected" -> "Double"))
   }
 
   def dataTypeUnsupportedByExtractValueError(
@@ -2034,11 +2035,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def secondArgumentOfFunctionIsNotIntegerError(
-      function: String, e: NumberFormatException): Throwable = {
+      function: String, parameter: String, e: NumberFormatException): Throwable = {
     // The second argument of {function} function needs to be an integer
     new AnalysisException(
-      errorClass = "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER",
-      messageParameters = Map("functionName" -> function),
+      errorClass = "INVALID_PARAMETER_VALUE",
+      messageParameters =
+        Map("parameter" -> parameter, "functionName" -> function, "expected" -> "Integer"),
       cause = Some(e))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/FirstLastTestSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/FirstLastTestSuite.scala
@@ -112,14 +112,14 @@ class FirstLastTestSuite extends SparkFunSuite {
     val msg1 = intercept[AnalysisException] {
       new First(input, Literal(1, IntegerType))
     }.getMessage
-    assert(msg1.contains("The second argument in first should be a boolean literal"))
+    assert(msg1.contains("INVALID_PARAMETER_VALUE"))
     val msg2 = intercept[AnalysisException] {
       new Last(input, Literal(1, IntegerType))
     }.getMessage
-    assert(msg2.contains("The second argument in last should be a boolean literal"))
+    assert(msg2.contains("INVALID_PARAMETER_VALUE"))
     val msg3 = intercept[AnalysisException] {
       new AnyValue(input, Literal(1, IntegerType))
     }.getMessage
-    assert(msg3.contains("The second argument in any_value should be a boolean literal"))
+    assert(msg3.contains("INVALID_PARAMETER_VALUE"))
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/date.sql.out
@@ -389,10 +389,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER",
+  "errorClass" : "INVALID_PARAMETER_VALUE",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "date_add"
+    "expected" : "Integer",
+    "functionName" : "date_add",
+    "parameter" : "'1.2'"
   }
 }
 
@@ -551,10 +553,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER",
+  "errorClass" : "INVALID_PARAMETER_VALUE",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "date_sub"
+    "expected" : "Integer",
+    "functionName" : "date_sub",
+    "parameter" : "'1.2'"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
@@ -389,10 +389,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER",
+  "errorClass" : "INVALID_PARAMETER_VALUE",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "date_add"
+    "expected" : "Integer",
+    "functionName" : "date_add",
+    "parameter" : "'1.2'"
   }
 }
 
@@ -551,10 +553,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER",
+  "errorClass" : "INVALID_PARAMETER_VALUE",
   "sqlState" : "22023",
   "messageParameters" : {
-    "functionName" : "date_sub"
+    "expected" : "Integer",
+    "functionName" : "date_sub",
+    "parameter" : "'1.2'"
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -376,15 +376,16 @@ class QueryCompilationErrorsSuite
     }
   }
 
-  test("SECOND_FUNCTION_ARGUMENT_NOT_INTEGER: " +
+  test("INVALID_PARAMETER_VALUE: " +
     "the second argument of 'date_add' function needs to be an integer") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
       checkError(
         exception = intercept[AnalysisException] {
           sql("select date_add('1982-08-15', 'x')").collect()
         },
-        errorClass = "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER",
-        parameters = Map("functionName" -> "date_add"),
+        errorClass = "INVALID_PARAMETER_VALUE",
+        parameters =
+          Map("parameter" -> "'x'", "functionName" -> "date_add", "expected" -> "Integer"),
         sqlState = "22023")
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The following errors can be consolidated thus dropped to `INVALID_PARAMETER_VALUE`:
 
- SECOND_FUNCTION_ARGUMENT_NOT_INTEGER
- _LEGACY_ERROR_TEMP_1104

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve error framework within Spark SQL.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT