### PR TITLE
[WIP][SPARK-41356][SQL] Refactor `ColumnVectorUtils#populate` method to use physical types

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.types.*;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.vectorized.ColumnarArray;
@@ -47,53 +48,49 @@ public class ColumnVectorUtils {
    * Populates the value of `row[fieldIdx]` into `ConstantColumnVector`.
    */
   public static void populate(ConstantColumnVector col, InternalRow row, int fieldIdx) {
-    DataType t = col.dataType();
+    DataType dt = col.dataType();
+    PhysicalDataType pdt = dt.physicalDataType();
 
     if (row.isNullAt(fieldIdx)) {
       col.setNull();
     } else {
-      if (t == DataTypes.BooleanType) {
+      if (pdt instanceof PhysicalBooleanType) {
         col.setBoolean(row.getBoolean(fieldIdx));
-      } else if (t == DataTypes.BinaryType) {
+      } else if (pdt instanceof PhysicalBinaryType) {
         col.setBinary(row.getBinary(fieldIdx));
-      } else if (t == DataTypes.ByteType) {
+      } else if (pdt instanceof PhysicalByteType) {
         col.setByte(row.getByte(fieldIdx));
-      } else if (t == DataTypes.ShortType) {
+      } else if (pdt instanceof PhysicalShortType) {
         col.setShort(row.getShort(fieldIdx));
-      } else if (t == DataTypes.IntegerType) {
+      } else if (pdt instanceof PhysicalIntegerType) {
         col.setInt(row.getInt(fieldIdx));
-      } else if (t == DataTypes.LongType) {
+      } else if (pdt instanceof PhysicalLongType) {
         col.setLong(row.getLong(fieldIdx));
-      } else if (t == DataTypes.FloatType) {
+      } else if (pdt instanceof PhysicalFloatType) {
         col.setFloat(row.getFloat(fieldIdx));
-      } else if (t == DataTypes.DoubleType) {
+      } else if (pdt instanceof PhysicalDoubleType) {
         col.setDouble(row.getDouble(fieldIdx));
-      } else if (t == DataTypes.StringType) {
+      } else if (pdt instanceof PhysicalStringType) {
         UTF8String v = row.getUTF8String(fieldIdx);
         col.setUtf8String(v);
-      } else if (t instanceof DecimalType) {
-        DecimalType dt = (DecimalType) t;
-        Decimal d = row.getDecimal(fieldIdx, dt.precision(), dt.scale());
-        if (dt.precision() <= Decimal.MAX_INT_DIGITS()) {
+      } else if (pdt instanceof PhysicalDecimalType) {
+        PhysicalDecimalType pd = (PhysicalDecimalType) pdt;
+        Decimal d = row.getDecimal(fieldIdx, pd.precision(), pd.scale());
+        if (pd.precision() <= Decimal.MAX_INT_DIGITS()) {
           col.setInt((int)d.toUnscaledLong());
-        } else if (dt.precision() <= Decimal.MAX_LONG_DIGITS()) {
+        } else if (pd.precision() <= Decimal.MAX_LONG_DIGITS()) {
           col.setLong(d.toUnscaledLong());
         } else {
           final BigInteger integer = d.toJavaBigDecimal().unscaledValue();
           byte[] bytes = integer.toByteArray();
           col.setBinary(bytes);
         }
-      } else if (t instanceof CalendarIntervalType) {
+      } else if (pdt instanceof PhysicalCalendarIntervalType) {
         // The value of `numRows` is irrelevant.
-        col.setCalendarInterval((CalendarInterval) row.get(fieldIdx, t));
-      } else if (t instanceof DateType || t instanceof YearMonthIntervalType) {
-        col.setInt(row.getInt(fieldIdx));
-      } else if (t instanceof TimestampType || t instanceof TimestampNTZType ||
-        t instanceof DayTimeIntervalType) {
-        col.setLong(row.getLong(fieldIdx));
+        col.setCalendarInterval((CalendarInterval) row.get(fieldIdx, dt));
       } else {
         throw new RuntimeException(String.format("DataType %s is not supported" +
-            " in column vectorized reader.", t.sql()));
+            " in column vectorized reader.", dt.sql()));
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The main change of this pr is refactor `ColumnVectorUtils#populate` method to use physical types for type matching to reduce branching.

 
### Why are the changes needed?
Use physical types for type matching to reduce branching:

- The physical type of `DateType` and `YearMonthIntervalType` are both `PhysicalIntegerType`, so they are combined into `pdt instanceof PhysicalIntegerType`
- The physical type of `TimestampType`, `TimestampNTZType` and `DayTimeIntervalType` are both `PhysicalLongType`, so they are combined into `pdt instanceof PhysicalLongType`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing `ColumnVectorUtilsSuite`