### PR TITLE
[SPARK-41243][CONNECT][PYTHON][DOCS] Update the protobuf version in README

### DIFF
--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -90,7 +90,7 @@ To use the release version of Spark Connect:
 
 ### Generate proto generated files for the Python client
 1. Install `buf version 1.8.0`: https://docs.buf.build/installation
-2. Run `pip install grpcio==1.48.1 protobuf==4.21.6 mypy-protobuf==3.3.0`
+2. Run `pip install grpcio==1.48.1 protobuf==3.19.4 mypy-protobuf==3.3.0`
 3. Run `./connector/connect/dev/generate_protos.sh`
 4. Optional Check `./dev/check-codegen-python.py`
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the protobuf version to be `3.19.3` in README.

### Why are the changes needed?
Since we have homogenized the protobuf version across server and client to be `3.19.3`, we should update the README to be consistent.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.
