### PR TITLE
[SPARK-41118][SQL][3.3] `to_number`/`try_to_number` should return `null` when format is `null`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
@@ -23,8 +23,64 @@ import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 import org.apache.spark.sql.catalyst.util.ToNumberParser
-import org.apache.spark.sql.types.{DataType, StringType}
+import org.apache.spark.sql.types.{DataType, DecimalType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
+
+abstract class ToNumberBase(left: Expression, right: Expression, errorOnFail: Boolean)
+  extends BinaryExpression with Serializable with ImplicitCastInputTypes with NullIntolerant {
+
+  private lazy val numberFormatter = {
+    val value = right.eval()
+    if (value != null) {
+      new ToNumberParser(value.toString.toUpperCase(Locale.ROOT), errorOnFail)
+    } else {
+      null
+    }
+  }
+
+  override def dataType: DataType = if (numberFormatter != null) {
+    numberFormatter.parsedDecimalType
+  } else {
+    DecimalType.USER_DEFAULT
+  }
+
+  override def inputTypes: Seq[DataType] = Seq(StringType, StringType)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    val inputTypeCheck = super.checkInputDataTypes()
+    if (inputTypeCheck.isSuccess) {
+      if (!right.foldable) {
+        TypeCheckResult.TypeCheckFailure(s"Format expression must be foldable, but got $right")
+      } else if (numberFormatter == null) {
+        TypeCheckResult.TypeCheckSuccess
+      } else {
+        numberFormatter.check()
+      }
+    } else {
+      inputTypeCheck
+    }
+  }
+
+  override def nullSafeEval(string: Any, format: Any): Any = {
+    val input = string.asInstanceOf[UTF8String]
+    numberFormatter.parse(input)
+  }
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val builder =
+      ctx.addReferenceObj("builder", numberFormatter, classOf[ToNumberParser].getName)
+    val eval = left.genCode(ctx)
+    ev.copy(code =
+      code"""
+        |${eval.code}
+        |boolean ${ev.isNull} = ${eval.isNull} || ($builder == null);
+        |${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
+        |if (!${ev.isNull}) {
+        |  ${ev.value} = $builder.parse(${eval.value});
+        |}
+      """.stripMargin)
+  }
+}
 
 /**
  * A function that converts strings to decimal values, returning an exception if the input string
@@ -68,43 +124,10 @@ import org.apache.spark.unsafe.types.UTF8String
   since = "3.3.0",
   group = "string_funcs")
 case class ToNumber(left: Expression, right: Expression)
-  extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
-  private lazy val numberFormat = right.eval().toString.toUpperCase(Locale.ROOT)
-  private lazy val numberFormatter = new ToNumberParser(numberFormat, true)
+  extends ToNumberBase(left, right, true) {
 
-  override def dataType: DataType = numberFormatter.parsedDecimalType
-  override def inputTypes: Seq[DataType] = Seq(StringType, StringType)
-  override def checkInputDataTypes(): TypeCheckResult = {
-    val inputTypeCheck = super.checkInputDataTypes()
-    if (inputTypeCheck.isSuccess) {
-      if (right.foldable) {
-        numberFormatter.check()
-      } else {
-        TypeCheckResult.TypeCheckFailure(s"Format expression must be foldable, but got $right")
-      }
-    } else {
-      inputTypeCheck
-    }
-  }
   override def prettyName: String = "to_number"
-  override def nullSafeEval(string: Any, format: Any): Any = {
-    val input = string.asInstanceOf[UTF8String]
-    numberFormatter.parse(input)
-  }
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val builder =
-      ctx.addReferenceObj("builder", numberFormatter, classOf[ToNumberParser].getName)
-    val eval = left.genCode(ctx)
-    ev.copy(code =
-      code"""
-        |${eval.code}
-        |boolean ${ev.isNull} = ${eval.isNull};
-        |${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
-        |if (!${ev.isNull}) {
-        |  ${ev.value} = $builder.parse(${eval.value});
-        |}
-      """.stripMargin)
-  }
+
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): ToNumber =
     copy(left = newLeft, right = newRight)
@@ -136,33 +159,12 @@ case class ToNumber(left: Expression, right: Expression)
   since = "3.3.0",
   group = "string_funcs")
 case class TryToNumber(left: Expression, right: Expression)
-  extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
-  private lazy val numberFormat = right.eval().toString.toUpperCase(Locale.ROOT)
-  private lazy val numberFormatter = new ToNumberParser(numberFormat, false)
+  extends ToNumberBase(left, right, false) {
 
-  override def dataType: DataType = numberFormatter.parsedDecimalType
-  override def inputTypes: Seq[DataType] = Seq(StringType, StringType)
   override def nullable: Boolean = true
-  override def checkInputDataTypes(): TypeCheckResult = ToNumber(left, right).checkInputDataTypes()
+
   override def prettyName: String = "try_to_number"
-  override def nullSafeEval(string: Any, format: Any): Any = {
-    val input = string.asInstanceOf[UTF8String]
-    numberFormatter.parse(input)
-  }
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val builder =
-      ctx.addReferenceObj("builder", numberFormatter, classOf[ToNumberParser].getName)
-    val eval = left.genCode(ctx)
-    ev.copy(code =
-      code"""
-        |${eval.code}
-        |boolean ${ev.isNull} = ${eval.isNull};
-        |${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
-        |if (!${ev.isNull}) {
-        |  ${ev.value} = $builder.parse(${eval.value});
-        |}
-      """.stripMargin)
-  }
+
   override protected def withNewChildrenInternal(
       newLeft: Expression,
       newRight: Expression): TryToNumber =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -1122,6 +1122,17 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
+  test("SPARK-41118: ToNumber: null format string") {
+    // if null format, to_number should return null
+    val toNumberExpr = ToNumber(Literal("454"), Literal(null, StringType))
+    assert(toNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+    checkEvaluation(toNumberExpr, null)
+
+    val tryToNumberExpr = TryToNumber(Literal("454"), Literal(null, StringType))
+    assert(tryToNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+    checkEvaluation(tryToNumberExpr, null)
+  }
+
   test("find in set") {
     checkEvaluation(
       FindInSet(Literal.create(null, StringType), Literal.create(null, StringType)), null)


### PR DESCRIPTION
Backport of #38635

### What changes were proposed in this pull request?

When a user specifies a null format in `to_number`/`try_to_number`, return `null`, with a data type of `DecimalType.USER_DEFAULT`, rather than throwing a `NullPointerException`.

Also, since the code for `ToNumber` and `TryToNumber` is virtually identical, put all common code in new abstract class `ToNumberBase` to avoid fixing the bug in two places.

### Why are the changes needed?

`to_number`/`try_to_number` currently throws a `NullPointerException` when the format is `null`:

```
spark-sql> SELECT to_number('454', null);
org.apache.spark.SparkException: The Spark SQL phase analysis failed with an internal error. Please, fill a bug report in, and provide the full stack trace.
	at org.apache.spark.sql.execution.QueryExecution$.toInternalError(QueryExecution.scala:500)
	at org.apache.spark.sql.execution.QueryExecution$.withInternalError(QueryExecution.scala:512)
	at org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$1(QueryExecution.scala:185)
...
Caused by: java.lang.NullPointerException
	at org.apache.spark.sql.catalyst.expressions.ToNumber.numberFormat$lzycompute(numberFormatExpressions.scala:72)
	at org.apache.spark.sql.catalyst.expressions.ToNumber.numberFormat(numberFormatExpressions.scala:72)
	at org.apache.spark.sql.catalyst.expressions.ToNumber.numberFormatter$lzycompute(numberFormatExpressions.scala:73)
	at org.apache.spark.sql.catalyst.expressions.ToNumber.numberFormatter(numberFormatExpressions.scala:73)
	at org.apache.spark.sql.catalyst.expressions.ToNumber.checkInputDataTypes(numberFormatExpressions.scala:81)
```
Also:
```
spark-sql> SELECT try_to_number('454', null);
org.apache.spark.SparkException: The Spark SQL phase analysis failed with an internal error. Please, fill a bug report in, and provide the full stack trace.
	at org.apache.spark.sql.execution.QueryExecution$.toInternalError(QueryExecution.scala:500)
	at org.apache.spark.sql.execution.QueryExecution$.withInternalError(QueryExecution.scala:512)
	at org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$1(QueryExecution.scala:185)
...
Caused by: java.lang.NullPointerException
	at org.apache.spark.sql.catalyst.expressions.ToNumber.numberFormat$lzycompute(numberFormatExpressions.scala:72)
	at org.apache.spark.sql.catalyst.expressions.ToNumber.numberFormat(numberFormatExpressions.scala:72)
	at org.apache.spark.sql.catalyst.expressions.ToNumber.numberFormatter$lzycompute(numberFormatExpressions.scala:73)
	at org.apache.spark.sql.catalyst.expressions.ToNumber.numberFormatter(numberFormatExpressions.scala:73)
	at org.apache.spark.sql.catalyst.expressions.ToNumber.checkInputDataTypes(numberFormatExpressions.scala:81)
	at org.apache.spark.sql.catalyst.expressions.TryToNumber.checkInputDataTypes(numberFormatExpressions.scala:146)
```
Compare to `to_binary` and `try_to_binary`:
```
spark-sql> SELECT to_binary('abc', null);
NULL
Time taken: 3.111 seconds, Fetched 1 row(s)
spark-sql> SELECT try_to_binary('abc', null);
NULL
Time taken: 0.06 seconds, Fetched 1 row(s)
spark-sql>
```
Also compare to `to_number` in PostgreSQL 11.18:
```
SELECT to_number('454', null) is null as a;
a
true
```

### Does this PR introduce _any_ user-facing change?

`to_number`/`try_to_number` with null format will now return `null` with a data type of `DecimalType.USER_DEFAULT`.

### How was this patch tested?

New unit test.