### PR TITLE
[SPARK-41196][CONNECT][FOLLOW-UP] Fix out of sync generated files for Python

### DIFF
--- a/python/pyspark/sql/connect/proto/base_pb2.py
+++ b/python/pyspark/sql/connect/proto/base_pb2.py
@@ -41,18 +41,25 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
 
 
 _PLAN = DESCRIPTOR.message_types_by_name["Plan"]
-_REQUEST = DESCRIPTOR.message_types_by_name["Request"]
-_REQUEST_USERCONTEXT = _REQUEST.nested_types_by_name["UserContext"]
-_RESPONSE = DESCRIPTOR.message_types_by_name["Response"]
-_RESPONSE_ARROWBATCH = _RESPONSE.nested_types_by_name["ArrowBatch"]
-_RESPONSE_JSONBATCH = _RESPONSE.nested_types_by_name["JSONBatch"]
-_RESPONSE_METRICS = _RESPONSE.nested_types_by_name["Metrics"]
-_RESPONSE_METRICS_METRICOBJECT = _RESPONSE_METRICS.nested_types_by_name["MetricObject"]
-_RESPONSE_METRICS_METRICOBJECT_EXECUTIONMETRICSENTRY = (
-    _RESPONSE_METRICS_METRICOBJECT.nested_types_by_name["ExecutionMetricsEntry"]
+_EXPLAIN = DESCRIPTOR.message_types_by_name["Explain"]
+_USERCONTEXT = DESCRIPTOR.message_types_by_name["UserContext"]
+_ANALYZEPLANREQUEST = DESCRIPTOR.message_types_by_name["AnalyzePlanRequest"]
+_ANALYZEPLANRESPONSE = DESCRIPTOR.message_types_by_name["AnalyzePlanResponse"]
+_EXECUTEPLANREQUEST = DESCRIPTOR.message_types_by_name["ExecutePlanRequest"]
+_EXECUTEPLANRESPONSE = DESCRIPTOR.message_types_by_name["ExecutePlanResponse"]
+_EXECUTEPLANRESPONSE_ARROWBATCH = _EXECUTEPLANRESPONSE.nested_types_by_name["ArrowBatch"]
+_EXECUTEPLANRESPONSE_JSONBATCH = _EXECUTEPLANRESPONSE.nested_types_by_name["JSONBatch"]
+_EXECUTEPLANRESPONSE_METRICS = _EXECUTEPLANRESPONSE.nested_types_by_name["Metrics"]
+_EXECUTEPLANRESPONSE_METRICS_METRICOBJECT = _EXECUTEPLANRESPONSE_METRICS.nested_types_by_name[
+    "MetricObject"
+]
+_EXECUTEPLANRESPONSE_METRICS_METRICOBJECT_EXECUTIONMETRICSENTRY = (
+    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT.nested_types_by_name["ExecutionMetricsEntry"]
 )
-_RESPONSE_METRICS_METRICVALUE = _RESPONSE_METRICS.nested_types_by_name["MetricValue"]
-_ANALYZERESPONSE = DESCRIPTOR.message_types_by_name["AnalyzeResponse"]
+_EXECUTEPLANRESPONSE_METRICS_METRICVALUE = _EXECUTEPLANRESPONSE_METRICS.nested_types_by_name[
+    "MetricValue"
+]
+_EXPLAIN_EXPLAINMODE = _EXPLAIN.enum_types_by_name["ExplainMode"]
 Plan = _reflection.GeneratedProtocolMessageType(
     "Plan",
     (_message.Message,),
@@ -64,47 +71,81 @@ Plan = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(Plan)
 
-Request = _reflection.GeneratedProtocolMessageType(
-    "Request",
+Explain = _reflection.GeneratedProtocolMessageType(
+    "Explain",
     (_message.Message,),
     {
-        "UserContext": _reflection.GeneratedProtocolMessageType(
-            "UserContext",
-            (_message.Message,),
-            {
-                "DESCRIPTOR": _REQUEST_USERCONTEXT,
-                "__module__": "spark.connect.base_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.Request.UserContext)
-            },
-        ),
-        "DESCRIPTOR": _REQUEST,
+        "DESCRIPTOR": _EXPLAIN,
         "__module__": "spark.connect.base_pb2"
-        # @@protoc_insertion_point(class_scope:spark.connect.Request)
+        # @@protoc_insertion_point(class_scope:spark.connect.Explain)
     },
 )
-_sym_db.RegisterMessage(Request)
-_sym_db.RegisterMessage(Request.UserContext)
+_sym_db.RegisterMessage(Explain)
 
-Response = _reflection.GeneratedProtocolMessageType(
-    "Response",
+UserContext = _reflection.GeneratedProtocolMessageType(
+    "UserContext",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _USERCONTEXT,
+        "__module__": "spark.connect.base_pb2"
+        # @@protoc_insertion_point(class_scope:spark.connect.UserContext)
+    },
+)
+_sym_db.RegisterMessage(UserContext)
+
+AnalyzePlanRequest = _reflection.GeneratedProtocolMessageType(
+    "AnalyzePlanRequest",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _ANALYZEPLANREQUEST,
+        "__module__": "spark.connect.base_pb2"
+        # @@protoc_insertion_point(class_scope:spark.connect.AnalyzePlanRequest)
+    },
+)
+_sym_db.RegisterMessage(AnalyzePlanRequest)
+
+AnalyzePlanResponse = _reflection.GeneratedProtocolMessageType(
+    "AnalyzePlanResponse",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _ANALYZEPLANRESPONSE,
+        "__module__": "spark.connect.base_pb2"
+        # @@protoc_insertion_point(class_scope:spark.connect.AnalyzePlanResponse)
+    },
+)
+_sym_db.RegisterMessage(AnalyzePlanResponse)
+
+ExecutePlanRequest = _reflection.GeneratedProtocolMessageType(
+    "ExecutePlanRequest",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _EXECUTEPLANREQUEST,
+        "__module__": "spark.connect.base_pb2"
+        # @@protoc_insertion_point(class_scope:spark.connect.ExecutePlanRequest)
+    },
+)
+_sym_db.RegisterMessage(ExecutePlanRequest)
+
+ExecutePlanResponse = _reflection.GeneratedProtocolMessageType(
+    "ExecutePlanResponse",
     (_message.Message,),
     {
         "ArrowBatch": _reflection.GeneratedProtocolMessageType(
             "ArrowBatch",
             (_message.Message,),
             {
-                "DESCRIPTOR": _RESPONSE_ARROWBATCH,
+                "DESCRIPTOR": _EXECUTEPLANRESPONSE_ARROWBATCH,
                 "__module__": "spark.connect.base_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.Response.ArrowBatch)
+                # @@protoc_insertion_point(class_scope:spark.connect.ExecutePlanResponse.ArrowBatch)
             },
         ),
         "JSONBatch": _reflection.GeneratedProtocolMessageType(
             "JSONBatch",
             (_message.Message,),
             {
-                "DESCRIPTOR": _RESPONSE_JSONBATCH,
+                "DESCRIPTOR": _EXECUTEPLANRESPONSE_JSONBATCH,
                 "__module__": "spark.connect.base_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.Response.JSONBatch)
+                # @@protoc_insertion_point(class_scope:spark.connect.ExecutePlanResponse.JSONBatch)
             },
         ),
         "Metrics": _reflection.GeneratedProtocolMessageType(
@@ -119,53 +160,42 @@ Response = _reflection.GeneratedProtocolMessageType(
                             "ExecutionMetricsEntry",
                             (_message.Message,),
                             {
-                                "DESCRIPTOR": _RESPONSE_METRICS_METRICOBJECT_EXECUTIONMETRICSENTRY,
+                                "DESCRIPTOR": _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT_EXECUTIONMETRICSENTRY,
                                 "__module__": "spark.connect.base_pb2"
-                                # @@protoc_insertion_point(class_scope:spark.connect.Response.Metrics.MetricObject.ExecutionMetricsEntry)
+                                # @@protoc_insertion_point(class_scope:spark.connect.ExecutePlanResponse.Metrics.MetricObject.ExecutionMetricsEntry)
                             },
                         ),
-                        "DESCRIPTOR": _RESPONSE_METRICS_METRICOBJECT,
+                        "DESCRIPTOR": _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT,
                         "__module__": "spark.connect.base_pb2"
-                        # @@protoc_insertion_point(class_scope:spark.connect.Response.Metrics.MetricObject)
+                        # @@protoc_insertion_point(class_scope:spark.connect.ExecutePlanResponse.Metrics.MetricObject)
                     },
                 ),
                 "MetricValue": _reflection.GeneratedProtocolMessageType(
                     "MetricValue",
                     (_message.Message,),
                     {
-                        "DESCRIPTOR": _RESPONSE_METRICS_METRICVALUE,
+                        "DESCRIPTOR": _EXECUTEPLANRESPONSE_METRICS_METRICVALUE,
                         "__module__": "spark.connect.base_pb2"
-                        # @@protoc_insertion_point(class_scope:spark.connect.Response.Metrics.MetricValue)
+                        # @@protoc_insertion_point(class_scope:spark.connect.ExecutePlanResponse.Metrics.MetricValue)
                     },
                 ),
-                "DESCRIPTOR": _RESPONSE_METRICS,
+                "DESCRIPTOR": _EXECUTEPLANRESPONSE_METRICS,
                 "__module__": "spark.connect.base_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.Response.Metrics)
+                # @@protoc_insertion_point(class_scope:spark.connect.ExecutePlanResponse.Metrics)
             },
         ),
