### PR TITLE
[MINOR][SQL] Get rid of redundant type cast

### DIFF
--- a/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/DelegateSymlinkTextInputFormat.java
+++ b/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/DelegateSymlinkTextInputFormat.java
@@ -47,7 +47,7 @@ public class DelegateSymlinkTextInputFormat extends SymlinkTextInputFormat {
 
     // Used for deserialisation.
     public DelegateSymlinkTextInputSplit() {
-      super((Path) null, 0, 0, (String[]) null);
+      super(null, 0, 0, (String[]) null);
       targetPath = null;
     }
 
@@ -97,7 +97,7 @@ public class DelegateSymlinkTextInputFormat extends SymlinkTextInputFormat {
   public RecordReader<LongWritable, Text> getRecordReader(
       InputSplit split, JobConf job, Reporter reporter) throws IOException {
     DelegateSymlinkTextInputSplit delegateSplit = (DelegateSymlinkTextInputSplit) split;
-    InputSplit targetSplit = ((SymlinkTextInputSplit) delegateSplit.getSplit()).getTargetSplit();
+    InputSplit targetSplit = delegateSplit.getSplit().getTargetSplit();
 
     // SPARK-40815: the code is derived from
     // https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/io/SymlinkTextInputFormat.java

--- a/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/orc/SparkOrcNewRecordReader.java
+++ b/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/orc/SparkOrcNewRecordReader.java
@@ -37,7 +37,7 @@ public class SparkOrcNewRecordReader extends
   private final int numColumns;
   OrcStruct value;
   private float progress = 0.0f;
-  private ObjectInspector objectInspector;
+  private final ObjectInspector objectInspector;
 
   public SparkOrcNewRecordReader(Reader file, Configuration conf,
       long offset, long length) throws IOException {
@@ -56,19 +56,17 @@ public class SparkOrcNewRecordReader extends
   }
 
   @Override
-  public NullWritable getCurrentKey() throws IOException,
-      InterruptedException {
+  public NullWritable getCurrentKey() {
     return NullWritable.get();
   }
 
   @Override
-  public OrcStruct getCurrentValue() throws IOException,
-      InterruptedException {
+  public OrcStruct getCurrentValue() {
     return value;
   }
 
   @Override
-  public float getProgress() throws IOException, InterruptedException {
+  public float getProgress() {
     return progress;
   }
 
@@ -78,7 +76,7 @@ public class SparkOrcNewRecordReader extends
   }
 
   @Override
-  public boolean nextKeyValue() throws IOException, InterruptedException {
+  public boolean nextKeyValue() throws IOException {
     if (reader.hasNext()) {
       reader.next(value);
       progress = reader.getProgress();

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -174,23 +174,23 @@ object HiveUDFExpressionBuilder extends SparkUDFExpressionBuilder {
       // expressions don't satisfy the hive UDF, such as type mismatch, input number
       // mismatch, etc. Here we catch the exception and throw AnalysisException instead.
       if (classOf[UDF].isAssignableFrom(clazz)) {
-        udfExpr = Some(HiveSimpleUDF(name, new HiveFunctionWrapper(clazz.getName), input))
+        udfExpr = Some(HiveSimpleUDF(name, HiveFunctionWrapper(clazz.getName), input))
         udfExpr.get.dataType // Force it to check input data types.
       } else if (classOf[GenericUDF].isAssignableFrom(clazz)) {
-        udfExpr = Some(HiveGenericUDF(name, new HiveFunctionWrapper(clazz.getName), input))
+        udfExpr = Some(HiveGenericUDF(name, HiveFunctionWrapper(clazz.getName), input))
         udfExpr.get.dataType // Force it to check input data types.
       } else if (classOf[AbstractGenericUDAFResolver].isAssignableFrom(clazz)) {
-        udfExpr = Some(HiveUDAFFunction(name, new HiveFunctionWrapper(clazz.getName), input))
+        udfExpr = Some(HiveUDAFFunction(name, HiveFunctionWrapper(clazz.getName), input))
         udfExpr.get.dataType // Force it to check input data types.
       } else if (classOf[UDAF].isAssignableFrom(clazz)) {
         udfExpr = Some(HiveUDAFFunction(
           name,
-          new HiveFunctionWrapper(clazz.getName),
+          HiveFunctionWrapper(clazz.getName),
           input,
           isUDAFBridgeRequired = true))
         udfExpr.get.dataType // Force it to check input data types.
       } else if (classOf[GenericUDTF].isAssignableFrom(clazz)) {
-        udfExpr = Some(HiveGenericUDTF(name, new HiveFunctionWrapper(clazz.getName), input))
+        udfExpr = Some(HiveGenericUDTF(name, HiveFunctionWrapper(clazz.getName), input))
         // Force it to check data types.
         udfExpr.get.asInstanceOf[HiveGenericUDTF].elementSchema
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.command.{CreateTableCommand, DDLUtils, InsertIntoDataSourceDirCommand}
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSourceStrategy}
 import org.apache.spark.sql.hive.execution._
-import org.apache.spark.sql.hive.execution.HiveScriptTransformationExec
 import org.apache.spark.sql.internal.HiveSerDe
 
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -181,7 +181,7 @@ class HadoopTableReader(
             // convert  /demo/data/year/month/day  to  /demo/data/*/*/*/
             def getPathPatternByPath(parNum: Int, tempPath: Path): String = {
               var path = tempPath
-              for (i <- (1 to parNum)) path = path.getParent
+              for (_ <- 1 to parNum) path = path.getParent
               val tails = (1 to parNum).map(_ => "*").mkString("/", "/", "/")
               path.toString + tails
             }
@@ -278,10 +278,10 @@ class HadoopTableReader(
     }.toSeq
 
     // Even if we don't use any partitions, we still need an empty RDD
-    if (hivePartitionRDDs.size == 0) {
+    if (hivePartitionRDDs.isEmpty) {
       new EmptyRDD[InternalRow](sparkSession.sparkContext)
     } else {
-      new UnionRDD(hivePartitionRDDs(0).context, hivePartitionRDDs)
+      new UnionRDD(hivePartitionRDDs.head.context, hivePartitionRDDs)
     }
   }
 
@@ -452,7 +452,7 @@ private[hive] object HadoopTableReader extends HiveInspectors with Logging {
   def initializeLocalJobConfFunc(path: String, tableDesc: TableDesc)(jobConf: JobConf): Unit = {
     FileInputFormat.setInputPaths(jobConf, Seq[Path](new Path(path)): _*)
     if (tableDesc != null) {
-      HiveTableUtil.configureJobPropertiesForStorageHandler(tableDesc, jobConf, true)
+      HiveTableUtil.configureJobPropertiesForStorageHandler(tableDesc, jobConf, input = true)
       Utilities.copyTableJobPropertiesToConf(tableDesc, jobConf)
     }
     val bufferSize = System.getProperty("spark.buffer.size", "65536")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -754,7 +754,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
     val addPartitionDesc = new AddPartitionDesc(db, table, ignoreIfExists)
     parts.zipWithIndex.foreach { case (s, i) =>
       addPartitionDesc.addPartition(
-        s.spec.asJava, s.storage.locationUri.map(CatalogUtils.URIToString(_)).orNull)
+        s.spec.asJava, s.storage.locationUri.map(CatalogUtils.URIToString).orNull)
       if (s.parameters.nonEmpty) {
         addPartitionDesc.getPartition(i).setPartParams(s.parameters.asJava)
       }
@@ -1199,13 +1199,11 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
   override def getDriverResults(driver: Driver): Seq[String] = {
     val res = new JArrayList[Object]()
     getDriverResultsMethod.invoke(driver, res)
-    res.asScala.map { r =>
-      r match {
-        case s: String => s
-        case a: Array[Object] => a(0).asInstanceOf[String]
-      }
-    }.toSeq
-  }
+    res.asScala.map {
+      case s: String => s
+      case a: Array[Object] => a(0).asInstanceOf[String]
+    }
+  }.toSeq
 
   override def getDatabaseOwnerName(db: Database): String = {
     Option(getDatabaseOwnerNameMethod.invoke(db)).map(_.asInstanceOf[String]).getOrElse("")

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -190,7 +190,7 @@ case class OptimizedCreateHiveTableAsSelectCommand(
     InsertIntoHadoopFsRelationCommand(
       hadoopRelation.location.rootPaths.head,
       Map.empty, // We don't support to convert partitioned table.
-      false,
+      ifPartitionNotExists = false,
       Seq.empty, // We don't support to convert partitioned table.
       hadoopRelation.bucketSpec,
       hadoopRelation.fileFormat,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveFileFormat.scala
@@ -85,7 +85,7 @@ class HiveFileFormat(fileSinkConf: FileSinkDesc)
 
     // Add table properties from storage handler to hadoopConf, so any custom storage
     // handler settings can be set to hadoopConf
-    HiveTableUtil.configureJobPropertiesForStorageHandler(tableDesc, conf, false)
+    HiveTableUtil.configureJobPropertiesForStorageHandler(tableDesc, conf, input = false)
     Utilities.copyTableJobPropertiesToConf(tableDesc, conf)
 
     // Avoid referencing the outer object.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -429,7 +429,7 @@ private[hive] case class HiveUDAFFunction(
   override def update(buffer: HiveUDAFBuffer, input: InternalRow): HiveUDAFBuffer = {
     // The input is original data, we create buffer with the partial1 evaluator.
     val nonNullBuffer = if (buffer == null) {
-      HiveUDAFBuffer(partial1HiveEvaluator.evaluator.getNewAggregationBuffer, false)
+      HiveUDAFBuffer(partial1HiveEvaluator.evaluator.getNewAggregationBuffer, canDoMerge = false)
     } else {
       buffer
     }
@@ -444,7 +444,7 @@ private[hive] case class HiveUDAFFunction(
   override def merge(buffer: HiveUDAFBuffer, input: HiveUDAFBuffer): HiveUDAFBuffer = {
     // The input is aggregate buffer, we create buffer with the final evaluator.
     val nonNullBuffer = if (buffer == null) {
-      HiveUDAFBuffer(finalHiveEvaluator.evaluator.getNewAggregationBuffer, true)
+      HiveUDAFBuffer(finalHiveEvaluator.evaluator.getNewAggregationBuffer, canDoMerge = true)
     } else {
       buffer
     }
@@ -457,7 +457,7 @@ private[hive] case class HiveUDAFFunction(
       val newBuf = finalHiveEvaluator.evaluator.getNewAggregationBuffer
       finalHiveEvaluator.evaluator.merge(
         newBuf, partial1HiveEvaluator.evaluator.terminatePartial(nonNullBuffer.buf))
-      HiveUDAFBuffer(newBuf, true)
+      HiveUDAFBuffer(newBuf, canDoMerge = true)
     } else {
       nonNullBuffer
     }
@@ -490,7 +490,7 @@ private[hive] case class HiveUDAFFunction(
   override def deserialize(bytes: Array[Byte]): HiveUDAFBuffer = {
     // Deserializes an `AggregationBuffer` from the shuffled partial aggregation phase to prepare
     // for global aggregation by merging multiple partial aggregation results within a single group.
-    HiveUDAFBuffer(aggBufferSerDe.deserialize(bytes), false)
+    HiveUDAFBuffer(aggBufferSerDe.deserialize(bytes), canDoMerge = false)
   }
 
   // Helper class used to de/serialize Hive UDAF `AggregationBuffer` objects


### PR DESCRIPTION
### What changes were proposed in this pull request?
A minor change to fix the compilation warning

`/spark/sql/hive/src/main/java/org/apache/hadoop/hive/ql/io/DelegateSymlinkTextInputFormat.java:100:30:  [cast] redundant cast to SymlinkTextInputSplit`

+ Minor Scala related refactoring in org.apache.spark.sql.hive package 

### Why are the changes needed?
 - To get rid of compilation warning and redundant type cast. 
 - Improve the code by minor Scala related refactoring in org.apache.spark.sql.hive package 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By existing unit tests
