### PR TITLE
[SPARK-41101][PYTHON][PROTOBUF] Message classname support for PYSPARK-PROTOBUF

### DIFF
--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 def from_protobuf(
     data: "ColumnOrName",
     messageName: str,
-    descFilePath = None,
+    descFilePath: Optional[str] = None,
     options: Optional[Dict[str, str]] = None,
 ) -> Column:
     """
@@ -48,9 +48,9 @@ def from_protobuf(
     ----------
     data : :class:`~pyspark.sql.Column` or str
         the binary column.
-    messageName: str
+    messageName: str, optional
         the protobuf message name to look for in descriptor file. Or
-        The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>,
+        The Protobuf class name. E.g. ``org.spark.examples.protobuf.ExampleEvent``,
         without descFilePath parameter.
         Using the spark-submit option --jars, add a messageClassName specific jar.
     descFilePath : str
@@ -131,7 +131,9 @@ def from_protobuf(
     return Column(jc)
 
 
-def to_protobuf(data: "ColumnOrName", messageName: str, descFilePath = None) -> Column:
+def to_protobuf(
+    data: "ColumnOrName", messageName: str, descFilePath: Optional[str] = None
+) -> Column:
     """
     Converts a column into binary of protobuf format.
 
@@ -141,9 +143,9 @@ def to_protobuf(data: "ColumnOrName", messageName: str, descFilePath = None) -> 
     ----------
     data : :class:`~pyspark.sql.Column` or str
         the data column.
-    messageName: str
+    messageName: str, optional
         the protobuf message name to look for in descriptor file. Or
-        The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>,
+        The Protobuf class name. E.g. ``org.spark.examples.protobuf.ExampleEvent``,
         without descFilePath parameter.
         Using the spark-submit option --jars, add a messageClassName specific jar.
     descFilePath : str

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 def from_protobuf(
     data: "ColumnOrName",
     messageName: str,
-    descFilePath: str,
+    descFilePath = None,
     options: Optional[Dict[str, str]] = None,
 ) -> Column:
     """
@@ -49,7 +49,10 @@ def from_protobuf(
     data : :class:`~pyspark.sql.Column` or str
         the binary column.
     messageName: str
-        the protobuf message name to look for in descriptor file.
+        the protobuf message name to look for in descriptor file. Or
+        The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>,
+        without descFilePath parameter.
+        Using the spark-submit option --jars, add a messageClassName specific jar.
     descFilePath : str
         the protobuf descriptor in Message GeneratedMessageV3 format.
     options : dict, optional
@@ -95,14 +98,32 @@ def from_protobuf(
     +------------------+
     |{2, Alice, 109200}|
     +------------------+
+    >>> data = [([(1668035962, 2020)])]
+    >>> ddl_schema = "value struct<seconds: LONG, nanos: INT>"
+    >>> df = spark.createDataFrame(data, ddl_schema)
+    >>> message_class_name = "org.sparkproject.spark-protobuf.protobuf.Timestamp"
+    >>> to_proto_df = df.select(to_protobuf(df.value, message_class_name).alias("value"))
+    >>> from_proto_df = to_proto_df.select(
+    ...     from_protobuf(to_proto_df.value, message_class_name).alias("value"))
+    >>> from_proto_df.show(truncate=False)
+    +------------------+
+    |value             |
+    +------------------+
+    |{1668035962, 2020}|
+    +------------------+
     """
 
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None
     try:
-        jc = sc._jvm.org.apache.spark.sql.protobuf.functions.from_protobuf(
-            _to_java_column(data), messageName, descFilePath, options or {}
-        )
+        if descFilePath is not None:
+            jc = sc._jvm.org.apache.spark.sql.protobuf.functions.from_protobuf(
+                _to_java_column(data), messageName, descFilePath, options or {}
+            )
+        else:
+            jc = sc._jvm.org.apache.spark.sql.protobuf.functions.from_protobuf(
+                _to_java_column(data), messageName
+            )
     except TypeError as e:
         if str(e) == "'JavaPackage' object is not callable":
             _print_missing_jar("Protobuf", "protobuf", "protobuf", sc.version)
