### PR TITLE
[SPARK-41126][K8S] `entrypoint.sh` should use its WORKDIR instead of `/tmp` directory

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -41,11 +41,11 @@ if [ -z "$JAVA_HOME" ]; then
 fi
 
 SPARK_CLASSPATH="$SPARK_CLASSPATH:${SPARK_HOME}/jars/*"
-env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' > /tmp/java_opts.txt
+env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' > java_opts.txt
 if [ "$(command -v readarray)" ]; then
-  readarray -t SPARK_EXECUTOR_JAVA_OPTS < /tmp/java_opts.txt
+  readarray -t SPARK_EXECUTOR_JAVA_OPTS < java_opts.txt
 else
-  SPARK_EXECUTOR_JAVA_OPTS=("${(@f)$(< /tmp/java_opts.txt)}")
+  SPARK_EXECUTOR_JAVA_OPTS=("${(@f)$(< java_opts.txt)}")
 fi
 
 if [ -n "$SPARK_EXTRA_CLASSPATH" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `entrypoint.sh` to use its WORKDIR instead of `/tmp` directory for its temporary file, `java_opts.txt`.

### Why are the changes needed?

In some environment, `/tmp` is shared with other containers or even other pods.

### Does this PR introduce _any_ user-facing change?

No, this `/tmp/java_opts.txt` file is not supposed to be shared by others.

### How was this patch tested?

Pass the CIs (including K8s Integration Tests).