### PR TITLE
[SPARK-41171][SQL] Push down filter through window when partitionSpec is empty

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -305,25 +305,6 @@ trait PredicateHelper extends AliasHelper with Logging {
     case _: MultiLikeBase => true
     case _ => false
   }
-
-  def extractLimits(condition: Expression, attr: Attribute): Option[Int] = {
-    val limits = splitConjunctivePredicates(condition).collect {
-      case EqualTo(Literal(limit: Int, IntegerType), e)
-        if e.semanticEquals(attr) => limit
-      case EqualTo(e, Literal(limit: Int, IntegerType))
-        if e.semanticEquals(attr) => limit
-      case LessThan(e, Literal(limit: Int, IntegerType))
-        if e.semanticEquals(attr) => limit - 1
-      case GreaterThan(Literal(limit: Int, IntegerType), e)
-        if e.semanticEquals(attr) => limit - 1
-      case LessThanOrEqual(e, Literal(limit: Int, IntegerType))
-        if e.semanticEquals(attr) => limit
-      case GreaterThanOrEqual(Literal(limit: Int, IntegerType), e)
-        if e.semanticEquals(attr) => limit
-    }
-
-    if (limits.nonEmpty) Some(limits.min) else None
-  }
 }
 
 @ExpressionDescription(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -305,6 +305,25 @@ trait PredicateHelper extends AliasHelper with Logging {
     case _: MultiLikeBase => true
     case _ => false
   }
+
+  def extractLimits(condition: Expression, attr: Attribute): Option[Int] = {
+    val limits = splitConjunctivePredicates(condition).collect {
+      case EqualTo(Literal(limit: Int, IntegerType), e)
+        if e.semanticEquals(attr) => limit
+      case EqualTo(e, Literal(limit: Int, IntegerType))
+        if e.semanticEquals(attr) => limit
+      case LessThan(e, Literal(limit: Int, IntegerType))
+        if e.semanticEquals(attr) => limit - 1
+      case GreaterThan(Literal(limit: Int, IntegerType), e)
+        if e.semanticEquals(attr) => limit - 1
+      case LessThanOrEqual(e, Literal(limit: Int, IntegerType))
+        if e.semanticEquals(attr) => limit
+      case GreaterThanOrEqual(Literal(limit: Int, IntegerType), e)
+        if e.semanticEquals(attr) => limit
+    }
+
+    if (limits.nonEmpty) Some(limits.min) else None
+  }
 }
 
 @ExpressionDescription(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushDownThroughWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushDownThroughWindow.scala
@@ -17,19 +17,21 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, CurrentRow, DenseRank, IntegerLiteral, NamedExpression, Rank, RowFrame, RowNumber, SpecifiedWindowFrame, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
-import org.apache.spark.sql.catalyst.plans.logical.{Limit, LocalLimit, LogicalPlan, Project, Sort, Window}
+import org.apache.spark.sql.catalyst.expressions.{Alias, CurrentRow, DenseRank, Expression, IntegerLiteral, Literal, NamedExpression, PredicateHelper, Rank, RowFrame, RowNumber, SpecifiedWindowFrame, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, Limit, LocalLimit, LogicalPlan, Project, Sort, Window}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreePattern.{LIMIT, WINDOW}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{FILTER, LIMIT, WINDOW}
 
 /**
  * Pushes down [[LocalLimit]] beneath WINDOW. This rule optimizes the following case:
  * {{{
  *   SELECT *, ROW_NUMBER() OVER(ORDER BY a) AS rn FROM Tab1 LIMIT 5 ==>
  *   SELECT *, ROW_NUMBER() OVER(ORDER BY a) AS rn FROM (SELECT * FROM Tab1 ORDER BY a LIMIT 5) t
+ *   SELECT *, ROW_NUMBER() OVER(ORDER BY a) AS rn FROM Tab1 WHERE rn <= 5 ==>
+ *   SELECT *, ROW_NUMBER() OVER(ORDER BY a) AS rn FROM (SELECT * FROM Tab1 ORDER BY a LIMIT 5) t
  * }}}
  */
-object LimitPushDownThroughWindow extends Rule[LogicalPlan] {
+object LimitPushDownThroughWindow extends Rule[LogicalPlan] with PredicateHelper {
   // The window frame of RankLike and RowNumberLike can only be UNBOUNDED PRECEDING to CURRENT ROW.
   private def supportsPushdownThroughWindow(
       windowExpressions: Seq[NamedExpression]): Boolean = windowExpressions.forall {
@@ -38,8 +40,24 @@ object LimitPushDownThroughWindow extends Rule[LogicalPlan] {
     case _ => false
   }
 
+  // Extract limit from filter condition and select the min limit.
+  private def extractLimit(
+      condition: Expression,
+      windowExpressions: Seq[NamedExpression]): Option[Int] = {
+    val limits = windowExpressions.collect {
+      case alias @ Alias(WindowExpression(_, _), _) =>
+        extractLimits(condition, alias.toAttribute)
+    }.filter(_.isDefined)
+
+    if (limits.nonEmpty) {
+      Some(limits.flatten.min)
+    } else {
+      None
+    }
+  }
+
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
-    _.containsAllPatterns(WINDOW, LIMIT), ruleId) {
+    _.containsAnyPattern(WINDOW, LIMIT, FILTER), ruleId) {
     // Adding an extra Limit below WINDOW when the partitionSpec of all window functions is empty.
     case LocalLimit(limitExpr @ IntegerLiteral(limit),
         window @ Window(windowExpressions, Nil, orderSpec, child))
@@ -54,5 +72,17 @@ object LimitPushDownThroughWindow extends Rule[LogicalPlan] {
         limit < conf.topKSortFallbackThreshold =>
       // Sort is needed here because we need global sort.
       project.copy(child = window.copy(child = Limit(limitExpr, Sort(orderSpec, true, child))))
+    case filter @ Filter(condition,
+        window @ Window(windowExpressions, Nil, orderSpec, child))
+      if filter.getTagValue(Filter.FILTER_PUSHED_AS_LIMIT).isEmpty &&
+        supportsPushdownThroughWindow(windowExpressions) && orderSpec.nonEmpty =>
+      val limit = extractLimit(condition, windowExpressions)
+      if (limit.isDefined && limit.get < conf.topKSortFallbackThreshold) {
+        val newWindow = window.copy(child = Limit(Literal(limit.get), Sort(orderSpec, true, child)))
+        filter.setTagValue(Filter.FILTER_PUSHED_AS_LIMIT, ())
+        filter.copy(child = newWindow)
+      } else {
+        filter
+      }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushDownThroughWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushDownThroughWindow.scala
@@ -81,8 +81,7 @@ object LimitPushDownThroughWindow extends Rule[LogicalPlan] with PredicateHelper
         if (limit < conf.topKSortFallbackThreshold) {
           val newWindow = window.copy(child = Limit(Literal(limit), Sort(orderSpec, true, child)))
           condition.setTagValue(Filter.FILTER_PUSHED_AS_LIMIT, ())
-          val newFilter = filter.copy(child = newWindow)
-          newFilter
+          filter.copy(child = newWindow)
         } else {
           filter
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -311,6 +311,10 @@ case class Filter(condition: Expression, child: LogicalPlan)
     copy(child = newChild)
 }
 
+object Filter {
+  val FILTER_PUSHED_AS_LIMIT = TreeNodeTag[Unit]("filter_pushed_as_limit")
+}
+
 abstract class SetOperation(left: LogicalPlan, right: LogicalPlan) extends BinaryNode {
 
   def duplicateResolved: Boolean = left.outputSet.intersect(right.outputSet).isEmpty

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownThroughWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownThroughWindowSuite.scala
@@ -210,7 +210,7 @@ class LimitPushdownThroughWindowSuite extends PlanTest {
       WithoutOptimize.execute(originalQuery.analyze))
   }
 
-  test("Push down filter through window when partitionSpec is empty") {
+  test("SPARK-41171: Push down filter through window when partitionSpec is empty") {
     val originalQuery = testRelation
       .select(a, b, c,
         windowExpr(RowNumber(), windowSpec(Nil, c.desc :: Nil, windowFrame)).as("rn"))

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/explain.txt
@@ -1,35 +1,39 @@
 == Physical Plan ==
-TakeOrderedAndProject (31)
-+- * Project (30)
-   +- * BroadcastHashJoin Inner BuildRight (29)
-      :- * Project (27)
-      :  +- * BroadcastHashJoin Inner BuildRight (26)
-      :     :- * Project (21)
-      :     :  +- * BroadcastHashJoin Inner BuildRight (20)
-      :     :     :- * Project (13)
-      :     :     :  +- * Filter (12)
-      :     :     :     +- Window (11)
-      :     :     :        +- * Sort (10)
-      :     :     :           +- Exchange (9)
-      :     :     :              +- * Filter (8)
-      :     :     :                 +- * HashAggregate (7)
-      :     :     :                    +- Exchange (6)
-      :     :     :                       +- * HashAggregate (5)
-      :     :     :                          +- * Project (4)
-      :     :     :                             +- * Filter (3)
-      :     :     :                                +- * ColumnarToRow (2)
-      :     :     :                                   +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :     +- BroadcastExchange (19)
-      :     :        +- * Project (18)
-      :     :           +- * Filter (17)
-      :     :              +- Window (16)
-      :     :                 +- * Sort (15)
-      :     :                    +- ReusedExchange (14)
-      :     +- BroadcastExchange (25)
-      :        +- * Filter (24)
-      :           +- * ColumnarToRow (23)
-      :              +- Scan parquet spark_catalog.default.item (22)
-      +- ReusedExchange (28)
+TakeOrderedAndProject (35)
++- * Project (34)
+   +- * BroadcastHashJoin Inner BuildRight (33)
+      :- * Project (28)
+      :  +- * BroadcastHashJoin Inner BuildLeft (27)
+      :     :- BroadcastExchange (23)
+      :     :  +- * Project (22)
+      :     :     +- * BroadcastHashJoin Inner BuildRight (21)
+      :     :        :- * Project (12)
+      :     :        :  +- * Filter (11)
+      :     :        :     +- Window (10)
+      :     :        :        +- TakeOrderedAndProject (9)
+      :     :        :           +- * Filter (8)
+      :     :        :              +- * HashAggregate (7)
+      :     :        :                 +- Exchange (6)
+      :     :        :                    +- * HashAggregate (5)
+      :     :        :                       +- * Project (4)
+      :     :        :                          +- * Filter (3)
+      :     :        :                             +- * ColumnarToRow (2)
+      :     :        :                                +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :        +- BroadcastExchange (20)
+      :     :           +- * Project (19)
+      :     :              +- * Filter (18)
+      :     :                 +- Window (17)
+      :     :                    +- TakeOrderedAndProject (16)
+      :     :                       +- * Filter (15)
+      :     :                          +- * HashAggregate (14)
+      :     :                             +- ReusedExchange (13)
+      :     +- * Filter (26)
+      :        +- * ColumnarToRow (25)
+      :           +- Scan parquet spark_catalog.default.item (24)
+      +- BroadcastExchange (32)
+         +- * Filter (31)
+            +- * ColumnarToRow (30)
+               +- Scan parquet spark_catalog.default.item (29)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -72,150 +76,174 @@ Results [2]: [ss_item_sk#1 AS item_sk#10, cast((avg(UnscaledValue(ss_net_profit#
 Input [2]: [item_sk#10, rank_col#11]
 Condition : (isnotnull(rank_col#11) AND (cast(rank_col#11 as decimal(13,7)) > (0.9 * Subquery scalar-subquery#12, [id=#13])))
 
-(9) Exchange
+(9) TakeOrderedAndProject
 Input [2]: [item_sk#10, rank_col#11]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=2]
+Arguments: 10, [rank_col#11 ASC NULLS FIRST], [item_sk#10, rank_col#11]
 
-(10) Sort [codegen id : 3]
-Input [2]: [item_sk#10, rank_col#11]
-Arguments: [rank_col#11 ASC NULLS FIRST], false, 0
-
-(11) Window
+(10) Window
 Input [2]: [item_sk#10, rank_col#11]
 Arguments: [rank(rank_col#11) windowspecdefinition(rank_col#11 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#14], [rank_col#11 ASC NULLS FIRST]
 
-(12) Filter [codegen id : 10]
+(11) Filter [codegen id : 6]
 Input [3]: [item_sk#10, rank_col#11, rnk#14]
 Condition : ((rnk#14 < 11) AND isnotnull(item_sk#10))
 
-(13) Project [codegen id : 10]
+(12) Project [codegen id : 6]
 Output [2]: [item_sk#10, rnk#14]
 Input [3]: [item_sk#10, rank_col#11, rnk#14]
 
-(14) ReusedExchange [Reuses operator id: 9]
-Output [2]: [item_sk#15, rank_col#16]
+(13) ReusedExchange [Reuses operator id: 6]
+Output [3]: [ss_item_sk#15, sum#16, count#17]
 
-(15) Sort [codegen id : 6]
-Input [2]: [item_sk#15, rank_col#16]
-Arguments: [rank_col#16 DESC NULLS LAST], false, 0
+(14) HashAggregate [codegen id : 4]
+Input [3]: [ss_item_sk#15, sum#16, count#17]
+Keys [1]: [ss_item_sk#15]
+Functions [1]: [avg(UnscaledValue(ss_net_profit#18))]
+Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#18))#19]
+Results [2]: [ss_item_sk#15 AS item_sk#20, cast((avg(UnscaledValue(ss_net_profit#18))#19 / 100.0) as decimal(11,6)) AS rank_col#21]
 
-(16) Window
-Input [2]: [item_sk#15, rank_col#16]
-Arguments: [rank(rank_col#16) windowspecdefinition(rank_col#16 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#17], [rank_col#16 DESC NULLS LAST]
+(15) Filter [codegen id : 4]
+Input [2]: [item_sk#20, rank_col#21]
+Condition : (isnotnull(rank_col#21) AND (cast(rank_col#21 as decimal(13,7)) > (0.9 * ReusedSubquery Subquery scalar-subquery#12, [id=#13])))
 
-(17) Filter [codegen id : 7]
-Input [3]: [item_sk#15, rank_col#16, rnk#17]
-Condition : ((rnk#17 < 11) AND isnotnull(item_sk#15))
+(16) TakeOrderedAndProject
+Input [2]: [item_sk#20, rank_col#21]
+Arguments: 10, [rank_col#21 DESC NULLS LAST], [item_sk#20, rank_col#21]
 
-(18) Project [codegen id : 7]
-Output [2]: [item_sk#15, rnk#17]
-Input [3]: [item_sk#15, rank_col#16, rnk#17]
+(17) Window
+Input [2]: [item_sk#20, rank_col#21]
+Arguments: [rank(rank_col#21) windowspecdefinition(rank_col#21 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#22], [rank_col#21 DESC NULLS LAST]
 
-(19) BroadcastExchange
-Input [2]: [item_sk#15, rnk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [plan_id=3]
+(18) Filter [codegen id : 5]
+Input [3]: [item_sk#20, rank_col#21, rnk#22]
+Condition : ((rnk#22 < 11) AND isnotnull(item_sk#20))
 
-(20) BroadcastHashJoin [codegen id : 10]
+(19) Project [codegen id : 5]
+Output [2]: [item_sk#20, rnk#22]
+Input [3]: [item_sk#20, rank_col#21, rnk#22]
+
+(20) BroadcastExchange
+Input [2]: [item_sk#20, rnk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [plan_id=2]
+
+(21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [rnk#14]
-Right keys [1]: [rnk#17]
+Right keys [1]: [rnk#22]
 Join type: Inner
 Join condition: None
 
-(21) Project [codegen id : 10]
-Output [3]: [item_sk#10, rnk#14, item_sk#15]
-Input [4]: [item_sk#10, rnk#14, item_sk#15, rnk#17]
+(22) Project [codegen id : 6]
+Output [3]: [item_sk#10, rnk#14, item_sk#20]
+Input [4]: [item_sk#10, rnk#14, item_sk#20, rnk#22]
 
-(22) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_product_name#19]
+(23) BroadcastExchange
+Input [3]: [item_sk#10, rnk#14, item_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+
+(24) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#23, i_product_name#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_product_name:string>
 
-(23) ColumnarToRow [codegen id : 8]
-Input [2]: [i_item_sk#18, i_product_name#19]
+(25) ColumnarToRow
+Input [2]: [i_item_sk#23, i_product_name#24]
 
-(24) Filter [codegen id : 8]
-Input [2]: [i_item_sk#18, i_product_name#19]
-Condition : isnotnull(i_item_sk#18)
+(26) Filter
+Input [2]: [i_item_sk#23, i_product_name#24]
+Condition : isnotnull(i_item_sk#23)
 
-(25) BroadcastExchange
-Input [2]: [i_item_sk#18, i_product_name#19]
+(27) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [item_sk#10]
+Right keys [1]: [i_item_sk#23]
+Join type: Inner
+Join condition: None
+
+(28) Project [codegen id : 8]
+Output [3]: [rnk#14, item_sk#20, i_product_name#24]
+Input [5]: [item_sk#10, rnk#14, item_sk#20, i_item_sk#23, i_product_name#24]
+
+(29) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#25, i_product_name#26]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_product_name:string>
+
+(30) ColumnarToRow [codegen id : 7]
+Input [2]: [i_item_sk#25, i_product_name#26]
+
+(31) Filter [codegen id : 7]
+Input [2]: [i_item_sk#25, i_product_name#26]
+Condition : isnotnull(i_item_sk#25)
+
+(32) BroadcastExchange
+Input [2]: [i_item_sk#25, i_product_name#26]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
-(26) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [item_sk#10]
-Right keys [1]: [i_item_sk#18]
+(33) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [item_sk#20]
+Right keys [1]: [i_item_sk#25]
 Join type: Inner
 Join condition: None
 
-(27) Project [codegen id : 10]
-Output [3]: [rnk#14, item_sk#15, i_product_name#19]
-Input [5]: [item_sk#10, rnk#14, item_sk#15, i_item_sk#18, i_product_name#19]
+(34) Project [codegen id : 8]
+Output [3]: [rnk#14, i_product_name#24 AS best_performing#27, i_product_name#26 AS worst_performing#28]
+Input [5]: [rnk#14, item_sk#20, i_product_name#24, i_item_sk#25, i_product_name#26]
 
-(28) ReusedExchange [Reuses operator id: 25]
-Output [2]: [i_item_sk#20, i_product_name#21]
-
-(29) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [item_sk#15]
-Right keys [1]: [i_item_sk#20]
-Join type: Inner
-Join condition: None
-
-(30) Project [codegen id : 10]
-Output [3]: [rnk#14, i_product_name#19 AS best_performing#22, i_product_name#21 AS worst_performing#23]
-Input [5]: [rnk#14, item_sk#15, i_product_name#19, i_item_sk#20, i_product_name#21]
-
-(31) TakeOrderedAndProject
-Input [3]: [rnk#14, best_performing#22, worst_performing#23]
-Arguments: 100, [rnk#14 ASC NULLS FIRST], [rnk#14, best_performing#22, worst_performing#23]
+(35) TakeOrderedAndProject
+Input [3]: [rnk#14, best_performing#27, worst_performing#28]
+Arguments: 100, [rnk#14 ASC NULLS FIRST], [rnk#14, best_performing#27, worst_performing#28]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
-* HashAggregate (38)
-+- Exchange (37)
-   +- * HashAggregate (36)
-      +- * Project (35)
-         +- * Filter (34)
-            +- * ColumnarToRow (33)
-               +- Scan parquet spark_catalog.default.store_sales (32)
+* HashAggregate (42)
++- Exchange (41)
+   +- * HashAggregate (40)
+      +- * Project (39)
+         +- * Filter (38)
+            +- * ColumnarToRow (37)
+               +- Scan parquet spark_catalog.default.store_sales (36)
 
 
-(32) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_addr_sk#24, ss_store_sk#25, ss_net_profit#26, ss_sold_date_sk#27]
+(36) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_store_sk), EqualTo(ss_store_sk,4), IsNull(ss_addr_sk)]
 ReadSchema: struct<ss_addr_sk:int,ss_store_sk:int,ss_net_profit:decimal(7,2)>
 
-(33) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_addr_sk#24, ss_store_sk#25, ss_net_profit#26, ss_sold_date_sk#27]
+(37) ColumnarToRow [codegen id : 1]
+Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 
-(34) Filter [codegen id : 1]
-Input [4]: [ss_addr_sk#24, ss_store_sk#25, ss_net_profit#26, ss_sold_date_sk#27]
-Condition : ((isnotnull(ss_store_sk#25) AND (ss_store_sk#25 = 4)) AND isnull(ss_addr_sk#24))
+(38) Filter [codegen id : 1]
+Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
+Condition : ((isnotnull(ss_store_sk#30) AND (ss_store_sk#30 = 4)) AND isnull(ss_addr_sk#29))
 
-(35) Project [codegen id : 1]
-Output [2]: [ss_store_sk#25, ss_net_profit#26]
-Input [4]: [ss_addr_sk#24, ss_store_sk#25, ss_net_profit#26, ss_sold_date_sk#27]
+(39) Project [codegen id : 1]
+Output [2]: [ss_store_sk#30, ss_net_profit#31]
+Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 
-(36) HashAggregate [codegen id : 1]
-Input [2]: [ss_store_sk#25, ss_net_profit#26]
-Keys [1]: [ss_store_sk#25]
-Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#26))]
-Aggregate Attributes [2]: [sum#28, count#29]
-Results [3]: [ss_store_sk#25, sum#30, count#31]
+(40) HashAggregate [codegen id : 1]
+Input [2]: [ss_store_sk#30, ss_net_profit#31]
+Keys [1]: [ss_store_sk#30]
+Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#31))]
+Aggregate Attributes [2]: [sum#33, count#34]
+Results [3]: [ss_store_sk#30, sum#35, count#36]
 
-(37) Exchange
-Input [3]: [ss_store_sk#25, sum#30, count#31]
-Arguments: hashpartitioning(ss_store_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(41) Exchange
+Input [3]: [ss_store_sk#30, sum#35, count#36]
+Arguments: hashpartitioning(ss_store_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(38) HashAggregate [codegen id : 2]
-Input [3]: [ss_store_sk#25, sum#30, count#31]
-Keys [1]: [ss_store_sk#25]
-Functions [1]: [avg(UnscaledValue(ss_net_profit#26))]
-Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#26))#32]
-Results [1]: [cast((avg(UnscaledValue(ss_net_profit#26))#32 / 100.0) as decimal(11,6)) AS rank_col#33]
+(42) HashAggregate [codegen id : 2]
+Input [3]: [ss_store_sk#30, sum#35, count#36]
+Keys [1]: [ss_store_sk#30]
+Functions [1]: [avg(UnscaledValue(ss_net_profit#31))]
+Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#31))#37]
+Results [1]: [cast((avg(UnscaledValue(ss_net_profit#31))#37 / 100.0) as decimal(11,6)) AS rank_col#38]
+
+Subquery:2 Hosting operator id = 15 Hosting Expression = ReusedSubquery Subquery scalar-subquery#12, [id=#13]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/simplified.txt
@@ -1,19 +1,19 @@
 TakeOrderedAndProject [rnk,best_performing,worst_performing]
-  WholeStageCodegen (10)
+  WholeStageCodegen (8)
     Project [rnk,i_product_name,i_product_name]
       BroadcastHashJoin [item_sk,i_item_sk]
         Project [rnk,item_sk,i_product_name]
           BroadcastHashJoin [item_sk,i_item_sk]
-            Project [item_sk,rnk,item_sk]
-              BroadcastHashJoin [rnk,rnk]
-                Project [item_sk,rnk]
-                  Filter [rnk,item_sk]
-                    InputAdapter
-                      Window [rank_col]
-                        WholeStageCodegen (3)
-                          Sort [rank_col]
-                            InputAdapter
-                              Exchange #1
+            InputAdapter
+              BroadcastExchange #1
+                WholeStageCodegen (6)
+                  Project [item_sk,rnk,item_sk]
+                    BroadcastHashJoin [rnk,rnk]
+                      Project [item_sk,rnk]
+                        Filter [rnk,item_sk]
+                          InputAdapter
+                            Window [rank_col]
+                              TakeOrderedAndProject [rank_col,item_sk]
                                 WholeStageCodegen (2)
                                   Filter [rank_col]
                                     Subquery #1
@@ -38,23 +38,28 @@ TakeOrderedAndProject [rnk,best_performing,worst_performing]
                                                   ColumnarToRow
                                                     InputAdapter
                                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                InputAdapter
-                  BroadcastExchange #4
-                    WholeStageCodegen (7)
-                      Project [item_sk,rnk]
-                        Filter [rnk,item_sk]
-                          InputAdapter
-                            Window [rank_col]
-                              WholeStageCodegen (6)
-                                Sort [rank_col]
-                                  InputAdapter
-                                    ReusedExchange [item_sk,rank_col] #1
-            InputAdapter
-              BroadcastExchange #5
-                WholeStageCodegen (8)
-                  Filter [i_item_sk]
-                    ColumnarToRow
                       InputAdapter
-                        Scan parquet spark_catalog.default.item [i_item_sk,i_product_name]
+                        BroadcastExchange #4
+                          WholeStageCodegen (5)
+                            Project [item_sk,rnk]
+                              Filter [rnk,item_sk]
+                                InputAdapter
+                                  Window [rank_col]
+                                    TakeOrderedAndProject [rank_col,item_sk]
+                                      WholeStageCodegen (4)
+                                        Filter [rank_col]
+                                          ReusedSubquery [rank_col] #1
+                                          HashAggregate [ss_item_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),item_sk,rank_col,sum,count]
+                                            InputAdapter
+                                              ReusedExchange [ss_item_sk,sum,count] #2
+            Filter [i_item_sk]
+              ColumnarToRow
+                InputAdapter
+                  Scan parquet spark_catalog.default.item [i_item_sk,i_product_name]
         InputAdapter
-          ReusedExchange [i_item_sk,i_product_name] #5
+          BroadcastExchange #5
+            WholeStageCodegen (7)
+              Filter [i_item_sk]
+                ColumnarToRow
+                  InputAdapter
+                    Scan parquet spark_catalog.default.item [i_item_sk,i_product_name]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
@@ -5,27 +5,27 @@ TakeOrderedAndProject (32)
       :- * Project (28)
       :  +- * BroadcastHashJoin Inner BuildRight (27)
       :     :- * Project (22)
-      :     :  +- * SortMergeJoin Inner (21)
-      :     :     :- * Sort (14)
-      :     :     :  +- * Project (13)
-      :     :     :     +- * Filter (12)
-      :     :     :        +- Window (11)
-      :     :     :           +- * Sort (10)
-      :     :     :              +- Exchange (9)
-      :     :     :                 +- * Filter (8)
-      :     :     :                    +- * HashAggregate (7)
-      :     :     :                       +- Exchange (6)
-      :     :     :                          +- * HashAggregate (5)
-      :     :     :                             +- * Project (4)
-      :     :     :                                +- * Filter (3)
-      :     :     :                                   +- * ColumnarToRow (2)
-      :     :     :                                      +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :     +- * Sort (20)
+      :     :  +- * BroadcastHashJoin Inner BuildRight (21)
+      :     :     :- * Project (12)
+      :     :     :  +- * Filter (11)
+      :     :     :     +- Window (10)
+      :     :     :        +- TakeOrderedAndProject (9)
+      :     :     :           +- * Filter (8)
+      :     :     :              +- * HashAggregate (7)
+      :     :     :                 +- Exchange (6)
+      :     :     :                    +- * HashAggregate (5)
+      :     :     :                       +- * Project (4)
+      :     :     :                          +- * Filter (3)
+      :     :     :                             +- * ColumnarToRow (2)
+      :     :     :                                +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :     +- BroadcastExchange (20)
       :     :        +- * Project (19)
       :     :           +- * Filter (18)
       :     :              +- Window (17)
-      :     :                 +- * Sort (16)
-      :     :                    +- ReusedExchange (15)
+      :     :                 +- TakeOrderedAndProject (16)
+      :     :                    +- * Filter (15)
+      :     :                       +- * HashAggregate (14)
+      :     :                          +- ReusedExchange (13)
       :     +- BroadcastExchange (26)
       :        +- * Filter (25)
       :           +- * ColumnarToRow (24)
@@ -73,107 +73,110 @@ Results [2]: [ss_item_sk#1 AS item_sk#10, cast((avg(UnscaledValue(ss_net_profit#
 Input [2]: [item_sk#10, rank_col#11]
 Condition : (isnotnull(rank_col#11) AND (cast(rank_col#11 as decimal(13,7)) > (0.9 * Subquery scalar-subquery#12, [id=#13])))
 
-(9) Exchange
+(9) TakeOrderedAndProject
 Input [2]: [item_sk#10, rank_col#11]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=2]
+Arguments: 10, [rank_col#11 ASC NULLS FIRST], [item_sk#10, rank_col#11]
 
-(10) Sort [codegen id : 3]
-Input [2]: [item_sk#10, rank_col#11]
-Arguments: [rank_col#11 ASC NULLS FIRST], false, 0
-
-(11) Window
+(10) Window
 Input [2]: [item_sk#10, rank_col#11]
 Arguments: [rank(rank_col#11) windowspecdefinition(rank_col#11 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#14], [rank_col#11 ASC NULLS FIRST]
 
-(12) Filter [codegen id : 4]
+(11) Filter [codegen id : 8]
 Input [3]: [item_sk#10, rank_col#11, rnk#14]
 Condition : ((rnk#14 < 11) AND isnotnull(item_sk#10))
 
-(13) Project [codegen id : 4]
+(12) Project [codegen id : 8]
 Output [2]: [item_sk#10, rnk#14]
 Input [3]: [item_sk#10, rank_col#11, rnk#14]
 
-(14) Sort [codegen id : 4]
-Input [2]: [item_sk#10, rnk#14]
-Arguments: [rnk#14 ASC NULLS FIRST], false, 0
+(13) ReusedExchange [Reuses operator id: 6]
+Output [3]: [ss_item_sk#15, sum#16, count#17]
 
-(15) ReusedExchange [Reuses operator id: 9]
-Output [2]: [item_sk#15, rank_col#16]
+(14) HashAggregate [codegen id : 4]
+Input [3]: [ss_item_sk#15, sum#16, count#17]
+Keys [1]: [ss_item_sk#15]
+Functions [1]: [avg(UnscaledValue(ss_net_profit#18))]
+Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#18))#19]
+Results [2]: [ss_item_sk#15 AS item_sk#20, cast((avg(UnscaledValue(ss_net_profit#18))#19 / 100.0) as decimal(11,6)) AS rank_col#21]
 
-(16) Sort [codegen id : 7]
-Input [2]: [item_sk#15, rank_col#16]
-Arguments: [rank_col#16 DESC NULLS LAST], false, 0
+(15) Filter [codegen id : 4]
+Input [2]: [item_sk#20, rank_col#21]
+Condition : (isnotnull(rank_col#21) AND (cast(rank_col#21 as decimal(13,7)) > (0.9 * ReusedSubquery Subquery scalar-subquery#12, [id=#13])))
+
+(16) TakeOrderedAndProject
+Input [2]: [item_sk#20, rank_col#21]
+Arguments: 10, [rank_col#21 DESC NULLS LAST], [item_sk#20, rank_col#21]
 
 (17) Window
-Input [2]: [item_sk#15, rank_col#16]
-Arguments: [rank(rank_col#16) windowspecdefinition(rank_col#16 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#17], [rank_col#16 DESC NULLS LAST]
+Input [2]: [item_sk#20, rank_col#21]
+Arguments: [rank(rank_col#21) windowspecdefinition(rank_col#21 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#22], [rank_col#21 DESC NULLS LAST]
 
-(18) Filter [codegen id : 8]
-Input [3]: [item_sk#15, rank_col#16, rnk#17]
-Condition : ((rnk#17 < 11) AND isnotnull(item_sk#15))
+(18) Filter [codegen id : 5]
+Input [3]: [item_sk#20, rank_col#21, rnk#22]
+Condition : ((rnk#22 < 11) AND isnotnull(item_sk#20))
 
-(19) Project [codegen id : 8]
-Output [2]: [item_sk#15, rnk#17]
-Input [3]: [item_sk#15, rank_col#16, rnk#17]
+(19) Project [codegen id : 5]
+Output [2]: [item_sk#20, rnk#22]
+Input [3]: [item_sk#20, rank_col#21, rnk#22]
 
-(20) Sort [codegen id : 8]
-Input [2]: [item_sk#15, rnk#17]
-Arguments: [rnk#17 ASC NULLS FIRST], false, 0
+(20) BroadcastExchange
+Input [2]: [item_sk#20, rnk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)),false), [plan_id=2]
 
-(21) SortMergeJoin [codegen id : 11]
+(21) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [rnk#14]
-Right keys [1]: [rnk#17]
+Right keys [1]: [rnk#22]
 Join type: Inner
 Join condition: None
 
-(22) Project [codegen id : 11]
-Output [3]: [item_sk#10, rnk#14, item_sk#15]
-Input [4]: [item_sk#10, rnk#14, item_sk#15, rnk#17]
+(22) Project [codegen id : 8]
+Output [3]: [item_sk#10, rnk#14, item_sk#20]
+Input [4]: [item_sk#10, rnk#14, item_sk#20, rnk#22]
 
 (23) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_product_name#19]
+Output [2]: [i_item_sk#23, i_product_name#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_product_name:string>
 
-(24) ColumnarToRow [codegen id : 9]
-Input [2]: [i_item_sk#18, i_product_name#19]
+(24) ColumnarToRow [codegen id : 6]
+Input [2]: [i_item_sk#23, i_product_name#24]
 
-(25) Filter [codegen id : 9]
-Input [2]: [i_item_sk#18, i_product_name#19]
-Condition : isnotnull(i_item_sk#18)
+(25) Filter [codegen id : 6]
+Input [2]: [i_item_sk#23, i_product_name#24]
+Condition : isnotnull(i_item_sk#23)
 
 (26) BroadcastExchange
-Input [2]: [i_item_sk#18, i_product_name#19]
+Input [2]: [i_item_sk#23, i_product_name#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(27) BroadcastHashJoin [codegen id : 11]
+(27) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [item_sk#10]
-Right keys [1]: [i_item_sk#18]
+Right keys [1]: [i_item_sk#23]
 Join type: Inner
 Join condition: None
 
-(28) Project [codegen id : 11]
-Output [3]: [rnk#14, item_sk#15, i_product_name#19]
-Input [5]: [item_sk#10, rnk#14, item_sk#15, i_item_sk#18, i_product_name#19]
+(28) Project [codegen id : 8]
+Output [3]: [rnk#14, item_sk#20, i_product_name#24]
+Input [5]: [item_sk#10, rnk#14, item_sk#20, i_item_sk#23, i_product_name#24]
 
 (29) ReusedExchange [Reuses operator id: 26]
-Output [2]: [i_item_sk#20, i_product_name#21]
+Output [2]: [i_item_sk#25, i_product_name#26]
 
-(30) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [item_sk#15]
-Right keys [1]: [i_item_sk#20]
+(30) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [item_sk#20]
+Right keys [1]: [i_item_sk#25]
 Join type: Inner
 Join condition: None
 
-(31) Project [codegen id : 11]
-Output [3]: [rnk#14, i_product_name#19 AS best_performing#22, i_product_name#21 AS worst_performing#23]
-Input [5]: [rnk#14, item_sk#15, i_product_name#19, i_item_sk#20, i_product_name#21]
+(31) Project [codegen id : 8]
+Output [3]: [rnk#14, i_product_name#24 AS best_performing#27, i_product_name#26 AS worst_performing#28]
+Input [5]: [rnk#14, item_sk#20, i_product_name#24, i_item_sk#25, i_product_name#26]
 
 (32) TakeOrderedAndProject
-Input [3]: [rnk#14, best_performing#22, worst_performing#23]
-Arguments: 100, [rnk#14 ASC NULLS FIRST], [rnk#14, best_performing#22, worst_performing#23]
+Input [3]: [rnk#14, best_performing#27, worst_performing#28]
+Arguments: 100, [rnk#14 ASC NULLS FIRST], [rnk#14, best_performing#27, worst_performing#28]
 
 ===== Subqueries =====
 
@@ -188,39 +191,41 @@ Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery
 
 
 (33) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_addr_sk#24, ss_store_sk#25, ss_net_profit#26, ss_sold_date_sk#27]
+Output [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_store_sk), EqualTo(ss_store_sk,4), IsNull(ss_addr_sk)]
 ReadSchema: struct<ss_addr_sk:int,ss_store_sk:int,ss_net_profit:decimal(7,2)>
 
 (34) ColumnarToRow [codegen id : 1]
-Input [4]: [ss_addr_sk#24, ss_store_sk#25, ss_net_profit#26, ss_sold_date_sk#27]
+Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 
 (35) Filter [codegen id : 1]
-Input [4]: [ss_addr_sk#24, ss_store_sk#25, ss_net_profit#26, ss_sold_date_sk#27]
-Condition : ((isnotnull(ss_store_sk#25) AND (ss_store_sk#25 = 4)) AND isnull(ss_addr_sk#24))
+Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
+Condition : ((isnotnull(ss_store_sk#30) AND (ss_store_sk#30 = 4)) AND isnull(ss_addr_sk#29))
 
 (36) Project [codegen id : 1]
-Output [2]: [ss_store_sk#25, ss_net_profit#26]
-Input [4]: [ss_addr_sk#24, ss_store_sk#25, ss_net_profit#26, ss_sold_date_sk#27]
+Output [2]: [ss_store_sk#30, ss_net_profit#31]
+Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 
 (37) HashAggregate [codegen id : 1]
-Input [2]: [ss_store_sk#25, ss_net_profit#26]
-Keys [1]: [ss_store_sk#25]
-Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#26))]
-Aggregate Attributes [2]: [sum#28, count#29]
-Results [3]: [ss_store_sk#25, sum#30, count#31]
+Input [2]: [ss_store_sk#30, ss_net_profit#31]
+Keys [1]: [ss_store_sk#30]
+Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#31))]
+Aggregate Attributes [2]: [sum#33, count#34]
+Results [3]: [ss_store_sk#30, sum#35, count#36]
 
 (38) Exchange
-Input [3]: [ss_store_sk#25, sum#30, count#31]
-Arguments: hashpartitioning(ss_store_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [3]: [ss_store_sk#30, sum#35, count#36]
+Arguments: hashpartitioning(ss_store_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (39) HashAggregate [codegen id : 2]
-Input [3]: [ss_store_sk#25, sum#30, count#31]
-Keys [1]: [ss_store_sk#25]
-Functions [1]: [avg(UnscaledValue(ss_net_profit#26))]
-Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#26))#32]
-Results [1]: [cast((avg(UnscaledValue(ss_net_profit#26))#32 / 100.0) as decimal(11,6)) AS rank_col#33]
+Input [3]: [ss_store_sk#30, sum#35, count#36]
+Keys [1]: [ss_store_sk#30]
+Functions [1]: [avg(UnscaledValue(ss_net_profit#31))]
+Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#31))#37]
+Results [1]: [cast((avg(UnscaledValue(ss_net_profit#31))#37 / 100.0) as decimal(11,6)) AS rank_col#38]
+
+Subquery:2 Hosting operator id = 15 Hosting Expression = ReusedSubquery Subquery scalar-subquery#12, [id=#13]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/simplified.txt
@@ -1,60 +1,57 @@
 TakeOrderedAndProject [rnk,best_performing,worst_performing]
-  WholeStageCodegen (11)
+  WholeStageCodegen (8)
     Project [rnk,i_product_name,i_product_name]
       BroadcastHashJoin [item_sk,i_item_sk]
         Project [rnk,item_sk,i_product_name]
           BroadcastHashJoin [item_sk,i_item_sk]
             Project [item_sk,rnk,item_sk]
-              SortMergeJoin [rnk,rnk]
+              BroadcastHashJoin [rnk,rnk]
+                Project [item_sk,rnk]
+                  Filter [rnk,item_sk]
+                    InputAdapter
+                      Window [rank_col]
+                        TakeOrderedAndProject [rank_col,item_sk]
+                          WholeStageCodegen (2)
+                            Filter [rank_col]
+                              Subquery #1
+                                WholeStageCodegen (2)
+                                  HashAggregate [ss_store_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),rank_col,sum,count]
+                                    InputAdapter
+                                      Exchange [ss_store_sk] #2
+                                        WholeStageCodegen (1)
+                                          HashAggregate [ss_store_sk,ss_net_profit] [sum,count,sum,count]
+                                            Project [ss_store_sk,ss_net_profit]
+                                              Filter [ss_store_sk,ss_addr_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.store_sales [ss_addr_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
+                              HashAggregate [ss_item_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),item_sk,rank_col,sum,count]
+                                InputAdapter
+                                  Exchange [ss_item_sk] #1
+                                    WholeStageCodegen (1)
+                                      HashAggregate [ss_item_sk,ss_net_profit] [sum,count,sum,count]
+                                        Project [ss_item_sk,ss_net_profit]
+                                          Filter [ss_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
                 InputAdapter
-                  WholeStageCodegen (4)
-                    Sort [rnk]
+                  BroadcastExchange #3
+                    WholeStageCodegen (5)
                       Project [item_sk,rnk]
                         Filter [rnk,item_sk]
                           InputAdapter
                             Window [rank_col]
-                              WholeStageCodegen (3)
-                                Sort [rank_col]
-                                  InputAdapter
-                                    Exchange #1
-                                      WholeStageCodegen (2)
-                                        Filter [rank_col]
-                                          Subquery #1
-                                            WholeStageCodegen (2)
-                                              HashAggregate [ss_store_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),rank_col,sum,count]
-                                                InputAdapter
-                                                  Exchange [ss_store_sk] #3
-                                                    WholeStageCodegen (1)
-                                                      HashAggregate [ss_store_sk,ss_net_profit] [sum,count,sum,count]
-                                                        Project [ss_store_sk,ss_net_profit]
-                                                          Filter [ss_store_sk,ss_addr_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.store_sales [ss_addr_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                                          HashAggregate [ss_item_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),item_sk,rank_col,sum,count]
-                                            InputAdapter
-                                              Exchange [ss_item_sk] #2
-                                                WholeStageCodegen (1)
-                                                  HashAggregate [ss_item_sk,ss_net_profit] [sum,count,sum,count]
-                                                    Project [ss_item_sk,ss_net_profit]
-                                                      Filter [ss_store_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                InputAdapter
-                  WholeStageCodegen (8)
-                    Sort [rnk]
-                      Project [item_sk,rnk]
-                        Filter [rnk,item_sk]
-                          InputAdapter
-                            Window [rank_col]
-                              WholeStageCodegen (7)
-                                Sort [rank_col]
-                                  InputAdapter
-                                    ReusedExchange [item_sk,rank_col] #1
+                              TakeOrderedAndProject [rank_col,item_sk]
+                                WholeStageCodegen (4)
+                                  Filter [rank_col]
+                                    ReusedSubquery [rank_col] #1
+                                    HashAggregate [ss_item_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),item_sk,rank_col,sum,count]
+                                      InputAdapter
+                                        ReusedExchange [ss_item_sk,sum,count] #1
             InputAdapter
               BroadcastExchange #4
-                WholeStageCodegen (9)
+                WholeStageCodegen (6)
                   Filter [i_item_sk]
                     ColumnarToRow
                       InputAdapter


### PR DESCRIPTION
### What changes were proposed in this pull request?
Sometimes, the SQL exists filter which condition compares rank-like window functions with number. For example,
```
SELECT *,
         ROW_NUMBER() OVER(ORDER BY a) AS rn
FROM Tab1
WHERE rn <= 5
```
We can create a `Limit(5)` and push down it as the child of `Window`.
```
SELECT *,
         ROW_NUMBER() OVER(ORDER BY a) AS rn
FROM 
    (SELECT *
    FROM Tab1
    ORDER BY  a LIMIT 5) t
```

In short, it supports following pattern:
```
SELECT (... (row_number|rank|dense_rank)()
    OVER (
ORDER BY  ... ) AS rn)
WHERE rn (==|<|<=) k
        AND other conditions
```
For these three rank functions (row_number|rank|dense_rank), the rank of a key computed on dataset always <= its total rows of whole dataset，so we can safely discard rows with rank > k, anywhere.

This PR also take over some functions from https://github.com/apache/spark/pull/34367.


### Why are the changes needed?
1. reduce the shuffle write
2. solve skewed-window problem.
3. improve the performance and TPC-DS.

### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
1. New test suites.
2. new micro benchmark
Before this PR
```
[info] Benchmark Top-K:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] ROW_NUMBER WITHOUT PARTITION                       10869          11498         928          1.9         518.3       1.0X
```
After this PR
```
[info] Benchmark Top-K:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] ROW_NUMBER WITHOUT PARTITION                       1578           1718         191         13.3          75.3       1.0X
```
3. manual test on TPC-DS
**Micro Benchmark**
TPC-DS data size: 2TB.
I created a variety of q67 by remove the window partition specification.
![image](https://user-images.githubusercontent.com/8486025/203880449-576a513c-2a88-40c3-9922-1ea7d2fbcdfc.png)
This improvement is valid for the variety of tpcds q67 and no regression for other test cases.

| TPC-DS Query   | Before(Seconds)  | After(Seconds)  | Speedup(Percent)  |
|  ----  | ----  | ----  | ----  |
| variety of q67 | 3204.723 | 307.2745 | 942.95% |
| All TPC-DS | 9249.702 | 6373.544 | 45.13% |