### PR TITLE
[SPARK-41416][SQL] Rewrite self join in in predicate to aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -233,6 +233,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
     Batch("Check Cartesian Products", Once,
       CheckCartesianProducts) :+
     Batch("RewriteSubquery", Once,
+      RewriteSelfJoinInInPredicate,
       RewritePredicateSubquery,
       PushPredicateThroughJoin,
       LimitPushDown,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -867,7 +867,7 @@ object RewriteSelfJoinInInPredicate extends Rule[LogicalPlan] with PredicateHelp
                   Project(newProjectList, aggPlan)
                 } else {
                   Project(newProjectList,
-                    Filter(buildBalancedPredicate(nonEqualJoinAttrs.map(
+                    Filter(buildBalancedPredicate(nonEqualJoinAttrs.toSeq.map(
                       expr => GreaterThan(expr.toAttribute, Literal(0L))), And),
                       aggPlan
                     )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -794,3 +794,98 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
     }
   }
 }
+
+/**
+ * Rewrite the SelfJoin resulting in duplicate rows used for IN predicate to aggregation.
+ * For IN predicate, duplicate rows does not have any value. It will be overhead.
+ * <p>
+ * Ex: TPCDS Q95: following CTE is used only in IN predicates for only one column comparison
+ * ({@code ws_order_number}). This results in exponential increase in Joined rows with too many
+ * duplicate rows.
+ * <pre>
+ * WITH ws_wh AS
+ * (
+ *        SELECT ws1.ws_order_number,
+ *               ws1.ws_warehouse_sk wh1,
+ *               ws2.ws_warehouse_sk wh2
+ *        FROM   web_sales ws1,
+ *               web_sales ws2
+ *        WHERE  ws1.ws_order_number = ws2.ws_order_number
+ *        AND    ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk)
+ * </pre>
+ * <p>
+ * Could be optimized as below:
+ * <pre>
+ * WITH ws_wh AS
+ *     (SELECT ws_order_number
+ *       FROM  web_sales
+ *       GROUP BY ws_order_number
+ *       HAVING COUNT(DISTINCT ws_warehouse_sk) > 1)
+ * </pre>
+ * Optimized CTE scans table only once and results in unique rows.
+ */
+object RewriteSelfJoinInInPredicate extends Rule[LogicalPlan] with PredicateHelper {
+
+  def rewrite(plan: LogicalPlan): LogicalPlan =
+    plan.transformWithPruning(_.containsAnyPattern(IN_SUBQUERY)) {
+      case f: Filter =>
+        f transformExpressions {
+          case in @ InSubquery(_, listQuery @ ListQuery(Project(projectList,
+            Join(left, right, Inner, Some(joinCond), _)), _, _, _, _, _))
+            if left.canonicalized ne right.canonicalized =>
+            val attrMapping = AttributeMap(right.output.zip(left.output))
+            val subCondExprs = splitConjunctivePredicates(joinCond transform {
+              case attr: Attribute => attrMapping.getOrElse(attr, attr)
+            })
+            val equalJoinAttrs = ArrayBuffer[Attribute]()
+            val nonEqualJoinAttrs = ArrayBuffer[NamedExpression]()
+            var hasComplexCond = false
+            subCondExprs map {
+              case EqualTo(attr1: Attribute, attr2: Attribute) if attr1.semanticEquals(attr2) =>
+                equalJoinAttrs += attr1
+
+              case Not(EqualTo(attr1: Attribute, attr2: Attribute))
+                if attr1.semanticEquals(attr2) =>
+                nonEqualJoinAttrs +=
+                  Alias(Count(attr1).toAggregateExpression(), "cnt_" + attr1.name)()
+
+              case _ => hasComplexCond = true
+            }
+
+            val newProjectList = projectList map {
+              case attr: Attribute => attrMapping.getOrElse(attr, attr)
+              case Alias(attr: Attribute, name) => Alias(attrMapping.getOrElse(attr, attr), name)()
+              case attr => attr
+            }
+
+            if (!hasComplexCond &&
+              AttributeSet(newProjectList).subsetOf(AttributeSet(equalJoinAttrs))) {
+              val aggPlan =
+                Aggregate(equalJoinAttrs.toSeq, (equalJoinAttrs ++ nonEqualJoinAttrs).toSeq, left)
+              val filterPlan =
+                if (nonEqualJoinAttrs.isEmpty) {
+                  Project(newProjectList, aggPlan)
+                } else {
+                  Project(newProjectList,
+                    Filter(buildBalancedPredicate(nonEqualJoinAttrs.map(
+                      expr => GreaterThan(expr.toAttribute, Literal(0L))), And),
+                      aggPlan
+                    )
+                  )
+                }
+
+              in.copy(query = listQuery.copy(plan = filterPlan))
+            } else {
+              in
+            }
+        }
+    }
+
+  def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!conf.getConf(SQLConf.REWRITE_SELFJOIN_IN_IN_PREDICATE)) {
+      plan
+    } else {
+      rewrite(plan)
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -135,6 +135,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.PushExtraPredicateThroughJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.PushFoldableIntoBranches" ::
       "org.apache.spark.sql.catalyst.optimizer.PushLeftSemiLeftAntiThroughJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.RewriteSelfJoinInInPredicate" ::
       "org.apache.spark.sql.catalyst.optimizer.ReassignLambdaVariableID" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveDispensableExpressions" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveLiteralFromGroupExpressions" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4027,6 +4027,13 @@ object SQLConf {
     .checkValues(ErrorMessageFormat.values.map(_.toString))
     .createWithDefault(ErrorMessageFormat.PRETTY.toString)
 
+  val REWRITE_SELFJOIN_IN_IN_PREDICATE =
+    buildConf("spark.sql.optimizer.RewriteSelfJoinInInPredicate")
+      .doc("Rewrite the SelfJoin resulting in duplicate rows used for IN predicate to aggregation")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSelfJoinInInPredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSelfJoinInInPredicateSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.ListQuery
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+import org.apache.spark.sql.internal.SQLConf.REWRITE_SELFJOIN_IN_IN_PREDICATE
+
+class RewriteSelfJoinInInPredicateSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("RewriteSubquery", FixedPoint(10), RewriteSelfJoinInInPredicate) :: Nil
+  }
+
+  val testRelation1 = LocalRelation($"a".int, $"b".int, $"c".int)
+  val testRelation2 = LocalRelation($"d".int, $"e".int)
+
+  test("Rewrite self join in in predicate to aggregate") {
+    withSQLConf(REWRITE_SELFJOIN_IN_IN_PREDICATE.key -> "true") {
+      val subQuery =
+        testRelation2.subquery("ws1")
+          .join(
+            testRelation2.subquery("ws2"), Inner,
+            Some($"ws1.d" === $"ws2.d" && $"ws1.e" =!= $"ws2.e"))
+          .select($"ws1.d")
+      val originalQuery = testRelation1.where($"b".in(ListQuery(subQuery))).analyze
+      val optimized = Optimize.execute(originalQuery.analyze)
+
+      val correctSubQuery =
+        testRelation2.as("ws1")
+          .groupBy($"d")($"d", count($"e").as("cnt_e"))
+          .where($"cnt_e" > 0L)
+
+      val correctAnswer =
+        testRelation1.where($"b".in(ListQuery(correctSubQuery.select($"d")))).analyze
+      comparePlans(optimized, correctAnswer)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Transforms the SelfJoin resulting in duplicate rows used for IN predicate to aggregation.
For IN predicate, duplicate rows does not have any value. It will be overhead.

Ex: TPCDS Q95: following CTE is used only in IN predicates for only one column comparison ({@code ws_order_number}).
This results in exponential increase in Joined rows with too many duplicate rows.

```sql
WITH ws_wh AS
(
       SELECT ws1.ws_order_number,
              ws1.ws_warehouse_sk wh1,
              ws2.ws_warehouse_sk wh2
       FROM   web_sales ws1,
              web_sales ws2
       WHERE  ws1.ws_order_number = ws2.ws_order_number
       AND    ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk)
```

Could be optimized as below:

```sql
WITH ws_wh AS
    (SELECT ws_order_number
      FROM  web_sales
      GROUP BY ws_order_number
      HAVING COUNT(DISTINCT ws_warehouse_sk) > 1)
```

Optimized CTE scans table only once and results in unique rows.


### Why are the changes needed?

Optimize TPCDS Q95,  reference code  
https://github.com/rohankumardubey/hetu/blob/master/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformUnCorrelatedInPredicateSubQuerySelfJoinToAggregate.java


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Added UT
