### PR TITLE
[SPARK-41441][SQL] Support Generate with no required child output to host outer references

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
@@ -667,6 +667,18 @@ object DecorrelateInnerQuery extends PredicateHelper {
             val newJoin = j.copy(left = newLeft, right = newRight, condition = newCondition)
             (newJoin, newJoinCond, newOuterReferenceMap)
 
+          case g: Generate if g.requiredChildOutput.isEmpty =>
+            // Generate with non-empty required child output cannot host
+            // outer reference. It is blocked by CheckAnalysis.
+            val outerReferences = collectOuterReferences(g.expressions)
+            val newOuterReferences = parentOuterReferences ++ outerReferences
+            val (newChild, joinCond, outerReferenceMap) =
+              decorrelate(g.child, newOuterReferences, aggregated)
+            // Replace all outer references in the original generator expression.
+            val newGenerator = replaceOuterReference(g.generator, outerReferenceMap)
+            val newGenerate = g.copy(generator = newGenerator, child = newChild)
+            (newGenerate, joinCond, outerReferenceMap)
+
           case u: UnaryNode =>
             val outerReferences = collectOuterReferences(u.expressions)
             assert(outerReferences.isEmpty, s"Correlated column is not allowed in $u")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.ScalarSubquery._
@@ -787,7 +788,7 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
           g.copy(generator = newGenerator, child = left)
 
         case o =>
-          throw new IllegalStateException(
+          throw SparkException.internalError(
             s"Unexpected plan when optimizing one row relation subquery: $o")
       }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -753,12 +753,13 @@ object RewriteLateralSubquery extends Rule[LogicalPlan] {
 object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
 
   object OneRowSubquery {
-    def unapply(plan: LogicalPlan): Option[Seq[NamedExpression]] = {
+    def unapply(plan: LogicalPlan): Option[UnaryNode] = {
       // SPARK-40800: always inline expressions to support a broader range of correlated
       // subqueries and avoid expensive domain joins.
       val alwaysInline = conf.getConf(SQLConf.ALWAYS_INLINE_ONE_ROW_RELATION_SUBQUERY)
       CollapseProject(EliminateSubqueryAliases(plan), alwaysInline = alwaysInline) match {
-        case Project(projectList, _: OneRowRelation) => Some(stripOuterReferences(projectList))
+        case p @ Project(_, _: OneRowRelation) => Some(p)
+        case g @ Generate(_, _, _, _, _, _: OneRowRelation) => Some(g)
         case _ => None
       }
     }
@@ -774,15 +775,28 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
    */
   private def rewrite(plan: LogicalPlan): LogicalPlan = plan.transformUpWithSubqueries {
     case LateralJoin(
-      left, right @ LateralSubquery(OneRowSubquery(projectList), _, _, _, _), _, None)
+      left, right @ LateralSubquery(OneRowSubquery(plan), _, _, _, _), _, None)
         if !hasCorrelatedSubquery(right.plan) && right.joinCond.isEmpty =>
-      Project(left.output ++ projectList, left)
+      plan match {
+        case Project(projectList, _: OneRowRelation) =>
+          val newPList = stripOuterReferences(projectList)
+          Project(left.output ++ newPList, left)
+
+        case g @ Generate(generator, _, _, _, _, _: OneRowRelation) =>
+          val newGenerator = stripOuterReference(generator)
+          g.copy(generator = newGenerator, child = left)
+
+        case o =>
+          throw new IllegalStateException(
+            s"Unexpected plan when optimizing one row relation subquery: $o")
+      }
+
     case p: LogicalPlan => p.transformExpressionsUpWithPruning(
       _.containsPattern(SCALAR_SUBQUERY)) {
-      case s @ ScalarSubquery(OneRowSubquery(projectList), _, _, _, _)
+      case s @ ScalarSubquery(OneRowSubquery(p @ Project(_, _: OneRowRelation)), _, _, _, _)
           if !hasCorrelatedSubquery(s.plan) && s.joinCond.isEmpty =>
-        assert(projectList.size == 1)
-        projectList.head
+        assert(p.projectList.size == 1)
+        p.projectList.head
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -796,7 +796,7 @@ object OptimizeOneRowRelationSubquery extends Rule[LogicalPlan] {
       case s @ ScalarSubquery(OneRowSubquery(p @ Project(_, _: OneRowRelation)), _, _, _, _)
           if !hasCorrelatedSubquery(s.plan) && s.joinCond.isEmpty =>
         assert(p.projectList.size == 1)
-        p.projectList.head
+        stripOuterReferences(p.projectList).head
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeOneRowRelationSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeOneRowRelationSubquerySuite.scala
@@ -20,11 +20,12 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.analysis.CleanupAliases
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.ScalarSubquery
+import org.apache.spark.sql.catalyst.expressions.{Explode, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical.{DomainJoin, LocalRelation, LogicalPlan, OneRowRelation}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.IntegerType
 
 class OptimizeOneRowRelationSubquerySuite extends PlanTest {
 
@@ -62,6 +63,7 @@ class OptimizeOneRowRelationSubquerySuite extends PlanTest {
   val b = $"b".int
   val t1 = LocalRelation(a, b)
   val t2 = LocalRelation($"c".int, $"d".int)
+  val t3 = LocalRelation(a, b, $"arr".array(IntegerType))
 
   test("Optimize scalar subquery with a single project") {
     // SELECT (SELECT a) FROM t1
@@ -161,6 +163,18 @@ class OptimizeOneRowRelationSubquerySuite extends PlanTest {
       .select(ScalarSubquery(inner).as("s")).select($"s" + 1)
     val query = t1.select(ScalarSubquery(subquery).as("sub"))
     val optimized = Optimize.execute(query.analyze)
+    assertHasDomainJoin(optimized)
+  }
+
+  test("SPARK-41441: optimize lateral subquery with Generate") {
+    val query1 = t3.lateralJoin(t0.generate(Explode($"arr")))
+    comparePlans(
+      Optimize.execute(query1.analyze),
+      t3.generate(Explode($"arr")).analyze)
+
+    // Should not optimize when the lateral subquery plan is more complex.
+    val query2 = t3.lateralJoin(t0.generate(Explode($"arr")).where($"col" > 0))
+    val optimized = Optimize.execute(query2.analyze)
     assertHasDomainJoin(optimized)
   }
 }

--- a/sql/core/src/test/resources/sql-tests/inputs/join-lateral.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/join-lateral.sql
@@ -2,6 +2,7 @@
 
 CREATE VIEW t1(c1, c2) AS VALUES (0, 1), (1, 2);
 CREATE VIEW t2(c1, c2) AS VALUES (0, 2), (0, 3);
+CREATE VIEW t3(c1, c2) AS VALUES (0, ARRAY(0, 1)), (1, ARRAY(2)), (2, ARRAY()), (null, ARRAY(4));
 
 -- lateral join with single column select
 SELECT * FROM t1, LATERAL (SELECT c1);
@@ -170,6 +171,13 @@ WITH cte1 AS (
 )
 SELECT * FROM cte2;
 
+-- SPARK-41441: lateral join with outer references in Generate
+SELECT * FROM t3 JOIN LATERAL (SELECT EXPLODE(c2));
+SELECT * FROM t3 JOIN LATERAL (SELECT EXPLODE_OUTER(c2));
+SELECT * FROM t3 JOIN LATERAL (SELECT EXPLODE(c2)) t(c3) ON c1 = c3;
+SELECT * FROM t3 LEFT JOIN LATERAL (SELECT EXPLODE(c2)) t(c3) ON c1 = c3;
+
 -- clean up
 DROP VIEW t1;
 DROP VIEW t2;
+DROP VIEW t3;

--- a/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
@@ -16,6 +16,14 @@ struct<>
 
 
 -- !query
+CREATE VIEW t3(c1, c2) AS VALUES (0, ARRAY(0, 1)), (1, ARRAY(2)), (2, ARRAY()), (null, ARRAY(4))
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
 SELECT * FROM t1, LATERAL (SELECT c1)
 -- !query schema
 struct<c1:int,c2:int,c1:int>
@@ -788,6 +796,48 @@ struct<c1:int,c2:int>
 
 
 -- !query
+SELECT * FROM t3 JOIN LATERAL (SELECT EXPLODE(c2))
+-- !query schema
+struct<c1:int,c2:array<int>,col:int>
+-- !query output
+0	[0,1]	0
+0	[0,1]	1
+1	[2]	2
+NULL	[4]	4
+
+
+-- !query
+SELECT * FROM t3 JOIN LATERAL (SELECT EXPLODE_OUTER(c2))
+-- !query schema
+struct<c1:int,c2:array<int>,col:int>
+-- !query output
+0	[0,1]	0
+0	[0,1]	1
+1	[2]	2
+2	[]	NULL
+NULL	[4]	4
+
+
+-- !query
+SELECT * FROM t3 JOIN LATERAL (SELECT EXPLODE(c2)) t(c3) ON c1 = c3
+-- !query schema
+struct<c1:int,c2:array<int>,c3:int>
+-- !query output
+0	[0,1]	0
+
+
+-- !query
+SELECT * FROM t3 LEFT JOIN LATERAL (SELECT EXPLODE(c2)) t(c3) ON c1 = c3
+-- !query schema
+struct<c1:int,c2:array<int>,c3:int>
+-- !query output
+0	[0,1]	0
+1	[2]	NULL
+2	[]	NULL
+NULL	[4]	NULL
+
+
+-- !query
 DROP VIEW t1
 -- !query schema
 struct<>
@@ -797,6 +847,14 @@ struct<>
 
 -- !query
 DROP VIEW t2
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DROP VIEW t3
 -- !query schema
 struct<>
 -- !query output


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR supports `Generate` with no required child output to host outer references. It updates DecorrelateInnerQuery to handle Generate and adds a new optimization for Generate and OneRowRelation in rule OptimizeOneRowRelationSubquery.

### Why are the changes needed?
Currently, CheckAnalysis allows `Generate` with no required child output to host outer references. However,  DecorrelateInnerQuery does not handle this case correctly.  For example
```
select * from t, lateral (select explode(array(c1, c2)))
```
This will throw an internal error:
```
AssertionError: assertion failed: Correlated column is not allowed in Generate
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests and SQL query tests.
