### PR TITLE
[SPARK-41504][K8S][R][TESTS] Update R version to 4.1.2 in Dockerfile comment

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
@@ -25,7 +25,7 @@ USER 0
 
 RUN mkdir ${SPARK_HOME}/R
 
-# Install R 4.0.4 (http://cloud.r-project.org/bin/linux/debian/)
+# Install R 4.1.2 (http://cloud.r-project.org/bin/linux/debian/)
 RUN \
   apt-get update && \
   apt install -y r-base r-base-dev && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update R version number comment from 4.0.4 to 4.1.2 in R Dockerfile.

### Why are the changes needed?

Apache Spark 3.3 used `R 4.0.4`, but Apache Spark 3.4 is using `R 4.1.2` in master branch.
```
$ docker run -it --rm apache/spark-r:3.3.1 R --version | grep 'R version'
R version 4.0.4 (2021-02-15) -- "Lost Library Book"
```

```
$ docker run -it --rm kubespark/spark-r:dev R --version | grep 'R version'
R version 4.1.2 (2021-11-01) -- "Bird Hippie"
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- GitHub Action logs show it.
    - https://github.com/apache/spark/actions/runs/3681318787/jobs/6227888255
```
Get:304 http://archive.ubuntu.com/ubuntu jammy/universe amd64 r-base-core amd64 4.1.2-1ubuntu2 [26.0 MB]
```