### PR TITLE
[SPARK-41256][CONNECT][FOLLOWUP] Fix compile error

### DIFF
--- a/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -438,12 +438,12 @@ class SparkConnectPlannerSuite extends SparkFunSuite with SparkConnectPlanTest {
                 .newBuilder()
                 .addName("test")
                 .setExpr(proto.Expression.newBuilder
-                  .setLiteral(proto.Expression.Literal.newBuilder.setI32(32))))
+                  .setLiteral(proto.Expression.Literal.newBuilder.setInteger(32))))
               .addNameExprList(proto.Expression.Alias
                 .newBuilder()
                 .addName("test")
                 .setExpr(proto.Expression.newBuilder
-                  .setLiteral(proto.Expression.Literal.newBuilder.setI32(32)))))
+                  .setLiteral(proto.Expression.Literal.newBuilder.setInteger(32)))))
           .build())
     }
   }
@@ -463,7 +463,7 @@ class SparkConnectPlannerSuite extends SparkFunSuite with SparkConnectPlanTest {
                   .addName("part1")
                   .addName("part2")
                   .setExpr(proto.Expression.newBuilder
-                    .setLiteral(proto.Expression.Literal.newBuilder.setI32(32)))))
+                    .setLiteral(proto.Expression.Literal.newBuilder.setInteger(32)))))
           .build())
     }
     assert(e.getMessage.contains("part1, part2"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/spark/commit/4c35c5bb5e545acb2f46a80218f68e69c868b388 made a breaking change in proto message, and cause https://github.com/apache/spark/commit/dcd9cae4a3cb715aa91e9679b0adc9aa43035b2f failed after merged

### Why are the changes needed?
to fix compile error:

```
[error] /__w/spark/spark/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala:441:67: value setI32 is not a member of org.apache.spark.connect.proto.Expression.Literal.Builder
[error]                   .setLiteral(proto.Expression.Literal.newBuilder.setI32(32))))
[error]                                                                   ^
[error] /__w/spark/spark/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala:446:67: value setI32 is not a member of org.apache.spark.connect.proto.Expression.Literal.Builder
[error]                   .setLiteral(proto.Expression.Literal.newBuilder.setI32(32)))))
[error]                                                                   ^
[error] /__w/spark/spark/connector/connect/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala:466:69: value setI32 is not a member of org.apache.spark.connect.proto.Expression.Literal.Builder
[error]                     .setLiteral(proto.Expression.Literal.newBuilder.setI32(32)))))
[error]                                                                     ^
[error] three errors found
``` 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local test