### PR TITLE
[SPARK-41121][BUILD] Upgrade `sbt-assembly` to 2.0.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "9.3"
 // checkstyle uses guava 31.0.1-jre.
 libraryDependencies += "com.google.guava" % "guava" % "31.0.1-jre"
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade sbt-assembly plugin from 1.2.0 to 2.0.0

### Why are the changes needed?
Release notes as follows:
https://github.com/sbt/sbt-assembly/releases/tag/v2.0.0
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/15246973/201500241-f40341b6-bbd2-4224-b18e-f2a696cae23b.png">


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.