### PR TITLE
[SPARK-41136][K8S] Shorten graceful shutdown time of ExecutorPodsSnapshotsStoreImpl to prevent blocking shutdown process

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -723,6 +723,19 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Maximum number of pending pods should be a positive integer")
       .createWithDefault(Int.MaxValue)
 
+  val KUBERNETES_EXECUTOR_SNAPSHOTS_SUBSCRIBERS_GRACE_PERIOD =
+    ConfigBuilder("spark.kubernetes.executorSnapshotsSubscribersShutdownGracePeriod")
+      .doc("Time to wait for graceful shutdown kubernetes-executor-snapshots-subscribers " +
+        "thread pool. Since it may be called by ShutdownHookManager, where timeout is " +
+        "controlled by hadoop configuration `hadoop.service.shutdown.timeout` " +
+        "(default is 30s). As the whole Spark shutdown procedure shares the above timeout, " +
+        "this value should be short than that to prevent blocking the following shutdown " +
+        "procedures.")
+      .version("3.4.0")
+      .timeConf(TimeUnit.SECONDS)
+      .checkValue(value => value > 0, "Gracefully shutdown period must be a positive time value")
+      .createWithDefaultString("20s")
+
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SERVICE_LABEL_PREFIX = "spark.kubernetes.driver.service.label."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshotsStoreImpl.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshotsStoreImpl.scala
@@ -23,10 +23,13 @@ import java.util.concurrent.locks.ReentrantLock
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 import io.fabric8.kubernetes.api.model.Pod
 
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.deploy.k8s.Config.KUBERNETES_EXECUTOR_SNAPSHOTS_SUBSCRIBERS_GRACE_PERIOD
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Clock
 import org.apache.spark.util.SystemClock
