### PR TITLE
[SPARK-41297] [CONNECT] [PYTHON] Support String Expressions in filter.

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -368,9 +368,7 @@ class DataFrame(object):
             expr = SQLExpression(condition)
         else:
             expr = condition
-        return DataFrame.withPlan(
-            plan.Filter(child=self._plan, filter=expr), session=self._session
-        )
+        return DataFrame.withPlan(plan.Filter(child=self._plan, filter=expr), session=self._session)
 
     def first(self) -> Optional[Row]:
         """Returns the first row as a :class:`Row`.

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -365,7 +365,7 @@ class DataFrame(object):
             Filtered DataFrame.
         """
         if isinstance(condition, str):
-            expr = SQLExpression(condition)
+            expr = cast(Expression, SQLExpression(condition))
         else:
             expr = condition
         return DataFrame.withPlan(plan.Filter(child=self._plan, filter=expr), session=self._session)

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -325,10 +325,14 @@ class DataFrame(object):
             session=self._session,
         )
 
-    def filter(self, condition: Expression) -> "DataFrame":
-        return DataFrame.withPlan(
-            plan.Filter(child=self._plan, filter=condition), session=self._session
-        )
+    def filter(self, condition: Union[Expression, str]) -> "DataFrame":
+        # The expression can be a SQL string expression.
+        if isinstance(condition, str):
+            expr = SQLExpression(condition)
+        else:
+            expr = condition
+
+        return DataFrame.withPlan(plan.Filter(child=self._plan, filter=expr), session=self._session)
 
     def first(self) -> Optional[Row]:
         """Returns the first row as a :class:`Row`.
@@ -636,7 +640,7 @@ class DataFrame(object):
             session=self._session,
         )
 
-    def where(self, condition: Expression) -> "DataFrame":
+    def where(self, condition: Union[Expression, str]) -> "DataFrame":
         return self.filter(condition)
 
     @property

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -70,6 +70,14 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
         self.assertEqual(plan.root.filter.condition.unresolved_function.parts, [">"])
         self.assertEqual(len(plan.root.filter.condition.unresolved_function.arguments), 2)
 
+    def test_filter_with_string_expr(self):
+        """SPARK-41297: filter supports SQL expression"""
+        df = self.connect.readTable(table_name=self.tbl_name)
+        plan = df.filter("id < 10")._plan.to_proto(self.connect)
+        self.assertIsNotNone(plan.root.filter)
+        self.assertIsNotNone(plan.root.filter.condition.expression_string)
+        self.assertEqual(plan.root.filter.condition.expression_string.expression, "id < 10")
+
     def test_fill_na(self):
         # SPARK-41128: Test fill na
         df = self.connect.readTable(table_name=self.tbl_name)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch extends the functionality of the DataFrame in Spark Connect by support passing string based SQL expressions to the filter. The expressions are passed as is to the server during evaluation. If the expression is not boolean an Analysis error is thrown.

```
spark.range(100).filter("id < 10").collect()
```


### Why are the changes needed?
Compatibility

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT