### PR TITLE
[SPARK-41327][CORE] Fix `SparkStatusTracker.getExecutorInfos` by switch On/OffHeapStorageMemory info

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
+++ b/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
@@ -114,10 +114,10 @@ class SparkStatusTracker private[spark] (sc: SparkContext, store: AppStatusStore
         port,
         cachedMem,
         exec.activeTasks,
-        exec.memoryMetrics.map(_.usedOffHeapStorageMemory).getOrElse(0L),
         exec.memoryMetrics.map(_.usedOnHeapStorageMemory).getOrElse(0L),
-        exec.memoryMetrics.map(_.totalOffHeapStorageMemory).getOrElse(0L),
-        exec.memoryMetrics.map(_.totalOnHeapStorageMemory).getOrElse(0L))
+        exec.memoryMetrics.map(_.usedOffHeapStorageMemory).getOrElse(0L),
+        exec.memoryMetrics.map(_.totalOnHeapStorageMemory).getOrElse(0L),
+        exec.memoryMetrics.map(_.totalOffHeapStorageMemory).getOrElse(0L))
     }.toArray
   }
 }

--- a/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
+++ b/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
@@ -100,7 +100,7 @@ class SparkStatusTracker private[spark] (sc: SparkContext, store: AppStatusStore
   /**
    * Returns information of all known executors, including host, port, cacheSize, numRunningTasks
    * and memory metrics.
-   * Note this include information for both the driver and executors. 
+   * Note this include information for both the driver and executors.
    */
   def getExecutorInfos: Array[SparkExecutorInfo] = {
     store.executorList(true).map { exec =>

--- a/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
+++ b/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
@@ -100,7 +100,7 @@ class SparkStatusTracker private[spark] (sc: SparkContext, store: AppStatusStore
   /**
    * Returns information of all known executors, including host, port, cacheSize, numRunningTasks
    * and memory metrics.
-   * Note this include information for both the driver and executors.
+   * Note this include information for both the driver and executors. 
    */
   def getExecutorInfos: Array[SparkExecutorInfo] = {
     store.executorList(true).map { exec =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `SparkStatusTracker.getExecutorInfos` to return a correct `on/offHeapStorageMemory`.

### Why are the changes needed?

`SparkExecutorInfoImpl` used the following parameter order.
https://github.com/apache/spark/blob/54c57fa86906f933e089a33ef25ae0c053769cc8/core/src/main/scala/org/apache/spark/StatusAPIImpl.scala#L42-L45

SPARK-20659 introduced a bug with wrong parameter order at Apache Spark 2.4.0.
- https://github.com/apache/spark/pull/20546/files#diff-7daca909d33ff8e9b4938e2b4a4aaa1558fbdf4604273b9e38cce32c55e1508cR118-R121

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Manually review.