### PR TITLE
[SPARK-41247][BUILD][FOLLOWUP] Make sbt and maven use the same Protobuf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
     <!-- Protobuf version for building with Hadoop/Yarn dependencies -->
     <protobuf.hadoopDependency.version>2.5.0</protobuf.hadoopDependency.version>
     <!-- Actual Protobuf version in Spark modules like Spark Connect, protobuf connector, etc. -->
+    <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
     <protobuf.version>3.21.9</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.6.3</zookeeper.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -86,6 +86,7 @@ object BuildCommons {
   val javaVersion = settingKey[String]("source and target JVM version for javac and scalac")
 
   // Google Protobuf version used for generating the protobuf.
+  // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
   val protoVersion = "3.21.9"
   // GRPC version used for Spark Connect.
   val gprcVersion = "1.47.0"

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -86,7 +86,7 @@ object BuildCommons {
   val javaVersion = settingKey[String]("source and target JVM version for javac and scalac")
 
   // Google Protobuf version used for generating the protobuf.
-  val protoVersion = "3.21.1"
+  val protoVersion = "3.21.9"
   // GRPC version used for Spark Connect.
   val gprcVersion = "1.47.0"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/38783 unify the Protobuf versions in Spark connect and Protobuf connector to `3.21.9` for maven, but sbt build and test still use `3.21.1`, so this pr make sbt also use Protobuf 3.21.9 to build and test.




### Why are the changes needed?
Make sbt and maven use the same Protobuf version for build and test


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions