### PR TITLE
[MINOR][SQL][TESTS] Restore the code style check of `QueryExecutionErrorsSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -448,7 +448,7 @@ class QueryExecutionErrorsSuite
 
       override def getResources(name: String): java.util.Enumeration[URL] = {
         if (name.equals("META-INF/services/org.apache.spark.sql.sources.DataSourceRegister")) {
-          // scalastyle:off
+          // scalastyle:off throwerror
           throw new ServiceConfigurationError(s"Illegal configuration-file syntax: $name",
             new NoClassDefFoundError("org.apache.spark.sql.sources.HadoopFsRelationProvider"))
           // scalastyle:on throwerror
@@ -632,7 +632,8 @@ class QueryExecutionErrorsSuite
       },
       errorClass = "UNSUPPORTED_DATATYPE",
       parameters = Map(
-        "typeName" -> "StructType()[1.1] failure: 'TimestampType' expected but 'S' found\n\nStructType()\n^"
+        "typeName" ->
+          "StructType()[1.1] failure: 'TimestampType' expected but 'S' found\n\nStructType()\n^"
       ),
       sqlState = "0A000")
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/blob/9af216d7ac26f0ec916833c2e80a01aef8933529/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala#L451-L454

As above code, line 451 in `QueryExecutionErrorsSuite.scala` turn off all scala style check and line 454 just turn on `throwerror` check, so the code after line 454 of the `QueryExecutionErrorsSuite.scala` will not be checked for code style except `throwerror`. 

This pr restore the code style check and fix a existing `File line length exceeds 100 characters.` case.



### Why are the changes needed?
Restore the code style check of `QueryExecutionErrorsSuite`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions