### PR TITLE
[SPARK-41001][CONNECT][TESTS][FOLLOWUP] `ChannelBuilderTests` should be skipped by `should_test_connect` flag

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -32,13 +32,16 @@ from pyspark.sql.types import StructType, StructField, LongType, StringType
 if have_pandas:
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
     from pyspark.sql.connect.client import ChannelBuilder
+    from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
     from pyspark.sql.connect.function_builder import udf
     from pyspark.sql.connect.functions import lit, col
+    from pyspark.testing.pandasutils import PandasOnSparkTestCase
+else:
+    from pyspark.testing.sqlutils import ReusedSQLTestCase as PandasOnSparkTestCase
 from pyspark.sql.dataframe import DataFrame
 import pyspark.sql.functions
-from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.sqlutils import have_pandas, pandas_requirement_message
 from pyspark.testing.utils import ReusedPySparkTestCase
 
 
@@ -881,6 +884,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         )
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class ChannelBuilderTests(ReusedPySparkTestCase):
     def test_invalid_connection_strings(self):
         invalid = [

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -37,7 +37,7 @@ if have_pandas:
     from pyspark.sql.connect.functions import lit, col
     from pyspark.testing.pandasutils import PandasOnSparkTestCase
 else:
-    from pyspark.testing.sqlutils import ReusedSQLTestCase as PandasOnSparkTestCase
+    from pyspark.testing.sqlutils import ReusedSQLTestCase as PandasOnSparkTestCase  # type: ignore
 from pyspark.sql.dataframe import DataFrame
 import pyspark.sql.functions
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -41,7 +41,6 @@ else:
 from pyspark.sql.dataframe import DataFrame
 import pyspark.sql.functions
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
-from pyspark.testing.sqlutils import have_pandas, pandas_requirement_message
 from pyspark.testing.utils import ReusedPySparkTestCase
 
 

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -26,7 +26,7 @@ if have_pandas:
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
     from pyspark.testing.pandasutils import PandasOnSparkTestCase
 else:
-    from pyspark.testing.sqlutils import ReusedSQLTestCase as PandasOnSparkTestCase
+    from pyspark.testing.sqlutils import ReusedSQLTestCase as PandasOnSparkTestCase  # type: ignore
 from pyspark.sql.dataframe import DataFrame
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.utils import ReusedPySparkTestCase

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -97,6 +97,7 @@ class PlanOnlyTestFixture(unittest.TestCase):
         return DataFrame.withPlan(SQL(query), cls.connect)  # type: ignore
 
     if have_pandas:
+
         @classmethod
         def _with_plan(cls, plan: LogicalPlan) -> "DataFrame":
             return DataFrame.withPlan(plan, cls.connect)  # type: ignore


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `ChannelBuilderTests` when `should_test_connect` is false.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
