### PR TITLE
[WIP][SPARK-41072][SQL][SS] Add the error class `STREAM_FAILED`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -911,6 +911,11 @@
       "Star (*) is not allowed in a select list when GROUP BY an ordinal position is used."
     ]
   },
+  "STREAM_FAILED" : {
+    "message" : [
+      "Execution of the stream <id> failed."
+    ]
+  },
   "TABLE_OR_VIEW_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create table or view <relationName> because it already exists.",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2820,4 +2820,11 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "location" -> toSQLValue(location.toString, StringType),
         "identifier" -> toSQLId(tableId.nameParts)))
   }
+
+  def streamFailed(id: String, cause: Throwable): Throwable = {
+    new SparkRuntimeException(
+      errorClass = "STREAM_FAILED",
+      messageParameters = Map("id" -> id),
+      cause)
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.streaming
 
-import java.io.{IOException, InterruptedIOException, UncheckedIOException}
+import java.io.{InterruptedIOException, IOException, UncheckedIOException}
 import java.nio.channels.ClosedByInterruptException
 import java.util.UUID
-import java.util.concurrent.{CountDownLatch, ExecutionException, TimeUnit, TimeoutException}
+import java.util.concurrent.{CountDownLatch, ExecutionException, TimeoutException, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -731,13 +731,14 @@ class QueryExecutionErrorsSuite
       val s: String = null
       s.length: Unit
     }.start()
-    val e = intercept[StreamingQueryException] {
+    val cause = intercept[StreamingQueryException] {
       query.awaitTermination()
-    }
+    }.cause
     checkError(
-      exception = e.cause.asInstanceOf[SparkThrowable],
+      exception = cause.asInstanceOf[SparkThrowable],
       errorClass = "STREAM_FAILED",
       parameters = Map("id" -> s"[id = ${query.id}, runId = ${query.runId}]"))
+    assert(cause.getCause.isInstanceOf[NullPointerException])
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.mockito.Mockito.{mock, spy, when}
 
 import org.apache.spark._
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.util.BadRecordException
 import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions}
 import org.apache.spark.sql.execution.datasources.jdbc.connection.ConnectionProvider
@@ -41,6 +41,7 @@ import org.apache.spark.sql.functions.{lit, lower, struct, sum, udf}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.EXCEPTION
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
+import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DataType, DecimalType, LongType, MetadataBuilder, StructType}
 import org.apache.spark.util.Utils
@@ -722,6 +723,21 @@ class QueryExecutionErrorsSuite
         JdbcDialects.unregisterDialect(testH2DialectUnsupportedJdbcTransaction)
       }
     }
+  }
+
+  test("STREAM_FAILED: NPE in user code") {
+    val ds = spark.readStream.format("rate").load()
+    val query = ds.writeStream.foreachBatch { (_: Dataset[Row], _: Long) =>
+      val s: String = null
+      s.length: Unit
+    }.start()
+    val e = intercept[StreamingQueryException] {
+      query.awaitTermination()
+    }
+    checkError(
+      exception = e.cause.asInstanceOf[SparkThrowable],
+      errorClass = "STREAM_FAILED",
+      parameters = Map("id" -> s"[id = ${query.id}, runId = ${query.runId}]"))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose throw `SparkRuntimeException` with error class `STREAM_FAILED` instead of `INTERNAL_ERROR` when a stream failed due to an exception in user code, and bypass `SparkThrowable` w/o wrapping it.

### Why are the changes needed?
To allow users to debug their queries easier.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
By running new tests:
```
$ build/sbt "sql/testOnly *QueryExecutionAnsiErrorsSuite"
$ build/sbt "sql/testOnly *QueryExecutionErrorsSuite"
```