### PR TITLE
[SPARK-41391][SQL] The output column name of `groupBy.agg(count_distinct)` is incorrect

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -443,10 +443,11 @@ object functions {
    * @since 3.2.0
    */
   @scala.annotation.varargs
-  def count_distinct(expr: Column, exprs: Column*): Column =
+  def count_distinct(expr: Column, exprs: Column*): Column = {
     // For usage like countDistinct("*"), we should let analyzer expand star and
     // resolve function.
-    Column(UnresolvedFunction("count", (expr +: exprs).map(_.expr), isDistinct = true))
+    withAggregateFunction(Count((expr +: exprs).map(_.expr)), isDistinct = true)
+  }
 
   /**
    * Aggregate function: returns the population covariance for two columns.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1135,8 +1135,12 @@ class DataFrameSuite extends QueryTest
   }
 
   test("SPARK-41391: Correct the output column name of groupBy.agg(count_distinct)") {
-    val df = person.groupBy("id").agg(count_distinct(col("name")))
-    assert(df.columns === Array("id", "count(DISTINCT name)"))
+    withTempView("person") {
+      person.createOrReplaceTempView("person")
+      val df1 = person.groupBy("id").agg(count_distinct(col("name")))
+      val df2 = spark.sql("SELECT id, COUNT(DISTINCT name) FROM person GROUP BY id")
+      assert(df1.columns === df2.columns)
+    }
   }
 
   test("summary advanced") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1134,6 +1134,11 @@ class DataFrameSuite extends QueryTest
     checkAnswer(approxSummaryDF, approxSummaryResult)
   }
 
+  test("SPARK-41391: Correct the output column name of groupBy.agg(count_distinct)") {
+    val df = person.groupBy("id").agg(count_distinct(col("name")))
+    assert(df.columns === Array("id", "count(DISTINCT name)"))
+  }
+
   test("summary advanced") {
     val stats = Array("count", "50.01%", "max", "mean", "min", "25%")
     val orderMatters = person2.summary(stats: _*)


### PR DESCRIPTION
### What changes were proposed in this pull request?
correct the output column name of `groupBy.agg(count_distinct)`


### Why are the changes needed?

before this PR: `[id: bigint, count(value): bigint]`

```
scala> val df = spark.range(1, 10).withColumn("value", lit(1))
df: org.apache.spark.sql.DataFrame = [id: bigint, value: int]

scala> df.select(count_distinct($"value"))
res0: org.apache.spark.sql.DataFrame = [count(DISTINCT value): bigint]

scala> df.groupBy("id").agg(count_distinct($"value"))
res1: org.apache.spark.sql.DataFrame = [id: bigint, count(value): bigint]

scala> df.select(sum_distinct($"value"))
res2: org.apache.spark.sql.DataFrame = [sum(DISTINCT value): bigint]

scala> df.groupBy("id").agg(sum_distinct($"value"))
res3: org.apache.spark.sql.DataFrame = [id: bigint, sum(DISTINCT value): bigint]

scala> df.createOrReplaceTempView("table")

scala> spark.sql(" SELECT id, COUNT(DISTINCT value) FROM table GROUP BY id ")
res5: org.apache.spark.sql.DataFrame = [id: bigint, count(DISTINCT value): bigint]
```

after this PR: `[id: bigint, count(DISTINCT value): bigint]`
```
scala> val df = spark.range(1, 10).withColumn("value", lit(1))
df: org.apache.spark.sql.DataFrame = [id: bigint, value: int]

scala> df.select(count_distinct($"value"))
res0: org.apache.spark.sql.DataFrame = [count(DISTINCT value): bigint]

scala> df.groupBy("id").agg(count_distinct($"value"))
res1: org.apache.spark.sql.DataFrame = [id: bigint, count(DISTINCT value): bigint]
```


### Does this PR introduce _any_ user-facing change?
the default column name changed


### How was this patch tested?
added UT