### PR TITLE
[SPARK-41223][BUILD] Upgrade slf4j to 2.0.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -134,7 +134,7 @@ javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-api/2.2.11//jaxb-api-2.2.11.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
-jcl-over-slf4j/2.0.3//jcl-over-slf4j-2.0.3.jar
+jcl-over-slf4j/2.0.4//jcl-over-slf4j-2.0.4.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jersey-client/2.36//jersey-client-2.36.jar
 jersey-common/2.36//jersey-common-2.36.jar
@@ -158,7 +158,7 @@ json4s-scalap_2.12/3.7.0-M11//json4s-scalap_2.12-3.7.0-M11.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/2.0.3//jul-to-slf4j-2.0.3.jar
+jul-to-slf4j/2.0.4//jul-to-slf4j-2.0.4.jar
 kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
 kubernetes-client-api/6.2.0//kubernetes-client-api-6.2.0.jar
 kubernetes-client/6.2.0//kubernetes-client-6.2.0.jar
@@ -247,7 +247,7 @@ scala-parser-combinators_2.12/2.1.1//scala-parser-combinators_2.12-2.1.1.jar
 scala-reflect/2.12.17//scala-reflect-2.12.17.jar
 scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.35//shims-0.9.35.jar
-slf4j-api/2.0.3//slf4j-api-2.0.3.jar
+slf4j-api/2.0.4//slf4j-api-2.0.4.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
 snappy-java/1.1.8.4//snappy-java-1.1.8.4.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -119,7 +119,7 @@ javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-api/2.2.11//jaxb-api-2.2.11.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
-jcl-over-slf4j/2.0.3//jcl-over-slf4j-2.0.3.jar
+jcl-over-slf4j/2.0.4//jcl-over-slf4j-2.0.4.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jdom2/2.0.6//jdom2-2.0.6.jar
 jersey-client/2.36//jersey-client-2.36.jar
@@ -142,7 +142,7 @@ json4s-jackson_2.12/3.7.0-M11//json4s-jackson_2.12-3.7.0-M11.jar
 json4s-scalap_2.12/3.7.0-M11//json4s-scalap_2.12-3.7.0-M11.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/2.0.3//jul-to-slf4j-2.0.3.jar
+jul-to-slf4j/2.0.4//jul-to-slf4j-2.0.4.jar
 kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
 kubernetes-client-api/6.2.0//kubernetes-client-api-6.2.0.jar
 kubernetes-client/6.2.0//kubernetes-client-6.2.0.jar
@@ -234,7 +234,7 @@ scala-parser-combinators_2.12/2.1.1//scala-parser-combinators_2.12-2.1.1.jar
 scala-reflect/2.12.17//scala-reflect-2.12.17.jar
 scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.35//shims-0.9.35.jar
-slf4j-api/2.0.3//slf4j-api-2.0.3.jar
+slf4j-api/2.0.4//slf4j-api-2.0.4.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
 snappy-java/1.1.8.4//snappy-java-1.1.8.4.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <maven.version>3.8.6</maven.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
-    <slf4j.version>2.0.3</slf4j.version>
+    <slf4j.version>2.0.4</slf4j.version>
     <log4j.version>2.19.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.4</hadoop.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade slf4j related dependencies from 2.0.3 to 2.0.4.



### Why are the changes needed?
A bug fix version:

- [LoggerFactory only loads services from context class loader](https://jira.qos.ch/browse/SLF4J-544)


The release notes as follows:

- https://www.slf4j.org/news.html#2.0.4


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA