### PR TITLE
[SPARK-41016][PS] Identical expressions should not be used on both sides of a binary operator

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_binary_ops.py
@@ -133,7 +133,6 @@ class BinaryOpsTest(OpsTestBase):
     def test_and(self):
         self.assertRaises(TypeError, lambda: self.psser & True)
         self.assertRaises(TypeError, lambda: self.psser & False)
-        self.assertRaises(TypeError, lambda: self.psser & self.psser)
 
     def test_rand(self):
         self.assertRaises(TypeError, lambda: True & self.psser)
@@ -142,7 +141,6 @@ class BinaryOpsTest(OpsTestBase):
     def test_or(self):
         self.assertRaises(TypeError, lambda: self.psser | True)
         self.assertRaises(TypeError, lambda: self.psser | False)
-        self.assertRaises(TypeError, lambda: self.psser | self.psser)
 
     def test_ror(self):
         self.assertRaises(TypeError, lambda: True | self.psser)
@@ -179,32 +177,26 @@ class BinaryOpsTest(OpsTestBase):
     def test_eq(self):
         byte_pdf, byte_psdf = self.byte_pdf, self.byte_psdf
         self.assert_eq(byte_pdf["this"] == byte_pdf["that"], byte_psdf["this"] == byte_psdf["that"])
-        self.assert_eq(byte_pdf["this"] == byte_pdf["this"], byte_psdf["this"] == byte_psdf["this"])
 
     def test_ne(self):
         byte_pdf, byte_psdf = self.byte_pdf, self.byte_psdf
         self.assert_eq(byte_pdf["this"] != byte_pdf["that"], byte_psdf["this"] != byte_psdf["that"])
-        self.assert_eq(byte_pdf["this"] != byte_pdf["this"], byte_psdf["this"] != byte_psdf["this"])
 
     def test_lt(self):
         byte_pdf, byte_psdf = self.byte_pdf, self.byte_psdf
         self.assert_eq(byte_pdf["this"] < byte_pdf["that"], byte_psdf["this"] < byte_psdf["that"])
-        self.assert_eq(byte_pdf["this"] < byte_pdf["this"], byte_psdf["this"] < byte_psdf["this"])
 
     def test_le(self):
         byte_pdf, byte_psdf = self.byte_pdf, self.byte_psdf
         self.assert_eq(byte_pdf["this"] <= byte_pdf["that"], byte_psdf["this"] <= byte_psdf["that"])
-        self.assert_eq(byte_pdf["this"] <= byte_pdf["this"], byte_psdf["this"] <= byte_psdf["this"])
 
     def test_gt(self):
         byte_pdf, byte_psdf = self.byte_pdf, self.byte_psdf
         self.assert_eq(byte_pdf["this"] > byte_pdf["that"], byte_psdf["this"] > byte_psdf["that"])
-        self.assert_eq(byte_pdf["this"] > byte_pdf["this"], byte_psdf["this"] > byte_psdf["this"])
 
     def test_ge(self):
         byte_pdf, byte_psdf = self.byte_pdf, self.byte_psdf
         self.assert_eq(byte_pdf["this"] >= byte_pdf["that"], byte_psdf["this"] >= byte_psdf["that"])
-        self.assert_eq(byte_pdf["this"] >= byte_pdf["this"], byte_psdf["this"] >= byte_psdf["this"])
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -225,8 +225,6 @@ class CategoricalOpsTest(OpsTestBase):
             psdf["this_ordered_numeric_cat"],
         )
         self.assert_eq(ordered_pser == 1, ordered_psser == 1)
-        self.assert_eq(pser == pser, psser == psser)
-        self.assert_eq(ordered_pser == ordered_pser, ordered_psser == ordered_psser)
 
         pser, psser = pdf["this_string_cat"], psdf["this_string_cat"]
         ordered_pser, ordered_psser = (
@@ -234,8 +232,6 @@ class CategoricalOpsTest(OpsTestBase):
             psdf["this_ordered_string_cat"],
         )
         self.assert_eq(pser == "x", psser == "x")
-        self.assert_eq(pser == pser, psser == psser)
-        self.assert_eq(ordered_pser == ordered_pser, ordered_psser == ordered_psser)
 
         self.assertRaisesRegex(
             TypeError,
@@ -295,8 +291,6 @@ class CategoricalOpsTest(OpsTestBase):
             psdf["this_ordered_numeric_cat"],
         )
         self.assert_eq(ordered_pser != 1, ordered_psser != 1)
-        self.assert_eq(pser != pser, psser != psser)
-        self.assert_eq(ordered_pser != ordered_pser, ordered_psser != ordered_psser)
 
         pser, psser = pdf["this_string_cat"], psdf["this_string_cat"]
         ordered_pser, ordered_psser = (
@@ -304,8 +298,6 @@ class CategoricalOpsTest(OpsTestBase):
             psdf["this_ordered_string_cat"],
         )
         self.assert_eq(pser != "x", psser != "x")
-        self.assert_eq(pser != pser, psser != psser)
-        self.assert_eq(ordered_pser != ordered_pser, ordered_psser != ordered_psser)
 
         self.assertRaisesRegex(
             TypeError,
@@ -354,14 +346,12 @@ class CategoricalOpsTest(OpsTestBase):
             psdf["this_ordered_numeric_cat"],
         )
         self.assert_eq(ordered_pser < 1, ordered_psser < 1)
-        self.assert_eq(ordered_pser < ordered_pser, ordered_psser < ordered_psser)
 
         ordered_pser, ordered_psser = (
             pdf["this_ordered_string_cat"],
             psdf["this_ordered_string_cat"],
         )
         self.assert_eq(ordered_pser < "x", ordered_psser < "x")
-        self.assert_eq(ordered_pser < ordered_pser, ordered_psser < ordered_psser)
 
         self.assertRaisesRegex(
             TypeError,
@@ -404,14 +394,13 @@ class CategoricalOpsTest(OpsTestBase):
             psdf["this_ordered_numeric_cat"],
         )
         self.assert_eq(ordered_pser <= 1, ordered_psser <= 1)
-        self.assert_eq(ordered_pser <= ordered_pser, ordered_psser <= ordered_psser)
 
         ordered_pser, ordered_psser = (
             pdf["this_ordered_string_cat"],
             psdf["this_ordered_string_cat"],
         )
         self.assert_eq(ordered_pser <= "x", ordered_psser <= "x")
-        self.assert_eq(ordered_pser <= ordered_pser, ordered_psser <= ordered_psser)
+
         self.assertRaisesRegex(
             TypeError,
             "Unordered Categoricals can only compare equality or not",
@@ -453,14 +442,13 @@ class CategoricalOpsTest(OpsTestBase):
             psdf["this_ordered_numeric_cat"],
         )
         self.assert_eq(ordered_pser > 1, ordered_psser > 1)
-        self.assert_eq(ordered_pser > ordered_pser, ordered_psser > ordered_psser)
 
         ordered_pser, ordered_psser = (
             pdf["this_ordered_string_cat"],
             psdf["this_ordered_string_cat"],
         )
         self.assert_eq(ordered_pser > "x", ordered_psser > "x")
-        self.assert_eq(ordered_pser > ordered_pser, ordered_psser > ordered_psser)
+
         self.assertRaisesRegex(
             TypeError,
             "Unordered Categoricals can only compare equality or not",
@@ -502,14 +490,13 @@ class CategoricalOpsTest(OpsTestBase):
             psdf["this_ordered_numeric_cat"],
         )
         self.assert_eq(ordered_pser >= 1, ordered_psser >= 1)
-        self.assert_eq(ordered_pser >= ordered_pser, ordered_psser >= ordered_psser)
 
         ordered_pser, ordered_psser = (
             pdf["this_ordered_string_cat"],
             psdf["this_ordered_string_cat"],
         )
         self.assert_eq(ordered_pser >= "x", ordered_psser >= "x")
-        self.assert_eq(ordered_pser >= ordered_pser, ordered_psser >= ordered_psser)
+
         self.assertRaisesRegex(
             TypeError,
             "Unordered Categoricals can only compare equality or not",

--- a/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_complex_ops.py
@@ -268,12 +268,6 @@ class ComplexOpsTest(OpsTestBase):
         self.assert_eq(
             pdf["this_struct"] == pdf["that_struct"], psdf["this_struct"] == psdf["that_struct"]
         )
-        self.assert_eq(
-            pdf["this_array"] == pdf["this_array"], psdf["this_array"] == psdf["this_array"]
-        )
-        self.assert_eq(
-            pdf["this_struct"] == pdf["this_struct"], psdf["this_struct"] == psdf["this_struct"]
-        )
 
     def test_ne(self):
         pdf, psdf = self.complex_pdf, self.complex_pdf
@@ -282,12 +276,6 @@ class ComplexOpsTest(OpsTestBase):
         )
         self.assert_eq(
             pdf["this_struct"] != pdf["that_struct"], psdf["this_struct"] != psdf["that_struct"]
-        )
-        self.assert_eq(
-            pdf["this_array"] != pdf["this_array"], psdf["this_array"] != psdf["this_array"]
-        )
-        self.assert_eq(
-            pdf["this_struct"] != pdf["this_struct"], psdf["this_struct"] != psdf["this_struct"]
         )
 
     def test_lt(self):
@@ -298,12 +286,6 @@ class ComplexOpsTest(OpsTestBase):
         self.assert_eq(
             pdf["this_struct"] < pdf["that_struct"], psdf["this_struct"] < psdf["that_struct"]
         )
-        self.assert_eq(
-            pdf["this_array"] < pdf["this_array"], psdf["this_array"] < psdf["this_array"]
-        )
-        self.assert_eq(
-            pdf["this_struct"] < pdf["this_struct"], psdf["this_struct"] < psdf["this_struct"]
-        )
 
     def test_le(self):
         pdf, psdf = self.complex_pdf, self.complex_pdf
@@ -312,12 +294,6 @@ class ComplexOpsTest(OpsTestBase):
         )
         self.assert_eq(
             pdf["this_struct"] <= pdf["that_struct"], psdf["this_struct"] <= psdf["that_struct"]
-        )
-        self.assert_eq(
-            pdf["this_array"] <= pdf["this_array"], psdf["this_array"] <= psdf["this_array"]
-        )
-        self.assert_eq(
-            pdf["this_struct"] <= pdf["this_struct"], psdf["this_struct"] <= psdf["this_struct"]
         )
 
     def test_gt(self):
@@ -328,12 +304,6 @@ class ComplexOpsTest(OpsTestBase):
         self.assert_eq(
             pdf["this_struct"] > pdf["that_struct"], psdf["this_struct"] > psdf["that_struct"]
         )
-        self.assert_eq(
-            pdf["this_array"] > pdf["this_array"], psdf["this_array"] > psdf["this_array"]
-        )
-        self.assert_eq(
-            pdf["this_struct"] > pdf["this_struct"], psdf["this_struct"] > psdf["this_struct"]
-        )
 
     def test_ge(self):
         pdf, psdf = self.complex_pdf, self.complex_pdf
@@ -342,12 +312,6 @@ class ComplexOpsTest(OpsTestBase):
         )
         self.assert_eq(
             pdf["this_struct"] >= pdf["that_struct"], psdf["this_struct"] >= psdf["that_struct"]
-        )
-        self.assert_eq(
-            pdf["this_array"] >= pdf["this_array"], psdf["this_array"] >= psdf["this_array"]
-        )
-        self.assert_eq(
-            pdf["this_struct"] >= pdf["this_struct"], psdf["this_struct"] >= psdf["this_struct"]
         )
 
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -202,32 +202,26 @@ class DateOpsTest(OpsTestBase):
     def test_eq(self):
         pdf, psdf = self.date_pdf, self.date_psdf
         self.assert_eq(pdf["this"] == pdf["that"], psdf["this"] == psdf["that"])
-        self.assert_eq(pdf["this"] == pdf["this"], psdf["this"] == psdf["this"])
 
     def test_ne(self):
         pdf, psdf = self.date_pdf, self.date_psdf
         self.assert_eq(pdf["this"] != pdf["that"], psdf["this"] != psdf["that"])
-        self.assert_eq(pdf["this"] != pdf["this"], psdf["this"] != psdf["this"])
 
     def test_lt(self):
         pdf, psdf = self.date_pdf, self.date_psdf
         self.assert_eq(pdf["this"] < pdf["that"], psdf["this"] < psdf["that"])
-        self.assert_eq(pdf["this"] < pdf["this"], psdf["this"] < psdf["this"])
 
     def test_le(self):
         pdf, psdf = self.date_pdf, self.date_psdf
         self.assert_eq(pdf["this"] <= pdf["that"], psdf["this"] <= psdf["that"])
-        self.assert_eq(pdf["this"] <= pdf["this"], psdf["this"] <= psdf["this"])
 
     def test_gt(self):
         pdf, psdf = self.date_pdf, self.date_psdf
         self.assert_eq(pdf["this"] > pdf["that"], psdf["this"] > psdf["that"])
-        self.assert_eq(pdf["this"] > pdf["this"], psdf["this"] > psdf["this"])
 
     def test_ge(self):
         pdf, psdf = self.date_pdf, self.date_psdf
         self.assert_eq(pdf["this"] >= pdf["that"], psdf["this"] >= psdf["that"])
-        self.assert_eq(pdf["this"] >= pdf["this"], psdf["this"] >= psdf["this"])
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_datetime_ops.py
@@ -208,32 +208,26 @@ class DatetimeOpsTest(OpsTestBase):
     def test_eq(self):
         pdf, psdf = self.datetime_pdf, self.datetime_psdf
         self.assert_eq(pdf["this"] == pdf["that"], psdf["this"] == psdf["that"])
-        self.assert_eq(pdf["this"] == pdf["this"], psdf["this"] == psdf["this"])
 
     def test_ne(self):
         pdf, psdf = self.datetime_pdf, self.datetime_psdf
         self.assert_eq(pdf["this"] != pdf["that"], psdf["this"] != psdf["that"])
-        self.assert_eq(pdf["this"] != pdf["this"], psdf["this"] != psdf["this"])
 
     def test_lt(self):
         pdf, psdf = self.datetime_pdf, self.datetime_psdf
         self.assert_eq(pdf["this"] < pdf["that"], psdf["this"] < psdf["that"])
-        self.assert_eq(pdf["this"] < pdf["this"], psdf["this"] < psdf["this"])
 
     def test_le(self):
         pdf, psdf = self.datetime_pdf, self.datetime_psdf
         self.assert_eq(pdf["this"] <= pdf["that"], psdf["this"] <= psdf["that"])
-        self.assert_eq(pdf["this"] <= pdf["this"], psdf["this"] <= psdf["this"])
 
     def test_gt(self):
         pdf, psdf = self.datetime_pdf, self.datetime_psdf
         self.assert_eq(pdf["this"] > pdf["that"], psdf["this"] > psdf["that"])
-        self.assert_eq(pdf["this"] > pdf["this"], psdf["this"] > psdf["this"])
 
     def test_ge(self):
         pdf, psdf = self.datetime_pdf, self.datetime_psdf
         self.assert_eq(pdf["this"] >= pdf["that"], psdf["this"] >= psdf["that"])
-        self.assert_eq(pdf["this"] >= pdf["this"], psdf["this"] >= psdf["this"])
 
 
 class DatetimeNTZOpsTest(DatetimeOpsTest):

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -195,21 +195,21 @@ class StringOpsTest(OpsTestBase):
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser == other_pser, psser == other_psser)
-        self.assert_eq(pser == pser, psser == psser)
+        #self.assert_eq(pser == pser, psser == psser)
 
     def test_ne(self):
         pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser != other_pser, psser != other_psser)
-        self.assert_eq(pser != pser, psser != psser)
+        #self.assert_eq(pser != pser, psser != psser)
 
     def test_lt(self):
         pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser < other_pser, psser < other_psser)
-        self.assert_eq(pser < pser, psser < psser)
+        #self.assert_eq(pser < pser, psser < psser)
 
     def test_le(self):
         pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf

--- a/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_string_ops.py
@@ -195,21 +195,18 @@ class StringOpsTest(OpsTestBase):
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser == other_pser, psser == other_psser)
-        #self.assert_eq(pser == pser, psser == psser)
 
     def test_ne(self):
         pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser != other_pser, psser != other_psser)
-        #self.assert_eq(pser != pser, psser != psser)
 
     def test_lt(self):
         pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf
         pser, psser = pdf["this"], psdf["this"]
         other_pser, other_psser = pdf["that"], psdf["that"]
         self.assert_eq(pser < other_pser, psser < other_psser)
-        #self.assert_eq(pser < pser, psser < psser)
 
     def test_le(self):
         pdf, psdf = self.bool_non_numeric_pdf, self.bool_non_numeric_psdf


### PR DESCRIPTION
### What changes were proposed in this pull request?
I'm scanning the code with sonar. 

[This is for python, javascript and css](https://sonarcloud.io/project/issues?resolved=false&id=spark-python). 

and [this is for java and scala](https://sonarcloud.io/project/issues?resolved=false&id=sparklocal)


One of the rules is "[Identical expressions should not be used on both sides of a binary operator.](https://sonarcloud.io/project/issues?languages=py&resolved=false&rules=python%3AS1764&id=spark-python)"
There are a lot of this 278 total, in pandas API test code. 


This PR will remove tests where we compare identical expressions on both sides. 

### Why are the changes needed?

Using the same value on either side of a binary operator is almost always a mistake. In the case of logical operators, it is either a copy/paste error and therefore a bug, or it is simply wasted code, and should be simplified. In the case of bitwise operators and most binary mathematical operators, having the same value on both sides of an operator yields predictable results, and should be simplified.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

