### PR TITLE
[SPARK-41034][CONNECT][PYTHON][FOLLOW-UP] Fix mypy annotations test

### DIFF
--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -677,7 +677,7 @@ class Repartition(LogicalPlan):
         self._num_partitions = num_partitions
         self._shuffle = shuffle
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         rel = proto.Relation()
         if self._child is not None:
             rel.repartition.input.CopyFrom(self._child.plan(session))
@@ -809,7 +809,7 @@ class StatSummary(LogicalPlan):
         super().__init__(child)
         self.statistics = statistics
 
-    def plan(self, session: Optional["RemoteSparkSession"]) -> proto.Relation:
+    def plan(self, session: "RemoteSparkSession") -> proto.Relation:
         assert self._child is not None
         plan = proto.Relation()
         plan.summary.input.CopyFrom(self._child.plan(session))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix python mypy


### Why are the changes needed?
https://github.com/apache/spark/pull/38541 breaks the linter

```
starting mypy annotations test...
annotations failed mypy checks:
python/pyspark/sql/connect/plan.py:683: error: Argument 1 to "plan" of "LogicalPlan" has incompatible type "Optional[RemoteSparkSession]"; expected "RemoteSparkSession"  [arg-type]
python/pyspark/sql/connect/plan.py:815: error: Argument 1 to "plan" of "LogicalPlan" has incompatible type "Optional[RemoteSparkSession]"; expected "RemoteSparkSession"  [arg-type]
Found 2 errors in 1 file (checked 369 source files)
1
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local test
