### PR TITLE
[SPARK-41365][UI] Stages UI page fails to load for proxy in specific yarn environment

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/StagesResource.scala
@@ -16,16 +16,11 @@
  */
 package org.apache.spark.status.api.v1
 
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets.UTF_8
 import java.util.{HashMap, List => JList, Locale}
 import javax.ws.rs.{NotFoundException => _, _}
 import javax.ws.rs.core.{Context, MediaType, MultivaluedMap, UriInfo}
 
 import scala.collection.JavaConverters._
-
-import org.glassfish.jersey.internal.util.collection.ImmutableMultivaluedMap
-import org.glassfish.jersey.uri.UriComponent
 
 import org.apache.spark.status.api.v1.TaskStatus._
 import org.apache.spark.ui.UIUtils
@@ -148,10 +143,8 @@ private[v1] class StagesResource extends BaseAppResource {
     @Context uriInfo: UriInfo):
   HashMap[String, Object] = {
     withUI { ui =>
-      // Decode URI twice here to avoid percent-encoding twice on the query string
-      val decodeURI = URLDecoder.decode(uriInfo.getRequestUri.getRawQuery, UTF_8.name())
-      val uriQueryParameters = new ImmutableMultivaluedMap[String, String](
-        UriComponent.decodeQuery(decodeURI, true))
+      // Decode URI params twice here to avoid percent-encoding twice
+      val uriQueryParameters = UIUtils.decodeURLParameter(uriInfo.getQueryParameters(true))
       val totalRecords = uriQueryParameters.getFirst("numTasks")
       var isSearch = false
       var searchValue: String = null

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -26,6 +26,7 @@ import scala.xml.Node
 
 import com.gargoylesoftware.css.parser.CSSParseException
 import com.gargoylesoftware.htmlunit.DefaultCssErrorHandler
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 import org.openqa.selenium.{By, WebDriver}
@@ -35,9 +36,8 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.time.SpanSugar._
 import org.scalatestplus.selenium.WebBrowser
-import org.apache.spark._
-import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap
 
+import org.apache.spark._
 import org.apache.spark.LocalSparkContext._
 import org.apache.spark.api.java.StorageLevels
 import org.apache.spark.deploy.history.HistoryServerSuite
@@ -845,9 +845,9 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers {
           "&search%255Bvalue%255D=&search%255Bregex%255D=false&numTasks=10&columnIndexToSort=4" +
           "&columnNameToSort=Locality%2520Level"
         val encodeOnceRes = Utils.tryWithResource(Source.fromURL(
-          apiUrl(sc.ui.get, "stages/0/0/taskTable?"+ encodeOnceQuery)))(_.mkString)
+          apiUrl(sc.ui.get, "stages/0/0/taskTable?" + encodeOnceQuery)))(_.mkString)
         val encodeTwiceRes = Utils.tryWithResource(Source.fromURL(
-          apiUrl(sc.ui.get, "stages/0/0/taskTable?"+ encodeTwiceQuery)))(_.mkString)
+          apiUrl(sc.ui.get, "stages/0/0/taskTable?" + encodeTwiceQuery)))(_.mkString)
         assert(encodeOnceRes.equals(encodeTwiceRes))
       }
     }

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -712,8 +712,6 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers {
       rdd.count()
 
       eventually(timeout(5.seconds), interval(100.milliseconds)) {
-        val str: String = Utils.tryWithResource(Source.fromURL(
-          apiUrl(sc.ui.get, "/stages/stage/0/0/taskTable?draw=1")))(_.mkString)
         val stage0 = Utils.tryWithResource(Source.fromURL(sc.ui.get.webUrl +
           "/stages/stage/?id=0&attempt=0&expandDagViz=true"))(_.mkString)
         assert(stage0.contains("digraph G {\n  subgraph clusterstage_0 {\n    " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
Stages UI page fails to load for proxy in some specific yarn environment.

### Why are the changes needed?
My environment CDH 5.8 , click to enter the spark UI from the yarn Resource Manager page
when visit the stage URI, it fails to load,  URI is
http://<yarn-url>:8088/proxy/application_1669877165233_0021/stages/stage/?id=0&attempt=0 

The issue is similar to, the final phenomenon of the issue is the same, because the parameter encode twice
[SPARK-32467](https://issues.apache.org/jira/browse/SPARK-32467)
[SPARK-33611](https://issues.apache.org/jira/browse/SPARK-33611)

The two issues solve two scenarios to avoid encode twice:
1. https redirect proxy
2. set reverse proxy enabled (spark.ui.reverseProxy)  in Nginx 

But if encode twice due to other reasons, such as this issue (yarn proxy), it will also fail when visit stage page.
It is better to decode parameter twice here. 
Just like fix here [SPARK-12708](https://issues.apache.org/jira/browse/SPARK-12708) [codes](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/ui/UIUtils.scala#L626)

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
new added UT