### PR TITLE
[WIP] [CONNECT] Support Cast and DataTypes as Literals

### DIFF
--- a/connector/connect/src/main/protobuf/spark/connect/expressions.proto
+++ b/connector/connect/src/main/protobuf/spark/connect/expressions.proto
@@ -71,6 +71,8 @@ message Expression {
       DataType.List empty_list = 31;
       DataType.Map empty_map = 32;
       UserDefined user_defined = 33;
+      // A data type literal to be used for casts etc.
+      DataType data_type = 34;
     }
 
     // whether the literal type should be treated as a nullable type. Applies to

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/dsl/package.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/dsl/package.scala
@@ -144,6 +144,28 @@ package object dsl {
         .newBuilder()
         .setLiteral(Expression.Literal.newBuilder().setI32(i))
         .build()
+
+    def protoStrToLiteral(s: String): Expression =
+      Expression
+        .newBuilder()
+        .setLiteral(Expression.Literal.newBuilder().setString(s).build())
+        .build()
+
+    def protoStrToTypeLiteral(s: String): Expression = {
+      val dt = s match {
+        case "string" =>
+          DataType.newBuilder().setString(DataType.String.getDefaultInstance).build()
+        case "float" => DataType.newBuilder().setFp32(DataType.FP32.getDefaultInstance).build()
+        case "double" => DataType.newBuilder().setFp64(DataType.FP64.getDefaultInstance).build()
+      }
+      Expression
+        .newBuilder()
+        .setLiteral(
+          Expression.Literal
+            .newBuilder()
+            .setDataType(dt))
+        .build()
+    }
   }
 
   object commands { // scalastyle:ignore

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
@@ -21,7 +21,7 @@ import scala.collection.convert.ImplicitConversions._
 
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.types.{DataType, IntegerType, LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, FloatType, IntegerType, LongType, StringType, StructField, StructType}
 
 /**
  * This object offers methods to convert to/from connect proto to catalyst types.
@@ -30,6 +30,7 @@ object DataTypeProtoConverter {
   def toCatalystType(t: proto.DataType): DataType = {
     t.getKindCase match {
       case proto.DataType.KindCase.I32 => IntegerType
+      case proto.DataType.KindCase.FP32 => FloatType
       case proto.DataType.KindCase.STRING => StringType
       case proto.DataType.KindCase.STRUCT => convertProtoDataTypeToCatalyst(t.getStruct)
       case _ =>
@@ -48,6 +49,8 @@ object DataTypeProtoConverter {
     t match {
       case IntegerType =>
         proto.DataType.newBuilder().setI32(proto.DataType.I32.getDefaultInstance).build()
+      case FloatType =>
+        proto.DataType.newBuilder().setFp32(proto.DataType.FP32.getDefaultInstance).build()
       case StringType =>
         proto.DataType.newBuilder().setString(proto.DataType.String.getDefaultInstance).build()
       case LongType =>

--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.Join.JoinType
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Row, SaveMode}
 import org.apache.spark.sql.catalyst.analysis
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, EvalMode}
 import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, LeftAnti, LeftOuter, LeftSemi, PlanTest, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -33,7 +33,7 @@ import org.apache.spark.sql.connect.dsl.expressions._
 import org.apache.spark.sql.connect.dsl.plans._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DataTypes, IntegerType, StringType, StructField, StructType}
 
 /**
  * This suite is based on connect DSL and test that given same dataframe operations, whether
@@ -89,6 +89,15 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
 
     val validPlan = connectTestRelation.select(callFunction(Seq("hex"), Seq("id".protoAttr)))
     assert(analyzePlan(transform(validPlan)) != null)
+  }
+
+  test("Cast") {
+    comparePlans(
+      connectTestRelation.select(
+        callFunction("cast", Seq("id".protoAttr, protoStrToTypeLiteral("float")))),
+      sparkTestRelation.select(
+        Column(
+          Cast(Column("id").expr, DataTypes.FloatType, None, EvalMode.fromSQLConf(SQLConf.get)))))
   }
 
   test("Basic filter") {

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -34,7 +34,7 @@ from pyspark import cloudpickle
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.plan import SQL, Range
-from pyspark.sql.types import DataType, StructType, StructField, LongType, StringType
+from pyspark.sql.types import DataType, StructType, StructField, LongType, StringType, FloatType
 
 from typing import Optional, Any, Union
 
@@ -377,6 +377,8 @@ class RemoteSparkSession(object):
             return StructType(structFields)
         elif schema.HasField("i64"):
             return LongType()
+        elif schema.HasField("fp32"):
+            return FloatType()
         elif schema.HasField("string"):
             return StringType()
         else:

--- a/python/pyspark/sql/connect/proto/expressions_pb2.py
+++ b/python/pyspark/sql/connect/proto/expressions_pb2.py
@@ -33,7 +33,7 @@ from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1fspark/connect/expressions.proto\x12\rspark.connect\x1a\x19spark/connect/types.proto\x1a\x19google/protobuf/any.proto"\xc2\x17\n\nExpression\x12=\n\x07literal\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x07literal\x12\x62\n\x14unresolved_attribute\x18\x02 \x01(\x0b\x32-.spark.connect.Expression.UnresolvedAttributeH\x00R\x13unresolvedAttribute\x12_\n\x13unresolved_function\x18\x03 \x01(\x0b\x32,.spark.connect.Expression.UnresolvedFunctionH\x00R\x12unresolvedFunction\x12Y\n\x11\x65xpression_string\x18\x04 \x01(\x0b\x32*.spark.connect.Expression.ExpressionStringH\x00R\x10\x65xpressionString\x12S\n\x0funresolved_star\x18\x05 \x01(\x0b\x32(.spark.connect.Expression.UnresolvedStarH\x00R\x0eunresolvedStar\x12\x37\n\x05\x61lias\x18\x06 \x01(\x0b\x32\x1f.spark.connect.Expression.AliasH\x00R\x05\x61lias\x1a\xa3\x10\n\x07Literal\x12\x1a\n\x07\x62oolean\x18\x01 \x01(\x08H\x00R\x07\x62oolean\x12\x10\n\x02i8\x18\x02 \x01(\x05H\x00R\x02i8\x12\x12\n\x03i16\x18\x03 \x01(\x05H\x00R\x03i16\x12\x12\n\x03i32\x18\x05 \x01(\x05H\x00R\x03i32\x12\x12\n\x03i64\x18\x07 \x01(\x03H\x00R\x03i64\x12\x14\n\x04\x66p32\x18\n \x01(\x02H\x00R\x04\x66p32\x12\x14\n\x04\x66p64\x18\x0b \x01(\x01H\x00R\x04\x66p64\x12\x18\n\x06string\x18\x0c \x01(\tH\x00R\x06string\x12\x18\n\x06\x62inary\x18\r \x01(\x0cH\x00R\x06\x62inary\x12\x1e\n\ttimestamp\x18\x0e \x01(\x03H\x00R\ttimestamp\x12\x14\n\x04\x64\x61te\x18\x10 \x01(\x05H\x00R\x04\x64\x61te\x12\x14\n\x04time\x18\x11 \x01(\x03H\x00R\x04time\x12l\n\x16interval_year_to_month\x18\x13 \x01(\x0b\x32\x35.spark.connect.Expression.Literal.IntervalYearToMonthH\x00R\x13intervalYearToMonth\x12l\n\x16interval_day_to_second\x18\x14 \x01(\x0b\x32\x35.spark.connect.Expression.Literal.IntervalDayToSecondH\x00R\x13intervalDayToSecond\x12\x1f\n\nfixed_char\x18\x15 \x01(\tH\x00R\tfixedChar\x12\x46\n\x08var_char\x18\x16 \x01(\x0b\x32).spark.connect.Expression.Literal.VarCharH\x00R\x07varChar\x12#\n\x0c\x66ixed_binary\x18\x17 \x01(\x0cH\x00R\x0b\x66ixedBinary\x12\x45\n\x07\x64\x65\x63imal\x18\x18 \x01(\x0b\x32).spark.connect.Expression.Literal.DecimalH\x00R\x07\x64\x65\x63imal\x12\x42\n\x06struct\x18\x19 \x01(\x0b\x32(.spark.connect.Expression.Literal.StructH\x00R\x06struct\x12\x39\n\x03map\x18\x1a \x01(\x0b\x32%.spark.connect.Expression.Literal.MapH\x00R\x03map\x12#\n\x0ctimestamp_tz\x18\x1b \x01(\x03H\x00R\x0btimestampTz\x12\x14\n\x04uuid\x18\x1c \x01(\x0cH\x00R\x04uuid\x12-\n\x04null\x18\x1d \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x04null\x12<\n\x04list\x18\x1e \x01(\x0b\x32&.spark.connect.Expression.Literal.ListH\x00R\x04list\x12=\n\nempty_list\x18\x1f \x01(\x0b\x32\x1c.spark.connect.DataType.ListH\x00R\temptyList\x12:\n\tempty_map\x18  \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x08\x65mptyMap\x12R\n\x0cuser_defined\x18! \x01(\x0b\x32-.spark.connect.Expression.Literal.UserDefinedH\x00R\x0buserDefined\x12\x1a\n\x08nullable\x18\x32 \x01(\x08R\x08nullable\x12\x38\n\x18type_variation_reference\x18\x33 \x01(\rR\x16typeVariationReference\x1a\x37\n\x07VarChar\x12\x14\n\x05value\x18\x01 \x01(\tR\x05value\x12\x16\n\x06length\x18\x02 \x01(\rR\x06length\x1aS\n\x07\x44\x65\x63imal\x12\x14\n\x05value\x18\x01 \x01(\x0cR\x05value\x12\x1c\n\tprecision\x18\x02 \x01(\x05R\tprecision\x12\x14\n\x05scale\x18\x03 \x01(\x05R\x05scale\x1a\xce\x01\n\x03Map\x12M\n\nkey_values\x18\x01 \x03(\x0b\x32..spark.connect.Expression.Literal.Map.KeyValueR\tkeyValues\x1ax\n\x08KeyValue\x12\x33\n\x03key\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x03key\x12\x37\n\x05value\x18\x02 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x05value\x1a\x43\n\x13IntervalYearToMonth\x12\x14\n\x05years\x18\x01 \x01(\x05R\x05years\x12\x16\n\x06months\x18\x02 \x01(\x05R\x06months\x1ag\n\x13IntervalDayToSecond\x12\x12\n\x04\x64\x61ys\x18\x01 \x01(\x05R\x04\x64\x61ys\x12\x18\n\x07seconds\x18\x02 \x01(\x05R\x07seconds\x12"\n\x0cmicroseconds\x18\x03 \x01(\x05R\x0cmicroseconds\x1a\x43\n\x06Struct\x12\x39\n\x06\x66ields\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06\x66ields\x1a\x41\n\x04List\x12\x39\n\x06values\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values\x1a`\n\x0bUserDefined\x12%\n\x0etype_reference\x18\x01 \x01(\rR\rtypeReference\x12*\n\x05value\x18\x02 \x01(\x0b\x32\x14.google.protobuf.AnyR\x05valueB\x0e\n\x0cliteral_type\x1a\x46\n\x13UnresolvedAttribute\x12/\n\x13unparsed_identifier\x18\x01 \x01(\tR\x12unparsedIdentifier\x1a\x63\n\x12UnresolvedFunction\x12\x14\n\x05parts\x18\x01 \x03(\tR\x05parts\x12\x37\n\targuments\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\targuments\x1a\x32\n\x10\x45xpressionString\x12\x1e\n\nexpression\x18\x01 \x01(\tR\nexpression\x1a\x10\n\x0eUnresolvedStar\x1aU\n\x12QualifiedAttribute\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12+\n\x04type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x04type\x1aJ\n\x05\x41lias\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12\x12\n\x04name\x18\x02 \x01(\tR\x04nameB\x0b\n\texpr_typeB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
+    b'\n\x1fspark/connect/expressions.proto\x12\rspark.connect\x1a\x19spark/connect/types.proto\x1a\x19google/protobuf/any.proto"\xfa\x17\n\nExpression\x12=\n\x07literal\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x07literal\x12\x62\n\x14unresolved_attribute\x18\x02 \x01(\x0b\x32-.spark.connect.Expression.UnresolvedAttributeH\x00R\x13unresolvedAttribute\x12_\n\x13unresolved_function\x18\x03 \x01(\x0b\x32,.spark.connect.Expression.UnresolvedFunctionH\x00R\x12unresolvedFunction\x12Y\n\x11\x65xpression_string\x18\x04 \x01(\x0b\x32*.spark.connect.Expression.ExpressionStringH\x00R\x10\x65xpressionString\x12S\n\x0funresolved_star\x18\x05 \x01(\x0b\x32(.spark.connect.Expression.UnresolvedStarH\x00R\x0eunresolvedStar\x12\x37\n\x05\x61lias\x18\x06 \x01(\x0b\x32\x1f.spark.connect.Expression.AliasH\x00R\x05\x61lias\x1a\xdb\x10\n\x07Literal\x12\x1a\n\x07\x62oolean\x18\x01 \x01(\x08H\x00R\x07\x62oolean\x12\x10\n\x02i8\x18\x02 \x01(\x05H\x00R\x02i8\x12\x12\n\x03i16\x18\x03 \x01(\x05H\x00R\x03i16\x12\x12\n\x03i32\x18\x05 \x01(\x05H\x00R\x03i32\x12\x12\n\x03i64\x18\x07 \x01(\x03H\x00R\x03i64\x12\x14\n\x04\x66p32\x18\n \x01(\x02H\x00R\x04\x66p32\x12\x14\n\x04\x66p64\x18\x0b \x01(\x01H\x00R\x04\x66p64\x12\x18\n\x06string\x18\x0c \x01(\tH\x00R\x06string\x12\x18\n\x06\x62inary\x18\r \x01(\x0cH\x00R\x06\x62inary\x12\x1e\n\ttimestamp\x18\x0e \x01(\x03H\x00R\ttimestamp\x12\x14\n\x04\x64\x61te\x18\x10 \x01(\x05H\x00R\x04\x64\x61te\x12\x14\n\x04time\x18\x11 \x01(\x03H\x00R\x04time\x12l\n\x16interval_year_to_month\x18\x13 \x01(\x0b\x32\x35.spark.connect.Expression.Literal.IntervalYearToMonthH\x00R\x13intervalYearToMonth\x12l\n\x16interval_day_to_second\x18\x14 \x01(\x0b\x32\x35.spark.connect.Expression.Literal.IntervalDayToSecondH\x00R\x13intervalDayToSecond\x12\x1f\n\nfixed_char\x18\x15 \x01(\tH\x00R\tfixedChar\x12\x46\n\x08var_char\x18\x16 \x01(\x0b\x32).spark.connect.Expression.Literal.VarCharH\x00R\x07varChar\x12#\n\x0c\x66ixed_binary\x18\x17 \x01(\x0cH\x00R\x0b\x66ixedBinary\x12\x45\n\x07\x64\x65\x63imal\x18\x18 \x01(\x0b\x32).spark.connect.Expression.Literal.DecimalH\x00R\x07\x64\x65\x63imal\x12\x42\n\x06struct\x18\x19 \x01(\x0b\x32(.spark.connect.Expression.Literal.StructH\x00R\x06struct\x12\x39\n\x03map\x18\x1a \x01(\x0b\x32%.spark.connect.Expression.Literal.MapH\x00R\x03map\x12#\n\x0ctimestamp_tz\x18\x1b \x01(\x03H\x00R\x0btimestampTz\x12\x14\n\x04uuid\x18\x1c \x01(\x0cH\x00R\x04uuid\x12-\n\x04null\x18\x1d \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x04null\x12<\n\x04list\x18\x1e \x01(\x0b\x32&.spark.connect.Expression.Literal.ListH\x00R\x04list\x12=\n\nempty_list\x18\x1f \x01(\x0b\x32\x1c.spark.connect.DataType.ListH\x00R\temptyList\x12:\n\tempty_map\x18  \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x08\x65mptyMap\x12R\n\x0cuser_defined\x18! \x01(\x0b\x32-.spark.connect.Expression.Literal.UserDefinedH\x00R\x0buserDefined\x12\x36\n\tdata_type\x18" \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x08\x64\x61taType\x12\x1a\n\x08nullable\x18\x32 \x01(\x08R\x08nullable\x12\x38\n\x18type_variation_reference\x18\x33 \x01(\rR\x16typeVariationReference\x1a\x37\n\x07VarChar\x12\x14\n\x05value\x18\x01 \x01(\tR\x05value\x12\x16\n\x06length\x18\x02 \x01(\rR\x06length\x1aS\n\x07\x44\x65\x63imal\x12\x14\n\x05value\x18\x01 \x01(\x0cR\x05value\x12\x1c\n\tprecision\x18\x02 \x01(\x05R\tprecision\x12\x14\n\x05scale\x18\x03 \x01(\x05R\x05scale\x1a\xce\x01\n\x03Map\x12M\n\nkey_values\x18\x01 \x03(\x0b\x32..spark.connect.Expression.Literal.Map.KeyValueR\tkeyValues\x1ax\n\x08KeyValue\x12\x33\n\x03key\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x03key\x12\x37\n\x05value\x18\x02 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x05value\x1a\x43\n\x13IntervalYearToMonth\x12\x14\n\x05years\x18\x01 \x01(\x05R\x05years\x12\x16\n\x06months\x18\x02 \x01(\x05R\x06months\x1ag\n\x13IntervalDayToSecond\x12\x12\n\x04\x64\x61ys\x18\x01 \x01(\x05R\x04\x64\x61ys\x12\x18\n\x07seconds\x18\x02 \x01(\x05R\x07seconds\x12"\n\x0cmicroseconds\x18\x03 \x01(\x05R\x0cmicroseconds\x1a\x43\n\x06Struct\x12\x39\n\x06\x66ields\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06\x66ields\x1a\x41\n\x04List\x12\x39\n\x06values\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values\x1a`\n\x0bUserDefined\x12%\n\x0etype_reference\x18\x01 \x01(\rR\rtypeReference\x12*\n\x05value\x18\x02 \x01(\x0b\x32\x14.google.protobuf.AnyR\x05valueB\x0e\n\x0cliteral_type\x1a\x46\n\x13UnresolvedAttribute\x12/\n\x13unparsed_identifier\x18\x01 \x01(\tR\x12unparsedIdentifier\x1a\x63\n\x12UnresolvedFunction\x12\x14\n\x05parts\x18\x01 \x03(\tR\x05parts\x12\x37\n\targuments\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\targuments\x1a\x32\n\x10\x45xpressionString\x12\x1e\n\nexpression\x18\x01 \x01(\tR\nexpression\x1a\x10\n\x0eUnresolvedStar\x1aU\n\x12QualifiedAttribute\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12+\n\x04type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x04type\x1aJ\n\x05\x41lias\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12\x12\n\x04name\x18\x02 \x01(\tR\x04nameB\x0b\n\texpr_typeB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
 )
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
@@ -43,37 +43,37 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b"\n\036org.apache.spark.connect.protoP\001"
     _EXPRESSION._serialized_start = 105
-    _EXPRESSION._serialized_end = 3115
+    _EXPRESSION._serialized_end = 3171
     _EXPRESSION_LITERAL._serialized_start = 613
-    _EXPRESSION_LITERAL._serialized_end = 2696
-    _EXPRESSION_LITERAL_VARCHAR._serialized_start = 1923
-    _EXPRESSION_LITERAL_VARCHAR._serialized_end = 1978
-    _EXPRESSION_LITERAL_DECIMAL._serialized_start = 1980
-    _EXPRESSION_LITERAL_DECIMAL._serialized_end = 2063
-    _EXPRESSION_LITERAL_MAP._serialized_start = 2066
-    _EXPRESSION_LITERAL_MAP._serialized_end = 2272
-    _EXPRESSION_LITERAL_MAP_KEYVALUE._serialized_start = 2152
-    _EXPRESSION_LITERAL_MAP_KEYVALUE._serialized_end = 2272
-    _EXPRESSION_LITERAL_INTERVALYEARTOMONTH._serialized_start = 2274
-    _EXPRESSION_LITERAL_INTERVALYEARTOMONTH._serialized_end = 2341
-    _EXPRESSION_LITERAL_INTERVALDAYTOSECOND._serialized_start = 2343
-    _EXPRESSION_LITERAL_INTERVALDAYTOSECOND._serialized_end = 2446
-    _EXPRESSION_LITERAL_STRUCT._serialized_start = 2448
-    _EXPRESSION_LITERAL_STRUCT._serialized_end = 2515
-    _EXPRESSION_LITERAL_LIST._serialized_start = 2517
-    _EXPRESSION_LITERAL_LIST._serialized_end = 2582
-    _EXPRESSION_LITERAL_USERDEFINED._serialized_start = 2584
-    _EXPRESSION_LITERAL_USERDEFINED._serialized_end = 2680
-    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_start = 2698
-    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_end = 2768
-    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_start = 2770
-    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_end = 2869
-    _EXPRESSION_EXPRESSIONSTRING._serialized_start = 2871
-    _EXPRESSION_EXPRESSIONSTRING._serialized_end = 2921
-    _EXPRESSION_UNRESOLVEDSTAR._serialized_start = 2923
-    _EXPRESSION_UNRESOLVEDSTAR._serialized_end = 2939
-    _EXPRESSION_QUALIFIEDATTRIBUTE._serialized_start = 2941
-    _EXPRESSION_QUALIFIEDATTRIBUTE._serialized_end = 3026
-    _EXPRESSION_ALIAS._serialized_start = 3028
-    _EXPRESSION_ALIAS._serialized_end = 3102
+    _EXPRESSION_LITERAL._serialized_end = 2752
+    _EXPRESSION_LITERAL_VARCHAR._serialized_start = 1979
+    _EXPRESSION_LITERAL_VARCHAR._serialized_end = 2034
+    _EXPRESSION_LITERAL_DECIMAL._serialized_start = 2036
+    _EXPRESSION_LITERAL_DECIMAL._serialized_end = 2119
+    _EXPRESSION_LITERAL_MAP._serialized_start = 2122
+    _EXPRESSION_LITERAL_MAP._serialized_end = 2328
+    _EXPRESSION_LITERAL_MAP_KEYVALUE._serialized_start = 2208
+    _EXPRESSION_LITERAL_MAP_KEYVALUE._serialized_end = 2328
+    _EXPRESSION_LITERAL_INTERVALYEARTOMONTH._serialized_start = 2330
+    _EXPRESSION_LITERAL_INTERVALYEARTOMONTH._serialized_end = 2397
+    _EXPRESSION_LITERAL_INTERVALDAYTOSECOND._serialized_start = 2399
+    _EXPRESSION_LITERAL_INTERVALDAYTOSECOND._serialized_end = 2502
+    _EXPRESSION_LITERAL_STRUCT._serialized_start = 2504
+    _EXPRESSION_LITERAL_STRUCT._serialized_end = 2571
+    _EXPRESSION_LITERAL_LIST._serialized_start = 2573
+    _EXPRESSION_LITERAL_LIST._serialized_end = 2638
+    _EXPRESSION_LITERAL_USERDEFINED._serialized_start = 2640
+    _EXPRESSION_LITERAL_USERDEFINED._serialized_end = 2736
+    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_start = 2754
+    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_end = 2824
+    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_start = 2826
+    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_end = 2925
+    _EXPRESSION_EXPRESSIONSTRING._serialized_start = 2927
+    _EXPRESSION_EXPRESSIONSTRING._serialized_end = 2977
+    _EXPRESSION_UNRESOLVEDSTAR._serialized_start = 2979
+    _EXPRESSION_UNRESOLVEDSTAR._serialized_end = 2995
+    _EXPRESSION_QUALIFIEDATTRIBUTE._serialized_start = 2997
+    _EXPRESSION_QUALIFIEDATTRIBUTE._serialized_end = 3082
+    _EXPRESSION_ALIAS._serialized_start = 3084
+    _EXPRESSION_ALIAS._serialized_end = 3158
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/expressions_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/expressions_pb2.pyi
@@ -283,6 +283,7 @@ class Expression(google.protobuf.message.Message):
         EMPTY_LIST_FIELD_NUMBER: builtins.int
         EMPTY_MAP_FIELD_NUMBER: builtins.int
         USER_DEFINED_FIELD_NUMBER: builtins.int
+        DATA_TYPE_FIELD_NUMBER: builtins.int
         NULLABLE_FIELD_NUMBER: builtins.int
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
         boolean: builtins.bool
@@ -328,6 +329,9 @@ class Expression(google.protobuf.message.Message):
         def empty_map(self) -> pyspark.sql.connect.proto.types_pb2.DataType.Map: ...
         @property
         def user_defined(self) -> global___Expression.Literal.UserDefined: ...
+        @property
+        def data_type(self) -> pyspark.sql.connect.proto.types_pb2.DataType:
+            """A data type literal to be used for casts etc."""
         nullable: builtins.bool
         """whether the literal type should be treated as a nullable type. Applies to
         all members of union other than the Typed null (which should directly
@@ -368,6 +372,7 @@ class Expression(google.protobuf.message.Message):
             empty_list: pyspark.sql.connect.proto.types_pb2.DataType.List | None = ...,
             empty_map: pyspark.sql.connect.proto.types_pb2.DataType.Map | None = ...,
             user_defined: global___Expression.Literal.UserDefined | None = ...,
+            data_type: pyspark.sql.connect.proto.types_pb2.DataType | None = ...,
             nullable: builtins.bool = ...,
             type_variation_reference: builtins.int = ...,
         ) -> None: ...
@@ -378,6 +383,8 @@ class Expression(google.protobuf.message.Message):
                 b"binary",
                 "boolean",
                 b"boolean",
+                "data_type",
+                b"data_type",
                 "date",
                 b"date",
                 "decimal",
@@ -439,6 +446,8 @@ class Expression(google.protobuf.message.Message):
                 b"binary",
                 "boolean",
                 b"boolean",
+                "data_type",
+                b"data_type",
                 "date",
                 b"date",
                 "decimal",
@@ -527,6 +536,7 @@ class Expression(google.protobuf.message.Message):
             "empty_list",
             "empty_map",
             "user_defined",
+            "data_type",
         ] | None: ...
 
     class UnresolvedAttribute(google.protobuf.message.Message):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -27,7 +27,7 @@ if have_pandas:
     import pandas
 
 from pyspark.sql import SparkSession, Row
-from pyspark.sql.types import StructType, StructField, LongType, StringType
+from pyspark.sql.types import StructType, StructField, LongType, StringType, FloatType
 
 if have_pandas:
     from pyspark.sql.connect.client import RemoteSparkSession, ChannelBuilder
@@ -231,6 +231,10 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         else:
             actualResult = pandasResult.values.tolist()
             self.assertEqual(len(expectResult), len(actualResult))
+
+    def test_cast(self) -> None:
+        dt = self.connect.range(1, 10).select(col("id").cast("float")).schema().fields[0].dataType
+        self.assertEqual(dt, FloatType())
 
 
 class ChannelBuilderTests(ReusedPySparkTestCase):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -464,6 +464,13 @@ object Cast extends QueryErrorsBase {
 
   def apply(
       child: Expression,
+      dataType: Expression,
+      ansiEnabled: Boolean): Cast = {
+    Cast(child, dataType.dataType, ansiEnabled)
+  }
+
+  def apply(
+      child: Expression,
       dataType: DataType,
       timeZoneId: Option[String],
       ansiEnabled: Boolean): Cast =
@@ -498,6 +505,9 @@ case class Cast(
 
   def this(child: Expression, dataType: DataType, timeZoneId: Option[String]) =
     this(child, dataType, timeZoneId, evalMode = EvalMode.fromSQLConf(SQLConf.get))
+
+  def this(child: Expression, dt: Expression) =
+    this(child, dt.dataType, None, EvalMode.fromSQLConf(SQLConf.get))
 
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))


### PR DESCRIPTION
## Discussion:

* Should functions that receive `DataType` as arguments be extended to support string literals that are then parsed into a type or should the functions support an expression as the type parameter that is a string and can be parsed into the datatype.



### What changes were proposed in this pull request?
Support the `Column.cast` functionality and extend the protocol to allow data types to be passed as literals. 

**This is an example and not fully thought through**

### Why are the changes needed?
Compat

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT, E2E