### PR TITLE
[MINOR][PYTHON][DOCS] Fix types and docstring in DataFrame.toDF

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4575,13 +4575,13 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         return DataFrame(jdf, self.sparkSession)
 
-    def toDF(self, *cols: "ColumnOrName") -> "DataFrame":
+    def toDF(self, *cols: str) -> "DataFrame":
         """Returns a new :class:`DataFrame` that with new specified column names
 
         Parameters
         ----------
         *cols : tuple
-            a tuple of string new column name or :class:`Column`. The length of the
+            a tuple of string new column name. The length of the
             list needs to be the same as the number of columns in the initial
             :class:`DataFrame`
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`df.toDF` cannot take `Column`s:

```python
>>> df.toDF(df.id)
```
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../spark/python/pyspark/sql/dataframe.py", line 4606, in toDF
    jdf = self._jdf.toDF(self._jseq(cols))
  File "/.../spark/python/pyspark/sql/dataframe.py", line 2413, in _jseq
    return _to_seq(self.sparkSession._sc, cols, converter)
  File "/.../spark/python/pyspark/sql/column.py", line 88, in _to_seq
    return sc._jvm.PythonUtils.toSeq(cols)
  File "/.../spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1314, in __call__
  File "/.../spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1277, in _build_args
  File "/.../spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1264, in _get_args
  File "/.../spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_collections.py", line 511, in convert
  File "/.../spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1314, in __call__
  File "/.../spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1277, in _build_args
  File "/.../forked/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1264, in _get_args
  File "/.../spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_collections.py", line 510, in convert
  File "/.../spark/python/pyspark/sql/column.py", line 622, in __iter__
    raise TypeError("Column is not iterable")
TypeError: Column is not iterable
```

This PR fixes the type and docstrings to remove the mention about `Column`

### Why are the changes needed?

To provide the correct documentation to the end users.

### Does this PR introduce _any_ user-facing change?

No for the main codes.
Yes for the docs.

### How was this patch tested?

CI in this PR should verify it via Python linters.
