### PR TITLE
[SPARK-41123][BUILD] Upgrade mysql-connector-java from 8.0.30 to 8.0.31

### DIFF
--- a/connector/docker-integration-tests/pom.xml
+++ b/connector/docker-integration-tests/pom.xml
@@ -164,7 +164,7 @@
     </dependency>
     <dependency>
       <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <artifactId>mysql-connector-j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/connector/docker-integration-tests/pom.xml
+++ b/connector/docker-integration-tests/pom.xml
@@ -163,7 +163,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
+      <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1193,8 +1193,8 @@
       </dependency>
       <dependency>
         <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
-        <version>8.0.30</version>
+        <artifactId>mysql-connector-j</artifactId>
+        <version>8.0.31</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1192,7 +1192,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>mysql</groupId>
+        <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
         <version>8.0.31</version>
         <scope>test</scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade mysql-connector-java from 8.0.30 to 8.0.31.
From v8.0.31 the artifact was moved to: [com.mysql](https://mvnrepository.com/artifact/com.mysql) » [mysql-connector-j](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)
<img width="839" alt="image" src="https://user-images.githubusercontent.com/15246973/201521236-d17cbdb4-080e-4b75-8667-b33f25ad613b.png">

### Why are the changes needed?
This version brings some bugs fixes, the release note as follows:
https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-31.html
Bugs Fixed, eg:
> Executing a PreparedStatment after applying setFetchSize(0) on it caused an ArrayIndexOutOfBoundsException. (Bug #104753, Bug #33286177)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.