### PR TITLE
[SPARK-41245][BUILD] Upgrade `postgresql` to 42.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1206,7 +1206,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.5.0</version>
+        <version>42.5.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade postgresql from 42.5.0 to 42.5.1

[Changelog](https://jdbc.postgresql.org/changelogs/2022-11-23-42.5.1-release/)

### Why are the changes needed?
[CVE-2022-41946](https://nvd.nist.gov/vuln/detail/CVE-2022-41946)


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA
