### PR TITLE
[SPARK-41463][SQL][TESTS] Ensure error class names contain only capital letters, numbers and underscores

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -147,6 +147,18 @@ class SparkThrowableSuite extends SparkFunSuite {
     assert(rereadErrorClassToInfoMap == errorReader.errorInfoMap)
   }
 
+  test("Error class names should contain only capital letters, numbers and underscores") {
+    val allowedChars = "[A-Z0-9_]*"
+    errorReader.errorInfoMap.foreach { e =>
+      assert(e._1.matches(allowedChars))
+      e._2.subClass.map { s =>
+        s.keys.foreach { k =>
+          assert(k.matches(allowedChars))
+        }
+      }
+    }
+  }
+
   test("Check if error class is missing") {
     val ex1 = intercept[SparkException] {
       getMessage("", Map.empty[String, String])

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -150,10 +150,10 @@ class SparkThrowableSuite extends SparkFunSuite {
   test("Error class names should contain only capital letters, numbers and underscores") {
     val allowedChars = "[A-Z0-9_]*"
     errorReader.errorInfoMap.foreach { e =>
-      assert(e._1.matches(allowedChars))
+      assert(e._1.matches(allowedChars), s"Error class: ${e._1} is invalid")
       e._2.subClass.map { s =>
         s.keys.foreach { k =>
-          assert(k.matches(allowedChars))
+          assert(k.matches(allowedChars), s"Error sub-class: $k is invalid")
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change adds a unit test to verify that error class and subclass names contain only capital letters, numbers and underscores.

### Why are the changes needed?
This is to ensure that the standard holds for error classes added in the future.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test only change. Also tried adding an invalid error class name and verified that the test failed locally.
