### PR TITLE
[SPARK-41418][BUILD] Upgrade scala-maven-plugin from 4.7.2 to 4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
       errors building different Hadoop versions.
       See: SPARK-36547, SPARK-38394.
        -->
-    <scala-maven-plugin.version>4.7.2</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.8.0</scala-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade scala-maven-plugin from 4.7.2 to 4.8.0

### Why are the changes needed?
1.This version brings enhancements for `Incremental compile`(https://github.com/davidB/scala-maven-plugin/commit/69a45c04a520e4ce691758fd99591a740f6a2c88) and upgrade zinc to 1.8.0(https://github.com/davidB/scala-maven-plugin/commit/7d5d9bcdb3c9a1b9b6bef8077fe0c785182c1c18)

2.4.7.2 VS 4.8.0
https://github.com/davidB/scala-maven-plugin/compare/4.7.2...4.8.0

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.