### PR TITLE
[SPARK-41080][SQL] Support Bit manipulation function SETBIT

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -233,6 +233,21 @@
           "The <inputName> value must to be a <requireType> literal of <validValues>, but got <inputValue>."
         ]
       },
+      "INVALID_BIT_POSITION_GREATER_THAN_MAX_SIZE" : {
+        "message" : [
+          "Invalid bit index position: <position> should be less than bit upper limit <size>"
+        ]
+      },
+      "INVALID_BIT_POSITION_LESS_THAN_ZERO" : {
+        "message" : [
+          "Invalid bit index position: <position> is less than zero"
+        ]
+      },
+      "INVALID_BIT_VALUE" : {
+        "message" : [
+          "Invalid bit value: Use 0 or 1"
+        ]
+      },
       "INVALID_JSON_MAP_KEY_TYPE" : {
         "message" : [
           "Input schema <schema> can only contain STRING as a key type for a MAP."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -778,6 +778,8 @@ object FunctionRegistry {
     expression[BitXorAgg]("bit_xor"),
     expression[BitwiseGet]("bit_get"),
     expression[BitwiseGet]("getbit", true),
+    expression[BitwiseSet]("bit_set"),
+    expression[BitwiseSet]("setbit", true),
 
     // json
     expression[StructsToJson]("to_json"),

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -47,6 +47,8 @@
 | org.apache.spark.sql.catalyst.expressions.BitwiseGet | getbit | SELECT getbit(11, 0) | struct<getbit(11, 0):tinyint> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseNot | ~ | SELECT ~ 0 | struct<~0:int> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseOr | &#124; | SELECT 3 &#124; 5 | struct<(3 &#124; 5):int> |
+| org.apache.spark.sql.catalyst.expressions.BitwiseSet | bit_set | SELECT  bit_set(0, 0) | struct<bit_set(0, 0, 1):int> |
+| org.apache.spark.sql.catalyst.expressions.BitwiseSet | setbit | SELECT  setbit(0, 0) | struct<setbit(0, 0, 1):int> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseXor | ^ | SELECT 3 ^ 5 | struct<(3 ^ 5):int> |
 | org.apache.spark.sql.catalyst.expressions.CallMethodViaReflection | java_method | SELECT java_method('java.util.UUID', 'randomUUID') | struct<java_method(java.util.UUID, randomUUID):string> |
 | org.apache.spark.sql.catalyst.expressions.CallMethodViaReflection | reflect | SELECT reflect('java.util.UUID', 'randomUUID') | struct<reflect(java.util.UUID, randomUUID):string> |

--- a/sql/core/src/test/resources/sql-tests/inputs/bitwise.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/bitwise.sql
@@ -75,3 +75,37 @@ select getbit(11L, 2 + 1), getbit(11L, 3 - 1), getbit(10L + 1, 1 * 1), getbit(ca
 select getbit(11L, 63);
 select getbit(11L, -1);
 select getbit(11L, 64);
+
+-- setbit
+select setbit(0, 0);
+select setbit(0, 3);
+select setbit(7, 3);
+select setbit(15, 3);
+select setbit(7, 3, 1);
+select setbit(7, 2, 0);
+select bit_set(0, 0);
+select bit_set(0, 3);
+select bit_set(7, 3);
+select bit_set(15, 3);
+select bit_set(7, 3, 1);
+select bit_set(7, 2, 0);
+select setbit(cast(32767 AS SMALLINT), 2, 1);
+select setbit(cast(32767 AS SMALLINT), 2, 0);
+select setbit(cast(127 AS TINYINT), 2, 0);
+select setbit(cast(127 AS TINYINT), 2, 1);
+select setbit(cast(9223372036854775807 AS BIGINT), 2, 1);
+select setbit(cast(9223372036854775807 AS BIGINT), 2, 0);
+select setbit(cast(9223372036854775807 AS BIGINT), 0, 0);
+select setbit(cast(9223372036854775807 AS BIGINT), 0, 1);
+select setbit(cast(9223372036854775807 AS BIGINT), 10, 0);
+select setbit(cast(140737488355327 AS BIGINT), 65, 0);
+select setbit(cast(123 AS TINYINT), 65, 0);
+select setbit(cast(123 AS SMALLINT), 65, 0);
+select setbit(cast(123 AS INT), 65, 0);
+select setbit(c1, 1, 0) from values (1234, 1, 0) as t(c1, c2, c3);
+select setbit(c1, c2, 0) from values (1234, 1, 0) as t(c1, c2, c3);
+select setbit(c1, 1, c3) from values (1234, 1, 0) as t(c1, c2, c3);
+select setbit(c1, 1, 0) from values (1234, 1, 0), (11, 1, 0) as t(c1, c2, c3);
+select setbit(123, 1, -1);
+select setbit(123, 1, 5);
+select setbit(123, -1, 1);

--- a/sql/core/src/test/resources/sql-tests/results/bitwise.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/bitwise.sql.out
@@ -302,3 +302,392 @@ struct<>
 -- !query output
 java.lang.IllegalArgumentException
 Invalid bit position: 64 exceeds the bit upper limit
+
+
+-- !query
+select setbit(0, 0)
+-- !query schema
+struct<setbit(0, 0, 1):int>
+-- !query output
+1
+
+
+-- !query
+select setbit(0, 3)
+-- !query schema
+struct<setbit(0, 3, 1):int>
+-- !query output
+8
+
+
+-- !query
+select setbit(7, 3)
+-- !query schema
+struct<setbit(7, 3, 1):int>
+-- !query output
+15
+
+
+-- !query
+select setbit(15, 3)
+-- !query schema
+struct<setbit(15, 3, 1):int>
+-- !query output
+15
+
+
+-- !query
+select setbit(7, 3, 1)
+-- !query schema
+struct<setbit(7, 3, 1):int>
+-- !query output
+15
+
+
+-- !query
+select setbit(7, 2, 0)
+-- !query schema
+struct<setbit(7, 2, 0):int>
+-- !query output
+3
+
+
+-- !query
+select bit_set(0, 0)
+-- !query schema
+struct<bit_set(0, 0, 1):int>
+-- !query output
+1
+
+
+-- !query
+select bit_set(0, 3)
+-- !query schema
+struct<bit_set(0, 3, 1):int>
+-- !query output
+8
+
+
+-- !query
+select bit_set(7, 3)
+-- !query schema
+struct<bit_set(7, 3, 1):int>
+-- !query output
+15
+
+
+-- !query
+select bit_set(15, 3)
+-- !query schema
+struct<bit_set(15, 3, 1):int>
+-- !query output
+15
+
+
+-- !query
+select bit_set(7, 3, 1)
+-- !query schema
+struct<bit_set(7, 3, 1):int>
+-- !query output
+15
+
+
+-- !query
+select bit_set(7, 2, 0)
+-- !query schema
+struct<bit_set(7, 2, 0):int>
+-- !query output
+3
+
+
+-- !query
+select setbit(cast(32767 AS SMALLINT), 2, 1)
+-- !query schema
+struct<setbit(CAST(32767 AS SMALLINT), 2, 1):smallint>
+-- !query output
+32767
+
+
+-- !query
+select setbit(cast(32767 AS SMALLINT), 2, 0)
+-- !query schema
+struct<setbit(CAST(32767 AS SMALLINT), 2, 0):smallint>
+-- !query output
+32763
+
+
+-- !query
+select setbit(cast(127 AS TINYINT), 2, 0)
+-- !query schema
+struct<setbit(CAST(127 AS TINYINT), 2, 0):tinyint>
+-- !query output
+123
+
+
+-- !query
+select setbit(cast(127 AS TINYINT), 2, 1)
+-- !query schema
+struct<setbit(CAST(127 AS TINYINT), 2, 1):tinyint>
+-- !query output
+127
+
+
+-- !query
+select setbit(cast(9223372036854775807 AS BIGINT), 2, 1)
+-- !query schema
+struct<setbit(CAST(9223372036854775807 AS BIGINT), 2, 1):bigint>
+-- !query output
+9223372036854775807
+
+
+-- !query
+select setbit(cast(9223372036854775807 AS BIGINT), 2, 0)
+-- !query schema
+struct<setbit(CAST(9223372036854775807 AS BIGINT), 2, 0):bigint>
+-- !query output
+9223372036854775803
+
+
+-- !query
+select setbit(cast(9223372036854775807 AS BIGINT), 0, 0)
+-- !query schema
+struct<setbit(CAST(9223372036854775807 AS BIGINT), 0, 0):bigint>
+-- !query output
+9223372036854775806
+
+
+-- !query
+select setbit(cast(9223372036854775807 AS BIGINT), 0, 1)
+-- !query schema
+struct<setbit(CAST(9223372036854775807 AS BIGINT), 0, 1):bigint>
+-- !query output
+9223372036854775807
+
+
+-- !query
+select setbit(cast(9223372036854775807 AS BIGINT), 10, 0)
+-- !query schema
+struct<setbit(CAST(9223372036854775807 AS BIGINT), 10, 0):bigint>
+-- !query output
+9223372036854774783
+
+
+-- !query
+select setbit(cast(140737488355327 AS BIGINT), 65, 0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_POSITION_GREATER_THAN_MAX_SIZE",
+  "messageParameters" : {
+    "position" : "65",
+    "size" : "64",
+    "sqlExpr" : "\"setbit(CAST(140737488355327 AS BIGINT), 65, 0)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 53,
+    "fragment" : "setbit(cast(140737488355327 AS BIGINT), 65, 0)"
+  } ]
+}
+
+
+-- !query
+select setbit(cast(123 AS TINYINT), 65, 0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_POSITION_GREATER_THAN_MAX_SIZE",
+  "messageParameters" : {
+    "position" : "65",
+    "size" : "8",
+    "sqlExpr" : "\"setbit(CAST(123 AS TINYINT), 65, 0)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 42,
+    "fragment" : "setbit(cast(123 AS TINYINT), 65, 0)"
+  } ]
+}
+
+
+-- !query
+select setbit(cast(123 AS SMALLINT), 65, 0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_POSITION_GREATER_THAN_MAX_SIZE",
+  "messageParameters" : {
+    "position" : "65",
+    "size" : "16",
+    "sqlExpr" : "\"setbit(CAST(123 AS SMALLINT), 65, 0)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 43,
+    "fragment" : "setbit(cast(123 AS SMALLINT), 65, 0)"
+  } ]
+}
+
+
+-- !query
+select setbit(cast(123 AS INT), 65, 0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_POSITION_GREATER_THAN_MAX_SIZE",
+  "messageParameters" : {
+    "position" : "65",
+    "size" : "32",
+    "sqlExpr" : "\"setbit(CAST(123 AS INT), 65, 0)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 38,
+    "fragment" : "setbit(cast(123 AS INT), 65, 0)"
+  } ]
+}
+
+
+-- !query
+select setbit(c1, 1, 0) from values (1234, 1, 0) as t(c1, c2, c3)
+-- !query schema
+struct<setbit(c1, 1, 0):int>
+-- !query output
+1232
+
+
+-- !query
+select setbit(c1, c2, 0) from values (1234, 1, 0) as t(c1, c2, c3)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "messageParameters" : {
+    "inputExpr" : "\"c2\"",
+    "inputName" : "position",
+    "inputType" : "\"INT\"",
+    "sqlExpr" : "\"setbit(c1, c2, 0)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "setbit(c1, c2, 0)"
+  } ]
+}
+
+
+-- !query
+select setbit(c1, 1, c3) from values (1234, 1, 0) as t(c1, c2, c3)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "messageParameters" : {
+    "inputExpr" : "\"c3\"",
+    "inputName" : "bit",
+    "inputType" : "\"INT\"",
+    "sqlExpr" : "\"setbit(c1, 1, c3)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "setbit(c1, 1, c3)"
+  } ]
+}
+
+
+-- !query
+select setbit(c1, 1, 0) from values (1234, 1, 0), (11, 1, 0) as t(c1, c2, c3)
+-- !query schema
+struct<setbit(c1, 1, 0):int>
+-- !query output
+1232
+9
+
+
+-- !query
+select setbit(123, 1, -1)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_VALUE",
+  "messageParameters" : {
+    "sqlExpr" : "\"setbit(123, 1, -1)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 25,
+    "fragment" : "setbit(123, 1, -1)"
+  } ]
+}
+
+
+-- !query
+select setbit(123, 1, 5)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_VALUE",
+  "messageParameters" : {
+    "sqlExpr" : "\"setbit(123, 1, 5)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "setbit(123, 1, 5)"
+  } ]
+}
+
+
+-- !query
+select setbit(123, -1, 1)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_POSITION_LESS_THAN_ZERO",
+  "messageParameters" : {
+    "position" : "-1",
+    "sqlExpr" : "\"setbit(123, -1, 1)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 25,
+    "fragment" : "setbit(123, -1, 1)"
+  } ]
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR implements a built-in function to change a bit at a specified position of IntegralType data.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
 A function for changing a bit at a specified position to a 1 or 0.  `SETBIT` takes the input and sets the bit specified by position to the value, 0 or 1, as provided by the value_arg argument.

`SETBIT(integer_type input, INT position [, INT bit_arg])`

The positions are numbered right to left, starting at zero. The position argument cannot be negative.
The bit_arg parameter only accepts a value of 0 or 1. If a value for bit_arg is not specified, the default value of 1 is used.


Ref:
 1) [Impala](https://impala.apache.org/docs/build/html/topics/impala_bit_functions.html#bit_functions__setbit)
 2) [Redis](https://redis.io/commands/setbit/)
 3) [Teradata](https://docs.teradata.com/r/Teradata-Database-SQL-Functions-Operators-Expressions-and-Predicates/March-2017/Bit/Byte-Manipulation-Functions/SETBIT)
 4) [MSSQL](https://learn.microsoft.com/en-us/sql/t-sql/functions/set-bit-transact-sql?view=sql-server-ver16)
 5) [Sybase](https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.help.sqlanywhere.12.0.1/dbreference/set-bit-function.html)
 6) [PostgreSQL](https://www.postgresql.org/docs/9.0/functions-binarystring.html)
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, a new built-in function `bit_set` and alias  `setbit`  added

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added test cases