### PR TITLE
[SPARK-41476][INFRA] Prevent `README.md` from triggering CIs

### DIFF
--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -84,7 +84,7 @@ def identify_changed_files_from_git_commits(patch_sha, target_branch=None, targe
         ["git", "diff", "--name-only", patch_sha, diff_target], universal_newlines=True
     )
     # Remove any empty strings
-    return [f for f in raw_output.split("\n") if f]
+    return [f for f in raw_output.split("\n") if f and not f.endswith('README.md')]
 
 
 def determine_modules_to_test(changed_modules, deduplicated=True):

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -34,18 +34,21 @@ def determine_modules_for_files(filenames):
     Given a list of filenames, return the set of modules that contain those files.
     If a file is not associated with a more specific submodule, then this method will consider that
     file to belong to the 'root' module. `.github` directory is counted only in GitHub Actions,
-    and `appveyor.yml` is always ignored because this file is dedicated only to AppVeyor builds.
+    and `appveyor.yml` is always ignored because this file is dedicated only to AppVeyor builds,
+    and `README.md` is always ignored too.
 
     >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
     ['pyspark-core', 'sql']
     >>> [x.name for x in determine_modules_for_files(["file_not_matched_by_any_subproject"])]
     ['root']
-    >>> [x.name for x in determine_modules_for_files(["appveyor.yml"])]
+    >>> [x.name for x in determine_modules_for_files(["appveyor.yml", "sql/README.md"])]
     []
     """
     changed_modules = set()
     for filename in filenames:
         if filename in ("appveyor.yml",):
+            continue
+        if filename.endswith("README.md"):
             continue
         if ("GITHUB_ACTIONS" not in os.environ) and filename.startswith(".github"):
             continue
@@ -84,7 +87,7 @@ def identify_changed_files_from_git_commits(patch_sha, target_branch=None, targe
         ["git", "diff", "--name-only", patch_sha, diff_target], universal_newlines=True
     )
     # Remove any empty strings
-    return [f for f in raw_output.split("\n") if f and not f.endswith("README.md")]
+    return [f for f in raw_output.split("\n") if f]
 
 
 def determine_modules_to_test(changed_modules, deduplicated=True):

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -84,7 +84,7 @@ def identify_changed_files_from_git_commits(patch_sha, target_branch=None, targe
         ["git", "diff", "--name-only", patch_sha, diff_target], universal_newlines=True
     )
     # Remove any empty strings
-    return [f for f in raw_output.split("\n") if f and not f.endswith('README.md')]
+    return [f for f in raw_output.split("\n") if f and not f.endswith("README.md")]
 
 
 def determine_modules_to_test(changed_modules, deduplicated=True):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR prevents `README.md`-only changes from triggering CIs.

### Why are the changes needed?

While CIs go slower and slower, we are also getting more and more `README.md` files.
```
$ find . -name 'README.md'
./resource-managers/kubernetes/integration-tests/README.md
./core/src/main/resources/error/README.md
./core/src/main/scala/org/apache/spark/deploy/security/README.md
./hadoop-cloud/README.md
./python/README.md
./R/pkg/README.md
./docs/README.md
./README.md
./common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
./common/tags/README.md
./connector/docker/README.md
./connector/docker/spark-test/README.md
./connector/connect/README.md
./connector/protobuf/README.md
./dev/README.md
./dev/ansible-for-test-node/roles/common/README.md
./dev/ansible-for-test-node/roles/jenkins-worker/README.md
./dev/ansible-for-test-node/README.md
./sql/core/src/test/README.md
./sql/core/src/main/scala/org/apache/spark/sql/test/README.md
./sql/core/src/main/scala/org/apache/spark/sql/jdbc/README.md
./sql/README.md
```

We can exclude these files in order to save the community CI resources.
https://github.com/apache/spark/blob/435f6b1b3588d8c3c719f0e23b91209dd5f7bdb9/.github/workflows/build_and_test.yml#L86-L89

### Does this PR introduce _any_ user-facing change?

No. This is an infra-only change.

### How was this patch tested?

Pass the doctest.
```
python -m doctest sparktestsupport/utils.py
```