### PR TITLE
[SPARK-41293][SQL][TESTS] Code cleanup for `assertXXX` methods in `ExpressionTypeCheckingSuite`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -44,16 +44,6 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite with SQLHelper with Quer
     intercept[AnalysisException](assertSuccess(expr))
   }
 
-  private def assertError(
-      expr: Expression,
-      errorClass: String,
-      messageParameters: Map[String, String]): Unit = {
-    checkError(
-      exception = analysisException(expr),
-      errorClass = errorClass,
-      parameters = messageParameters)
-  }
-
   private def assertSuccess(expr: Expression): Unit = {
     val analyzed = testRelation.select(expr.as("c")).analyze
     SimpleAnalyzer.checkAnalysis(analyzed)
@@ -61,26 +51,41 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite with SQLHelper with Quer
 
   private def assertErrorForBinaryDifferingTypes(
       expr: Expression, messageParameters: Map[String, String]): Unit = {
-    assertError(expr, "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES", messageParameters)
+    checkError(
+      exception = analysisException(expr),
+      errorClass = "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
+      parameters = messageParameters)
   }
 
   private def assertErrorForOrderingTypes(
       expr: Expression, messageParameters: Map[String, String]): Unit = {
-    assertError(expr, "DATATYPE_MISMATCH.INVALID_ORDERING_TYPE", messageParameters)
+    checkError(
+      exception = analysisException(expr),
+      errorClass = "DATATYPE_MISMATCH.INVALID_ORDERING_TYPE",
+      parameters = messageParameters)
   }
 
   private def assertErrorForDataDifferingTypes(
       expr: Expression, messageParameters: Map[String, String]): Unit = {
-    assertError(expr, "DATATYPE_MISMATCH.DATA_DIFF_TYPES", messageParameters)
+    checkError(
+      exception = analysisException(expr),
+      errorClass = "DATATYPE_MISMATCH.DATA_DIFF_TYPES",
+      parameters = messageParameters)
   }
 
   private def assertErrorForWrongNumParameters(
       expr: Expression, messageParameters: Map[String, String]): Unit = {
-    assertError(expr, "DATATYPE_MISMATCH.WRONG_NUM_ARGS", messageParameters)
+    checkError(
+      exception = analysisException(expr),
+      errorClass = "DATATYPE_MISMATCH.WRONG_NUM_ARGS",
+      parameters = messageParameters)
   }
 
   private def assertForWrongType(expr: Expression, messageParameters: Map[String, String]): Unit = {
-    assertError(expr, "DATATYPE_MISMATCH.BINARY_OP_WRONG_TYPE", messageParameters)
+    checkError(
+      exception = analysisException(expr),
+      errorClass = "DATATYPE_MISMATCH.BINARY_OP_WRONG_TYPE",
+      parameters = messageParameters)
   }
 
   test("check types for unary arithmetic") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -44,67 +44,43 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite with SQLHelper with Quer
     intercept[AnalysisException](assertSuccess(expr))
   }
 
-  def assertError(expr: Expression, errorMessage: String): Unit = {
-    val e = intercept[AnalysisException] {
-      assertSuccess(expr)
-    }
-    assert(e.getMessage.contains(
-      s"cannot resolve '${expr.sql}' due to data type mismatch:"))
-    assert(e.getMessage.contains(errorMessage))
+  private def assertError(
+      expr: Expression,
+      errorClass: String,
+      messageParameters: Map[String, String]): Unit = {
+    checkError(
+      exception = analysisException(expr),
+      errorClass = errorClass,
+      parameters = messageParameters)
   }
 
-  def assertSuccess(expr: Expression): Unit = {
+  private def assertSuccess(expr: Expression): Unit = {
     val analyzed = testRelation.select(expr.as("c")).analyze
     SimpleAnalyzer.checkAnalysis(analyzed)
   }
 
-  def assertErrorForBinaryDifferingTypes(
+  private def assertErrorForBinaryDifferingTypes(
       expr: Expression, messageParameters: Map[String, String]): Unit = {
-    checkError(
-      exception = intercept[AnalysisException] {
-        assertSuccess(expr)
-      },
-      errorClass = "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
-      parameters = messageParameters)
+    assertError(expr, "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES", messageParameters)
   }
 
-  def assertErrorForOrderingTypes(
+  private def assertErrorForOrderingTypes(
       expr: Expression, messageParameters: Map[String, String]): Unit = {
-    checkError(
-      exception = intercept[AnalysisException] {
-        assertSuccess(expr)
-      },
-      errorClass = "DATATYPE_MISMATCH.INVALID_ORDERING_TYPE",
-      parameters = messageParameters)
+    assertError(expr, "DATATYPE_MISMATCH.INVALID_ORDERING_TYPE", messageParameters)
   }
 
-  def assertErrorForDataDifferingTypes(
+  private def assertErrorForDataDifferingTypes(
       expr: Expression, messageParameters: Map[String, String]): Unit = {
-    checkError(
-      exception = intercept[AnalysisException] {
-        assertSuccess(expr)
-      },
-      errorClass = "DATATYPE_MISMATCH.DATA_DIFF_TYPES",
-      parameters = messageParameters)
+    assertError(expr, "DATATYPE_MISMATCH.DATA_DIFF_TYPES", messageParameters)
   }
 
-  def assertErrorForWrongNumParameters(
+  private def assertErrorForWrongNumParameters(
       expr: Expression, messageParameters: Map[String, String]): Unit = {
-    checkError(
-      exception = intercept[AnalysisException] {
-        assertSuccess(expr)
-      },
-      errorClass = "DATATYPE_MISMATCH.WRONG_NUM_ARGS",
-      parameters = messageParameters)
+    assertError(expr, "DATATYPE_MISMATCH.WRONG_NUM_ARGS", messageParameters)
   }
 
-  def assertForWrongType(expr: Expression, messageParameters: Map[String, String]): Unit = {
-    checkError(
-      exception = intercept[AnalysisException] {
-        assertSuccess(expr)
-      },
-      errorClass = "DATATYPE_MISMATCH.BINARY_OP_WRONG_TYPE",
-      parameters = messageParameters)
+  private def assertForWrongType(expr: Expression, messageParameters: Map[String, String]): Unit = {
+    assertError(expr, "DATATYPE_MISMATCH.BINARY_OP_WRONG_TYPE", messageParameters)
   }
 
   test("check types for unary arithmetic") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr do some code clean up for `assertXXX` method in `ExpressionTypeCheckingSuite`:

1.  Reuse `analysisException` instead of duplicate `intercept[AnalysisException](assertSuccess(expr))` in `assertErrorForXXX` methods.
2. remove  `assertError` method that is no longer used 
3. Change `assertErrorForXXX` methods access scope to `private` due to they are only used in `ExpressionTypeCheckingSuite`.


### Why are the changes needed?
Code clean up.


### Does this PR introduce _any_ user-facing change?
No, just for test

### How was this patch tested?
Pass GitHub Actions
