### PR TITLE
[SPARK-41143][SQL] Add named argument syntax support for table-valued function

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -946,6 +946,18 @@
       "Star (*) is not allowed in a select list when GROUP BY an ordinal position is used."
     ]
   },
+  "TABLE_FUNCTION_DUPLICATED_NAMED_ARGUMENTS" : {
+    "message" : [
+      "Found a duplicated argument <name> being set at position <pos>."
+    ],
+    "sqlState" : "42000"
+  },
+  "TABLE_FUNCTION_UNEXPECTED_ARGUMENT" : {
+    "message" : [
+      "Found an unexpected argument <expression> at position <pos>, an unnamed argument can not be provided after a named argument."
+    ],
+    "sqlState" : "42000"
+  },
   "TABLE_OR_VIEW_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create table or view <relationName> because it already exists.",

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
@@ -413,6 +413,7 @@ COLON: ':';
 ARROW: '->';
 HENT_START: '/*+';
 HENT_END: '*/';
+FAT_ARROW: '=>';
 
 STRING
     : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -769,7 +769,7 @@ inlineTable
     ;
 
 functionTable
-    : funcName=functionName LEFT_PAREN (expression (COMMA expression)*)? RIGHT_PAREN tableAlias
+    : funcName=functionName LEFT_PAREN (functionArgument (COMMA functionArgument)*)? RIGHT_PAREN tableAlias
     ;
 
 tableAlias
@@ -840,6 +840,15 @@ transformArgument
 
 expression
     : booleanExpression
+    ;
+
+namedArgumentExpression
+    : key=identifier FAT_ARROW value=expression
+    ;
+
+functionArgument
+    : expression
+    | namedArgumentExpression
     ;
 
 expressionSeq

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -324,6 +324,21 @@ object LiteralTreeBits {
   val nullLiteralBits: BitSet = new ImmutableBitSet(TreePattern.maxId, LITERAL.id, NULL_LITERAL.id)
 }
 
+case class NamedArgumentExpression(key: String, value: Expression) extends LeafExpression {
+  override def nullable: Boolean = false
+
+  override def eval(input: InternalRow): Any =
+    throw new UnsupportedOperationException(s"Cannot evaluate expression: $this")
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
+    throw new UnsupportedOperationException(
+      "NamedArgumentExpression cannot generate code directly")
+
+  override def dataType: DataType = StringType
+
+  override def toString: String = s"""$key => $value"""
+}
+
 /**
  * In order to do type checking, use Literal.create() instead of constructor
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1444,9 +1444,16 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
     if (name.length > 1) {
       throw QueryParsingErrors.invalidTableValuedFunctionNameError(name, ctx)
     }
-
-    val tvf = UnresolvedTableValuedFunction(
-      name, func.expression.asScala.map(expression).toSeq, aliases)
+    val args = func.functionArgument.asScala.map { e =>
+      if (e.namedArgumentExpression != null) {
+        val key = e.namedArgumentExpression.key.strictIdentifier
+        val value = e.namedArgumentExpression.value
+        NamedArgumentExpression(key.getText, expression(value))
+      } else {
+        expression(e)
+      }
+    }
+    val tvf = UnresolvedTableValuedFunction(name, args, aliases)
     tvf.optionalMap(func.tableAlias.strictIdentifier)(aliasPlan)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/NamedArgumentFunction.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/NamedArgumentFunction.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import java.util.Locale
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, NamedArgumentExpression}
+import org.apache.spark.sql.errors.QueryCompilationErrors.{tableFunctionDuplicateNamedArguments, tableFunctionUnexpectedArgument}
+import org.apache.spark.sql.types._
+
+/**
+ * A trait to define a named argument function:
+ * Usage: _FUNC_(arg0, arg1, arg2, arg5 => value5, arg8 => value8)
+ *
+ * - Arguments can be passed positionally or by name
+ * - Positional arguments cannot come after a named argument
+ */
+trait NamedArgumentFunction {
+  /**
+   * A trait [[Param]] that is used to define function parameter
+   * - name: case insensitive name
+   * - dataType: expected data type
+   * - required: if the parameter is required
+   * - default: the default value of the parameter if not provided
+   */
+  protected trait Param {
+    val name: String
+    val dataType: DataType
+    val required: Boolean
+    val default: Option[Any]
+  }
+
+  /**
+   * Function parameters
+   */
+  def parameters: Seq[Param]
+
+  /**
+   * Input expressions
+   */
+  def inputExpressions: Seq[Expression]
+
+  /**
+   * positionalArguments: positional arguments extracted from input expressions
+   * namedArguments: named arguments extracted from input expressions
+   */
+  lazy val (positionalArguments, namedArguments):
+    (Seq[Expression], Seq[NamedArgumentExpression]) = {
+    val positionalBuffer = mutable.ArrayBuffer[Expression]()
+    val namedBuffer = mutable.ArrayBuffer[NamedArgumentExpression]()
+    val namedSet = mutable.Set[String]()
+    inputExpressions.zipWithIndex.foreach {
+      case (NamedArgumentExpression(key, _), i)
+        if namedSet.contains(key.toLowerCase(Locale.ROOT)) =>
+        throw tableFunctionDuplicateNamedArguments(key, i)
+      case (kv @ NamedArgumentExpression(key, _), _) =>
+        namedSet.add(key.toLowerCase(Locale.ROOT))
+        namedBuffer += kv
+      case (e: Expression, i) if namedBuffer.nonEmpty =>
+        throw tableFunctionUnexpectedArgument(e, i)
+      case (e: Expression, _) => positionalBuffer += e
+    }
+    (positionalBuffer, namedBuffer)
+  }
+
+  /**
+   * Sanity check: cannot define duplicated function parameters
+   */
+  private def checkDuplicatedParameters(): Unit = {
+    assert(parameters.map(_.name.toLowerCase(Locale.ROOT)).toSet.size == parameters.size,
+      "Cannot define duplicated parameters in named argument function.")
+  }
+
+  checkDuplicatedParameters()
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3380,4 +3380,20 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
         "unsupported" -> unsupported.toString,
         "class" -> unsupported.getClass.toString))
   }