-        "DESCRIPTOR": _RESPONSE,
+        "DESCRIPTOR": _EXECUTEPLANRESPONSE,
         "__module__": "spark.connect.base_pb2"
-        # @@protoc_insertion_point(class_scope:spark.connect.Response)
+        # @@protoc_insertion_point(class_scope:spark.connect.ExecutePlanResponse)
     },
 )
-_sym_db.RegisterMessage(Response)
-_sym_db.RegisterMessage(Response.ArrowBatch)
-_sym_db.RegisterMessage(Response.JSONBatch)
-_sym_db.RegisterMessage(Response.Metrics)
-_sym_db.RegisterMessage(Response.Metrics.MetricObject)
-_sym_db.RegisterMessage(Response.Metrics.MetricObject.ExecutionMetricsEntry)
-_sym_db.RegisterMessage(Response.Metrics.MetricValue)
-
-AnalyzeResponse = _reflection.GeneratedProtocolMessageType(
-    "AnalyzeResponse",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _ANALYZERESPONSE,
-        "__module__": "spark.connect.base_pb2"
-        # @@protoc_insertion_point(class_scope:spark.connect.AnalyzeResponse)
-    },
-)
-_sym_db.RegisterMessage(AnalyzeResponse)
+_sym_db.RegisterMessage(ExecutePlanResponse)
+_sym_db.RegisterMessage(ExecutePlanResponse.ArrowBatch)
+_sym_db.RegisterMessage(ExecutePlanResponse.JSONBatch)
+_sym_db.RegisterMessage(ExecutePlanResponse.Metrics)
+_sym_db.RegisterMessage(ExecutePlanResponse.Metrics.MetricObject)
+_sym_db.RegisterMessage(ExecutePlanResponse.Metrics.MetricObject.ExecutionMetricsEntry)
+_sym_db.RegisterMessage(ExecutePlanResponse.Metrics.MetricValue)
 
 _SPARKCONNECTSERVICE = DESCRIPTOR.services_by_name["SparkConnectService"]
 if _descriptor._USE_C_DESCRIPTORS == False:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix out of sync generated files for Python.

This happens on a rare case for protobuf version change. https://github.com/apache/spark/pull/38693 downgraded protobuf versions.

There were something not generated before but with the protobuf version downgraded that was generated (and this is why there was no merge conflict). However [the downgrading PR](https://github.com/apache/spark/pull/38693) was based on old code before https://github.com/apache/spark/pull/38638 so the protobuf generates based on stale code which leads to stale generated files. 

The way to better avoid this is when upon such change, it should lock the repo (partially on some directory to reduce impact), do the work, merge, and enforce pending PR to rebase. However this is not feasible (or too heavy) for concurrent development on Spark repo.  

Another approach is to ask relevant PR to rebase, re-generate for python then merge. Though there could be still a gap here (a PR merged right right before merge button clicked) but that is minimized. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix out of sync generated files for Python.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT