### PR TITLE
[SPARK-41402][SQL][CONNECT] Override prettyName of StringDecode

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -4095,37 +4095,36 @@ def concat_ws(sep: str, *cols: "ColumnOrName") -> Column:
     return _invoke_function("concat_ws", lit(sep), *[_to_col(c) for c in cols])
 
 
-# TODO: enable with SPARK-41402
-# def decode(col: "ColumnOrName", charset: str) -> Column:
-#     """
-#     Computes the first argument into a string from a binary using the provided character set
-#     (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
-#
-#     .. versionadded:: 3.4.0
-#
-#     Parameters
-#     ----------
-#     col : :class:`~pyspark.sql.Column` or str
-#         target column to work on.
-#     charset : str
-#         charset to use to decode to.
-#
-#     Returns
-#     -------
-#     :class:`~pyspark.sql.Column`
-#         the column for computed results.
-#
-#     Examples
-#     --------
-#     >>> df = spark.createDataFrame([('abcd',)], ['a'])
-#     >>> df.select(decode("a", "UTF-8")).show()
-#     +----------------------+
-#     |stringdecode(a, UTF-8)|
-#     +----------------------+
-#     |                  abcd|
-#     +----------------------+
-#     """
-#     return _invoke_function("decode", _to_col(col), lit(charset))
+def decode(col: "ColumnOrName", charset: str) -> Column:
+    """
+    Computes the first argument into a string from a binary using the provided character set
+    (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
+
+    .. versionadded:: 3.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to work on.
+    charset : str
+        charset to use to decode to.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column for computed results.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([('abcd',)], ['a'])
+    >>> df.select(decode("a", "UTF-8")).show()
+    +----------------+
+    |decode(a, UTF-8)|
+    +----------------+
+    |            abcd|
+    +----------------+
+    """
+    return _invoke_function("decode", _to_col(col), lit(charset))
 
 
 def encode(col: "ColumnOrName", charset: str) -> Column:

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -5560,11 +5560,11 @@ def decode(col: "ColumnOrName", charset: str) -> Column:
     --------
     >>> df = spark.createDataFrame([('abcd',)], ['a'])
     >>> df.select(decode("a", "UTF-8")).show()
-    +----------------------+
-    |stringdecode(a, UTF-8)|
-    +----------------------+
-    |                  abcd|
-    +----------------------+
+    +----------------+
+    |decode(a, UTF-8)|
+    +----------------+
+    |            abcd|
+    +----------------+
     """
     return _invoke_function("decode", _to_java_column(col), charset)
 

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -623,22 +623,10 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
             sdf.select(SF.concat_ws("-", sdf.a, "c")).toPandas(),
         )
 
-        # Disable the test for "decode" because of inconsistent column names,
-        # as shown below
-        #
-        # >>> sdf.select(SF.decode("c", "UTF-8")).toPandas()
-        # stringdecode(c, UTF-8)
-        # 0                   None
-        # 1                     ab
-        # >>> cdf.select(CF.decode("c", "UTF-8")).toPandas()
-        # decode(c, UTF-8)
-        # 0             None
-        # 1               ab
-        #
-        # self.assert_eq(
-        #     cdf.select(CF.decode("c", "UTF-8")).toPandas(),
-        #     sdf.select(SF.decode("c", "UTF-8")).toPandas(),
-        # )
+        self.assert_eq(
+            cdf.select(CF.decode("c", "UTF-8")).toPandas(),
+            sdf.select(SF.decode("c", "UTF-8")).toPandas(),
+        )
 
         self.assert_eq(
             cdf.select(CF.encode("c", "UTF-8")).toPandas(),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2552,6 +2552,8 @@ case class StringDecode(bin: Expression, charset: Expression)
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): StringDecode =
     copy(bin = newLeft, charset = newRight)
+
+  override def prettyName: String = "decode"
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to change `prettyName` of `StringDecode` to `decode` to keep the name as was. It was changed from SPARK-33527.

Note that I don't change `nodeName` here to keep the strings in the plan to differentiate `Decode` from `StringDecode`.

### Why are the changes needed?

This is technically a beahviour change (or regression) from SPARK-33527 although we don't guarantee the compatibility there.

### Does this PR introduce _any_ user-facing change?

Yes, it changes the default output column name from `stringdecode` to `decode`.

### How was this patch tested?

Relates unittests were fixed together.
