### PR TITLE
[SPARK-41439][CONNECT][PYTHON][FOLLOWUP] Make unpivot of `connect/dataframe.py` consistent with `pyspark/dataframe.py`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -826,8 +826,8 @@ class DataFrame(object):
 
     def unpivot(
         self,
-        ids: List["ColumnOrName"],
-        values: List["ColumnOrName"],
+        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
+        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
         variableColumnName: str,
         valueColumnName: str,
     ) -> "DataFrame":
@@ -852,8 +852,24 @@ class DataFrame(object):
         -------
         :class:`DataFrame`
         """
+
+        def to_jcols(
+            cols: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]]
+        ) -> List["ColumnOrName"]:
+            if cols is None:
+                lst = []
+            elif isinstance(cols, tuple):
+                lst = list(cols)
+            elif isinstance(cols, list):
+                lst = cols
+            else:
+                lst = [cols]
+            return lst
+
         return DataFrame.withPlan(
-            plan.Unpivot(self._plan, ids, values, variableColumnName, valueColumnName),
+            plan.Unpivot(
+                self._plan, to_jcols(ids), to_jcols(values), variableColumnName, valueColumnName
+            ),
             self._session,
         )
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -783,6 +783,29 @@ class SparkConnectTests(SparkConnectSQLTestCase):
                 """Cannot resolve column name "x" among (a, b, c)""", str(context.exception)
             )
 
+    def test_unpivot(self):
+        self.assert_eq(
+            self.connect.read.table(self.tbl_name)
+            .filter("id > 3")
+            .unpivot(["id"], ["name"], "variable", "value")
+            .toPandas(),
+            self.spark.read.table(self.tbl_name)
+            .filter("id > 3")
+            .unpivot(["id"], ["name"], "variable", "value")
+            .toPandas(),
+        )
+
+        self.assert_eq(
+            self.connect.read.table(self.tbl_name)
+            .filter("id > 3")
+            .unpivot("id", None, "variable", "value")
+            .toPandas(),
+            self.spark.read.table(self.tbl_name)
+            .filter("id > 3")
+            .unpivot("id", None, "variable", "value")
+            .toPandas(),
+        )
+
     def test_with_columns(self):
         # SPARK-41256: test withColumn(s).
         self.assert_eq(

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -189,7 +189,7 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
 
         plan = (
             df.filter(df.col_name > 3)
-            .unpivot(["id"], [], "variable", "value")
+            .unpivot(["id"], None, "variable", "value")
             ._plan.to_proto(self.connect)
         )
         self.assertTrue(len(plan.root.unpivot.ids) == 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR lets `unpivot` of `connect/dataframe.py` consistent with `pyspark/dataframe.py` and adds test cases for connect's `unpivot`.

This PR follows up https://github.com/apache/spark/pull/38973

### Why are the changes needed?
1. Lets `unpivot` of `connect/dataframe.py` consistent with `pyspark/dataframe.py`
2. Add test cases for connect's `unpivot`.


### Does this PR introduce _any_ user-facing change?
'No'. New API


### How was this patch tested?
New test cases.
