### PR TITLE
[SPARK-41132][SQL] Convert LikeAny and NotLikeAny to InSet if no pattern contains wildcards

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -780,6 +780,13 @@ object LikeSimplification extends Rule[LogicalPlan] with PredicateHelper {
       } else {
         simplifyLike(input, pattern.toString, escapeChar).getOrElse(l)
       }
+    case LikeAny(child, patterns)
+      if patterns.map(_.toString).forall { case equalTo(_) => true case _ => false } =>
+      InSet(child, patterns.toSet)
+    case NotLikeAny(child, patterns)
+      if patterns.map(_.toString).forall { case equalTo(_) => true case _ => false } =>
+      Not(InSet(child, patterns.toSet))
+
     case l @ LikeAll(child, patterns) if CollapseProject.isCheap(child) =>
       simplifyMultiLike(child, patterns, l)
     case l @ NotLikeAll(child, patterns) if CollapseProject.isCheap(child) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -270,5 +270,13 @@ class LikeSimplificationSuite extends PlanTest {
     comparePlans(
       Optimize.execute(testRelation.where($"a" notLikeAny("ab", "cd", "ef")).analyze),
       testRelation.where(Not(InSet($"a", Set("ab", "cd", "ef").map(convertToCatalyst)))).analyze)
+    comparePlans(
+      Optimize.execute(testRelation.where($"a" likeAny("ab", "cd%", "ef", "%gh")).analyze),
+      testRelation.where(InSet($"a", Set("ab", "ef").map(convertToCatalyst)) ||
+        (StartsWith($"a", "cd") || EndsWith($"a", "gh"))).analyze)
+    comparePlans(
+      Optimize.execute(testRelation.where($"a" notLikeAny("ab", "cd%", "ef", "%gh")).analyze),
+      testRelation.where(Not(InSet($"a", Set("ab", "ef").map(convertToCatalyst))) ||
+        (Not(StartsWith($"a", "cd")) || Not(EndsWith($"a", "gh")))).analyze)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Improve likeAny and notLikeAny performance.

We can optimize query `SELECT * FROM tab WHERE trim(addr) LIKE ANY ('5001', '5002%', '%5003', '5004', '5001')` to `SELECT * FROM tab WHERE trim(addr) IN ('5001', '5004') OR trim(addr) like '5002%' OR trim(addr) like '%5003'`

Before this PR
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_281-b09 on Mac OS X 10.16
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Multi like query:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Query with LikeAny simplification                  2335           2456         184          0.0      233496.6       1.0X
```
After this PR
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_281-b09 on Mac OS X 10.16
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Multi like query:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Query with LikeAny simplification                  1912           1966          50          0.0      191230.9       1.0X
```

### Why are the changes needed?

Match with set values will be faster than regex expressions.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Add UT