### PR TITLE
[SPARK-41186][INFRA][PS][TESTS] Upgrade infra and replace `list_run_infos` with `search_runs` in mlflow doctest

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -17,9 +17,9 @@
 
 # Image for building and testing Spark branches. Based on Ubuntu 20.04.
 # See also in https://hub.docker.com/_/ubuntu
-FROM ubuntu:focal-20220922
+FROM ubuntu:focal-20221019
 
-ENV FULL_REFRESH_DATE 20221019
+ENV FULL_REFRESH_DATE 20221118
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
@@ -32,7 +32,6 @@ RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update
@@ -45,7 +44,6 @@ RUN mkdir -p /usr/local/pypy/pypy3.7 && \
     ln -sf /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'pandas<=1.5.1' scipy coverage matplotlib
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list
@@ -65,6 +63,9 @@ RUN Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='ht
 
 # See more in SPARK-39735
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
+
+RUN pypy3 -m pip install numpy 'pandas<=1.5.1' scipy coverage matplotlib
+RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl
 
 # Add Python deps for Spark Connect.
 RUN python3.9 -m pip install grpcio protobuf

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -65,10 +65,7 @@ RUN Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='ht
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
 
 RUN pypy3 -m pip install numpy 'pandas<=1.5.1' scipy coverage matplotlib
-RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl
+RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl 'memory-profiler==0.60.0'
 
 # Add Python deps for Spark Connect.
 RUN python3.9 -m pip install grpcio protobuf
-
-# SPARK-41186: Move memory-profiler to pyspark deps install when mlfow doctest test fix
-RUN python3.9 -m pip install 'memory-profiler==0.60.0'

--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -165,8 +165,8 @@ def load_model(
     dataframe:
 
     >>> from pyspark.pandas.mlflow import load_model
-    >>> run_info = client.list_run_infos(exp_id)[-1]
-    >>> model = load_model("runs:/{run_id}/model".format(run_id=run_info.run_uuid))
+    >>> run_info = client.search_runs(exp_id)[-1].info
+    >>> model = load_model("runs:/{run_id}/model".format(run_id=run_info.run_id))
     >>> prediction_df = ps.DataFrame({"x1": [2.0], "x2": [4.0]})
     >>> prediction_df["prediction"] = model.predict(prediction_df)
     >>> prediction_df


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch
- Upgrade ubuntu to `ubuntu:focal-20221019` (current latest)
- Deps changes:
  - mlflow from 1.30.0 to 2.0.1
  - All diff: https://www.diffchecker.com/VEgd3px1
- Replace `list_run_infos` with `search_runs` in mlflow doctest.
Since mlfow 1.29.0 (https://github.com/mlflow/mlflow/commit/fb9abf98595c1b32117aac90b0b2170ce120cd9f), `list_run_infos` is deprecated and instead by `search_runs`
- This patch also move the python installation in the end of file because python installation changes frequently.

### Why are the changes needed?
We hit this error after infra upgrade: https://github.com/apache/spark/pull/38611#issuecomment-1319430302

### Does this PR introduce _any_ user-facing change?
No, test only

### How was this patch tested?
Test passed with mlflow 1.30.0 and 2.0.1
