### PR TITLE
[SPARK-41091][BUILD][3.2] Fix Docker release tool for branch-3.2

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get clean && apt-get update && $APT_INSTALL gnupg ca-certificates && \
   $APT_INSTALL r-base r-base-dev && \
   $APT_INSTALL libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev && \
   $APT_INSTALL texlive-latex-base texlive texlive-fonts-extra texinfo qpdf texlive-latex-extra && \
+  $APT_INSTALL libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev && \
   Rscript -e "install.packages(c('curl', 'xml2', 'httr', 'devtools', 'testthat', 'knitr', 'rmarkdown', 'markdown', 'roxygen2', 'e1071', 'survival'), repos='https://cloud.r-project.org/')" && \
   Rscript -e "devtools::install_github('jimhester/lintr')" && \
   # Install tools needed to build the documentation.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This tries to fix `do-release-docker.sh` for branch-3.2.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently the following error will occur if running the script in `branch-3.2`:
```
#5 917.4 g++ -std=gnu++14 -shared -L/usr/lib/R/lib -Wl,-Bsymbolic-functions -Wl,-z,relro -o testthat.so init.o reassign.o test-catch.o test-example.o test-runner.o -L/usr/lib/R/lib -lR
#5 917.5 installing to /usr/local/lib/R/site-library/00LOCK-testthat/00new/testthat/libs
#5 917.5 ** R
#5 917.5 ** inst
#5 917.5 ** byte-compile and prepare package for lazy loading
#5 924.4 ** help
#5 924.6 *** installing help indices
#5 924.7 *** copying figures
#5 924.7 ** building package indices
#5 924.9 ** installing vignettes
#5 924.9 ** testing if installed package can be loaded from temporary location
#5 925.1 ** checking absolute paths in shared objects and dynamic libraries
#5 925.1 ** testing if installed package can be loaded from final location
#5 925.5 ** testing if installed package keeps a record of temporary installation path
#5 925.5 * DONE (testthat)
#5 925.8 ERROR: dependency 'pkgdown' is not available for package 'devtools'
#5 925.8 * removing '/usr/local/lib/R/site-library/devtools'
#5 925.8
#5 925.8 The downloaded source packages are in
#5 925.8        '/tmp/Rtmp3nJI60/downloaded_packages'
#5 925.8 Warning messages:
#5 925.8 1: In install.packages(c("curl", "xml2", "httr", "devtools", "testthat",  :
#5 925.8   installation of package 'textshaping' had non-zero exit status
#5 925.8 2: In install.packages(c("curl", "xml2", "httr", "devtools", "testthat",  :
#5 925.8   installation of package 'ragg' had non-zero exit status
#5 925.8 3: In install.packages(c("curl", "xml2", "httr", "devtools", "testthat",  :
#5 925.8   installation of package 'pkgdown' had non-zero exit status
#5 925.8 4: In install.packages(c("curl", "xml2", "httr", "devtools", "testthat",  :
#5 925.8   installation of package 'devtools' had non-zero exit status
#5 926.0 Error in loadNamespace(x) : there is no package called 'devtools'
#5 926.0 Calls: loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
#5 926.0 Execution halted 
```

The same error doesn't happen on master. I checked the diff between the two and it seems the following line:
```
$APT_INSTALL libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev && \
```

introduced in https://github.com/apache/spark/pull/34728 made the difference.

I verified that after adding the line, `do-release-docker.sh` (dry run mode) was able to finish successfully.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually