### PR TITLE
[SPARK-41390][SQL] Update the script used to generate `register` function in `UDFRegistration`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/UDFRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/UDFRegistration.scala
@@ -145,8 +145,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
         |  def builder(e: Seq[Expression]) = if (e.length == $x) {
         |    finalUdf.createScalaUDF(e)
         |  } else {
-        |    throw new AnalysisException("Invalid number of arguments for function " + name +
-        |      ". Expected: $x; Found: " + e.length)
+        |    throw QueryCompilationErrors.invalidFunctionArgumentsError(name, "$x", e.length)
         |  }
         |  functionRegistry.createOrReplaceTempFunction(name, builder, "scala_udf")
         |  finalUdf
@@ -171,8 +170,7 @@ class UDFRegistration private[sql] (functionRegistry: FunctionRegistry) extends 
         |  def builder(e: Seq[Expression]) = if (e.length == $i) {
         |    ScalaUDF(func, replaced, e, Nil, udfName = Some(name))
         |  } else {
-        |    throw new AnalysisException("Invalid number of arguments for function " + name +
-        |      ". Expected: $i; Found: " + e.length)
+        |    throw QueryCompilationErrors.invalidFunctionArgumentsError(name, "$i", e.length)
         |  }
         |  functionRegistry.createOrReplaceTempFunction(name, builder, "java_udf")
         |}""".stripMargin)


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-35065 use `QueryCompilationErrors.invalidFunctionArgumentsError` instead of  `throw new AnalysisException(...)` for `register` function in `UDFRegistration`,  but the script used to generate `register` function has not been updated, so this pr update the script.


### Why are the changes needed?
Update the script used to generate `register` function in `UDFRegistration`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually checked the results of the script.
