### PR TITLE
[SPARK-41475][CONNECT] Fix lint-scala command error and typo

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -38,9 +38,10 @@ private[spark] object Connect {
 
   val CONNECT_GRPC_ARROW_MAX_BATCH_SIZE =
     ConfigBuilder("spark.connect.grpc.arrow.maxBatchSize")
-      .doc("When using Apache Arrow, limit the maximum size of one arrow batch that " +
-        "can be sent from server side to client side. Currently, we conservatively use 70% " +
-        "of it because the size is not accurate but estimated.")
+      .doc(
+        "When using Apache Arrow, limit the maximum size of one arrow batch that " +
+          "can be sent from server side to client side. Currently, we conservatively use 70% " +
+          "of it because the size is not accurate but estimated.")
       .version("3.4.0")
       .bytesConf(ByteUnit.MiB)
       .createWithDefaultString("4m")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -322,8 +322,7 @@ class SparkConnectPlanner(session: SparkSession) {
         None,
         rel.getVariableColumnName,
         Seq(rel.getValueColumnName),
-        transformRelation(rel.getInput)
-      )
+        transformRelation(rel.getInput))
     } else {
       val values = rel.getValuesList.asScala.toArray.map { expr =>
         Column(transformExpression(expr))
@@ -335,8 +334,7 @@ class SparkConnectPlanner(session: SparkSession) {
         None,
         rel.getVariableColumnName,
         Seq(rel.getValueColumnName),
-        transformRelation(rel.getInput)
-      )
+        transformRelation(rel.getInput))
     }
   }
 

--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -29,14 +29,14 @@ ERRORS=$(./build/mvn \
     -Dscalafmt.skip=false \
     -Dscalafmt.validateOnly=true \
     -Dscalafmt.changedOnly=false \
-    -pl connector/connect \
+    -pl connector/connect/server \
     2>&1 | grep -e "^Requires formatting" \
 )
 
 if test ! -z "$ERRORS"; then
   echo -e "The scalafmt check failed on connector/connect at following occurrences:\n\n$ERRORS\n"
   echo "Before submitting your change, please make sure to format your code using the following command:"
-  echo "./build/mvn -Pscala-2.12 scalafmt:format -Dscalafmt.skip=fase -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect"
+  echo "./build/mvn -Pscala-2.12 scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect/server"
   exit 1
 else
   echo -e "Scalafmt checks passed."


### PR DESCRIPTION
### What changes were proposed in this pull request?
We separate connect into server and common, but failed to update the `lint-scala` tools.
fix a typo: fase -> false
format the code.


### Why are the changes needed?
We can check the scala code format without it.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No
