### PR TITLE
[SPARK-41238][CONNECT][PYTHON][FOLLOWUP] Support `DayTimeIntervalType` in the client

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -383,7 +383,17 @@ class SparkConnectClient(object):
         elif schema.HasField("timestamp"):
             return TimestampType()
         elif schema.HasField("day_time_interval"):
-            return DayTimeIntervalType()
+            start: Optional[int] = (
+                schema.day_time_interval.start_field
+                if schema.day_time_interval.HasField("start_field")
+                else None
+            )
+            end: Optional[int] = (
+                schema.day_time_interval.end_field
+                if schema.day_time_interval.HasField("end_field")
+                else None
+            )
+            return DayTimeIntervalType(startField=start, endField=end)
         elif schema.HasField("array"):
             return ArrayType(
                 self._proto_schema_to_pyspark_schema(schema.array.element_type),

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -171,6 +171,13 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             self.connect.sql(query).schema,
         )
 
+        # test DayTimeIntervalType
+        query = """ SELECT INTERVAL '100 10:30' DAY TO MINUTE AS interval """
+        self.assertEqual(
+            self.spark.sql(query).schema,
+            self.connect.sql(query).schema,
+        )
+
         # test MapType
         query = """
             SELECT * FROM VALUES


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support `DayTimeIntervalType` in the client


### Why are the changes needed?
In https://github.com/apache/spark/pull/38770, I forgot to deal with `DayTimeIntervalType`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added test case, the schema should be 
```
In [1]: query = """ SELECT INTERVAL '100 10:30' DAY TO MINUTE AS interval """

In [2]: spark.sql(query).schema
Out[2]: StructType([StructField('interval', DayTimeIntervalType(0, 2), False)])
```
