### PR TITLE
[SPARK-41301] [CONNECT] Homogenize Behavior for SparkSession.range()

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -257,7 +257,7 @@ class SparkSession(object):
     def range(
         self,
         start: int,
-        end: int,
+        end: Optional[int] = None,
         step: int = 1,
         numPartitions: Optional[int] = None,
     ) -> DataFrame:
@@ -283,6 +283,12 @@ class SparkSession(object):
         -------
         :class:`DataFrame`
         """
+        if end is None:
+            actual_end = start
+            start = 0
+        else:
+            actual_end = end
+
         return DataFrame.withPlan(
-            Range(start=start, end=end, step=step, num_partitions=numPartitions), self
+            Range(start=start, end=actual_end, step=step, num_partitions=numPartitions), self
         )

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -363,6 +363,10 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             self.connect.range(start=0, end=10, step=3, numPartitions=2).toPandas(),
             self.spark.range(start=0, end=10, step=3, numPartitions=2).toPandas(),
         )
+        # SPARK-41301
+        self.assert_eq(
+            self.connect.range(10).toPandas(), self.connect.range(start=0, end=10).toPandas()
+        )
 
     def test_create_global_temp_view(self):
         # SPARK-41127: test global temp view creation.


### PR DESCRIPTION
### What changes were proposed in this pull request?
In PySpark the `end` parameter to `SparkSession.range` is optional and the first parameter is then used with an implicit `0` for `start`. This patch homogenizes the behavior for Spark Connect.

### Why are the changes needed?
Compatibility.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT