### PR TITLE
[SPARK-41395][SQL] `InterpretedMutableProjection` should use `setDecimal` to set null values for decimals in an unsafe row

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedMutableProjection.scala
@@ -58,6 +58,7 @@ class InterpretedMutableProjection(expressions: Seq[Expression]) extends Mutable
     case _ => true
   }
   private[this] var mutableRow: InternalRow = new GenericInternalRow(expressions.size)
+  private[this] var unsafeMutableRow = false
   def currentValue: InternalRow = mutableRow
 
   override def target(row: InternalRow): MutableProjection = {
@@ -68,32 +69,36 @@ class InterpretedMutableProjection(expressions: Seq[Expression]) extends Mutable
         validExprs.map(_._1.dataType).filterNot(UnsafeRow.isMutable)
           .map(_.catalogString).mkString(", "))
     mutableRow = row
+    unsafeMutableRow = if (mutableRow.isInstanceOf[UnsafeRow]) true else false;
     this
   }
 
   private[this] val fieldWriters: Array[Any => Unit] = validExprs.map { case (e, i) =>
     val writer = InternalRow.getWriter(i, e.dataType)
-    val nullSafeWriter: (InternalRow, Any) => Unit = e.dataType match {
-      case DecimalType.Fixed(precision, _) if precision > Decimal.MAX_LONG_DIGITS =>
-        (row, v: Any) => {
-          if (v == null && !row.isInstanceOf[UnsafeRow]) {
-            row.setNullAt(i)
-          } else {
-            writer(row, v)
-          }
-        }
-      case _ =>
-        (row, v: Any) => {
-          if (v == null) {
-            row.setNullAt(i)
-          } else {
-            writer(row, v)
-          }
-        }
-    }
     if (!e.nullable) {
       (v: Any) => writer(mutableRow, v)
     } else {
+      val nullSafeWriter: (InternalRow, Any) => Unit = e.dataType match {
+        case DecimalType.Fixed(precision, _) if precision > Decimal.MAX_LONG_DIGITS =>
+          (row, v: Any) => {
+            // The check of unsafeMutableRow has to happen at run time, rather than at
+            // field writer creation time, because `InterpretedMutableProjection#target`
+            // can be called after the field writers are created.
+            if (v == null && !unsafeMutableRow) {
+              row.setNullAt(i)
+            } else {
+              writer(row, v)
+            }
+          }
+        case _ =>
+          (row, v: Any) => {
+            if (v == null) {
+              row.setNullAt(i)
+            } else {
+              writer(row, v)
+            }
+          }
+      }
       (v: Any) => nullSafeWriter(mutableRow, v)
     }
   }.toArray

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MutableProjectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MutableProjectionSuite.scala
@@ -75,8 +75,8 @@ class MutableProjectionSuite extends SparkFunSuite with ExpressionEvalHelper {
       .apply(new GenericInternalRow(bufferSchema.length))
 
     val scalaRows = Seq(
-      Seq(BigDecimal(5), null),
-      Seq(BigDecimal(10), BigDecimal(11)))
+      Seq(null, null),
+      Seq(BigDecimal(77.77), BigDecimal(245.00)))
 
     scalaRows.foreach { scalaRow =>
       val inputRow = InternalRow.fromSeq(scalaRow.zip(bufferTypes).map {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MutableProjectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MutableProjectionSuite.scala
@@ -65,48 +65,66 @@ class MutableProjectionSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(SafeProjection.create(fixedLengthTypes)(projUnsafeRow) === inputRow)
   }
 
-  testBothCodegenAndInterpreted("SPARK-41395: unsafe buffer with null decimal (high precision)") {
-    val bufferSchema = StructType(Array(
-      StructField("dec1", DecimalType(27, 2), nullable = true),
-      StructField("dec2", DecimalType(27, 2), nullable = true)))
-    val bufferTypes = Array[DataType](DecimalType(27, 2), DecimalType(27, 2))
+  def testRows(
+      bufferSchema: StructType,
+      buffer: InternalRow,
+      scalaRows: Seq[Seq[Any]]): Unit = {
+    val bufferTypes = bufferSchema.map(_.dataType).toArray
     val proj = createMutableProjection(bufferTypes)
-    val unsafeBuffer = UnsafeProjection.create(bufferSchema)
-      .apply(new GenericInternalRow(bufferSchema.length))
-
-    val scalaRows = Seq(
-      Seq(null, null),
-      Seq(BigDecimal(77.77), BigDecimal(245.00)))
 
     scalaRows.foreach { scalaRow =>
       val inputRow = InternalRow.fromSeq(scalaRow.zip(bufferTypes).map {
         case (v, dataType) => CatalystTypeConverters.createToCatalystConverter(dataType)(v)
       })
-      val projRow = proj.target(unsafeBuffer)(inputRow)
+      val projRow = proj.target(buffer)(inputRow)
       assert(SafeProjection.create(bufferTypes)(projRow) === inputRow)
     }
+  }
+
+  testBothCodegenAndInterpreted("SPARK-41395: unsafe buffer with null decimal (high precision)") {
+    val bufferSchema = StructType(Array(
+      StructField("dec1", DecimalType(27, 2), nullable = true),
+      StructField("dec2", DecimalType(27, 2), nullable = true)))
+    val buffer = UnsafeProjection.create(bufferSchema)
+      .apply(new GenericInternalRow(bufferSchema.length))
+    val scalaRows = Seq(
+      Seq(null, null),
+      Seq(BigDecimal(77.77), BigDecimal(245.00)))
+    testRows(bufferSchema, buffer, scalaRows)
   }
 
   testBothCodegenAndInterpreted("SPARK-41395: unsafe buffer with null decimal (low precision)") {
     val bufferSchema = StructType(Array(
       StructField("dec1", DecimalType(10, 2), nullable = true),
       StructField("dec2", DecimalType(10, 2), nullable = true)))
-    val bufferTypes = Array[DataType](DecimalType(10, 2), DecimalType(10, 2))
-    val proj = createMutableProjection(bufferTypes)
-    val unsafeBuffer = UnsafeProjection.create(bufferSchema)
+    val buffer = UnsafeProjection.create(bufferSchema)
       .apply(new GenericInternalRow(bufferSchema.length))
-
     val scalaRows = Seq(
       Seq(null, null),
       Seq(BigDecimal(77.77), BigDecimal(245.00)))
+    testRows(bufferSchema, buffer, scalaRows)
+  }
 
-    scalaRows.foreach { scalaRow =>
-      val inputRow = InternalRow.fromSeq(scalaRow.zip(bufferTypes).map {
-        case (v, dataType) => CatalystTypeConverters.createToCatalystConverter(dataType)(v)
-      })
-      val projRow = proj.target(unsafeBuffer)(inputRow)
-      assert(SafeProjection.create(bufferTypes)(projRow) === inputRow)
-    }
+  testBothCodegenAndInterpreted("SPARK-41395: generic buffer with null decimal (high precision)") {
+    val bufferSchema = StructType(Array(
+      StructField("dec1", DecimalType(27, 2), nullable = true),
+      StructField("dec2", DecimalType(27, 2), nullable = true)))
+    val buffer = new GenericInternalRow(bufferSchema.length)
+    val scalaRows = Seq(
+      Seq(null, null),
+      Seq(BigDecimal(77.77), BigDecimal(245.00)))
+    testRows(bufferSchema, buffer, scalaRows)
+  }
+
+  testBothCodegenAndInterpreted("SPARK-41395: generic buffer with null decimal (low precision)") {
+    val bufferSchema = StructType(Array(
+      StructField("dec1", DecimalType(10, 2), nullable = true),
+      StructField("dec2", DecimalType(10, 2), nullable = true)))
+    val buffer = new GenericInternalRow(bufferSchema.length)
+    val scalaRows = Seq(
+      Seq(null, null),
+      Seq(BigDecimal(77.77), BigDecimal(245.00)))
+    testRows(bufferSchema, buffer, scalaRows)
   }
 
   testBothCodegenAndInterpreted("variable-length types") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `InterpretedMutableProjection` to use `setDecimal` rather than `setNullAt` to set null values for decimals in unsafe rows.

### Why are the changes needed?

The following returns the wrong answer:

```
set spark.sql.codegen.wholeStage=false;
set spark.sql.codegen.factoryMode=NO_CODEGEN;

select max(col1), max(col2) from values
(cast(null  as decimal(27,2)), cast(null   as decimal(27,2))),
(cast(77.77 as decimal(27,2)), cast(245.00 as decimal(27,2)))
as data(col1, col2);

+---------+---------+
|max(col1)|max(col2)|
+---------+---------+
|null     |239.88   |
+---------+---------+
```
This is because `InterpretedMutableProjection` inappropriately uses `InternalRow#setNullAt` on unsafe rows to set null for decimal types with precision > `Decimal.MAX_LONG_DIGITS`.

When `setNullAt` is used, the pointer to the decimal's storage area in the variable length region gets zeroed out. Later, when `InterpretedMutableProjection` calls `setDecimal` on that field, `UnsafeRow#setDecimal` picks up the zero pointer and stores decimal data on top of the null-tracking bit set. Later updates to the null-tracking bit set (e.g., calls to `setNotNullAt`) further corrupt the decimal data (turning 245.00 into 239.88, for example). The stomping of the null-tracking bit set also can make non-null fields appear null (turning 77.77 into null, for example).

This bug can manifest for end-users after codegen fallback (say, if an expression's generated code fails to compile).

[Codegen for mutable projection](https://github.com/apache/spark/blob/89b2ee27d258dec8fe265fa862846e800a374d8e/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala#L1729) uses `mutableRow.setDecimal` for null decimal values regardless of precision or the type for `mutableRow`, so this PR does the same.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit tests.
