### PR TITLE
[SPARK-41197][BUILD] Upgrade Kafka to 3.3.1

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
@@ -537,6 +537,8 @@ class KafkaTestUtils(
     props.put("key.serializer", classOf[StringSerializer].getName)
     // wait for all in-sync replicas to ack sends
     props.put("acks", "all")
+    props.put("partitioner.class",
+        classOf[org.apache.kafka.clients.producer.internals.DefaultPartitioner].getName)
     setAuthenticationConfigIfNeeded(props)
     props
   }

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
@@ -538,7 +538,7 @@ class KafkaTestUtils(
     // wait for all in-sync replicas to ack sends
     props.put("acks", "all")
     props.put("partitioner.class",
-        classOf[org.apache.kafka.clients.producer.internals.DefaultPartitioner].getName)
+      classOf[org.apache.kafka.clients.producer.internals.DefaultPartitioner].getName)
     setAuthenticationConfigIfNeeded(props)
     props
   }

--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
@@ -263,6 +263,8 @@ private[kafka010] class KafkaTestUtils extends Logging {
     props.put("key.serializer", classOf[StringSerializer].getName)
     // wait for all in-sync replicas to ack sends
     props.put("acks", "all")
+    props.put("partitioner.class",
+        classOf[org.apache.kafka.clients.producer.internals.DefaultPartitioner].getName)
     props
   }
 

--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
@@ -264,7 +264,7 @@ private[kafka010] class KafkaTestUtils extends Logging {
     // wait for all in-sync replicas to ack sends
     props.put("acks", "all")
     props.put("partitioner.class",
-        classOf[org.apache.kafka.clients.producer.internals.DefaultPartitioner].getName)
+      classOf[org.apache.kafka.clients.producer.internals.DefaultPartitioner].getName)
     props
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>2.3</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
-    <kafka.version>3.2.3</kafka.version>
+    <kafka.version>3.3.1</kafka.version>
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.3</parquet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR upgrades Kafka to 3.3.1 release.

The new default partitioner keeps track of how many bytes are produced per-partition and once the amount exceeds `batch.size`, it switches to the next partition. For spark kafka tests, this will result in records being sent to only one partition in some tests.
`KafkaTestUtils.producerConfiguration` is modified to use `DefaultPartitioner`.

### Why are the changes needed?
Kafka 3.3.1 release has new features along with bug fixes: https://www.confluent.io/blog/apache-kafka-3-3-0-new-features-and-updates/

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing test suite