### PR TITLE
[SPARK-41447][CORE] Reduce the number of `doMergeApplicationListing` invocations

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -541,7 +541,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
               // later on if it was not possible to parse it.
               try {
                 if (conf.get(CLEANER_ENABLED) && reader.modificationTime <
-                  clock.getTimeMillis() - conf.get(MAX_LOG_AGE_S) * 1000) {
+                    clock.getTimeMillis() - conf.get(MAX_LOG_AGE_S) * 1000) {
                   logInfo(s"Deleting expired event log ${reader.rootPath.toString}")
                   deleteLog(fs, reader.rootPath)
                   false

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -541,8 +541,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
               // later on if it was not possible to parse it.
               try {
                 if (conf.get(CLEANER_ENABLED) &&
-                  reader.modificationTime <
-                    clock.getTimeMillis() - conf.get(MAX_LOG_AGE_S) * 1000) {
+                    reader.modificationTime < clock.getTimeMillis() - conf.get(MAX_LOG_AGE_S) * 1000) {
                   logInfo(s"Deleting expired event log ${reader.rootPath.toString}")
                   deleteLog(fs, reader.rootPath)
                   false

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -544,9 +544,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
                     clock.getTimeMillis() - conf.get(MAX_LOG_AGE_S) * 1000) {
                   logInfo(s"Deleting expired event log ${reader.rootPath.toString}")
                   deleteLog(fs, reader.rootPath)
-                  // Because the exception could be thrown for either of the two reads,
-                  // when the exception is thrown, we should also cleanup the log info
-                  // from listing db if the first read had succeeded.
+                  // If the LogInfo read had succeeded, but the ApplicationInafoWrapper
+                  // read failure and throw the exception, we should also cleanup the log
+                  // info from listing db.
                   listing.delete(classOf[LogInfo], reader.rootPath.toString)
                   false
                 } else if (count < conf.get(UPDATE_BATCHSIZE)) {

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -986,7 +986,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         } catch {
           case _: NoSuchElementException =>
             if (reader.modificationTime < maxTime) {
-              logInfo(s"Deleting unlisted expired event log ${reader.rootPath.toString}")
+              logInfo(s"Deleting unlisted event log ${reader.rootPath.toString}")
               deleteLog(fs, reader.rootPath)
             }
         }

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -540,8 +540,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
               // try to parse it. This will allow the cleaner code to detect the file as stale
               // later on if it was not possible to parse it.
               try {
-                if (conf.get(CLEANER_ENABLED) &&
-                    reader.modificationTime < clock.getTimeMillis() - conf.get(MAX_LOG_AGE_S) * 1000) {
+                if (conf.get(CLEANER_ENABLED) && reader.modificationTime <
+                  clock.getTimeMillis() - conf.get(MAX_LOG_AGE_S) * 1000) {
                   logInfo(s"Deleting expired event log ${reader.rootPath.toString}")
                   deleteLog(fs, reader.rootPath)
                   false

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1705,7 +1705,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     provider.stop()
   }
 
-  test("clean up expired event log files that don't exist in listing db") {
+  test("SPARK-41447: clean up expired event log files that don't exist in listing db") {
     val maxAge = TimeUnit.SECONDS.toMillis(10)
     val clock = new ManualClock(maxAge / 2)
     val provider = new FsHistoryProvider(

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1705,7 +1705,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
     provider.stop()
   }
 
-  test("SPARK-41447: clean up expired event log files that don't exist in listing db") {
+  test("SPARK-41447: Reduce the number of doMergeApplicationListing invocations") {
     class TestFsHistoryProvider(conf: SparkConf, clock: Clock)
       extends FsHistoryProvider(conf, clock) {
       var doMergeApplicationListingCall = 0


### PR DESCRIPTION
### What changes were proposed in this pull request?
When restarting the history server, In history server log,
we can see many `INFO FsHIstoryProvider: Finished parsing application_xxx` followed by
`INFO FsHIstoryProvider: Deleting expired event log for application_xxx`.
This is caused by the expired and unlisted log files also be parsed, and then execute `checkAndCleanLog` to delete parsed info, this means that the parsing is unnecessary.

If there are a large number of expired log files in the log directory, it will affect the speed of replay.

In order to avoid this, we can add a logic to clean up these expired log files before calling `doMergeApplicationListing`.

### Why are the changes needed?
    
    Reduce the number of doMergeApplicationListing invocations when execute checkForLogs, avoid parse unnecessary log files.

### Does this PR introduce _any_ user-facing change?

    NO
    
### How was this patch tested?
    
    UT