### PR TITLE
[SPARK-41461][BUILD][CORE] Support user configurable protoc executables when building Spark Core.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -758,6 +758,4 @@
     </profile>
   </profiles>
 
-
-
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -696,7 +696,9 @@
     <profile>
       <id>default-protoc</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipDefaultProtoc</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -755,5 +757,7 @@
       </build>
     </profile>
   </profiles>
+
+
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -643,26 +643,6 @@
           </relocations>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.github.os72</groupId>
-        <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>${protoc-jar-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
-              <protocVersion>${protobuf.version}</protocVersion>
-              <inputDirectories>
-                <include>src/main/protobuf</include>
-              </inputDirectories>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -709,6 +689,67 @@
             <configuration>
               <executable>${project.basedir}${file.separator}..${file.separator}R${file.separator}install-dev${script.extension}</executable>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>default-protoc</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.os72</groupId>
+            <artifactId>protoc-jar-maven-plugin</artifactId>
+            <version>${protoc-jar-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+                  <protocVersion>${protobuf.version}</protocVersion>
+                  <inputDirectories>
+                    <include>src/main/protobuf</include>
+                  </inputDirectories>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>user-defined-protoc</id>
+      <properties>
+        <core.protoc.executable.path>${env.CORE_PROTOC_EXEC_PATH}</core.protoc.executable.path>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.os72</groupId>
+            <artifactId>protoc-jar-maven-plugin</artifactId>
+            <version>${protoc-jar-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+                  <protocVersion>${protobuf.version}</protocVersion>
+                  <protocCommand>${core.protoc.executable.path}</protocCommand>
+                  <inputDirectories>
+                    <include>src/main/protobuf</include>
+                  </inputDirectories>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -317,3 +317,21 @@ To build and run tests on IPv6-only environment, the following configurations ar
     export MAVEN_OPTS="-Djava.net.preferIPv6Addresses=true"
     export SBT_OPTS="-Djava.net.preferIPv6Addresses=true"
     export SERIAL_SBT_TESTS=1
+
+### Building with user-defined `protoc`
+
+When the user cannot use the official `protoc` binary files to build the `core` module in the compilation environment, for example, compiling `core` module on CentOS 6 or CentOS 7 which the default `glibc` version is less than 2.14, we can try to compile and test by specifying the user-defined `protoc` binary files as follows:
+
+```bash
+export CORE_PROTOC_EXEC_PATH=/path-to-protoc-exe
+./build/mvn -Puser-defined-protoc clean package
+```
+
+or
+
+```bash
+export CORE_PROTOC_EXEC_PATH=/path-to-protoc-exe
+./build/sbt -Puser-defined-protoc clean package
+```
+
+The user-defined `protoc` binary files can be produced in the user's compilation environment by source code compilation, for compilation steps, please refer to [protobuf](https://github.com/protocolbuffers/protobuf).

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -324,7 +324,7 @@ When the user cannot use the official `protoc` binary files to build the `core` 
 
 ```bash
 export CORE_PROTOC_EXEC_PATH=/path-to-protoc-exe
-./build/mvn -Puser-defined-protoc clean package
+./build/mvn -Puser-defined-protoc -DskipDefaultProtoc clean package
 ```
 
 or

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -115,12 +115,16 @@ object SparkBuild extends PomBuild {
       val connectProtocExecPath = Properties.envOrNone("CONNECT_PROTOC_EXEC_PATH")
       val connectPluginExecPath = Properties.envOrNone("CONNECT_PLUGIN_EXEC_PATH")
       val protobufProtocExecPath = Properties.envOrNone("PROTOBUF_PROTOC_EXEC_PATH")
+      val coreProtocExecPath = Properties.envOrNone("CORE_PROTOC_EXEC_PATH")
       if (connectProtocExecPath.isDefined && connectPluginExecPath.isDefined) {
         sys.props.put("connect.protoc.executable.path", connectProtocExecPath.get)
         sys.props.put("connect.plugin.executable.path", connectPluginExecPath.get)
       }
       if (protobufProtocExecPath.isDefined) {
         sys.props.put("protobuf.protoc.executable.path", protobufProtocExecPath.get)
+      }
+      if (coreProtocExecPath.isDefined) {
+        sys.props.put("core.protoc.executable.path", coreProtocExecPath.get)
       }
     }
     profiles
@@ -644,7 +648,16 @@ object Core {
       val propsFile = baseDirectory.value / "target" / "extra-resources" / "spark-version-info.properties"
       Seq(propsFile)
     }.taskValue
-  )
+  ) ++ {
+    val coreProtocExecPath = sys.props.get("core.protoc.executable.path")
+    if (coreProtocExecPath.isDefined) {
+      Seq(
+        PB.protocExecutable := file(coreProtocExecPath.get)
+      )
+    } else {
+      Seq.empty
+    }
+  }
 }
 
 object SparkConnectCommon {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR use profile named `-Puser-defined-protoc` to support that users can build and test `core` module by specifying custom `protoc` executables.


### Why are the changes needed?
As described in [SPARK-41461](https://issues.apache.org/jira/browse/SPARK-41461), the latest versions of `protoc` have the minimum version requirements for basic libraries such as `glibc` and `glibcxx`. Because of that it is not possible to compile the `core` module out of the box on CentOS 6 or CentOS 7. Instead the following error messages is shown:
```
[ERROR] /home/disk1/spark-ut/spark/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto [0:0]: /tmp/protoc5792311590243222147.exe: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /tmp/protoc5792311590243222147.exe)
[ERROR] /home/disk1/spark-ut/spark/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto [0:0]: /tmp/protoc5792311590243222147.exe: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.18' not found (required by /tmp/protoc5792311590243222147.exe)
[ERROR] /home/disk1/spark-ut/spark/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto [0:0]: /tmp/protoc5792311590243222147.exe: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.14' not found (required by /tmp/protoc5792311590243222147.exe)
[ERROR] /home/disk1/spark-ut/spark/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto [0:0]: /tmp/protoc5792311590243222147.exe: /usr/lib64/libstdc++.so.6: version `CXXABI_1.3.5' not found (required by /tmp/protoc5792311590243222147.exe)
```


### Does this PR introduce _any_ user-facing change?
No, the way to using official pre-release `protoc` binary files is activated by default.


### How was this patch tested?
- Pass GitHub Actions
- Manual test on CentOS6u3 and CentOS7u4
```bash
export CORE_PROTOC_EXEC_PATH=/path-to-protoc-exe
./build/mvn clean install -pl core -Puser-defined-protoc -am -DskipTests -DskipDefaultProtoc
./build/mvn clean test -pl core -Puser-defined-protoc -DskipDefaultProtoc
```
and
```bash
export CORE_PROTOC_EXEC_PATH=/path-to-protoc-exe
./build/sbt clean "core/compile" -Puser-defined-protoc
./build/sbt "core/test" -Puser-defined-protoc
```