### PR TITLE
[SPARK-41346][CONNECT][TESTS][FOLLOWUP] Fix `test_connect_function` to import `PandasOnSparkTestCase` properly

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -24,9 +24,11 @@ from pyspark.sql import SparkSession
 
 if have_pandas:
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
+    from pyspark.testing.pandasutils import PandasOnSparkTestCase
+else:
+    from pyspark.testing.sqlutils import ReusedSQLTestCase as PandasOnSparkTestCase
 from pyspark.sql.dataframe import DataFrame
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.utils import ReusedPySparkTestCase
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `test_connect_function` to import `PandasOnSparkTestCase` properly. If we handle `import` properly, the test cases are ignored properly because `should_test_connect` assumes `have_pandas`

https://github.com/apache/spark/blob/97976a5cc915597fd2606602d18c52c075a03bf6/python/pyspark/testing/connectutils.py#L49

### Why are the changes needed?

SPARK-41346 imported `PandasOnSparkTestCase` outside of  `if have_pandas:`.

https://github.com/apache/spark/blob/97976a5cc915597fd2606602d18c52c075a03bf6/python/pyspark/sql/tests/connect/test_connect_function.py#L25-L29

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

**BEFORE**
```
$ python/run-tests --testnames pyspark.sql.tests.connect.test_connect_function
...
ModuleNotFoundError: No module named 'pandas'
```

**AFTER**
```
$ python/run-tests --testnames pyspark.sql.tests.connect.test_connect_function
...
Skipped tests in pyspark.sql.tests.connect.test_connect_function with python3.9:
      test_aggregation_functions (pyspark.sql.tests.connect.test_connect_function.SparkConnectFunctionTests) ... skip (0.004s)
      test_math_functions (pyspark.sql.tests.connect.test_connect_function.SparkConnectFunctionTests) ... skip (0.004s)
      test_normal_functions (pyspark.sql.tests.connect.test_connect_function.SparkConnectFunctionTests) ... skip (0.002s)
      test_sort_with_nulls_order (pyspark.sql.tests.connect.test_connect_function.SparkConnectFunctionTests) ... skip (0.001s)
      test_sorting_functions_with_column (pyspark.sql.tests.connect.test_connect_function.SparkConnectFunctionTests) ... skip (0.001s)
```