### PR TITLE
[SPARK-41341][CORE] Wait shuffle fetch to finish when decommission executor

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -243,6 +243,10 @@ public class TransportContext implements Closeable {
     return registeredConnections;
   }
 
+  public int getNumOpenStream() {
+    return rpcHandler.getStreamManager().numStreamStates();
+  }
+
   @Override
   public void close() {
     if (chunkFetchWorkers != null) {

--- a/common/network-common/src/main/java/org/apache/spark/network/server/StreamManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/StreamManager.java
@@ -100,4 +100,10 @@ public abstract class StreamManager {
    */
   public void streamSent(String streamId) { }
 
+  /**
+   * Number of opening streams
+   */
+  public int numStreamStates() {
+    return 0;
+  }
 }

--- a/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/BlockTransferService.scala
@@ -121,4 +121,6 @@ abstract class BlockTransferService extends BlockStoreClient {
     val future = uploadBlock(hostname, port, execId, blockId, blockData, level, classTag)
     ThreadUtils.awaitResult(future, Duration.Inf)
   }
+
+  def numPendingBlockFetches(): Int
 }

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -217,4 +217,6 @@ private[spark] class NettyBlockTransferService(
       transportContext.close()
     }
   }
+
+  override def numPendingBlockFetches(): Int = transportContext.getNumOpenStream
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1956,6 +1956,10 @@ private[spark] class BlockManager(
     decommissioner.map(_.lastMigrationInfo()).getOrElse((0, false))
   }
 
+  private[spark] def getNumPendingBlockFetches(): Int = {
+    blockTransferService.numPendingBlockFetches()
+  }
+
   private[storage] def getMigratableRDDBlocks(): Seq[ReplicateBlock] =
     master.getReplicateInfoForRDDBlocks(blockManagerId)
 

--- a/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/BlockTransferServiceSuite.scala
@@ -91,6 +91,8 @@ class BlockTransferServiceSuite extends SparkFunSuite with TimeLimits {
         // This method is unused in this test
         throw new UnsupportedOperationException("uploadBlock")
       }
+
+      override def numPendingBlockFetches(): Int = 0
     }
 
     val e = intercept[SparkException] {

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -2287,6 +2287,8 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
       }
       super.fetchBlockSync(host, port, execId, blockId, tempFileManager)
     }
+
+    override def numPendingBlockFetches(): Int = 0
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Wait for shuffle fetch to finish when decommissioning executors by checking number of opening streams.

### Why are the changes needed?
When shuffle fetch with some opening streams is in progress and executor self-exit after decommission, there'll be fetch failed caused by executor self-exit. To fix this, let decommissioned executor wait pending shuffle fetch to be finished.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested
