### PR TITLE
[SPARK-41480][SQL][DOCS] Update documentation for input_file_name

### DIFF
--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -4784,7 +4784,7 @@ setMethod("grouping_id",
           })
 
 #' @details
-#' \code{input_file_name}: Creates a string column with the input file name for a given row.
+#' \code{input_file_name}: Creates a string column with the URI encoded input file name for a given row.
 #' The method should be used with no argument.
 #'
 #' @rdname column_nonaggregate_functions

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -283,7 +283,7 @@ def greatest(*cols: "ColumnOrName") -> Column:
 
 def input_file_name() -> Column:
     """
-    Creates a string column for the file name of the current Spark task.
+    Creates a string column for the URI encoded file name of the current Spark task.
 
     .. versionadded:: 3.4.0
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2693,7 +2693,7 @@ def grouping_id(*cols: "ColumnOrName") -> Column:
 
 def input_file_name() -> Column:
     """
-    Creates a string column for the file name of the current Spark task.
+    Creates a string column for the URI encoded file name of the current Spark task.
 
     .. versionadded:: 1.6.0
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/inputFileBlock.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/inputFileBlock.scala
@@ -26,7 +26,9 @@ import org.apache.spark.unsafe.types.UTF8String
 
 // scalastyle:off whitespace.end.of.line
 @ExpressionDescription(
-  usage = "_FUNC_() - Returns the name of the file being read, or empty string if not available.",
+  usage =
+    "_FUNC_() - Returns the URI encoded name of the file being read," +
+      " or empty string if not available.",
   examples = """
     Examples:
       > SELECT _FUNC_();

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1273,7 +1273,7 @@ object functions {
   def coalesce(e: Column*): Column = withExpr { Coalesce(e.map(_.expr)) }
 
   /**
-   * Creates a string column for the file name of the current Spark task.
+   * Creates a string column for the URI encoded file name of the current Spark task.
    *
    * @group normal_funcs
    * @since 1.6.0


### PR DESCRIPTION
`input_file_name()` returns the URI encoded file name ([the string](https://github.com/apache/spark/blob/69aa727ff495f6698fe9b37e952dfaf36f1dd5eb/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/inputFileBlock.scala#L49) `input_file_name()` is based on always comes from a [Hadoop Path](https://github.com/apache/spark/blob/f8277d3aa308d267ff0423f85ffd884480cedf59/core/src/main/scala/org/apache/spark/rdd/HadoopRDD.scala#L255)/[URI encoded path](https://github.com/apache/spark/blob/0d91f9c3f3f1e756e1ae02cb0e166385163026ea/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FilePartitionReader.scala#L104)). Update the documentation to reflect this.