### PR TITLE
[SPARK-41361] [SQL] Invalid call toAttribute on unresolved object exception caused by WidenSetOperationTypes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ScriptTransformation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ScriptTransformation.scala
@@ -32,7 +32,13 @@ case class ScriptTransformation(
     child: LogicalPlan,
     ioschema: ScriptInputOutputSchema) extends UnaryNode {
   @transient
-  override lazy val references: AttributeSet = AttributeSet(child.output)
+  override lazy val references: AttributeSet = {
+    if (child.resolved) {
+      AttributeSet(child.output)
+    } else {
+      AttributeSet.empty
+    }
+  }
 
   override protected def withNewChildInternal(newChild: LogicalPlan): ScriptTransformation =
     copy(child = newChild)

--- a/sql/core/src/test/resources/sql-tests/inputs/union.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/union.sql
@@ -59,6 +59,15 @@ SELECT SUM(t.v) FROM (
   SELECT v + v AS v FROM t3
 ) t;
 
+-- SPARK-41361: Invalid call toAttribute on unresolved object exception caused by WidenSetOperationTypes
+SELECT
+TRANSFORM(*) USING 'cat' AS (a)
+FROM
+(
+SELECT c2 AS c from t2
+UNION
+SELECT c2 AS c from t1);
+
 -- Clean-up
 DROP VIEW IF EXISTS t1;
 DROP VIEW IF EXISTS t2;

--- a/sql/core/src/test/resources/sql-tests/results/union.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/union.sql.out
@@ -157,6 +157,23 @@ struct<sum(v):decimal(21,0)>
 
 
 -- !query
+SELECT
+TRANSFORM(*) USING 'cat' AS (a)
+FROM
+(
+SELECT c2 AS c from t2
+UNION
+SELECT c2 AS c from t1)
+-- !query schema
+struct<a:string>
+-- !query output
+1
+4
+a
+b
+
+
+-- !query
 DROP VIEW IF EXISTS t1
 -- !query schema
 struct<>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The problem can be reproduced in the following way:
```shell
spark-sql> CREATE OR REPLACE TEMPORARY VIEW t1 AS VALUES (1, 'a'), (2, 'b') tbl(c1, c2);

spark-sql> CREATE OR REPLACE TEMPORARY VIEW t2 AS VALUES (1.0, 1), (2.0, 4) tbl(c1, c2); 

spark-sql> SELECT
         > TRANSFORM(*) USING 'cat' AS (a)
         > FROM
         > (
         > SELECT c2 AS c from t2
         > UNION
         > SELECT c2 AS c from t1);
Invalid call to toAttribute on unresolved object
```
The reason is that when WidenSetOperationTypes rewrites the reference of the parent plan (possibly Unresolved), it will call the references of the parent plan to obtain all Attributes.

ScriptTransformation overrides references, and it takes `child.output` as references.

This problem may occur if the child of ScriptTransformation is Unresolved.

### Why are the changes needed?
fix the problem


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
added Test
