### PR TITLE
[SPARK-41332][CONNECT][PYTHON]  Fix `nullOrdering` in `SortOrder`

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -305,21 +305,21 @@ class SortOrder(Expression):
         return str(self.ref) + " ASC" if self.ascending else " DESC"
 
     def to_plan(self, session: "SparkConnectClient") -> proto.Expression:
-        # TODO: move SortField from relations.proto to expression.proto
-        expr = proto.Sort.SortField()
-        expr.expression.CopyFrom(self.ref.to_plan(session))
+        # TODO(SPARK-41334): move SortField from relations.proto to expressions.proto
+        sort = proto.Sort.SortField()
+        sort.expression.CopyFrom(self.ref.to_plan(session))
 
         if self._ascending:
-            expr.direction = proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING
+            sort.direction = proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING
         else:
-            expr.direction = proto.Sort.SortDirection.SORT_DIRECTION_DESCENDING
+            sort.direction = proto.Sort.SortDirection.SORT_DIRECTION_DESCENDING
 
         if self._nullsLast:
-            expr.nulls = proto.Sort.SortNulls.SORT_NULLS_LAST
+            sort.nulls = proto.Sort.SortNulls.SORT_NULLS_LAST
         else:
-            expr.nulls = proto.Sort.SortNulls.SORT_NULLS_FIRST
+            sort.nulls = proto.Sort.SortNulls.SORT_NULLS_FIRST
 
-        return cast(proto.Expression, expr)
+        return cast(proto.Expression, sort)
 
     def ascending(self) -> bool:
         return self._ascending

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import get_args, TYPE_CHECKING, Callable, Any, Union, overload
+from typing import get_args, TYPE_CHECKING, Callable, Any, Union, overload, cast
 
 import json
 import decimal
@@ -269,10 +269,10 @@ class ColumnReference(Expression):
         return expr
 
     def desc(self) -> "SortOrder":
-        return SortOrder(self, ascending=False)
+        return SortOrder(self, ascending=False, nullsLast=True)
 
     def asc(self) -> "SortOrder":
-        return SortOrder(self, ascending=True)
+        return SortOrder(self, ascending=True, nullsLast=False)
 
     def __str__(self) -> str:
         return f"ColumnReference({self._unparsed_identifier})"
@@ -295,9 +295,7 @@ class SQLExpression(Expression):
 
 
 class SortOrder(Expression):
-    def __init__(
-        self, col: ColumnReference, ascending: bool = True, nullsLast: bool = True
-    ) -> None:
+    def __init__(self, col: Expression, ascending: bool = True, nullsLast: bool = False) -> None:
         super().__init__()
         self.ref = col
         self._ascending = ascending
@@ -307,7 +305,21 @@ class SortOrder(Expression):
         return str(self.ref) + " ASC" if self.ascending else " DESC"
 
     def to_plan(self, session: "SparkConnectClient") -> proto.Expression:
