### PR TITLE
[SPARK-41182][SQL] Assign a name to the error class _LEGACY_ERROR_TEMP_1102

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -656,6 +656,11 @@
     ],
     "sqlState" : "42000"
   },
+  "INVALID_EXTRACT_FIELD" : {
+    "message" : [
+      "Literals of the type <field> are currently not supported for the <sourceDataType> type."
+    ]
+  },
   "INVALID_FIELD_NAME" : {
     "message" : [
       "Field name <fieldName> is invalid: <path> is not a struct."
@@ -1324,11 +1329,6 @@
   "UNSUPPORTED_GROUPING_EXPRESSION" : {
     "message" : [
       "grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup"
-    ]
-  },
-  "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE" : {
-    "message" : [
-      "Literals of the type <field> are currently not supported for the <sourceDataType> type."
     ]
   },
   "UNSUPPORTED_SAVE_MODE" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -682,7 +682,7 @@
     ]
   },
   "INVALID_EXTRACT_FIELD" : {
-    "message": [
+    "message" : [
       "Cannot extract <field> from <expr>."
     ]
   },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1326,6 +1326,11 @@
       "grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup"
     ]
   },
+  "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE" : {
+    "message" : [
+      "Literals of the type <field> are currently not supported for the <sourceDataType> type."
+    ]
+  },
   "UNSUPPORTED_SAVE_MODE" : {
     "message" : [
       "The save mode <saveMode> is not supported for:"
@@ -2193,11 +2198,6 @@
   "_LEGACY_ERROR_TEMP_1101" : {
     "message" : [
       "Invalid value for the '<argName>' parameter of function '<funcName>': <invalidValue>.<endingMsg>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1102" : {
-    "message" : [
-      "Literals of type '<field>' are currently not supported for the <srcDataType> type."
     ]
   },
   "_LEGACY_ERROR_TEMP_1103" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1073,7 +1073,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
 
   def literalTypeUnsupportedForSourceTypeError(field: String, source: Expression): Throwable = {
     new AnalysisException(
-      errorClass = "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
+      errorClass = "INVALID_EXTRACT_FIELD",
       messageParameters = Map(
         "field" -> toSQLId(field),
         "sourceDataType" -> toSQLType(source.dataType)))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1073,10 +1073,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
 
   def literalTypeUnsupportedForSourceTypeError(field: String, source: Expression): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1102",
+      errorClass = "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
       messageParameters = Map(
-        "field" -> field,
-        "srcDataType" -> source.dataType.catalogString))
+        "field" -> toSQLId(field),
+        "sourceDataType" -> toSQLType(source.dataType)))
   }
 
   def arrayComponentTypeUnsupportedError(clz: Class[_]): Throwable = {

--- a/sql/core/src/test/resources/sql-tests/results/extract.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/extract.sql.out
@@ -317,7 +317,7 @@ select extract(not_supported from c) from t
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `not_supported` are currently not supported for the "STRING" type.; line 1 pos 7
+[INVALID_EXTRACT_FIELD] Literals of the type `not_supported` are currently not supported for the "STRING" type.; line 1 pos 7
 
 
 -- !query
@@ -326,7 +326,7 @@ select extract(not_supported from i) from t
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `not_supported` are currently not supported for the "INTERVAL YEAR TO MONTH" type.; line 1 pos 7
+[INVALID_EXTRACT_FIELD] Literals of the type `not_supported` are currently not supported for the "INTERVAL YEAR TO MONTH" type.; line 1 pos 7
 
 
 -- !query
@@ -335,7 +335,7 @@ select extract(not_supported from j) from t
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `not_supported` are currently not supported for the "INTERVAL DAY TO SECOND" type.; line 1 pos 7
+[INVALID_EXTRACT_FIELD] Literals of the type `not_supported` are currently not supported for the "INTERVAL DAY TO SECOND" type.; line 1 pos 7
 
 -- !query
 select date_part('year', c), date_part('year', ntz), date_part('year', i) from t
@@ -648,7 +648,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
+  "errorClass" : "INVALID_EXTRACT_FIELD",
   "messageParameters" : {
     "field" : "`not_supported`",
     "sourceDataType" : "\"STRING\""
@@ -923,7 +923,7 @@ select extract(DAY from interval '2-1' YEAR TO MONTH)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `DAY` are currently not supported for the "INTERVAL YEAR TO MONTH" type.; line 1 pos 7
+[INVALID_EXTRACT_FIELD] Literals of the type `DAY` are currently not supported for the "INTERVAL YEAR TO MONTH" type.; line 1 pos 7
 
 
 -- !query
@@ -933,7 +933,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
+  "errorClass" : "INVALID_EXTRACT_FIELD",
   "messageParameters" : {
     "field" : "`DAY`",
     "sourceDataType" : "\"INTERVAL YEAR TO MONTH\""
@@ -955,7 +955,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
+  "errorClass" : "INVALID_EXTRACT_FIELD",
   "messageParameters" : {
     "field" : "`not_supported`",
     "sourceDataType" : "\"INTERVAL YEAR TO MONTH\""
@@ -1080,7 +1080,7 @@ select extract(MONTH from interval '123 12:34:56.789123123' DAY TO SECOND)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `MONTH` are currently not supported for the "INTERVAL DAY TO SECOND" type.; line 1 pos 7
+[INVALID_EXTRACT_FIELD] Literals of the type `MONTH` are currently not supported for the "INTERVAL DAY TO SECOND" type.; line 1 pos 7
 
 -- !query
 select date_part('not_supported', interval '123 12:34:56.789123123' DAY TO SECOND)
@@ -1089,7 +1089,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
+  "errorClass" : "INVALID_EXTRACT_FIELD",
   "messageParameters" : {
     "field" : "`not_supported`",
     "sourceDataType" : "\"INTERVAL DAY TO SECOND\""

--- a/sql/core/src/test/resources/sql-tests/results/extract.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/extract.sql.out
@@ -317,7 +317,7 @@ select extract(not_supported from c) from t
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'not_supported' are currently not supported for the string type.; line 1 pos 7
+[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `not_supported` are currently not supported for the "STRING" type.; line 1 pos 7
 
 
 -- !query
@@ -326,7 +326,7 @@ select extract(not_supported from i) from t
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'not_supported' are currently not supported for the interval year to month type.; line 1 pos 7
+[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `not_supported` are currently not supported for the "INTERVAL YEAR TO MONTH" type.; line 1 pos 7
 
 
 -- !query
@@ -335,8 +335,7 @@ select extract(not_supported from j) from t
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'not_supported' are currently not supported for the interval day to second type.; line 1 pos 7
-
+[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `not_supported` are currently not supported for the "INTERVAL DAY TO SECOND" type.; line 1 pos 7
 
 -- !query
 select date_part('year', c), date_part('year', ntz), date_part('year', i) from t
@@ -649,10 +648,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1102",
+  "errorClass" : "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
   "messageParameters" : {
-    "field" : "not_supported",
-    "srcDataType" : "string"
+    "field" : "`not_supported`",
+    "sourceDataType" : "\"STRING\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -924,7 +923,7 @@ select extract(DAY from interval '2-1' YEAR TO MONTH)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'DAY' are currently not supported for the interval year to month type.; line 1 pos 7
+[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `DAY` are currently not supported for the "INTERVAL YEAR TO MONTH" type.; line 1 pos 7
 
 
 -- !query
@@ -934,10 +933,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1102",
+  "errorClass" : "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
   "messageParameters" : {
-    "field" : "DAY",
-    "srcDataType" : "interval year to month"
+    "field" : "`DAY`",
+    "sourceDataType" : "\"INTERVAL YEAR TO MONTH\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -956,10 +955,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1102",
+  "errorClass" : "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
   "messageParameters" : {
-    "field" : "not_supported",
-    "srcDataType" : "interval year to month"
+    "field" : "`not_supported`",
+    "sourceDataType" : "\"INTERVAL YEAR TO MONTH\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1081,8 +1080,7 @@ select extract(MONTH from interval '123 12:34:56.789123123' DAY TO SECOND)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Literals of type 'MONTH' are currently not supported for the interval day to second type.; line 1 pos 7
-
+[UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE] Literals of the type `MONTH` are currently not supported for the "INTERVAL DAY TO SECOND" type.; line 1 pos 7
 
 -- !query
 select date_part('not_supported', interval '123 12:34:56.789123123' DAY TO SECOND)
@@ -1091,10 +1089,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1102",
+  "errorClass" : "UNSUPPORTED_LITERAL_FOR_SOURCE_TYPE",
   "messageParameters" : {
-    "field" : "not_supported",
-    "srcDataType" : "interval day to second"
+    "field" : "`not_supported`",
+    "sourceDataType" : "\"INTERVAL DAY TO SECOND\""
   },
   "queryContext" : [ {
     "objectType" : "",


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to assign the name `INVALID_EXTRACT_FIELD` to the error class `_LEGACY_ERROR_TEMP_1102`.

### Why are the changes needed?
Proper names of error classes should improve user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.