### PR TITLE
[SPARK-41368][SQL] Reorder the window partition expressions by expression stats

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4027,6 +4027,13 @@ object SQLConf {
     .checkValues(ErrorMessageFormat.values.map(_.toString))
     .createWithDefault(ErrorMessageFormat.PRETTY.toString)
 
+  val REORDER_WINDOW_PARTITION_EXPRESSIONS =
+    buildConf("spark.sql.reorderWindowPartitionExpressions")
+    .doc("Reorder the window partition expressions by expression stats")
+    .version("3.4.0")
+    .booleanConf
+    .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -4837,6 +4844,9 @@ class SQLConf extends Serializable with Logging {
 
   def allowsTempViewCreationWithMultipleNameparts: Boolean =
     getConf(SQLConf.ALLOW_TEMP_VIEW_CREATION_WITH_MULTIPLE_NAME_PARTS)
+
+  def reorderWindowPartitionExpressions: Boolean =
+    getConf(SQLConf.REORDER_WINDOW_PARTITION_EXPRESSIONS)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReorderWindowPartitionExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReorderWindowPartitionExpressionsSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import scala.util.Random
+
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.plans.logical.Window
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ReorderWindowPartitionExpressionsSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
+  test("reorder window group expressions by stats") {
+    withTable("t") {
+      withSQLConf(
+        SQLConf.CBO_ENABLED.key -> "true",
+        SQLConf.REORDER_WINDOW_PARTITION_EXPRESSIONS.key -> "true") {
+        val rand = new Random()
+        spark.range(1, 100000, 1, 10)
+          .map(i => (i, i % 100, s"name-${rand.nextInt(100000)}"))
+          .toDF("a", "b", "c")
+          .write.format("parquet").saveAsTable("t")
+        spark.sql(s"ANALYZE TABLE t COMPUTE STATISTICS FOR COLUMNS a, b")
+        val df = sql("SELECT *, row_number() over(partition by b, a order by c desc) as rn FROM t")
+        checkAnswer(
+          df,
+          sql("SELECT *, row_number() over(partition by a, b order by c) as rn FROM t"))
+
+        assert(df.queryExecution.optimizedPlan.collect {
+          case Window(_, partitionSpec, _, _) =>
+            partitionSpec.map(_.asInstanceOf[NamedExpression].name)
+        }.head === Seq("a", "b"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

We can reorder window partition expressions by the distinct values stats.
Sorting with high cardinality will be faster.

Benchmark
```
object WindowBenchmark extends SqlBasedBenchmark {
  import spark.implicits._
  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
    val rand = new Random()
    spark.range(1, 10000000, 1, 10)
      .map(i => (i, i % 100, s"name-${rand.nextInt(100000)}")).toDF("a", "b", "c")
      .repartition(10, 'c)
      .write.format("parquet").saveAsTable("t")

    spark.sql(s"ANALYZE TABLE t COMPUTE STATISTICS FOR COLUMNS a, b")
    runBenchmark("Window benchmark") {
      val benchmark = new Benchmark("Window", 10000, 3, output = output)
      val query = "SELECT *, row_number() over(partition by b, a order by c) as rn FROM t"
      benchmark.addCase("Without reorder window partition expressions") { _ =>
        spark.sql(query).noop()
      }
      benchmark.addCase("With reorder window partition expressions") { _ =>
        withSQLConf(
          SQLConf.CBO_ENABLED.key -> "true",
          SQLConf.REORDER_WINDOW_PARTITION_EXPRESSIONS.key -> "true") {
          spark.sql(query).noop()
        }
      }
      benchmark.run()
    }
  }
}
```

Benchmark result:
```
Window:                                       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------
Disable reorder window partition expressions          13338          14035        1138          0.0     1333756.2       1.0X
Enable reorder window partition expressions              5981           6030          77          0.0      598102.1       2.2X
```

### Why are the changes needed?

Improve Window operation


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added UT
