### PR TITLE
[SPARK-41369][CONNECT] Add connect common to servers' shaded jar

### DIFF
--- a/connector/connect/server/pom.xml
+++ b/connector/connect/server/pom.xml
@@ -256,6 +256,7 @@
               <include>com.google.j2objc:j2objc-annotations</include>
               <include>org.checkerframework:checker-qual</include>
               <include>com.google.code.gson:gson</include>
+              <include>org.apache.spark:spark-connect-common_${scala.binary.version}</include>
             </includes>
           </artifactSet>
           <relocations>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This adds the connect common jar to the servers' shaded assembly jar. This was missed in the previous PR.

### Why are the changes needed?
Some developers prefer Maven over SBT. Without this change the python tests won't run.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Yes, manually. We don't have automated tests running that touch maven.