### PR TITLE
[SPARK-41451][K8S] Avoid using empty abbrevMarker in StringUtils.abbreviate

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -275,7 +275,7 @@ private[spark] object KubernetesConf {
         .toLowerCase(Locale.ROOT)
         .replaceAll("[^a-z0-9\\-]", "-")
         .replaceAll("-+", "-"),
-      "-", // avoid using empty string, see https://issues.apache.org/jira/browse/LANG-1463
+      "-",
       KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH
     ).stripPrefix("-").stripSuffix("-")
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -275,7 +275,7 @@ private[spark] object KubernetesConf {
         .toLowerCase(Locale.ROOT)
         .replaceAll("[^a-z0-9\\-]", "-")
         .replaceAll("-+", "-"),
-      "-",
+      "-", // avoid using empty string, see https://issues.apache.org/jira/browse/LANG-1463
       KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH
     ).stripPrefix("-").stripSuffix("-")
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -266,16 +266,16 @@ private[spark] object KubernetesConf {
 
   def getAppNameLabel(appName: String): String = {
     // According to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels,
-    // must be 63 characters or less to follow the DNS label standard, so take the 63 characters
-    // of the appName name as the label. In addition, label value must start and end with
-    // an alphanumeric character.
+    // must be 63 characters or less to follow the DNS label standard, for appName longer than
+    // 63 characters, replace the tail w/ "-abbr" as the label. In addition, label value must
+    // start and end with an alphanumeric character.
     StringUtils.abbreviate(
       s"$appName"
         .trim
         .toLowerCase(Locale.ROOT)
         .replaceAll("[^a-z0-9\\-]", "-")
         .replaceAll("-+", "-"),
-      "-",
+      "-abbr",
       KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH
     ).stripPrefix("-").stripSuffix("-")
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -275,7 +275,7 @@ private[spark] object KubernetesConf {
         .toLowerCase(Locale.ROOT)
         .replaceAll("[^a-z0-9\\-]", "-")
         .replaceAll("-+", "-"),
-      "",
+      "-",
       KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH
     ).stripPrefix("-").stripSuffix("-")
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -241,14 +241,14 @@ class KubernetesConfSuite extends SparkFunSuite {
   test("SPARK-36566: get app name label") {
     assert(KubernetesConf.getAppNameLabel(" Job+Spark-Pi 2021") === "job-spark-pi-2021")
     assert(KubernetesConf.getAppNameLabel("a" * 63) === "a" * 63)
-    assert(KubernetesConf.getAppNameLabel("a" * 64) === "a" * 62)
-    assert(KubernetesConf.getAppNameLabel("a" * 253) === "a" * 62)
+    assert(KubernetesConf.getAppNameLabel("a" * 64) === "a" * 58 + "-abbr")
+    assert(KubernetesConf.getAppNameLabel("a" * 253) === "a" * 58 + "-abbr")
   }
 
   test("SPARK-38630: K8s label value should start and end with alphanumeric") {
     assert(KubernetesConf.getAppNameLabel("-hello-") === "hello")
-    assert(KubernetesConf.getAppNameLabel("a" * 62 + "-aaa") === "a" * 62)
-    assert(KubernetesConf.getAppNameLabel("-" + "a" * 63) === "a" * 61)
+    assert(KubernetesConf.getAppNameLabel("a" * 62 + "-aaa") === "a" * 58 + "-abbr")
+    assert(KubernetesConf.getAppNameLabel("-" + "a" * 63) === "a" * 57 + "-abbr")
   }
 
   test("SPARK-40869: Resource name prefix should not start with a hyphen") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -241,14 +241,14 @@ class KubernetesConfSuite extends SparkFunSuite {
   test("SPARK-36566: get app name label") {
     assert(KubernetesConf.getAppNameLabel(" Job+Spark-Pi 2021") === "job-spark-pi-2021")
     assert(KubernetesConf.getAppNameLabel("a" * 63) === "a" * 63)
-    assert(KubernetesConf.getAppNameLabel("a" * 64) === "a" * 63)
-    assert(KubernetesConf.getAppNameLabel("a" * 253) === "a" * 63)
+    assert(KubernetesConf.getAppNameLabel("a" * 64) === "a" * 62)
+    assert(KubernetesConf.getAppNameLabel("a" * 253) === "a" * 62)
   }
 
   test("SPARK-38630: K8s label value should start and end with alphanumeric") {
     assert(KubernetesConf.getAppNameLabel("-hello-") === "hello")
     assert(KubernetesConf.getAppNameLabel("a" * 62 + "-aaa") === "a" * 62)
-    assert(KubernetesConf.getAppNameLabel("-" + "a" * 63) === "a" * 62)
+    assert(KubernetesConf.getAppNameLabel("-" + "a" * 63) === "a" * 61)
   }
 
   test("SPARK-40869: Resource name prefix should not start with a hyphen") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Use "-abbr" instead of empty abbrevMarker in `StringUtils.abbreviate` in `KubernetesConf.getAppNameLabel`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[LANG-1463](https://issues.apache.org/jira/browse/LANG-1463) affects Apache Commons Lang3 3.6~3.9, and it may cause `KubernetesConf#getAppNameLabel` return unexpected value and eventually cause the job failed to request executors.

```
2022-12-08 11:47:37 [WARN] [kubernetes-executor-snapshots-subscribers-1] org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl#94 - Exception when notifying snapshot subscriber.
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://xxxxxxxxx:6443/api/v1/namespaces/spark/pods. Message: Pod "kyuubi-connection-spark-sql-hive-c11b352d-d4ce-4d11-bb68-128bfdd5000f-43048584efd88528-exec-3" is invalid: metadata.labels: Invalid value: "kyuubi-connection-spark-sql-hive-c11b352d-d4ce-4d11-bb68-128bfdd5000f": must be no more than 63 characters. Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=metadata.labels, message=Invalid value: "kyuubi-connection-spark-sql-hive-c11b352d-d4ce-4d11-bb68-128bfdd5000f": must be no more than 63 characters, reason=FieldValueInvalid, additionalProperties={})], group=null, kind=Pod, name=kyuubi-connection-spark-sql-hive-c11b352d-d4ce-4d11-bb68-128bfdd5000f-43048584efd88528-exec-3, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=Pod "kyuubi-connection-spark-sql-hive-c11b352d-d4ce-4d11-bb68-128bfdd5000f-43048584efd88528-exec-3" is invalid: metadata.labels: Invalid value: "kyuubi-connection-spark-sql-hive-c11b352d-d4ce-4d11-bb68-128bfdd5000f": must be no more than 63 characters, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Invalid, status=Failure, additionalProperties={}).
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:682) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:661) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:612) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:555) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:518) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:305) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:644) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:83) ~[kubernetes-client-5.12.2.jar:?]
	at io.fabric8.kubernetes.client.dsl.base.CreateOnlyResourceOperation.create(CreateOnlyResourceOperation.java:61) ~[kubernetes-client-5.12.2.jar:?]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$requestNewExecutors$1(ExecutorPodsAllocator.scala:462) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:158) ~[scala-library-2.12.15.jar:?]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.requestNewExecutors(ExecutorPodsAllocator.scala:421) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$onNewSnapshots$37(ExecutorPodsAllocator.scala:385) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$onNewSnapshots$37$adapted(ExecutorPodsAllocator.scala:378) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62) ~[scala-library-2.12.15.jar:?]
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55) ~[scala-library-2.12.15.jar:?]
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49) ~[scala-library-2.12.15.jar:?]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.onNewSnapshots(ExecutorPodsAllocator.scala:378) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$start$3(ExecutorPodsAllocator.scala:131) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsAllocator.$anonfun$start$3$adapted(ExecutorPodsAllocator.scala:130) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl$SnapshotsSubscriber.org$apache$spark$scheduler$cluster$k8s$ExecutorPodsSnapshotsStoreImpl$SnapshotsSubscriber$$processSnapshotsInternal(ExecutorPodsSnapshotsStoreImpl.scala:143) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl$SnapshotsSubscriber.processSnapshots(ExecutorPodsSnapshotsStoreImpl.scala:131) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at org.apache.spark.scheduler.cluster.k8s.ExecutorPodsSnapshotsStoreImpl$$anon$1.run(ExecutorPodsSnapshotsStoreImpl.scala:94) ~[spark-kubernetes_2.12-3.3.1.2-SNAPSHOT.jar:3.3.1.2-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_352]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_352]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_352]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[?:1.8.0_352]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_352]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_352]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_352]
```

Strictly speaking, it's not an issue of Spark, because Spark depends on a higher version of Apache Commons Lang3 which fixed [LANG-1463](https://issues.apache.org/jira/browse/LANG-1463), but considering the following facts, I strongly suggest to avoid using empty abbrevMarker in `StringUtils.abbreviate`.

- I suppose the trim algorithm of long app name is some kind of Spark internal implementation, this change should not affect Spark users.
- It's a common case that users or vendors want to tune the version of some dependencies because they need to align w/ other components, this change makes the Spark compatible w/ Apache Commons Lang3 3.6~3.9 as well(specific to this case).
- For those developers who are used to creating "fat jar" but w/o properly class relocation, a "StringUtils" class may be shipped by the "fat jar", supposing the "fat jar" is a plugin of Spark and it was added into `SPARK_HOME/jars`, then Spark has a chance to load that bad class, then trigger the bug. (actually we are in such situation, I know we should not blame Spark, but this PR makes Spark much tolerated) 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT updated, and manually tested.