### PR TITLE
[SPARK-41410][K8S][FOLLOWUP] Remove PVC_COUNTER decrement

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -455,7 +455,6 @@ class ExecutorPodsAllocator(
             .inNamespace(namespace)
             .resource(createdExecutorPod)
             .delete()
-          PVC_COUNTER.decrementAndGet()
           throw e
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to remove `PVC_COUNTER` decrement part to handle exception cases.

### Why are the changes needed?

This PR handles the following two cases.

1. If pod creation API throws `KubernetesClientException`, we should not change `PVC_COUNTER`.
2. In case of (1), Spark try to delete pod. If pod deletion API also throws `KubernetesClientException`, we should not change `PVC_COUNTER`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test case.