### PR TITLE
[SPARK-41109][SQL] Rename the error class _LEGACY_ERROR_TEMP_1216 to INVALID_LIKE_PATTERN

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -632,8 +632,20 @@
   },
   "INVALID_LIKE_PATTERN" : {
     "message" : [
-      "The pattern '<pattern>' is invalid, <message>."
-    ]
+      "The pattern <pattern> is invalid."
+    ],
+    "subClass" : {
+      "ESC_IN_THE_MIDDLE" : {
+        "message" : [
+          "the escape character is not allowed to precede <char>."
+        ]
+      },
+      "ESC_AT_THE_END" : {
+        "message" : [
+          "the escape character is not allowed to end with."
+        ]
+      }
+    }
   },
   "INVALID_PANDAS_UDF_PLACEMENT" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -630,6 +630,11 @@
       "Input schema <jsonSchema> can only contain STRING as a key type for a MAP."
     ]
   },
+  "INVALID_LIKE_PATTERN" : {
+    "message" : [
+      "The pattern '<pattern>' is invalid, <message>."
+    ]
+  },
   "INVALID_PANDAS_UDF_PLACEMENT" : {
     "message" : [
       "The group aggregate pandas UDF <functionList> cannot be invoked together with as other, non-pandas aggregate functions."
@@ -2674,11 +2679,6 @@
   "_LEGACY_ERROR_TEMP_1215" : {
     "message" : [
       "char/varchar type can only be used in the table schema. You can set <config> to true, so that Spark treat them as string type as same as Spark 3.0 and earlier."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1216" : {
-    "message" : [
-      "The pattern '<pattern>' is invalid, <message>."
     ]
   },
   "_LEGACY_ERROR_TEMP_1218" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -47,8 +47,6 @@ object StringUtils extends Logging {
     val in = pattern.iterator
     val out = new StringBuilder()
 
-    def fail(message: String) = throw QueryCompilationErrors.invalidPatternError(pattern, message)
-
     while (in.hasNext) {
       in.next match {
         case c1 if c1 == escapeChar && in.hasNext =>
@@ -56,9 +54,11 @@ object StringUtils extends Logging {
           c match {
             case '_' | '%' => out ++= Pattern.quote(Character.toString(c))
             case c if c == escapeChar => out ++= Pattern.quote(Character.toString(c))
-            case _ => fail(s"the escape character is not allowed to precede '$c'")
+            case _ => throw QueryCompilationErrors.escapeCharacterInTheMiddleError(
+              pattern, Character.toString(c))
           }
-        case c if c == escapeChar => fail("it is not allowed to end with the escape character")
+        case c if c == escapeChar =>
+          throw QueryCompilationErrors.escapeCharacterAtTheEndError(pattern)
         case '_' => out ++= "."
         case '%' => out ++= ".*"
         case c => out ++= Pattern.quote(Character.toString(c))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2132,12 +2132,19 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       messageParameters = Map("config" -> SQLConf.LEGACY_CHAR_VARCHAR_AS_STRING.key))
   }
 
-  def invalidPatternError(pattern: String, message: String): Throwable = {
+  def escapeCharacterInTheMiddleError(pattern: String, char: String): Throwable = {
     new AnalysisException(
-      errorClass = "INVALID_LIKE_PATTERN",
+      errorClass = "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
       messageParameters = Map(
         "pattern" -> toSQLValue(pattern, StringType),
-        "message" -> message))
+        "char" -> toSQLValue(char, StringType)))
+  }
+
+  def escapeCharacterAtTheEndError(pattern: String): Throwable = {
+    new AnalysisException(
+      errorClass = "INVALID_LIKE_PATTERN.ESC_AT_THE_END",
+      messageParameters = Map(
+        "pattern" -> toSQLValue(pattern, StringType)))
   }
 
   def tableIdentifierExistsError(tableIdentifier: TableIdentifier): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2134,7 +2134,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
 
   def invalidPatternError(pattern: String, message: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1216",
+      errorClass = "INVALID_LIKE_PATTERN",
       messageParameters = Map(
         "pattern" -> toSQLValue(pattern, StringType),
         "message" -> message))

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/strings.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/strings.sql.out
@@ -444,7 +444,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1216",
+  "errorClass" : "INVALID_LIKE_PATTERN",
   "messageParameters" : {
     "message" : "the escape character is not allowed to precede 'a'",
     "pattern" : "'m%aca'"
@@ -459,7 +459,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1216",
+  "errorClass" : "INVALID_LIKE_PATTERN",
   "messageParameters" : {
     "message" : "the escape character is not allowed to precede 'a'",
     "pattern" : "'m%aca'"
@@ -474,7 +474,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1216",
+  "errorClass" : "INVALID_LIKE_PATTERN",
   "messageParameters" : {
     "message" : "the escape character is not allowed to precede 'a'",
     "pattern" : "'m%a%%a'"
@@ -489,7 +489,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1216",
+  "errorClass" : "INVALID_LIKE_PATTERN",
   "messageParameters" : {
     "message" : "the escape character is not allowed to precede 'a'",
     "pattern" : "'m%a%%a'"
@@ -504,7 +504,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1216",
+  "errorClass" : "INVALID_LIKE_PATTERN",
   "messageParameters" : {
     "message" : "the escape character is not allowed to precede 'e'",
     "pattern" : "'b_ear'"
@@ -519,7 +519,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1216",
+  "errorClass" : "INVALID_LIKE_PATTERN",
   "messageParameters" : {
     "message" : "the escape character is not allowed to precede 'e'",
     "pattern" : "'b_ear'"
@@ -534,7 +534,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1216",
+  "errorClass" : "INVALID_LIKE_PATTERN",
   "messageParameters" : {
     "message" : "the escape character is not allowed to precede 'e'",
     "pattern" : "'b_e__r'"
@@ -549,7 +549,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1216",
+  "errorClass" : "INVALID_LIKE_PATTERN",
   "messageParameters" : {
     "message" : "the escape character is not allowed to precede 'e'",
     "pattern" : "'b_e__r'"

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/strings.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/strings.sql.out
@@ -444,9 +444,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_LIKE_PATTERN",
+  "errorClass" : "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
   "messageParameters" : {
-    "message" : "the escape character is not allowed to precede 'a'",
+    "char" : "'a'",
     "pattern" : "'m%aca'"
   }
 }
@@ -459,9 +459,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_LIKE_PATTERN",
+  "errorClass" : "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
   "messageParameters" : {
-    "message" : "the escape character is not allowed to precede 'a'",
+    "char" : "'a'",
     "pattern" : "'m%aca'"
   }
 }
@@ -474,9 +474,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_LIKE_PATTERN",
+  "errorClass" : "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
   "messageParameters" : {
-    "message" : "the escape character is not allowed to precede 'a'",
+    "char" : "'a'",
     "pattern" : "'m%a%%a'"
   }
 }
@@ -489,9 +489,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_LIKE_PATTERN",
+  "errorClass" : "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
   "messageParameters" : {
-    "message" : "the escape character is not allowed to precede 'a'",
+    "char" : "'a'",
     "pattern" : "'m%a%%a'"
   }
 }
@@ -504,9 +504,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_LIKE_PATTERN",
+  "errorClass" : "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
   "messageParameters" : {
-    "message" : "the escape character is not allowed to precede 'e'",
+    "char" : "'e'",
     "pattern" : "'b_ear'"
   }
 }
@@ -519,9 +519,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_LIKE_PATTERN",
+  "errorClass" : "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
   "messageParameters" : {
-    "message" : "the escape character is not allowed to precede 'e'",
+    "char" : "'e'",
     "pattern" : "'b_ear'"
   }
 }
@@ -534,9 +534,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_LIKE_PATTERN",
+  "errorClass" : "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
   "messageParameters" : {
-    "message" : "the escape character is not allowed to precede 'e'",
+    "char" : "'e'",
     "pattern" : "'b_e__r'"
   }
 }
@@ -549,9 +549,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_LIKE_PATTERN",
+  "errorClass" : "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
   "messageParameters" : {
-    "message" : "the escape character is not allowed to precede 'e'",
+    "char" : "'e'",
     "pattern" : "'b_e__r'"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3713,7 +3713,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         exception = intercept[AnalysisException] {
           sql("SELECT s LIKE 'm%@ca' ESCAPE '%' FROM df").collect()
         },
-        errorClass = "_LEGACY_ERROR_TEMP_1216",
+        errorClass = "INVALID_LIKE_PATTERN",
         parameters = Map(
           "pattern" -> "'m%@ca'",
           "message" -> "the escape character is not allowed to precede '@'"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -30,6 +30,7 @@ import org.apache.commons.io.FileUtils
 
 import org.apache.spark.{AccumulatorSuite, SparkException}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
+import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.{GenericRow, Hex}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Partial}
 import org.apache.spark.sql.catalyst.optimizer.{ConvertToLocalRelation, NestedColumnAliasingSuite}
@@ -3713,12 +3714,25 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         exception = intercept[AnalysisException] {
           sql("SELECT s LIKE 'm%@ca' ESCAPE '%' FROM df").collect()
         },
-        errorClass = "INVALID_LIKE_PATTERN",
+        errorClass = "INVALID_LIKE_PATTERN.ESC_IN_THE_MIDDLE",
         parameters = Map(
-          "pattern" -> "'m%@ca'",
-          "message" -> "the escape character is not allowed to precede '@'"))
+          "pattern" -> toSQLValue("m%@ca", StringType),
+          "char" -> toSQLValue("@", StringType)))
 
       checkAnswer(sql("SELECT s LIKE 'm@@ca' ESCAPE '@' FROM df"), Row(true))
+    }
+  }
+
+  test("the escape character is not allowed to end with") {
+    withTempView("df") {
+      Seq("jialiuping").toDF("a").createOrReplaceTempView("df")
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("SELECT a LIKE 'jialiuping%' ESCAPE '%' FROM df").collect()
+        },
+        errorClass = "INVALID_LIKE_PATTERN.ESC_AT_THE_END",
+        parameters = Map("pattern" -> toSQLValue("jialiuping%", StringType)))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to rename the legacy error class _LEGACY_ERROR_TEMP_1216 to INVALID_LIKE_PATTERN.

### Why are the changes needed?
Proper names of error classes should improve user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
By running the affected test suites:
> $ build/sbt "sql/testOnly *SQLQuerySuite"
> $ PYSPARK_PYTHON=python3 build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z strings.sql"