### PR TITLE
[SPARK-40809][CONNECT][PYTHON][TESTS] Fix pyspark-connect test failed with Scala 2.13

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -387,7 +387,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
         with self.assertRaises(grpc.RpcError) as exc:
             self.connect.range(1, 10).select(col("id").alias("this", "is", "not")).collect()
-        self.assertIn("Buffer(this, is, not)", str(exc.exception))
+        self.assertIn("(this, is, not)", str(exc.exception))
 
 
 class ChannelBuilderTests(ReusedPySparkTestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr simplify assertions to fix `pyspark-connect` test failed with Scala 2.13.




### Why are the changes needed?
Fix Scala 2.13 daily test:

- https://github.com/apache/spark/actions/runs/3517345801/jobs/5895043640

```
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/sql/tests/connect/test_connect_basic.py", line 337, in test_alias
    self.assertIn("Buffer(this, is, not)", str(exc.exception))
AssertionError: 'Buffer(this, is, not)' not found in '<_MultiThreadedRendezvous of RPC that terminated with:\n\tstatus = StatusCode.UNKNOWN\n\tdetails = "[INTERNAL_ERROR] Found the unresolved operator: \'Project [id#24L AS List(this, is, not)]"\n\tdebug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:15002 {created_time:"2022-11-21T19:25:59.902777537+00:00", grpc_status:2, grpc_message:"[INTERNAL_ERROR] Found the unresolved operator: \\\'Project [id#24L AS List(this, is, not)]"}"\n>'
```

The error message with Scala 2.13 contains `List(this, is, not)` instead of `ArrayBuffer(this, is, not)`.

### Does this PR introduce _any_ user-facing change?
No, just for test


### How was this patch tested?
Pass GitHub Actions