### PR TITLE
[SPARK-41251][PS][INFRA] Upgrade pandas from 1.5.1 to 1.5.2

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -64,8 +64,8 @@ RUN Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='ht
 # See more in SPARK-39735
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
 
-RUN pypy3 -m pip install numpy 'pandas<=1.5.1' scipy coverage matplotlib
-RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.1' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl 'memory-profiler==0.60.0'
+RUN pypy3 -m pip install numpy 'pandas<=1.5.2' scipy coverage matplotlib
+RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.2' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl 'memory-profiler==0.60.0'
 
 # Add Python deps for Spark Connect.
 RUN python3.9 -m pip install grpcio protobuf

--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -98,7 +98,7 @@ def generate_supported_api(output_rst_file_path: str) -> None:
 
     Write supported APIs documentation.
     """
-    pandas_latest_version = "1.5.1"
+    pandas_latest_version = "1.5.2"
     if LooseVersion(pd.__version__) != LooseVersion(pandas_latest_version):
         msg = (
             "Warning: Latest version of pandas (%s) is required to generate the documentation; "


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes upgrading pandas to 1.5.2, for pandas API on Spark.
New version of pandas (1.5.2) was released at Nov 22, 2022, brings some bug fix, the release notes as follows:
https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.5.2.html

### Why are the changes needed?
We should follow the behavior of latest pandas, and support it.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.