### PR TITLE
[SPARK-41175][SQL] Assign a name to the error class _LEGACY_ERROR_TEMP_1078

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -48,6 +48,11 @@
     ],
     "sqlState" : "42000"
   },
+  "CANNOT_LOAD_FUNCTION_CLASS" : {
+    "message" : [
+      "Cannot load class <className> when registering the function <functionName>, please make sure it is on the classpath."
+    ]
+  },
   "CANNOT_LOAD_PROTOBUF_CLASS" : {
     "message" : [
       "Could not load Protobuf class with name <protobufClassName>. <explanation>."
@@ -2073,11 +2078,6 @@
   "_LEGACY_ERROR_TEMP_1076" : {
     "message" : [
       "Partition spec is invalid. <details>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1078" : {
-    "message" : [
-      "Can not load class '<className>' when registering the function '<func>', please make sure it is on the classpath."
     ]
   },
   "_LEGACY_ERROR_TEMP_1079" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -899,10 +899,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def cannotLoadClassWhenRegisteringFunctionError(
       className: String, func: FunctionIdentifier): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1078",
+      errorClass = "CANNOT_LOAD_FUNCTION_CLASS",
       messageParameters = Map(
         "className" -> className,
-        "func" -> func.toString))
+        "functionName" -> toSQLId(func.toString)))
   }
 
   def resourceTypeNotSupportedError(resourceType: String): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1477,6 +1477,21 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
       assert(
         catalog.lookupFunction(
           FunctionIdentifier("temp1"), arguments) === Literal(arguments.length))
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.registerFunction(
+            CatalogFunction(FunctionIdentifier("temp2", None),
+              "function_class_cannot_load", Seq.empty[FunctionResource]),
+            overrideIfExists = false,
+            None)
+        },
+        errorClass = "CANNOT_LOAD_FUNCTION_CLASS",
+        parameters = Map(
+          "className" -> "function_class_cannot_load",
+          "functionName" -> "`temp2`"
+        )
+      )
     }
   }
 

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf.sql.out
@@ -66,7 +66,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "CANNOT_LOAD_FUNCTION_CLASS",
   "messageParameters" : {
     "className" : "test.non.existent.udaf",
-    "functionName" : "spark_catalog.default.udaf1"
+    "functionName" : "`spark_catalog`.`default`.`udaf1`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf.sql.out
@@ -63,10 +63,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1078",
+  "errorClass" : "CANNOT_LOAD_FUNCTION_CLASS",
   "messageParameters" : {
     "className" : "test.non.existent.udaf",
-    "func" : "spark_catalog.default.udaf1"
+    "functionName" : "spark_catalog.default.udaf1"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-udaf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-udaf.sql.out
@@ -66,7 +66,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "CANNOT_LOAD_FUNCTION_CLASS",
   "messageParameters" : {
     "className" : "test.non.existent.udaf",
-    "functionName" : "spark_catalog.default.udaf1"
+    "functionName" : "`spark_catalog`.`default`.`udaf1`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-udaf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-udaf.sql.out
@@ -63,10 +63,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1078",
+  "errorClass" : "CANNOT_LOAD_FUNCTION_CLASS",
   "messageParameters" : {
     "className" : "test.non.existent.udaf",
-    "func" : "spark_catalog.default.udaf1"
+    "functionName" : "spark_catalog.default.udaf1"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3827,10 +3827,16 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
           s"default.$functionName" -> false,
           functionName -> true) {
           // create temporary function without class
-          val e = intercept[AnalysisException] {
-            sql(s"CREATE TEMPORARY FUNCTION $functionName AS '$sumFuncClass'")
-          }.getMessage
-          assert(e.contains("Can not load class 'org.apache.spark.examples.sql.Spark33084"))
+          checkError(
+            exception = intercept[AnalysisException] {
+              sql(s"CREATE TEMPORARY FUNCTION $functionName AS '$sumFuncClass'")
+            },
+            errorClass = "CANNOT_LOAD_FUNCTION_CLASS",
+            parameters = Map(
+              "className" -> "org.apache.spark.examples.sql.Spark33084",
+              "functionName" -> "`test_udf`"
+            )
+          )
           sql("ADD JAR ivy://org.apache.spark:SPARK-33084:1.0")
           sql(s"CREATE TEMPORARY FUNCTION $functionName AS '$sumFuncClass'")
           // create a view using a function in 'default' database

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2092,10 +2092,16 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
       val function = CatalogFunction(func, "test.non.exists.udf", Seq.empty)
       spark.sessionState.catalog.createFunction(function, false)
       assert(!spark.sessionState.catalog.isRegisteredFunction(func))
-      val err = intercept[AnalysisException] {
-        sql("REFRESH FUNCTION func1")
-      }.getMessage
-      assert(err.contains("Can not load class"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("REFRESH FUNCTION func1")
+        },
+        errorClass = "CANNOT_LOAD_FUNCTION_CLASS",
+        parameters = Map(
+          "className" -> "test.non.exists.udf",
+          "functionName" -> "`spark_catalog`.`default`.`func1`"
+        )
+      )
       assert(!spark.sessionState.catalog.isRegisteredFunction(func))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to assign the name `CANNOT_LOAD_FUNCTION_CLASS` to the error class _LEGACY_ERROR_TEMP_1078.

### Why are the changes needed?
Proper names of error classes should improve user experience with Spark SQL.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the affected test suites:
> $ build/sbt "catalyst/testOnly *SessionCatalogSuite"