### PR TITLE
[SPARK-41408][BUILD] Upgrade scala-maven-plugin to 4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
       errors building different Hadoop versions.
       See: SPARK-36547, SPARK-38394.
        -->
-    <scala-maven-plugin.version>4.7.2</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.8.0</scala-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade scala-maven-plugin to 4.8.0


### Why are the changes needed?
This version upgrade zinc to 1.8.0 and inlcude some bug fix, the all change from 4.7.2 as follows:

- https://github.com/davidB/scala-maven-plugin/compare/4.7.2...4.8.0


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions