### PR TITLE
[SPARK-41225][CONNECT][PYTHON][FOLLOWUP] Disable `semanticHash`, `sameSemantics`, `_repr_html_ `

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1109,6 +1109,15 @@ class DataFrame(object):
     def toJSON(self, *args: Any, **kwargs: Any) -> None:
         raise NotImplementedError("toJSON() is not implemented.")
 
+    def _repr_html_(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("_repr_html_() is not implemented.")
+
+    def semanticHash(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("semanticHash() is not implemented.")
+
+    def sameSemantics(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("sameSemantics() is not implemented.")
+
 
 class DataFrameNaFunctions:
     """Functionality for working with missing data in :class:`DataFrame`.

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -328,6 +328,9 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
             "toLocalIterator",
             "checkpoint",
             "localCheckpoint",
+            "_repr_html_",
+            "semanticHash",
+            "sameSemantics"
         ):
             with self.assertRaises(NotImplementedError):
                 getattr(df, f)()

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -330,7 +330,7 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
             "localCheckpoint",
             "_repr_html_",
             "semanticHash",
-            "sameSemantics"
+            "sameSemantics",
         ):
             with self.assertRaises(NotImplementedError):
                 getattr(df, f)()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disable `semanticHash`, `sameSemantics`, `_repr_html_ `


### Why are the changes needed?
1, Disable `semanticHash`, `sameSemantics` according to the discussions in https://github.com/apache/spark/pull/38742
2, Disable `_repr_html_ ` since it requires [eager mode](https://github.com/apache/spark/blob/40a9a6ef5b89f0c3d19db4a43b8a73decaa173c3/python/pyspark/sql/dataframe.py#L878), otherwise, it just returns `None`

```
In [2]: spark.range(start=0, end=10)._repr_html_() is None
Out[2]: True

```

### Does this PR introduce _any_ user-facing change?
for these three methods, throw `NotImplementedError`


### How was this patch tested?
added test cases
