### PR TITLE
[SPARK-41250][CONNECT][PYTHON] DataFrame. toPandas should not return optional pandas dataframe

### DIFF
--- a/connector/connect/src/main/protobuf/spark/connect/base.proto
+++ b/connector/connect/src/main/protobuf/spark/connect/base.proto
@@ -174,6 +174,8 @@ message ExecutePlanResponse {
 service SparkConnectService {
 
   // Executes a request that contains the query and returns a stream of [[Response]].
+  //
+  // It is guaranteed that there is at least one ARROW batch returned even if the result set is empty.
   rpc ExecutePlan(ExecutePlanRequest) returns (stream ExecutePlanResponse) {}
 
   // Analyzes a query and returns a [[AnalyzeResponse]] containing metadata about the query.

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -300,7 +300,7 @@ class RemoteSparkSession(object):
         req = self._execute_plan_request_with_metadata()
         req.plan.command.create_function.CopyFrom(fun)
 
-        self._execute_and_fetch(req)
+        self._execute(req)
         return name
 
     def _build_metrics(self, metrics: "pb2.ExecutePlanResponse.Metrics") -> List[PlanMetrics]:
@@ -350,7 +350,7 @@ class RemoteSparkSession(object):
             Range(start=start, end=end, step=step, num_partitions=numPartitions), self
         )
 
-    def _to_pandas(self, plan: pb2.Plan) -> Optional[pandas.DataFrame]:
+    def _to_pandas(self, plan: pb2.Plan) -> "pandas.DataFrame":
         req = self._execute_plan_request_with_metadata()
         req.plan.CopyFrom(plan)
         return self._execute_and_fetch(req)
@@ -398,7 +398,7 @@ class RemoteSparkSession(object):
         if self._user_id:
             req.user_context.user_id = self._user_id
         req.plan.command.CopyFrom(command)
-        self._execute_and_fetch(req)
+        self._execute(req)
         return
 
     def _execute_plan_request_with_metadata(self) -> pb2.ExecutePlanRequest:
@@ -439,13 +439,16 @@ class RemoteSparkSession(object):
         resp = self._stub.AnalyzePlan(req, metadata=self._builder.metadata())
         return AnalyzeResult.fromProto(resp)
 
-    def _process_batch(self, b: pb2.ExecutePlanResponse) -> Optional[pandas.DataFrame]:
-        if b.arrow_batch is not None and len(b.arrow_batch.data) > 0:
-            with pa.ipc.open_stream(b.arrow_batch.data) as rd:
-                return rd.read_pandas()
-        return None
+    def _process_batch(self, arrow_batch: pb2.ExecutePlanResponse.ArrowBatch) -> "pandas.DataFrame":
+        with pa.ipc.open_stream(arrow_batch.data) as rd:
+            return rd.read_pandas()
 
-    def _execute_and_fetch(self, req: pb2.ExecutePlanRequest) -> Optional[pandas.DataFrame]:
+    def _execute(self, req: pb2.ExecutePlanRequest) -> None:
+        for b in self._stub.ExecutePlan(req, metadata=self._builder.metadata()):
+            continue
+        return
+
+    def _execute_and_fetch(self, req: pb2.ExecutePlanRequest) -> "pandas.DataFrame":
         import pandas as pd
 
         m: Optional[pb2.ExecutePlanResponse.Metrics] = None
@@ -454,23 +457,21 @@ class RemoteSparkSession(object):
         for b in self._stub.ExecutePlan(req, metadata=self._builder.metadata()):
             if b.metrics is not None:
                 m = b.metrics
-
-            pb = self._process_batch(b)
-            if pb is not None:
+            if b.HasField("arrow_batch"):
+                pb = self._process_batch(b.arrow_batch)
                 result_dfs.append(pb)
 
-        if len(result_dfs) > 0:
-            df = pd.concat(result_dfs)
+        assert len(result_dfs) > 0
 
-            # pd.concat generates non-consecutive index like:
-            #   Int64Index([0, 1, 0, 1, 2, 0, 1, 0, 1, 2], dtype='int64')
-            # set it to RangeIndex to be consistent with pyspark
-            n = len(df)
-            df.set_index(pd.RangeIndex(start=0, stop=n, step=1), inplace=True)
+        df = pd.concat(result_dfs)
 
-            # Attach the metrics to the DataFrame attributes.
-            if m is not None:
-                df.attrs["metrics"] = self._build_metrics(m)
-            return df
-        else:
-            return None
+        # pd.concat generates non-consecutive index like:
+        #   Int64Index([0, 1, 0, 1, 2, 0, 1, 0, 1, 2], dtype='int64')
+        # set it to RangeIndex to be consistent with pyspark
+        n = len(df)
+        df.set_index(pd.RangeIndex(start=0, stop=n, step=1), inplace=True)
+
+        # Attach the metrics to the DataFrame attributes.
+        if m is not None:
+            df.attrs["metrics"] = self._build_metrics(m)
+        return df

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -789,7 +789,7 @@ class DataFrame(object):
         else:
             return []
 
-    def toPandas(self) -> Optional["pandas.DataFrame"]:
+    def toPandas(self) -> "pandas.DataFrame":
         if self._plan is None:
             raise Exception("Cannot collect on empty plan.")
         if self._session is None:

--- a/python/pyspark/sql/connect/proto/base_pb2_grpc.py
+++ b/python/pyspark/sql/connect/proto/base_pb2_grpc.py
@@ -46,7 +46,10 @@ class SparkConnectServiceServicer(object):
     """Main interface for the SparkConnect service."""
 
     def ExecutePlan(self, request, context):
-        """Executes a request that contains the query and returns a stream of [[Response]]."""
+        """Executes a request that contains the query and returns a stream of [[Response]].
+
+        It is guaranteed that there is at least one ARROW batch returned even if the result set is empty.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The server guarantees to send at least one arrow batch with schema even there is empty result. In this case, `DataFrame. toPandas` always can return a Pandas DataFrame.

This PR decouples the client side execution path for `Command` and `Relation` to remove `Optional` from the returneed type of `DataFrame. toPandas `. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
API coverage.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT