### PR TITLE
[SPARK-41096][SQL] Support reading parquet FIXED_LEN_BYTE_ARRAY type

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
@@ -176,6 +176,8 @@ public class ParquetVectorUpdaterFactory {
           return new FixedLenByteArrayAsLongUpdater(arrayLen);
         } else if (canReadAsBinaryDecimal(descriptor, sparkType)) {
           return new FixedLenByteArrayUpdater(arrayLen);
+        } else if (sparkType == DataTypes.BinaryType) {
+          return new BinaryUpdater();
         }
         break;
       default:

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java
@@ -177,7 +177,7 @@ public class ParquetVectorUpdaterFactory {
         } else if (canReadAsBinaryDecimal(descriptor, sparkType)) {
           return new FixedLenByteArrayUpdater(arrayLen);
         } else if (sparkType == DataTypes.BinaryType) {
-          return new BinaryUpdater();
+          return new FixedLenByteArrayUpdater(arrayLen);
         }
         break;
       default:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -297,6 +297,7 @@ class ParquetToSparkSchemaConverter(
           case _: DecimalLogicalTypeAnnotation =>
             makeDecimalType(Decimal.maxPrecisionForBytes(parquetType.getTypeLength))
           case _: IntervalLogicalTypeAnnotation => typeNotImplemented()
+          case null => BinaryType
           case _ => illegalType()
         }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -36,6 +36,7 @@ import org.apache.parquet.hadoop._
 import org.apache.parquet.hadoop.example.ExampleParquetWriter
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP
+import org.apache.parquet.io.api.Binary
 import org.apache.parquet.schema.{MessageType, MessageTypeParser}
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkException, TestUtils}
@@ -111,22 +112,23 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
     }
   }
 
-  test("SPARK-XXXXX: FIXED_LEN_BYTE_ARRAY support") {
-    import org.apache.parquet.io.api.Binary
+  test("SPARK-41096: FIXED_LEN_BYTE_ARRAY support") {
     Seq(true, false).foreach { dictionaryEnabled =>
       def makeRawParquetFile(path: Path): Unit = {
         val schemaStr =
           """message root {
             |  required FIXED_LEN_BYTE_ARRAY(1) a;
+            |  required FIXED_LEN_BYTE_ARRAY(3) b;
             |}
         """.stripMargin
         val schema = MessageTypeParser.parseMessageType(schemaStr)
 
         val writer = createParquetWriter(schema, path, dictionaryEnabled)
 
-        (0 until 10).map(_.toLong).foreach { n =>
+        (0 until 10).map(_.toString).foreach { n =>
           val record = new SimpleGroup(schema)
-          record.add(0, Binary.fromString(n.toString))
+          record.add(0, Binary.fromString(n))
+          record.add(1, Binary.fromString(n + n + n))
           writer.write(record)
         }
         writer.close()
@@ -135,9 +137,11 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "part-r-0.parquet")
         makeRawParquetFile(path)
-        readParquetFile(path.toString) { df =>
-          checkAnswer(df, (0 until 10).map(n =>
-            Row(Array(n + 48)))) // "0" is 48 in ascii
+        Seq(true, false).foreach { vectorizedReaderEnabled =>
+          readParquetFile(path.toString, vectorizedReaderEnabled) { df =>
+            checkAnswer(df, (48 until 58).map(n => // char '0' is 48 in ascii
+              Row(Array(n), Array(n, n, n))))
+          }
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Parquet supports FIXED_LEN_BYTE_ARRAY (FLBA) data type. However, Spark Parquet reader currently cannot handle FLBA.
This PR proposes to read FLBA column as BinaryType data in Spark.

### Why are the changes needed?
Iceberg Parquet reader, for example, can handle FLBA. This PR reduces the implementation gap between Spark and Iceberg Parquet reader.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test added