### PR TITLE
[SPARK-41063][BUILD] Clean all except files in Git repository before running Mima

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -315,6 +315,7 @@ def detect_binary_inop_with_mima(extra_profiles):
         "[info] Detecting binary incompatibilities with MiMa using SBT with these profiles: ",
         profiles,
     )
+    run_cmd(["git", "clean", "-fxd"])  # See https://github.com/sbt/sbt/issues/6183
     run_cmd([os.path.join(SPARK_HOME, "dev", "mima"), profiles])
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to clean all (except the files in Git repository) before running Mima.

### Why are the changes needed?

For an unknown reason, the compilation goes into an infinite loop at Scala 2.13 build (see https://github.com/apache/spark/actions/runs/3422432297/jobs/5699849548), presumably some leftovers some SBT or Zinc (https://github.com/sbt/sbt/issues/6183). 

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should test it out.