### PR TITLE
[SPARK-41107][PYTHON][INFRA][TESTS] Install memory-profiler in the CI

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -32,7 +32,7 @@ RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl 'memory-profiler==0.60.0'
+RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update
@@ -68,3 +68,6 @@ ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library
 
 # Add Python deps for Spark Connect.
 RUN python3.9 -m pip install grpcio protobuf
+
+# SPARK-41186: Move memory-profiler to pyspark deps install when mlfow doctest test fix
+RUN python3.9 -m pip install 'memory-profiler==0.60.0'

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -32,7 +32,7 @@ RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl memory-profiler
+RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl 'memory-profiler==0.60.0'
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -32,7 +32,7 @@ RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl
+RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl memory-profiler
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -28,7 +28,6 @@ from pyspark.find_spark_home import _find_spark_home
 
 have_scipy = False
 have_numpy = False
-have_memory_profiler = False
 try:
     import scipy.sparse  # noqa: F401
 
@@ -42,13 +41,6 @@ try:
     have_numpy = True
 except ImportError:
     # No NumPy, but that's okay, we'll skip those tests
-    pass
-try:
-    import memory_profiler  # type: ignore[import] # noqa: F401
-
-    have_memory_profiler = True
-except ImportError:
-    # No memory-profiler, but that's okay, we'll skip those tests
     pass
 
 

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -28,6 +28,7 @@ from pyspark.find_spark_home import _find_spark_home
 
 have_scipy = False
 have_numpy = False
+have_memory_profiler = False
 try:
     import scipy.sparse  # noqa: F401
 
@@ -41,6 +42,13 @@ try:
     have_numpy = True
 except ImportError:
     # No NumPy, but that's okay, we'll skip those tests
+    pass
+try:
+    import memory_profiler  # noqa: F401
+
+    have_memory_profiler = True
+except ImportError:
+    # No memory-profiler, but that's okay, we'll skip those tests
     pass
 
 

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -44,7 +44,7 @@ except ImportError:
     # No NumPy, but that's okay, we'll skip those tests
     pass
 try:
-    import memory_profiler  # noqa: F401
+    import memory_profiler  # type: ignore[import] # noqa: F401
 
     have_memory_profiler = True
 except ImportError:

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -29,17 +29,10 @@ import pandas as pd
 from pyspark import SparkConf, SparkContext
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import pandas_udf, udf
-from pyspark.testing.utils import PySparkTestCase
-
-try:
-    import memory_profiler  # type: ignore[import] # noqa: F401
-
-    has_memory_profiler = True
-except Exception:
-    has_memory_profiler = False
+from pyspark.testing.utils import PySparkTestCase, have_memory_profiler
 
 
-@unittest.skipIf(not has_memory_profiler, "Must have memory-profiler installed.")
+@unittest.skipIf(not have_memory_profiler, "Must have memory-profiler installed.")
 class MemoryProfilerTests(PySparkTestCase):
     def setUp(self):
         self._old_sys_path = list(sys.path)

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -27,12 +27,13 @@ from unittest import mock
 import pandas as pd
 
 from pyspark import SparkConf, SparkContext
+from pyspark.profiler import has_memory_profiler
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import pandas_udf, udf
-from pyspark.testing.utils import PySparkTestCase, have_memory_profiler
+from pyspark.testing.utils import PySparkTestCase
 
 
-@unittest.skipIf(not have_memory_profiler, "Must have memory-profiler installed.")
+@unittest.skipIf(not has_memory_profiler, "Must have memory-profiler installed.")
 class MemoryProfilerTests(PySparkTestCase):
     def setUp(self):
         self._old_sys_path = list(sys.path)

--- a/python/pyspark/tests/test_profiler.py
+++ b/python/pyspark/tests/test_profiler.py
@@ -22,10 +22,11 @@ import unittest
 from io import StringIO
 
 from pyspark import SparkConf, SparkContext, BasicProfiler
+from pyspark.profiler import has_memory_profiler
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import udf
 from pyspark.sql.utils import PythonException
-from pyspark.testing.utils import PySparkTestCase, have_memory_profiler
+from pyspark.testing.utils import PySparkTestCase
 
 
 class ProfilerTests(PySparkTestCase):
@@ -126,7 +127,7 @@ class ProfilerTests2(unittest.TestCase):
         finally:
             sc.stop()
 
-    @unittest.skipIf(have_memory_profiler, "Test when memory-profiler is not installed.")
+    @unittest.skipIf(has_memory_profiler, "Test when memory-profiler is not installed.")
     def test_no_memory_profile_installed(self):
         sc = SparkContext(
             conf=SparkConf()

--- a/python/pyspark/tests/test_profiler.py
+++ b/python/pyspark/tests/test_profiler.py
@@ -25,7 +25,7 @@ from pyspark import SparkConf, SparkContext, BasicProfiler
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import udf
 from pyspark.sql.utils import PythonException
-from pyspark.testing.utils import PySparkTestCase
+from pyspark.testing.utils import PySparkTestCase, have_memory_profiler
 
 
 class ProfilerTests(PySparkTestCase):
@@ -126,6 +126,7 @@ class ProfilerTests2(unittest.TestCase):
         finally:
             sc.stop()
 
+    @unittest.skipIf(have_memory_profiler, "Test when memory-profiler is not installed.")
     def test_no_memory_profile_installed(self):
         sc = SparkContext(
             conf=SparkConf()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Install [memory-profiler](https://pypi.org/project/memory-profiler/) in the CI in order to enable memory profiling tests.

### Why are the changes needed?
That's a sub-task of [SPARK-40281](https://issues.apache.org/jira/browse/SPARK-40281) Memory Profiler on Executors.

PySpark memory profiler depends on memory-profiler. The PR proposes to install memory-profiler in the CI to enable related tests.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.

SPARK-40281