### PR TITLE
[SPARK-41203] [CONNECT] Support Dataframe.tansform in Python client.

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -25,6 +25,7 @@ from typing import (
     Union,
     TYPE_CHECKING,
     overload,
+    Callable,
     cast,
 )
 
@@ -755,6 +756,62 @@ class DataFrame(object):
                 raise Exception("Empty plan.")
         else:
             return self._schema
+
+    def transform(self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any) -> "DataFrame":
+        """Returns a new :class:`DataFrame`. Concise syntax for chaining custom transformations.
+
+        .. versionadded:: 3.0.0
+
+        Parameters
+        ----------
+        func : function
+            a function that takes and returns a :class:`DataFrame`.
+        *args
+            Positional arguments to pass to func.
+
+            .. versionadded:: 3.3.0
+        **kwargs
+            Keyword arguments to pass to func.
+
+            .. versionadded:: 3.3.0
+
+        Returns
+        -------
+        :class:`DataFrame`
+            Transformed DataFrame.
+
+        Examples
+        --------
+        >>> from pyspark.sql.connect.functions import col
+        >>> df = spark.createDataFrame([(1, 1.0), (2, 2.0)], ["int", "float"])
+        >>> def cast_all_to_int(input_df):
+        ...     return input_df.select([col(col_name).cast("int") for col_name in input_df.columns])
+        >>> def sort_columns_asc(input_df):
+        ...     return input_df.select(*sorted(input_df.columns))
+        >>> df.transform(cast_all_to_int).transform(sort_columns_asc).show()
+        +-----+---+
+        |float|int|
+        +-----+---+
+        |    1|  1|
+        |    2|  2|
+        +-----+---+
+
+        >>> def add_n(input_df, n):
+        ...     return input_df.select([(col(col_name) + n).alias(col_name)
+        ...                             for col_name in input_df.columns])
+        >>> df.transform(add_n, 1).transform(add_n, n=10).show()
+        +---+-----+
+        |int|float|
+        +---+-----+
+        | 12| 12.0|
+        | 13| 13.0|
+        +---+-----+
+        """
+        result = func(self, *args, **kwargs)
+        assert isinstance(
+            result, DataFrame
+        ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)
+        return result
 
     def explain(
         self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -760,7 +760,7 @@ class DataFrame(object):
     def transform(self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any) -> "DataFrame":
         """Returns a new :class:`DataFrame`. Concise syntax for chaining custom transformations.
 
-        .. versionadded:: 3.0.0
+        .. versionadded:: 3.4.0
 
         Parameters
         ----------
@@ -769,11 +769,8 @@ class DataFrame(object):
         *args
             Positional arguments to pass to func.
 
-            .. versionadded:: 3.3.0
         **kwargs
             Keyword arguments to pass to func.
-
-            .. versionadded:: 3.3.0
 
         Returns
         -------

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -307,7 +307,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             self.assertEqual(len(expectResult), len(actualResult))
 
     def test_simple_transform(self) -> None:
-        """SPARK-39375: Support DF.transform"""
+        """SPARK-41203: Support DF.transform"""
 
         def transform_df(input_df: DataFrame) -> DataFrame:
             return input_df.select((col("id") + lit(10)).alias("id"))

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -35,6 +35,7 @@ if have_pandas:
     from pyspark.sql.connect.function_builder import udf
     from pyspark.sql.connect.functions import lit, col
 from pyspark.sql.dataframe import DataFrame
+from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.utils import ReusedPySparkTestCase
@@ -309,7 +310,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
     def test_simple_transform(self) -> None:
         """SPARK-41203: Support DF.transform"""
 
-        def transform_df(input_df: DataFrame) -> DataFrame:
+        def transform_df(input_df: CDataFrame) -> CDataFrame:
             return input_df.select((col("id") + lit(10)).alias("id"))
 
         df = self.connect.range(1, 100)
@@ -319,7 +320,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
         # Check assertion.
         with self.assertRaises(AssertionError):
-            df.transform(lambda x: 2)
+            df.transform(lambda x: 2)  # type: ignore
 
     def test_alias(self) -> None:
         """Testing supported and unsupported alias"""

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -318,7 +318,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertEqual(result_right, result_left)
 
         # Check assertion.
-        with self.assertRaises(AssertionError) as exc:
+        with self.assertRaises(AssertionError):
             df.transform(lambda x: 2)
 
     def test_alias(self) -> None:

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -306,6 +306,21 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             actualResult = pandasResult.values.tolist()
             self.assertEqual(len(expectResult), len(actualResult))
 
+    def test_simple_transform(self) -> None:
+        """SPARK-39375: Support DF.transform"""
+
+        def transform_df(input_df: DataFrame) -> DataFrame:
+            return input_df.select((col("id") + lit(10)).alias("id"))
+
+        df = self.connect.range(1, 100)
+        result_left = df.transform(transform_df).collect()
+        result_right = self.connect.range(11, 110).collect()
+        self.assertEqual(result_right, result_left)
+
+        # Check assertion.
+        with self.assertRaises(AssertionError) as exc:
+            df.transform(lambda x: 2)
+
     def test_alias(self) -> None:
         """Testing supported and unsupported alias"""
         col0 = (


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support client-side transformations of the DataFrame.

### Why are the changes needed?
Compatibility

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT