### PR TITLE
[SPARK-41257][INFRA] Upgrade actions/labeler to v4

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -47,7 +47,7 @@ jobs:
     #
     # However, these are not in a published release and the current `main` branch
     # has some issues upon testing.
-    - uses: actions/labeler@5f867a63be70efff62b767459b009290364495eb # pin@2.2.0
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade actions/labeler to v4


### Why are the changes needed?
Since https://github.com/actions/labeler/releases/tag/v4.0.0 use node 16 to cleanup warning: `Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/labeler@5f867a63be70efff62b767459b009290364495eb` like https://github.com/apache/spark/actions/runs/3540940080


### Does this PR introduce _any_ user-facing change?
No, dev only

### How was this patch tested?
Test in my local repo based on this patch:
https://github.com/Yikun/spark/pull/188
https://github.com/Yikun/spark/pull/189