### PR TITLE
[SPARK-41350][SQL] Allow simple name access of join hidden columns after subquery alias

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1627,7 +1627,15 @@ case class SubqueryAlias(
 
   override def output: Seq[Attribute] = {
     val qualifierList = identifier.qualifier :+ alias
-    child.output.map(_.withQualifier(qualifierList))
+    child.output.map { attr =>
+      // `SubqueryAlias` sets a new qualifier for its output columns. It doesn't make sense to still
+      // restrict the hidden columns of natural/using join to be accessed by qualified name only.
+      if (attr.qualifiedAccessOnly) {
+        attr.markAsAllowAnyAccess().withQualifier(qualifierList)
+      } else {
+        attr.withQualifier(qualifierList)
+      }
+    }
   }
 
   override def metadataOutput: Seq[Attribute] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -212,5 +212,12 @@ package object util extends Logging {
         .putBoolean(QUALIFIED_ACCESS_ONLY, true)
         .build()
     )
+
+    def markAsAllowAnyAccess(): Attribute = attr.withMetadata(
+      new MetadataBuilder()
+        .withMetadata(attr.metadata)
+        .remove(QUALIFIED_ACCESS_ONLY)
+        .build()
+    )
   }
 }

--- a/sql/core/src/test/resources/sql-tests/inputs/natural-join.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/natural-join.sql
@@ -50,6 +50,8 @@ SELECT *, nt2.k FROM nt1 natural join nt2;
 
 SELECT nt1.k, nt2.k FROM nt1 natural join nt2;
 
+SELECT k FROM (SELECT nt2.k FROM nt1 natural join nt2);
+
 SELECT nt1.k, nt2.k FROM nt1 natural join nt2 where k = "one";
 
 SELECT * FROM (SELECT * FROM nt1 natural join nt2);

--- a/sql/core/src/test/resources/sql-tests/inputs/using-join.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/using-join.sql
@@ -19,6 +19,8 @@ SELECT nt1.*, nt2.* FROM nt1 left outer join nt2 using (k);
 
 SELECT nt1.k, nt2.k FROM nt1 left outer join nt2 using (k);
 
+SELECT k FROM (SELECT nt2.k FROM nt1 left outer join nt2 using (k));
+
 SELECT nt1.k, nt2.k FROM nt1 left outer join nt2 using (k) ORDER BY nt2.k;
 
 SELECT k, nt1.k FROM nt1 left outer join nt2 using (k);
@@ -43,6 +45,8 @@ SELECT nt1.*, nt2.* FROM nt1 right outer join nt2 using (k);
 
 SELECT nt1.k, nt2.k FROM nt1 right outer join nt2 using (k);
 
+SELECT k FROM (SELECT nt1.k FROM nt1 right outer join nt2 using (k));
+
 SELECT k, nt1.k FROM nt1 right outer join nt2 using (k);
 
 SELECT k, nt2.k FROM nt1 right outer join nt2 using (k);
@@ -55,6 +59,8 @@ SELECT nt1.*, nt2.* FROM nt1 full outer join nt2 using (k);
 
 SELECT nt1.k, nt2.k FROM nt1 full outer join nt2 using (k);
 
+SELECT k FROM (SELECT nt2.k FROM nt1 full outer join nt2 using (k));
+
 SELECT k, nt1.k FROM nt1 full outer join nt2 using (k);
 
 SELECT k, nt2.k FROM nt1 full outer join nt2 using (k);
@@ -66,6 +72,8 @@ SELECT k FROM nt1 inner join nt2 using (k);
 SELECT nt1.*, nt2.* FROM nt1 inner join nt2 using (k);
 
 SELECT nt1.k, nt2.k FROM nt1 inner join nt2 using (k);
+
+SELECT k FROM (SELECT nt2.k FROM nt1 inner join nt2 using (k));
 
 SELECT k, nt1.k FROM nt1 inner join nt2 using (k);
 

--- a/sql/core/src/test/resources/sql-tests/results/natural-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/natural-join.sql.out
@@ -185,6 +185,16 @@ two	two
 
 
 -- !query
+SELECT k FROM (SELECT nt2.k FROM nt1 natural join nt2)
+-- !query schema
+struct<k:string>
+-- !query output
+one
+one
+two
+
+
+-- !query
 SELECT nt1.k, nt2.k FROM nt1 natural join nt2 where k = "one"
 -- !query schema
 struct<k:string,k:string>

--- a/sql/core/src/test/resources/sql-tests/results/using-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/using-join.sql.out
@@ -69,6 +69,17 @@ two	two
 
 
 -- !query
+SELECT k FROM (SELECT nt2.k FROM nt1 left outer join nt2 using (k))
+-- !query schema
+struct<k:string>
+-- !query output
+NULL
+one
+one
+two
+
+
+-- !query
 SELECT nt1.k, nt2.k FROM nt1 left outer join nt2 using (k) ORDER BY nt2.k
 -- !query schema
 struct<k:string,k:string>
@@ -191,6 +202,17 @@ two	two
 
 
 -- !query
+SELECT k FROM (SELECT nt1.k FROM nt1 right outer join nt2 using (k))
+-- !query schema
+struct<k:string>
+-- !query output
+NULL
+one
+one
+two
+
+
+-- !query
 SELECT k, nt1.k FROM nt1 right outer join nt2 using (k)
 -- !query schema
 struct<k:string,k:string>
@@ -261,6 +283,18 @@ two	two
 
 
 -- !query
+SELECT k FROM (SELECT nt2.k FROM nt1 full outer join nt2 using (k))
+-- !query schema
+struct<k:string>
+-- !query output
+NULL
+four
+one
+one
+two
+
+
+-- !query
 SELECT k, nt1.k FROM nt1 full outer join nt2 using (k)
 -- !query schema
 struct<k:string,k:string>
@@ -324,6 +358,16 @@ struct<k:string,k:string>
 one	one
 one	one
 two	two
+
+
+-- !query
+SELECT k FROM (SELECT nt2.k FROM nt1 inner join nt2 using (k))
+-- !query schema
+struct<k:string>
+-- !query output
+one
+one
+two
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This fixes a regression caused by https://github.com/apache/spark/pull/37758 . In https://github.com/apache/spark/pull/37758 , we decided to only allow qualified name access for using/natural join hidden columns, to fix other problems around hidden columns.

We thought that is not a breaking change, as you can only access the join hidden columns by qualified names to disambiguate. However, one case is missed: when we wrap the join with a subquery alias, the ambiguity is gone and we should allow simple name access.

This PR fixes this bug by removing the qualified access only restriction in `SubqueryAlias.output`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix a regression.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, certain querys that failed with `UNRESOLVED_COLUMN` before this PR can work now.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests