### PR TITLE
[SPARK-41109][CORE][FOLLOWUP] Re-order error class to fix `SparkThrowableSuite`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -643,14 +643,14 @@
       "The pattern <pattern> is invalid."
     ],
     "subClass" : {
-      "ESC_IN_THE_MIDDLE" : {
-        "message" : [
-          "the escape character is not allowed to precede <char>."
-        ]
-      },
       "ESC_AT_THE_END" : {
         "message" : [
           "the escape character is not allowed to end with."
+        ]
+      },
+      "ESC_IN_THE_MIDDLE" : {
+        "message" : [
+          "the escape character is not allowed to precede <char>."
         ]
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix error class order of `ESC_IN_THE_MIDDLE` and `ESC_AT_THE_END` to make GA task passed.

### Why are the changes needed?
Fix GA test task failed.




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GA
- Manual test:

```
build/sbt "core/testOnly *SparkThrowableSuite"
```

**Before**

```
[info] - Error classes are correctly formatted *** FAILED *** (91 milliseconds)
[info]   "...ass" : {
[info]         "ESC_[AT_THE_END" : {
[info]           "message" : [
[info]             "the escape character is not allowed to end with."
[info]           ]
[info]         },
[info]         "ESC_IN_THE_MIDDLE" : {
[info]           "message" : [
[info]             "the escape character is not allowed to precede <char>]."
[info]           ]
[info]         }..." did not equal "...ass" : {
[info]         "ESC_[IN_THE_MIDDLE" : {
[info]           "message" : [
[info]             "the escape character is not allowed to precede <char>."
[info]           ]
[info]         },
[info]         "ESC_AT_THE_END" : {
[info]           "message" : [
[info]             "the escape character is not allowed to end with]."
[info]           ]
[info]         }..." (SparkThrowableSuite.scala:98)
```
**After**

```
[info] SparkThrowableSuite:
[info] - No duplicate error classes (39 milliseconds)
[info] - Error classes are correctly formatted (61 milliseconds)
[info] - SQLSTATE invariants (13 milliseconds)
[info] - Message invariants (15 milliseconds)
[info] - Message format invariants (33 milliseconds)
[info] - Round trip (33 milliseconds)
[info] - Check if error class is missing (32 milliseconds)
[info] - Check if message parameters match message format (8 milliseconds)
[info] - Error message is formatted (1 millisecond)
[info] - Try catching legacy SparkError (1 millisecond)
[info] - Try catching SparkError with error class (1 millisecond)
[info] - Try catching internal SparkError (1 millisecond)
[info] - Get message in the specified format (15 milliseconds)
[info] - overwrite error classes (190 milliseconds)
[info] - prohibit dots in error class names (57 milliseconds)
[info] Run completed in 2 seconds, 317 milliseconds.
[info] Total number of tests run: 15
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 15, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 16 s, completed 2022-11-14 19:34:11
```
