### PR TITLE
[SPARK-41413][SQL] Avoid shuffle in Storage-Partitioned Join when partition keys mismatch, but join expressions are compatible

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroRowReaderSuite.scala
@@ -59,7 +59,7 @@ class AvroRowReaderSuite
 
       val df = spark.read.format("avro").load(dir.getCanonicalPath)
       val fileScan = df.queryExecution.executedPlan collectFirst {
-        case BatchScanExec(_, f: AvroScan, _, _, _, _) => f
+        case BatchScanExec(_, f: AvroScan, _, _, _, _, _) => f
       }
       val filePath = fileScan.get.fileIndex.inputFiles(0)
       val fileSize = new File(new URI(filePath)).length

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -2350,7 +2350,7 @@ class AvroV2Suite extends AvroSuite with ExplainSuiteHelper {
       })
 
       val fileScan = df.queryExecution.executedPlan collectFirst {
-        case BatchScanExec(_, f: AvroScan, _, _, _, _) => f
+        case BatchScanExec(_, f: AvroScan, _, _, _, _, _) => f
       }
       assert(fileScan.nonEmpty)
       assert(fileScan.get.partitionFilters.nonEmpty)
@@ -2383,7 +2383,7 @@ class AvroV2Suite extends AvroSuite with ExplainSuiteHelper {
       assert(filterCondition.isDefined)
 
       val fileScan = df.queryExecution.executedPlan collectFirst {
-        case BatchScanExec(_, f: AvroScan, _, _, _, _) => f
+        case BatchScanExec(_, f: AvroScan, _, _, _, _, _) => f
       }
       assert(fileScan.nonEmpty)
       assert(fileScan.get.partitionFilters.isEmpty)
@@ -2464,7 +2464,7 @@ class AvroV2Suite extends AvroSuite with ExplainSuiteHelper {
             .where("value = 'a'")
 
           val fileScan = df.queryExecution.executedPlan collectFirst {
-            case BatchScanExec(_, f: AvroScan, _, _, _, _) => f
+            case BatchScanExec(_, f: AvroScan, _, _, _, _, _) => f
           }
           assert(fileScan.nonEmpty)
           if (filtersPushdown) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -695,7 +695,7 @@ case class KeyGroupedShuffleSpec(
     //  4. the partition values, if present on both sides, are following the same order.
     case otherSpec @ KeyGroupedShuffleSpec(otherPartitioning, otherDistribution) =>
       distribution.clustering.length == otherDistribution.clustering.length &&
-        numPartitions == other.numPartitions && isExpressionsCompatible(otherSpec) &&
+        numPartitions == other.numPartitions && areKeysCompatible(otherSpec) &&
           partitioning.partitionValuesOpt.zip(otherPartitioning.partitionValuesOpt).forall {
             case (left, right) => left.zip(right).forall { case (l, r) =>
               ordering.compare(l, r) == 0
@@ -706,7 +706,9 @@ case class KeyGroupedShuffleSpec(
     case _ => false
   }
 
-  def isExpressionsCompatible(other: KeyGroupedShuffleSpec): Boolean = {
+  // Whether the partition keys (i.e., partition expressions) are compatible between this and the
+  // `other` spec.
+  def areKeysCompatible(other: KeyGroupedShuffleSpec): Boolean = {
     val expressions = partitioning.expressions
     val otherExpressions = other.partitioning.expressions
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -693,14 +693,14 @@ case class KeyGroupedShuffleSpec(
     //    3.3 each pair of partition expressions at the same index must share compatible
     //        transform functions.
     //  4. the partition values, if present on both sides, are following the same order.
-    case otherSpec@KeyGroupedShuffleSpec(otherPartitioning, otherDistribution) =>
+    case otherSpec @ KeyGroupedShuffleSpec(otherPartitioning, otherDistribution) =>
       distribution.clustering.length == otherDistribution.clustering.length &&
         numPartitions == other.numPartitions && isExpressionsCompatible(otherSpec) &&
-        partitioning.partitionValuesOpt.zip(otherPartitioning.partitionValuesOpt).forall {
-          case (left, right) => left.zip(right).forall { case (l, r) =>
-            ordering.compare(l, r) == 0
+          partitioning.partitionValuesOpt.zip(otherPartitioning.partitionValuesOpt).forall {
+            case (left, right) => left.zip(right).forall { case (l, r) =>
+              ordering.compare(l, r) == 0
+            }
           }
-        }
     case ShuffleSpecCollection(specs) =>
       specs.exists(isCompatibleWith)
     case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1405,13 +1405,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val V2_BUCKETING_PUSH_PART_KEYS_ENABLED =
-    buildConf("spark.sql.sources.v2.bucketing.pushPartKeys.enabled")
-      .doc(s"Whether to pushdown common partition keys when ${V2_BUCKETING_ENABLED.key} is " +
-        "enabled. When turned on, if both sides of a join are of KeyGroupedPartitioning, even if " +
-        "they don't have the exact same partition keys, Spark will calculate a superset of " +
-        "partition keys and pushdown that info to scan nodes, which will use empty partitions " +
-        "for the missing keys on either side. This could help to eliminate unnecessary shuffles")
+  val V2_BUCKETING_PUSH_PART_VALUES_ENABLED =
+    buildConf("spark.sql.sources.v2.bucketing.pushPartValues.enabled")
+      .doc(s"Whether to pushdown common partition values when ${V2_BUCKETING_ENABLED.key} is " +
+        "enabled. When turned on, if both sides of a join are of KeyGroupedPartitioning and if " +
+        "they share compatible partition keys, even if they don't have the exact same partition " +
+        "values, Spark will calculate a superset of partition values and pushdown that info to " +
+        "scan nodes, which will use empty partitions for the missing partition values on either " +
+        "side. This could help to eliminate unnecessary shuffles")
       .version("3.4.0")
       .booleanConf
       .createWithDefault(false)
@@ -4525,7 +4526,8 @@ class SQLConf extends Serializable with Logging {
 
   def v2BucketingEnabled: Boolean = getConf(SQLConf.V2_BUCKETING_ENABLED)
 
-  def v2BucketingPushPartKeysEnabled: Boolean = getConf(SQLConf.V2_BUCKETING_PUSH_PART_KEYS_ENABLED)
+  def v2BucketingPushPartValuesEnabled: Boolean =
+    getConf(SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED)
 
   def dataFrameSelfJoinAutoResolveAmbiguity: Boolean =
     getConf(DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1405,6 +1405,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val V2_BUCKETING_PUSH_PART_KEYS_ENABLED =
+    buildConf("spark.sql.sources.v2.bucketing.pushPartKeys.enabled")
+      .doc(s"Whether to pushdown common partition keys when ${V2_BUCKETING_ENABLED.key} is " +
+        "enabled. When turned on, if both sides of a join are of KeyGroupedPartitioning, even if " +
+        "they don't have the exact same partition keys, Spark will calculate a superset of " +
+        "partition keys and pushdown that info to scan nodes, which will use empty partitions " +
+        "for the missing keys on either side. This could help to eliminate unnecessary shuffles")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val BUCKETING_MAX_BUCKETS = buildConf("spark.sql.sources.bucketing.maxBuckets")
     .doc("The maximum number of buckets allowed.")
     .version("2.4.0")
@@ -4513,6 +4524,8 @@ class SQLConf extends Serializable with Logging {
   def autoBucketedScanEnabled: Boolean = getConf(SQLConf.AUTO_BUCKETED_SCAN_ENABLED)
 
   def v2BucketingEnabled: Boolean = getConf(SQLConf.V2_BUCKETING_ENABLED)
+
+  def v2BucketingPushPartKeysEnabled: Boolean = getConf(SQLConf.V2_BUCKETING_PUSH_PART_KEYS_ENABLED)
 
   def dataFrameSelfJoinAutoResolveAmbiguity: Boolean =
     getConf(DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -134,9 +134,9 @@ case class BatchScanExec(
         case p: KeyGroupedPartitioning =>
           val partitionMapping = finalPartitions.map(s =>
             s.head.asInstanceOf[HasPartitionKey].partitionKey() -> s).toMap
-          finalPartitions = p.partitionValuesOpt.get.map { partKey =>
+          finalPartitions = p.partitionValuesOpt.get.map { partValue =>
             // Use empty partition for those partition values that are not present
-            partitionMapping.getOrElse(partKey, Seq.empty)
+            partitionMapping.getOrElse(partValue, Seq.empty)
           }
         case _ =>
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -247,7 +247,6 @@ case class EnsureRequirements(
     children
   }
 
-
   private def checkKeyGroupedSpec(shuffleSpec: ShuffleSpec): Boolean = {
     def check(spec: KeyGroupedShuffleSpec): Boolean = {
       val attributes = spec.partitioning.expressions.flatMap(_.collectLeaves())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -160,8 +160,11 @@ case class EnsureRequirements(
             node.mapChildren(child => populatePartitionValues(child, values))
         }
 
-      // Check if 1) all children are of `KeyGroupedPartitioning` and 2) they are all compatible
-      // with each other. If both are true, skip shuffle.
+      // Check if the following conditions are satisfied:
+      //   1. There are exactly two children (e.g., join). Note that Spark doesn't support
+      //      multi-way join at the moment, so this check should be sufficient.
+      //   2. All children are of `KeyGroupedPartitioning`, and they are compatible with each other
+      // If both are true, skip shuffle.
       val allCompatible = childrenIndexes.length == 2 && {
         val left = childrenIndexes.head
         val right = childrenIndexes(1)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -185,7 +185,7 @@ case class EnsureRequirements(
           //   `day(b)`: [1, 2, 3]
           // Following the case 2 above, we don't have to shuffle both sides, but instead can just
           // push the common set of partition values: `[0, 1, 2, 3]` down to the two data sources.
-          if (!isCompatible && conf.v2BucketingPushPartKeysEnabled) {
+          if (!isCompatible && conf.v2BucketingPushPartValuesEnabled) {
             (getRootSpec(specs(left)), getRootSpec(specs(right))) match {
               case (leftSpec: KeyGroupedShuffleSpec, rightSpec: KeyGroupedShuffleSpec) =>
                 // Check if the two children are partition keys compatible. If so, find the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -46,6 +46,8 @@ trait ShuffledJoin extends JoinCodegenSupport {
 
   override def outputPartitioning: Partitioning = joinType match {
     case _: InnerLike =>
+      val leftP = left.outputPartitioning
+      val rightP = right.outputPartitioning
       PartitioningCollection(Seq(left.outputPartitioning, right.outputPartitioning))
     case LeftOuter => left.outputPartitioning
     case RightOuter => right.outputPartitioning

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledJoin.scala
@@ -46,8 +46,6 @@ trait ShuffledJoin extends JoinCodegenSupport {
 
   override def outputPartitioning: Partitioning = joinType match {
     case _: InnerLike =>
-      val leftP = left.outputPartitioning
-      val rightP = right.outputPartitioning
       PartitioningCollection(Seq(left.outputPartitioning, right.outputPartitioning))
     case LeftOuter => left.outputPartitioning
     case RightOuter => right.outputPartitioning

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -861,7 +861,7 @@ class FileBasedDataSourceSuite extends QueryTest
           })
 
           val fileScan = df.queryExecution.executedPlan collectFirst {
-            case BatchScanExec(_, f: FileScan, _, _, _, _) => f
+            case BatchScanExec(_, f: FileScan, _, _, _, _, _) => f
           }
           assert(fileScan.nonEmpty)
           assert(fileScan.get.partitionFilters.nonEmpty)
@@ -901,7 +901,7 @@ class FileBasedDataSourceSuite extends QueryTest
           assert(filterCondition.isDefined)
 
           val fileScan = df.queryExecution.executedPlan collectFirst {
-            case BatchScanExec(_, f: FileScan, _, _, _, _) => f
+            case BatchScanExec(_, f: FileScan, _, _, _, _, _) => f
           }
           assert(fileScan.nonEmpty)
           assert(fileScan.get.partitionFilters.isEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -52,9 +52,9 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
   override def beforeAll(): Unit = {
     super.beforeAll()
     originalV2BucketingEnabled = conf.getConf(V2_BUCKETING_ENABLED)
-    originalV2BucketingPushPartKeysEnabled = conf.getConf(V2_BUCKETING_PUSH_PART_KEYS_ENABLED)
+    originalV2BucketingPushPartKeysEnabled = conf.getConf(V2_BUCKETING_PUSH_PART_VALUES_ENABLED)
     conf.setConf(V2_BUCKETING_ENABLED, true)
-    conf.setConf(V2_BUCKETING_PUSH_PART_KEYS_ENABLED, true)
+    conf.setConf(V2_BUCKETING_PUSH_PART_VALUES_ENABLED, true)
     originalAutoBroadcastJoinThreshold = conf.getConf(AUTO_BROADCASTJOIN_THRESHOLD)
     conf.setConf(AUTO_BROADCASTJOIN_THRESHOLD, -1L)
   }
@@ -64,7 +64,7 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
       super.afterAll()
     } finally {
       conf.setConf(V2_BUCKETING_ENABLED, originalV2BucketingEnabled)
-      conf.setConf(V2_BUCKETING_PUSH_PART_KEYS_ENABLED, originalV2BucketingPushPartKeysEnabled)
+      conf.setConf(V2_BUCKETING_PUSH_PART_VALUES_ENABLED, originalV2BucketingPushPartKeysEnabled)
       conf.setConf(AUTO_BROADCASTJOIN_THRESHOLD, originalAutoBroadcastJoinThreshold)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -416,21 +416,22 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
     assert(shuffles.isEmpty, "should not add shuffle when partition keys mismatch")
   }
 
-  test("partitioned join: partition values from one side are subset of those from the other side") {
+  test("SPARK-41413: partitioned join: partition values from one side are subset of those from " +
+      "the other side") {
     val items_partitions = Array(bucket(4, "id"))
     createTable(items, items_schema, items_partitions)
 
     sql(s"INSERT INTO testcat.ns.$items VALUES " +
-        s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
-        s"(3, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
-        s"(4, 'cc', 15.5, cast('2020-02-01' as timestamp))")
+        "(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+        "(3, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
+        "(4, 'cc', 15.5, cast('2020-02-01' as timestamp))")
 
     val purchases_partitions = Array(bucket(4, "item_id"))
     createTable(purchases, purchases_schema, purchases_partitions)
 
     sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
-        s"(1, 42.0, cast('2020-01-01' as timestamp)), " +
-        s"(3, 19.5, cast('2020-02-01' as timestamp))")
+        "(1, 42.0, cast('2020-01-01' as timestamp)), " +
+        "(3, 19.5, cast('2020-02-01' as timestamp))")
 
     val df = sql("SELECT id, name, i.price as purchase_price, p.price as sale_price " +
         s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -447,21 +448,21 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
     checkAnswer(df, Seq(Row(1, "aa", 40.0, 42.0), Row(3, "bb", 10.0, 19.5)))
   }
 
-  test("partitioned join: partition values from both sides overlaps") {
+  test("SPARK-41413: partitioned join: partition values from both sides overlaps") {
     val items_partitions = Array(identity("id"))
     createTable(items, items_schema, items_partitions)
 
     sql(s"INSERT INTO testcat.ns.$items VALUES " +
-        s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
-        s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
-        s"(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
+        "(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+        "(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
+        "(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
 
     val purchases_partitions = Array(identity("item_id"))
     createTable(purchases, purchases_schema, purchases_partitions)
     sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
-        s"(1, 42.0, cast('2020-01-01' as timestamp)), " +
-        s"(2, 19.5, cast('2020-02-01' as timestamp)), " +
-        s"(4, 30.0, cast('2020-02-01' as timestamp))")
+        "(1, 42.0, cast('2020-01-01' as timestamp)), " +
+        "(2, 19.5, cast('2020-02-01' as timestamp)), " +
+        "(4, 30.0, cast('2020-02-01' as timestamp))")
 
     val df = sql("SELECT id, name, i.price as purchase_price, p.price as sale_price " +
         s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -478,20 +479,20 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
     checkAnswer(df, Seq(Row(1, "aa", 40.0, 42.0), Row(2, "bb", 10.0, 19.5)))
   }
 
-  test("partitioned join: non-overlapping partition values from both sides") {
+  test("SPARK-41413: partitioned join: non-overlapping partition values from both sides") {
     val items_partitions = Array(identity("id"))
     createTable(items, items_schema, items_partitions)
     sql(s"INSERT INTO testcat.ns.$items VALUES " +
-        s"(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
-        s"(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
-        s"(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
+        "(1, 'aa', 40.0, cast('2020-01-01' as timestamp)), " +
+        "(2, 'bb', 10.0, cast('2020-01-01' as timestamp)), " +
+        "(3, 'cc', 15.5, cast('2020-02-01' as timestamp))")
 
     val purchases_partitions = Array(identity("item_id"))
     createTable(purchases, purchases_schema, purchases_partitions)
     sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
-        s"(4, 42.0, cast('2020-01-01' as timestamp)), " +
-        s"(5, 19.5, cast('2020-02-01' as timestamp)), " +
-        s"(6, 30.0, cast('2020-02-01' as timestamp))")
+        "(4, 42.0, cast('2020-01-01' as timestamp)), " +
+        "(5, 19.5, cast('2020-02-01' as timestamp)), " +
+        "(6, 30.0, cast('2020-02-01' as timestamp))")
 
     val df = sql("SELECT id, name, i.price as purchase_price, p.price as sale_price " +
         s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.connector.distributions.Distributions
 import org.apache.spark.sql.connector.expressions._
 import org.apache.spark.sql.connector.expressions.Expressions._
-import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
@@ -438,12 +437,6 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
         "ON i.id = p.item_id ORDER BY id, purchase_price, sale_price")
 
     val shuffles = collectShuffles(df.queryExecution.executedPlan)
-    shuffles.foreach { s =>
-      assert(s.outputPartitioning.isInstanceOf[KeyGroupedPartitioning],
-        s"expected KeyGroupedPartitioning but found ${s.outputPartitioning.getClass.getName}")
-      assert(s.outputPartitioning.numPartitions == 3,
-        s"expected 3 partitions for $s but found ${s.outputPartitioning.numPartitions}")
-    }
     assert(shuffles.isEmpty, "should not contain any shuffle")
     checkAnswer(df, Seq(Row(1, "aa", 40.0, 42.0), Row(3, "bb", 10.0, 19.5)))
   }
@@ -469,12 +462,6 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
         "ON i.id = p.item_id ORDER BY id, purchase_price, sale_price")
 
     val shuffles = collectShuffles(df.queryExecution.executedPlan)
-    shuffles.foreach { s =>
-      assert(s.outputPartitioning.isInstanceOf[KeyGroupedPartitioning],
-        s"expected KeyGroupedPartitioning but found ${s.outputPartitioning.getClass.getName}")
-      assert(s.outputPartitioning.numPartitions == 4,
-        s"expected 4 partitions for $s but found ${s.outputPartitioning.numPartitions}")
-    }
     assert(shuffles.isEmpty, "should not contain any shuffle")
     checkAnswer(df, Seq(Row(1, "aa", 40.0, 42.0), Row(2, "bb", 10.0, 19.5)))
   }
@@ -499,12 +486,6 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
         "ON i.id = p.item_id ORDER BY id, purchase_price, sale_price")
 
     val shuffles = collectShuffles(df.queryExecution.executedPlan)
-    shuffles.foreach { s =>
-      assert(s.outputPartitioning.isInstanceOf[KeyGroupedPartitioning],
-        s"expected KeyGroupedPartitioning but found ${s.outputPartitioning.getClass.getName}")
-      assert(s.outputPartitioning.numPartitions == 6,
-        s"expected 6 partitions for $s but found ${s.outputPartitioning.numPartitions}")
-    }
     assert(shuffles.isEmpty, "should not contain any shuffle")
     checkAnswer(df, Seq.empty)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitionsSuite.scala
@@ -165,7 +165,7 @@ class PruneFileSourcePartitionsSuite extends PrunePartitionSuiteBase with Shared
   override def getScanExecPartitionSize(plan: SparkPlan): Long = {
     plan.collectFirst {
       case p: FileSourceScanExec => p.selectedPartitions.length
-      case BatchScanExec(_, scan: FileScan, _, _, _, _) =>
+      case BatchScanExec(_, scan: FileScan, _, _, _, _, _) =>
         scan.fileIndex.listFiles(scan.partitionFilters, scan.dataFilters).length
     }.get
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PrunePartitionSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PrunePartitionSuiteBase.scala
@@ -95,7 +95,7 @@ abstract class PrunePartitionSuiteBase extends StatisticsCollectionTestBase {
     assert(getScanExecPartitionSize(plan) == expectedPartitionCount)
 
     val collectFn: PartialFunction[SparkPlan, Seq[Expression]] = collectPartitionFiltersFn orElse {
-      case BatchScanExec(_, scan: FileScan, _, _, _, _) => scan.partitionFilters
+      case BatchScanExec(_, scan: FileScan, _, _, _, _, _) => scan.partitionFilters
     }
     val pushedDownPartitionFilters = plan.collectFirst(collectFn)
       .map(exps => exps.filterNot(e => e.isInstanceOf[IsNotNull]))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcV2SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcV2SchemaPruningSuite.scala
@@ -40,7 +40,7 @@ class OrcV2SchemaPruningSuite extends SchemaPruningSuite with AdaptiveSparkPlanH
   override def checkScanSchemata(df: DataFrame, expectedSchemaCatalogStrings: String*): Unit = {
     val fileSourceScanSchemata =
       collect(df.queryExecution.executedPlan) {
-        case BatchScanExec(_, scan: OrcScan, _, _, _, _) => scan.readDataSchema
+        case BatchScanExec(_, scan: OrcScan, _, _, _, _, _) => scan.readDataSchema
       }
     assert(fileSourceScanSchemata.size === expectedSchemaCatalogStrings.size,
       s"Found ${fileSourceScanSchemata.size} file sources in dataframe, " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -980,7 +980,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
   }
 
   test("SPARK-41413: check compatibility when partition values mismatch") {
-    withSQLConf(SQLConf.V2_BUCKETING_PUSH_PART_KEYS_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true") {
       val leftPartValues = Seq(Array[Any](1, 1), Array[Any](2, 2)).map(new GenericInternalRow(_))
       val rightPartValues = Seq(Array[Any](1, 1), Array[Any](2, 2), Array[Any](3, 3))
           .map(new GenericInternalRow(_))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -979,6 +979,94 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-41413: check compatibility when partition values mismatch") {
+    withSQLConf(SQLConf.V2_BUCKETING_PUSH_PART_KEYS_ENABLED.key -> "true") {
+      val leftPartValues = Seq(Array[Any](1, 1), Array[Any](2, 2)).map(new GenericInternalRow(_))
+      val rightPartValues = Seq(Array[Any](1, 1), Array[Any](2, 2), Array[Any](3, 3))
+          .map(new GenericInternalRow(_))
+
+      var plan1 = DummySparkPlan(
+        outputPartitioning = KeyGroupedPartitioning(bucket(4, exprB) :: bucket(8, exprC) :: Nil,
+          leftPartValues.length, Some(leftPartValues))
+      )
+      var plan2 = DummySparkPlan(
+        outputPartitioning = KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
+          rightPartValues.length, Some(rightPartValues))
+      )
+
+      // simple case
+      var smjExec = SortMergeJoinExec(
+        exprA :: exprB :: exprC :: Nil, exprA :: exprC :: exprB :: Nil, Inner, None, plan1, plan2)
+      applyEnsureRequirementsWithSubsetKeys(smjExec) match {
+        case SortMergeJoinExec(_, _, _, _,
+        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+          assert(left.expressions === Seq(bucket(4, exprB), bucket(8, exprC)))
+          assert(right.expressions === Seq(bucket(4, exprC), bucket(8, exprB)))
+        case other => fail(other.toString)
+      }
+
+      // With partition collections
+      plan1 = DummySparkPlan(outputPartitioning =
+        PartitioningCollection(
+          Seq(KeyGroupedPartitioning(bucket(4, exprB) :: bucket(8, exprC) :: Nil,
+            leftPartValues.length, Some(leftPartValues)),
+            KeyGroupedPartitioning(bucket(4, exprB) :: bucket(8, exprC) :: Nil,
+              leftPartValues.length, Some(leftPartValues)))
+        )
+      )
+
+      smjExec = SortMergeJoinExec(
+        exprA :: exprB :: exprC :: Nil, exprA :: exprC :: exprB :: Nil, Inner, None, plan1, plan2)
+      applyEnsureRequirementsWithSubsetKeys(smjExec) match {
+        case SortMergeJoinExec(_, _, _, _,
+        SortExec(_, _, DummySparkPlan(_, _, left: PartitioningCollection, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+          assert(left.partitionings.length == 2)
+          assert(left.partitionings.head.isInstanceOf[KeyGroupedPartitioning])
+          assert(left.partitionings.head.asInstanceOf[KeyGroupedPartitioning].expressions ==
+            Seq(bucket(4, exprB), bucket(8, exprC)))
+          assert(right.expressions === Seq(bucket(4, exprC), bucket(8, exprB)))
+        case other => fail(other.toString)
+      }
+
+      // Nested partition collections
+      plan2 = DummySparkPlan(outputPartitioning =
+        PartitioningCollection(
+          Seq(
+            PartitioningCollection(
+              Seq(
+                KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
+                  rightPartValues.length, Some(rightPartValues)),
+                KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
+                  rightPartValues.length, Some(rightPartValues)))),
+              PartitioningCollection(
+                Seq(
+                  KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
+                    rightPartValues.length, Some(rightPartValues)),
+                  KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
+                    rightPartValues.length, Some(rightPartValues))))
+          )
+        )
+      )
+
+      smjExec = SortMergeJoinExec(
+        exprA :: exprB :: exprC :: Nil, exprA :: exprC :: exprB :: Nil, Inner, None, plan1, plan2)
+      applyEnsureRequirementsWithSubsetKeys(smjExec) match {
+        case SortMergeJoinExec(_, _, _, _,
+        SortExec(_, _, DummySparkPlan(_, _, left: PartitioningCollection, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: PartitioningCollection, _, _), _), _) =>
+          assert(left.partitionings.length == 2)
+          assert(left.partitionings.head.isInstanceOf[KeyGroupedPartitioning])
+          assert(left.partitionings.head.asInstanceOf[KeyGroupedPartitioning].expressions ==
+              Seq(bucket(4, exprB), bucket(8, exprC)))
+          assert(right.partitionings.length == 2)
+          assert(right.partitionings.head.isInstanceOf[PartitioningCollection])
+        case other => fail(other.toString)
+      }
+    }
+  }
+
   def bucket(numBuckets: Int, expr: Expression): TransformExpression = {
     TransformExpression(BucketFunction, Seq(expr), Some(numBuckets))
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This enhances Storage Partitioned Join by handling mismatch partition keys from both sides of the join and skip shuffle in certain cases.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently in Storage Partitioned Join, when the partition transform expressions match, but the partition keys don't, we'd still fallback to shuffle. This is not necessary since we can find out the common set of partition keys and populate that to the scan nodes. On the scan node, those missing partition keys can be filled with empty partitions. 

The above scenario is pretty common for `MERGE INTO` queries, as the changing data to be merged into the base table often need to be applied to new partitions. The current implementation will cause these queries to trigger shuffle and thus become expensive.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added a few new tests in `KeyGroupedPartitioningSuite`.