### PR TITLE
[SPARK-41137][SQL] Rename `LATERAL_JOIN_OF_TYPE` to `INVALID_LATERAL_JOIN_TYPE`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -638,6 +638,11 @@
       "Input schema <jsonSchema> can only contain STRING as a key type for a MAP."
     ]
   },
+  "INVALID_LATERAL_JOIN_TYPE" : {
+    "message" : [
+      "The <joinType> JOIN with LATERAL correlation is not allowed because an OUTER subquery cannot correlate to its join partner. Remove the LATERAL correlation or use an INNER JOIN, or LEFT OUTER JOIN instead."
+    ]
+  },
   "INVALID_LIKE_PATTERN" : {
     "message" : [
       "The pattern <pattern> is invalid."
@@ -1138,11 +1143,6 @@
       "INSERT_PARTITION_SPEC_IF_NOT_EXISTS" : {
         "message" : [
           "INSERT INTO <tableName> IF NOT EXISTS in the PARTITION spec."
-        ]
-      },
-      "INVALID_LATERAL_JOIN_TYPE" : {
-        "message" : [
-          "The <joinType> JOIN with LATERAL correlation is not allowed because an OUTER subquery cannot correlate to its join partner. Remove the LATERAL correlation or use an INNER JOIN, or LEFT OUTER JOIN instead."
         ]
       },
       "JDBC_TRANSACTION" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1140,14 +1140,14 @@
           "INSERT INTO <tableName> IF NOT EXISTS in the PARTITION spec."
         ]
       },
+      "INVALID_LATERAL_JOIN_TYPE" : {
+        "message" : [
+          "The <joinType> JOIN with LATERAL correlation is not allowed because an OUTER subquery cannot correlate to its join partner. Remove the LATERAL correlation or use an INNER JOIN, or LEFT OUTER JOIN instead."
+        ]
+      },
       "JDBC_TRANSACTION" : {
         "message" : [
           "The target JDBC server does not support transactions and can only support ALTER TABLE with a single action."
-        ]
-      },
-      "LATERAL_JOIN_OF_TYPE" : {
-        "message" : [
-          "<joinType> JOIN with LATERAL correlation."
         ]
       },
       "LATERAL_JOIN_USING" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -127,7 +127,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def unsupportedLateralJoinTypeError(ctx: ParserRuleContext, joinType: String): Throwable = {
     new ParseException(
-      errorClass = "UNSUPPORTED_FEATURE.INVALID_LATERAL_JOIN_TYPE",
+      errorClass = "INVALID_LATERAL_JOIN_TYPE",
       messageParameters = Map("joinType" -> toSQLStmt(joinType)),
       ctx)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -127,7 +127,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def unsupportedLateralJoinTypeError(ctx: ParserRuleContext, joinType: String): Throwable = {
     new ParseException(
-      errorClass = "UNSUPPORTED_FEATURE.LATERAL_JOIN_OF_TYPE",
+      errorClass = "UNSUPPORTED_FEATURE.INVALID_LATERAL_JOIN_TYPE",
       messageParameters = Map("joinType" -> toSQLStmt(joinType)),
       ctx)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -60,7 +60,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       "LEFT ANTI" -> (17, 72)).foreach { case (joinType, (start, stop)) =>
       checkError(
         exception = parseException(s"SELECT * FROM t1 $joinType JOIN LATERAL (SELECT c1 + c2 AS c3) ON c2 = c3"),
-        errorClass = "UNSUPPORTED_FEATURE.LATERAL_JOIN_OF_TYPE",
+        errorClass = "UNSUPPORTED_FEATURE.INVALID_LATERAL_JOIN_TYPE",
         sqlState = "0A000",
         parameters = Map("joinType" -> joinType),
         context = ExpectedContext(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -60,7 +60,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       "LEFT ANTI" -> (17, 72)).foreach { case (joinType, (start, stop)) =>
       checkError(
         exception = parseException(s"SELECT * FROM t1 $joinType JOIN LATERAL (SELECT c1 + c2 AS c3) ON c2 = c3"),
-        errorClass = "UNSUPPORTED_FEATURE.INVALID_LATERAL_JOIN_TYPE",
+        errorClass = "INVALID_LATERAL_JOIN_TYPE",
         sqlState = "0A000",
         parameters = Map("joinType" -> joinType),
         context = ExpectedContext(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -61,7 +61,6 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       checkError(
         exception = parseException(s"SELECT * FROM t1 $joinType JOIN LATERAL (SELECT c1 + c2 AS c3) ON c2 = c3"),
         errorClass = "INVALID_LATERAL_JOIN_TYPE",
-        sqlState = "0A000",
         parameters = Map("joinType" -> joinType),
         context = ExpectedContext(
           fragment = s"$joinType JOIN LATERAL (SELECT c1 + c2 AS c3) ON c2 = c3",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename `LATERAL_JOIN_OF_TYPE` to `INVALID_LATERAL_JOIN_TYPE`.

Also remove this from the sub-class under `UNSUPPORTED FEATURE`, and improve the error messages.


### Why are the changes needed?

This should not belongs to `UNSUPPORTED FEATURE`, since RIGHT and FULL outer join makes no sense for LATERAL joins.

### Does this PR introduce _any_ user-facing change?

The error message improved

From
```
The feature is not supported: RIGHT OUTER JOIN with LATERAL correlation.
```

To
```
The RIGHT OUTER JOIN with LATERAL correlation is not allowed because an OUTER subquery cannot correlate to its join partner. Remove the LATERAL correlation or use an INNER JOIN, or LEFT OUTER JOIN instead.
```


### How was this patch tested?

```
./build/sbt “sql/testOnly org.apache.spark.sql.SQLQueryTestSuite*”
```
