### PR TITLE
[SPARK-41385][K8S] Replace deprecated `.newInstance()` in K8s module

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -40,7 +40,7 @@ private[spark] class KubernetesDriverBuilder {
 
     val userFeatures = conf.get(Config.KUBERNETES_DRIVER_POD_FEATURE_STEPS)
       .map { className =>
-        val feature = Utils.classForName[Any](className).newInstance()
+        val feature = Utils.classForName[Any](className).getConstructor().newInstance()
         val initializedFeature = feature match {
           // Since 3.3, allow user to implement feature with KubernetesDriverConf
           case d: KubernetesDriverCustomFeatureConfigStep =>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -43,7 +43,7 @@ private[spark] class KubernetesExecutorBuilder {
 
     val userFeatures = conf.get(Config.KUBERNETES_EXECUTOR_POD_FEATURE_STEPS)
       .map { className =>
-        val feature = Utils.classForName[Any](className).newInstance()
+        val feature = Utils.classForName[Any](className).getConstructor().newInstance()
         val initializedFeature = feature match {
           // Since 3.3, allow user to implement feature with KubernetesExecutorConf
           case e: KubernetesExecutorCustomFeatureConfigStep =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to replace the deprecated `Class.newInstance` with `Class.getConstructor.newInstance`.

### Why are the changes needed?

SPARK-25984 removed these instances at Spark 3.0.0.

SPARK-37145 introduced newly two instances at Spark 3.3.0.
```
$ git grep classForName | grep newInstance | grep -v getConstructor
resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala:        val feature = Utils.classForName[Any](className).newInstance()
resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala:        val feature = Utils.classForName[Any](className).newInstance()
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.