### PR TITLE
[MINOR][SQL] Fix error message for `UNEXPECTED_INPUT_TYPE`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -399,7 +399,7 @@
       },
       "UNEXPECTED_INPUT_TYPE" : {
         "message" : [
-          "Parameter <paramIndex> requires <requiredType> type, however <inputSql> is of type <inputType>."
+          "Parameter <paramIndex> requires the <requiredType> type, however <inputSql> has the type <inputType>."
         ]
       },
       "UNEXPECTED_NULL" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -399,7 +399,7 @@
       },
       "UNEXPECTED_INPUT_TYPE" : {
         "message" : [
-          "parameter <paramIndex> requires <requiredType> type, however, <inputSql> is of <inputType> type."
+          "Parameter <paramIndex> requires <requiredType> type, however <inputSql> is of type <inputType>."
         ]
       },
       "UNEXPECTED_NULL" : {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to correct the minor syntax on error message for `UNEXPECTED_INPUT_TYPE`,

### Why are the changes needed?

Error message should be started with upper-case character, and clear to read.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

```
./build/sbt “sql/testOnly org.apache.spark.sql.SQLQueryTestSuite*”
```