### PR TITLE
[MINOR][PYTHON][DOCS] Correct the type hint for `from_csv`

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -8036,7 +8036,7 @@ def sequence(
 
 def from_csv(
     col: "ColumnOrName",
-    schema: Union[StructType, Column, str],
+    schema: Union[Column, str],
     options: Optional[Dict[str, str]] = None,
 ) -> Column:
     """


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct the type hint for `from_csv`


### Why are the changes needed?
`from_csv` actually does not support `StructType` for now

https://github.com/apache/spark/blob/master/python/pyspark/sql/functions.py#L8084-L8090


### Does this PR introduce _any_ user-facing change?
the generated doc

### How was this patch tested?
existing UT