@@ -58,7 +61,8 @@ import org.apache.spark.util.ThreadUtils
  */
 private[spark] class ExecutorPodsSnapshotsStoreImpl(
     subscribersExecutor: ScheduledExecutorService,
-    clock: Clock = new SystemClock)
+    clock: Clock = new SystemClock,
+    conf: SparkConf = SparkContext.getActive.get.conf)
   extends ExecutorPodsSnapshotsStore with Logging {
 
   private val SNAPSHOT_LOCK = new Object()
@@ -94,7 +98,8 @@ private[spark] class ExecutorPodsSnapshotsStoreImpl(
 
   override def stop(): Unit = {
     pollingTasks.asScala.foreach(_.cancel(false))
-    ThreadUtils.shutdown(subscribersExecutor)
+    val awaitSeconds = conf.get(KUBERNETES_EXECUTOR_SNAPSHOTS_SUBSCRIBERS_GRACE_PERIOD)
+    ThreadUtils.shutdown(subscribersExecutor, FiniteDuration(awaitSeconds, TimeUnit.SECONDS))
   }
 
   override def updatePod(updatedPod: Pod): Unit = SNAPSHOT_LOCK.synchronized {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -103,7 +103,7 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
     val subscribersExecutor = ThreadUtils
       .newDaemonThreadPoolScheduledExecutor(
         "kubernetes-executor-snapshots-subscribers", 2)
-    val snapshotsStore = new ExecutorPodsSnapshotsStoreImpl(subscribersExecutor)
+    val snapshotsStore = new ExecutorPodsSnapshotsStoreImpl(subscribersExecutor, conf = sc.conf)
 
     val executorPodsLifecycleEventHandler = new ExecutorPodsLifecycleManager(
       sc.conf,

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshotsStoreSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsSnapshotsStoreSuite.scala
@@ -24,7 +24,7 @@ import org.jmock.lib.concurrent.DeterministicScheduler
 import org.scalatest.BeforeAndAfter
 import scala.collection.mutable
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.util.ManualClock
 
@@ -37,7 +37,8 @@ class ExecutorPodsSnapshotsStoreSuite extends SparkFunSuite with BeforeAndAfter 
   before {
     eventBufferScheduler = new DeterministicScheduler()
     clock = new ManualClock()
-    eventQueueUnderTest = new ExecutorPodsSnapshotsStoreImpl(eventBufferScheduler, clock)
+    val conf = new SparkConf()
+    eventQueueUnderTest = new ExecutorPodsSnapshotsStoreImpl(eventBufferScheduler, clock, conf)
     ExecutorPodsSnapshot.setShouldCheckAllContainers(false)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Shorten graceful shutdown time of `ExecutorPodsSnapshotsStoreImpl#stop` from 30s to 20s to prevent blocking shutdown process

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently `ExecutorPodsSnapshotsStoreImpl#stop` has a 30s graceful shutdown duration, since it could be called in shutdown hook, and in default that MGR has 30s shutdown timeout as well, then it may block the following shutdown process.

```
SparkContext#stop
  DagScheduler#stop
    TaskScheduler#stop
      KubernetesClusterSchedulerBackend#stop
        ExecutorPodsSnapshotsStoreImpl#stop
```

Here is a case, that `SparkContext#stop` is blocked by `ExecutorPodsSnapshotsStoreImpl#stop`, and the `InterruptedException` causes the `SparkContext#stop` failed to execute the following shutdown process after `_dagScheduler.stop(exitCode)` including `_eventLogger.foreach(_.stop())`, so that the user can not find the completed application in SHS.
```
2022-11-03 12:51:50 [WARN] [Thread-3] org.apache.hadoop.util.ShutdownHookManager#128 - ShutdownHook '$anon$2' timeout, java.util.concurrent.TimeoutException
java.util.concurrent.TimeoutException: null
	at java.util.concurrent.FutureTask.get(FutureTask.java:205) ~[?:1.8.0_345]
	at org.apache.hadoop.util.ShutdownHookManager.executeShutdown(ShutdownHookManager.java:124) ~[hadoop-common-2.9.2.1.jar:?]
	at org.apache.hadoop.util.ShutdownHookManager$1.run(ShutdownHookManager.java:95) ~[hadoop-common-2.9.2.1.jar:?]
2022-11-03 12:51:50 [WARN] [shutdown-hook-0] org.apache.spark.SparkContext#94 - Ignoring Exception while stopping SparkContext from shutdown hook
java.lang.InterruptedException: null
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014) ~[?:1.8.0_345]
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2088) ~[?:1.8.0_345]
	at java.util.concurrent.ThreadPoolExecutor.awaitTermination(ThreadPoolExecutor.java:1475) ~[?:1.8.0_345]
	at org.apache.spark.util.ThreadUtils$.shutdown(ThreadUtils.scala:347) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl.stop(ExecutorPodsSnapshotsStoreImpl.scala:97) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.KubernetesClusterSchedulerBackend.$anonfun$stop$2(KubernetesClusterSchedulerBackend.scala:146) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.util.Utils$.tryLogNonFatalError(Utils.scala:1488) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.cluster.k8s.KubernetesClusterSchedulerBackend.stop(KubernetesClusterSchedulerBackend.scala:146) ~[spark-kubernetes_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.TaskSchedulerImpl.stop(TaskSchedulerImpl.scala:931) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.scheduler.DAGScheduler.stop(DAGScheduler.scala:2786) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.SparkContext.$anonfun$stop$11(SparkContext.scala:2095) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.util.Utils$.tryLogNonFatalError(Utils.scala:1488) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.SparkContext.stop(SparkContext.scala:2095) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.SparkContext.$anonfun$new$35(SparkContext.scala:660) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.util.SparkShutdownHook.run(ShutdownHookManager.scala:214) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.util.SparkShutdownHookManager.$anonfun$runAll$2(ShutdownHookManager.scala:188) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) ~[scala-library-2.12.15.jar:?]
	at org.apache.spark.util.Utils$.logUncaughtExceptions(Utils.scala:2070) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.util.SparkShutdownHookManager.$anonfun$runAll$1(ShutdownHookManager.scala:188) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23) ~[scala-library-2.12.15.jar:?]
	at scala.util.Try$.apply(Try.scala:213) ~[scala-library-2.12.15.jar:?]
	at org.apache.spark.util.SparkShutdownHookManager.runAll(ShutdownHookManager.scala:188) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at org.apache.spark.util.SparkShutdownHookManager$$anon$2.run(ShutdownHookManager.scala:178) ~[spark-core_2.12-3.3.1.1.jar:3.3.1.1]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_345]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_345]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_345]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_345]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_345]
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT.