### PR TITLE
[SQL] Add product encoders for local classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <module>tools</module>
     <module>streaming</module>
     <module>sql/catalyst</module>
+    <module>sql/catalyst-macros</module>
     <module>sql/core</module>
     <module>sql/hive</module>
     <module>assembly</module>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -45,8 +45,11 @@ object BuildCommons {
 
   private val buildLocation = file(".").getAbsoluteFile.getParentFile
 
-  val sqlProjects@Seq(catalyst, sql, hive, hiveThriftServer, tokenProviderKafka010, sqlKafka010, avro, protobuf) = Seq(
-    "catalyst", "sql", "hive", "hive-thriftserver", "token-provider-kafka-0-10", "sql-kafka-0-10", "avro", "protobuf"
+  val sqlProjects@Seq(
+    catalyst, catalystMacros, sql, hive, hiveThriftServer, tokenProviderKafka010, sqlKafka010, avro, protobuf
+  ) = Seq(
+    "catalyst", "catalyst-macros", "sql", "hive", "hive-thriftserver", "token-provider-kafka-0-10", "sql-kafka-0-10",
+    "avro", "protobuf"
   ).map(ProjectRef(buildLocation, _))
 
   val streamingProjects@Seq(streaming, streamingKafka010) =
@@ -390,7 +393,7 @@ object SparkBuild extends PomBuild {
   val mimaProjects = allProjects.filterNot { x =>
     Seq(
       spark, hive, hiveThriftServer, repl, networkCommon, networkShuffle, networkYarn,
-      unsafe, tags, tokenProviderKafka010, sqlKafka010, connect, protobuf
+      unsafe, tags, tokenProviderKafka010, sqlKafka010, connect, protobuf, catalystMacros
     ).contains(x)
   }
 

--- a/sql/catalyst-macros/pom.xml
+++ b/sql/catalyst-macros/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-parent_2.12</artifactId>
+        <version>3.4.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spark-catalyst-macros_2.12</artifactId>
+    <packaging>jar</packaging>
+    <name>Spark Project Catalyst Macros</name>
+    <url>https://spark.apache.org/</url>
+    <properties>
+        <sbt.project.name>catalyst-macros</sbt.project.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/DeepClassTagMacros.scala
+++ b/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/DeepClassTagMacros.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.macros
+
+import scala.reflect.macros.whitebox
+
+/**
+ * Macro implementation for type class [[DeepClassTag]].
+ *
+ * @since 3.4.0
+ */
+class DeepClassTagMacros(val c: whitebox.Context) {
+  import c.universe._
+
+  implicit class ModifiersOps(left: Modifiers) {
+    def &(right: FlagSet): Modifiers = left match {
+      case Modifiers(flags, privateWithin, annots) =>
+        Modifiers(flags & right, privateWithin, annots)
+    }
+  }
+
+  implicit class FlagSetOps(left: FlagSet) {
+    def &(right: FlagSet): FlagSet =
+      (left.asInstanceOf[Long] & right.asInstanceOf[Long]).asInstanceOf[FlagSet]
+    def unary_~ : FlagSet = (~left.asInstanceOf[Long]).asInstanceOf[FlagSet]
+  }
+
+  def removeDeferred(tree: TypeDef): TypeDef = tree match {
+    case q"$mods type $tpname[..$tparams] = $tpt" =>
+      q"${mods & ~Flag.DEFERRED} type $tpname[..$tparams] = $tpt"
+  }
+
+  def mkExistentialTypeTree(tpe: Type): Tree = {
+    def mkTargs0(count: Int): Seq[TypeName] =
+      (0 until count).map(i => TypeName(c.freshName(s"targ$i")))
+    def mkTargs(symb: Symbol): Seq[TypeName] = mkTargs0(typeParams(symb).length)
+    def typeParams(symb: Symbol): Seq[Symbol] = symb.typeSignature.typeParams
+
+    val typeSymbol = tpe.typeSymbol
+    val targs = mkTargs(typeSymbol)
+    val tparams = typeParams(typeSymbol)
+    val targDefs: Seq[Tree] = tparams.zip(targs).map { case (tparam, targ) =>
+      val targParamDefs: Seq[TypeDef] =
+        mkTargs(tparam).map(targ => removeDeferred(q"type $targ"))
+      q"type $targ[..$targParamDefs]"
+    }
+    tq"${tpe.typeSymbol}[..$targs] forSome { ..$targDefs }"
+  }
+
+  val catalyst = q"_root_.org.apache.spark.sql.catalyst"
+  val ClassTagApplication = tq"$catalyst.ClassTagApplication"
+  val scalaT = q"_root_.scala"
+
+  def mkApplication(tpe: Type): Tree = {
+    val dealiased = tpe.dealias
+    val existentialTpeTree = mkExistentialTypeTree(dealiased)
+    val tpeCtag = q"$scalaT.reflect.classTag[$existentialTpeTree]"
+    val targCtags = dealiased.typeArgs.map(mkApplication)
+    q"new $ClassTagApplication($tpeCtag, $scalaT.List.apply[$ClassTagApplication](..$targCtags))"
+  }
+
+  def mkDeepClassTagImpl[T: WeakTypeTag]: Tree = {
+    val T = weakTypeOf[T]
+    q"new $catalyst.DeepClassTag[$T](${mkApplication(T)})"
+  }
+}

--- a/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/DeepDealiaserMacros.scala
+++ b/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/DeepDealiaserMacros.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.macros
+
+import scala.reflect.macros.blackbox
+
+/**
+ * Macro implementation for [[DeepDealiaser]].
+ *
+ * @since 3.4.0
+ */
+class DeepDealiaserMacros(val c: blackbox.Context) extends StandardTrees {
+  import c.universe._
+
+  def dealiasStaticTypeImpl[T: WeakTypeTag]: Tree = {
+    val dealiased = dealiasDynamicType(weakTypeOf[T])
+    toRuntime(dealiased)
+  }
+
+  def dealiasDynamicType(tpe: Type): Type = {
+    val dealiased = tpe.dealias
+    val newTycon = dealiased.typeConstructor
+    val newTargs = dealiased.typeArgs.map(dealiasDynamicType)
+    appliedType(newTycon, newTargs)
+  }
+
+  def toRuntime(tpe: Type): Tree = q"$ru.weakTypeOf[$tpe]"
+}

--- a/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/ExpressionEncoderMacros.scala
+++ b/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/ExpressionEncoderMacros.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.macros
+
+import scala.reflect.macros.blackbox
+
+/**
+ * Macro implementation for [[ExpressionEncoder]] of local classes.
+ *
+ * @since 3.4.0
+ */
+class ExpressionEncoderMacros(val c: blackbox.Context) extends StandardTrees {
+  import c.universe._
+
+  def localImpl[T: WeakTypeTag]()(classTag: Tree, deepClassTag: Tree): Tree = {
+    val T = weakTypeOf[T]
+    val tpe = q"$LocalTypeImprover.improveStaticType[$T]($deepClassTag)"
+    val serializer = q"$ScalaReflection.serializerForType($tpe)"
+    val deserializer = q"$ScalaReflection.deserializerForType($tpe)"
+    q"new $ExpressionEncoder[$T]($serializer, $deserializer, $classTag)"
+  }
+}

--- a/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/LocalTypeImproverMacros.scala
+++ b/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/LocalTypeImproverMacros.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.macros
+
+import scala.reflect.macros.blackbox
+
+/**
+ * Macro implementation for [[LocalTypeImprover]].
+ *
+ * @since 3.4.0
+ */
+class LocalTypeImproverMacros(val c: blackbox.Context) extends StandardTrees {
+  import c.universe._
+
+  def improveStaticTypeImpl[T: WeakTypeTag](deepClassTag: Tree): Tree =
+    q"""$LocalTypeImprover.improveDynamicType(
+      $DeepDealiaser.dealiasStaticType[${weakTypeOf[T]}],
+      $deepClassTag.classTags
+    )"""
+}

--- a/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/StandardTrees.scala
+++ b/sql/catalyst-macros/src/main/scala/org/apache/spark/sql/catalyst/macros/StandardTrees.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.macros
+
+import scala.reflect.macros.blackbox
+
+/**
+ * A convenience trait to mix-in for macros.
+ *
+ * @since 3.4.0
+ */
+trait StandardTrees {
+  val c: blackbox.Context
+  import c.universe._
+
+  lazy val catalyst = q"$rootT.org.apache.spark.sql.catalyst"
+  lazy val ClassTagApplication = tq"$catalyst.ClassTagApplication"
+  lazy val DeepClassTag = tq"$catalyst.DeepClassTag"
+  lazy val DeepDealiaser = q"$catalyst.DeepDealiaser"
+  lazy val ExpressionEncoder = tq"$catalyst.encoders.ExpressionEncoder"
+  lazy val ListT = q"$scalaT.`package`.List"
+  lazy val LocalTypeImprover = q"$catalyst.LocalTypeImprover"
+  lazy val reflectT = q"$scalaT.reflect"
+  lazy val rootT = q"_root_"
+  lazy val ru = q"$scalaT.reflect.runtime.`package`.universe"
+  lazy val scalaT = q"$rootT.scala"
+  lazy val ScalaReflection = q"$catalyst.ScalaReflection"
+}

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -53,7 +53,6 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst-macros_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -51,6 +51,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-catalyst-macros_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -309,7 +309,7 @@ object Encoders {
   def product[T <: Product : TypeTag]: Encoder[T] = ExpressionEncoder()
 
   /**
-   * An encoder for Scala's local product type (local case classes, etc).
+   * An encoder for Scala's local product type (local case classes, their type aliases, etc).
    * @since 3.4.0
    */
   def localProduct[T <: Product : WeakTypeTag : ClassTag : DeepClassTag]: Encoder[T] =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/Encoders.scala
@@ -20,8 +20,9 @@ package org.apache.spark.sql
 import java.lang.reflect.Modifier
 
 import scala.reflect.{classTag, ClassTag}
-import scala.reflect.runtime.universe.TypeTag
+import scala.reflect.runtime.universe.{TypeTag, WeakTypeTag}
 
+import org.apache.spark.sql.catalyst.DeepClassTag
 import org.apache.spark.sql.catalyst.analysis.GetColumnByOrdinal
 import org.apache.spark.sql.catalyst.encoders.{encoderFor, ExpressionEncoder}
 import org.apache.spark.sql.catalyst.expressions.{BoundReference, Cast}
@@ -306,6 +307,13 @@ object Encoders {
    * @since 2.0.0
    */
   def product[T <: Product : TypeTag]: Encoder[T] = ExpressionEncoder()
+
+  /**
+   * An encoder for Scala's local product type (local case classes, etc).
+   * @since 3.4.0
+   */
+  def localProduct[T <: Product : WeakTypeTag : ClassTag : DeepClassTag]: Encoder[T] =
+    ExpressionEncoder.local()
 
   /**
    * An encoder for Scala's primitive int type.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/LocalTypeImprover.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/LocalTypeImprover.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import scala.annotation.implicitNotFound
+import scala.reflect.ClassTag
+
+import ScalaReflection.universe.{appliedType, internal, weakTypeOf, Type, WeakTypeTag}
+import macros.DeepClassTagMacros
+
+case class ClassTagApplication(tycon: ClassTag[_], targs: List[ClassTagApplication])
+
+/**
+ * A type class generalizing `ClassTag`. It recursively attaches `ClassTag`s to type arguments,
+ * their type arguments, etc.
+ *
+ * @since 3.4.0
+ */
+@implicitNotFound("Must be classes: ${T}, its type arguments, their type arguments, etc.")
+class DeepClassTag[T](val classTags: ClassTagApplication)
+
+object DeepClassTag {
+  def apply[T: DeepClassTag]: DeepClassTag[T] = implicitly[DeepClassTag[T]]
+
+  import scala.language.experimental.macros
+  implicit def mkDeepClassTag[T]: DeepClassTag[T] = macro DeepClassTagMacros.mkDeepClassTagImpl[T]
+}
+
+/**
+ * Transforms a type having `WeakTypeTag` but not having `TypeTag` (i.e. Scala free type, type of
+ * local case class, etc) into the one having `TypeTag` using `ClassTag`.
+ *
+ * E.g. it transforms `TypeRef(NoPrefix, TypeName("Local"), List())` into
+ * `TypeRef(NoPrefix, TypeName("$Local$1"), List())` for local (method-inner) class `Local`.
+ *
+ * Handles type arguments recursively.
+ *
+ * In runtime reflection, dealiasing seems not to work for local type aliases.
+ *
+ * @since 3.4.0
+ */
+object LocalTypeImprover {
+  def improveStaticType[T: WeakTypeTag : DeepClassTag]: Type =
+    improveDynamicType(weakTypeOf[T], DeepClassTag[T].classTags)
+
+  def improveDynamicType(tpe: Type, classTags: ClassTagApplication): Type = {
+    val newTycon = improveFreeType(tpe, classTags.tycon.runtimeClass)
+    val targs = tpe.dealias.typeArgs
+    assert(
+      targs.length == classTags.targs.length,
+      s"( $targs ).length == ( ${classTags.targs} ).length"
+    )
+    val newArgs = targs.zip(classTags.targs).map((improveDynamicType _).tupled)
+    appliedType(newTycon, newArgs)
+  }
+
+  def improveFreeType(tpe: Type, cls: Class[_]): Type =
+    if (internal.isFreeType(tpe.typeSymbol)) {
+      val typeArgs = tpe.dealias.typeArgs
+      val typeConstructor = ScalaReflection.mirror.classSymbol(cls).toType.typeConstructor
+      appliedType(typeConstructor, typeArgs)
+    } else tpe
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -603,8 +603,13 @@ object ScalaReflection extends ScalaReflection {
           // is necessary here. Because for a nullable nested inputObject with struct data
           // type, e.g. StructType(IntegerType, StringType), it will return nullable=true
           // for IntegerType without KnownNotNull. And that's what we do not expect to.
-          val fieldValue = Invoke(KnownNotNull(inputObject), fieldName, dataTypeFor(fieldType),
-            returnNullable = !fieldType.typeSymbol.asClass.isPrimitive)
+          val fieldValue = if (getClassFromType(tpe).isLocalClass && fieldName == "$outer") {
+            PrivateFieldInvoke(KnownNotNull(inputObject), fieldName, dataTypeFor(fieldType),
+              returnNullable = !fieldType.typeSymbol.asClass.isPrimitive)
+          } else {
+            Invoke(KnownNotNull(inputObject), fieldName, dataTypeFor(fieldType),
+              returnNullable = !fieldType.typeSymbol.asClass.isPrimitive)
+          }
           val clsName = getClassNameFromType(fieldType)
           val newPath = walkedTypePath.recordField(clsName, fieldName)
           (fieldName, serializerFor(fieldValue, fieldType, newPath, seenTypeSet + t))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -423,7 +423,13 @@ case class PrivateFieldInvoke(
 
     val assignResult0 = s"${ev.value} = (${CodeGenerator.boxedType(javaType)}) $fieldResult;"
 
-    val assignResult = if (returnPrimitive || returnNullable) {
+    val assignResult = if (returnPrimitive) {
+      s"""
+         |if ($fieldResult != null) {
+         |  $assignResult0
+         |}
+         |""".stripMargin
+    } else if (returnNullable) {
       s"""
          |if ($fieldResult != null) {
          |  $assignResult0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -346,7 +346,9 @@ case class StaticInvoke(
 
 /**
  * Calls the specified field (possibly, private) on an object. Used for the `$outer` field of a
- * local class. If the `targetObject` expression evaluates to null then null will be returned.
+ * local class.
+ *
+ * If the `targetObject` expression evaluates to null then null will be returned.
  *
  * In some cases, due to erasure, the schema may expect a primitive type when in fact the method
  * is returning java.lang.Object.  In this case, we will generate code that attempts to unbox the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -453,6 +453,9 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       s"""A method named "$name" is not declared in any enclosing class nor any supertype""")
   }
 
+  def fieldNotDeclaredError(name: String): Throwable =
+    SparkException.internalError(s"""A field named "$name" is not declared""")
+
   def constructorNotFoundError(cls: String): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "_LEGACY_ERROR_TEMP_2020",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/BoundedDeepClassTagSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/BoundedDeepClassTagSuite.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import scala.language.higherKinds
+import scala.reflect.classTag
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class BoundedDeepClassTagSuite extends AnyFunSuite {
+  class A[b[c[d >: DLo <: DHi,
+              d1 >: DLo <: DHi,
+              d2 >: DLo <: DHi
+             ] >: CLo[d, d1, d2] <: CHi[d, d1, d2],
+            c1[d >: DLo <: DHi,
+               d1 >: DLo <: DHi,
+               d2 >: DLo <: DHi
+              ] >: CLo[d, d1, d2] <: CHi[d, d1, d2]
+           ] >: BLo[c, c1] <: BHi[c, c1]]
+  class BHi[c[d >: DLo <: DHi,
+              d1 >: DLo <: DHi,
+              d2 >: DLo <: DHi
+             ] >: CLo[d, d1, d2] <: CHi[d, d1, d2],
+            c1[d >: DLo <: DHi,
+               d1 >: DLo <: DHi,
+               d2 >: DLo <: DHi
+              ] >: CLo[d, d1, d2] <: CHi[d, d1, d2]
+           ]
+  class B[c[d >: DLo <: DHi,
+            d1 >: DLo <: DHi,
+            d2 >: DLo <: DHi
+           ] >: CLo[d, d1, d2] <: CHi[d, d1, d2],
+          c1[d >: DLo <: DHi,
+             d1 >: DLo <: DHi,
+             d2 >: DLo <: DHi
+            ] >: CLo[d, d1, d2] <: CHi[d, d1, d2]
+         ] extends BHi[c, c1]
+  class BLo[c[d >: DLo <: DHi,
+              d1 >: DLo <: DHi,
+              d2 >: DLo <: DHi
+             ] >: CLo[d, d1, d2] <: CHi[d, d1, d2],
+            c1[d >: DLo <: DHi,
+               d1 >: DLo <: DHi,
+               d2 >: DLo <: DHi
+              ] >: CLo[d, d1, d2] <: CHi[d, d1, d2]
+           ] extends B[c, c1]
+  class CHi[d >: DLo <: DHi, d1 >: DLo <: DHi, d2 >: DLo <: DHi]
+  class C[d >: DLo <: DHi, d1 >: DLo <: DHi, d2 >: DLo <: DHi] extends CHi[d, d1, d2]
+  class CLo[d >: DLo <: DHi, d1 >: DLo <: DHi, d2 >: DLo <: DHi] extends C[d, d1, d2]
+  class DHi
+  class D extends DHi
+  class DLo extends D
+
+  type AB = A[B]
+  type BC = B[C, C]
+  type CD = C[D, D, D]
+
+  // scalastyle:off
+  type AExist = A[b] forSome { type b[_[_, _, _], _[_, _, _]] }
+  type BExist = B[c, c1] forSome {type c[_, _, _]; type c1[_, _, _]}
+  // scalastyle:on
+  type CExist = C[_, _, _]
+
+  val aCtag = classTag[AExist]
+  val bCtag = classTag[BExist]
+  val cCtag = classTag[CExist]
+  val dCtag = classTag[D]
+
+  val bApp = ClassTagApplication(bCtag, Nil)
+  val cApp = ClassTagApplication(cCtag, Nil)
+  val dApp = ClassTagApplication(dCtag, Nil)
+
+  test("bounded DeepClassTag, kind 3") {
+    assert(DeepClassTag[AB].classTags ==
+      ClassTagApplication(aCtag, List(bApp))
+    )
+  }
+
+  test("bounded DeepClassTag, kind 2") {
+    assert(DeepClassTag[BC].classTags ==
+      ClassTagApplication(bCtag, List(cApp, cApp))
+    )
+  }
+
+  test("bounded DeepClassTag, kind 1") {
+    assert(DeepClassTag[CD].classTags ==
+      ClassTagApplication(cCtag, List(dApp, dApp, dApp))
+    )
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DeepClassTagSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DeepClassTagSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import scala.language.higherKinds
+import scala.reflect.classTag
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class DeepClassTagSuite extends AnyFunSuite {
+  class A[b[_[_, _, _], _[_, _, _]]]
+  class B[c[_, _, _], c1[_, _, _]]
+  class C[d, d1, d2]
+  class D
+
+  type AB = A[B]
+  type BC = B[C, C]
+  type CD = C[D, D, D]
+
+  // otherwise: avoid using structural types, Scalastyle confuses existential with structural types?
+  // scalastyle:off
+  type AExist = A[b] forSome { type b[_[_, _, _], _[_, _, _]] }
+  type BExist = B[c, c1] forSome {type c[_, _, _]; type c1[_, _, _]}
+  // scalastyle:on
+  type CExist = C[_, _, _]
+
+  val aCtag = classTag[AExist]
+  val bCtag = classTag[BExist]
+  val cCtag = classTag[CExist]
+  val dCtag = classTag[D]
+
+  val bApp = ClassTagApplication(bCtag, Nil)
+  val cApp = ClassTagApplication(cCtag, Nil)
+  val dApp = ClassTagApplication(dCtag, Nil)
+
+  test("DeepClassTag, kind 3") {
+    assert(DeepClassTag[AB].classTags ==
+      ClassTagApplication(aCtag, List(bApp))
+    )
+  }
+
+  test("DeepClassTag, kind 2") {
+    assert(DeepClassTag[BC].classTags ==
+      ClassTagApplication(bCtag, List(cApp, cApp))
+    )
+  }
+
+  test("DeepClassTag, kind 1") {
+    assert(DeepClassTag[CD].classTags ==
+      ClassTagApplication(cCtag, List(dApp, dApp, dApp))
+    )
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DeepDealiaserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DeepDealiaserSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import scala.reflect.runtime.universe.{typeOf, NoPrefix, TypeRef}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class DeepDealiaserSuite extends AnyFunSuite {
+  class Inner
+  type InnerAlias = Inner
+
+  test("deep dealias of inner class") {
+    assert(DeepDealiaser.dealiasStaticType[InnerAlias] =:= typeOf[Inner])
+  }
+
+  class GenericInner[T]
+  type IntGenInnerAlias = GenericInner[Int]
+  type GenGenInnerAlias = GenericInner[IntGenInnerAlias]
+
+  test("deep dealias of generic inner class") {
+    assert(DeepDealiaser.dealiasStaticType[IntGenInnerAlias] =:= typeOf[GenericInner[Int]])
+  }
+
+  test("deep dealias of generic nested class with inner type argument") {
+    assert(DeepDealiaser.dealiasStaticType[GenGenInnerAlias] =:=
+      typeOf[GenericInner[GenericInner[Int]]])
+  }
+
+  test("deep dealias of local class") {
+    class Local
+    type LocalAlias = Local
+
+    // a workaround because:
+    //   weakTypeOf[Local] =:!= weakTypeOf[Local],
+    //   symbolOf[Local] != symbolOf[Local]
+    DeepDealiaser.dealiasStaticType[LocalAlias] match {
+      case tr: TypeRef @unchecked =>
+        assert(tr.pre =:= NoPrefix &&
+          tr.sym.fullName == "<none>.Local")
+    }
+  }
+
+  test("deep dealias of generic local class") {
+    class GenericLocal[T]
+    type IntGenLocalAlias = GenericLocal[Int]
+    type GenGenLocalAlias = GenericLocal[IntGenLocalAlias]
+
+    DeepDealiaser.dealiasStaticType[IntGenLocalAlias] match {
+      case tr: TypeRef @unchecked =>
+        assert(tr.pre =:= NoPrefix &&
+          tr.sym.fullName == "<none>.GenericLocal" &&
+          tr.args == List(typeOf[Int]), "generic local class")
+    }
+
+    DeepDealiaser.dealiasStaticType[GenGenLocalAlias] match {
+      case tr: TypeRef @unchecked =>
+        assert(tr.pre =:= NoPrefix &&
+          tr.sym.fullName == "<none>.GenericLocal" &&
+          tr.args.collect {case tr: TypeRef @unchecked =>
+            (tr.pre, tr.sym.fullName, tr.args)
+          } == List((NoPrefix, "<none>.GenericLocal", List(typeOf[Int]))),
+          "generic local class with local type argument")
+    }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/LocalTypeImproverSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/LocalTypeImproverSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+import scala.reflect.runtime.universe.showRaw
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class LocalTypeImproverSuite extends AnyFunSuite {
+  test("LocalTypeImprover") {
+    case class Local()
+
+    val clsName = getClass.getName
+    val newName = """"$Local$1""""
+
+    assert(showRaw(
+      LocalTypeImprover.improveStaticType[Local]
+    ) == s"TypeRef(ThisType($clsName), TypeName($newName), List())")
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -283,34 +283,14 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
       type BoolGenLocal = GenericLocal[Boolean]
       type GenGenLocal = GenericLocal[GenericLocal[Boolean]]
 
-      val m = intercept[AssertionError] {
-        encodeDecodeTest(
-          GenericLocal[Boolean](1, "a", true),
-          "ignored")(ExpressionEncoder.local[BoolGenLocal]()
-        )
-      }.getMessage
-      test("alias for generic local class") {
-        assert(m.contains(
-          "( List() ).length == ( List(ClassTagApplication(Boolean,List())) ).length"
-        ))
-      }
+      encodeDecodeTest(
+        GenericLocal[Boolean](1, "a", true),
+        "alias for generic local class")(ExpressionEncoder.local[BoolGenLocal]())
 
-      val m1 = intercept[AssertionError] {
-        encodeDecodeTest(
-          GenericLocal[BoolGenLocal](1, "a", GenericLocal(2, "b", true)),
-          "ignored")(
-          ExpressionEncoder.local[GenGenLocal]()
-        )
-      }.getMessage
-      test("alias for generic local class with local type argument") {
-        assert(
-          Seq(
-            "( List() ).length == ( List(ClassTagApplication(org.apache.spark.sql.catalyst" +
-              ".encoders.ExpressionEncoderSuite$SerializableOuter$GenericLocal$",
-            ",List(ClassTagApplication(Boolean,List())))) ).length"
-          ).forall(m1.contains)
-        )
-      }
+      encodeDecodeTest(
+        GenericLocal[BoolGenLocal](1, "a", GenericLocal(2, "b", true)),
+        "alias for generic local class with local type argument")(
+        ExpressionEncoder.local[GenGenLocal]())
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -41,6 +41,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 class InvokeTargetClass extends Serializable {
+  private val privatePrimitiveField: Int = 1
+  private val privateField: Integer = 1
+  private val privateNullField: Integer = null
   def filterInt(e: Any): Any = e.asInstanceOf[Int] > 0
   def filterPrimitiveInt(e: Int): Boolean = e > 0
   def binOp(e1: Int, e2: Double): Double = e1 + e2
@@ -178,6 +181,18 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val inputInt = Seq(BoundReference(0, ObjectType(classOf[Any]), true))
     val inputPrimitiveInt = Seq(BoundReference(0, IntegerType, false))
     val inputSum = Seq(BoundReference(0, IntegerType, false), BoundReference(1, DoubleType, false))
+
+    checkObjectExprEvaluation(
+      PrivateFieldInvoke(funcObj, "privatePrimitiveField", IntegerType, false),
+      1, InternalRow.fromSeq(Seq()))
+
+    checkObjectExprEvaluation(
+      PrivateFieldInvoke(funcObj, "privateField", IntegerType, false),
+      Integer.valueOf(1), InternalRow.fromSeq(Seq()))
+
+    checkObjectExprEvaluation(
+      PrivateFieldInvoke(funcObj, "privateNullField", IntegerType, true),
+      null, InternalRow.fromSeq(Seq()))
 
     checkObjectExprEvaluation(
       Invoke(funcObj, "filterInt", ObjectType(classOf[Any]), inputInt),

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -268,13 +268,12 @@ trait LowPrioritySQLImplicits extends LowerPrioritySQLImplicits {
 }
 
 /**
- * Lower priority implicit methods for converting objects of local classes into [[Dataset]]s.
+ * Lower priority implicit methods for converting objects of local classes (not having `TypeTag`)
+ * into [[Dataset]]s.
  * Conflicting implicits are placed here to disambiguate resolution.
  *
  * Reasons for including specific implicits:
  * newLocalProductEncoder - to disambiguate for `T`s which have both `TypeTag` and `WeakTypeTag`.
- *
- * Doesn't work for type aliases of local classes.
  */
 trait LowerPrioritySQLImplicits {
   /** @since 3.4.0 */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
It is proposed to add product `Dataset` encoders for local (method-inner) classes. Already existing encoders are for top-level and inner classes.

In Scala free types including local classes do not have `TypeTag`s (which the existing encoders and Spark `ScalaReflection` in general are based on). New encoders use new runtime-reflection component `LocalTypeImprover` transforming a type having `WeakTypeTag` but not having `TypeTag` into the one having `TypeTag` based on the corresponding `ClassTag` (e.g. it transforms `TypeRef(NoPrefix, TypeName("Local"), List())` into `TypeRef(NoPrefix, TypeName("$Local$1"), List())` for a local class `Local`).

<strike>Sadly, this will not always work with type aliases of local classes because Scala runtime reflection [not always](https://gist.github.com/DmytroMitin/51b3978fafe79957c2649ab114c74f9b) supports dealiasing (`.dealias`) such kind of type aliases (on contrary to aliases for top-level/inner classes and on contrary to compile-time reflection). This is a limitation of Scala runtime reflection. (For example see that aliases do not work in [tests](https://github.com/apache/spark/pull/38740/files#diff-777864577010260134ae949c0c65db65b6d4ae562f29cffe47a3d1420e4dd090R255-R286) but do work [here](https://gist.github.com/DmytroMitin/56044515e031fcf1e977ab213013861d).)</strike> _I moved dealiasing from runtime to compile time (introducing `DeepDealiaser` component) and now encoders work even for type aliases of local classes._

Since such type improvement should be applied to a type and its type arguments recursively, new macro-implemented type class `DeepClassTag` is introduced. 

Since for a local class nested into an outer class (not object) the link to the outer class is saved in a private field `$outer` (corresponding to the 1st argument of the local-class primary constructor), for encoding, a new expression type `PrivateFieldInvoke` is proposed similarly to existing `Invoke` and `StaticInvoke`. For decoding, existing expression type `NewInstance` is enough. For inner classes `$outer` is handled transparently by Scala reflection but for local classes Java reflection and manual handling seems the only option. For a local class nested into an outer object, `Invoke`/`NewInstance` are enough.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This would unify existing functionality (contribute to its consistency) and improve user experience.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
With this change the code
```scala
def run = {
  case class Local(id: Int, name: String)

  spark.read
    .json("file.json")
    .as[Local]
    .show()
}
```
will produce
```
+---+----+
| id|name|
+---+----+
|  0| aaa|
|  1| bbb|
|  2| ccc|
+---+----+
```
similarly to already working code
```scala
case class Inner(id: Int, name: String)

def run = {
  spark.read
    .json("file.json")
    .as[Inner]
    .show()
}
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New tests.

---

Motivated by the discussion in https://stackoverflow.com/questions/74362186/why-is-the-spark-implicits-import-not-helping-with-encoder-derivation-inside-a
