### PR TITLE
[SPARK-41238][CONNECT][PYTHON] Support more built-in datatypes

### DIFF
--- a/connector/connect/src/main/protobuf/spark/connect/expressions.proto
+++ b/connector/connect/src/main/protobuf/spark/connect/expressions.proto
@@ -68,7 +68,7 @@ message Expression {
       bytes uuid = 28;
       DataType null = 29; // a typed null literal
       List list = 30;
-      DataType.List empty_list = 31;
+      DataType.Array empty_array = 31;
       DataType.Map empty_map = 32;
       UserDefined user_defined = 33;
     }

--- a/connector/connect/src/main/protobuf/spark/connect/types.proto
+++ b/connector/connect/src/main/protobuf/spark/connect/types.proto
@@ -26,31 +26,48 @@ option java_package = "org.apache.spark.connect.proto";
 // itself but only describes it.
 message DataType {
   oneof kind {
-    Boolean bool = 1;
-    I8 i8 = 2;
-    I16 i16 = 3;
-    I32 i32 = 5;
+    NULL null = 1;
+
+    Binary binary = 2;
+
+    Boolean boolean = 3;
+
+    // Numeric
+    I8 i8 = 4;
+    I16 i16 = 5;
+    I32 i32 = 6;
     I64 i64 = 7;
-    FP32 fp32 = 10;
-    FP64 fp64 = 11;
-    String string = 12;
-    Binary binary = 13;
-    Timestamp timestamp = 14;
-    Date date = 16;
-    Time time = 17;
-    IntervalYear interval_year = 19;
-    IntervalDay interval_day = 20;
-    TimestampTZ timestamp_tz = 29;
-    UUID uuid = 32;
 
-    FixedChar fixed_char = 21;
-    VarChar varchar = 22;
-    FixedBinary fixed_binary = 23;
-    Decimal decimal = 24;
+    FP32 fp32 = 8;
+    FP64 fp64 = 9;
+    Decimal decimal = 10;
 
-    Struct struct = 25;
-    List list = 27;
-    Map map = 28;
+    // String
+    String string = 11;
+    Char char = 12;
+    VarChar var_char = 13;
+
+    // Datatime
+    Date date = 14;
+    Timestamp timestamp = 15;
+    TimestampNTZ timestamp_ntz = 16;
+
+    // Interval
+    CalendarInterval calendar_interval = 17;
+    YearMonthInterval year_month_interval = 18;
+    DayTimeInterval day_time_interval = 19;
+
+    // Complex types
+    Array array = 20;
+    Struct struct = 21;
+    Map map = 22;
+
+    IntervalYear interval_year = 23;
+    IntervalDay interval_day = 24;
+
+    UUID uuid = 25;
+
+    FixedBinary fixed_binary = 26;
 
     uint32 user_defined_type_reference = 31;
   }
@@ -91,6 +108,10 @@ message DataType {
     uint32 type_variation_reference = 1;
   }
 
+  message NULL {
+    uint32 type_variation_reference = 1;
+  }
+
   message Timestamp {
     uint32 type_variation_reference = 1;
   }
@@ -99,11 +120,7 @@ message DataType {
     uint32 type_variation_reference = 1;
   }
 
-  message Time {
-    uint32 type_variation_reference = 1;
-  }
-
-  message TimestampTZ {
+  message TimestampNTZ {
     uint32 type_variation_reference = 1;
   }
 
@@ -115,12 +132,28 @@ message DataType {
     uint32 type_variation_reference = 1;
   }
 
+  message CalendarInterval {
+    uint32 type_variation_reference = 1;
+  }
+
+  message YearMonthInterval {
+    optional int32 start_field = 1;
+    optional int32 end_field = 2;
+    uint32 type_variation_reference = 3;
+  }
+
+  message DayTimeInterval {
+    optional int32 start_field = 1;
+    optional int32 end_field = 2;
+    uint32 type_variation_reference = 3;
+  }
+
   message UUID {
     uint32 type_variation_reference = 1;
   }
 
   // Start compound types.
-  message FixedChar {
+  message Char {
     int32 length = 1;
     uint32 type_variation_reference = 2;
   }
@@ -136,14 +169,14 @@ message DataType {
   }
 
   message Decimal {
-    int32 scale = 1;
-    int32 precision = 2;
+    optional int32 scale = 1;
+    optional int32 precision = 2;
     uint32 type_variation_reference = 3;
   }
 
   message StructField {
-    DataType type = 1;
-    string name = 2;
+    string name = 1;
+    DataType data_type = 2;
     bool nullable = 3;
     map<string, string> metadata = 4;
   }
@@ -153,16 +186,16 @@ message DataType {
     uint32 type_variation_reference = 2;
   }
 
-  message List {
-    DataType DataType = 1;
-    uint32 type_variation_reference = 2;
-    bool element_nullable = 3;
+  message Array {
+    DataType element_type = 1;
+    bool contains_null = 2;
+    uint32 type_variation_reference = 3;
   }
 
   message Map {
-    DataType key = 1;
-    DataType value = 2;
-    uint32 type_variation_reference = 3;
-    bool value_nullable = 4;
+    DataType key_type = 1;
+    DataType value_type = 2;
+    bool value_contains_null = 3;
+    uint32 type_variation_reference = 4;
   }
 }

--- a/connector/connect/src/main/protobuf/spark/connect/types.proto
+++ b/connector/connect/src/main/protobuf/spark/connect/types.proto
@@ -32,27 +32,27 @@ message DataType {
 
     Boolean boolean = 3;
 
-    // Numeric
-    I8 i8 = 4;
-    I16 i16 = 5;
-    I32 i32 = 6;
-    I64 i64 = 7;
+    // Numeric types
+    Byte byte = 4;
+    Short short = 5;
+    Integer integer = 6;
+    Long long = 7;
 
-    FP32 fp32 = 8;
-    FP64 fp64 = 9;
+    Float float = 8;
+    Double double = 9;
     Decimal decimal = 10;
 
-    // String
+    // String types
     String string = 11;
     Char char = 12;
     VarChar var_char = 13;
 
-    // Datatime
+    // Datatime types
     Date date = 14;
     Timestamp timestamp = 15;
     TimestampNTZ timestamp_ntz = 16;
 
-    // Interval
+    // Interval types
     CalendarInterval calendar_interval = 17;
     YearMonthInterval year_month_interval = 18;
     DayTimeInterval day_time_interval = 19;
@@ -62,8 +62,6 @@ message DataType {
     Struct struct = 21;
     Map map = 22;
 
-    IntervalYear interval_year = 23;
-    IntervalDay interval_day = 24;
 
     UUID uuid = 25;
 
@@ -76,27 +74,27 @@ message DataType {
     uint32 type_variation_reference = 1;
   }
 
-  message I8 {
+  message Byte {
     uint32 type_variation_reference = 1;
   }
 
-  message I16 {
+  message Short {
     uint32 type_variation_reference = 1;
   }
 
-  message I32 {
+  message Integer {
     uint32 type_variation_reference = 1;
   }
 
-  message I64 {
+  message Long {
     uint32 type_variation_reference = 1;
   }
 
-  message FP32 {
+  message Float {
     uint32 type_variation_reference = 1;
   }
 
-  message FP64 {
+  message Double {
     uint32 type_variation_reference = 1;
   }
 
@@ -121,14 +119,6 @@ message DataType {
   }
 
   message TimestampNTZ {
-    uint32 type_variation_reference = 1;
-  }
-
-  message IntervalYear {
-    uint32 type_variation_reference = 1;
-  }
-
-  message IntervalDay {
     uint32 type_variation_reference = 1;
   }
 

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/dsl/package.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/dsl/package.scala
@@ -67,7 +67,7 @@ package object dsl {
 
       /** Creates a new AttributeReference of type int */
       def int: Expression.QualifiedAttribute = protoQualifiedAttrWithType(
-        DataType.newBuilder().setI32(DataType.I32.newBuilder()).build())
+        DataType.newBuilder().setInteger(DataType.Integer.newBuilder()).build())
 
       private def protoQualifiedAttrWithType(dataType: DataType): Expression.QualifiedAttribute =
         Expression.QualifiedAttribute

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/dsl/package.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/dsl/package.scala
@@ -55,6 +55,7 @@ package object dsl {
           val structField = DataType.StructField.newBuilder()
           structField.setName(attr.getName)
           structField.setDataType(attr.getType)
+          structField.setNullable(true)
           structExpr.addFields(structField)
         }
         Expression.QualifiedAttribute

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/dsl/package.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/dsl/package.scala
@@ -54,7 +54,7 @@ package object dsl {
         for (attr <- attrs) {
           val structField = DataType.StructField.newBuilder()
           structField.setName(attr.getName)
-          structField.setType(attr.getType)
+          structField.setDataType(attr.getType)
           structExpr.addFields(structField)
         }
         Expression.QualifiedAttribute

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
@@ -21,7 +21,7 @@ import scala.collection.convert.ImplicitConversions._
 
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.types.{DataType, IntegerType, LongType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.types._
 
 /**
  * This object offers methods to convert to/from connect proto to catalyst types.
@@ -29,65 +29,242 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType, MapType, Str
 object DataTypeProtoConverter {
   def toCatalystType(t: proto.DataType): DataType = {
     t.getKindCase match {
+      case proto.DataType.KindCase.NULL => NullType
+
+      case proto.DataType.KindCase.BINARY => BinaryType
+
+      case proto.DataType.KindCase.BOOLEAN => BooleanType
+
+      case proto.DataType.KindCase.I8 => ByteType
+      case proto.DataType.KindCase.I16 => ShortType
       case proto.DataType.KindCase.I32 => IntegerType
+      case proto.DataType.KindCase.I64 => LongType
+
+      case proto.DataType.KindCase.FP32 => FloatType
+      case proto.DataType.KindCase.FP64 => DoubleType
+      case proto.DataType.KindCase.DECIMAL => toCatalystDecimalType(t.getDecimal)
+
       case proto.DataType.KindCase.STRING => StringType
-      case proto.DataType.KindCase.STRUCT => convertProtoDataTypeToCatalyst(t.getStruct)
-      case proto.DataType.KindCase.MAP => convertProtoDataTypeToCatalyst(t.getMap)
+      case proto.DataType.KindCase.CHAR => CharType(t.getChar.getLength)
+      case proto.DataType.KindCase.VAR_CHAR => VarcharType(t.getVarChar.getLength)
+
+      case proto.DataType.KindCase.DATE => DateType
+      case proto.DataType.KindCase.TIMESTAMP => TimestampType
+      case proto.DataType.KindCase.TIMESTAMP_NTZ => TimestampNTZType
+
+      case proto.DataType.KindCase.CALENDAR_INTERVAL => CalendarIntervalType
+      case proto.DataType.KindCase.YEAR_MONTH_INTERVAL =>
+        toCatalystYearMonthIntervalType(t.getYearMonthInterval)
+      case proto.DataType.KindCase.DAY_TIME_INTERVAL =>
+        toCatalystDayTimeIntervalType(t.getDayTimeInterval)
+
+      case proto.DataType.KindCase.ARRAY => toCatalystArrayType(t.getArray)
+      case proto.DataType.KindCase.STRUCT => toCatalystStructType(t.getStruct)
+      case proto.DataType.KindCase.MAP => toCatalystMapType(t.getMap)
       case _ =>
         throw InvalidPlanInput(s"Does not support convert ${t.getKindCase} to catalyst types.")
     }
   }
 
-  private def convertProtoDataTypeToCatalyst(t: proto.DataType.Struct): StructType = {
-    // TODO: handle nullability
-    val structFields =
-      t.getFieldsList.map(f => StructField(f.getName, toCatalystType(f.getType))).toList
-    StructType.apply(structFields)
+  private def toCatalystDecimalType(t: proto.DataType.Decimal): DecimalType = {
+    (t.hasPrecision, t.hasScale) match {
+      case (true, true) => DecimalType(t.getPrecision, t.getScale)
+      case (true, false) => new DecimalType(t.getPrecision)
+      case _ => new DecimalType()
+    }
   }
 
-  private def convertProtoDataTypeToCatalyst(t: proto.DataType.Map): MapType = {
-    MapType(toCatalystType(t.getKey), toCatalystType(t.getValue))
+  private def toCatalystYearMonthIntervalType(t: proto.DataType.YearMonthInterval) = {
+    (t.hasStartField, t.hasEndField) match {
+      case (true, true) => YearMonthIntervalType(t.getStartField.toByte, t.getEndField.toByte)
+      case (true, false) => YearMonthIntervalType(t.getStartField.toByte)
+      case _ => YearMonthIntervalType()
+    }
+  }
+
+  private def toCatalystDayTimeIntervalType(t: proto.DataType.DayTimeInterval) = {
+    (t.hasStartField, t.hasEndField) match {
+      case (true, true) => DayTimeIntervalType(t.getStartField.toByte, t.getEndField.toByte)
+      case (true, false) => DayTimeIntervalType(t.getStartField.toByte)
+      case _ => DayTimeIntervalType()
+    }
+  }
+
+  private def toCatalystArrayType(t: proto.DataType.Array): ArrayType = {
+    ArrayType(toCatalystType(t.getElementType), t.getContainsNull)
+  }
+
+  private def toCatalystStructType(t: proto.DataType.Struct): StructType = {
+    val fields = t.getFieldsList.toSeq.map(f =>
+      StructField(f.getName, toCatalystType(f.getDataType), f.getNullable))
+    StructType.apply(fields)
+  }
+
+  private def toCatalystMapType(t: proto.DataType.Map): MapType = {
+    MapType(toCatalystType(t.getKeyType), toCatalystType(t.getValueType), t.getValueContainsNull)
   }
 
   def toConnectProtoType(t: DataType): proto.DataType = {
     t match {
+      case NullType =>
+        proto.DataType
+          .newBuilder()
+          .setNull(proto.DataType.NULL.getDefaultInstance)
+          .build()
+
+      case BooleanType =>
+        proto.DataType
+          .newBuilder()
+          .setBoolean(proto.DataType.Boolean.getDefaultInstance)
+          .build()
+
+      case BinaryType =>
+        proto.DataType
+          .newBuilder()
+          .setBinary(proto.DataType.Binary.getDefaultInstance)
+          .build()
+
+      case ByteType =>
+        proto.DataType
+          .newBuilder()
+          .setI8(proto.DataType.I8.getDefaultInstance)
+          .build()
+      case ShortType =>
+        proto.DataType
+          .newBuilder()
+          .setI16(proto.DataType.I16.getDefaultInstance)
+          .build()
       case IntegerType =>
-        proto.DataType.newBuilder().setI32(proto.DataType.I32.getDefaultInstance).build()
-      case StringType =>
-        proto.DataType.newBuilder().setString(proto.DataType.String.getDefaultInstance).build()
+        proto.DataType
+          .newBuilder()
+          .setI32(proto.DataType.I32.getDefaultInstance)
+          .build()
       case LongType =>
-        proto.DataType.newBuilder().setI64(proto.DataType.I64.getDefaultInstance).build()
-      case struct: StructType =>
-        toConnectProtoStructType(struct)
-      case map: MapType => toConnectProtoMapType(map)
+        proto.DataType
+          .newBuilder()
+          .setI64(proto.DataType.I64.getDefaultInstance)
+          .build()
+
+      case FloatType =>
+        proto.DataType
+          .newBuilder()
+          .setFp32(proto.DataType.FP32.getDefaultInstance)
+          .build()
+      case DoubleType =>
+        proto.DataType
+          .newBuilder()
+          .setFp64(proto.DataType.FP64.getDefaultInstance)
+          .build()
+      case DecimalType.Fixed(precision, scale) =>
+        proto.DataType
+          .newBuilder()
+          .setDecimal(
+            proto.DataType.Decimal.newBuilder().setPrecision(precision).setScale(scale).build())
+          .build()
+
+      case StringType =>
+        proto.DataType
+          .newBuilder()
+          .setString(proto.DataType.String.getDefaultInstance)
+          .build()
+      case CharType(length) =>
+        proto.DataType
+          .newBuilder()
+          .setChar(proto.DataType.Char.newBuilder().setLength(length).build())
+          .build()
+      case VarcharType(length) =>
+        proto.DataType
+          .newBuilder()
+          .setVarChar(proto.DataType.VarChar.newBuilder().setLength(length).build())
+          .build()
+
+      case DateType =>
+        proto.DataType
+          .newBuilder()
+          .setDate(proto.DataType.Date.getDefaultInstance)
+          .build()
+      case TimestampType =>
+        proto.DataType
+          .newBuilder()
+          .setTimestamp(proto.DataType.Timestamp.getDefaultInstance)
+          .build()
+      case TimestampNTZType =>
+        proto.DataType
+          .newBuilder()
+          .setTimestampNtz(proto.DataType.TimestampNTZ.getDefaultInstance)
+          .build()
+
+      case CalendarIntervalType =>
+        proto.DataType
+          .newBuilder()
+          .setCalendarInterval(proto.DataType.CalendarInterval.getDefaultInstance)
+          .build()
+      case YearMonthIntervalType(startField, endField) =>
+        proto.DataType
+          .newBuilder()
+          .setYearMonthInterval(
+            proto.DataType.YearMonthInterval
+              .newBuilder()
+              .setStartField(startField)
+              .setEndField(endField)
+              .build())
+          .build()
+      case DayTimeIntervalType(startField, endField) =>
+        proto.DataType
+          .newBuilder()
+          .setDayTimeInterval(
+            proto.DataType.DayTimeInterval
+              .newBuilder()
+              .setStartField(startField)
+              .setEndField(endField)
+              .build())
+          .build()
+
+      case ArrayType(elementType: DataType, containsNull: Boolean) =>
+        proto.DataType
+          .newBuilder()
+          .setArray(
+            proto.DataType.Array
+              .newBuilder()
+              .setElementType(toConnectProtoType(elementType))
+              .setContainsNull(containsNull)
+              .build())
+          .build()
+
+      case StructType(fields: Array[StructField]) =>
+        val protoFields = fields.map {
+          case StructField(name: String, dataType: DataType, nullable: Boolean, _) =>
+            proto.DataType.StructField
+              .newBuilder()
+              .setName(name)
+              .setDataType(toConnectProtoType(dataType))
+              .setNullable(nullable)
+              .build()
+        }
+        proto.DataType
+          .newBuilder()
+          .setStruct(
+            proto.DataType.Struct
+              .newBuilder()
+              .addAllFields(protoFields.toSeq)
+              .build())
+          .build()
+
+      case MapType(keyType: DataType, valueType: DataType, valueContainsNull: Boolean) =>
+        proto.DataType
+          .newBuilder()
+          .setMap(
+            proto.DataType.Map
+              .newBuilder()
+              .setKeyType(toConnectProtoType(keyType))
+              .setValueType(toConnectProtoType(valueType))
+              .setValueContainsNull(valueContainsNull)
+              .build())
+          .build()
+
       case _ =>
         throw InvalidPlanInput(s"Does not support convert ${t.typeName} to connect proto types.")
     }
-  }
-
-  def toConnectProtoMapType(schema: MapType): proto.DataType = {
-    proto.DataType
-      .newBuilder()
-      .setMap(
-        proto.DataType.Map
-          .newBuilder()
-          .setKey(toConnectProtoType(schema.keyType))
-          .setValue(toConnectProtoType(schema.valueType))
-          .build())
-      .build()
-  }
-
-  def toConnectProtoStructType(schema: StructType): proto.DataType = {
-    val struct = proto.DataType.Struct.newBuilder()
-    for (structField <- schema.fields) {
-      struct.addFields(
-        proto.DataType.StructField
-          .newBuilder()
-          .setName(structField.name)
-          .setType(toConnectProtoType(structField.dataType))
-          .setNullable(structField.nullable))
-    }
-    proto.DataType.newBuilder().setStruct(struct).build()
   }
 
   def toSaveMode(mode: proto.WriteOperation.SaveMode): SaveMode = {

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
@@ -35,13 +35,13 @@ object DataTypeProtoConverter {
 
       case proto.DataType.KindCase.BOOLEAN => BooleanType
 
-      case proto.DataType.KindCase.I8 => ByteType
-      case proto.DataType.KindCase.I16 => ShortType
-      case proto.DataType.KindCase.I32 => IntegerType
-      case proto.DataType.KindCase.I64 => LongType
+      case proto.DataType.KindCase.BYTE => ByteType
+      case proto.DataType.KindCase.SHORT => ShortType
+      case proto.DataType.KindCase.INTEGER => IntegerType
+      case proto.DataType.KindCase.LONG => LongType
 
-      case proto.DataType.KindCase.FP32 => FloatType
-      case proto.DataType.KindCase.FP64 => DoubleType
+      case proto.DataType.KindCase.FLOAT => FloatType
+      case proto.DataType.KindCase.DOUBLE => DoubleType
       case proto.DataType.KindCase.DECIMAL => toCatalystDecimalType(t.getDecimal)
 
       case proto.DataType.KindCase.STRING => StringType
@@ -127,33 +127,33 @@ object DataTypeProtoConverter {
       case ByteType =>
         proto.DataType
           .newBuilder()
-          .setI8(proto.DataType.I8.getDefaultInstance)
+          .setByte(proto.DataType.Byte.getDefaultInstance)
           .build()
       case ShortType =>
         proto.DataType
           .newBuilder()
-          .setI16(proto.DataType.I16.getDefaultInstance)
+          .setShort(proto.DataType.Short.getDefaultInstance)
           .build()
       case IntegerType =>
         proto.DataType
           .newBuilder()
-          .setI32(proto.DataType.I32.getDefaultInstance)
+          .setInteger(proto.DataType.Integer.getDefaultInstance)
           .build()
       case LongType =>
         proto.DataType
           .newBuilder()
-          .setI64(proto.DataType.I64.getDefaultInstance)
+          .setLong(proto.DataType.Long.getDefaultInstance)
           .build()
 
       case FloatType =>
         proto.DataType
           .newBuilder()
-          .setFp32(proto.DataType.FP32.getDefaultInstance)
+          .setFloat(proto.DataType.Float.getDefaultInstance)
           .build()
       case DoubleType =>
         proto.DataType
           .newBuilder()
-          .setFp64(proto.DataType.FP64.getDefaultInstance)
+          .setDouble(proto.DataType.Double.getDefaultInstance)
           .build()
       case DecimalType.Fixed(precision, scale) =>
         proto.DataType

--- a/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
+++ b/connector/connect/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
@@ -95,8 +95,14 @@ object DataTypeProtoConverter {
   }
 
   private def toCatalystStructType(t: proto.DataType.Struct): StructType = {
-    val fields = t.getFieldsList.toSeq.map(f =>
-      StructField(f.getName, toCatalystType(f.getDataType), f.getNullable))
+    // TODO: support metadata
+    val fields = t.getFieldsList.toSeq.map { protoField =>
+      StructField(
+        name = protoField.getName,
+        dataType = toCatalystType(protoField.getDataType),
+        nullable = protoField.getNullable,
+        metadata = Metadata.empty)
+    }
     StructType.apply(fields)
   }
 
@@ -129,16 +135,19 @@ object DataTypeProtoConverter {
           .newBuilder()
           .setByte(proto.DataType.Byte.getDefaultInstance)
           .build()
+
       case ShortType =>
         proto.DataType
           .newBuilder()
           .setShort(proto.DataType.Short.getDefaultInstance)
           .build()
+
       case IntegerType =>
         proto.DataType
           .newBuilder()
           .setInteger(proto.DataType.Integer.getDefaultInstance)
           .build()
+
       case LongType =>
         proto.DataType
           .newBuilder()
@@ -150,11 +159,13 @@ object DataTypeProtoConverter {
           .newBuilder()
           .setFloat(proto.DataType.Float.getDefaultInstance)
           .build()
+
       case DoubleType =>
         proto.DataType
           .newBuilder()
           .setDouble(proto.DataType.Double.getDefaultInstance)
           .build()
+
       case DecimalType.Fixed(precision, scale) =>
         proto.DataType
           .newBuilder()
@@ -167,11 +178,13 @@ object DataTypeProtoConverter {
           .newBuilder()
           .setString(proto.DataType.String.getDefaultInstance)
           .build()
+
       case CharType(length) =>
         proto.DataType
           .newBuilder()
           .setChar(proto.DataType.Char.newBuilder().setLength(length).build())
           .build()
+
       case VarcharType(length) =>
         proto.DataType
           .newBuilder()
@@ -183,11 +196,13 @@ object DataTypeProtoConverter {
           .newBuilder()
           .setDate(proto.DataType.Date.getDefaultInstance)
           .build()
+
       case TimestampType =>
         proto.DataType
           .newBuilder()
           .setTimestamp(proto.DataType.Timestamp.getDefaultInstance)
           .build()
+
       case TimestampNTZType =>
         proto.DataType
           .newBuilder()
@@ -199,6 +214,7 @@ object DataTypeProtoConverter {
           .newBuilder()
           .setCalendarInterval(proto.DataType.CalendarInterval.getDefaultInstance)
           .build()
+
       case YearMonthIntervalType(startField, endField) =>
         proto.DataType
           .newBuilder()
@@ -209,6 +225,7 @@ object DataTypeProtoConverter {
               .setEndField(endField)
               .build())
           .build()
+
       case DayTimeIntervalType(startField, endField) =>
         proto.DataType
           .newBuilder()
@@ -232,8 +249,13 @@ object DataTypeProtoConverter {
           .build()
 
       case StructType(fields: Array[StructField]) =>
-        val protoFields = fields.map {
-          case StructField(name: String, dataType: DataType, nullable: Boolean, _) =>
+        // TODO: support metadata
+        val protoFields = fields.toSeq.map {
+          case StructField(
+                name: String,
+                dataType: DataType,
+                nullable: Boolean,
+                metadata: Metadata) =>
             proto.DataType.StructField
               .newBuilder()
               .setName(name)
@@ -246,7 +268,7 @@ object DataTypeProtoConverter {
           .setStruct(
             proto.DataType.Struct
               .newBuilder()
-              .addAllFields(protoFields.toSeq)
+              .addAllFields(protoFields)
               .build())
           .build()
 

--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -60,10 +60,10 @@ class SparkConnectServiceSuite extends SharedSparkSession {
       assert(schema.getFieldsCount == 2)
       assert(
         schema.getFields(0).getName == "col1"
-          && schema.getFields(0).getType.getKindCase == proto.DataType.KindCase.I32)
+          && schema.getFields(0).getDataType.getKindCase == proto.DataType.KindCase.I32)
       assert(
         schema.getFields(1).getName == "col2"
-          && schema.getFields(1).getType.getKindCase == proto.DataType.KindCase.STRING)
+          && schema.getFields(1).getDataType.getKindCase == proto.DataType.KindCase.STRING)
     }
   }
 

--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -60,7 +60,7 @@ class SparkConnectServiceSuite extends SharedSparkSession {
       assert(schema.getFieldsCount == 2)
       assert(
         schema.getFields(0).getName == "col1"
-          && schema.getFields(0).getDataType.getKindCase == proto.DataType.KindCase.I32)
+          && schema.getFields(0).getDataType.getKindCase == proto.DataType.KindCase.INTEGER)
       assert(
         schema.getFields(1).getName == "col2"
           && schema.getFields(1).getDataType.getKindCase == proto.DataType.KindCase.STRING)

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -32,7 +32,29 @@ from pyspark import cloudpickle
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.plan import SQL, Range
-from pyspark.sql.types import DataType, StructType, StructField, LongType, StringType
+from pyspark.sql.types import (
+    DataType,
+    ByteType,
+    ShortType,
+    IntegerType,
+    FloatType,
+    DateType,
+    TimestampType,
+    DayTimeIntervalType,
+    MapType,
+    StringType,
+    CharType,
+    VarcharType,
+    StructType,
+    StructField,
+    ArrayType,
+    DoubleType,
+    LongType,
+    DecimalType,
+    BinaryType,
+    BooleanType,
+    NullType,
+)
 
 from typing import Iterable, Optional, Any, Union, List, Tuple, Dict
 
@@ -356,38 +378,78 @@ class RemoteSparkSession(object):
         return self._execute_and_fetch(req)
 
     def _proto_schema_to_pyspark_schema(self, schema: pb2.DataType) -> DataType:
-        if schema.HasField("struct"):
-            structFields = []
-            for proto_field in schema.struct.fields:
-                structFields.append(
-                    StructField(
-                        proto_field.name,
-                        self._proto_schema_to_pyspark_schema(proto_field.type),
-                        proto_field.nullable,
-                    )
-                )
-            return StructType(structFields)
+        if schema.HasField("null"):
+            return NullType()
+        elif schema.HasField("boolean"):
+            return BooleanType()
+        elif schema.HasField("binary"):
+            return BinaryType()
+        elif schema.HasField("i8"):
+            return ByteType()
+        elif schema.HasField("i16"):
+            return ShortType()
+        elif schema.HasField("i32"):
+            return IntegerType()
         elif schema.HasField("i64"):
             return LongType()
+        elif schema.HasField("fp32"):
+            return FloatType()
+        elif schema.HasField("fp64"):
+            return DoubleType()
+        elif schema.HasField("decimal"):
+            p = schema.decimal.precision if schema.decimal.HasField("precision") else 10
+            s = schema.decimal.scale if schema.decimal.HasField("scale") else 0
+            return DecimalType(precision=p, scale=s)
         elif schema.HasField("string"):
             return StringType()
+        elif schema.HasField("char"):
+            return CharType(schema.char.length)
+        elif schema.HasField("var_char"):
+            return VarcharType(schema.var_char.length)
+        elif schema.HasField("date"):
+            return DateType()
+        elif schema.HasField("timestamp"):
+            return TimestampType()
+        elif schema.HasField("day_time_interval"):
+            return DayTimeIntervalType()
+        elif schema.HasField("array"):
+            return ArrayType(
+                self._proto_schema_to_pyspark_schema(schema.array.element_type),
+                schema.array.contains_null,
+            )
+        elif schema.HasField("struct"):
+            fields = [
+                StructField(
+                    f.name,
+                    self._proto_schema_to_pyspark_schema(f.data_type),
+                    f.nullable,
+                )
+                for f in schema.struct.fields
+            ]
+            return StructType(fields)
+        elif schema.HasField("map"):
+            return MapType(
+                self._proto_schema_to_pyspark_schema(schema.map.key_type),
+                self._proto_schema_to_pyspark_schema(schema.map.value_type),
+                schema.map.value_contains_null,
+            )
         else:
-            raise Exception("Only support long, string, struct conversion")
+            raise Exception(f"Unsupported data type {schema}")
 
     def schema(self, plan: pb2.Plan) -> StructType:
         proto_schema = self._analyze(plan).schema
         # Server side should populate the struct field which is the schema.
         assert proto_schema.HasField("struct")
-        structFields = []
-        for proto_field in proto_schema.struct.fields:
-            structFields.append(
-                StructField(
-                    proto_field.name,
-                    self._proto_schema_to_pyspark_schema(proto_field.type),
-                    proto_field.nullable,
-                )
+
+        fields = [
+            StructField(
+                f.name,
+                self._proto_schema_to_pyspark_schema(f.data_type),
+                f.nullable,
             )
-        return StructType(structFields)
+            for f in proto_schema.struct.fields
+        ]
+        return StructType(fields)
 
     def explain_string(self, plan: pb2.Plan, explain_mode: str = "extended") -> str:
         result = self._analyze(plan, explain_mode)

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -384,17 +384,17 @@ class RemoteSparkSession(object):
             return BooleanType()
         elif schema.HasField("binary"):
             return BinaryType()
-        elif schema.HasField("i8"):
+        elif schema.HasField("byte"):
             return ByteType()
-        elif schema.HasField("i16"):
+        elif schema.HasField("short"):
             return ShortType()
-        elif schema.HasField("i32"):
+        elif schema.HasField("integer"):
             return IntegerType()
-        elif schema.HasField("i64"):
+        elif schema.HasField("long"):
             return LongType()
-        elif schema.HasField("fp32"):
+        elif schema.HasField("float"):
             return FloatType()
-        elif schema.HasField("fp64"):
+        elif schema.HasField("double"):
             return DoubleType()
         elif schema.HasField("decimal"):
             p = schema.decimal.precision if schema.decimal.HasField("precision") else 10

--- a/python/pyspark/sql/connect/proto/expressions_pb2.py
+++ b/python/pyspark/sql/connect/proto/expressions_pb2.py
@@ -34,7 +34,7 @@ from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1fspark/connect/expressions.proto\x12\rspark.connect\x1a\x19spark/connect/types.proto\x1a\x19google/protobuf/any.proto"\xf0\x17\n\nExpression\x12=\n\x07literal\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x07literal\x12\x62\n\x14unresolved_attribute\x18\x02 \x01(\x0b\x32-.spark.connect.Expression.UnresolvedAttributeH\x00R\x13unresolvedAttribute\x12_\n\x13unresolved_function\x18\x03 \x01(\x0b\x32,.spark.connect.Expression.UnresolvedFunctionH\x00R\x12unresolvedFunction\x12Y\n\x11\x65xpression_string\x18\x04 \x01(\x0b\x32*.spark.connect.Expression.ExpressionStringH\x00R\x10\x65xpressionString\x12S\n\x0funresolved_star\x18\x05 \x01(\x0b\x32(.spark.connect.Expression.UnresolvedStarH\x00R\x0eunresolvedStar\x12\x37\n\x05\x61lias\x18\x06 \x01(\x0b\x32\x1f.spark.connect.Expression.AliasH\x00R\x05\x61lias\x1a\xa3\x10\n\x07Literal\x12\x1a\n\x07\x62oolean\x18\x01 \x01(\x08H\x00R\x07\x62oolean\x12\x10\n\x02i8\x18\x02 \x01(\x05H\x00R\x02i8\x12\x12\n\x03i16\x18\x03 \x01(\x05H\x00R\x03i16\x12\x12\n\x03i32\x18\x05 \x01(\x05H\x00R\x03i32\x12\x12\n\x03i64\x18\x07 \x01(\x03H\x00R\x03i64\x12\x14\n\x04\x66p32\x18\n \x01(\x02H\x00R\x04\x66p32\x12\x14\n\x04\x66p64\x18\x0b \x01(\x01H\x00R\x04\x66p64\x12\x18\n\x06string\x18\x0c \x01(\tH\x00R\x06string\x12\x18\n\x06\x62inary\x18\r \x01(\x0cH\x00R\x06\x62inary\x12\x1e\n\ttimestamp\x18\x0e \x01(\x03H\x00R\ttimestamp\x12\x14\n\x04\x64\x61te\x18\x10 \x01(\x05H\x00R\x04\x64\x61te\x12\x14\n\x04time\x18\x11 \x01(\x03H\x00R\x04time\x12l\n\x16interval_year_to_month\x18\x13 \x01(\x0b\x32\x35.spark.connect.Expression.Literal.IntervalYearToMonthH\x00R\x13intervalYearToMonth\x12l\n\x16interval_day_to_second\x18\x14 \x01(\x0b\x32\x35.spark.connect.Expression.Literal.IntervalDayToSecondH\x00R\x13intervalDayToSecond\x12\x1f\n\nfixed_char\x18\x15 \x01(\tH\x00R\tfixedChar\x12\x46\n\x08var_char\x18\x16 \x01(\x0b\x32).spark.connect.Expression.Literal.VarCharH\x00R\x07varChar\x12#\n\x0c\x66ixed_binary\x18\x17 \x01(\x0cH\x00R\x0b\x66ixedBinary\x12\x45\n\x07\x64\x65\x63imal\x18\x18 \x01(\x0b\x32).spark.connect.Expression.Literal.DecimalH\x00R\x07\x64\x65\x63imal\x12\x42\n\x06struct\x18\x19 \x01(\x0b\x32(.spark.connect.Expression.Literal.StructH\x00R\x06struct\x12\x39\n\x03map\x18\x1a \x01(\x0b\x32%.spark.connect.Expression.Literal.MapH\x00R\x03map\x12#\n\x0ctimestamp_tz\x18\x1b \x01(\x03H\x00R\x0btimestampTz\x12\x14\n\x04uuid\x18\x1c \x01(\x0cH\x00R\x04uuid\x12-\n\x04null\x18\x1d \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x04null\x12<\n\x04list\x18\x1e \x01(\x0b\x32&.spark.connect.Expression.Literal.ListH\x00R\x04list\x12=\n\nempty_list\x18\x1f \x01(\x0b\x32\x1c.spark.connect.DataType.ListH\x00R\temptyList\x12:\n\tempty_map\x18  \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x08\x65mptyMap\x12R\n\x0cuser_defined\x18! \x01(\x0b\x32-.spark.connect.Expression.Literal.UserDefinedH\x00R\x0buserDefined\x12\x1a\n\x08nullable\x18\x32 \x01(\x08R\x08nullable\x12\x38\n\x18type_variation_reference\x18\x33 \x01(\rR\x16typeVariationReference\x1a\x37\n\x07VarChar\x12\x14\n\x05value\x18\x01 \x01(\tR\x05value\x12\x16\n\x06length\x18\x02 \x01(\rR\x06length\x1aS\n\x07\x44\x65\x63imal\x12\x14\n\x05value\x18\x01 \x01(\x0cR\x05value\x12\x1c\n\tprecision\x18\x02 \x01(\x05R\tprecision\x12\x14\n\x05scale\x18\x03 \x01(\x05R\x05scale\x1a\xce\x01\n\x03Map\x12M\n\nkey_values\x18\x01 \x03(\x0b\x32..spark.connect.Expression.Literal.Map.KeyValueR\tkeyValues\x1ax\n\x08KeyValue\x12\x33\n\x03key\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x03key\x12\x37\n\x05value\x18\x02 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x05value\x1a\x43\n\x13IntervalYearToMonth\x12\x14\n\x05years\x18\x01 \x01(\x05R\x05years\x12\x16\n\x06months\x18\x02 \x01(\x05R\x06months\x1ag\n\x13IntervalDayToSecond\x12\x12\n\x04\x64\x61ys\x18\x01 \x01(\x05R\x04\x64\x61ys\x12\x18\n\x07seconds\x18\x02 \x01(\x05R\x07seconds\x12"\n\x0cmicroseconds\x18\x03 \x01(\x05R\x0cmicroseconds\x1a\x43\n\x06Struct\x12\x39\n\x06\x66ields\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06\x66ields\x1a\x41\n\x04List\x12\x39\n\x06values\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values\x1a`\n\x0bUserDefined\x12%\n\x0etype_reference\x18\x01 \x01(\rR\rtypeReference\x12*\n\x05value\x18\x02 \x01(\x0b\x32\x14.google.protobuf.AnyR\x05valueB\x0e\n\x0cliteral_type\x1a\x46\n\x13UnresolvedAttribute\x12/\n\x13unparsed_identifier\x18\x01 \x01(\tR\x12unparsedIdentifier\x1a\x63\n\x12UnresolvedFunction\x12\x14\n\x05parts\x18\x01 \x03(\tR\x05parts\x12\x37\n\targuments\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\targuments\x1a\x32\n\x10\x45xpressionString\x12\x1e\n\nexpression\x18\x01 \x01(\tR\nexpression\x1a\x10\n\x0eUnresolvedStar\x1aU\n\x12QualifiedAttribute\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12+\n\x04type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x04type\x1ax\n\x05\x41lias\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12\x12\n\x04name\x18\x02 \x03(\tR\x04name\x12\x1f\n\x08metadata\x18\x03 \x01(\tH\x00R\x08metadata\x88\x01\x01\x42\x0b\n\t_metadataB\x0b\n\texpr_typeB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
+    b'\n\x1fspark/connect/expressions.proto\x12\rspark.connect\x1a\x19spark/connect/types.proto\x1a\x19google/protobuf/any.proto"\xf3\x17\n\nExpression\x12=\n\x07literal\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x07literal\x12\x62\n\x14unresolved_attribute\x18\x02 \x01(\x0b\x32-.spark.connect.Expression.UnresolvedAttributeH\x00R\x13unresolvedAttribute\x12_\n\x13unresolved_function\x18\x03 \x01(\x0b\x32,.spark.connect.Expression.UnresolvedFunctionH\x00R\x12unresolvedFunction\x12Y\n\x11\x65xpression_string\x18\x04 \x01(\x0b\x32*.spark.connect.Expression.ExpressionStringH\x00R\x10\x65xpressionString\x12S\n\x0funresolved_star\x18\x05 \x01(\x0b\x32(.spark.connect.Expression.UnresolvedStarH\x00R\x0eunresolvedStar\x12\x37\n\x05\x61lias\x18\x06 \x01(\x0b\x32\x1f.spark.connect.Expression.AliasH\x00R\x05\x61lias\x1a\xa6\x10\n\x07Literal\x12\x1a\n\x07\x62oolean\x18\x01 \x01(\x08H\x00R\x07\x62oolean\x12\x10\n\x02i8\x18\x02 \x01(\x05H\x00R\x02i8\x12\x12\n\x03i16\x18\x03 \x01(\x05H\x00R\x03i16\x12\x12\n\x03i32\x18\x05 \x01(\x05H\x00R\x03i32\x12\x12\n\x03i64\x18\x07 \x01(\x03H\x00R\x03i64\x12\x14\n\x04\x66p32\x18\n \x01(\x02H\x00R\x04\x66p32\x12\x14\n\x04\x66p64\x18\x0b \x01(\x01H\x00R\x04\x66p64\x12\x18\n\x06string\x18\x0c \x01(\tH\x00R\x06string\x12\x18\n\x06\x62inary\x18\r \x01(\x0cH\x00R\x06\x62inary\x12\x1e\n\ttimestamp\x18\x0e \x01(\x03H\x00R\ttimestamp\x12\x14\n\x04\x64\x61te\x18\x10 \x01(\x05H\x00R\x04\x64\x61te\x12\x14\n\x04time\x18\x11 \x01(\x03H\x00R\x04time\x12l\n\x16interval_year_to_month\x18\x13 \x01(\x0b\x32\x35.spark.connect.Expression.Literal.IntervalYearToMonthH\x00R\x13intervalYearToMonth\x12l\n\x16interval_day_to_second\x18\x14 \x01(\x0b\x32\x35.spark.connect.Expression.Literal.IntervalDayToSecondH\x00R\x13intervalDayToSecond\x12\x1f\n\nfixed_char\x18\x15 \x01(\tH\x00R\tfixedChar\x12\x46\n\x08var_char\x18\x16 \x01(\x0b\x32).spark.connect.Expression.Literal.VarCharH\x00R\x07varChar\x12#\n\x0c\x66ixed_binary\x18\x17 \x01(\x0cH\x00R\x0b\x66ixedBinary\x12\x45\n\x07\x64\x65\x63imal\x18\x18 \x01(\x0b\x32).spark.connect.Expression.Literal.DecimalH\x00R\x07\x64\x65\x63imal\x12\x42\n\x06struct\x18\x19 \x01(\x0b\x32(.spark.connect.Expression.Literal.StructH\x00R\x06struct\x12\x39\n\x03map\x18\x1a \x01(\x0b\x32%.spark.connect.Expression.Literal.MapH\x00R\x03map\x12#\n\x0ctimestamp_tz\x18\x1b \x01(\x03H\x00R\x0btimestampTz\x12\x14\n\x04uuid\x18\x1c \x01(\x0cH\x00R\x04uuid\x12-\n\x04null\x18\x1d \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x04null\x12<\n\x04list\x18\x1e \x01(\x0b\x32&.spark.connect.Expression.Literal.ListH\x00R\x04list\x12@\n\x0b\x65mpty_array\x18\x1f \x01(\x0b\x32\x1d.spark.connect.DataType.ArrayH\x00R\nemptyArray\x12:\n\tempty_map\x18  \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x08\x65mptyMap\x12R\n\x0cuser_defined\x18! \x01(\x0b\x32-.spark.connect.Expression.Literal.UserDefinedH\x00R\x0buserDefined\x12\x1a\n\x08nullable\x18\x32 \x01(\x08R\x08nullable\x12\x38\n\x18type_variation_reference\x18\x33 \x01(\rR\x16typeVariationReference\x1a\x37\n\x07VarChar\x12\x14\n\x05value\x18\x01 \x01(\tR\x05value\x12\x16\n\x06length\x18\x02 \x01(\rR\x06length\x1aS\n\x07\x44\x65\x63imal\x12\x14\n\x05value\x18\x01 \x01(\x0cR\x05value\x12\x1c\n\tprecision\x18\x02 \x01(\x05R\tprecision\x12\x14\n\x05scale\x18\x03 \x01(\x05R\x05scale\x1a\xce\x01\n\x03Map\x12M\n\nkey_values\x18\x01 \x03(\x0b\x32..spark.connect.Expression.Literal.Map.KeyValueR\tkeyValues\x1ax\n\x08KeyValue\x12\x33\n\x03key\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x03key\x12\x37\n\x05value\x18\x02 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x05value\x1a\x43\n\x13IntervalYearToMonth\x12\x14\n\x05years\x18\x01 \x01(\x05R\x05years\x12\x16\n\x06months\x18\x02 \x01(\x05R\x06months\x1ag\n\x13IntervalDayToSecond\x12\x12\n\x04\x64\x61ys\x18\x01 \x01(\x05R\x04\x64\x61ys\x12\x18\n\x07seconds\x18\x02 \x01(\x05R\x07seconds\x12"\n\x0cmicroseconds\x18\x03 \x01(\x05R\x0cmicroseconds\x1a\x43\n\x06Struct\x12\x39\n\x06\x66ields\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06\x66ields\x1a\x41\n\x04List\x12\x39\n\x06values\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values\x1a`\n\x0bUserDefined\x12%\n\x0etype_reference\x18\x01 \x01(\rR\rtypeReference\x12*\n\x05value\x18\x02 \x01(\x0b\x32\x14.google.protobuf.AnyR\x05valueB\x0e\n\x0cliteral_type\x1a\x46\n\x13UnresolvedAttribute\x12/\n\x13unparsed_identifier\x18\x01 \x01(\tR\x12unparsedIdentifier\x1a\x63\n\x12UnresolvedFunction\x12\x14\n\x05parts\x18\x01 \x03(\tR\x05parts\x12\x37\n\targuments\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\targuments\x1a\x32\n\x10\x45xpressionString\x12\x1e\n\nexpression\x18\x01 \x01(\tR\nexpression\x1a\x10\n\x0eUnresolvedStar\x1aU\n\x12QualifiedAttribute\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12+\n\x04type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x04type\x1ax\n\x05\x41lias\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12\x12\n\x04name\x18\x02 \x03(\tR\x04name\x12\x1f\n\x08metadata\x18\x03 \x01(\tH\x00R\x08metadata\x88\x01\x01\x42\x0b\n\t_metadataB\x0b\n\texpr_typeB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
 )
 
 
@@ -235,37 +235,37 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b"\n\036org.apache.spark.connect.protoP\001"
     _EXPRESSION._serialized_start = 105
-    _EXPRESSION._serialized_end = 3161
+    _EXPRESSION._serialized_end = 3164
     _EXPRESSION_LITERAL._serialized_start = 613
-    _EXPRESSION_LITERAL._serialized_end = 2696
-    _EXPRESSION_LITERAL_VARCHAR._serialized_start = 1923
-    _EXPRESSION_LITERAL_VARCHAR._serialized_end = 1978
-    _EXPRESSION_LITERAL_DECIMAL._serialized_start = 1980
-    _EXPRESSION_LITERAL_DECIMAL._serialized_end = 2063
-    _EXPRESSION_LITERAL_MAP._serialized_start = 2066
-    _EXPRESSION_LITERAL_MAP._serialized_end = 2272
-    _EXPRESSION_LITERAL_MAP_KEYVALUE._serialized_start = 2152
-    _EXPRESSION_LITERAL_MAP_KEYVALUE._serialized_end = 2272
-    _EXPRESSION_LITERAL_INTERVALYEARTOMONTH._serialized_start = 2274
-    _EXPRESSION_LITERAL_INTERVALYEARTOMONTH._serialized_end = 2341
-    _EXPRESSION_LITERAL_INTERVALDAYTOSECOND._serialized_start = 2343
-    _EXPRESSION_LITERAL_INTERVALDAYTOSECOND._serialized_end = 2446
-    _EXPRESSION_LITERAL_STRUCT._serialized_start = 2448
-    _EXPRESSION_LITERAL_STRUCT._serialized_end = 2515
-    _EXPRESSION_LITERAL_LIST._serialized_start = 2517
-    _EXPRESSION_LITERAL_LIST._serialized_end = 2582
-    _EXPRESSION_LITERAL_USERDEFINED._serialized_start = 2584
-    _EXPRESSION_LITERAL_USERDEFINED._serialized_end = 2680
-    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_start = 2698
-    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_end = 2768
-    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_start = 2770
-    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_end = 2869
-    _EXPRESSION_EXPRESSIONSTRING._serialized_start = 2871
-    _EXPRESSION_EXPRESSIONSTRING._serialized_end = 2921
-    _EXPRESSION_UNRESOLVEDSTAR._serialized_start = 2923
-    _EXPRESSION_UNRESOLVEDSTAR._serialized_end = 2939
-    _EXPRESSION_QUALIFIEDATTRIBUTE._serialized_start = 2941
-    _EXPRESSION_QUALIFIEDATTRIBUTE._serialized_end = 3026
-    _EXPRESSION_ALIAS._serialized_start = 3028
-    _EXPRESSION_ALIAS._serialized_end = 3148
+    _EXPRESSION_LITERAL._serialized_end = 2699
+    _EXPRESSION_LITERAL_VARCHAR._serialized_start = 1926
+    _EXPRESSION_LITERAL_VARCHAR._serialized_end = 1981
+    _EXPRESSION_LITERAL_DECIMAL._serialized_start = 1983
+    _EXPRESSION_LITERAL_DECIMAL._serialized_end = 2066
+    _EXPRESSION_LITERAL_MAP._serialized_start = 2069
+    _EXPRESSION_LITERAL_MAP._serialized_end = 2275
+    _EXPRESSION_LITERAL_MAP_KEYVALUE._serialized_start = 2155
+    _EXPRESSION_LITERAL_MAP_KEYVALUE._serialized_end = 2275
+    _EXPRESSION_LITERAL_INTERVALYEARTOMONTH._serialized_start = 2277
+    _EXPRESSION_LITERAL_INTERVALYEARTOMONTH._serialized_end = 2344
+    _EXPRESSION_LITERAL_INTERVALDAYTOSECOND._serialized_start = 2346
+    _EXPRESSION_LITERAL_INTERVALDAYTOSECOND._serialized_end = 2449
+    _EXPRESSION_LITERAL_STRUCT._serialized_start = 2451
+    _EXPRESSION_LITERAL_STRUCT._serialized_end = 2518
+    _EXPRESSION_LITERAL_LIST._serialized_start = 2520
+    _EXPRESSION_LITERAL_LIST._serialized_end = 2585
+    _EXPRESSION_LITERAL_USERDEFINED._serialized_start = 2587
+    _EXPRESSION_LITERAL_USERDEFINED._serialized_end = 2683
+    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_start = 2701
+    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_end = 2771
+    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_start = 2773
+    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_end = 2872
+    _EXPRESSION_EXPRESSIONSTRING._serialized_start = 2874
+    _EXPRESSION_EXPRESSIONSTRING._serialized_end = 2924
+    _EXPRESSION_UNRESOLVEDSTAR._serialized_start = 2926
+    _EXPRESSION_UNRESOLVEDSTAR._serialized_end = 2942
+    _EXPRESSION_QUALIFIEDATTRIBUTE._serialized_start = 2944
+    _EXPRESSION_QUALIFIEDATTRIBUTE._serialized_end = 3029
+    _EXPRESSION_ALIAS._serialized_start = 3031
+    _EXPRESSION_ALIAS._serialized_end = 3151
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/expressions_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/expressions_pb2.pyi
@@ -280,7 +280,7 @@ class Expression(google.protobuf.message.Message):
         UUID_FIELD_NUMBER: builtins.int
         NULL_FIELD_NUMBER: builtins.int
         LIST_FIELD_NUMBER: builtins.int
-        EMPTY_LIST_FIELD_NUMBER: builtins.int
+        EMPTY_ARRAY_FIELD_NUMBER: builtins.int
         EMPTY_MAP_FIELD_NUMBER: builtins.int
         USER_DEFINED_FIELD_NUMBER: builtins.int
         NULLABLE_FIELD_NUMBER: builtins.int
@@ -323,7 +323,7 @@ class Expression(google.protobuf.message.Message):
         @property
         def list(self) -> global___Expression.Literal.List: ...
         @property
-        def empty_list(self) -> pyspark.sql.connect.proto.types_pb2.DataType.List: ...
+        def empty_array(self) -> pyspark.sql.connect.proto.types_pb2.DataType.Array: ...
         @property
         def empty_map(self) -> pyspark.sql.connect.proto.types_pb2.DataType.Map: ...
         @property
@@ -365,7 +365,7 @@ class Expression(google.protobuf.message.Message):
             uuid: builtins.bytes = ...,
             null: pyspark.sql.connect.proto.types_pb2.DataType | None = ...,
             list: global___Expression.Literal.List | None = ...,
-            empty_list: pyspark.sql.connect.proto.types_pb2.DataType.List | None = ...,
+            empty_array: pyspark.sql.connect.proto.types_pb2.DataType.Array | None = ...,
             empty_map: pyspark.sql.connect.proto.types_pb2.DataType.Map | None = ...,
             user_defined: global___Expression.Literal.UserDefined | None = ...,
             nullable: builtins.bool = ...,
@@ -382,8 +382,8 @@ class Expression(google.protobuf.message.Message):
                 b"date",
                 "decimal",
                 b"decimal",
-                "empty_list",
-                b"empty_list",
+                "empty_array",
+                b"empty_array",
                 "empty_map",
                 b"empty_map",
                 "fixed_binary",
@@ -443,8 +443,8 @@ class Expression(google.protobuf.message.Message):
                 b"date",
                 "decimal",
                 b"decimal",
-                "empty_list",
-                b"empty_list",
+                "empty_array",
+                b"empty_array",
                 "empty_map",
                 b"empty_map",
                 "fixed_binary",
@@ -524,7 +524,7 @@ class Expression(google.protobuf.message.Message):
             "uuid",
             "null",
             "list",
-            "empty_list",
+            "empty_array",
             "empty_map",
             "user_defined",
         ] | None: ...

--- a/python/pyspark/sql/connect/proto/types_pb2.py
+++ b/python/pyspark/sql/connect/proto/types_pb2.py
@@ -30,26 +30,24 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x19spark/connect/types.proto\x12\rspark.connect"\xc8"\n\x08\x44\x61taType\x12\x32\n\x04null\x18\x01 \x01(\x0b\x32\x1c.spark.connect.DataType.NULLH\x00R\x04null\x12\x38\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x1e.spark.connect.DataType.BinaryH\x00R\x06\x62inary\x12;\n\x07\x62oolean\x18\x03 \x01(\x0b\x32\x1f.spark.connect.DataType.BooleanH\x00R\x07\x62oolean\x12,\n\x02i8\x18\x04 \x01(\x0b\x32\x1a.spark.connect.DataType.I8H\x00R\x02i8\x12/\n\x03i16\x18\x05 \x01(\x0b\x32\x1b.spark.connect.DataType.I16H\x00R\x03i16\x12/\n\x03i32\x18\x06 \x01(\x0b\x32\x1b.spark.connect.DataType.I32H\x00R\x03i32\x12/\n\x03i64\x18\x07 \x01(\x0b\x32\x1b.spark.connect.DataType.I64H\x00R\x03i64\x12\x32\n\x04\x66p32\x18\x08 \x01(\x0b\x32\x1c.spark.connect.DataType.FP32H\x00R\x04\x66p32\x12\x32\n\x04\x66p64\x18\t \x01(\x0b\x32\x1c.spark.connect.DataType.FP64H\x00R\x04\x66p64\x12;\n\x07\x64\x65\x63imal\x18\n \x01(\x0b\x32\x1f.spark.connect.DataType.DecimalH\x00R\x07\x64\x65\x63imal\x12\x38\n\x06string\x18\x0b \x01(\x0b\x32\x1e.spark.connect.DataType.StringH\x00R\x06string\x12\x32\n\x04\x63har\x18\x0c \x01(\x0b\x32\x1c.spark.connect.DataType.CharH\x00R\x04\x63har\x12<\n\x08var_char\x18\r \x01(\x0b\x32\x1f.spark.connect.DataType.VarCharH\x00R\x07varChar\x12\x32\n\x04\x64\x61te\x18\x0e \x01(\x0b\x32\x1c.spark.connect.DataType.DateH\x00R\x04\x64\x61te\x12\x41\n\ttimestamp\x18\x0f \x01(\x0b\x32!.spark.connect.DataType.TimestampH\x00R\ttimestamp\x12K\n\rtimestamp_ntz\x18\x10 \x01(\x0b\x32$.spark.connect.DataType.TimestampNTZH\x00R\x0ctimestampNtz\x12W\n\x11\x63\x61lendar_interval\x18\x11 \x01(\x0b\x32(.spark.connect.DataType.CalendarIntervalH\x00R\x10\x63\x61lendarInterval\x12[\n\x13year_month_interval\x18\x12 \x01(\x0b\x32).spark.connect.DataType.YearMonthIntervalH\x00R\x11yearMonthInterval\x12U\n\x11\x64\x61y_time_interval\x18\x13 \x01(\x0b\x32\'.spark.connect.DataType.DayTimeIntervalH\x00R\x0f\x64\x61yTimeInterval\x12\x35\n\x05\x61rray\x18\x14 \x01(\x0b\x32\x1d.spark.connect.DataType.ArrayH\x00R\x05\x61rray\x12\x38\n\x06struct\x18\x15 \x01(\x0b\x32\x1e.spark.connect.DataType.StructH\x00R\x06struct\x12/\n\x03map\x18\x16 \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x03map\x12K\n\rinterval_year\x18\x17 \x01(\x0b\x32$.spark.connect.DataType.IntervalYearH\x00R\x0cintervalYear\x12H\n\x0cinterval_day\x18\x18 \x01(\x0b\x32#.spark.connect.DataType.IntervalDayH\x00R\x0bintervalDay\x12\x32\n\x04uuid\x18\x19 \x01(\x0b\x32\x1c.spark.connect.DataType.UUIDH\x00R\x04uuid\x12H\n\x0c\x66ixed_binary\x18\x1a \x01(\x0b\x32#.spark.connect.DataType.FixedBinaryH\x00R\x0b\x66ixedBinary\x12?\n\x1buser_defined_type_reference\x18\x1f \x01(\rH\x00R\x18userDefinedTypeReference\x1a\x43\n\x07\x42oolean\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a>\n\x02I8\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I16\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I32\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I64\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x46P32\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x46P64\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06String\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x42inary\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04NULL\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x45\n\tTimestamp\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x44\x61te\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aH\n\x0cTimestampNTZ\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aH\n\x0cIntervalYear\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aG\n\x0bIntervalDay\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aL\n\x10\x43\x61lendarInterval\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\xb3\x01\n\x11YearMonthInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1a\xb1\x01\n\x0f\x44\x61yTimeInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1a@\n\x04UUID\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aX\n\x04\x43har\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a[\n\x07VarChar\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a_\n\x0b\x46ixedBinary\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\x99\x01\n\x07\x44\x65\x63imal\x12\x19\n\x05scale\x18\x01 \x01(\x05H\x00R\x05scale\x88\x01\x01\x12!\n\tprecision\x18\x02 \x01(\x05H\x01R\tprecision\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x08\n\x06_scaleB\x0c\n\n_precision\x1a\xff\x01\n\x0bStructField\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x34\n\tdata_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x08\x64\x61taType\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\x12M\n\x08metadata\x18\x04 \x03(\x0b\x32\x31.spark.connect.DataType.StructField.MetadataEntryR\x08metadata\x1a;\n\rMetadataEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x1a\x7f\n\x06Struct\x12;\n\x06\x66ields\x18\x01 \x03(\x0b\x32#.spark.connect.DataType.StructFieldR\x06\x66ields\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\xa2\x01\n\x05\x41rray\x12:\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x0b\x65lementType\x12#\n\rcontains_null\x18\x02 \x01(\x08R\x0c\x63ontainsNull\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReference\x1a\xdb\x01\n\x03Map\x12\x32\n\x08key_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x07keyType\x12\x36\n\nvalue_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\tvalueType\x12.\n\x13value_contains_null\x18\x03 \x01(\x08R\x11valueContainsNull\x12\x38\n\x18type_variation_reference\x18\x04 \x01(\rR\x16typeVariationReferenceB\x06\n\x04kindB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
+    b'\n\x19spark/connect/types.proto\x12\rspark.connect"\xce \n\x08\x44\x61taType\x12\x32\n\x04null\x18\x01 \x01(\x0b\x32\x1c.spark.connect.DataType.NULLH\x00R\x04null\x12\x38\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x1e.spark.connect.DataType.BinaryH\x00R\x06\x62inary\x12;\n\x07\x62oolean\x18\x03 \x01(\x0b\x32\x1f.spark.connect.DataType.BooleanH\x00R\x07\x62oolean\x12\x32\n\x04\x62yte\x18\x04 \x01(\x0b\x32\x1c.spark.connect.DataType.ByteH\x00R\x04\x62yte\x12\x35\n\x05short\x18\x05 \x01(\x0b\x32\x1d.spark.connect.DataType.ShortH\x00R\x05short\x12;\n\x07integer\x18\x06 \x01(\x0b\x32\x1f.spark.connect.DataType.IntegerH\x00R\x07integer\x12\x32\n\x04long\x18\x07 \x01(\x0b\x32\x1c.spark.connect.DataType.LongH\x00R\x04long\x12\x35\n\x05\x66loat\x18\x08 \x01(\x0b\x32\x1d.spark.connect.DataType.FloatH\x00R\x05\x66loat\x12\x38\n\x06\x64ouble\x18\t \x01(\x0b\x32\x1e.spark.connect.DataType.DoubleH\x00R\x06\x64ouble\x12;\n\x07\x64\x65\x63imal\x18\n \x01(\x0b\x32\x1f.spark.connect.DataType.DecimalH\x00R\x07\x64\x65\x63imal\x12\x38\n\x06string\x18\x0b \x01(\x0b\x32\x1e.spark.connect.DataType.StringH\x00R\x06string\x12\x32\n\x04\x63har\x18\x0c \x01(\x0b\x32\x1c.spark.connect.DataType.CharH\x00R\x04\x63har\x12<\n\x08var_char\x18\r \x01(\x0b\x32\x1f.spark.connect.DataType.VarCharH\x00R\x07varChar\x12\x32\n\x04\x64\x61te\x18\x0e \x01(\x0b\x32\x1c.spark.connect.DataType.DateH\x00R\x04\x64\x61te\x12\x41\n\ttimestamp\x18\x0f \x01(\x0b\x32!.spark.connect.DataType.TimestampH\x00R\ttimestamp\x12K\n\rtimestamp_ntz\x18\x10 \x01(\x0b\x32$.spark.connect.DataType.TimestampNTZH\x00R\x0ctimestampNtz\x12W\n\x11\x63\x61lendar_interval\x18\x11 \x01(\x0b\x32(.spark.connect.DataType.CalendarIntervalH\x00R\x10\x63\x61lendarInterval\x12[\n\x13year_month_interval\x18\x12 \x01(\x0b\x32).spark.connect.DataType.YearMonthIntervalH\x00R\x11yearMonthInterval\x12U\n\x11\x64\x61y_time_interval\x18\x13 \x01(\x0b\x32\'.spark.connect.DataType.DayTimeIntervalH\x00R\x0f\x64\x61yTimeInterval\x12\x35\n\x05\x61rray\x18\x14 \x01(\x0b\x32\x1d.spark.connect.DataType.ArrayH\x00R\x05\x61rray\x12\x38\n\x06struct\x18\x15 \x01(\x0b\x32\x1e.spark.connect.DataType.StructH\x00R\x06struct\x12/\n\x03map\x18\x16 \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x03map\x12\x32\n\x04uuid\x18\x19 \x01(\x0b\x32\x1c.spark.connect.DataType.UUIDH\x00R\x04uuid\x12H\n\x0c\x66ixed_binary\x18\x1a \x01(\x0b\x32#.spark.connect.DataType.FixedBinaryH\x00R\x0b\x66ixedBinary\x12?\n\x1buser_defined_type_reference\x18\x1f \x01(\rH\x00R\x18userDefinedTypeReference\x1a\x43\n\x07\x42oolean\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x42yte\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x41\n\x05Short\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x43\n\x07Integer\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04Long\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x41\n\x05\x46loat\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x44ouble\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06String\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x42inary\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04NULL\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x45\n\tTimestamp\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x44\x61te\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aH\n\x0cTimestampNTZ\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aL\n\x10\x43\x61lendarInterval\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\xb3\x01\n\x11YearMonthInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1a\xb1\x01\n\x0f\x44\x61yTimeInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1a@\n\x04UUID\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aX\n\x04\x43har\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a[\n\x07VarChar\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a_\n\x0b\x46ixedBinary\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\x99\x01\n\x07\x44\x65\x63imal\x12\x19\n\x05scale\x18\x01 \x01(\x05H\x00R\x05scale\x88\x01\x01\x12!\n\tprecision\x18\x02 \x01(\x05H\x01R\tprecision\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x08\n\x06_scaleB\x0c\n\n_precision\x1a\xff\x01\n\x0bStructField\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x34\n\tdata_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x08\x64\x61taType\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\x12M\n\x08metadata\x18\x04 \x03(\x0b\x32\x31.spark.connect.DataType.StructField.MetadataEntryR\x08metadata\x1a;\n\rMetadataEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x1a\x7f\n\x06Struct\x12;\n\x06\x66ields\x18\x01 \x03(\x0b\x32#.spark.connect.DataType.StructFieldR\x06\x66ields\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\xa2\x01\n\x05\x41rray\x12:\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x0b\x65lementType\x12#\n\rcontains_null\x18\x02 \x01(\x08R\x0c\x63ontainsNull\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReference\x1a\xdb\x01\n\x03Map\x12\x32\n\x08key_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x07keyType\x12\x36\n\nvalue_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\tvalueType\x12.\n\x13value_contains_null\x18\x03 \x01(\x08R\x11valueContainsNull\x12\x38\n\x18type_variation_reference\x18\x04 \x01(\rR\x16typeVariationReferenceB\x06\n\x04kindB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
 )
 
 
 _DATATYPE = DESCRIPTOR.message_types_by_name["DataType"]
 _DATATYPE_BOOLEAN = _DATATYPE.nested_types_by_name["Boolean"]
-_DATATYPE_I8 = _DATATYPE.nested_types_by_name["I8"]
-_DATATYPE_I16 = _DATATYPE.nested_types_by_name["I16"]
-_DATATYPE_I32 = _DATATYPE.nested_types_by_name["I32"]
-_DATATYPE_I64 = _DATATYPE.nested_types_by_name["I64"]
-_DATATYPE_FP32 = _DATATYPE.nested_types_by_name["FP32"]
-_DATATYPE_FP64 = _DATATYPE.nested_types_by_name["FP64"]
+_DATATYPE_BYTE = _DATATYPE.nested_types_by_name["Byte"]
+_DATATYPE_SHORT = _DATATYPE.nested_types_by_name["Short"]
+_DATATYPE_INTEGER = _DATATYPE.nested_types_by_name["Integer"]
+_DATATYPE_LONG = _DATATYPE.nested_types_by_name["Long"]
+_DATATYPE_FLOAT = _DATATYPE.nested_types_by_name["Float"]
+_DATATYPE_DOUBLE = _DATATYPE.nested_types_by_name["Double"]
 _DATATYPE_STRING = _DATATYPE.nested_types_by_name["String"]
 _DATATYPE_BINARY = _DATATYPE.nested_types_by_name["Binary"]
 _DATATYPE_NULL = _DATATYPE.nested_types_by_name["NULL"]
 _DATATYPE_TIMESTAMP = _DATATYPE.nested_types_by_name["Timestamp"]
 _DATATYPE_DATE = _DATATYPE.nested_types_by_name["Date"]
 _DATATYPE_TIMESTAMPNTZ = _DATATYPE.nested_types_by_name["TimestampNTZ"]
-_DATATYPE_INTERVALYEAR = _DATATYPE.nested_types_by_name["IntervalYear"]
-_DATATYPE_INTERVALDAY = _DATATYPE.nested_types_by_name["IntervalDay"]
 _DATATYPE_CALENDARINTERVAL = _DATATYPE.nested_types_by_name["CalendarInterval"]
 _DATATYPE_YEARMONTHINTERVAL = _DATATYPE.nested_types_by_name["YearMonthInterval"]
 _DATATYPE_DAYTIMEINTERVAL = _DATATYPE.nested_types_by_name["DayTimeInterval"]
@@ -76,58 +74,58 @@ DataType = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.DataType.Boolean)
             },
         ),
-        "I8": _reflection.GeneratedProtocolMessageType(
-            "I8",
+        "Byte": _reflection.GeneratedProtocolMessageType(
+            "Byte",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_I8,
+                "DESCRIPTOR": _DATATYPE_BYTE,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.I8)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Byte)
             },
         ),
-        "I16": _reflection.GeneratedProtocolMessageType(
-            "I16",
+        "Short": _reflection.GeneratedProtocolMessageType(
+            "Short",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_I16,
+                "DESCRIPTOR": _DATATYPE_SHORT,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.I16)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Short)
             },
         ),
-        "I32": _reflection.GeneratedProtocolMessageType(
-            "I32",
+        "Integer": _reflection.GeneratedProtocolMessageType(
+            "Integer",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_I32,
+                "DESCRIPTOR": _DATATYPE_INTEGER,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.I32)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Integer)
             },
         ),
-        "I64": _reflection.GeneratedProtocolMessageType(
-            "I64",
+        "Long": _reflection.GeneratedProtocolMessageType(
+            "Long",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_I64,
+                "DESCRIPTOR": _DATATYPE_LONG,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.I64)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Long)
             },
         ),
-        "FP32": _reflection.GeneratedProtocolMessageType(
-            "FP32",
+        "Float": _reflection.GeneratedProtocolMessageType(
+            "Float",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_FP32,
+                "DESCRIPTOR": _DATATYPE_FLOAT,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.FP32)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Float)
             },
         ),
-        "FP64": _reflection.GeneratedProtocolMessageType(
-            "FP64",
+        "Double": _reflection.GeneratedProtocolMessageType(
+            "Double",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_FP64,
+                "DESCRIPTOR": _DATATYPE_DOUBLE,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.FP64)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Double)
             },
         ),
         "String": _reflection.GeneratedProtocolMessageType(
@@ -182,24 +180,6 @@ DataType = _reflection.GeneratedProtocolMessageType(
                 "DESCRIPTOR": _DATATYPE_TIMESTAMPNTZ,
                 "__module__": "spark.connect.types_pb2"
                 # @@protoc_insertion_point(class_scope:spark.connect.DataType.TimestampNTZ)
-            },
-        ),
-        "IntervalYear": _reflection.GeneratedProtocolMessageType(
-            "IntervalYear",
-            (_message.Message,),
-            {
-                "DESCRIPTOR": _DATATYPE_INTERVALYEAR,
-                "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.IntervalYear)
-            },
-        ),
-        "IntervalDay": _reflection.GeneratedProtocolMessageType(
-            "IntervalDay",
-            (_message.Message,),
-            {
-                "DESCRIPTOR": _DATATYPE_INTERVALDAY,
-                "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.IntervalDay)
             },
         ),
         "CalendarInterval": _reflection.GeneratedProtocolMessageType(
@@ -326,20 +306,18 @@ DataType = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(DataType)
 _sym_db.RegisterMessage(DataType.Boolean)
-_sym_db.RegisterMessage(DataType.I8)
-_sym_db.RegisterMessage(DataType.I16)
-_sym_db.RegisterMessage(DataType.I32)
-_sym_db.RegisterMessage(DataType.I64)
-_sym_db.RegisterMessage(DataType.FP32)
-_sym_db.RegisterMessage(DataType.FP64)
+_sym_db.RegisterMessage(DataType.Byte)
+_sym_db.RegisterMessage(DataType.Short)
+_sym_db.RegisterMessage(DataType.Integer)
+_sym_db.RegisterMessage(DataType.Long)
+_sym_db.RegisterMessage(DataType.Float)
+_sym_db.RegisterMessage(DataType.Double)
 _sym_db.RegisterMessage(DataType.String)
 _sym_db.RegisterMessage(DataType.Binary)
 _sym_db.RegisterMessage(DataType.NULL)
 _sym_db.RegisterMessage(DataType.Timestamp)
 _sym_db.RegisterMessage(DataType.Date)
 _sym_db.RegisterMessage(DataType.TimestampNTZ)
-_sym_db.RegisterMessage(DataType.IntervalYear)
-_sym_db.RegisterMessage(DataType.IntervalDay)
 _sym_db.RegisterMessage(DataType.CalendarInterval)
 _sym_db.RegisterMessage(DataType.YearMonthInterval)
 _sym_db.RegisterMessage(DataType.DayTimeInterval)
@@ -361,61 +339,57 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _DATATYPE_STRUCTFIELD_METADATAENTRY._options = None
     _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_options = b"8\001"
     _DATATYPE._serialized_start = 45
-    _DATATYPE._serialized_end = 4469
-    _DATATYPE_BOOLEAN._serialized_start = 1727
-    _DATATYPE_BOOLEAN._serialized_end = 1794
-    _DATATYPE_I8._serialized_start = 1796
-    _DATATYPE_I8._serialized_end = 1858
-    _DATATYPE_I16._serialized_start = 1860
-    _DATATYPE_I16._serialized_end = 1923
-    _DATATYPE_I32._serialized_start = 1925
-    _DATATYPE_I32._serialized_end = 1988
-    _DATATYPE_I64._serialized_start = 1990
-    _DATATYPE_I64._serialized_end = 2053
-    _DATATYPE_FP32._serialized_start = 2055
-    _DATATYPE_FP32._serialized_end = 2119
-    _DATATYPE_FP64._serialized_start = 2121
-    _DATATYPE_FP64._serialized_end = 2185
-    _DATATYPE_STRING._serialized_start = 2187
-    _DATATYPE_STRING._serialized_end = 2253
-    _DATATYPE_BINARY._serialized_start = 2255
-    _DATATYPE_BINARY._serialized_end = 2321
-    _DATATYPE_NULL._serialized_start = 2323
-    _DATATYPE_NULL._serialized_end = 2387
-    _DATATYPE_TIMESTAMP._serialized_start = 2389
-    _DATATYPE_TIMESTAMP._serialized_end = 2458
-    _DATATYPE_DATE._serialized_start = 2460
-    _DATATYPE_DATE._serialized_end = 2524
-    _DATATYPE_TIMESTAMPNTZ._serialized_start = 2526
-    _DATATYPE_TIMESTAMPNTZ._serialized_end = 2598
-    _DATATYPE_INTERVALYEAR._serialized_start = 2600
-    _DATATYPE_INTERVALYEAR._serialized_end = 2672
-    _DATATYPE_INTERVALDAY._serialized_start = 2674
-    _DATATYPE_INTERVALDAY._serialized_end = 2745
-    _DATATYPE_CALENDARINTERVAL._serialized_start = 2747
-    _DATATYPE_CALENDARINTERVAL._serialized_end = 2823
-    _DATATYPE_YEARMONTHINTERVAL._serialized_start = 2826
-    _DATATYPE_YEARMONTHINTERVAL._serialized_end = 3005
-    _DATATYPE_DAYTIMEINTERVAL._serialized_start = 3008
-    _DATATYPE_DAYTIMEINTERVAL._serialized_end = 3185
-    _DATATYPE_UUID._serialized_start = 3187
-    _DATATYPE_UUID._serialized_end = 3251
-    _DATATYPE_CHAR._serialized_start = 3253
-    _DATATYPE_CHAR._serialized_end = 3341
-    _DATATYPE_VARCHAR._serialized_start = 3343
-    _DATATYPE_VARCHAR._serialized_end = 3434
-    _DATATYPE_FIXEDBINARY._serialized_start = 3436
-    _DATATYPE_FIXEDBINARY._serialized_end = 3531
-    _DATATYPE_DECIMAL._serialized_start = 3534
-    _DATATYPE_DECIMAL._serialized_end = 3687
-    _DATATYPE_STRUCTFIELD._serialized_start = 3690
-    _DATATYPE_STRUCTFIELD._serialized_end = 3945
-    _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_start = 3886
-    _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_end = 3945
-    _DATATYPE_STRUCT._serialized_start = 3947
-    _DATATYPE_STRUCT._serialized_end = 4074
-    _DATATYPE_ARRAY._serialized_start = 4077
-    _DATATYPE_ARRAY._serialized_end = 4239
-    _DATATYPE_MAP._serialized_start = 4242
-    _DATATYPE_MAP._serialized_end = 4461
+    _DATATYPE._serialized_end = 4219
+    _DATATYPE_BOOLEAN._serialized_start = 1612
+    _DATATYPE_BOOLEAN._serialized_end = 1679
+    _DATATYPE_BYTE._serialized_start = 1681
+    _DATATYPE_BYTE._serialized_end = 1745
+    _DATATYPE_SHORT._serialized_start = 1747
+    _DATATYPE_SHORT._serialized_end = 1812
+    _DATATYPE_INTEGER._serialized_start = 1814
+    _DATATYPE_INTEGER._serialized_end = 1881
+    _DATATYPE_LONG._serialized_start = 1883
+    _DATATYPE_LONG._serialized_end = 1947
+    _DATATYPE_FLOAT._serialized_start = 1949
+    _DATATYPE_FLOAT._serialized_end = 2014
+    _DATATYPE_DOUBLE._serialized_start = 2016
+    _DATATYPE_DOUBLE._serialized_end = 2082
+    _DATATYPE_STRING._serialized_start = 2084
+    _DATATYPE_STRING._serialized_end = 2150
+    _DATATYPE_BINARY._serialized_start = 2152
+    _DATATYPE_BINARY._serialized_end = 2218
+    _DATATYPE_NULL._serialized_start = 2220
+    _DATATYPE_NULL._serialized_end = 2284
+    _DATATYPE_TIMESTAMP._serialized_start = 2286
+    _DATATYPE_TIMESTAMP._serialized_end = 2355
+    _DATATYPE_DATE._serialized_start = 2357
+    _DATATYPE_DATE._serialized_end = 2421
+    _DATATYPE_TIMESTAMPNTZ._serialized_start = 2423
+    _DATATYPE_TIMESTAMPNTZ._serialized_end = 2495
+    _DATATYPE_CALENDARINTERVAL._serialized_start = 2497
+    _DATATYPE_CALENDARINTERVAL._serialized_end = 2573
+    _DATATYPE_YEARMONTHINTERVAL._serialized_start = 2576
+    _DATATYPE_YEARMONTHINTERVAL._serialized_end = 2755
+    _DATATYPE_DAYTIMEINTERVAL._serialized_start = 2758
+    _DATATYPE_DAYTIMEINTERVAL._serialized_end = 2935
+    _DATATYPE_UUID._serialized_start = 2937
+    _DATATYPE_UUID._serialized_end = 3001
+    _DATATYPE_CHAR._serialized_start = 3003
+    _DATATYPE_CHAR._serialized_end = 3091
+    _DATATYPE_VARCHAR._serialized_start = 3093
+    _DATATYPE_VARCHAR._serialized_end = 3184
+    _DATATYPE_FIXEDBINARY._serialized_start = 3186
+    _DATATYPE_FIXEDBINARY._serialized_end = 3281
+    _DATATYPE_DECIMAL._serialized_start = 3284
+    _DATATYPE_DECIMAL._serialized_end = 3437
+    _DATATYPE_STRUCTFIELD._serialized_start = 3440
+    _DATATYPE_STRUCTFIELD._serialized_end = 3695
+    _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_start = 3636
+    _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_end = 3695
+    _DATATYPE_STRUCT._serialized_start = 3697
+    _DATATYPE_STRUCT._serialized_end = 3824
+    _DATATYPE_ARRAY._serialized_start = 3827
+    _DATATYPE_ARRAY._serialized_end = 3989
+    _DATATYPE_MAP._serialized_start = 3992
+    _DATATYPE_MAP._serialized_end = 4211
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/types_pb2.py
+++ b/python/pyspark/sql/connect/proto/types_pb2.py
@@ -30,7 +30,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x19spark/connect/types.proto\x12\rspark.connect"\xc1\x1c\n\x08\x44\x61taType\x12\x35\n\x04\x62ool\x18\x01 \x01(\x0b\x32\x1f.spark.connect.DataType.BooleanH\x00R\x04\x62ool\x12,\n\x02i8\x18\x02 \x01(\x0b\x32\x1a.spark.connect.DataType.I8H\x00R\x02i8\x12/\n\x03i16\x18\x03 \x01(\x0b\x32\x1b.spark.connect.DataType.I16H\x00R\x03i16\x12/\n\x03i32\x18\x05 \x01(\x0b\x32\x1b.spark.connect.DataType.I32H\x00R\x03i32\x12/\n\x03i64\x18\x07 \x01(\x0b\x32\x1b.spark.connect.DataType.I64H\x00R\x03i64\x12\x32\n\x04\x66p32\x18\n \x01(\x0b\x32\x1c.spark.connect.DataType.FP32H\x00R\x04\x66p32\x12\x32\n\x04\x66p64\x18\x0b \x01(\x0b\x32\x1c.spark.connect.DataType.FP64H\x00R\x04\x66p64\x12\x38\n\x06string\x18\x0c \x01(\x0b\x32\x1e.spark.connect.DataType.StringH\x00R\x06string\x12\x38\n\x06\x62inary\x18\r \x01(\x0b\x32\x1e.spark.connect.DataType.BinaryH\x00R\x06\x62inary\x12\x41\n\ttimestamp\x18\x0e \x01(\x0b\x32!.spark.connect.DataType.TimestampH\x00R\ttimestamp\x12\x32\n\x04\x64\x61te\x18\x10 \x01(\x0b\x32\x1c.spark.connect.DataType.DateH\x00R\x04\x64\x61te\x12\x32\n\x04time\x18\x11 \x01(\x0b\x32\x1c.spark.connect.DataType.TimeH\x00R\x04time\x12K\n\rinterval_year\x18\x13 \x01(\x0b\x32$.spark.connect.DataType.IntervalYearH\x00R\x0cintervalYear\x12H\n\x0cinterval_day\x18\x14 \x01(\x0b\x32#.spark.connect.DataType.IntervalDayH\x00R\x0bintervalDay\x12H\n\x0ctimestamp_tz\x18\x1d \x01(\x0b\x32#.spark.connect.DataType.TimestampTZH\x00R\x0btimestampTz\x12\x32\n\x04uuid\x18  \x01(\x0b\x32\x1c.spark.connect.DataType.UUIDH\x00R\x04uuid\x12\x42\n\nfixed_char\x18\x15 \x01(\x0b\x32!.spark.connect.DataType.FixedCharH\x00R\tfixedChar\x12;\n\x07varchar\x18\x16 \x01(\x0b\x32\x1f.spark.connect.DataType.VarCharH\x00R\x07varchar\x12H\n\x0c\x66ixed_binary\x18\x17 \x01(\x0b\x32#.spark.connect.DataType.FixedBinaryH\x00R\x0b\x66ixedBinary\x12;\n\x07\x64\x65\x63imal\x18\x18 \x01(\x0b\x32\x1f.spark.connect.DataType.DecimalH\x00R\x07\x64\x65\x63imal\x12\x38\n\x06struct\x18\x19 \x01(\x0b\x32\x1e.spark.connect.DataType.StructH\x00R\x06struct\x12\x32\n\x04list\x18\x1b \x01(\x0b\x32\x1c.spark.connect.DataType.ListH\x00R\x04list\x12/\n\x03map\x18\x1c \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x03map\x12?\n\x1buser_defined_type_reference\x18\x1f \x01(\rH\x00R\x18userDefinedTypeReference\x1a\x43\n\x07\x42oolean\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a>\n\x02I8\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I16\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I32\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I64\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x46P32\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x46P64\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06String\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x42inary\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x45\n\tTimestamp\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x44\x61te\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04Time\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aG\n\x0bTimestampTZ\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aH\n\x0cIntervalYear\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aG\n\x0bIntervalDay\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04UUID\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a]\n\tFixedChar\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a[\n\x07VarChar\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a_\n\x0b\x46ixedBinary\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1aw\n\x07\x44\x65\x63imal\x12\x14\n\x05scale\x18\x01 \x01(\x05R\x05scale\x12\x1c\n\tprecision\x18\x02 \x01(\x05R\tprecision\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReference\x1a\xf6\x01\n\x0bStructField\x12+\n\x04type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x04type\x12\x12\n\x04name\x18\x02 \x01(\tR\x04name\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\x12M\n\x08metadata\x18\x04 \x03(\x0b\x32\x31.spark.connect.DataType.StructField.MetadataEntryR\x08metadata\x1a;\n\rMetadataEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x1a\x7f\n\x06Struct\x12;\n\x06\x66ields\x18\x01 \x03(\x0b\x32#.spark.connect.DataType.StructFieldR\x06\x66ields\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\xa0\x01\n\x04List\x12\x33\n\x08\x44\x61taType\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x08\x44\x61taType\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x12)\n\x10\x65lement_nullable\x18\x03 \x01(\x08R\x0f\x65lementNullable\x1a\xc0\x01\n\x03Map\x12)\n\x03key\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x03key\x12-\n\x05value\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x05value\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReference\x12%\n\x0evalue_nullable\x18\x04 \x01(\x08R\rvalueNullableB\x06\n\x04kindB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
+    b'\n\x19spark/connect/types.proto\x12\rspark.connect"\xc8"\n\x08\x44\x61taType\x12\x32\n\x04null\x18\x01 \x01(\x0b\x32\x1c.spark.connect.DataType.NULLH\x00R\x04null\x12\x38\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x1e.spark.connect.DataType.BinaryH\x00R\x06\x62inary\x12;\n\x07\x62oolean\x18\x03 \x01(\x0b\x32\x1f.spark.connect.DataType.BooleanH\x00R\x07\x62oolean\x12,\n\x02i8\x18\x04 \x01(\x0b\x32\x1a.spark.connect.DataType.I8H\x00R\x02i8\x12/\n\x03i16\x18\x05 \x01(\x0b\x32\x1b.spark.connect.DataType.I16H\x00R\x03i16\x12/\n\x03i32\x18\x06 \x01(\x0b\x32\x1b.spark.connect.DataType.I32H\x00R\x03i32\x12/\n\x03i64\x18\x07 \x01(\x0b\x32\x1b.spark.connect.DataType.I64H\x00R\x03i64\x12\x32\n\x04\x66p32\x18\x08 \x01(\x0b\x32\x1c.spark.connect.DataType.FP32H\x00R\x04\x66p32\x12\x32\n\x04\x66p64\x18\t \x01(\x0b\x32\x1c.spark.connect.DataType.FP64H\x00R\x04\x66p64\x12;\n\x07\x64\x65\x63imal\x18\n \x01(\x0b\x32\x1f.spark.connect.DataType.DecimalH\x00R\x07\x64\x65\x63imal\x12\x38\n\x06string\x18\x0b \x01(\x0b\x32\x1e.spark.connect.DataType.StringH\x00R\x06string\x12\x32\n\x04\x63har\x18\x0c \x01(\x0b\x32\x1c.spark.connect.DataType.CharH\x00R\x04\x63har\x12<\n\x08var_char\x18\r \x01(\x0b\x32\x1f.spark.connect.DataType.VarCharH\x00R\x07varChar\x12\x32\n\x04\x64\x61te\x18\x0e \x01(\x0b\x32\x1c.spark.connect.DataType.DateH\x00R\x04\x64\x61te\x12\x41\n\ttimestamp\x18\x0f \x01(\x0b\x32!.spark.connect.DataType.TimestampH\x00R\ttimestamp\x12K\n\rtimestamp_ntz\x18\x10 \x01(\x0b\x32$.spark.connect.DataType.TimestampNTZH\x00R\x0ctimestampNtz\x12W\n\x11\x63\x61lendar_interval\x18\x11 \x01(\x0b\x32(.spark.connect.DataType.CalendarIntervalH\x00R\x10\x63\x61lendarInterval\x12[\n\x13year_month_interval\x18\x12 \x01(\x0b\x32).spark.connect.DataType.YearMonthIntervalH\x00R\x11yearMonthInterval\x12U\n\x11\x64\x61y_time_interval\x18\x13 \x01(\x0b\x32\'.spark.connect.DataType.DayTimeIntervalH\x00R\x0f\x64\x61yTimeInterval\x12\x35\n\x05\x61rray\x18\x14 \x01(\x0b\x32\x1d.spark.connect.DataType.ArrayH\x00R\x05\x61rray\x12\x38\n\x06struct\x18\x15 \x01(\x0b\x32\x1e.spark.connect.DataType.StructH\x00R\x06struct\x12/\n\x03map\x18\x16 \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x03map\x12K\n\rinterval_year\x18\x17 \x01(\x0b\x32$.spark.connect.DataType.IntervalYearH\x00R\x0cintervalYear\x12H\n\x0cinterval_day\x18\x18 \x01(\x0b\x32#.spark.connect.DataType.IntervalDayH\x00R\x0bintervalDay\x12\x32\n\x04uuid\x18\x19 \x01(\x0b\x32\x1c.spark.connect.DataType.UUIDH\x00R\x04uuid\x12H\n\x0c\x66ixed_binary\x18\x1a \x01(\x0b\x32#.spark.connect.DataType.FixedBinaryH\x00R\x0b\x66ixedBinary\x12?\n\x1buser_defined_type_reference\x18\x1f \x01(\rH\x00R\x18userDefinedTypeReference\x1a\x43\n\x07\x42oolean\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a>\n\x02I8\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I16\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I32\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a?\n\x03I64\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x46P32\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x46P64\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06String\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x42inary\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04NULL\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x45\n\tTimestamp\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x44\x61te\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aH\n\x0cTimestampNTZ\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aH\n\x0cIntervalYear\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aG\n\x0bIntervalDay\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aL\n\x10\x43\x61lendarInterval\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\xb3\x01\n\x11YearMonthInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1a\xb1\x01\n\x0f\x44\x61yTimeInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1a@\n\x04UUID\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aX\n\x04\x43har\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a[\n\x07VarChar\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a_\n\x0b\x46ixedBinary\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\x99\x01\n\x07\x44\x65\x63imal\x12\x19\n\x05scale\x18\x01 \x01(\x05H\x00R\x05scale\x88\x01\x01\x12!\n\tprecision\x18\x02 \x01(\x05H\x01R\tprecision\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x08\n\x06_scaleB\x0c\n\n_precision\x1a\xff\x01\n\x0bStructField\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x34\n\tdata_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x08\x64\x61taType\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\x12M\n\x08metadata\x18\x04 \x03(\x0b\x32\x31.spark.connect.DataType.StructField.MetadataEntryR\x08metadata\x1a;\n\rMetadataEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x1a\x7f\n\x06Struct\x12;\n\x06\x66ields\x18\x01 \x03(\x0b\x32#.spark.connect.DataType.StructFieldR\x06\x66ields\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\xa2\x01\n\x05\x41rray\x12:\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x0b\x65lementType\x12#\n\rcontains_null\x18\x02 \x01(\x08R\x0c\x63ontainsNull\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReference\x1a\xdb\x01\n\x03Map\x12\x32\n\x08key_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x07keyType\x12\x36\n\nvalue_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\tvalueType\x12.\n\x13value_contains_null\x18\x03 \x01(\x08R\x11valueContainsNull\x12\x38\n\x18type_variation_reference\x18\x04 \x01(\rR\x16typeVariationReferenceB\x06\n\x04kindB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
 )
 
 
@@ -44,21 +44,24 @@ _DATATYPE_FP32 = _DATATYPE.nested_types_by_name["FP32"]
 _DATATYPE_FP64 = _DATATYPE.nested_types_by_name["FP64"]
 _DATATYPE_STRING = _DATATYPE.nested_types_by_name["String"]
 _DATATYPE_BINARY = _DATATYPE.nested_types_by_name["Binary"]
+_DATATYPE_NULL = _DATATYPE.nested_types_by_name["NULL"]
 _DATATYPE_TIMESTAMP = _DATATYPE.nested_types_by_name["Timestamp"]
 _DATATYPE_DATE = _DATATYPE.nested_types_by_name["Date"]
-_DATATYPE_TIME = _DATATYPE.nested_types_by_name["Time"]
-_DATATYPE_TIMESTAMPTZ = _DATATYPE.nested_types_by_name["TimestampTZ"]
+_DATATYPE_TIMESTAMPNTZ = _DATATYPE.nested_types_by_name["TimestampNTZ"]
 _DATATYPE_INTERVALYEAR = _DATATYPE.nested_types_by_name["IntervalYear"]
 _DATATYPE_INTERVALDAY = _DATATYPE.nested_types_by_name["IntervalDay"]
+_DATATYPE_CALENDARINTERVAL = _DATATYPE.nested_types_by_name["CalendarInterval"]
+_DATATYPE_YEARMONTHINTERVAL = _DATATYPE.nested_types_by_name["YearMonthInterval"]
+_DATATYPE_DAYTIMEINTERVAL = _DATATYPE.nested_types_by_name["DayTimeInterval"]
 _DATATYPE_UUID = _DATATYPE.nested_types_by_name["UUID"]
-_DATATYPE_FIXEDCHAR = _DATATYPE.nested_types_by_name["FixedChar"]
+_DATATYPE_CHAR = _DATATYPE.nested_types_by_name["Char"]
 _DATATYPE_VARCHAR = _DATATYPE.nested_types_by_name["VarChar"]
 _DATATYPE_FIXEDBINARY = _DATATYPE.nested_types_by_name["FixedBinary"]
 _DATATYPE_DECIMAL = _DATATYPE.nested_types_by_name["Decimal"]
 _DATATYPE_STRUCTFIELD = _DATATYPE.nested_types_by_name["StructField"]
 _DATATYPE_STRUCTFIELD_METADATAENTRY = _DATATYPE_STRUCTFIELD.nested_types_by_name["MetadataEntry"]
 _DATATYPE_STRUCT = _DATATYPE.nested_types_by_name["Struct"]
-_DATATYPE_LIST = _DATATYPE.nested_types_by_name["List"]
+_DATATYPE_ARRAY = _DATATYPE.nested_types_by_name["Array"]
 _DATATYPE_MAP = _DATATYPE.nested_types_by_name["Map"]
 DataType = _reflection.GeneratedProtocolMessageType(
     "DataType",
@@ -145,6 +148,15 @@ DataType = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.DataType.Binary)
             },
         ),
+        "NULL": _reflection.GeneratedProtocolMessageType(
+            "NULL",
+            (_message.Message,),
+            {
+                "DESCRIPTOR": _DATATYPE_NULL,
+                "__module__": "spark.connect.types_pb2"
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.NULL)
+            },
+        ),
         "Timestamp": _reflection.GeneratedProtocolMessageType(
             "Timestamp",
             (_message.Message,),
@@ -163,22 +175,13 @@ DataType = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.DataType.Date)
             },
         ),
-        "Time": _reflection.GeneratedProtocolMessageType(
-            "Time",
+        "TimestampNTZ": _reflection.GeneratedProtocolMessageType(
+            "TimestampNTZ",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_TIME,
+                "DESCRIPTOR": _DATATYPE_TIMESTAMPNTZ,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Time)
-            },
-        ),
-        "TimestampTZ": _reflection.GeneratedProtocolMessageType(
-            "TimestampTZ",
-            (_message.Message,),
-            {
-                "DESCRIPTOR": _DATATYPE_TIMESTAMPTZ,
-                "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.TimestampTZ)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.TimestampNTZ)
             },
         ),
         "IntervalYear": _reflection.GeneratedProtocolMessageType(
@@ -199,6 +202,33 @@ DataType = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.DataType.IntervalDay)
             },
         ),
+        "CalendarInterval": _reflection.GeneratedProtocolMessageType(
+            "CalendarInterval",
+            (_message.Message,),
+            {
+                "DESCRIPTOR": _DATATYPE_CALENDARINTERVAL,
+                "__module__": "spark.connect.types_pb2"
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.CalendarInterval)
+            },
+        ),
+        "YearMonthInterval": _reflection.GeneratedProtocolMessageType(
+            "YearMonthInterval",
+            (_message.Message,),
+            {
+                "DESCRIPTOR": _DATATYPE_YEARMONTHINTERVAL,
+                "__module__": "spark.connect.types_pb2"
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.YearMonthInterval)
+            },
+        ),
+        "DayTimeInterval": _reflection.GeneratedProtocolMessageType(
+            "DayTimeInterval",
+            (_message.Message,),
+            {
+                "DESCRIPTOR": _DATATYPE_DAYTIMEINTERVAL,
+                "__module__": "spark.connect.types_pb2"
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.DayTimeInterval)
+            },
+        ),
         "UUID": _reflection.GeneratedProtocolMessageType(
             "UUID",
             (_message.Message,),
@@ -208,13 +238,13 @@ DataType = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.DataType.UUID)
             },
         ),
-        "FixedChar": _reflection.GeneratedProtocolMessageType(
-            "FixedChar",
+        "Char": _reflection.GeneratedProtocolMessageType(
+            "Char",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_FIXEDCHAR,
+                "DESCRIPTOR": _DATATYPE_CHAR,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.FixedChar)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Char)
             },
         ),
         "VarChar": _reflection.GeneratedProtocolMessageType(
@@ -271,13 +301,13 @@ DataType = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.DataType.Struct)
             },
         ),
-        "List": _reflection.GeneratedProtocolMessageType(
-            "List",
+        "Array": _reflection.GeneratedProtocolMessageType(
+            "Array",
             (_message.Message,),
             {
-                "DESCRIPTOR": _DATATYPE_LIST,
+                "DESCRIPTOR": _DATATYPE_ARRAY,
                 "__module__": "spark.connect.types_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.DataType.List)
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.Array)
             },
         ),
         "Map": _reflection.GeneratedProtocolMessageType(
@@ -304,21 +334,24 @@ _sym_db.RegisterMessage(DataType.FP32)
 _sym_db.RegisterMessage(DataType.FP64)
 _sym_db.RegisterMessage(DataType.String)
 _sym_db.RegisterMessage(DataType.Binary)
+_sym_db.RegisterMessage(DataType.NULL)
 _sym_db.RegisterMessage(DataType.Timestamp)
 _sym_db.RegisterMessage(DataType.Date)
-_sym_db.RegisterMessage(DataType.Time)
-_sym_db.RegisterMessage(DataType.TimestampTZ)
+_sym_db.RegisterMessage(DataType.TimestampNTZ)
 _sym_db.RegisterMessage(DataType.IntervalYear)
 _sym_db.RegisterMessage(DataType.IntervalDay)
+_sym_db.RegisterMessage(DataType.CalendarInterval)
+_sym_db.RegisterMessage(DataType.YearMonthInterval)
+_sym_db.RegisterMessage(DataType.DayTimeInterval)
 _sym_db.RegisterMessage(DataType.UUID)
-_sym_db.RegisterMessage(DataType.FixedChar)
+_sym_db.RegisterMessage(DataType.Char)
 _sym_db.RegisterMessage(DataType.VarChar)
 _sym_db.RegisterMessage(DataType.FixedBinary)
 _sym_db.RegisterMessage(DataType.Decimal)
 _sym_db.RegisterMessage(DataType.StructField)
 _sym_db.RegisterMessage(DataType.StructField.MetadataEntry)
 _sym_db.RegisterMessage(DataType.Struct)
-_sym_db.RegisterMessage(DataType.List)
+_sym_db.RegisterMessage(DataType.Array)
 _sym_db.RegisterMessage(DataType.Map)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
@@ -328,55 +361,61 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _DATATYPE_STRUCTFIELD_METADATAENTRY._options = None
     _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_options = b"8\001"
     _DATATYPE._serialized_start = 45
-    _DATATYPE._serialized_end = 3694
-    _DATATYPE_BOOLEAN._serialized_start = 1461
-    _DATATYPE_BOOLEAN._serialized_end = 1528
-    _DATATYPE_I8._serialized_start = 1530
-    _DATATYPE_I8._serialized_end = 1592
-    _DATATYPE_I16._serialized_start = 1594
-    _DATATYPE_I16._serialized_end = 1657
-    _DATATYPE_I32._serialized_start = 1659
-    _DATATYPE_I32._serialized_end = 1722
-    _DATATYPE_I64._serialized_start = 1724
-    _DATATYPE_I64._serialized_end = 1787
-    _DATATYPE_FP32._serialized_start = 1789
-    _DATATYPE_FP32._serialized_end = 1853
-    _DATATYPE_FP64._serialized_start = 1855
-    _DATATYPE_FP64._serialized_end = 1919
-    _DATATYPE_STRING._serialized_start = 1921
-    _DATATYPE_STRING._serialized_end = 1987
-    _DATATYPE_BINARY._serialized_start = 1989
-    _DATATYPE_BINARY._serialized_end = 2055
-    _DATATYPE_TIMESTAMP._serialized_start = 2057
-    _DATATYPE_TIMESTAMP._serialized_end = 2126
-    _DATATYPE_DATE._serialized_start = 2128
-    _DATATYPE_DATE._serialized_end = 2192
-    _DATATYPE_TIME._serialized_start = 2194
-    _DATATYPE_TIME._serialized_end = 2258
-    _DATATYPE_TIMESTAMPTZ._serialized_start = 2260
-    _DATATYPE_TIMESTAMPTZ._serialized_end = 2331
-    _DATATYPE_INTERVALYEAR._serialized_start = 2333
-    _DATATYPE_INTERVALYEAR._serialized_end = 2405
-    _DATATYPE_INTERVALDAY._serialized_start = 2407
-    _DATATYPE_INTERVALDAY._serialized_end = 2478
-    _DATATYPE_UUID._serialized_start = 2480
-    _DATATYPE_UUID._serialized_end = 2544
-    _DATATYPE_FIXEDCHAR._serialized_start = 2546
-    _DATATYPE_FIXEDCHAR._serialized_end = 2639
-    _DATATYPE_VARCHAR._serialized_start = 2641
-    _DATATYPE_VARCHAR._serialized_end = 2732
-    _DATATYPE_FIXEDBINARY._serialized_start = 2734
-    _DATATYPE_FIXEDBINARY._serialized_end = 2829
-    _DATATYPE_DECIMAL._serialized_start = 2831
-    _DATATYPE_DECIMAL._serialized_end = 2950
-    _DATATYPE_STRUCTFIELD._serialized_start = 2953
-    _DATATYPE_STRUCTFIELD._serialized_end = 3199
-    _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_start = 3140
-    _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_end = 3199
-    _DATATYPE_STRUCT._serialized_start = 3201
-    _DATATYPE_STRUCT._serialized_end = 3328
-    _DATATYPE_LIST._serialized_start = 3331
-    _DATATYPE_LIST._serialized_end = 3491
-    _DATATYPE_MAP._serialized_start = 3494
-    _DATATYPE_MAP._serialized_end = 3686
+    _DATATYPE._serialized_end = 4469
+    _DATATYPE_BOOLEAN._serialized_start = 1727
+    _DATATYPE_BOOLEAN._serialized_end = 1794
+    _DATATYPE_I8._serialized_start = 1796
+    _DATATYPE_I8._serialized_end = 1858
+    _DATATYPE_I16._serialized_start = 1860
+    _DATATYPE_I16._serialized_end = 1923
+    _DATATYPE_I32._serialized_start = 1925
+    _DATATYPE_I32._serialized_end = 1988
+    _DATATYPE_I64._serialized_start = 1990
+    _DATATYPE_I64._serialized_end = 2053
+    _DATATYPE_FP32._serialized_start = 2055
+    _DATATYPE_FP32._serialized_end = 2119
+    _DATATYPE_FP64._serialized_start = 2121
+    _DATATYPE_FP64._serialized_end = 2185
+    _DATATYPE_STRING._serialized_start = 2187
+    _DATATYPE_STRING._serialized_end = 2253
+    _DATATYPE_BINARY._serialized_start = 2255
+    _DATATYPE_BINARY._serialized_end = 2321
+    _DATATYPE_NULL._serialized_start = 2323
+    _DATATYPE_NULL._serialized_end = 2387
+    _DATATYPE_TIMESTAMP._serialized_start = 2389
+    _DATATYPE_TIMESTAMP._serialized_end = 2458
+    _DATATYPE_DATE._serialized_start = 2460
+    _DATATYPE_DATE._serialized_end = 2524
+    _DATATYPE_TIMESTAMPNTZ._serialized_start = 2526
+    _DATATYPE_TIMESTAMPNTZ._serialized_end = 2598
+    _DATATYPE_INTERVALYEAR._serialized_start = 2600
+    _DATATYPE_INTERVALYEAR._serialized_end = 2672
+    _DATATYPE_INTERVALDAY._serialized_start = 2674
+    _DATATYPE_INTERVALDAY._serialized_end = 2745
+    _DATATYPE_CALENDARINTERVAL._serialized_start = 2747
+    _DATATYPE_CALENDARINTERVAL._serialized_end = 2823
+    _DATATYPE_YEARMONTHINTERVAL._serialized_start = 2826
+    _DATATYPE_YEARMONTHINTERVAL._serialized_end = 3005
+    _DATATYPE_DAYTIMEINTERVAL._serialized_start = 3008
+    _DATATYPE_DAYTIMEINTERVAL._serialized_end = 3185
+    _DATATYPE_UUID._serialized_start = 3187
+    _DATATYPE_UUID._serialized_end = 3251
+    _DATATYPE_CHAR._serialized_start = 3253
+    _DATATYPE_CHAR._serialized_end = 3341
+    _DATATYPE_VARCHAR._serialized_start = 3343
+    _DATATYPE_VARCHAR._serialized_end = 3434
+    _DATATYPE_FIXEDBINARY._serialized_start = 3436
+    _DATATYPE_FIXEDBINARY._serialized_end = 3531
+    _DATATYPE_DECIMAL._serialized_start = 3534
+    _DATATYPE_DECIMAL._serialized_end = 3687
+    _DATATYPE_STRUCTFIELD._serialized_start = 3690
+    _DATATYPE_STRUCTFIELD._serialized_end = 3945
+    _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_start = 3886
+    _DATATYPE_STRUCTFIELD_METADATAENTRY._serialized_end = 3945
+    _DATATYPE_STRUCT._serialized_start = 3947
+    _DATATYPE_STRUCT._serialized_end = 4074
+    _DATATYPE_ARRAY._serialized_start = 4077
+    _DATATYPE_ARRAY._serialized_end = 4239
+    _DATATYPE_MAP._serialized_start = 4242
+    _DATATYPE_MAP._serialized_end = 4461
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/types_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/types_pb2.pyi
@@ -72,7 +72,7 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class I8(google.protobuf.message.Message):
+    class Byte(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
@@ -89,7 +89,7 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class I16(google.protobuf.message.Message):
+    class Short(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
@@ -106,7 +106,7 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class I32(google.protobuf.message.Message):
+    class Integer(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
@@ -123,7 +123,7 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class I64(google.protobuf.message.Message):
+    class Long(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
@@ -140,7 +140,7 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class FP32(google.protobuf.message.Message):
+    class Float(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
@@ -157,7 +157,7 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class FP64(google.protobuf.message.Message):
+    class Double(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
@@ -260,40 +260,6 @@ class DataType(google.protobuf.message.Message):
         ) -> None: ...
 
     class TimestampNTZ(google.protobuf.message.Message):
-        DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-        TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
-        type_variation_reference: builtins.int
-        def __init__(
-            self,
-            *,
-            type_variation_reference: builtins.int = ...,
-        ) -> None: ...
-        def ClearField(
-            self,
-            field_name: typing_extensions.Literal[
-                "type_variation_reference", b"type_variation_reference"
-            ],
-        ) -> None: ...
-
-    class IntervalYear(google.protobuf.message.Message):
-        DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-        TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
-        type_variation_reference: builtins.int
-        def __init__(
-            self,
-            *,
-            type_variation_reference: builtins.int = ...,
-        ) -> None: ...
-        def ClearField(
-            self,
-            field_name: typing_extensions.Literal[
-                "type_variation_reference", b"type_variation_reference"
-            ],
-        ) -> None: ...
-
-    class IntervalDay(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
@@ -723,12 +689,12 @@ class DataType(google.protobuf.message.Message):
     NULL_FIELD_NUMBER: builtins.int
     BINARY_FIELD_NUMBER: builtins.int
     BOOLEAN_FIELD_NUMBER: builtins.int
-    I8_FIELD_NUMBER: builtins.int
-    I16_FIELD_NUMBER: builtins.int
-    I32_FIELD_NUMBER: builtins.int
-    I64_FIELD_NUMBER: builtins.int
-    FP32_FIELD_NUMBER: builtins.int
-    FP64_FIELD_NUMBER: builtins.int
+    BYTE_FIELD_NUMBER: builtins.int
+    SHORT_FIELD_NUMBER: builtins.int
+    INTEGER_FIELD_NUMBER: builtins.int
+    LONG_FIELD_NUMBER: builtins.int
+    FLOAT_FIELD_NUMBER: builtins.int
+    DOUBLE_FIELD_NUMBER: builtins.int
     DECIMAL_FIELD_NUMBER: builtins.int
     STRING_FIELD_NUMBER: builtins.int
     CHAR_FIELD_NUMBER: builtins.int
@@ -742,8 +708,6 @@ class DataType(google.protobuf.message.Message):
     ARRAY_FIELD_NUMBER: builtins.int
     STRUCT_FIELD_NUMBER: builtins.int
     MAP_FIELD_NUMBER: builtins.int
-    INTERVAL_YEAR_FIELD_NUMBER: builtins.int
-    INTERVAL_DAY_FIELD_NUMBER: builtins.int
     UUID_FIELD_NUMBER: builtins.int
     FIXED_BINARY_FIELD_NUMBER: builtins.int
     USER_DEFINED_TYPE_REFERENCE_FIELD_NUMBER: builtins.int
@@ -754,37 +718,37 @@ class DataType(google.protobuf.message.Message):
     @property
     def boolean(self) -> global___DataType.Boolean: ...
     @property
-    def i8(self) -> global___DataType.I8:
-        """Numeric"""
+    def byte(self) -> global___DataType.Byte:
+        """Numeric types"""
     @property
-    def i16(self) -> global___DataType.I16: ...
+    def short(self) -> global___DataType.Short: ...
     @property
-    def i32(self) -> global___DataType.I32: ...
+    def integer(self) -> global___DataType.Integer: ...
     @property
-    def i64(self) -> global___DataType.I64: ...
+    def long(self) -> global___DataType.Long: ...
     @property
-    def fp32(self) -> global___DataType.FP32: ...
+    def float(self) -> global___DataType.Float: ...
     @property
-    def fp64(self) -> global___DataType.FP64: ...
+    def double(self) -> global___DataType.Double: ...
     @property
     def decimal(self) -> global___DataType.Decimal: ...
     @property
     def string(self) -> global___DataType.String:
-        """String"""
+        """String types"""
     @property
     def char(self) -> global___DataType.Char: ...
     @property
     def var_char(self) -> global___DataType.VarChar: ...
     @property
     def date(self) -> global___DataType.Date:
-        """Datatime"""
+        """Datatime types"""
     @property
     def timestamp(self) -> global___DataType.Timestamp: ...
     @property
     def timestamp_ntz(self) -> global___DataType.TimestampNTZ: ...
     @property
     def calendar_interval(self) -> global___DataType.CalendarInterval:
-        """Interval"""
+        """Interval types"""
     @property
     def year_month_interval(self) -> global___DataType.YearMonthInterval: ...
     @property
@@ -797,10 +761,6 @@ class DataType(google.protobuf.message.Message):
     @property
     def map(self) -> global___DataType.Map: ...
     @property
-    def interval_year(self) -> global___DataType.IntervalYear: ...
-    @property
-    def interval_day(self) -> global___DataType.IntervalDay: ...
-    @property
     def uuid(self) -> global___DataType.UUID: ...
     @property
     def fixed_binary(self) -> global___DataType.FixedBinary: ...
@@ -811,12 +771,12 @@ class DataType(google.protobuf.message.Message):
         null: global___DataType.NULL | None = ...,
         binary: global___DataType.Binary | None = ...,
         boolean: global___DataType.Boolean | None = ...,
-        i8: global___DataType.I8 | None = ...,
-        i16: global___DataType.I16 | None = ...,
-        i32: global___DataType.I32 | None = ...,
-        i64: global___DataType.I64 | None = ...,
-        fp32: global___DataType.FP32 | None = ...,
-        fp64: global___DataType.FP64 | None = ...,
+        byte: global___DataType.Byte | None = ...,
+        short: global___DataType.Short | None = ...,
+        integer: global___DataType.Integer | None = ...,
+        long: global___DataType.Long | None = ...,
+        float: global___DataType.Float | None = ...,
+        double: global___DataType.Double | None = ...,
         decimal: global___DataType.Decimal | None = ...,
         string: global___DataType.String | None = ...,
         char: global___DataType.Char | None = ...,
@@ -830,8 +790,6 @@ class DataType(google.protobuf.message.Message):
         array: global___DataType.Array | None = ...,
         struct: global___DataType.Struct | None = ...,
         map: global___DataType.Map | None = ...,
-        interval_year: global___DataType.IntervalYear | None = ...,
-        interval_day: global___DataType.IntervalDay | None = ...,
         uuid: global___DataType.UUID | None = ...,
         fixed_binary: global___DataType.FixedBinary | None = ...,
         user_defined_type_reference: builtins.int = ...,
@@ -845,6 +803,8 @@ class DataType(google.protobuf.message.Message):
             b"binary",
             "boolean",
             b"boolean",
+            "byte",
+            b"byte",
             "calendar_interval",
             b"calendar_interval",
             "char",
@@ -855,30 +815,24 @@ class DataType(google.protobuf.message.Message):
             b"day_time_interval",
             "decimal",
             b"decimal",
+            "double",
+            b"double",
             "fixed_binary",
             b"fixed_binary",
-            "fp32",
-            b"fp32",
-            "fp64",
-            b"fp64",
-            "i16",
-            b"i16",
-            "i32",
-            b"i32",
-            "i64",
-            b"i64",
-            "i8",
-            b"i8",
-            "interval_day",
-            b"interval_day",
-            "interval_year",
-            b"interval_year",
+            "float",
+            b"float",
+            "integer",
+            b"integer",
             "kind",
             b"kind",
+            "long",
+            b"long",
             "map",
             b"map",
             "null",
             b"null",
+            "short",
+            b"short",
             "string",
             b"string",
             "struct",
@@ -906,6 +860,8 @@ class DataType(google.protobuf.message.Message):
             b"binary",
             "boolean",
             b"boolean",
+            "byte",
+            b"byte",
             "calendar_interval",
             b"calendar_interval",
             "char",
@@ -916,30 +872,24 @@ class DataType(google.protobuf.message.Message):
             b"day_time_interval",
             "decimal",
             b"decimal",
+            "double",
+            b"double",
             "fixed_binary",
             b"fixed_binary",
-            "fp32",
-            b"fp32",
-            "fp64",
-            b"fp64",
-            "i16",
-            b"i16",
-            "i32",
-            b"i32",
-            "i64",
-            b"i64",
-            "i8",
-            b"i8",
-            "interval_day",
-            b"interval_day",
-            "interval_year",
-            b"interval_year",
+            "float",
+            b"float",
+            "integer",
+            b"integer",
             "kind",
             b"kind",
+            "long",
+            b"long",
             "map",
             b"map",
             "null",
             b"null",
+            "short",
+            b"short",
             "string",
             b"string",
             "struct",
@@ -964,12 +914,12 @@ class DataType(google.protobuf.message.Message):
         "null",
         "binary",
         "boolean",
-        "i8",
-        "i16",
-        "i32",
-        "i64",
-        "fp32",
-        "fp64",
+        "byte",
+        "short",
+        "integer",
+        "long",
+        "float",
+        "double",
         "decimal",
         "string",
         "char",
@@ -983,8 +933,6 @@ class DataType(google.protobuf.message.Message):
         "array",
         "struct",
         "map",
-        "interval_year",
-        "interval_day",
         "uuid",
         "fixed_binary",
         "user_defined_type_reference",

--- a/python/pyspark/sql/connect/proto/types_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/types_pb2.pyi
@@ -39,6 +39,7 @@ import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.message
 import sys
+import typing
 
 if sys.version_info >= (3, 8):
     import typing as typing_extensions
@@ -207,6 +208,23 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
+    class NULL(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
+        type_variation_reference: builtins.int
+        def __init__(
+            self,
+            *,
+            type_variation_reference: builtins.int = ...,
+        ) -> None: ...
+        def ClearField(
+            self,
+            field_name: typing_extensions.Literal[
+                "type_variation_reference", b"type_variation_reference"
+            ],
+        ) -> None: ...
+
     class Timestamp(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -241,24 +259,7 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class Time(google.protobuf.message.Message):
-        DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-        TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
-        type_variation_reference: builtins.int
-        def __init__(
-            self,
-            *,
-            type_variation_reference: builtins.int = ...,
-        ) -> None: ...
-        def ClearField(
-            self,
-            field_name: typing_extensions.Literal[
-                "type_variation_reference", b"type_variation_reference"
-            ],
-        ) -> None: ...
-
-    class TimestampTZ(google.protobuf.message.Message):
+    class TimestampNTZ(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
@@ -309,6 +310,129 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
+    class CalendarInterval(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
+        type_variation_reference: builtins.int
+        def __init__(
+            self,
+            *,
+            type_variation_reference: builtins.int = ...,
+        ) -> None: ...
+        def ClearField(
+            self,
+            field_name: typing_extensions.Literal[
+                "type_variation_reference", b"type_variation_reference"
+            ],
+        ) -> None: ...
+
+    class YearMonthInterval(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        START_FIELD_FIELD_NUMBER: builtins.int
+        END_FIELD_FIELD_NUMBER: builtins.int
+        TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
+        start_field: builtins.int
+        end_field: builtins.int
+        type_variation_reference: builtins.int
+        def __init__(
+            self,
+            *,
+            start_field: builtins.int | None = ...,
+            end_field: builtins.int | None = ...,
+            type_variation_reference: builtins.int = ...,
+        ) -> None: ...
+        def HasField(
+            self,
+            field_name: typing_extensions.Literal[
+                "_end_field",
+                b"_end_field",
+                "_start_field",
+                b"_start_field",
+                "end_field",
+                b"end_field",
+                "start_field",
+                b"start_field",
+            ],
+        ) -> builtins.bool: ...
+        def ClearField(
+            self,
+            field_name: typing_extensions.Literal[
+                "_end_field",
+                b"_end_field",
+                "_start_field",
+                b"_start_field",
+                "end_field",
+                b"end_field",
+                "start_field",
+                b"start_field",
+                "type_variation_reference",
+                b"type_variation_reference",
+            ],
+        ) -> None: ...
+        @typing.overload
+        def WhichOneof(
+            self, oneof_group: typing_extensions.Literal["_end_field", b"_end_field"]
+        ) -> typing_extensions.Literal["end_field"] | None: ...
+        @typing.overload
+        def WhichOneof(
+            self, oneof_group: typing_extensions.Literal["_start_field", b"_start_field"]
+        ) -> typing_extensions.Literal["start_field"] | None: ...
+
+    class DayTimeInterval(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        START_FIELD_FIELD_NUMBER: builtins.int
+        END_FIELD_FIELD_NUMBER: builtins.int
+        TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
+        start_field: builtins.int
+        end_field: builtins.int
+        type_variation_reference: builtins.int
+        def __init__(
+            self,
+            *,
+            start_field: builtins.int | None = ...,
+            end_field: builtins.int | None = ...,
+            type_variation_reference: builtins.int = ...,
+        ) -> None: ...
+        def HasField(
+            self,
+            field_name: typing_extensions.Literal[
+                "_end_field",
+                b"_end_field",
+                "_start_field",
+                b"_start_field",
+                "end_field",
+                b"end_field",
+                "start_field",
+                b"start_field",
+            ],
+        ) -> builtins.bool: ...
+        def ClearField(
+            self,
+            field_name: typing_extensions.Literal[
+                "_end_field",
+                b"_end_field",
+                "_start_field",
+                b"_start_field",
+                "end_field",
+                b"end_field",
+                "start_field",
+                b"start_field",
+                "type_variation_reference",
+                b"type_variation_reference",
+            ],
+        ) -> None: ...
+        @typing.overload
+        def WhichOneof(
+            self, oneof_group: typing_extensions.Literal["_end_field", b"_end_field"]
+        ) -> typing_extensions.Literal["end_field"] | None: ...
+        @typing.overload
+        def WhichOneof(
+            self, oneof_group: typing_extensions.Literal["_start_field", b"_start_field"]
+        ) -> typing_extensions.Literal["start_field"] | None: ...
+
     class UUID(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -326,7 +450,7 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class FixedChar(google.protobuf.message.Message):
+    class Char(google.protobuf.message.Message):
         """Start compound types."""
 
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -400,13 +524,30 @@ class DataType(google.protobuf.message.Message):
         def __init__(
             self,
             *,
-            scale: builtins.int = ...,
-            precision: builtins.int = ...,
+            scale: builtins.int | None = ...,
+            precision: builtins.int | None = ...,
             type_variation_reference: builtins.int = ...,
         ) -> None: ...
+        def HasField(
+            self,
+            field_name: typing_extensions.Literal[
+                "_precision",
+                b"_precision",
+                "_scale",
+                b"_scale",
+                "precision",
+                b"precision",
+                "scale",
+                b"scale",
+            ],
+        ) -> builtins.bool: ...
         def ClearField(
             self,
             field_name: typing_extensions.Literal[
+                "_precision",
+                b"_precision",
+                "_scale",
+                b"_scale",
                 "precision",
                 b"precision",
                 "scale",
@@ -415,6 +556,14 @@ class DataType(google.protobuf.message.Message):
                 b"type_variation_reference",
             ],
         ) -> None: ...
+        @typing.overload
+        def WhichOneof(
+            self, oneof_group: typing_extensions.Literal["_precision", b"_precision"]
+        ) -> typing_extensions.Literal["precision"] | None: ...
+        @typing.overload
+        def WhichOneof(
+            self, oneof_group: typing_extensions.Literal["_scale", b"_scale"]
+        ) -> typing_extensions.Literal["scale"] | None: ...
 
     class StructField(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -436,13 +585,13 @@ class DataType(google.protobuf.message.Message):
                 self, field_name: typing_extensions.Literal["key", b"key", "value", b"value"]
             ) -> None: ...
 
-        TYPE_FIELD_NUMBER: builtins.int
         NAME_FIELD_NUMBER: builtins.int
+        DATA_TYPE_FIELD_NUMBER: builtins.int
         NULLABLE_FIELD_NUMBER: builtins.int
         METADATA_FIELD_NUMBER: builtins.int
-        @property
-        def type(self) -> global___DataType: ...
         name: builtins.str
+        @property
+        def data_type(self) -> global___DataType: ...
         nullable: builtins.bool
         @property
         def metadata(
@@ -451,18 +600,25 @@ class DataType(google.protobuf.message.Message):
         def __init__(
             self,
             *,
-            type: global___DataType | None = ...,
             name: builtins.str = ...,
+            data_type: global___DataType | None = ...,
             nullable: builtins.bool = ...,
             metadata: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
         ) -> None: ...
         def HasField(
-            self, field_name: typing_extensions.Literal["type", b"type"]
+            self, field_name: typing_extensions.Literal["data_type", b"data_type"]
         ) -> builtins.bool: ...
         def ClearField(
             self,
             field_name: typing_extensions.Literal[
-                "metadata", b"metadata", "name", b"name", "nullable", b"nullable", "type", b"type"
+                "data_type",
+                b"data_type",
+                "metadata",
+                b"metadata",
+                "name",
+                b"name",
+                "nullable",
+                b"nullable",
             ],
         ) -> None: ...
 
@@ -491,33 +647,33 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
-    class List(google.protobuf.message.Message):
+    class Array(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-        DATATYPE_FIELD_NUMBER: builtins.int
+        ELEMENT_TYPE_FIELD_NUMBER: builtins.int
+        CONTAINS_NULL_FIELD_NUMBER: builtins.int
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
-        ELEMENT_NULLABLE_FIELD_NUMBER: builtins.int
         @property
-        def DataType(self) -> global___DataType: ...
+        def element_type(self) -> global___DataType: ...
+        contains_null: builtins.bool
         type_variation_reference: builtins.int
-        element_nullable: builtins.bool
         def __init__(
             self,
             *,
-            DataType: global___DataType | None = ...,
+            element_type: global___DataType | None = ...,
+            contains_null: builtins.bool = ...,
             type_variation_reference: builtins.int = ...,
-            element_nullable: builtins.bool = ...,
         ) -> None: ...
         def HasField(
-            self, field_name: typing_extensions.Literal["DataType", b"DataType"]
+            self, field_name: typing_extensions.Literal["element_type", b"element_type"]
         ) -> builtins.bool: ...
         def ClearField(
             self,
             field_name: typing_extensions.Literal[
-                "DataType",
-                b"DataType",
-                "element_nullable",
-                b"element_nullable",
+                "contains_null",
+                b"contains_null",
+                "element_type",
+                b"element_type",
                 "type_variation_reference",
                 b"type_variation_reference",
             ],
@@ -526,69 +682,80 @@ class DataType(google.protobuf.message.Message):
     class Map(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
-        KEY_FIELD_NUMBER: builtins.int
-        VALUE_FIELD_NUMBER: builtins.int
+        KEY_TYPE_FIELD_NUMBER: builtins.int
+        VALUE_TYPE_FIELD_NUMBER: builtins.int
+        VALUE_CONTAINS_NULL_FIELD_NUMBER: builtins.int
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
-        VALUE_NULLABLE_FIELD_NUMBER: builtins.int
         @property
-        def key(self) -> global___DataType: ...
+        def key_type(self) -> global___DataType: ...
         @property
-        def value(self) -> global___DataType: ...
+        def value_type(self) -> global___DataType: ...
+        value_contains_null: builtins.bool
         type_variation_reference: builtins.int
-        value_nullable: builtins.bool
         def __init__(
             self,
             *,
-            key: global___DataType | None = ...,
-            value: global___DataType | None = ...,
+            key_type: global___DataType | None = ...,
+            value_type: global___DataType | None = ...,
+            value_contains_null: builtins.bool = ...,
             type_variation_reference: builtins.int = ...,
-            value_nullable: builtins.bool = ...,
         ) -> None: ...
         def HasField(
-            self, field_name: typing_extensions.Literal["key", b"key", "value", b"value"]
+            self,
+            field_name: typing_extensions.Literal[
+                "key_type", b"key_type", "value_type", b"value_type"
+            ],
         ) -> builtins.bool: ...
         def ClearField(
             self,
             field_name: typing_extensions.Literal[
-                "key",
-                b"key",
+                "key_type",
+                b"key_type",
                 "type_variation_reference",
                 b"type_variation_reference",
-                "value",
-                b"value",
-                "value_nullable",
-                b"value_nullable",
+                "value_contains_null",
+                b"value_contains_null",
+                "value_type",
+                b"value_type",
             ],
         ) -> None: ...
 
-    BOOL_FIELD_NUMBER: builtins.int
+    NULL_FIELD_NUMBER: builtins.int
+    BINARY_FIELD_NUMBER: builtins.int
+    BOOLEAN_FIELD_NUMBER: builtins.int
     I8_FIELD_NUMBER: builtins.int
     I16_FIELD_NUMBER: builtins.int
     I32_FIELD_NUMBER: builtins.int
     I64_FIELD_NUMBER: builtins.int
     FP32_FIELD_NUMBER: builtins.int
     FP64_FIELD_NUMBER: builtins.int
+    DECIMAL_FIELD_NUMBER: builtins.int
     STRING_FIELD_NUMBER: builtins.int
-    BINARY_FIELD_NUMBER: builtins.int
-    TIMESTAMP_FIELD_NUMBER: builtins.int
+    CHAR_FIELD_NUMBER: builtins.int
+    VAR_CHAR_FIELD_NUMBER: builtins.int
     DATE_FIELD_NUMBER: builtins.int
-    TIME_FIELD_NUMBER: builtins.int
+    TIMESTAMP_FIELD_NUMBER: builtins.int
+    TIMESTAMP_NTZ_FIELD_NUMBER: builtins.int
+    CALENDAR_INTERVAL_FIELD_NUMBER: builtins.int
+    YEAR_MONTH_INTERVAL_FIELD_NUMBER: builtins.int
+    DAY_TIME_INTERVAL_FIELD_NUMBER: builtins.int
+    ARRAY_FIELD_NUMBER: builtins.int
+    STRUCT_FIELD_NUMBER: builtins.int
+    MAP_FIELD_NUMBER: builtins.int
     INTERVAL_YEAR_FIELD_NUMBER: builtins.int
     INTERVAL_DAY_FIELD_NUMBER: builtins.int
-    TIMESTAMP_TZ_FIELD_NUMBER: builtins.int
     UUID_FIELD_NUMBER: builtins.int
-    FIXED_CHAR_FIELD_NUMBER: builtins.int
-    VARCHAR_FIELD_NUMBER: builtins.int
     FIXED_BINARY_FIELD_NUMBER: builtins.int
-    DECIMAL_FIELD_NUMBER: builtins.int
-    STRUCT_FIELD_NUMBER: builtins.int
-    LIST_FIELD_NUMBER: builtins.int
-    MAP_FIELD_NUMBER: builtins.int
     USER_DEFINED_TYPE_REFERENCE_FIELD_NUMBER: builtins.int
     @property
-    def bool(self) -> global___DataType.Boolean: ...
+    def null(self) -> global___DataType.NULL: ...
     @property
-    def i8(self) -> global___DataType.I8: ...
+    def binary(self) -> global___DataType.Binary: ...
+    @property
+    def boolean(self) -> global___DataType.Boolean: ...
+    @property
+    def i8(self) -> global___DataType.I8:
+        """Numeric"""
     @property
     def i16(self) -> global___DataType.I16: ...
     @property
@@ -600,81 +767,96 @@ class DataType(google.protobuf.message.Message):
     @property
     def fp64(self) -> global___DataType.FP64: ...
     @property
-    def string(self) -> global___DataType.String: ...
+    def decimal(self) -> global___DataType.Decimal: ...
     @property
-    def binary(self) -> global___DataType.Binary: ...
+    def string(self) -> global___DataType.String:
+        """String"""
+    @property
+    def char(self) -> global___DataType.Char: ...
+    @property
+    def var_char(self) -> global___DataType.VarChar: ...
+    @property
+    def date(self) -> global___DataType.Date:
+        """Datatime"""
     @property
     def timestamp(self) -> global___DataType.Timestamp: ...
     @property
-    def date(self) -> global___DataType.Date: ...
+    def timestamp_ntz(self) -> global___DataType.TimestampNTZ: ...
     @property
-    def time(self) -> global___DataType.Time: ...
+    def calendar_interval(self) -> global___DataType.CalendarInterval:
+        """Interval"""
+    @property
+    def year_month_interval(self) -> global___DataType.YearMonthInterval: ...
+    @property
+    def day_time_interval(self) -> global___DataType.DayTimeInterval: ...
+    @property
+    def array(self) -> global___DataType.Array:
+        """Complex types"""
+    @property
+    def struct(self) -> global___DataType.Struct: ...
+    @property
+    def map(self) -> global___DataType.Map: ...
     @property
     def interval_year(self) -> global___DataType.IntervalYear: ...
     @property
     def interval_day(self) -> global___DataType.IntervalDay: ...
     @property
-    def timestamp_tz(self) -> global___DataType.TimestampTZ: ...
-    @property
     def uuid(self) -> global___DataType.UUID: ...
     @property
-    def fixed_char(self) -> global___DataType.FixedChar: ...
-    @property
-    def varchar(self) -> global___DataType.VarChar: ...
-    @property
     def fixed_binary(self) -> global___DataType.FixedBinary: ...
-    @property
-    def decimal(self) -> global___DataType.Decimal: ...
-    @property
-    def struct(self) -> global___DataType.Struct: ...
-    @property
-    def list(self) -> global___DataType.List: ...
-    @property
-    def map(self) -> global___DataType.Map: ...
     user_defined_type_reference: builtins.int
     def __init__(
         self,
         *,
-        bool: global___DataType.Boolean | None = ...,
+        null: global___DataType.NULL | None = ...,
+        binary: global___DataType.Binary | None = ...,
+        boolean: global___DataType.Boolean | None = ...,
         i8: global___DataType.I8 | None = ...,
         i16: global___DataType.I16 | None = ...,
         i32: global___DataType.I32 | None = ...,
         i64: global___DataType.I64 | None = ...,
         fp32: global___DataType.FP32 | None = ...,
         fp64: global___DataType.FP64 | None = ...,
+        decimal: global___DataType.Decimal | None = ...,
         string: global___DataType.String | None = ...,
-        binary: global___DataType.Binary | None = ...,
-        timestamp: global___DataType.Timestamp | None = ...,
+        char: global___DataType.Char | None = ...,
+        var_char: global___DataType.VarChar | None = ...,
         date: global___DataType.Date | None = ...,
-        time: global___DataType.Time | None = ...,
+        timestamp: global___DataType.Timestamp | None = ...,
+        timestamp_ntz: global___DataType.TimestampNTZ | None = ...,
+        calendar_interval: global___DataType.CalendarInterval | None = ...,
+        year_month_interval: global___DataType.YearMonthInterval | None = ...,
+        day_time_interval: global___DataType.DayTimeInterval | None = ...,
+        array: global___DataType.Array | None = ...,
+        struct: global___DataType.Struct | None = ...,
+        map: global___DataType.Map | None = ...,
         interval_year: global___DataType.IntervalYear | None = ...,
         interval_day: global___DataType.IntervalDay | None = ...,
-        timestamp_tz: global___DataType.TimestampTZ | None = ...,
         uuid: global___DataType.UUID | None = ...,
-        fixed_char: global___DataType.FixedChar | None = ...,
-        varchar: global___DataType.VarChar | None = ...,
         fixed_binary: global___DataType.FixedBinary | None = ...,
-        decimal: global___DataType.Decimal | None = ...,
-        struct: global___DataType.Struct | None = ...,
-        list: global___DataType.List | None = ...,
-        map: global___DataType.Map | None = ...,
         user_defined_type_reference: builtins.int = ...,
     ) -> None: ...
     def HasField(
         self,
         field_name: typing_extensions.Literal[
+            "array",
+            b"array",
             "binary",
             b"binary",
-            "bool",
-            b"bool",
+            "boolean",
+            b"boolean",
+            "calendar_interval",
+            b"calendar_interval",
+            "char",
+            b"char",
             "date",
             b"date",
+            "day_time_interval",
+            b"day_time_interval",
             "decimal",
             b"decimal",
             "fixed_binary",
             b"fixed_binary",
-            "fixed_char",
-            b"fixed_char",
             "fp32",
             b"fp32",
             "fp64",
@@ -693,43 +875,49 @@ class DataType(google.protobuf.message.Message):
             b"interval_year",
             "kind",
             b"kind",
-            "list",
-            b"list",
             "map",
             b"map",
+            "null",
+            b"null",
             "string",
             b"string",
             "struct",
             b"struct",
-            "time",
-            b"time",
             "timestamp",
             b"timestamp",
-            "timestamp_tz",
-            b"timestamp_tz",
+            "timestamp_ntz",
+            b"timestamp_ntz",
             "user_defined_type_reference",
             b"user_defined_type_reference",
             "uuid",
             b"uuid",
-            "varchar",
-            b"varchar",
+            "var_char",
+            b"var_char",
+            "year_month_interval",
+            b"year_month_interval",
         ],
     ) -> builtins.bool: ...
     def ClearField(
         self,
         field_name: typing_extensions.Literal[
+            "array",
+            b"array",
             "binary",
             b"binary",
-            "bool",
-            b"bool",
+            "boolean",
+            b"boolean",
+            "calendar_interval",
+            b"calendar_interval",
+            "char",
+            b"char",
             "date",
             b"date",
+            "day_time_interval",
+            b"day_time_interval",
             "decimal",
             b"decimal",
             "fixed_binary",
             b"fixed_binary",
-            "fixed_char",
-            b"fixed_char",
             "fp32",
             b"fp32",
             "fp64",
@@ -748,54 +936,57 @@ class DataType(google.protobuf.message.Message):
             b"interval_year",
             "kind",
             b"kind",
-            "list",
-            b"list",
             "map",
             b"map",
+            "null",
+            b"null",
             "string",
             b"string",
             "struct",
             b"struct",
-            "time",
-            b"time",
             "timestamp",
             b"timestamp",
-            "timestamp_tz",
-            b"timestamp_tz",
+            "timestamp_ntz",
+            b"timestamp_ntz",
             "user_defined_type_reference",
             b"user_defined_type_reference",
             "uuid",
             b"uuid",
-            "varchar",
-            b"varchar",
+            "var_char",
+            b"var_char",
+            "year_month_interval",
+            b"year_month_interval",
         ],
     ) -> None: ...
     def WhichOneof(
         self, oneof_group: typing_extensions.Literal["kind", b"kind"]
     ) -> typing_extensions.Literal[
-        "bool",
+        "null",
+        "binary",
+        "boolean",
         "i8",
         "i16",
         "i32",
         "i64",
         "fp32",
         "fp64",
+        "decimal",
         "string",
-        "binary",
-        "timestamp",
+        "char",
+        "var_char",
         "date",
-        "time",
+        "timestamp",
+        "timestamp_ntz",
+        "calendar_interval",
+        "year_month_interval",
+        "day_time_interval",
+        "array",
+        "struct",
+        "map",
         "interval_year",
         "interval_day",
-        "timestamp_tz",
         "uuid",
-        "fixed_char",
-        "varchar",
         "fixed_binary",
-        "decimal",
-        "struct",
-        "list",
-        "map",
         "user_defined_type_reference",
     ] | None: ...
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -144,6 +144,58 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             schema,
         )
 
+        # test FloatType, DoubleType, DecimalType, StringType, BooleanType, NullType
+        query = """
+            SELECT * FROM VALUES
+            (float(1.0), double(1.0), 1.0, "1", true, NULL),
+            (float(2.0), double(2.0), 2.0, "2", false, NULL),
+            (float(3.0), double(3.0), NULL, "3", false, NULL)
+            AS tab(a, b, c, d, e, f)
+            """
+        self.assertEqual(
+            self.spark.sql(query).schema,
+            self.connect.sql(query).schema,
+        )
+
+        # test TimestampType, DateType
+        query = """
+            SELECT * FROM VALUES
+            (TIMESTAMP('2019-04-12 15:50:00'), DATE('2022-02-22')),
+            (TIMESTAMP('2019-04-12 15:50:00'), NULL),
+            (NULL, DATE('2022-02-22'))
+            AS tab(a, b)
+            """
+        self.assertEqual(
+            self.spark.sql(query).schema,
+            self.connect.sql(query).schema,
+        )
+
+        # test MapType
+        query = """
+            SELECT * FROM VALUES
+            (MAP('a', 'ab'), MAP(1, 2, 3, 4)),
+            (MAP('x', NULL), NULL),
+            (NULL, MAP(-1, -2, -3, -4))
+            AS tab(a, b)
+            """
+        self.assertEqual(
+            self.spark.sql(query).schema,
+            self.connect.sql(query).schema,
+        )
+
+        # test ArrayType
+        query = """
+            SELECT * FROM VALUES
+            (ARRAY('a', 'ab'), ARRAY(1, 2, 3, 4)),
+            (ARRAY('x', NULL), NULL),
+            (NULL, ARRAY(-1, -2, -3, -4))
+            AS tab(a, b)
+            """
+        self.assertEqual(
+            self.spark.sql(query).schema,
+            self.connect.sql(query).schema,
+        )
+
     def test_simple_binary_expressions(self):
         """Test complex expression"""
         df = self.connect.read.table(self.tbl_name)


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, in the sever side, make `proto_datatype` <-> `catalyst_datatype` conversion support all the built-in sql datatypes;

2, in the client side, make `proto_datatype` <-> `pyspark_catalyst_datatype` conversion support [all the datatypes that are supported in pyspark now.](https://github.com/apache/spark/blob/master/python/pyspark/sql/types.py#L60-L83)



### Why are the changes needed?
right now, only `long`, `string`, `struct` are supported

```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.UNKNOWN
        details = "Does not support convert float to connect proto types."
        debug_error_string = "{"created":"@1669206685.760099000","description":"Error received from peer ipv6:[::1]:15002","file":"src/core/lib/surface/call.cc","file_line":1064,"grpc_message":"Does not support convert float to connect proto types.","grpc_status":2}"
```

this PR make the schema and literal expr support more datatypes.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added UT