### PR TITLE
[SPARK-41072][SQL][SS] Add the error class `STREAM_FAILED` to `StreamingQueryException`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -931,7 +931,7 @@
   },
   "STREAM_FAILED" : {
     "message" : [
-      "Query [id = <id>, runId = <runId>] terminated with exception: <msg>"
+      "Query [id = <id>, runId = <runId>] terminated with exception: <message>"
     ]
   },
   "TABLE_OR_VIEW_ALREADY_EXISTS" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -929,6 +929,11 @@
       "Star (*) is not allowed in a select list when GROUP BY an ordinal position is used."
     ]
   },
+  "STREAM_FAILED" : {
+    "message" : [
+      "Query [id = <id>, runId = <runId>] terminated with exception: <msg>"
+    ]
+  },
   "TABLE_OR_VIEW_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create table or view <relationName> because it already exists.",

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -117,7 +117,10 @@ object MimaExcludes {
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.storage.ShuffleBlockFetcherIterator#FetchRequest.copy"),
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.storage.ShuffleBlockFetcherIterator#FetchRequest.copy$default$2"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.storage.ShuffleBlockFetcherIterator#FetchRequest.this"),
-    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.storage.ShuffleBlockFetcherIterator#FetchRequest.apply")
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.storage.ShuffleBlockFetcherIterator#FetchRequest.apply"),
+
+    // [SPARK-41072][SS] Add the error class STREAM_FAILED to StreamingQueryException
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StreamingQueryException.this")
   )
 
   // Defulat exclude rules

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table}
 import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2, ReadLimit, SparkDataStream}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfoImpl, SupportsTruncate, Write}
-import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.command.StreamingExplainCommand
 import org.apache.spark.sql.execution.datasources.v2.StreamWriterCommitProgress
 import org.apache.spark.sql.internal.SQLConf
@@ -320,14 +319,17 @@ abstract class StreamExecution(
         // This is a workaround for HADOOP-12074: `Shell.runCommand` converts `InterruptedException`
         // to `new IOException(ie.toString())` before Hadoop 2.8.
         updateStatusMessage("Stopped")
-      case t: Throwable =>
-        val e = QueryExecution.toInternalError(msg = s"Execution of the stream $name failed.", t)
+      case e: Throwable =>
         streamDeathCause = new StreamingQueryException(
           toDebugString(includeLogicalPlan = isInitialized),
-          s"Query $prettyIdString terminated with exception: ${e.getMessage}",
-          e,
+          cause = e,
           committedOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString,
-          availableOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString)
+          availableOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString,
+          errorClass = "STREAM_FAILED",
+          messageParameters = Map(
+            "id" -> id.toString,
+            "runId" -> runId.toString,
+            "msg" -> e.getMessage))
         logError(s"Query $prettyIdString terminated with error", e)
         updateStatusMessage(s"Terminated with exception: ${e.getMessage}")
         // Rethrow the fatal errors to allow the user using `Thread.UncaughtExceptionHandler` to

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -320,6 +320,7 @@ abstract class StreamExecution(
         // to `new IOException(ie.toString())` before Hadoop 2.8.
         updateStatusMessage("Stopped")
       case e: Throwable =>
+        val message = if (e.getMessage == null) "" else e.getMessage
         streamDeathCause = new StreamingQueryException(
           toDebugString(includeLogicalPlan = isInitialized),
           cause = e,
@@ -329,9 +330,9 @@ abstract class StreamExecution(
           messageParameters = Map(
             "id" -> id.toString,
             "runId" -> runId.toString,
-            "msg" -> e.getMessage))
+            "message" -> message))
         logError(s"Query $prettyIdString terminated with error", e)
-        updateStatusMessage(s"Terminated with exception: ${e.getMessage}")
+        updateStatusMessage(s"Terminated with exception: $message")
         // Rethrow the fatal errors to allow the user using `Thread.UncaughtExceptionHandler` to
         // handle them
         if (!NonFatal(e)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.streaming
 
+import scala.collection.JavaConverters._
+
+import org.apache.spark.{SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.annotation.Evolving
 
 /**
@@ -34,8 +37,27 @@ class StreamingQueryException private[sql](
     val message: String,
     val cause: Throwable,
     val startOffset: String,
-    val endOffset: String)
-  extends Exception(message, cause) {
+    val endOffset: String,
+    errorClass: String,
+    messageParameters: Map[String, String])
+  extends Exception(message, cause) with SparkThrowable {
+
+  def this(
+      queryDebugString: String,
+      cause: Throwable,
+      startOffset: String,
+      endOffset: String,
+      errorClass: String,
+      messageParameters: Map[String, String]) = {
+    this(
+      queryDebugString,
+      message = SparkThrowableHelper.getMessage(errorClass, messageParameters),
+      cause,
+      startOffset,
+      endOffset,
+      errorClass,
+      messageParameters)
+  }
 
   /** Time when the exception occurred */
   val time: Long = System.currentTimeMillis
@@ -43,4 +65,8 @@ class StreamingQueryException private[sql](
   override def toString(): String =
     s"""${classOf[StreamingQueryException].getName}: ${cause.getMessage}
        |$queryDebugString""".stripMargin
+
+  override def getErrorClass: String = errorClass
+
+  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to change the exception `StreamingQueryException` by extending `SparkThrowable` and new error class `STREAM_FAILED` which is set on raising `StreamingQueryException` on any stream failures.

### Why are the changes needed?
To be consistent to other Spark's exception like `SparkException`, and to improve user experience with Spark APIs.

### Does this PR introduce _any_ user-facing change?
Yes, it extends the existing API.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "core/testOnly *SparkThrowableSuite"
$ build/sbt "sql/testOnly *QueryExecutionErrorsSuite"
```