### PR TITLE
[SPARK-XXXXX][SS] Use latestCommittedBatchId as currentBatchId when resuming late batch

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -400,6 +400,12 @@ class MicroBatchExecution(
                   // The V2 API does not have the same edge case requiring getBatch to be called
                   // here, so we do nothing here.
               }
+              // Last batch was not committed successfully. We need to re-executing the batch.
+              // `currentBatchId` should be latest committed batch id, because we will use
+              // `currentBatchId` to construct `IncrementalExecution` while running the batch.
+              // If we use `latestBatchId` from offset log, state providers will try to load
+              // state map of `latestBatchId`, but the version of states is not committed.
+              currentBatchId = latestCommittedBatchId
             } else if (latestCommittedBatchId < latestBatchId - 1) {
               logWarning(s"Batch completion log latest batch id is " +
                 s"${latestCommittedBatchId}, which is not trailing " +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch changes `currentBatchId` when `MicroBatchExecution` tries to resume from late batch from offset log. Previously it takes `latestBatchId` from offset log. This patch changes it to `latestCommittedBatchId`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We have customer streaming job which is unable to restart from failed status after it failed to commit delta files. For example, if previous run failed to commit 14.delta, when the job restarted, it tried to read 14.delta. Because 14.delta doesn't exist (not committed), the job cannot be restarted to resume from late batch.

When `MicroBatchExecution` populates start offsets, it reads late batch id (`latestBatchId`) from offset log and committed batch id (`latestCommittedBatchId`) from commit log. Currently if `latestCommittedBatchId` == `latestBatchId` - 1, it means that we resume from late batch. But it uses `latestBatchId` as `currentBatchId` to run batch. Obviously, `latestBatchId` is 14 for above example, and `latestCommittedBatchId` is 13. 

Because `IncrementalExecution` uses `currentBatchId` to load checkpointed states, it tries to load version 14 of delta files. But version 14 is not committed in late run. So resume run always fails because it cannot load non existing delta file.

We should use `latestCommittedBatchId` as `currentBatchId` instead of `latestBatchId` for the case resuming last batch.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests.