### PR TITLE
[SPARK-41205][SQL] Check that format is foldable in `TryToBinary`

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/string-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/string-functions.sql
@@ -225,3 +225,7 @@ select to_binary(null, cast(null as string));
 -- invalid format
 select to_binary('abc', 1);
 select to_binary('abc', 'invalidFormat');
+-- format must be foldable
+SELECT to_binary(col1, col2) from values ('abc', 'utf-8') as data(col1, col2);
+-- non-foldable input string
+SELECT to_binary(col1, 'utf-8') from values ('abc') as data(col1);

--- a/sql/core/src/test/resources/sql-tests/inputs/try-string-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/try-string-functions.sql
@@ -46,5 +46,7 @@ select try_to_binary(null, cast(null as string));
 -- invalid format
 select try_to_binary('abc', 1);
 select try_to_binary('abc', 'invalidFormat');
--- format must be folable
+-- format must be foldable
 SELECT try_to_binary(col1, col2) from values ('abc', 'utf-8') as data(col1, col2);
+-- non-foldable input string
+SELECT try_to_binary(col1, 'utf-8') from values ('abc') as data(col1);

--- a/sql/core/src/test/resources/sql-tests/inputs/try-string-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/try-string-functions.sql
@@ -46,3 +46,5 @@ select try_to_binary(null, cast(null as string));
 -- invalid format
 select try_to_binary('abc', 1);
 select try_to_binary('abc', 'invalidFormat');
+-- format must be folable
+SELECT try_to_binary(col1, col2) from values ('abc', 'utf-8') as data(col1, col2);

--- a/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
@@ -1597,3 +1597,20 @@ org.apache.spark.sql.AnalysisException
     "invalidValue" : "invalidformat"
   }
 }
+
+
+-- !query
+SELECT to_binary(col1, col2) from values ('abc', 'utf-8') as data(col1, col2)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+The 'format' parameter of function 'to_binary' needs to be a string literal.; line 1 pos 7
+
+
+-- !query
+SELECT to_binary(col1, 'utf-8') from values ('abc') as data(col1)
+-- !query schema
+struct<to_binary(col1, utf-8):binary>
+-- !query output
+abc

--- a/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
@@ -1529,3 +1529,20 @@ org.apache.spark.sql.AnalysisException
     "invalidValue" : "invalidformat"
   }
 }
+
+
+-- !query
+SELECT to_binary(col1, col2) from values ('abc', 'utf-8') as data(col1, col2)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+The 'format' parameter of function 'to_binary' needs to be a string literal.; line 1 pos 7
+
+
+-- !query
+SELECT to_binary(col1, 'utf-8') from values ('abc') as data(col1)
+-- !query schema
+struct<to_binary(col1, utf-8):binary>
+-- !query output
+abc

--- a/sql/core/src/test/resources/sql-tests/results/try-string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/try-string-functions.sql.out
@@ -281,3 +281,12 @@ select try_to_binary('abc', 'invalidFormat')
 struct<try_to_binary(abc, invalidFormat):binary>
 -- !query output
 NULL
+
+
+-- !query
+SELECT try_to_binary(col1, col2) from values ('abc', 'utf-8') as data(col1, col2)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+The 'format' parameter of function 'try_to_binary' needs to be a string literal.; line 1 pos 7

--- a/sql/core/src/test/resources/sql-tests/results/try-string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/try-string-functions.sql.out
@@ -290,3 +290,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 The 'format' parameter of function 'try_to_binary' needs to be a string literal.; line 1 pos 7
+
+
+-- !query
+SELECT try_to_binary(col1, 'utf-8') from values ('abc') as data(col1)
+-- !query schema
+struct<try_to_binary(col1, utf-8):binary>
+-- !query output
+abc


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `TryToBinary`'s constructor to test whether the format expression is foldable before creating the replacement expression.

### Why are the changes needed?

`try_to_binary`, when called with non-foldable format, throws an unhelpful error message:

```
spark-sql> SELECT try_to_binary(col1, col2) from values ('abc', 'utf-8') as data(col1, col2);
[INTERNAL_ERROR] The Spark SQL phase analysis failed with an internal error. You hit a bug in Spark or the Spark plugins you use. Please, report this bug to the corresponding communities or vendors, and provide the full stack trace.
org.apache.spark.SparkException: [INTERNAL_ERROR] The Spark SQL phase analysis failed with an internal error. You hit a bug in Spark or the Spark plugins you use. Please, report this bug to the corresponding communities or vendors, and provide the full stack trace.
	at org.apache.spark.SparkException$.internalError(SparkException.scala:88)
...
Caused by: java.lang.AssertionError: assertion failed
	at scala.Predef$.assert(Predef.scala:208)
	at org.apache.spark.sql.catalyst.expressions.ToBinary.$anonfun$replacement$1(stringExpressions.scala:2597)
	at scala.Option.map(Option.scala:230)
	at org.apache.spark.sql.catalyst.expressions.ToBinary.replacement$lzycompute(stringExpressions.scala:2596)
	at org.apache.spark.sql.catalyst.expressions.ToBinary.replacement(stringExpressions.scala:2596)
```
`TryToBinary` creates an instance of `ToBinary` as a replacement expression. However, `ToBinary`'s default constructor does not check whether the format expression is foldable, so the code that creates `ToBinary`'s own replacement expression fails with an assertion failure.

`ToBinary` is not typically instantiated using the default constructor. The function registry uses the second auxiliary constructor, which does check whether format is foldable. The code that creates `ToBinary`'s replacement expression assumes this second auxiliary constructor is always used.

`TryToBinary` cannot use `ToBinary`'s second auxiliary constructor because it needs to set `nullOnInvalidFormat` to `true`.

After this PR, the above example will throw a more useful error message:
```
spark-sql> SELECT try_to_binary(col1, col2) from values ('abc', 'utf-8') as data(col1, col2);
The 'format' parameter of function 'try_to_binary' needs to be a string literal.; line 1 pos 7
spark-sql> 
```
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New tests.
