### PR TITLE
[SPARK-41433][CONNECT] Make Max Arrow BatchSize configurable

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.connect.config
 
 import org.apache.spark.internal.config.ConfigBuilder
+import org.apache.spark.network.util.ByteUnit
 
 private[spark] object Connect {
 
@@ -34,4 +35,12 @@ private[spark] object Connect {
       .version("3.4.0")
       .stringConf
       .createOptional
+
+  val CONNECT_GRPC_ARROW_MAX_BATCH_SIZE =
+    ConfigBuilder("spark.connect.grpc.arrow.maxBatchSize")
+      .doc("When using Apache Arrow, limit the maximum size of one arrow batch that " +
+        "can be sent from server side to client side.")
+      .version("3.4.0")
+      .bytesConf(ByteUnit.MiB)
+      .createWithDefaultString("4m")
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make Max Arrow BatchSize configurable


### Why are the changes needed?
make batchsize configurable


### Does this PR introduce _any_ user-facing change?
yes, one new configration


### How was this patch tested?
existing tests