### PR TITLE
[SPARK-41366][CONNECT][FOLLOWUP] Import `Column` if pandas is available

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -21,7 +21,6 @@ import tempfile
 
 import grpc  # type: ignore
 
-from pyspark.sql.connect.column import Column
 from pyspark.testing.sqlutils import have_pandas, SQLTestUtils
 
 if have_pandas:
@@ -33,6 +32,7 @@ from pyspark.sql.types import StructType, StructField, LongType, StringType
 if have_pandas:
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
     from pyspark.sql.connect.client import ChannelBuilder
+    from pyspark.sql.connect.column import Column
     from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
     from pyspark.sql.connect.function_builder import udf
     from pyspark.sql.connect.functions import lit, col


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to move `Column` import statement in order to a test issue 

### Why are the changes needed?

`Column` requires `pandas` dependency.
```
$ python/run-tests.py --modules pyspark-connect
...
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/sql/tests/connect/test_connect_basic.py", line 24, in <module>
    from pyspark.sql.connect.column import Column
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/sql/connect/__init__.py", line 22, in <module>
    from pyspark.sql.connect.dataframe import DataFrame  # noqa: F401
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/sql/connect/dataframe.py", line 33, in <module>
    import pandas
ModuleNotFoundError: No module named 'pandas'
```

### Does this PR introduce _any_ user-facing change?

No. This is a test-only fix.

### How was this patch tested?

Manually tests on a system without `pandas`.
```
$ python/run-tests.py --modules pyspark-connect
```