@@ -110,7 +131,7 @@ def from_protobuf(
     return Column(jc)
 
 
-def to_protobuf(data: "ColumnOrName", messageName: str, descFilePath: str) -> Column:
+def to_protobuf(data: "ColumnOrName", messageName: str, descFilePath = None) -> Column:
     """
     Converts a column into binary of protobuf format.
 
@@ -121,7 +142,10 @@ def to_protobuf(data: "ColumnOrName", messageName: str, descFilePath: str) -> Co
     data : :class:`~pyspark.sql.Column` or str
         the data column.
     messageName: str
-        the protobuf message name to look for in descriptor file.
+        the protobuf message name to look for in descriptor file. Or
+        The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>,
+        without descFilePath parameter.
+        Using the spark-submit option --jars, add a messageClassName specific jar.
     descFilePath : str
         the protobuf descriptor in Message GeneratedMessageV3 format.
 
@@ -157,13 +181,31 @@ def to_protobuf(data: "ColumnOrName", messageName: str, descFilePath: str) -> Co
     +-------------------------------------------+
     |[08 02 12 05 41 6C 69 63 65 18 9C 91 9F 06]|
     +-------------------------------------------+
+    >>> data = [([(1668035962, 2020)])]
+    >>> ddl_schema = "value struct<seconds: LONG, nanos: INT>"
+    >>> df = spark.createDataFrame(data, ddl_schema)
+    >>> message_class_name = "org.sparkproject.spark-protobuf.protobuf.Timestamp"
+    >>> proto_df = df.select(to_protobuf(df.value, message_class_name).alias("suite"))
+    >>> proto_df.show(truncate=False)
+    +----------------------------+
+    |suite                       |
+    +----------------------------+
+    |[08 FA EA B0 9B 06 10 E4 0F]|
+    +----------------------------+
     """
+
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None
     try:
-        jc = sc._jvm.org.apache.spark.sql.protobuf.functions.to_protobuf(
-            _to_java_column(data), messageName, descFilePath
-        )
+        if descFilePath is not None:
+            jc = sc._jvm.org.apache.spark.sql.protobuf.functions.to_protobuf(
+                _to_java_column(data), messageName, descFilePath
+            )
+        else:
+            jc = sc._jvm.org.apache.spark.sql.protobuf.functions.to_protobuf(
+                _to_java_column(data), messageName
+            )
+
     except TypeError as e:
         if str(e) == "'JavaPackage' object is not callable":
             _print_missing_jar("Protobuf", "protobuf", "protobuf", sc.version)

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -38,7 +38,10 @@ def from_protobuf(
     """
     Converts a binary column of Protobuf format into its corresponding catalyst value.
     The specified schema must match the read data, otherwise the behavior is undefined:
-    it may fail or return arbitrary result.
+    it may fail or return arbitrary result. The jar containing Java class should be shaded.
+    Specifically, ``com.google.protobuf.*`` should be shaded to
+    ``org.sparkproject.spark-protobuf.protobuf.*``.
+
     To deserialize the data with a compatible and evolved schema, the expected
     Protobuf schema can be set via the option protobuf descriptor.
 
@@ -135,7 +138,10 @@ def to_protobuf(
     data: "ColumnOrName", messageName: str, descFilePath: Optional[str] = None
 ) -> Column:
     """
-    Converts a column into binary of protobuf format.
+    Converts a column into binary of protobuf format. The specified Protobuf class must match the
+    data, otherwise the behavior is undefined: it may fail or return arbitrary result. The jar
+    containing Java class should be shaded. Specifically, ``com.google.protobuf.*`` should be
+    shaded to ``org.sparkproject.spark-protobuf.protobuf.*``.
 
     .. versionadded:: 3.4.0
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Adding message classname support for pyspark-protobuf 
- functions from_protobuf and to_protobuf


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### How was this patch tested?

- Python Doctests.
- To avoid adding an extra jar, I used the existing spark-protobuf jar because it has a shadded google-protobuf and used a Timestamp message as an example protobuf messageClassName in Doctests

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

 @rangadi @HyukjinKwon  