+
+  def tableFunctionDuplicateNamedArguments(name: String, pos: Int): Throwable = {
+    new AnalysisException(
+      errorClass = "TABLE_FUNCTION_DUPLICATED_NAMED_ARGUMENTS",
+      messageParameters = Map(
+        "name" -> name,
+        "pos" -> pos.toString))
+  }
+
+  def tableFunctionUnexpectedArgument(e: Expression, pos: Int): Throwable = {
+    new AnalysisException(
+      errorClass = "TABLE_FUNCTION_UNEXPECTED_ARGUMENT",
+      messageParameters = Map(
+        "expression" -> e.toString,
+        "pos" -> pos.toString))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -852,6 +852,31 @@ class PlanParserSuite extends AnalysisTest {
         stop = 43))
   }
 
+  test("table valued function with named arguments") {
+    // All named arguments
+    assertEqual(
+      "select * from my_tvf(arg1 => 'value1', arg2 => true)",
+      UnresolvedTableValuedFunction("my_tvf",
+        NamedArgumentExpression("arg1", Literal("value1")) ::
+          NamedArgumentExpression("arg2", Literal(true)) :: Nil, Seq.empty).select(star()))
+
+    // Unnamed and named arguments
+    assertEqual(
+      "select * from my_tvf(2, arg1 => 'value1', arg2 => true)",
+      UnresolvedTableValuedFunction("my_tvf",
+        Literal(2) ::
+          NamedArgumentExpression("arg1", Literal("value1")) ::
+          NamedArgumentExpression("arg2", Literal(true)) :: Nil, Seq.empty).select(star()))
+
+    // Mixed arguments
+    assertEqual(
+      "select * from my_tvf(arg1 => 'value1', 2, arg2 => true)",
+      UnresolvedTableValuedFunction("my_tvf",
+        NamedArgumentExpression("arg1", Literal("value1")) ::
+          Literal(2) ::
+          NamedArgumentExpression("arg2", Literal(true)) :: Nil, Seq.empty).select(star()))
+  }
+
   test("SPARK-20311 range(N) as alias") {
     assertEqual(
       "SELECT * FROM range(10) AS t",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/NamedArgumentFunctionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/NamedArgumentFunctionSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, NamedArgumentExpression}
+import org.apache.spark.sql.types.{DataType, StringType}
+
+class NamedArgumentFunctionSuite extends SparkFunSuite {
+
+  private def createMyFunction(
+      params: Seq[String],
+      expressions: Seq[Expression]): NamedArgumentFunction = {
+    case class MyFunction() extends NamedArgumentFunction {
+      case class MyParam(name: String) extends Param {
+        override val dataType: DataType = StringType
+        override val required: Boolean = false
+        override val default: Option[Any] = None
+      }
+      override def parameters: Seq[Param] = params.map(MyParam)
+      override def inputExpressions: Seq[Expression] = expressions
+    }
+    MyFunction()
+  }
+
+  test("Named function happy path") {
+    val myFunction = createMyFunction(
+      Seq("name", "age"),
+      Seq(Literal("jack"), NamedArgumentExpression("age", Literal("18"))))
+    assert(myFunction.positionalArguments == Seq(Literal("jack")))
+    assert(myFunction.namedArguments == Seq(NamedArgumentExpression("age", Literal("18"))))
+  }
+
+  test("An unnamed argument after a named argument") {
+    val myFunction = createMyFunction(
+      Seq("name", "age"),
+      Seq(NamedArgumentExpression("name", Literal("jack")), Literal("18")))
+    checkError(
+      exception = intercept[AnalysisException](myFunction.positionalArguments),
+      errorClass = "TABLE_FUNCTION_UNEXPECTED_ARGUMENT",
+      parameters = Map("expression" -> "18", "pos" -> "1")
+    )
+  }
+
+  test("User passes duplicated arguments") {
+    val myFunction = createMyFunction(
+      Seq("name", "age"),
+      Seq(
+        Literal("18"),
+        NamedArgumentExpression("name", Literal("jack")),
+        NamedArgumentExpression("name", Literal("lily"))
+      ))
+    checkError(
+      exception = intercept[AnalysisException](myFunction.positionalArguments),
+      errorClass = "TABLE_FUNCTION_DUPLICATED_NAMED_ARGUMENTS",
+      parameters = Map("name" -> "name", "pos" -> "2")
+    )
+  }
+
+  test("Define named argument function with duplicated params") {
+    val e = intercept[AssertionError] {
+      createMyFunction(Seq("name", "name"), Seq.empty[Expression])
+    }
+    assert(e.getMessage.contains(
+      "Cannot define duplicated parameters in named argument function."))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Support named argument table-valued functions in Spark SQL

General usage: `_FUNC_(arg0, arg1, arg2, arg5 => value5, arg8 => value8)`

- Arguments can be passed positionally or by name.
- Positional arguments cannot come after a named argument.

This PR adds syntax support to table-valued functions: `arg0 => value0` and adds a trait.

### Why are the changes needed?
Better UX when using the Spark SQL function


### Does this PR introduce _any_ user-facing change?
No (not in this PR, this PR only adds syntax support)


### How was this patch tested?
New UTs
