### PR TITLE
[SPARK-41089][YARN][SHUFFLE] Relocate Netty native arm64 libs

### DIFF
--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -174,7 +174,11 @@
                           tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_x86_64.so" />
                     <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib"
                           tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_kqueue_x86_64.jnilib" />
-                    <jar destfile="${shuffle.jar}" basedir="${project.build.directory}/exploded" />
+                  <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_epoll_aarch_64.so"
+                        tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_aarch_64.so" />
+                  <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"
+                        tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_kqueue_aarch_64.jnilib" />
+                  <jar destfile="${shuffle.jar}" basedir="${project.build.directory}/exploded" />
                 </target>
             </configuration>
             <goals>

--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -174,11 +174,11 @@
                           tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_x86_64.so" />
                     <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib"
                           tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_kqueue_x86_64.jnilib" />
-                  <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_epoll_aarch_64.so"
-                        tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_aarch_64.so" />
-                  <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"
-                        tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_kqueue_aarch_64.jnilib" />
-                  <jar destfile="${shuffle.jar}" basedir="${project.build.directory}/exploded" />
+                    <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_epoll_aarch_64.so"
+                          tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_aarch_64.so" />
+                    <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"
+                          tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_kqueue_aarch_64.jnilib" />
+                    <jar destfile="${shuffle.jar}" basedir="${project.build.directory}/exploded" />
                 </target>
             </configuration>
             <goals>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SPARK-27610 relocated the netty x86 native libs, and the recent version netty ships arm64 native libs as well, we should do same thing to make it works on arm64 platform.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Align arm64 behavior w/ x86

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, bug fix for ARM64 platform.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Before patch
```
➜  apache-spark git:(SPARK-41089) ll common/network-yarn/target/exploded/META-INF/native
total 752
-rw-r--r--  1 chengpan  staff   101K Oct 11 23:24 libnetty_transport_native_epoll_aarch_64.so
-rw-r--r--  1 chengpan  staff    94K Oct 11 17:57 libnetty_transport_native_kqueue_aarch_64.jnilib
-rw-r--r--  1 chengpan  staff    93K Oct 11 23:27 liborg_sparkproject_netty_transport_native_epoll_x86_64.so
-rw-r--r--  1 chengpan  staff    77K Oct 11 17:51 liborg_sparkproject_netty_transport_native_kqueue_x86_64.jnilib
drwxr-xr-x  3 chengpan  staff    96B Nov  9 13:46 linux32
drwxr-xr-x  3 chengpan  staff    96B Nov  9 13:46 linux64
drwxr-xr-x  3 chengpan  staff    96B Nov  9 13:46 osx
drwxr-xr-x  3 chengpan  staff    96B Nov  9 13:46 windows32
drwxr-xr-x  3 chengpan  staff    96B Nov  9 13:46 windows64
```

After patch
```
➜  apache-spark git:(SPARK-41089) ll common/network-yarn/target/exploded/META-INF/native
total 752
-rw-r--r--  1 chengpan  staff   101K Oct 11 23:24 liborg_sparkproject_netty_transport_native_epoll_aarch_64.so
-rw-r--r--  1 chengpan  staff    93K Oct 11 23:27 liborg_sparkproject_netty_transport_native_epoll_x86_64.so
-rw-r--r--  1 chengpan  staff    94K Oct 11 17:57 liborg_sparkproject_netty_transport_native_kqueue_aarch_64.jnilib
-rw-r--r--  1 chengpan  staff    77K Oct 11 17:51 liborg_sparkproject_netty_transport_native_kqueue_x86_64.jnilib
drwxr-xr-x  3 chengpan  staff    96B Nov 10 12:07 linux32
drwxr-xr-x  3 chengpan  staff    96B Nov 10 12:07 linux64
drwxr-xr-x  3 chengpan  staff    96B Nov 10 12:07 osx
drwxr-xr-x  3 chengpan  staff    96B Nov 10 12:07 windows32
drwxr-xr-x  3 chengpan  staff    96B Nov 10 12:07 windows64
```