### PR TITLE
[SPARK-40270][PS][FOLLOWUP] Skip test_style when pandas <1.3.0

### DIFF
--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -7076,7 +7076,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
     @unittest.skipIf(
         LooseVersion(pd.__version__) < LooseVersion("1.3.0"),
-        "pandas support `Styler.to_latex` since 1.3.0"
+        "pandas support `Styler.to_latex` since 1.3.0",
     )
     def test_style(self):
         # Currently, the `style` function returns a pandas object `Styler` as it is,

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -7074,6 +7074,10 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         psdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.cov(), psdf.cov())
 
+    @unittest.skipIf(
+        LooseVersion(pd.__version__) < LooseVersion("1.3.0"),
+        "pandas support `Styler.to_latex` since 1.3.0"
+    )
     def test_style(self):
         # Currently, the `style` function returns a pandas object `Styler` as it is,
         # processing only the number of rows declared in `compute.max_rows`.


### PR DESCRIPTION
### What changes were proposed in this pull request?
According to https://pandas.pydata.org/docs/reference/api/pandas.io.formats.style.Styler.to_latex.html:
`pandas.io.formats.style.Styler.to_latex` introduced since 1.3.0, so before panda 1.3.0, should skip the check

```
ERROR [0.180s]: test_style (pyspark.pandas.tests.test_dataframe.DataFrameTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/pandas/tests/test_dataframe.py", line 5795, in test_style
    check_style()
  File "/__w/spark/spark/python/pyspark/pandas/tests/test_dataframe.py", line 5793, in check_style
    self.assert_eq(pdf_style.to_latex(), psdf_style.to_latex())
AttributeError: 'Styler' object has no attribute 'to_latex'
```

Related: https://github.com/apache/spark/commit/58375a86e6ff49c5bcee49939fbd98eb848ae59f

### Why are the changes needed?
This test break the 3.2 branch pyspark test (with python 3.6 + pandas 1.1.x), so I think better add the `skipIf` it.

See also https://github.com/apache/spark/pull/38982#issuecomment-1343923114


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- CI passed
- Test on 3.2 branch: https://github.com/Yikun/spark/pull/194, https://github.com/Yikun/spark/actions/runs/3655564439/jobs/6177030747