### PR TITLE
[SPARK-41201][CONNECT][PYTHON][TEST][FOLLOWUP] Reenable test_fill_na

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -325,7 +325,6 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             .toPandas(),
         )
 
-    @unittest.skip("test_fill_na is flaky")
     def test_fill_na(self):
         # SPARK-41128: Test fill na
         query = """


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reenable test_fill_na


### Why are the changes needed?
`test_fill_na` was disabled by mistake in https://github.com/apache/spark/pull/38723


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
reenabled test