### PR TITLE
[SPARK-41474][PROTOBUF][BUILD] Exclude `proto` files from `spark-protobuf` jar

### DIFF
--- a/connector/protobuf/pom.xml
+++ b/connector/protobuf/pom.xml
@@ -107,6 +107,14 @@
               </includes>
             </relocation>
           </relocations>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>google/protobuf/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `.proto` files from `spark-protobuf` JAR file.

### Why are the changes needed?

The `proto` files are not used.

**BEFORE**
```
$ jar tvf target/spark-protobuf_2.12-3.4.0-SNAPSHOT.jar | grep '\.proto$'
  5909 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/any.proto
  7734 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/api.proto
  8754 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/compiler/plugin.proto
 38497 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/descriptor.proto
  4895 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/duration.proto
  2363 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/empty.proto
  8185 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/field_mask.proto
  2341 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/source_context.proto
  3779 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/struct.proto
  6459 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/timestamp.proto
  6126 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/type.proto
  4042 Wed Oct 26 17:25:38 PDT 2022 google/protobuf/wrappers.proto
```

**AFTER**
```
$ jar tvf target/spark-protobuf_2.12-3.4.0-SNAPSHOT.jar | grep '\.proto$'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually check the jar file contents.