### PR TITLE
[SPARK-41260][PYTHON][SS] Cast NumPy instances to Python primitive types in GroupState update

### DIFF
--- a/python/pyspark/sql/streaming/state.py
+++ b/python/pyspark/sql/streaming/state.py
@@ -131,12 +131,23 @@ class GroupState:
         if newValue is None:
             raise ValueError("'None' is not a valid state value")
 
+        converted = []
         if has_numpy:
             import numpy as np
 
             # In order to convert NumPy types to Python primitive types.
-            newValue = tuple(v.tolist() for v in newValue if isinstance(v, np.generic))
-        self._value = Row(*newValue)
+            for v in newValue:
+                if isinstance(v, np.generic):
+                    converted.append(v.tolist())
+                # Address a couple of pandas dtypes too.
+                if hasattr(v, "to_pytimedelta"):
+                    converted.append(v.to_pytimedelta())
+                if hasattr(v, "to_pydatetime"):
+                    converted.append(v.to_pydatetime())
+        else:
+            converted = list(newValue)
+
+        self._value = Row(*converted)
         self._defined = True
         self._updated = True
         self._removed = False

--- a/python/pyspark/sql/streaming/state.py
+++ b/python/pyspark/sql/streaming/state.py
@@ -133,6 +133,7 @@ class GroupState:
 
         if has_numpy:
             import numpy as np
+
             # In order to convert NumPy types to Python primitive types.
             newValue = tuple(v.tolist() for v in newValue if isinstance(v, np.generic))
         self._value = Row(*newValue)

--- a/python/pyspark/sql/streaming/state.py
+++ b/python/pyspark/sql/streaming/state.py
@@ -19,6 +19,7 @@ import json
 from typing import Tuple, Optional
 
 from pyspark.sql.types import DateType, Row, StructType
+from pyspark.sql.utils import has_numpy
 
 __all__ = ["GroupState", "GroupStateTimeout"]
 
@@ -130,6 +131,10 @@ class GroupState:
         if newValue is None:
             raise ValueError("'None' is not a valid state value")
 
+        if has_numpy:
+            import numpy as np
+            # In order to convert NumPy types to Python primitive types.
+            newValue = tuple(v.tolist() for v in newValue if isinstance(v, np.generic))
         self._value = Row(*newValue)
         self._defined = True
         self._updated = True

--- a/python/pyspark/sql/streaming/state.py
+++ b/python/pyspark/sql/streaming/state.py
@@ -140,10 +140,12 @@ class GroupState:
                 if isinstance(v, np.generic):
                     converted.append(v.tolist())
                 # Address a couple of pandas dtypes too.
-                if hasattr(v, "to_pytimedelta"):
+                elif hasattr(v, "to_pytimedelta"):
                     converted.append(v.to_pytimedelta())
-                if hasattr(v, "to_pydatetime"):
+                elif hasattr(v, "to_pydatetime"):
                     converted.append(v.to_pydatetime())
+                else:
+                    converted.append(v)
         else:
             converted = list(newValue)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsInPandasWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsInPandasWithStateSuite.scala
@@ -894,26 +894,44 @@ class FlatMapGroupsInPandasWithStateSuite extends StateStoreMetricsTest {
       """
         |import pandas as pd
         |import numpy as np
+        |import datetime
         |from pyspark.sql.types import StructType, StructField, StringType
         |
-        |tpe = StructType([
-        |    StructField("key", StringType()),
-        |    StructField("valueAsString", StringType())])
+        |tpe = StructType([StructField("key", StringType())])
         |
         |def func(key, pdf_iter, state):
-        |    np_value = np.int64(1)  # NumPy instance
-        |    state.update((np_value,))
-        |    yield pd.DataFrame({'key': [key[0]], 'valueAsString': [str(np_value)]})
+        |    pdf = pd.DataFrame({
+        |        'int32': [np.int32(1)],
+        |        'int64': [np.int64(1)],
+        |        'float32': [np.float32(1)],
+        |        'float64': [np.float64(1)],
+        |        'bool': [True],
+        |        'datetime': [datetime.datetime(1990, 1, 1, 0, 0, 0)],
+        |        'timedelta': [datetime.timedelta(1)]
+        |    })
+        |
+        |    state.update(tuple(pdf.iloc[0]))
+        |    # Assert on Python primitive type comparison.
+        |    assert state.get == (
+        |        1, 1, 1.0, 1.0, True,
+        |        datetime.datetime(1990, 1, 1, 0, 0, 0), datetime.timedelta(1)
+        |    )
+        |    yield pd.DataFrame({'key': [key[0]]})
         |""".stripMargin
     val pythonFunc = TestGroupedMapPandasUDFWithState(
       name = "pandas_grouped_map_with_state", pythonScript = pythonScript)
 
     val inputData = MemoryStream[String]
-    val outputStructType = StructType(
-      Seq(
-        StructField("key", StringType),
-        StructField("valueAsString", StringType)))
-    val stateStructType = StructType(Seq(StructField("value", LongType)))
+    val outputStructType = StructType(Seq(StructField("key", StringType)))
+    val stateStructType = StructType(Seq(
+      StructField("int32", IntegerType),
+      StructField("int64", LongType),
+      StructField("float32", FloatType),
+      StructField("float64", DoubleType),
+      StructField("bool", BooleanType),
+      StructField("datetime", DateType),
+      StructField("timedelta", DayTimeIntervalType())
+    ))
     val inputDataDS = inputData.toDS()
     val result =
       inputDataDS
@@ -927,7 +945,7 @@ class FlatMapGroupsInPandasWithStateSuite extends StateStoreMetricsTest {
 
     testStream(result, Update)(
       AddData(inputData, "a"),
-      CheckNewAnswer(("a", "1")),
+      CheckNewAnswer("a"),
       assertNumStateRows(total = 1, updated = 1)
     )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to cast NumPy instances in `GroupState.update`.  Previously, if we pass a NumPy instance to `GroupState.update`, then it failed with an exception as below:

```
net.razorvine.pickle.PickleException: expected zero arguments for construction of ClassDict (for numpy.dtype). This happens when an unsupported/unregistered class is being unpickled that requires construction arguments. Fix it by registering a custom IObjectConstructor for this class.
	at net.razorvine.pickle.objects.ClassDictConstructor.construct(ClassDictConstructor.java:23)
	at net.razorvine.pickle.Unpickler.load_reduce(Unpickler.java:759)
	at net.razorvine.pickle.Unpickler.dispatch(Unpickler.java:199)
	at net.razorvine.pickle.Unpickler.load(Unpickler.java:109)
	at net.razorvine.pickle.Unpickler.loads(Unpickler.java:122)
	at org.apache.spark.sql.api.python.PythonSQLUtils$.$anonfun$toJVMRow$1(PythonSQLUtils.scala:125)
```

### Why are the changes needed?

`applyInPandasWithState` uses pandas instances so it is very common to extract a NumPy instance from the pandas and set it to the group state.

### Does this PR introduce _any_ user-facing change?

No because this new API is not released yet.

### How was this patch tested?

Manually tested, and unittest was added.