### PR TITLE
[SPARK-41085][SQL] Support Bit manipulation function COUNTSET

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -233,6 +233,21 @@
           "The <inputName> value must to be a <requireType> literal of <validValues>, but got <inputValue>."
         ]
       },
+      "INVALID_BIT_POSITION_GREATER_THAN_MAX_SIZE" : {
+        "message" : [
+          "Invalid bit index position: <position> should be less than bit upper limit <size>"
+        ]
+      },
+      "INVALID_BIT_POSITION_LESS_THAN_ZERO" : {
+        "message" : [
+          "Invalid bit index position: <position> is less than zero"
+        ]
+      },
+      "INVALID_BIT_VALUE" : {
+        "message" : [
+          "Invalid bit value: Use 0 or 1"
+        ]
+      },
       "INVALID_JSON_MAP_KEY_TYPE" : {
         "message" : [
           "Input schema <schema> can only contain STRING as a key type for a MAP."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -773,6 +773,7 @@ object FunctionRegistry {
     expression[BitwiseOr]("|"),
     expression[BitwiseXor]("^"),
     expression[BitwiseCount]("bit_count"),
+    expression[BitwiseCount]("countset", true),
     expression[BitAndAgg]("bit_and"),
     expression[BitOrAgg]("bit_or"),
     expression[BitXorAgg]("bit_xor"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/BitwiseExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/BitwiseExpressionsSuite.scala
@@ -26,6 +26,15 @@ class BitwiseExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   import IntegralLiteralTestUtils._
 
+  test("BitwiseCount") {
+    (1 to 64).map(BigInt(2).pow(_).toLong).foreach { input =>
+      checkEvaluation(BitwiseCount(Literal(input), Literal(1)), java.lang.Long.bitCount(input))
+      checkEvaluation(
+        BitwiseCount(Literal(input), Literal(0)),
+        java.lang.Long.SIZE - java.lang.Long.bitCount(input))
+    }
+  }
+
   test("BitwiseNOT") {
     def check(input: Any, expected: Any): Unit = {
       val expr = BitwiseNot(Literal(input))

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -42,7 +42,8 @@
 | org.apache.spark.sql.catalyst.expressions.Bin | bin | SELECT bin(13) | struct<bin(13):string> |
 | org.apache.spark.sql.catalyst.expressions.BitLength | bit_length | SELECT bit_length('Spark SQL') | struct<bit_length(Spark SQL):int> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseAnd | & | SELECT 3 & 5 | struct<(3 & 5):int> |
-| org.apache.spark.sql.catalyst.expressions.BitwiseCount | bit_count | SELECT bit_count(0) | struct<bit_count(0):int> |
+| org.apache.spark.sql.catalyst.expressions.BitwiseCount | bit_count | SELECT bit_count(2) | struct<bit_count(2, 1):int> |
+| org.apache.spark.sql.catalyst.expressions.BitwiseCount | countset | SELECT countset(2) | struct<bit_count(2, 1):int> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseGet | bit_get | SELECT bit_get(11, 0) | struct<bit_get(11, 0):tinyint> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseGet | getbit | SELECT getbit(11, 0) | struct<getbit(11, 0):tinyint> |
 | org.apache.spark.sql.catalyst.expressions.BitwiseNot | ~ | SELECT ~ 0 | struct<~0:int> |

--- a/sql/core/src/test/resources/sql-tests/inputs/bitwise.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/bitwise.sql
@@ -2,41 +2,70 @@
 
 -- null
 select bit_count(null);
+select bit_count(null, 1);
 
 -- boolean
 select bit_count(true);
+select bit_count(true, 0);
 select bit_count(false);
+select bit_count(false, 1);
 
 -- byte/tinyint
 select bit_count(cast(1 as tinyint));
+select bit_count(cast(1 as tinyint), 0);
 select bit_count(cast(2 as tinyint));
+select bit_count(cast(2 as tinyint), 0);
 select bit_count(cast(3 as tinyint));
+select bit_count(cast(3 as tinyint), 1);
+select bit_count(cast(3 as tinyint), 0);
 
 -- short/smallint
 select bit_count(1S);
+select bit_count(1S, 0);
+select bit_count(1S, 1);
 select bit_count(2S);
+select bit_count(2S, 0);
 select bit_count(3S);
+select bit_count(3S, 1);
+select bit_count(3S, 0);
 
 -- int
 select bit_count(1);
+select bit_count(1, 0);
 select bit_count(2);
+select bit_count(2, 1);
 select bit_count(3);
+select bit_count(3, 0);
 
 -- long/bigint
 select bit_count(1L);
+select bit_count(1L, 0);
+select countset(2L, 1);
 select bit_count(2L);
-select bit_count(3L);
+select countset(3L);
 
 -- negative num
 select bit_count(-1L);
+select bit_count(-1L, 0);
+select countset(-1L, 1);
 
 -- edge value
 select bit_count(9223372036854775807L);
+select bit_count(9223372036854775807L, 0);
+select bit_count(9223372036854775807L, 1);
 select bit_count(-9223372036854775808L);
+select bit_count(-9223372036854775808L, 0);
 
 -- other illegal arguments
 select bit_count("bit count");
+select bit_count(123, 5);
+select bit_count(123, -1);
+select bit_count("bit count", 0);
 select bit_count('a');
+select bit_count('a', 0);
+select countset(c1, c2), countset(c1, c3) from values (1234, 1, 0) as t(c1, c2, c3);
+select countset(c1, c2) from values (1234, -1) as t(c1, c2);
+select countset(c1, c2) from values (1234, 10) as t(c1, c2);
 
 -- test for bit_xor
 --

--- a/sql/core/src/test/resources/sql-tests/results/bitwise.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/bitwise.sql.out
@@ -2,7 +2,15 @@
 -- !query
 select bit_count(null)
 -- !query schema
-struct<bit_count(NULL):int>
+struct<bit_count(NULL, 1):int>
+-- !query output
+NULL
+
+
+-- !query
+select bit_count(null, 1)
+-- !query schema
+struct<bit_count(NULL, 1):int>
 -- !query output
 NULL
 
@@ -10,15 +18,31 @@ NULL
 -- !query
 select bit_count(true)
 -- !query schema
-struct<bit_count(true):int>
+struct<bit_count(true, 1):int>
 -- !query output
 1
 
 
 -- !query
+select bit_count(true, 0)
+-- !query schema
+struct<bit_count(true, 0):int>
+-- !query output
+0
+
+
+-- !query
 select bit_count(false)
 -- !query schema
-struct<bit_count(false):int>
+struct<bit_count(false, 1):int>
+-- !query output
+0
+
+
+-- !query
+select bit_count(false, 1)
+-- !query schema
+struct<bit_count(false, 1):int>
 -- !query output
 0
 
@@ -26,31 +50,79 @@ struct<bit_count(false):int>
 -- !query
 select bit_count(cast(1 as tinyint))
 -- !query schema
-struct<bit_count(CAST(1 AS TINYINT)):int>
+struct<bit_count(CAST(1 AS TINYINT), 1):int>
 -- !query output
 1
+
+
+-- !query
+select bit_count(cast(1 as tinyint), 0)
+-- !query schema
+struct<bit_count(CAST(1 AS TINYINT), 0):int>
+-- !query output
+7
 
 
 -- !query
 select bit_count(cast(2 as tinyint))
 -- !query schema
-struct<bit_count(CAST(2 AS TINYINT)):int>
+struct<bit_count(CAST(2 AS TINYINT), 1):int>
 -- !query output
 1
 
 
 -- !query
+select bit_count(cast(2 as tinyint), 0)
+-- !query schema
+struct<bit_count(CAST(2 AS TINYINT), 0):int>
+-- !query output
+7
+
+
+-- !query
 select bit_count(cast(3 as tinyint))
 -- !query schema
-struct<bit_count(CAST(3 AS TINYINT)):int>
+struct<bit_count(CAST(3 AS TINYINT), 1):int>
 -- !query output
 2
 
 
 -- !query
+select bit_count(cast(3 as tinyint), 1)
+-- !query schema
+struct<bit_count(CAST(3 AS TINYINT), 1):int>
+-- !query output
+2
+
+
+-- !query
+select bit_count(cast(3 as tinyint), 0)
+-- !query schema
+struct<bit_count(CAST(3 AS TINYINT), 0):int>
+-- !query output
+6
+
+
+-- !query
 select bit_count(1S)
 -- !query schema
-struct<bit_count(1):int>
+struct<bit_count(1, 1):int>
+-- !query output
+1
+
+
+-- !query
+select bit_count(1S, 0)
+-- !query schema
+struct<bit_count(1, 0):int>
+-- !query output
+15
+
+
+-- !query
+select bit_count(1S, 1)
+-- !query schema
+struct<bit_count(1, 1):int>
 -- !query output
 1
 
@@ -58,31 +130,71 @@ struct<bit_count(1):int>
 -- !query
 select bit_count(2S)
 -- !query schema
-struct<bit_count(2):int>
+struct<bit_count(2, 1):int>
 -- !query output
 1
+
+
+-- !query
+select bit_count(2S, 0)
+-- !query schema
+struct<bit_count(2, 0):int>
+-- !query output
+15
 
 
 -- !query
 select bit_count(3S)
 -- !query schema
-struct<bit_count(3):int>
+struct<bit_count(3, 1):int>
 -- !query output
 2
 
 
 -- !query
+select bit_count(3S, 1)
+-- !query schema
+struct<bit_count(3, 1):int>
+-- !query output
+2
+
+
+-- !query
+select bit_count(3S, 0)
+-- !query schema
+struct<bit_count(3, 0):int>
+-- !query output
+14
+
+
+-- !query
 select bit_count(1)
 -- !query schema
-struct<bit_count(1):int>
+struct<bit_count(1, 1):int>
 -- !query output
 1
 
 
 -- !query
+select bit_count(1, 0)
+-- !query schema
+struct<bit_count(1, 0):int>
+-- !query output
+31
+
+
+-- !query
 select bit_count(2)
 -- !query schema
-struct<bit_count(2):int>
+struct<bit_count(2, 1):int>
+-- !query output
+1
+
+
+-- !query
+select bit_count(2, 1)
+-- !query schema
+struct<bit_count(2, 1):int>
 -- !query output
 1
 
@@ -90,15 +202,39 @@ struct<bit_count(2):int>
 -- !query
 select bit_count(3)
 -- !query schema
-struct<bit_count(3):int>
+struct<bit_count(3, 1):int>
 -- !query output
 2
 
 
 -- !query
+select bit_count(3, 0)
+-- !query schema
+struct<bit_count(3, 0):int>
+-- !query output
+30
+
+
+-- !query
 select bit_count(1L)
 -- !query schema
-struct<bit_count(1):int>
+struct<bit_count(1, 1):int>
+-- !query output
+1
+
+
+-- !query
+select bit_count(1L, 0)
+-- !query schema
+struct<bit_count(1, 0):int>
+-- !query output
+63
+
+
+-- !query
+select countset(2L, 1)
+-- !query schema
+struct<bit_count(2, 1):int>
 -- !query output
 1
 
@@ -106,15 +242,15 @@ struct<bit_count(1):int>
 -- !query
 select bit_count(2L)
 -- !query schema
-struct<bit_count(2):int>
+struct<bit_count(2, 1):int>
 -- !query output
 1
 
 
 -- !query
-select bit_count(3L)
+select countset(3L)
 -- !query schema
-struct<bit_count(3):int>
+struct<bit_count(3, 1):int>
 -- !query output
 2
 
@@ -122,7 +258,23 @@ struct<bit_count(3):int>
 -- !query
 select bit_count(-1L)
 -- !query schema
-struct<bit_count(-1):int>
+struct<bit_count(-1, 1):int>
+-- !query output
+64
+
+
+-- !query
+select bit_count(-1L, 0)
+-- !query schema
+struct<bit_count(-1, 0):int>
+-- !query output
+0
+
+
+-- !query
+select countset(-1L, 1)
+-- !query schema
+struct<bit_count(-1, 1):int>
 -- !query output
 64
 
@@ -130,7 +282,23 @@ struct<bit_count(-1):int>
 -- !query
 select bit_count(9223372036854775807L)
 -- !query schema
-struct<bit_count(9223372036854775807):int>
+struct<bit_count(9223372036854775807, 1):int>
+-- !query output
+63
+
+
+-- !query
+select bit_count(9223372036854775807L, 0)
+-- !query schema
+struct<bit_count(9223372036854775807, 0):int>
+-- !query output
+1
+
+
+-- !query
+select bit_count(9223372036854775807L, 1)
+-- !query schema
+struct<bit_count(9223372036854775807, 1):int>
 -- !query output
 63
 
@@ -138,9 +306,17 @@ struct<bit_count(9223372036854775807):int>
 -- !query
 select bit_count(-9223372036854775808L)
 -- !query schema
-struct<bit_count(-9223372036854775808):int>
+struct<bit_count(-9223372036854775808, 1):int>
 -- !query output
 1
+
+
+-- !query
+select bit_count(-9223372036854775808L, 0)
+-- !query schema
+struct<bit_count(-9223372036854775808, 0):int>
+-- !query output
+63
 
 
 -- !query
@@ -156,7 +332,7 @@ org.apache.spark.sql.AnalysisException
     "inputType" : "\"STRING\"",
     "paramIndex" : "1",
     "requiredType" : "(\"INTEGRAL\" or \"BOOLEAN\")",
-    "sqlExpr" : "\"bit_count(bit count)\""
+    "sqlExpr" : "\"bit_count(bit count, 1)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -164,6 +340,73 @@ org.apache.spark.sql.AnalysisException
     "startIndex" : 8,
     "stopIndex" : 29,
     "fragment" : "bit_count(\"bit count\")"
+  } ]
+}
+
+
+-- !query
+select bit_count(123, 5)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_VALUE",
+  "messageParameters" : {
+    "sqlExpr" : "\"bit_count(123, 5)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "bit_count(123, 5)"
+  } ]
+}
+
+
+-- !query
+select bit_count(123, -1)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.INVALID_BIT_VALUE",
+  "messageParameters" : {
+    "sqlExpr" : "\"bit_count(123, -1)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 25,
+    "fragment" : "bit_count(123, -1)"
+  } ]
+}
+
+
+-- !query
+select bit_count("bit count", 0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "messageParameters" : {
+    "inputSql" : "\"bit count\"",
+    "inputType" : "\"STRING\"",
+    "paramIndex" : "1",
+    "requiredType" : "(\"INTEGRAL\" or \"BOOLEAN\")",
+    "sqlExpr" : "\"bit_count(bit count, 0)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 32,
+    "fragment" : "bit_count(\"bit count\", 0)"
   } ]
 }
 
@@ -181,7 +424,7 @@ org.apache.spark.sql.AnalysisException
     "inputType" : "\"STRING\"",
     "paramIndex" : "1",
     "requiredType" : "(\"INTEGRAL\" or \"BOOLEAN\")",
-    "sqlExpr" : "\"bit_count(a)\""
+    "sqlExpr" : "\"bit_count(a, 1)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -189,6 +432,103 @@ org.apache.spark.sql.AnalysisException
     "startIndex" : 8,
     "stopIndex" : 21,
     "fragment" : "bit_count('a')"
+  } ]
+}
+
+
+-- !query
+select bit_count('a', 0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "messageParameters" : {
+    "inputSql" : "\"a\"",
+    "inputType" : "\"STRING\"",
+    "paramIndex" : "1",
+    "requiredType" : "(\"INTEGRAL\" or \"BOOLEAN\")",
+    "sqlExpr" : "\"bit_count(a, 0)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "bit_count('a', 0)"
+  } ]
+}
+
+
+-- !query
+select countset(c1, c2), countset(c1, c3) from values (1234, 1, 0) as t(c1, c2, c3)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "messageParameters" : {
+    "inputExpr" : "\"c2\"",
+    "inputName" : "bitExpr",
+    "inputType" : "\"INT\"",
+    "sqlExpr" : "\"bit_count(c1, c2)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 23,
+    "fragment" : "countset(c1, c2)"
+  } ]
+}
+
+
+-- !query
+select countset(c1, c2) from values (1234, -1) as t(c1, c2)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "messageParameters" : {
+    "inputExpr" : "\"c2\"",
+    "inputName" : "bitExpr",
+    "inputType" : "\"INT\"",
+    "sqlExpr" : "\"bit_count(c1, c2)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 23,
+    "fragment" : "countset(c1, c2)"
+  } ]
+}
+
+
+-- !query
+select countset(c1, c2) from values (1234, 10) as t(c1, c2)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "messageParameters" : {
+    "inputExpr" : "\"c2\"",
+    "inputName" : "bitExpr",
+    "inputType" : "\"INT\"",
+    "sqlExpr" : "\"bit_count(c1, c2)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 23,
+    "fragment" : "countset(c1, c2)"
   } ]
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support Bit manipulation function COUNTSET . The function will return the number of 1 bits in the specified integer value. If the optional second argument is set to zero, it will return the number of 0 bits instead. 

ref: 
[teradata](https://docs.teradata.com/r/kmuOwjp1zEYg98JsB8fu_A/T0FkxKpg3Di73RALIdepIA)
[impala](https://impala.apache.org/docs/build/html/topics/impala_bit_functions.html)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Refactored existing function `bit_count` to accept an optional second argument 0 or 1, the default value of the second argument is 1, hence it will return the number of 1 bits, if the second argument is not given.

COUNTSET(integer_type a [, INT zero_or_one])

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, the existing built-in function `bit_count` has been modified to accept a second argument and also added aliased  `countset`
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added test cases
