### PR TITLE
[SPARK-41291][CONNECT][PYTHON] `DataFrame.explain` should print and return None

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -951,29 +951,9 @@ class DataFrame(object):
         ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)
         return result
 
-    def explain(
+    def _explain_string(
         self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None
     ) -> str:
-        """Retruns plans in string for debugging purpose.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        extended : bool, optional
-            default ``False``. If ``False``, returns only the physical plan.
-            When this is a string without specifying the ``mode``, it works as the mode is
-            specified.
-        mode : str, optional
-            specifies the expected output format of plans.
-
-            * ``simple``: Print only a physical plan.
-            * ``extended``: Print both logical and physical plans.
-            * ``codegen``: Print a physical plan and generated codes if they are available.
-            * ``cost``: Print a logical plan and statistics if they are available.
-            * ``formatted``: Split explain output into two sections: a physical plan outline \
-                and node details.
-        """
         if extended is not None and mode is not None:
             raise ValueError("extended and mode should not be set together.")
 
@@ -1017,6 +997,31 @@ class DataFrame(object):
             return self._session.client.explain_string(query, explain_mode)
         else:
             return ""
+
+    def explain(
+        self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None
+    ) -> None:
+        """Retruns plans in string for debugging purpose.
+
+        .. versionadded:: 3.4.0
+
+        Parameters
+        ----------
+        extended : bool, optional
+            default ``False``. If ``False``, returns only the physical plan.
+            When this is a string without specifying the ``mode``, it works as the mode is
+            specified.
+        mode : str, optional
+            specifies the expected output format of plans.
+
+            * ``simple``: Print only a physical plan.
+            * ``extended``: Print both logical and physical plans.
+            * ``codegen``: Print a physical plan and generated codes if they are available.
+            * ``cost``: Print a logical plan and statistics if they are available.
+            * ``formatted``: Split explain output into two sections: a physical plan outline \
+                and node details.
+        """
+        print(self._explain_string(extended=extended, mode=mode))
 
     def createGlobalTempView(self, name: str) -> None:
         """Creates a global temporary view with this :class:`DataFrame`.

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -133,7 +133,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
     def test_simple_explain_string(self):
         df = self.connect.read.table(self.tbl_name).limit(10)
-        result = df.explain()
+        result = df._explain_string()
         self.assertGreater(len(result), 0)
 
     def test_schema(self):
@@ -325,7 +325,9 @@ class SparkConnectTests(SparkConnectSQLTestCase):
     def test_subquery_alias(self) -> None:
         # SPARK-40938: test subquery alias.
         plan_text = (
-            self.connect.read.table(self.tbl_name).alias("special_alias").explain(extended=True)
+            self.connect.read.table(self.tbl_name)
+            .alias("special_alias")
+            ._explain_string(extended=True)
         )
         self.assertTrue("special_alias" in plan_text)
 
@@ -506,14 +508,14 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
     def test_explain_string(self):
         # SPARK-41122: test explain API.
-        plan_str = self.connect.sql("SELECT 1").explain(extended=True)
+        plan_str = self.connect.sql("SELECT 1")._explain_string(extended=True)
         self.assertTrue("Parsed Logical Plan" in plan_str)
         self.assertTrue("Analyzed Logical Plan" in plan_str)
         self.assertTrue("Optimized Logical Plan" in plan_str)
         self.assertTrue("Physical Plan" in plan_str)
 
         with self.assertRaises(ValueError) as context:
-            self.connect.sql("SELECT 1").explain(mode="unknown")
+            self.connect.sql("SELECT 1")._explain_string(mode="unknown")
         self.assertTrue("unknown" in str(context.exception))
 
     def test_simple_datasource_read(self) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?
`DataFrame.explain` should print and return None


### Why are the changes needed?
to match the behavior in PySpark

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
updated tests