### PR TITLE
[SPARK-41220][SQL] Range partitioner sample supports column pruning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -448,6 +448,9 @@ case class RangePartitioning(
   override def createShuffleSpec(distribution: ClusteredDistribution): ShuffleSpec =
     RangeShuffleSpec(this.numPartitions, distribution)
 
+  override lazy val canonicalized: Expression =
+    RangePartitioning(ordering.map(_.canonicalized.asInstanceOf[SortOrder]), numPartitions)
+
   override protected def stringArgs: Iterator[Any] = Iterator(ordering, numPartitions)
 
   override protected def withNewChildrenInternal(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -435,6 +435,13 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val OPTIMIZE_SAMPLE_FOR_RANGE_PARTITION_ENABLED =
+    buildConf("spark.sql.optimizer.optimizeSampleForRangePartition.enabled")
+      .doc("When set to true, Spark would try to optimize sample plan for range partitioning.")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val COMPRESS_CACHED = buildConf("spark.sql.inMemoryColumnarStorage.compressed")
     .doc("When set to true Spark SQL will automatically select a compression codec for each " +
       "column based on statistics of the data.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.adaptive.{AdaptiveExecutionContext, InsertAdaptiveSparkPlan}
 import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableUnnecessaryBucketedScan}
 import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
-import org.apache.spark.sql.execution.exchange.EnsureRequirements
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, OptimizeSampleForRangePartitioning}
 import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
 import org.apache.spark.sql.execution.streaming.{IncrementalExecution, OffsetSeqMetadata}
 import org.apache.spark.sql.internal.SQLConf
@@ -428,6 +428,7 @@ object QueryExecution {
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,
       EnsureRequirements(),
+      OptimizeSampleForRangePartitioning,
       // `ReplaceHashWithSortAgg` needs to be added after `EnsureRequirements` to guarantee the
       // sort order of each node is checked to be valid.
       ReplaceHashWithSortAgg,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -183,7 +183,9 @@ case class AdaptiveSparkPlanExec(
 
   @transient val initialPlan = context.session.withActive {
     applyPhysicalRules(
-      inputPlan, queryStagePreparationRules, Some((planChangeLogger, "AQE Preparations")))
+      inputPlan,
+      queryStagePreparationRules ++ Seq(OptimizeSampleForRangePartitioning),
+      Some((planChangeLogger, "AQE Preparations")))
   }
 
   @volatile private var currentPhysicalPlan = initialPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/OptimizeSampleForRangePartitioning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/OptimizeSampleForRangePartitioning.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.exchange
+
+import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.plans.physical.RangePartitioning
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * [[RangePartitioning]] would do sample for range bounds. By default, the plan for sample is same
+ * with the plan for shuffle.
+ * The rule decouples the plan for shuffle and for sample. Ideally the plan for sample depends on
+ * the sort orders expression, so it can be optimized to prune unnecessary columns.
+ *
+ * Note, this rule would not optimize the plan which contains multi shuffle exchanges.
+ */
+object OptimizeSampleForRangePartitioning extends Rule[SparkPlan] {
+
+  private def hasBenefit(plan: SparkPlan): Boolean = {
+    if (conf.getConf(SQLConf.OPTIMIZE_SAMPLE_FOR_RANGE_PARTITION_ENABLED)) {
+      var numRangePartitioning = 0
+      var numShuffleWithoutGlobalSort = 0
+      plan.foreach {
+        case ShuffleExchangeExec(r: RangePartitioning, child, _) if child.logicalLink.isDefined &&
+          r.ordering.flatMap(_.references).size < child.outputSet.size =>
+          numRangePartitioning += 1
+        case _: ShuffleExchangeExec => numShuffleWithoutGlobalSort += 1
+        case _ =>
+      }
+      numRangePartitioning == 1 && numShuffleWithoutGlobalSort == 0
+    } else {
+      false
+    }
+  }
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!hasBenefit(plan)) {
+      return plan
+    }
+
+    plan.transform {
+      case shuffle @ ShuffleExchangeExec(r: RangePartitioning, child, _) =>
+        val planForSample = child.logicalLink.map { p =>
+          val named = r.ordering.zipWithIndex.map { case (order, i) =>
+            Alias(order.child, s"_sort_$i")()
+          }
+          Project(named, p.clone())
+        }
+
+        val rangePartitioningWithSample = r.copy(planForSample = planForSample)
+        shuffle.copy(outputPartitioning = rangePartitioningWithSample)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/OptimizeSampleForRangePartitioning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/OptimizeSampleForRangePartitioning.scala
@@ -40,6 +40,7 @@ object OptimizeSampleForRangePartitioning extends Rule[SparkPlan] {
       var numShuffleWithoutGlobalSort = 0
       plan.foreach {
         case ShuffleExchangeExec(r: RangePartitioning, child, _) if child.logicalLink.isDefined &&
+          !child.logicalLink.get.isStreaming &&
           r.ordering.flatMap(_.references).size < child.outputSet.size =>
           numRangePartitioning += 1
         case _: ShuffleExchangeExec => numShuffleWithoutGlobalSort += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{ShuffleWriteMetricsReporter, ShuffleWriteProcessor}
 import org.apache.spark.shuffle.sort.SortShuffleManager
-import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BoundReference, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.LazilyGeneratedOrdering
@@ -290,8 +290,8 @@ object ShuffleExchangeExec {
           // re-optimize sample plan
           // this new query execution for sample is still a part of the original plan
           // so we do not need to assign a new execution id.
-          Dataset.ofRows(SparkSession.getActiveSession.orNull, sample)
-            .queryExecution.executedPlan.execute().mapPartitionsInternal { iter =>
+          QueryExecution.prepareExecutedPlan(SparkSession.getActiveSession.orNull, sample)
+            .execute().mapPartitionsInternal { iter =>
             val mutablePair = new MutablePair[InternalRow, Null]()
             // Internally, RangePartitioner runs a job on the RDD that samples keys to compute
             // partition bounds. To get accurate samples, we need to copy the mutable keys.

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DistributionAndOrderingSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DistributionAndOrderingSuiteBase.scala
@@ -56,7 +56,7 @@ abstract class DistributionAndOrderingSuiteBase
         partitionValues)
     case PartitioningCollection(partitionings) =>
       PartitioningCollection(partitionings.map(resolvePartitioning(_, plan)))
-    case RangePartitioning(ordering, numPartitions) =>
+    case RangePartitioning(ordering, numPartitions, _) =>
       RangePartitioning(ordering.map(resolveAttrs(_, plan).asInstanceOf[SortOrder]), numPartitions)
     case p @ SinglePartition =>
       p

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -993,7 +993,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
 
       val projects = collect(planned) { case p: ProjectExec => p }
       assert(projects.exists(_.outputPartitioning match {
-        case RangePartitioning(Seq(SortOrder(ar: AttributeReference, _, _, _)), _) =>
+        case RangePartitioning(Seq(SortOrder(ar: AttributeReference, _, _, _)), _, _) =>
           ar.name == "id1"
         case _ => false
       }))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/OptimizeSampleForRangePartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/OptimizeSampleForRangePartitioningSuite.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.exchange
+
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.catalyst.plans.physical.RangePartitioning
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+
+class OptimizeSampleForRangePartitioningSuite
+  extends QueryTest with SharedSparkSession with AdaptiveSparkPlanHelper {
+
+  protected override def beforeAll(): Unit = {
+    super.beforeAll()
+    val data = Seq(
+      Seq(9, null, "x"),
+      Seq(null, 3, "y"),
+      Seq(1, 7, null),
+      Seq(null, 0, null),
+      Seq(1, null, null),
+      Seq(null, null, "b"),
+      Seq(5, 3, "z"),
+      Seq(7, 1, "a"),
+      Seq(5, 1, "b"),
+      Seq(8, 2, "a"))
+    val schema = new StructType().add("c1", IntegerType, nullable = true)
+      .add("c2", IntegerType, nullable = true)
+      .add("c3", StringType, nullable = true)
+    val rdd = spark.sparkContext.parallelize(data)
+    spark.createDataFrame(rdd.map(s => Row.fromSeq(s)), schema)
+      .write.format("parquet").saveAsTable("t")
+  }
+
+  protected override def afterAll(): Unit = {
+    spark.sql("DROP TABLE IF EXISTS t")
+    super.afterAll()
+  }
+
+  private def checkQuery(query: => DataFrame, optimized: Boolean): Unit = {
+    withSQLConf(SQLConf.OPTIMIZE_SAMPLE_FOR_RANGE_PARTITION_ENABLED.key -> "true") {
+      val df = query
+      assert(collect(df.queryExecution.executedPlan) {
+        case shuffle @ ShuffleExchangeExec(r: RangePartitioning, _, _)
+            if r.planForSample.isDefined => shuffle
+      }.nonEmpty == optimized)
+
+      var expected: Array[Row] = null
+      withSQLConf(SQLConf.OPTIMIZE_SAMPLE_FOR_RANGE_PARTITION_ENABLED.key -> "false") {
+        expected = query.collect()
+      }
+      checkAnswer(df, expected)
+    }
+  }
+
+  test("Optimize global sort") {
+    Seq(
+      ("", "ORDER BY c1"),
+      ("", " ORDER BY c1, c2"),
+      ("/*+ repartition_by_range(c1) */", ""),
+      ("/*+ repartition_by_range(c1, c2) */", "")).foreach { case (head, tail) =>
+      checkQuery(
+        sql(s"SELECT $head * FROM t $tail"),
+        true)
+
+      checkQuery(
+        sql(s"SELECT $head * FROM t WHERE c1 > 4 $tail"),
+        true)
+
+      checkQuery(
+        sql(s"SELECT $head * FROM t WHERE c2 > 1 $tail"),
+        true)
+
+      checkQuery(
+        sql(s"SELECT $head * FROM (SELECT * FROM t WHERE c2 > 1 $tail) WHERE c1 > rand()"),
+        true)
+    }
+  }
+
+  test("Do not optimize global sort") {
+    Seq(
+      ("", "ORDER BY c1"),
+      ("/*+ repartition_by_range(c1) */", "")).foreach { case (head, tail) =>
+      // more than one shuffle
+      checkQuery(
+        sql(s"SELECT $head c1 FROM t GROUP BY c1 $tail"),
+        false)
+    }
+
+    Seq(
+      ("", "ORDER BY c1, c2"),
+      ("/*+ repartition_by_range(c1, c2) */", "")).foreach { case (head, tail) =>
+      // references of sort order is same with query output
+      checkQuery(
+        sql(s"SELECT $head c1, c2 FROM t $tail"),
+        false)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/OptimizeSampleForRangePartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/OptimizeSampleForRangePartitioningSuite.scala
@@ -69,7 +69,7 @@ class OptimizeSampleForRangePartitioningSuite
     }
   }
 
-  test("Optimize global sort") {
+  test("Optimize range partitioning") {
     Seq(
       ("", "ORDER BY c1"),
       ("", " ORDER BY c1, c2"),
@@ -93,7 +93,7 @@ class OptimizeSampleForRangePartitioningSuite
     }
   }
 
-  test("Do not optimize global sort") {
+  test("Do not optimize range partitioning") {
     Seq(
       ("", "ORDER BY c1"),
       ("/*+ repartition_by_range(c1) */", "")).foreach { case (head, tail) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Make `RangePartitioning` take a new parameter  `planForSample`, so we can pass the it to `ShuffleExchangeExec`.

Add a new rule `OptimizeSampleForRangePartitioning` to infer the `planForSample` if has benefit at preparations phase.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When do a global sort or repartition by range, firstly we do sample to get the range bounds, then use the range partitioner to do shuffle exchange.

The issue is, the plan for sample is coupled with the original query. What we need for sample plan is the columns for sort order but the original query plan contains all data columns. So we can do column pruning for the sample plan to only fetch the ordering columns.

A common example is: `OPTIMIZE table ZORDER BY columns`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no it's improve performance

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add tests

performace test:
```
val rows = 1000000
val columns = (0 until(200)).map(i => s"uuid() c$i")
spark.range(rows).selectExpr(columns: _*).repartition(30).write.format("parquet").saveAsTable("t")
spark.sql("SELECT * FROM t ORDER BY c0, c1, c2").write.format("noop").mode("overwrite").save()
```
after do column pruning, the stage for sample from 7s -> 0.4s, the whole query 1.4X
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/12025282/203262222-9099cd3c-27f1-46e5-8fc9-e38bf3bd79e5.png">