-        return self.ref.to_plan(session)
+        # TODO: move SortField from relations.proto to expression.proto
+        expr = proto.Sort.SortField()
+        expr.expression.CopyFrom(self.ref.to_plan(session))
+
+        if self._ascending:
+            expr.direction = proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING
+        else:
+            expr.direction = proto.Sort.SortDirection.SORT_DIRECTION_DESCENDING
+
+        if self._nullsLast:
+            expr.nulls = proto.Sort.SortNulls.SORT_NULLS_LAST
+        else:
+            expr.nulls = proto.Sort.SortNulls.SORT_NULLS_FIRST
+
+        return cast(proto.Expression, expr)
 
     def ascending(self) -> bool:
         return self._ascending

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -28,7 +28,7 @@ from typing import (
 import pandas
 import pyarrow as pa
 import pyspark.sql.connect.proto as proto
-from pyspark.sql.connect.column import Column
+from pyspark.sql.connect.column import Column, SortOrder, ColumnReference
 
 
 if TYPE_CHECKING:
@@ -492,7 +492,7 @@ class Sort(LogicalPlan):
     def __init__(
         self,
         child: Optional["LogicalPlan"],
-        columns: List[Union[Column, str]],
+        columns: List["ColumnOrName"],
         is_global: bool,
     ) -> None:
         super().__init__(child)
@@ -500,32 +500,19 @@ class Sort(LogicalPlan):
         self.is_global = is_global
 
     def col_to_sort_field(
-        self, col: Union[Column, str], session: "SparkConnectClient"
+        self, col: "ColumnOrName", session: "SparkConnectClient"
     ) -> proto.Sort.SortField:
+        sort: Optional[SortOrder] = None
         if isinstance(col, Column):
-            sf = proto.Sort.SortField()
-            sf.expression.CopyFrom(col.to_plan(session))
-            sf.direction = (
-                proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING
-                if col._expr.ascending
-                else proto.Sort.SortDirection.SORT_DIRECTION_DESCENDING
-            )
-            sf.nulls = (
-                proto.Sort.SortNulls.SORT_NULLS_FIRST
-                if not col._expr.nullsLast
-                else proto.Sort.SortNulls.SORT_NULLS_LAST
-            )
-            return sf
-        else:
-            sf = proto.Sort.SortField()
-            # Check string
-            if isinstance(col, Column):
-                sf.expression.CopyFrom(col.to_plan(session))
+            if isinstance(col._expr, SortOrder):
+                sort = col._expr
             else:
-                sf.expression.CopyFrom(self.unresolved_attr(col))
-            sf.direction = proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING
-            sf.nulls = proto.Sort.SortNulls.SORT_NULLS_LAST
-            return sf
+                sort = SortOrder(col._expr)
+        else:
+            sort = SortOrder(ColumnReference(name=col))
+        assert sort is not None
+
+        return cast(proto.Sort.SortField, sort.to_plan(session))
 
     def plan(self, session: "SparkConnectClient") -> proto.Relation:
         assert self._child is not None

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -192,10 +192,26 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
             ["col_a", "col_b"],
         )
         self.assertEqual(plan.root.sort.is_global, True)
+        self.assertEqual(
+            plan.root.sort.sort_fields[0].direction,
+            proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING,
+        )
+        self.assertEqual(
+            plan.root.sort.sort_fields[0].direction,
+            proto.Sort.SortNulls.SORT_NULLS_FIRST,
+        )
+        self.assertEqual(
+            plan.root.sort.sort_fields[1].direction,
+            proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING,
+        )
+        self.assertEqual(
+            plan.root.sort.sort_fields[1].direction,
+            proto.Sort.SortNulls.SORT_NULLS_FIRST,
+        )
 
         plan = (
             df.filter(df.col_name > 3)
-            .sortWithinPartitions("col_a", "col_b")
+            .sortWithinPartitions(df.col_a.desc(), df.col_b.asc())
             ._plan.to_proto(self.connect)
         )
         self.assertEqual(
@@ -206,6 +222,22 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
             ["col_a", "col_b"],
         )
         self.assertEqual(plan.root.sort.is_global, False)
+        self.assertEqual(
+            plan.root.sort.sort_fields[0].direction,
+            proto.Sort.SortDirection.SORT_DIRECTION_DESCENDING,
+        )
+        self.assertEqual(
+            plan.root.sort.sort_fields[0].direction,
+            proto.Sort.SortNulls.SORT_NULLS_LAST,
+        )
+        self.assertEqual(
+            plan.root.sort.sort_fields[1].direction,
+            proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING,
+        )
+        self.assertEqual(
+            plan.root.sort.sort_fields[1].direction,
+            proto.Sort.SortNulls.SORT_NULLS_FIRST,
+        )
 
     def test_drop(self):
         # SPARK-41169: test drop


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix the wrong `nullOrdering`


### Why are the changes needed?
existing implementation generate incorrect `nullOrdering`;



### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added ut
