### PR TITLE
[SPARK-40875] [CONNECT] [FOLLOW] Retain Group expressions in aggregate.

### DIFF
--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -441,11 +441,14 @@ class SparkConnectPlanner(session: SparkSession) {
           case x => UnresolvedAlias(x)
         }
 
+    // Retain group columns in aggregate expressions:
+    val aggExprs =
+      groupingExprs ++ rel.getResultExpressionsList.asScala.map(transformResultExpression)
+
     logical.Aggregate(
       child = transformRelation(rel.getInput),
       groupingExpressions = groupingExprs.toSeq,
-      aggregateExpressions =
-        rel.getResultExpressionsList.asScala.map(transformResultExpression).toSeq)
+      aggregateExpressions = aggExprs.toSeq)
   }
 
   private def transformResultExpression(exp: proto.Expression): expressions.NamedExpression = {

--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -148,29 +148,25 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
   }
 
   test("Aggregate with more than 1 grouping expressions") {
-    withSQLConf(SQLConf.DATAFRAME_RETAIN_GROUP_COLUMNS.key -> "false") {
-      val connectPlan =
-        connectTestRelation.groupBy("id".protoAttr, "name".protoAttr)()
-      val sparkPlan =
-        sparkTestRelation.groupBy(Column("id"), Column("name")).agg(Map.empty[String, String])
-      comparePlans(connectPlan, sparkPlan)
-    }
+    val connectPlan =
+      connectTestRelation.groupBy("id".protoAttr, "name".protoAttr)()
+    val sparkPlan =
+      sparkTestRelation.groupBy(Column("id"), Column("name")).agg(Map.empty[String, String])
+    comparePlans(connectPlan, sparkPlan)
   }
 
   test("Aggregate expressions") {
-    withSQLConf(SQLConf.DATAFRAME_RETAIN_GROUP_COLUMNS.key -> "false") {
-      val connectPlan =
-        connectTestRelation.groupBy("id".protoAttr)(proto_min("name".protoAttr))
-      val sparkPlan =
-        sparkTestRelation.groupBy(Column("id")).agg(min(Column("name")))
-      comparePlans(connectPlan, sparkPlan)
+    val connectPlan =
+      connectTestRelation.groupBy("id".protoAttr)(proto_min("name".protoAttr))
+    val sparkPlan =
+      sparkTestRelation.groupBy(Column("id")).agg(min(Column("name")))
+    comparePlans(connectPlan, sparkPlan)
 
-      val connectPlan2 =
-        connectTestRelation.groupBy("id".protoAttr)(proto_min("name".protoAttr).as("agg1"))
-      val sparkPlan2 =
-        sparkTestRelation.groupBy(Column("id")).agg(min(Column("name")).as("agg1"))
-      comparePlans(connectPlan2, sparkPlan2)
-    }
+    val connectPlan2 =
+      connectTestRelation.groupBy("id".protoAttr)(proto_min("name".protoAttr).as("agg1"))
+    val sparkPlan2 =
+      sparkTestRelation.groupBy(Column("id")).agg(min(Column("name")).as("agg1"))
+    comparePlans(connectPlan2, sparkPlan2)
   }
 
   test("Test as(alias: String)") {

--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.connect.dsl.commands._
 import org.apache.spark.sql.connect.dsl.expressions._
 import org.apache.spark.sql.connect.dsl.plans._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up improving the behavior and compatibility for aggregate relations using Spark Connect. Previously, Spark Connect would not retain the group by columns in the aggregation similar to very old Spark behavior that is by default not set.

### Why are the changes needed?
Compatibility.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT