### PR TITLE
[MINOR][CONNECT][DOCS] Document parallelism=1 in Spark Connect testing

### DIFF
--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -82,7 +82,7 @@ To use the release version of Spark Connect:
 
 ```bash
 # Run all Spark Connect Python tests as a module.
-./python/run-tests --module pyspark-connect
+./python/run-tests --module pyspark-connect --parallelism 1
 ```
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to document the correct way of running Spark Connect tests with `--parallelism 1` option in `./python/run-tests` script.

### Why are the changes needed?

Without this option, the tests cannot run due to the port conflicts. It fails with port already in use.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually ran the commands.
