### PR TITLE
[SPARK-41088][SQL] Add PartialAggregate and FinalAggregate logic operators

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/PhysicalAggregationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/PhysicalAggregationSuite.scala
@@ -39,6 +39,7 @@ class PhysicalAggregationSuite extends PlanTest {
       groupingExpressions,
       aggregateExpressions,
       resultExpressions,
+      None,
       _ /* child */
     ) = analyzedQuery
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR add `PartialAggregate` and `FinalAggregate` logic operators.

### Why are the changes needed?

To implement these features:
1. Push partial distinct through join.
2. Partial deduplicate the right side of left semi/anti join.
3. Push down limit through aggregate if it is group only.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.
