### PR TITLE
[SPARK-41156][SQL] Remove the class `TypeCheckFailure`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -4874,16 +4874,6 @@
       "Hint not found: <name>"
     ]
   },
-  "_LEGACY_ERROR_TEMP_2314" : {
-    "message" : [
-      "cannot resolve '<sqlExpr>' due to argument data type mismatch: <msg>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2315" : {
-    "message" : [
-      "cannot resolve '<sqlExpr>' due to data type mismatch: <msg><hint>"
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2316" : {
     "message" : [
       "observed metrics should be named: <operator>"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -217,10 +217,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             hof.checkArgumentDataTypes() match {
               case checkRes: TypeCheckResult.DataTypeMismatch =>
                 hof.dataTypeMismatch(hof, checkRes)
-              case TypeCheckResult.TypeCheckFailure(message) =>
-                hof.failAnalysis(
-                  errorClass = "_LEGACY_ERROR_TEMP_2314",
-                  messageParameters = Map("sqlExpr" -> hof.sql, "msg" -> message))
             }
 
           // If an attribute can't be resolved as a map key of string type, either the key should be
@@ -243,15 +239,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               case checkRes: TypeCheckResult.DataTypeMismatch =>
                 e.setTagValue(DATA_TYPE_MISMATCH_ERROR, true)
                 e.dataTypeMismatch(e, checkRes)
-              case TypeCheckResult.TypeCheckFailure(message) =>
-                e.setTagValue(DATA_TYPE_MISMATCH_ERROR, true)
-                extraHintForAnsiTypeCoercionExpression(operator)
-                e.failAnalysis(
-                  errorClass = "_LEGACY_ERROR_TEMP_2315",
-                  messageParameters = Map(
-                    "sqlExpr" -> e.sql,
-                    "msg" -> message,
-                    "hint" -> extraHintForAnsiTypeCoercionExpression(operator)))
             }
 
           case c: Cast if !c.resolved =>
@@ -767,7 +754,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
         case e: Expression if e.getTagValue(DATA_TYPE_MISMATCH_ERROR).contains(true) &&
             e.checkInputDataTypes().isFailure =>
           e.checkInputDataTypes() match {
-            case TypeCheckResult.TypeCheckFailure(_) | _: TypeCheckResult.DataTypeMismatch =>
+            case _: TypeCheckResult.DataTypeMismatch =>
               issueFixedIfAnsiOff = false
           }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCheckResult.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCheckResult.scala
@@ -36,14 +36,6 @@ object TypeCheckResult {
   }
 
   /**
-   * Represents the failing result of `Expression.checkInputDataTypes`,
-   * with an error message to show the reason of failure.
-   */
-  case class TypeCheckFailure(message: String) extends TypeCheckResult {
-    def isSuccess: Boolean = false
-  }
-
-  /**
    * Represents an error of data type mismatch with the `DATATYPE_MISMATCH` error class.
    *
    * @param errorSubClass A sub-class of `DATATYPE_MISMATCH`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -413,7 +413,7 @@ object Cast extends QueryErrorsBase {
     }
   }
 
-  def typeCheckFailureMessage(
+  private def dataTypeMismatchError(
       from: DataType,
       to: DataType,
       fallbackConf: Option[(String, String)]): DataTypeMismatch = {
@@ -515,18 +515,18 @@ case class Cast(
     evalMode == EvalMode.TRY
   }
 
-  private def typeCheckFailureInCast: DataTypeMismatch = evalMode match {
+  private def dataTypeMismatchInCast: DataTypeMismatch = evalMode match {
     case EvalMode.ANSI =>
       if (getTagValue(Cast.BY_TABLE_INSERTION).isDefined) {
-        Cast.typeCheckFailureMessage(child.dataType, dataType,
+        Cast.dataTypeMismatchError(child.dataType, dataType,
           Some(SQLConf.STORE_ASSIGNMENT_POLICY.key ->
             SQLConf.StoreAssignmentPolicy.LEGACY.toString))
       } else {
-        Cast.typeCheckFailureMessage(child.dataType, dataType,
+        Cast.dataTypeMismatchError(child.dataType, dataType,
           Some(SQLConf.ANSI_ENABLED.key -> "false"))
       }
     case EvalMode.TRY =>
-      Cast.typeCheckFailureMessage(child.dataType, dataType, None)
+      Cast.dataTypeMismatchError(child.dataType, dataType, None)
     case _ =>
       DataTypeMismatch(
         errorSubClass = "CAST_WITHOUT_SUGGESTION",
@@ -545,7 +545,7 @@ case class Cast(
     if (canCast) {
       TypeCheckResult.TypeCheckSuccess
     } else {
-      typeCheckFailureInCast
+      dataTypeMismatchInCast
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -237,8 +237,6 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
     // In doesn't support map type and will fail the analyzer.
     val map = Literal.create(create_map(1 -> 1), MapType(IntegerType, IntegerType))
     In(map, Seq(map)).checkInputDataTypes() match {
-      case TypeCheckResult.TypeCheckFailure(msg) =>
-        assert(msg.contains("function in does not support ordering on type map"))
       case TypeCheckResult.DataTypeMismatch(errorSubClass, messageParameters) =>
         assert(errorSubClass == "INVALID_ORDERING_TYPE")
         assert(messageParameters === Map(


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to remove the class `TypeCheckFailure` since it is not used anymore after migration onto the `DataTypeMismatch` class (converted to an error sub-class of `DATATYPE_MISMATCH`). Also this PR removes the error classes `_LEGACY_ERROR_TEMP_2314` and `_LEGACY_ERROR_TEMP_2315`.

### Why are the changes needed?
To improve code maintenance by removing the dead class and dependent code. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "test:testOnly *PredicateSuite"
```