### PR TITLE
[SPARK-41159][SQL] Optimize like any and like all expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -369,7 +369,7 @@ sealed abstract class MultiLikeBase
             |if($matchRes == null) {
             |  ${ev.isNull} = true;
             |} else {
-            |  ${ev.value} = ret;
+            |  ${ev.value} = $matchRes;
             |}
         """.stripMargin)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -358,14 +358,15 @@ sealed abstract class MultiLikeBase
             if (p != null) s"""$v.addPattern("${p.toString}");""" else s"$v.addPattern(null);"
           ).mkString("\n"),
         forceInline = true)
+    val matchRes = ctx.freshName("matchRes")
 
     ev.copy(code =
       code"""
             |${eval.code}
             |boolean ${ev.value} = false;
             |boolean ${ev.isNull} = false;
-            |Boolean ret = (Boolean) ($matchHelper.matches(${eval.value}));
-            |if(ret == null) {
+            |Boolean $matchRes = (Boolean) ($matchHelper.matches(${eval.value}));
+            |if($matchRes == null) {
             |  ${ev.isNull} = true;
             |} else {
             |  ${ev.value} = ret;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -261,7 +261,7 @@ case class MatchMultiHelper(
     patternBufs += UTF8String.fromString(pattern)
   }
 
-  protected lazy val cache: Seq[UTF8String => Boolean] = patternBufs.filterNot(_ == null)
+  protected lazy val cache: Seq[UTF8String => Boolean] = patternBufs.toSeq.filterNot(_ == null)
     .map(s => {
       val escapeChar = '\\'
       val func =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -362,8 +362,14 @@ sealed abstract class MultiLikeBase
     ev.copy(code =
       code"""
             |${eval.code}
-            |Boolean ${ev.value} = (Boolean) ($matchHelper.matches(${eval.value}));
-            |boolean ${ev.isNull} = ${ev.value} == null;
+            |boolean ${ev.value} = false;
+            |boolean ${ev.isNull} = false;
+            |Boolean ret = (Boolean) ($matchHelper.matches(${eval.value}));
+            |if(ret == null) {
+            |  ${ev.isNull} = true;
+            |} else {
+            |  ${ev.value} = ret;
+            |}
         """.stripMargin)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -707,11 +707,11 @@ object SupportedBinaryExpr {
 object LikeSimplification extends Rule[LogicalPlan] with PredicateHelper {
   // if guards below protect from escapes on trailing %.
   // Cases like "something\%" are not optimized, but this does not affect correctness.
-  private val startsWith = "([^_%]+)%".r
-  private val endsWith = "%([^_%]+)".r
-  private val startsAndEndsWith = "([^_%]+)%([^_%]+)".r
-  private val contains = "%([^_%]+)%".r
-  private val equalTo = "([^_%]*)".r
+  val startsWith = "([^_%]+)%".r
+  val endsWith = "%([^_%]+)".r
+  val startsAndEndsWith = "([^_%]+)%([^_%]+)".r
+  val contains = "%([^_%]+)%".r
+  val equalTo = "([^_%]*)".r
 
   private def simplifyLike(
       input: Expression, pattern: String, escapeChar: Char = '\\'): Option[Expression] = {

--- a/sql/core/benchmarks/LikeAnyBenchmark-results.txt
+++ b/sql/core/benchmarks/LikeAnyBenchmark-results.txt
@@ -1,0 +1,8 @@
+OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1022-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Multi like query:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Query with multi like                              1128           1188          87          0.0     1128237.2       1.0X
+Query with LikeAny simplification                  5032           5075          43          0.0     5031594.6       0.2X
+Query without LikeAny simplification                172            177           8          0.0      171789.4       6.6X
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LikeAnyBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/LikeAnyBenchmark.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import java.io.File
+
+import scala.util.Random
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.DataFrame
+
+/**
+ * Benchmark to measure like any expressions performance.
+ *
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt: bin/spark-submit --class <this class>
+ *     --jars <spark core test jar>,<spark catalyst test jar> <spark sql test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/LikeAnyBenchmark-results.txt".
+ * }}}
+ */
+object LikeAnyBenchmark extends SqlBasedBenchmark {
+  import spark.implicits._
+
+  private val numRows = 1000
+  private val width = 5
+
+  def withTempTable(tableNames: String*)(f: => Unit): Unit = {
+    try f finally tableNames.foreach(spark.catalog.dropTempView)
+  }
+
+  private def saveAsTable(df: DataFrame, dir: File): Unit = {
+    val parquetPath = dir.getCanonicalPath + "/parquet"
+    df.write.mode("overwrite").parquet(parquetPath)
+    spark.read.parquet(parquetPath).createOrReplaceTempView("parquetTable")
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    withTempPath { dir =>
+      withTempTable("parquetTable") {
+        val selectExpr = (1 to width).map(i => s"CAST(value + 1000000 AS STRING) c$i")
+        val df = spark.range(0, numRows, 1, 100)
+          .map(_ => Random.nextLong).selectExpr(selectExpr: _*)
+        saveAsTable(df, dir)
+
+        val benchmark =
+          new Benchmark("Multi like query", numRows, minNumIters = 3, output = output)
+        val multiLikeExpr =
+          Range(1000, 1200).map(i => s"c1 like '%$i%'").mkString(" or ")
+        benchmark.addCase("Query with multi like", numIters = 3) { _ =>
+          spark.sql(s"SELECT * FROM parquetTable WHERE $multiLikeExpr").noop()
+        }
+
+        val likeAnyExpr =
+          Range(1000, 1200).map(i => s"'%$i%'").mkString("c1 like any(", ", ", ")")
+        benchmark.addCase("Query with LikeAny", numIters = 3) { _ =>
+          spark.sql(s"SELECT * FROM parquetTable WHERE $likeAnyExpr").noop()
+        }
+        benchmark.run()
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Optimize like any and like all expressions with startWith, endWith, contains, equalTo methods.

### Why are the changes needed?

Now like any and like all expressions will be very slow whether enable or disable LikeSimplification rule.
Refer to `org.apache.spark.sql.execution.benchmark.LikeAnyBenchmark`

```
OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1022-azure
Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
[info] Multi like query:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] Query with multi like                              1439           1518          78          0.0     1438904.6       1.0X
[info] Query with LikeAny simplification                  1392           1427          30          0.0     1392103.7       1.0X
[info] Query without LikeAny simplification                368            374           5          0.0      368485.2       3.9X
```


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Exists UT
