### PR TITLE
[SPARK-41406][SQL] Refactor error message for `NUM_COLUMNS_MISMATCH` to make it more generic

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -943,7 +943,7 @@
   },
   "NUM_COLUMNS_MISMATCH" : {
     "message" : [
-      "<operator> can only be performed on tables with the same number of columns, but the first table has <refNumColumns> columns and the <invalidOrdinalNum> table has <invalidNumColumns> columns."
+      "<operator> expects matching number of columns. But the left side (target) has <leftNumCols> while the right side (source) has <rightNumCols>."
     ]
   },
   "ORDER_BY_POS_OUT_OF_RANGE" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -943,7 +943,7 @@
   },
   "NUM_COLUMNS_MISMATCH" : {
     "message" : [
-      "<operator> expects matching number of columns. But the left side (target) has <leftNumCols> while the right side (source) has <rightNumCols>."
+      "<operator> can only be performed on inputs with the same number of columns, but the first input has <firstNumColumns> columns and the <invalidOrdinalNum> input has <invalidNumColumns> columns."
     ]
   },
   "ORDER_BY_POS_OUT_OF_RANGE" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -552,9 +552,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   errorClass = "NUM_COLUMNS_MISMATCH",
                   messageParameters = Map(
                     "operator" -> toSQLStmt(operator.nodeName),
-                    "refNumColumns" -> ref.length.toString,
-                    "invalidOrdinalNum" -> ordinalNumber(ti + 1),
-                    "invalidNumColumns" -> child.output.length.toString))
+                    "leftNumCols" -> ref.length.toString,
+                    "rightNumCols" -> child.output.length.toString))
               }
 
               val dataTypesAreCompatibleFn = getDataTypesAreCompatibleFn(operator)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -552,8 +552,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   errorClass = "NUM_COLUMNS_MISMATCH",
                   messageParameters = Map(
                     "operator" -> toSQLStmt(operator.nodeName),
-                    "leftNumCols" -> ref.length.toString,
-                    "rightNumCols" -> child.output.length.toString))
+                    "firstNumColumns" -> ref.length.toString,
+                    "invalidOrdinalNum" -> ordinalNumber(ti + 1),
+                    "invalidNumColumns" -> child.output.length.toString))
               }
 
               val dataTypesAreCompatibleFn = getDataTypesAreCompatibleFn(operator)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -564,7 +564,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   e.failAnalysis(
                     errorClass = "_LEGACY_ERROR_TEMP_2430",
                     messageParameters = Map(
-                      "operator" -> operator.nodeName,
+                      "operator" -> toSQLStmt(operator.nodeName),
                       "ci" -> ordinalNumber(ci),
                       "ti" -> ordinalNumber(ti + 1),
                       "dt1" -> dt1.catalogString,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -342,7 +342,7 @@ case class Intersect(
     right: LogicalPlan,
     isAll: Boolean) extends SetOperation(left, right) {
 
-  override def nodeName: String = getClass.getSimpleName + ( if ( isAll ) "All" else "" )
+  override def nodeName: String = getClass.getSimpleName + ( if ( isAll ) " All" else "" )
 
   final override val nodePatterns: Seq[TreePattern] = Seq(INTERSECT)
 
@@ -372,7 +372,7 @@ case class Except(
     left: LogicalPlan,
     right: LogicalPlan,
     isAll: Boolean) extends SetOperation(left, right) {
-  override def nodeName: String = getClass.getSimpleName + ( if ( isAll ) "All" else "" )
+  override def nodeName: String = getClass.getSimpleName + ( if ( isAll ) " All" else "" )
   /** We don't use right.output because those rows get excluded from the set. */
   override def output: Seq[Attribute] = left.output
 

--- a/sql/core/src/test/resources/sql-tests/results/except-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/except-all.sql.out
@@ -230,9 +230,10 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
-    "leftNumCols" : "1",
-    "operator" : "EXCEPT ALL",
-    "rightNumCols" : "2"
+    "firstNumColumns" : "1",
+    "invalidNumColumns" : "2",
+    "invalidOrdinalNum" : "second",
+    "operator" : "EXCEPT ALL"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/except-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/except-all.sql.out
@@ -230,10 +230,9 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
-    "invalidNumColumns" : "2",
-    "invalidOrdinalNum" : "second",
+    "leftNumCols" : "1",
     "operator" : "EXCEPTALL",
-    "refNumColumns" : "1"
+    "rightNumCols" : "2"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/except-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/except-all.sql.out
@@ -145,7 +145,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "array<int>",
     "dt2" : "int",
     "hint" : "",
-    "operator" : "ExceptAll",
+    "operator" : "EXCEPT ALL",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -231,7 +231,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
     "leftNumCols" : "1",
-    "operator" : "EXCEPTALL",
+    "operator" : "EXCEPT ALL",
     "rightNumCols" : "2"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/intersect-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/intersect-all.sql.out
@@ -126,10 +126,9 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
-    "invalidNumColumns" : "2",
-    "invalidOrdinalNum" : "second",
+    "leftNumCols" : "1",
     "operator" : "INTERSECTALL",
-    "refNumColumns" : "1"
+    "rightNumCols" : "2"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/intersect-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/intersect-all.sql.out
@@ -126,9 +126,10 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
-    "leftNumCols" : "1",
-    "operator" : "INTERSECT ALL",
-    "rightNumCols" : "2"
+    "firstNumColumns" : "1",
+    "invalidNumColumns" : "2",
+    "invalidOrdinalNum" : "second",
+    "operator" : "INTERSECT ALL"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/intersect-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/intersect-all.sql.out
@@ -102,7 +102,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "array<int>",
     "dt2" : "int",
     "hint" : "",
-    "operator" : "IntersectAll",
+    "operator" : "INTERSECT ALL",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -127,7 +127,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
     "leftNumCols" : "1",
-    "operator" : "INTERSECTALL",
+    "operator" : "INTERSECT ALL",
     "rightNumCols" : "2"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/widenSetOperationTypes.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/widenSetOperationTypes.sql.out
@@ -92,7 +92,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "tinyint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -118,7 +118,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "tinyint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -144,7 +144,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "tinyint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -170,7 +170,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "tinyint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -268,7 +268,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "smallint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -294,7 +294,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "smallint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -320,7 +320,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "smallint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -346,7 +346,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "smallint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -444,7 +444,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "int",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -470,7 +470,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "int",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -496,7 +496,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "int",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -522,7 +522,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "int",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -620,7 +620,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "bigint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -646,7 +646,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "bigint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -672,7 +672,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "bigint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -698,7 +698,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "bigint",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -796,7 +796,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "float",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -822,7 +822,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "float",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -848,7 +848,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "float",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -874,7 +874,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "float",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -972,7 +972,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "double",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -998,7 +998,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "double",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1024,7 +1024,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "double",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1050,7 +1050,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "double",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1148,7 +1148,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "decimal(10,0)",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1174,7 +1174,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "decimal(10,0)",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1200,7 +1200,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "decimal(10,0)",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1226,7 +1226,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "decimal(10,0)",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1324,7 +1324,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "string",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1350,7 +1350,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "string",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1394,7 +1394,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "tinyint",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1420,7 +1420,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "smallint",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1446,7 +1446,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "int",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1472,7 +1472,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "bigint",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1498,7 +1498,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "float",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1524,7 +1524,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "double",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1550,7 +1550,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "decimal(10,0)",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1576,7 +1576,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "string",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1611,7 +1611,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1637,7 +1637,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1663,7 +1663,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "binary",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1689,7 +1689,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "tinyint",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1715,7 +1715,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "smallint",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1741,7 +1741,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "int",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1767,7 +1767,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "bigint",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1793,7 +1793,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "float",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1819,7 +1819,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "double",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1845,7 +1845,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "decimal(10,0)",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1871,7 +1871,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "string",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1897,7 +1897,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1931,7 +1931,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "timestamp",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1957,7 +1957,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "date",
     "dt2" : "boolean",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -1983,7 +1983,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "tinyint",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2009,7 +2009,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "smallint",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2035,7 +2035,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "int",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2061,7 +2061,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "bigint",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2087,7 +2087,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "float",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2113,7 +2113,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "double",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2139,7 +2139,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "decimal(10,0)",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2174,7 +2174,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2200,7 +2200,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "timestamp",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2244,7 +2244,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "tinyint",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2270,7 +2270,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "smallint",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2296,7 +2296,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "int",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2322,7 +2322,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "bigint",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2348,7 +2348,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "float",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2374,7 +2374,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "double",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2400,7 +2400,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "decimal(10,0)",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2435,7 +2435,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "binary",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -2461,7 +2461,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "boolean",
     "dt2" : "date",
     "hint" : "",
-    "operator" : "Union",
+    "operator" : "UNION",
     "ti" : "second"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-except-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-except-all.sql.out
@@ -230,9 +230,10 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
-    "leftNumCols" : "1",
-    "operator" : "EXCEPT ALL",
-    "rightNumCols" : "2"
+    "firstNumColumns" : "1",
+    "invalidNumColumns" : "2",
+    "invalidOrdinalNum" : "second",
+    "operator" : "EXCEPT ALL"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-except-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-except-all.sql.out
@@ -230,10 +230,9 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
-    "invalidNumColumns" : "2",
-    "invalidOrdinalNum" : "second",
+    "leftNumCols" : "1",
     "operator" : "EXCEPTALL",
-    "refNumColumns" : "1"
+    "rightNumCols" : "2"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-except-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-except-all.sql.out
@@ -145,7 +145,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "array<int>",
     "dt2" : "int",
     "hint" : "",
-    "operator" : "ExceptAll",
+    "operator" : "EXCEPT ALL",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -231,7 +231,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
     "leftNumCols" : "1",
-    "operator" : "EXCEPTALL",
+    "operator" : "EXCEPT ALL",
     "rightNumCols" : "2"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-intersect-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-intersect-all.sql.out
@@ -126,10 +126,9 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
-    "invalidNumColumns" : "2",
-    "invalidOrdinalNum" : "second",
+    "leftNumCols" : "1",
     "operator" : "INTERSECTALL",
-    "refNumColumns" : "1"
+    "rightNumCols" : "2"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-intersect-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-intersect-all.sql.out
@@ -126,9 +126,10 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
-    "leftNumCols" : "1",
-    "operator" : "INTERSECT ALL",
-    "rightNumCols" : "2"
+    "firstNumColumns" : "1",
+    "invalidNumColumns" : "2",
+    "invalidOrdinalNum" : "second",
+    "operator" : "INTERSECT ALL"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-intersect-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-intersect-all.sql.out
@@ -102,7 +102,7 @@ org.apache.spark.sql.AnalysisException
     "dt1" : "array<int>",
     "dt2" : "int",
     "hint" : "",
-    "operator" : "IntersectAll",
+    "operator" : "INTERSECT ALL",
     "ti" : "second"
   },
   "queryContext" : [ {
@@ -127,7 +127,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "NUM_COLUMNS_MISMATCH",
   "messageParameters" : {
     "leftNumCols" : "1",
-    "operator" : "INTERSECTALL",
+    "operator" : "INTERSECT ALL",
     "rightNumCols" : "2"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -530,8 +530,10 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       errorClass = "NUM_COLUMNS_MISMATCH",
       parameters = Map(
         "operator" -> "UNION",
-        "leftNumCols" -> "2",
-        "rightNumCols" -> "3"))
+        "firstNumColumns" -> "2",
+        "invalidOrdinalNum" -> "second",
+        "invalidNumColumns" -> "3")
+    )
 
     df1 = Seq((1, 2, 3)).toDF("a", "b", "c")
     df2 = Seq((4, 5, 6)).toDF("a", "c", "d")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -1010,7 +1010,7 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
     val errMsg = intercept[AnalysisException] {
       df1.unionByName(df2)
     }.getMessage
-    assert(errMsg.contains("Union can only be performed on tables with" +
+    assert(errMsg.contains("UNION can only be performed on tables with" +
       " compatible column types." +
       " The third column of the second table is struct<c1:int,c2:int,c3:struct<c3:int,c5:int>>" +
       " type which is not compatible with struct<c1:int,c2:int,c3:struct<c3:int>> at the same" +
@@ -1094,7 +1094,7 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
 
     val err = intercept[AnalysisException](df7.union(df8).collect())
     assert(err.message
-      .contains("Union can only be performed on tables with compatible column types"))
+      .contains("UNION can only be performed on tables with compatible column types"))
   }
 
   test("SPARK-36546: Add unionByName support to arrays of structs") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -530,9 +530,8 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       errorClass = "NUM_COLUMNS_MISMATCH",
       parameters = Map(
         "operator" -> "UNION",
-        "refNumColumns" -> "2",
-        "invalidOrdinalNum" -> "second",
-        "invalidNumColumns" -> "3"))
+        "leftNumCols" -> "2",
+        "rightNumCols" -> "3"))
 
     df1 = Seq((1, 2, 3)).toDF("a", "b", "c")
     df2 = Seq((4, 5, 6)).toDF("a", "c", "d")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -2690,10 +2690,24 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       checkAnswer(sql("SELECT struct(1 a) UNION ALL (SELECT struct(2 A))"),
         Row(Row(1)) :: Row(Row(2)) :: Nil)
 
-      val m2 = intercept[AnalysisException] {
-        sql("SELECT struct(1 a) EXCEPT (SELECT struct(2 A))")
-      }.message
-      assert(m2.contains("Except can only be performed on tables with compatible column types"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("SELECT struct(1 a) EXCEPT (SELECT struct(2 A))")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_2430",
+        parameters = Map(
+          "operator" -> "EXCEPT",
+          "dt1" -> "struct<A:int>",
+          "dt2" -> "struct<a:int>",
+          "hint" -> "",
+          "ci" -> "first",
+          "ti" -> "second"
+        ),
+        context = ExpectedContext(
+          fragment = "SELECT struct(1 a) EXCEPT (SELECT struct(2 A))",
+          start = 0,
+          stop = 45)
+      )
 
       withTable("t", "S") {
         sql("CREATE TABLE t(c struct<f:int>) USING parquet")


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to refactor error message for `NUM_COLUMNS_MISMATCH` to make it more generic.

### Why are the changes needed?
The changes improve the error framework.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
Update existed UT.
Pass GA.