### PR TITLE
[MINOR][DOCS] Move 4 functions from 'Normal Functions' to 'Collection Functions'

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -28,10 +28,7 @@ Normal Functions
 
     col
     column
-    create_map
     lit
-    array
-    map_from_arrays
     broadcast
     coalesce
     input_file_name
@@ -42,7 +39,6 @@ Normal Functions
     rand
     randn
     spark_partition_id
-    struct
     when
     bitwise_not
     bitwiseNOT
@@ -150,10 +146,12 @@ Collection Functions
 .. autosummary::
     :toctree: api/
 
+    array
     array_contains
     arrays_overlap
-    slice
     array_join
+    create_map
+    slice
     concat
     array_position
     element_at
@@ -172,6 +170,7 @@ Collection Functions
     transform_keys
     transform_values
     map_filter
+    map_from_arrays
     map_zip_with
     explode
     explode_outer
@@ -186,6 +185,7 @@ Collection Functions
     schema_of_json
     to_json
     size
+    struct
     sort_array
     array_max
     array_min


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move 4 functions from 'Normal Functions' to 'Collection Functions':

1. `create_map`
2. `array`
3. `map_from_arrays`
4. `strcut`

### Why are the changes needed?
they should be [collection functions](https://github.com/apache/spark/blob/master/python/pyspark/sql/functions.py#L6355-L6440)


### Does this PR introduce _any_ user-facing change?
doc updated

### How was this patch tested?
doc-only
