### PR TITLE
[SPARK-41316][SQL] Enable tail-recursion wherever possible

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import scala.annotation.tailrec
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
@@ -116,6 +118,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
    * do not add a subquery that might have an expensive computation
    */
   private def isSelectiveFilterOverScan(plan: LogicalPlan): Boolean = {
+    @tailrec
     def isSelective(
         p: LogicalPlan,
         predicateReference: AttributeSet,
@@ -225,6 +228,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
   }
 
   // This checks if there is already a DPP filter, as this rule is called just after DPP.
+  @tailrec
   def hasDynamicPruningSubquery(
       left: LogicalPlan,
       right: LogicalPlan,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1083,6 +1083,7 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
   }
 
   private object ExtractOnlyRef {
+    @scala.annotation.tailrec
     def unapply(expr: Expression): Option[Attribute] = expr match {
       case a: Alias => unapply(a.child)
       case e: ExtractValue => unapply(e.children.head)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -157,6 +157,7 @@ object ScanOperation extends OperationHelper {
 }
 
 object NodeWithOnlyDeterministicProjectAndFilter {
+  @scala.annotation.tailrec
   def unapply(plan: LogicalPlan): Option[LogicalPlan] = plan match {
     case Project(projectList, child) if projectList.forall(_.deterministic) => unapply(child)
     case Filter(cond, child) if cond.deterministic => unapply(child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -454,6 +454,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
     case other => (other, false)
   }
 
+  @scala.annotation.tailrec
   private def pushDownOffset(
       plan: LogicalPlan,
       offset: Int): Boolean = plan match {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Similar to SPARK-37783, this pr adds `@scala.annotation.tailrec` inspected by IDE (IntelliJ),  these are new cases after Spark 3.3.


### Why are the changes needed?
To improve performance.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GItHub Actions