### PR TITLE
[SPARK-41210][K8S] Window based executor failure tracking mechanism

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -750,6 +750,25 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Gracefully shutdown period must be a positive time value")
       .createWithDefaultString("20s")
 
+  val KUBERNETES_MAX_EXECUTOR_FAILURES =
+    ConfigBuilder("spark.kubernetes.executor.maxNumFailures")
+      .doc("Spark exit if the number of failed executors exceeds this threshold. This " +
+        s"configuration only take effect when ${KUBERNETES_ALLOCATION_PODS_ALLOCATOR.key} " +
+        s"is set to 'direct'.")
+      .version("3.4.0")
+      .intConf
+      .createOptional
+
+  val KUBERNETES_EXECUTOR_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS =
+    ConfigBuilder("spark.kubernetes.executor.failuresValidityInterval")
+      .doc("Interval after which Executor failures will be considered independent and not " +
+        "accumulate towards the attempt count. This configuration is take effect when " +
+        s"${KUBERNETES_ALLOCATION_PODS_ALLOCATOR.key} is set to 'direct'.")
+      .version("3.4.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .checkValue(value => value > 0, "failures validity interval should be positive")
+      .createOptional
+
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."
   val KUBERNETES_DRIVER_SERVICE_LABEL_PREFIX = "spark.kubernetes.driver.service.label."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -755,8 +755,9 @@ private[spark] object Config extends Logging {
       .doc("Spark exit if the number of failed executors exceeds this threshold. This " +
         s"configuration only take effect when ${KUBERNETES_ALLOCATION_PODS_ALLOCATOR.key} " +
         s"is set to 'direct'.")
-      .version("3.4.0")
+      .version("3.5.0")
       .intConf
+      .checkValue(value => value > 0, "Max number of failures must be a positive value")
       .createOptional
 
   val KUBERNETES_EXECUTOR_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS =
@@ -764,9 +765,9 @@ private[spark] object Config extends Logging {
       .doc("Interval after which Executor failures will be considered independent and not " +
         "accumulate towards the attempt count. This configuration is take effect when " +
         s"${KUBERNETES_ALLOCATION_PODS_ALLOCATOR.key} is set to 'direct'.")
-      .version("3.4.0")
+      .version("3.5.0")
       .timeConf(TimeUnit.MILLISECONDS)
-      .checkValue(value => value > 0, "failures validity interval should be positive")
+      .checkValue(value => value > 0, "Validity interval of failures must be positive")
       .createOptional
 
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -274,9 +274,7 @@ class ExecutorPodsAllocator(
       }
 
       val currentFailedExecutorIds = podsForRpId.filter {
-        case (_, PodFailed(pod)) =>
-          pod.getSpec
-          true
+        case (_, PodFailed(_)) => true
         case _ => false
       }.keySet
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -36,7 +36,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{DYN_ALLOCATION_EXECUTOR_IDLE_TIMEOUT, DYN_ALLOCATION_MAX_EXECUTORS, EXECUTOR_INSTANCES}
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.scheduler.cluster.SchedulerBackendUtils.DEFAULT_NUMBER_EXECUTORS
-import org.apache.spark.util.{Clock, Utils}
+import org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.EXIT_MAX_EXECUTOR_FAILURES
+import org.apache.spark.util.{Clock, SystemClock, Utils}
 
 class ExecutorPodsAllocator(
     conf: SparkConf,
@@ -70,6 +71,8 @@ class ExecutorPodsAllocator(
   protected val podAllocationDelay = conf.get(KUBERNETES_ALLOCATION_BATCH_DELAY)
 
   protected val maxPendingPods = conf.get(KUBERNETES_MAX_PENDING_PODS)
+
+  private val maxNumExecutorFailuresOpt = conf.get(KUBERNETES_MAX_EXECUTOR_FAILURES)
 
   protected val podCreationTimeout = math.max(
     podAllocationDelay * 5,
@@ -117,6 +120,12 @@ class ExecutorPodsAllocator(
   // if they happen to come up before the deletion takes effect.
   @volatile protected var deletedExecutorIds = Set.empty[Long]
 
+  @volatile private var failedExecutorIds = Set.empty[Long]
+
+  private[k8s] val failureTracker = new FailureTracker(conf, clock)
+
+  def getNumExecutorsFailed: Int = failureTracker.numFailedExecutors
+
   def start(applicationId: String, schedulerBackend: KubernetesClusterSchedulerBackend): Unit = {
     appId = applicationId
     driverPod.foreach { pod =>
@@ -130,8 +139,14 @@ class ExecutorPodsAllocator(
           .waitUntilReady(driverPodReadinessTimeout, TimeUnit.SECONDS)
       }
     }
-    snapshotsStore.addSubscriber(podAllocationDelay) {
-      onNewSnapshots(applicationId, schedulerBackend, _)
+    snapshotsStore.addSubscriber(podAllocationDelay) { executorPodsSnapshot =>
+      onNewSnapshots(applicationId, schedulerBackend, executorPodsSnapshot)
+      maxNumExecutorFailuresOpt.foreach { maxNumExecutorFailures =>
+        if (failureTracker.numFailedExecutors > maxNumExecutorFailures) {
+          logError(s"Max number of executor failures ($maxNumExecutorFailures) reached")
+          stopApplication(EXIT_MAX_EXECUTOR_FAILURES)
+        }
+      }
     }
   }
 
@@ -147,6 +162,10 @@ class ExecutorPodsAllocator(
   }
 
   def isDeleted(executorId: String): Boolean = deletedExecutorIds.contains(executorId.toLong)
+
+  private[k8s] def stopApplication(exitCode: Int): Unit = {
+    sys.exit(exitCode)
+  }
 
   protected def onNewSnapshots(
       applicationId: String,
@@ -253,6 +272,21 @@ class ExecutorPodsAllocator(
         case PodRunning(_) => true
         case _ => false
       }
+
+      val currentFailedExecutorIds = podsForRpId.filter {
+        case (_, PodFailed(pod)) =>
+          pod.getSpec
+          true
+        case _ => false
+      }.keySet
+
+      val newFailedExecutorIds = currentFailedExecutorIds -- failedExecutorIds
+      if (newFailedExecutorIds.nonEmpty) {
+        logWarning(s"${newFailedExecutorIds.size} new failed executors.")
+      }
+      failedExecutorIds = failedExecutorIds ++ currentFailedExecutorIds
+
+      failureTracker.registerExecutorFailure(newFailedExecutorIds.toSet)
 
       val (schedulerKnownPendingExecsForRpId, currentPendingExecutorsForRpId) = podsForRpId.filter {
         case (_, PodPending(_)) => true
@@ -520,10 +554,46 @@ class ExecutorPodsAllocator(
 
 private[spark] object ExecutorPodsAllocator {
 
+  private[spark] val EXIT_MAX_EXECUTOR_FAILURES = 11
+
   // A utility function to split the available slots among the specified consumers
   def splitSlots[T](consumers: Seq[T], slots: Int): Seq[(T, Int)] = {
     val d = slots / consumers.size
     val r = slots % consumers.size
     consumers.take(r).map((_, d + 1)) ++ consumers.takeRight(consumers.size - r).map((_, d))
+  }
+}
+
+private[spark] class FailureTracker(
+  conf: SparkConf,
+  val clock: Clock = new SystemClock) extends Logging {
+
+  private val executorFailuresValidityIntervalOpt =
+    conf.get(KUBERNETES_EXECUTOR_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS)
+
+  private val failedExecutorsTimestamps = new mutable.HashMap[Long, Long]()
+
+  private def updateAndCountFailures(
+      failedExecutorsWithTimestamps: mutable.HashMap[Long, Long]): Int = {
+    executorFailuresValidityIntervalOpt.foreach { validityInterval =>
+      if (failedExecutorsWithTimestamps.nonEmpty) {
+        val startTime = clock.getTimeMillis() - validityInterval
+        failedExecutorsWithTimestamps.foreach { case (podId, failedTime) =>
+          if (failedTime < startTime) {
+            failedExecutorsWithTimestamps.remove(podId)
+          }
+        }
+      }
+    }
+    failedExecutorsWithTimestamps.size
+  }
+
+  def numFailedExecutors: Int = synchronized {
+    updateAndCountFailures(failedExecutorsTimestamps)
+  }
+
+  def registerExecutorFailure(podIds: Set[Long]): Unit = synchronized {
+    val failedTime = clock.getTimeMillis()
+    podIds.foreach { podId => failedExecutorsTimestamps.put(podId, failedTime) }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fail Spark Application when number of executor failures reach threshold.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Sometimes, the executors can not launch successfully because of the wrong configuration, but in K8s, Driver does not know that, and just keep requesting new executors.

This adds functionality similar to YARN[1] to K8s.

[1] [SPARK-6735](https://issues.apache.org/jira/browse/SPARK-6735)

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
New feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT added, and manually tested in internal K8s cluster.