### PR TITLE
[SPARK-41207][SQL] Fix BinaryArithmetic with negative scale

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -234,7 +234,17 @@ abstract class BinaryArithmetic extends BinaryOperator
   }
 
   override def dataType: DataType = (left.dataType, right.dataType) match {
-    case (DecimalType.Fixed(p1, s1), DecimalType.Fixed(p2, s2)) =>
+    case (DecimalType.Fixed(lp, ls), DecimalType.Fixed(rp, rs)) =>
+      // compatible with negative scale
+      val (p1, s1, p2, s2) = if (ls < 0 && rs < 0) {
+        (lp - ls, 0, rp - rs, 0)
+      } else if (ls < 0) {
+        (lp - ls, 0, rp, rs)
+      } else if (rs < 0) {
+        (lp, ls, rp - rs, 0)
+      } else {
+        (lp, ls, rp, rs)
+      }
       resultDecimalType(p1, s1, p2, s2)
     case _ => left.dataType
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionSuite.scala
@@ -276,9 +276,9 @@ class DecimalPrecisionSuite extends AnalysisTest with BeforeAndAfter {
       val a = AttributeReference("a", DecimalType(3, -10))()
       val b = AttributeReference("b", DecimalType(1, -1))()
       val c = AttributeReference("c", DecimalType(35, 1))()
-      checkType(Multiply(a, b), DecimalType(5, -11))
-      checkType(Multiply(a, c), DecimalType(38, -9))
-      checkType(Multiply(b, c), DecimalType(37, 0))
+      checkType(Multiply(a, b), DecimalType(16, 0))
+      checkType(Multiply(a, c), DecimalType(38, 1))
+      checkType(Multiply(b, c), DecimalType(38, 1))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Make BinaryArithmetic result decimal type compatible with negative scale.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

BinaryArithmetic adjust presicion and scale does not respect negative scale. Some operators may return a decimal type which presicion less than scale. 

This pr fixs three things:

1. work with divide, this is a long time bug. before the error msg:
  ```
  -- 3.3
  Caused by: java.lang.AssertionError: assertion failed
    at scala.Predef$.assert(Predef.scala:208)
    at org.apache.spark.sql.types.DecimalType$.adjustPrecisionScale(DecimalType.scala:183)
    at org.apache.spark.sql.catalyst.analysis.DecimalPrecision$$anonfun$decimalAndDecimal$1.applyOrElse(DecimalPrecision.scala:145)
    at org.apache.spark.sql.catalyst.analysis.DecimalPrecision$$anonfun$decimalAndDecimal$1.applyOrElse(DecimalPrecision.scala:94)
    at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:175)
    at org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$CombinedTypeCoercionRule.$anonfun$transform$3(TypeCoercion.scala:178)
    at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
    at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
    at scala.collection.immutable.List.foldLeft(List.scala:91)
    at org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$CombinedTypeCoercionRule.$anonfun$transform$2(TypeCoercion.scala:177)
  
  -- 3.4
  Caused by: java.lang.AssertionError: assertion failed
    at scala.Predef$.assert(Predef.scala:208)
    at org.apache.spark.sql.types.DecimalType$.adjustPrecisionScale(DecimalType.scala:184)
    at org.apache.spark.sql.catalyst.expressions.Divide.resultDecimalType(arithmetic.scala:802)
    at org.apache.spark.sql.catalyst.expressions.BinaryArithmetic.dataType(arithmetic.scala:238)
    at org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$Division$$anonfun$3.applyOrElse(TypeCoercion.scala:515)
    at org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$Division$$anonfun$3.applyOrElse(TypeCoercion.scala:509)
    at org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$CombinedTypeCoercionRule.$anonfun$transform$3(TypeCoercion.scala:190)
    at scala.collection.LinearSeqOptimized.foldLeft(LinearSeqOptimized.scala:126)
    at scala.collection.LinearSeqOptimized.foldLeft$(LinearSeqOptimized.scala:122)
    at scala.collection.immutable.List.foldLeft(List.scala:91)
    at org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$CombinedTypeCoercionRule.$anonfun$transform$2(TypeCoercion.scala:189)
  ```

2. fix IntegralDivide can not work with 3.4 :
  ```
  org.apache.spark.sql.AnalysisException: Decimal scale (0) cannot be greater than precision (-4).
    at org.apache.spark.sql.errors.QueryCompilationErrors$.decimalCannotGreaterThanPrecisionError(QueryCompilationErrors.scala:2237)
    at org.apache.spark.sql.types.DecimalType.<init>(DecimalType.scala:49)
    at org.apache.spark.sql.types.DecimalType$.bounded(DecimalType.scala:164)
    at org.apache.spark.sql.catalyst.expressions.IntegralDivide.resultDecimalType(arithmetic.scala:868)
  ```

3. correct the result for some operators which do not fail. e.g. remainder if right side precision bigger than 38


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, bug fix when enable `spark.sql.legacy.allowNegativeScaleOfDecimal`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test