### PR TITLE
[SPARK-41346][CONNECT][PYTHON] Implement `asc` and `desc` functions

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -510,6 +510,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.test_connect_plan_only",
         "pyspark.sql.tests.connect.test_connect_select_ops",
         "pyspark.sql.tests.connect.test_connect_basic",
+        "pyspark.sql.tests.connect.test_connect_function",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -26,6 +26,7 @@ from pyspark.sql.types import TimestampType, DayTimeIntervalType, DateType
 import pyspark.sql.connect.proto as proto
 
 if TYPE_CHECKING:
+    from pyspark.sql.connect._typing import ColumnOrName
     from pyspark.sql.connect.client import SparkConnectClient
     import pyspark.sql.connect.proto as proto
 
@@ -73,7 +74,7 @@ def sql_expression(expr: str) -> "Column":
     return Column(SQLExpression(expr))
 
 
-class Expression(object):
+class Expression:
     """
     Expression base class.
     """
@@ -84,7 +85,7 @@ class Expression(object):
     def to_plan(self, session: "SparkConnectClient") -> "proto.Expression":
         ...
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         ...
 
     def alias(self, *alias: str, **kwargs: Any) -> "ColumnAlias":
@@ -124,18 +125,6 @@ class Expression(object):
         assert not kwargs, "Unexpected kwargs where passed: %s" % kwargs
         return ColumnAlias(self, list(alias), metadata)
 
-    def desc(self) -> "SortOrder":
-        ...
-
-    def asc(self) -> "SortOrder":
-        ...
-
-    def ascending(self) -> bool:
-        ...
-
-    def nullsLast(self) -> bool:
-        ...
-
     def name(self) -> str:
         ...
 
@@ -164,7 +153,7 @@ class ColumnAlias(Expression):
             exp.alias.expr.CopyFrom(self._parent.to_plan(session))
             return exp
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return f"Alias({self._parent}, ({','.join(self._alias)}))"
 
 
@@ -244,7 +233,7 @@ class LiteralExpression(Expression):
 
         return expr
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return f"Literal({self._value})"
 
 
@@ -258,7 +247,7 @@ class ColumnReference(Expression):
     def from_qualified_name(cls, name: str) -> "ColumnReference":
         return ColumnReference(name)
 
-    def __init__(self, name: Union[str, "Column"]) -> None:
+    def __init__(self, name: "ColumnOrName") -> None:
         super().__init__()
         if isinstance(name, str):
             self._unparsed_identifier = name
@@ -281,7 +270,7 @@ class ColumnReference(Expression):
     def asc(self) -> "SortOrder":
         return SortOrder(self, ascending=True, nullsLast=False)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return f"ColumnReference({self._unparsed_identifier})"
 
 
@@ -302,19 +291,23 @@ class SQLExpression(Expression):
 
 
 class SortOrder(Expression):
-    def __init__(self, col: Expression, ascending: bool = True, nullsLast: bool = False) -> None:
+    def __init__(self, child: Expression, ascending: bool = True, nullsLast: bool = False) -> None:
         super().__init__()
-        self.ref = col
+        self._child = child
         self._ascending = ascending
         self._nullsLast = nullsLast
 
-    def __str__(self) -> str:
-        return str(self.ref) + " ASC" if self.ascending else " DESC"
+    def __repr__(self) -> str:
+        return (
+            str(self._child)
+            + (" ASC" if self._ascending else " DESC")
+            + (" NULLS LAST" if self._nullsLast else " NULLS FIRST")
+        )
 
     def to_plan(self, session: "SparkConnectClient") -> proto.Expression:
         # TODO(SPARK-41334): move SortField from relations.proto to expressions.proto
         sort = proto.Sort.SortField()
-        sort.expression.CopyFrom(self.ref.to_plan(session))
+        sort.expression.CopyFrom(self._child.to_plan(session))
 
         if self._ascending:
             sort.direction = proto.Sort.SortDirection.SORT_DIRECTION_ASCENDING
@@ -327,12 +320,6 @@ class SortOrder(Expression):
             sort.nulls = proto.Sort.SortNulls.SORT_NULLS_FIRST
 
         return cast(proto.Expression, sort)
-
-    def ascending(self) -> bool:
-        return self._ascending
-
-    def nullsLast(self) -> bool:
-        return self._nullsLast
 
 
 class ScalarFunctionExpression(Expression):
@@ -351,11 +338,11 @@ class ScalarFunctionExpression(Expression):
         fun.unresolved_function.arguments.extend([x.to_plan(session) for x in self._args])
         return fun
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return f"({self._op} ({', '.join([str(x) for x in self._args])}))"
 
 
-class Column(object):
+class Column:
     """
     A column in a DataFrame. Column can refer to different things based on the
     wrapped expression. Some common examples include attribute references, functions,
@@ -701,11 +688,23 @@ class Column(object):
     def alias(self, *alias: str, **kwargs: Any) -> "Column":
         return Column(self._expr.alias(*alias, **kwargs))
 
-    def desc(self) -> "Column":
-        return Column(self._expr.desc())
-
     def asc(self) -> "Column":
-        return Column(self._expr.asc())
+        return self.asc_nulls_first()
+
+    def asc_nulls_first(self) -> "Column":
+        return Column(SortOrder(self._expr, ascending=True, nullsLast=False))
+
+    def asc_nulls_last(self) -> "Column":
+        return Column(SortOrder(self._expr, ascending=True, nullsLast=True))
+
+    def desc(self) -> "Column":
+        return self.desc_nulls_last()
+
+    def desc_nulls_first(self) -> "Column":
+        return Column(SortOrder(self._expr, ascending=False, nullsLast=False))
+
+    def desc_nulls_last(self) -> "Column":
+        return Column(SortOrder(self._expr, ascending=False, nullsLast=True))
 
     def name(self) -> str:
         return self._expr.name()
@@ -715,5 +714,5 @@ class Column(object):
     def _lit(self, x: Any) -> "Column":
         return Column(LiteralExpression(x))
 
-    def __str__(self) -> str:
-        return self._expr.__str__()
+    def __repr__(self) -> str:
+        return "Column<'%s'>" % self._expr.__repr__()

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -16,14 +16,247 @@
 #
 from pyspark.sql.connect.column import Column, LiteralExpression, ColumnReference
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyspark.sql.connect._typing import ColumnOrName
 
 # TODO(SPARK-40538) Add support for the missing PySpark functions.
+
+
+def _to_col(col: "ColumnOrName") -> Column:
+    return col if isinstance(col, Column) else column(col)
 
 
 def col(x: str) -> Column:
     return Column(ColumnReference(x))
 
 
+column = col
+
+
 def lit(x: Any) -> Column:
     return Column(LiteralExpression(x))
+
+
+def asc(col: "ColumnOrName") -> Column:
+    """
+    Returns a sort expression based on the ascending order of the given column name.
+
+    .. versionadded:: 3.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the ascending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    Sort by the column 'id' in the descending order.
+
+    >>> df = spark.range(5)
+    >>> df = df.sort(desc("id"))
+    >>> df.show()
+    +---+
+    | id|
+    +---+
+    |  4|
+    |  3|
+    |  2|
+    |  1|
+    |  0|
+    +---+
+
+    Sort by the column 'id' in the ascending order.
+
+    >>> df.orderBy(asc("id")).show()
+    +---+
+    | id|
+    +---+
+    |  0|
+    |  1|
+    |  2|
+    |  3|
+    |  4|
+    +---+
+    """
+    return _to_col(col).asc()
+
+
+def asc_nulls_first(col: "ColumnOrName") -> Column:
+    """
+    Returns a sort expression based on the ascending order of the given
+    column name, and null values return before non-null values.
+
+    .. versionadded:: 2.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the ascending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    >>> df1 = spark.createDataFrame([(1, "Bob"),
+    ...                              (0, None),
+    ...                              (2, "Alice")], ["age", "name"])
+    >>> df1.sort(asc_nulls_first(df1.name)).show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  0| null|
+    |  2|Alice|
+    |  1|  Bob|
+    +---+-----+
+
+    """
+    return _to_col(col).asc_nulls_first()
+
+
+def asc_nulls_last(col: "ColumnOrName") -> Column:
+    """
+    Returns a sort expression based on the ascending order of the given
+    column name, and null values appear after non-null values.
+
+    .. versionadded:: 2.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the ascending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    >>> df1 = spark.createDataFrame([(0, None),
+    ...                              (1, "Bob"),
+    ...                              (2, "Alice")], ["age", "name"])
+    >>> df1.sort(asc_nulls_last(df1.name)).show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  2|Alice|
+    |  1|  Bob|
+    |  0| null|
+    +---+-----+
+
+    """
+    return _to_col(col).asc_nulls_last()
+
+
+def desc(col: "ColumnOrName") -> Column:
+    """
+    Returns a sort expression based on the descending order of the given column name.
+
+    .. versionadded:: 3.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the descending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    Sort by the column 'id' in the descending order.
+
+    >>> spark.range(5).orderBy(desc("id")).show()
+    +---+
+    | id|
+    +---+
+    |  4|
+    |  3|
+    |  2|
+    |  1|
+    |  0|
+    +---+
+    """
+    return _to_col(col).desc()
+
+
+def desc_nulls_first(col: "ColumnOrName") -> Column:
+    """
+    Returns a sort expression based on the descending order of the given
+    column name, and null values appear before non-null values.
+
+    .. versionadded:: 2.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the descending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    >>> df1 = spark.createDataFrame([(0, None),
+    ...                              (1, "Bob"),
+    ...                              (2, "Alice")], ["age", "name"])
+    >>> df1.sort(desc_nulls_first(df1.name)).show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  0| null|
+    |  1|  Bob|
+    |  2|Alice|
+    +---+-----+
+
+    """
+    return _to_col(col).desc_nulls_first()
+
+
+def desc_nulls_last(col: "ColumnOrName") -> Column:
+    """
+    Returns a sort expression based on the descending order of the given
+    column name, and null values appear after non-null values.
+
+    .. versionadded:: 2.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the descending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    >>> df1 = spark.createDataFrame([(0, None),
+    ...                              (1, "Bob"),
+    ...                              (2, "Alice")], ["age", "name"])
+    >>> df1.sort(desc_nulls_last(df1.name)).show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  1|  Bob|
+    |  2|Alice|
+    |  0| null|
+    +---+-----+
+
+    """
+    return _to_col(col).desc_nulls_last()

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -93,7 +93,7 @@ def asc_nulls_first(col: "ColumnOrName") -> Column:
     Returns a sort expression based on the ascending order of the given
     column name, and null values return before non-null values.
 
-    .. versionadded:: 2.4.0
+    .. versionadded:: 3.4.0
 
     Parameters
     ----------
@@ -128,7 +128,7 @@ def asc_nulls_last(col: "ColumnOrName") -> Column:
     Returns a sort expression based on the ascending order of the given
     column name, and null values appear after non-null values.
 
-    .. versionadded:: 2.4.0
+    .. versionadded:: 3.4.0
 
     Parameters
     ----------
@@ -197,7 +197,7 @@ def desc_nulls_first(col: "ColumnOrName") -> Column:
     Returns a sort expression based on the descending order of the given
     column name, and null values appear before non-null values.
 
-    .. versionadded:: 2.4.0
+    .. versionadded:: 3.4.0
 
     Parameters
     ----------
@@ -232,7 +232,7 @@ def desc_nulls_last(col: "ColumnOrName") -> Column:
     Returns a sort expression based on the descending order of the given
     column name, and null values appear after non-null values.
 
-    .. versionadded:: 2.4.0
+    .. versionadded:: 3.4.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
@@ -182,7 +182,7 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
     def test_column_alias(self) -> None:
         # SPARK-40809: Support for Column Aliases
         col0 = fun.col("a").alias("martin")
-        self.assertEqual("Alias(ColumnReference(a), (martin))", str(col0))
+        self.assertEqual("Column<'Alias(ColumnReference(a), (martin))'>", str(col0))
 
         col0 = fun.col("a").alias("martin", metadata={"pii": True})
         plan = col0.to_plan(self.session.client)

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -1,0 +1,184 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Any
+import unittest
+import tempfile
+
+from pyspark.testing.sqlutils import have_pandas, SQLTestUtils
+
+from pyspark.sql import SparkSession, Row
+from pyspark.sql.types import StructType, StructField, StringType
+
+if have_pandas:
+    from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
+from pyspark.sql.dataframe import DataFrame
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.utils import ReusedPySparkTestCase
+
+
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class SparkConnectSQLTestCase(PandasOnSparkTestCase, ReusedPySparkTestCase, SQLTestUtils):
+    """Parent test fixture class for all Spark Connect related
+    test cases."""
+
+    if have_pandas:
+        connect: RemoteSparkSession
+    tbl_name: str
+    tbl_name_empty: str
+    df_text: "DataFrame"
+    spark: SparkSession
+
+    @classmethod
+    def setUpClass(cls: Any):
+        ReusedPySparkTestCase.setUpClass()
+        cls.tempdir = tempfile.NamedTemporaryFile(delete=False)
+        cls.hive_available = True
+        # Create the new Spark Session
+        cls.spark = SparkSession(cls.sc)
+        cls.testData = [Row(key=i, value=str(i)) for i in range(100)]
+        cls.testDataStr = [Row(key=str(i)) for i in range(100)]
+        cls.df = cls.sc.parallelize(cls.testData).toDF()
+        cls.df_text = cls.sc.parallelize(cls.testDataStr).toDF()
+
+        cls.tbl_name = "test_connect_basic_table_1"
+        cls.tbl_name_empty = "test_connect_basic_table_empty"
+
+        # Cleanup test data
+        cls.spark_connect_clean_up_test_data()
+        # Load test data
+        cls.spark_connect_load_test_data()
+
+    @classmethod
+    def tearDownClass(cls: Any) -> None:
+        cls.spark_connect_clean_up_test_data()
+        ReusedPySparkTestCase.tearDownClass()
+
+    @classmethod
+    def spark_connect_load_test_data(cls: Any):
+        # Setup Remote Spark Session
+        cls.connect = RemoteSparkSession.builder.remote().getOrCreate()
+        df = cls.spark.createDataFrame([(x, f"{x}") for x in range(100)], ["id", "name"])
+        # Since we might create multiple Spark sessions, we need to create global temporary view
+        # that is specifically maintained in the "global_temp" schema.
+        df.write.saveAsTable(cls.tbl_name)
+        empty_table_schema = StructType(
+            [
+                StructField("firstname", StringType(), True),
+                StructField("middlename", StringType(), True),
+                StructField("lastname", StringType(), True),
+            ]
+        )
+        emptyRDD = cls.spark.sparkContext.emptyRDD()
+        empty_df = cls.spark.createDataFrame(emptyRDD, empty_table_schema)
+        empty_df.write.saveAsTable(cls.tbl_name_empty)
+
+    @classmethod
+    def spark_connect_clean_up_test_data(cls: Any) -> None:
+        cls.spark.sql("DROP TABLE IF EXISTS {}".format(cls.tbl_name))
+        cls.spark.sql("DROP TABLE IF EXISTS {}".format(cls.tbl_name_empty))
+
+
+class SparkConnectFunctionTests(SparkConnectSQLTestCase):
+    """These test cases exercise the interface to the proto plan
+    generation but do not call Spark."""
+
+    def test_sorting_functions_with_column(self):
+        from pyspark.sql.connect import functions as CF
+        from pyspark.sql.connect.column import Column
+
+        funs = [
+            CF.asc_nulls_first,
+            CF.asc_nulls_last,
+            CF.desc_nulls_first,
+            CF.desc_nulls_last,
+        ]
+        exprs = [CF.col("x"), "x"]
+
+        for fun in funs:
+            for _expr in exprs:
+                res = fun(_expr)
+                self.assertIsInstance(res, Column)
+                self.assertIn(f"""{fun.__name__.replace("_", " ").upper()}'""", str(res))
+
+        for _expr in exprs:
+            res = CF.asc(_expr)
+            self.assertIsInstance(res, Column)
+            self.assertIn("""ASC NULLS FIRST'""", str(res))
+
+        for _expr in exprs:
+            res = CF.desc(_expr)
+            self.assertIsInstance(res, Column)
+            self.assertIn("""DESC NULLS LAST'""", str(res))
+
+    def test_sort_with_nulls_order(self):
+        from pyspark.sql import functions as SF
+        from pyspark.sql.connect import functions as CF
+
+        query = """
+            SELECT * FROM VALUES
+            (false, 1, NULL), (false, NULL, 2.0), (NULL, 3, 3.0)
+            AS tab(a, b, c)
+            """
+        # +-----+----+----+
+        # |    a|   b|   c|
+        # +-----+----+----+
+        # |false|   1|null|
+        # |false|null| 2.0|
+        # | null|   3| 3.0|
+        # +-----+----+----+
+
+        cdf = self.connect.sql(query)
+        sdf = self.spark.sql(query)
+
+        for c in ["a", "b", "c"]:
+            self.assert_eq(
+                cdf.orderBy(CF.asc(c)).toPandas(),
+                sdf.orderBy(SF.asc(c)).toPandas(),
+            )
+            self.assert_eq(
+                cdf.orderBy(CF.asc_nulls_first(c)).toPandas(),
+                sdf.orderBy(SF.asc_nulls_first(c)).toPandas(),
+            )
+            self.assert_eq(
+                cdf.orderBy(CF.asc_nulls_last(c)).toPandas(),
+                sdf.orderBy(SF.asc_nulls_last(c)).toPandas(),
+            )
+            self.assert_eq(
+                cdf.orderBy(CF.desc(c)).toPandas(),
+                sdf.orderBy(SF.desc(c)).toPandas(),
+            )
+            self.assert_eq(
+                cdf.orderBy(CF.desc_nulls_first(c)).toPandas(),
+                sdf.orderBy(SF.desc_nulls_first(c)).toPandas(),
+            )
+            self.assert_eq(
+                cdf.orderBy(CF.desc_nulls_last(c)).toPandas(),
+                sdf.orderBy(SF.desc_nulls_last(c)).toPandas(),
+            )
+
+
+if __name__ == "__main__":
+    from pyspark.sql.tests.connect.test_connect_function import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -131,14 +131,14 @@ class SparkConnectFunctionTests(SparkConnectSQLTestCase):
 
         query = """
             SELECT * FROM VALUES
-            (false, 1, NULL), (false, NULL, 2.0), (NULL, 3, 3.0)
+            (false, 1, NULL), (true, NULL, 2.0), (NULL, 3, 3.0)
             AS tab(a, b, c)
             """
         # +-----+----+----+
         # |    a|   b|   c|
         # +-----+----+----+
         # |false|   1|null|
-        # |false|null| 2.0|
+        # | true|null| 2.0|
         # | null|   3| 3.0|
         # +-----+----+----+
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, remove `asc` and `desc` from `Expression`;
2, add `asc_nulls_first`, `asc_nulls_last`, `desc_nulls_first`, `desc_nulls_last` in `Column`;
3, add these methods in `functions`;
4, add a new test file for functions

### Why are the changes needed?
for api coverage

### Does this PR introduce _any_ user-facing change?
yes, new APIs


### How was this patch tested?
added ut