### PR TITLE
[SPARK-41351][CONNECT] Column should support != operator

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -511,6 +511,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.test_connect_select_ops",
         "pyspark.sql.tests.connect.test_connect_basic",
         "pyspark.sql.tests.connect.test_connect_function",
+        "pyspark.sql.tests.connect.test_connect_column",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -505,6 +505,13 @@ class Column:
     isNull = _unary_op("isNull", _isNull_doc)
     isNotNull = _unary_op("isNotNull", _isNotNull_doc)
 
+    def __ne__(  # type: ignore[override]
+            self,
+            other: Any,
+    ) -> "Column":
+        """binary function"""
+        return _bin_op("notEqual")(self, other)
+
     # string methods
     def contains(self, other: Union[PrimitiveType, "Column"]) -> "Column":
         """

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -510,7 +510,7 @@ class Column:
             other: Any,
     ) -> "Column":
         """binary function"""
-        return _bin_op("!=")(self, other)
+        return _func_op("not", _bin_op("==")(self, other))
 
     # string methods
     def contains(self, other: Union[PrimitiveType, "Column"]) -> "Column":

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -506,11 +506,11 @@ class Column:
     isNotNull = _unary_op("isNotNull", _isNotNull_doc)
 
     def __ne__(  # type: ignore[override]
-            self,
-            other: Any,
+        self,
+        other: Any,
     ) -> "Column":
         """binary function"""
-        return _func_op("not", _bin_op("==")(self, other))
+        return _func_op("not")(_bin_op("==")(self, other))
 
     # string methods
     def contains(self, other: Union[PrimitiveType, "Column"]) -> "Column":

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -510,7 +510,7 @@ class Column:
             other: Any,
     ) -> "Column":
         """binary function"""
-        return _bin_op("notEqual")(self, other)
+        return _bin_op("!=")(self, other)
 
     # string methods
     def contains(self, other: Union[PrimitiveType, "Column"]) -> "Column":

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -870,11 +870,6 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertEqual(4.0, res[0][1])
         self.assertEqual(5.0, res[1][1])
 
-    def test_column_operator(self):
-        # SPARK-41351: Column needs to support !=
-        df = self.connect.range(10)
-        self.assertEqual(9, df.select(df.id != lit(1)).collect())
-
     def test_crossjoin(self):
         # SPARK-41227: Test CrossJoin
         connect_df = self.connect.read.table(self.tbl_name)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -870,6 +870,11 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertEqual(4.0, res[0][1])
         self.assertEqual(5.0, res[1][1])
 
+    def test_column_operator(self):
+        # SPARK-41351: Column needs to support !=
+        df = self.connect.range(10)
+        self.assertEqual(9, df.select(df.id != lit(1)).collect())
+
     def test_crossjoin(self):
         # SPARK-41227: Test CrossJoin
         connect_df = self.connect.read.table(self.tbl_name)

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -14,16 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
 
 from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
 from pyspark.testing.sqlutils import have_pandas
 
 if have_pandas:
-    from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
-    from pyspark.sql.connect.client import ChannelBuilder
-    from pyspark.sql.connect.function_builder import udf
-    from pyspark.sql.connect.functions import lit, col
+    from pyspark.sql.connect.functions import lit
 
 
 class SparkConnectTests(SparkConnectSQLTestCase):

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -30,6 +30,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
 
 if __name__ == "__main__":
+    import unittest
     from pyspark.sql.tests.connect.test_connect_column import *  # noqa: F401
 
     try:

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-import grpc  # type: ignore
+import unittest
 
 from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
 from pyspark.testing.sqlutils import have_pandas

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import grpc  # type: ignore
+
+from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
+from pyspark.testing.sqlutils import have_pandas
+
+if have_pandas:
+    pass
+
+if have_pandas:
+    from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
+    from pyspark.sql.connect.client import ChannelBuilder
+    from pyspark.sql.connect.function_builder import udf
+    from pyspark.sql.connect.functions import lit, col
+
+
+class SparkConnectTests(SparkConnectSQLTestCase):
+    def test_column_operator(self):
+        # SPARK-41351: Column needs to support !=
+        df = self.connect.range(10)
+        self.assertEqual(9, len(df.filter(df.id != lit(1)).collect()))
+
+
+if __name__ == "__main__":
+    from pyspark.sql.tests.connect.test_connect_column import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -20,9 +20,6 @@ from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
 from pyspark.testing.sqlutils import have_pandas
 
 if have_pandas:
-    pass
-
-if have_pandas:
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
     from pyspark.sql.connect.client import ChannelBuilder
     from pyspark.sql.connect.function_builder import udf


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch fixes a bug that the `Column` does not support the != operator.

### Why are the changes needed?
Compat

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT