### PR TITLE
[SPARK-41200][CORE] BytesToBytesMap's longArray size can be up to MAX_CAPACITY

### DIFF
--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -812,9 +812,7 @@ public final class BytesToBytesMap extends MemoryConsumer {
 
         // If the map has reached its growth threshold, try to grow it.
         if (numKeys >= growthThreshold) {
-          // We use two array entries per key, so the array size is twice the capacity.
-          // We should compare the current capacity of the array, instead of its size.
-          if (longArray.size() / 2 < MAX_CAPACITY) {
+          if (longArray.size() < MAX_CAPACITY) {
             try {
               growAndRehash();
             } catch (SparkOutOfMemoryError oom) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In BytesToBytesMap, the longArray size can be up to `MAX_CAPACITY` instead `MAX_CAPACITY/2` since `MAX_CAPACITY` already take `two array entries per key` into account.

### Why are the changes needed?
Fix bug to handle larger dataset in BytestoBytesMap


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existings UT
