### PR TITLE
[SPARK-41138][PYTHON] `DataFrame.na.fill` should have the same augment types as `DataFrame.fillna`

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4924,9 +4924,9 @@ class DataFrameNaFunctions:
     def fill(
         self,
         value: Union["LiteralType", Dict[str, "LiteralType"]],
-        subset: Optional[List[str]] = None,
+        subset: Optional[Union[str, Tuple[str, ...], List[str]]] = None,
     ) -> DataFrame:
-        return self.df.fillna(value=value, subset=subset)  # type: ignore[arg-type]
+        return self.df.fillna(value=value, subset=subset)
 
     fill.__doc__ = DataFrame.fillna.__doc__
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `DataFrame.na.fill` have the same augment types as `DataFrame.fillna`


### Why are the changes needed?
`DataFrame.na.fill` just internally invokes `DataFrame.fillna`, and they share the same doc
their augment types should be the same

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing tests
