### PR TITLE
[SPARK-41212][CONNECT][PYTHON] Implement `DataFrame.isEmpty`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -122,6 +122,20 @@ class DataFrame(object):
         new_frame._plan = plan
         return new_frame
 
+    def isEmpty(self) -> bool:
+        """Returns ``True`` if this :class:`DataFrame` is empty.
+
+        .. versionadded:: 3.4.0
+
+        Returns
+        -------
+        bool
+            Whether it's empty DataFrame or not.
+        """
+        if "is_empty" not in self._cache:
+            self._cache["is_empty"] = len(self.take(1)) == 0
+        return bool(self._cache["is_empty"])
+
     def select(self, *cols: "ExpressionOrString") -> "DataFrame":
         return DataFrame.withPlan(plan.Project(self._plan, *cols), session=self._session)
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -132,9 +132,7 @@ class DataFrame(object):
         bool
             Whether it's empty DataFrame or not.
         """
-        if "is_empty" not in self._cache:
-            self._cache["is_empty"] = len(self.take(1)) == 0
-        return bool(self._cache["is_empty"])
+        return len(self.take(1)) == 0
 
     def select(self, *cols: "ExpressionOrString") -> "DataFrame":
         return DataFrame.withPlan(plan.Project(self._plan, *cols), session=self._session)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -319,6 +319,11 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertEqual(1, len(pdf.columns))  # one column
         self.assertEqual("X", pdf.columns[0])
 
+    def test_is_empty(self):
+        # SPARK-41212: Test is empty
+        self.assertFalse(self.connect.sql("SELECT 1 AS X").isEmpty())
+        self.assertTrue(self.connect.sql("SELECT 1 AS X LIMIT 0").isEmpty())
+
     def test_session(self):
         self.assertEqual(self.connect, self.connect.sql("SELECT 1").sparkSession())
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `DataFrame.isEmpty`


### Why are the changes needed?
API Coverage


### Does this PR introduce _any_ user-facing change?
Yes, new api


### How was this patch tested?
added UT