### PR TITLE
[SPARK-41477][CONNECT][PYTHON] Correctly infer the datatype of literal integers

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -32,6 +32,12 @@ if TYPE_CHECKING:
     import pyspark.sql.connect.proto as proto
 
 
+JVM_INT_MIN = -(1 << 31)
+JVM_INT_MAX = (1 << 31) - 1
+JVM_LONG_MIN = -(1 << 63)
+JVM_LONG_MAX = (1 << 63) - 1
+
+
 def _func_op(name: str, doc: str = "") -> Callable[["Column"], "Column"]:
     def _(self: "Column") -> "Column":
         return scalar_function(name, self)
@@ -180,9 +186,9 @@ class LiteralExpression(Expression):
         elif isinstance(self._value, bool):
             expr.literal.boolean = bool(self._value)
         elif isinstance(self._value, int):
-            if -2147483648 <= self._value <= 2147483647:
+            if JVM_INT_MIN <= self._value <= JVM_INT_MAX:
                 expr.literal.integer = int(self._value)
-            elif -9223372036854775808 <= self._value <= 9223372036854775807:
+            elif JVM_LONG_MIN <= self._value <= JVM_LONG_MAX:
                 expr.literal.long = int(self._value)
             else:
                 raise ValueError(f"integer {self._value} out of bounds")

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -180,7 +180,12 @@ class LiteralExpression(Expression):
         elif isinstance(self._value, bool):
             expr.literal.boolean = bool(self._value)
         elif isinstance(self._value, int):
-            expr.literal.long = int(self._value)
+            if -2147483648 <= self._value <= 2147483647:
+                expr.literal.integer = int(self._value)
+            elif -9223372036854775808 <= self._value <= 9223372036854775807:
+                expr.literal.long = int(self._value)
+            else:
+                raise ValueError(f"integer {self._value} out of bounds")
         elif isinstance(self._value, float):
             expr.literal.double = float(self._value)
         elif isinstance(self._value, str):

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -99,39 +99,34 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
         from pyspark.sql import functions as SF
         from pyspark.sql.connect import functions as CF
-
-        int_min = -2147483648
-        int_max = 2147483647
-
-        long_min = -9223372036854775808
-        long_max = 9223372036854775807
+        from pyspark.sql.connect.column import JVM_INT_MIN, JVM_INT_MAX, JVM_LONG_MIN, JVM_LONG_MAX
 
         cdf1 = cdf.select(
             CF.lit(0),
             CF.lit(1),
             CF.lit(-1),
-            CF.lit(int_max),
-            CF.lit(int_min),
-            CF.lit(int_max + 1),
-            CF.lit(int_min - 1),
-            CF.lit(long_max),
-            CF.lit(long_min),
-            CF.lit(long_max - 1),
-            CF.lit(long_min + 1),
+            CF.lit(JVM_INT_MAX),
+            CF.lit(JVM_INT_MIN),
+            CF.lit(JVM_INT_MAX + 1),
+            CF.lit(JVM_INT_MIN - 1),
+            CF.lit(JVM_LONG_MAX),
+            CF.lit(JVM_LONG_MIN),
+            CF.lit(JVM_LONG_MAX - 1),
+            CF.lit(JVM_LONG_MIN + 1),
         )
 
         sdf1 = sdf.select(
             SF.lit(0),
             SF.lit(1),
             SF.lit(-1),
-            SF.lit(int_max),
-            SF.lit(int_min),
-            SF.lit(int_max + 1),
-            SF.lit(int_min - 1),
-            SF.lit(long_max),
-            SF.lit(long_min),
-            SF.lit(long_max - 1),
-            SF.lit(long_min + 1),
+            SF.lit(JVM_INT_MAX),
+            SF.lit(JVM_INT_MIN),
+            SF.lit(JVM_INT_MAX + 1),
+            SF.lit(JVM_INT_MIN - 1),
+            SF.lit(JVM_LONG_MAX),
+            SF.lit(JVM_LONG_MIN),
+            SF.lit(JVM_LONG_MAX - 1),
+            SF.lit(JVM_LONG_MIN + 1),
         )
 
         self.assertEqual(cdf1.schema, sdf1.schema)
@@ -141,13 +136,13 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             ValueError,
             "integer 9223372036854775808 out of bounds",
         ):
-            cdf.select(CF.lit(long_max + 1)).show()
+            cdf.select(CF.lit(JVM_LONG_MAX + 1)).show()
 
         with self.assertRaisesRegex(
             ValueError,
             "integer -9223372036854775809 out of bounds",
         ):
-            cdf.select(CF.lit(long_min - 1)).show()
+            cdf.select(CF.lit(JVM_LONG_MIN - 1)).show()
 
     def test_cast(self):
         df = self.connect.read.table(self.tbl_name)

--- a/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
@@ -70,7 +70,7 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
         map_lit_p = map_lit.to_plan(None)
         self.assertEqual(2, len(map_lit_p.literal.map.pairs))
         self.assertEqual("this", map_lit_p.literal.map.pairs[0].key.string)
-        self.assertEqual(12, map_lit_p.literal.map.pairs[1].key.long)
+        self.assertEqual(12, map_lit_p.literal.map.pairs[1].key.integer)
 
         val = {"this": fun.lit("is"), 12: [12, 32, 43]}
         map_lit = fun.lit(val)
@@ -91,7 +91,10 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
 
         self.assertIsNotNone(fun.lit(10).to_plan(None))
         plan = fun.lit(10).to_plan(None)
-        self.assertIs(plan.literal.long, 10)
+        self.assertIs(plan.literal.integer, 10)
+
+        plan = fun.lit(1 << 33).to_plan(None)
+        self.assertIs(plan.literal.long, 1 << 33)
 
     def test_numeric_literal_types(self):
         int_lit = fun.lit(10)
@@ -169,13 +172,13 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
         p2 = fun.lit(t2).to_plan(None)
         self.assertIsNotNone(p2)
         self.assertTrue(p2.literal.HasField("struct"))
-        self.assertEqual(p2.literal.struct.fields[0].long, 1)
+        self.assertEqual(p2.literal.struct.fields[0].integer, 1)
         self.assertEqual(p2.literal.struct.fields[1].string, "xyz")
 
         p3 = fun.lit(t3).to_plan(None)
         self.assertIsNotNone(p3)
         self.assertTrue(p3.literal.HasField("struct"))
-        self.assertEqual(p3.literal.struct.fields[0].long, 1)
+        self.assertEqual(p3.literal.struct.fields[0].integer, 1)
         self.assertEqual(p3.literal.struct.fields[1].string, "abc")
         self.assertEqual(p3.literal.struct.fields[2].struct.fields[0].double, 3.5)
         self.assertEqual(p3.literal.struct.fields[2].struct.fields[1].boolean, True)
@@ -209,7 +212,7 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
         lit_fun = expr_plan.unresolved_function.arguments[1]
         self.assertIsInstance(lit_fun, ProtoExpression)
         self.assertIsInstance(lit_fun.literal, ProtoExpression.Literal)
-        self.assertEqual(lit_fun.literal.long, 10)
+        self.assertEqual(lit_fun.literal.integer, 10)
 
         mod_fun = expr_plan.unresolved_function.arguments[0]
         self.assertIsInstance(mod_fun, ProtoExpression)

--- a/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column_expressions.py
@@ -94,7 +94,7 @@ class SparkConnectColumnExpressionSuite(PlanOnlyTestFixture):
         self.assertIs(plan.literal.integer, 10)
 
         plan = fun.lit(1 << 33).to_plan(None)
-        self.assertIs(plan.literal.long, 1 << 33)
+        self.assertEqual(plan.literal.long, 1 << 33)
 
     def test_numeric_literal_types(self):
         int_lit = fun.lit(10)


### PR DESCRIPTION
### What changes were proposed in this pull request?
check the bounds of integer and choose the correct datatypes


### Why are the changes needed?
to match pyspark:

```

In [15]: int_max = 2147483647

In [16]: long_max = 9223372036854775807

In [17]: sdf = spark.range(0, 1)

In [18]: sdf.select(lit(0), lit(int_max), lit(int_max + 1), lit(long_max))
Out[18]: DataFrame[0: int, 2147483647: int, 2147483648: bigint, 9223372036854775807: bigint]

In [19]: sdf.select(lit(0), lit(int_max), lit(int_max + 1), lit(long_max), lit(long_max + 1))
---------------------------------------------------------------------------
Py4JError                                 Traceback (most recent call last)
Cell In[19], line 1
----> 1 sdf.select(lit(0), lit(int_max), lit(int_max + 1), lit(long_max), lit(long_max + 1))

File ~/Dev/spark/python/pyspark/sql/functions.py:179, in lit(col)
    177     if dt is not None:
    178         return _invoke_function("lit", col).astype(dt)
--> 179 return _invoke_function("lit", col)

File ~/Dev/spark/python/pyspark/sql/functions.py:88, in _invoke_function(name, *args)
     86 assert SparkContext._active_spark_context is not None
     87 jf = _get_jvm_function(name, SparkContext._active_spark_context)
---> 88 return Column(jf(*args))

...

File ~/Dev/spark/python/pyspark/sql/utils.py:199, in capture_sql_exception.<locals>.deco(*a, **kw)
    197 def deco(*a: Any, **kw: Any) -> Any:
    198     try:
--> 199         return f(*a, **kw)
    200     except Py4JJavaError as e:
    201         converted = convert_exception(e.java_exception)

File ~/Dev/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/protocol.py:330, in get_return_value(answer, gateway_client, target_id, name)
    326         raise Py4JJavaError(
    327             "An error occurred while calling {0}{1}{2}.\n".
    328             format(target_id, ".", name), value)
    329     else:
--> 330         raise Py4JError(
    331             "An error occurred while calling {0}{1}{2}. Trace:\n{3}\n".
    332             format(target_id, ".", name, value))
    333 else:
    334     raise Py4JError(
    335         "An error occurred while calling {0}{1}{2}".
    336         format(target_id, ".", name))

Py4JError: An error occurred while calling z:org.apache.spark.sql.functions.lit. Trace:
java.lang.NumberFormatException: For input string: "9223372036854775808"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)

```



### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added ut