### PR TITLE
[SPARK-41507][SQL] Correct group of collection_funcs and fix description of `ExpressionDescription#group`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionDescription.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionDescription.java
@@ -109,9 +109,9 @@ public @interface ExpressionDescription {
     String note() default "";
     /**
      * Valid group names are almost the same with one defined as `groupname` in
-     * `sql/functions.scala`. But, `collection_funcs` is split into fine-grained three groups:
-     * `array_funcs`, `map_funcs`, and `json_funcs`. See `ExpressionInfo` for the
-     * detailed group names.
+     * `sql/functions.scala`. But, `collection_funcs` is split into fine-grained six groups:
+     * `array_funcs`, `map_funcs`, `generator_funcs`, `lambda_funcs`, `csv_funcs` and `json_funcs`.
+     * See `ExpressionInfo` for the detailed group names.
      */
     String group() default "";
     String since() default "";

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2482,7 +2482,7 @@ case class TryElementAt(left: Expression, right: Expression, replacement: Expres
   note = """
     Concat logic for arrays is available since 2.4.0.
   """,
-  group = "array_funcs",
+  group = "collection_funcs",
   since = "1.5.0")
 case class Concat(children: Seq[Expression]) extends ComplexTypeMergingExpression
   with QueryErrorsBase {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1212,7 +1212,7 @@ case class Shuffle(child: Expression, randomSeed: Option[Long] = None)
       > SELECT _FUNC_(array(2, 1, 4, 3));
        [3,4,1,2]
   """,
-  group = "array_funcs",
+  group = "collection_funcs",
   since = "1.5.0",
   note = """
     Reverse logic for arrays is available since 2.4.0.
@@ -2228,7 +2228,7 @@ case class Get(
        b
   """,
   since = "2.4.0",
-  group = "map_funcs")
+  group = "collection_funcs")
 case class ElementAt(
     left: Expression,
     right: Expression,
@@ -2452,7 +2452,7 @@ case class ElementAt(
        b
   """,
   since = "3.3.0",
-  group = "map_funcs")
+  group = "collection_funcs")
 case class TryElementAt(left: Expression, right: Expression, replacement: Expression)
   extends RuntimeReplaceable with InheritAnalysisRules {
   def this(left: Expression, right: Expression) =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1212,7 +1212,7 @@ case class Shuffle(child: Expression, randomSeed: Option[Long] = None)
       > SELECT _FUNC_(array(2, 1, 4, 3));
        [3,4,1,2]
   """,
-  group = "collection_funcs",
+  group = "array_funcs",
   since = "1.5.0",
   note = """
     Reverse logic for arrays is available since 2.4.0.
@@ -2482,7 +2482,7 @@ case class TryElementAt(left: Expression, right: Expression, replacement: Expres
   note = """
     Concat logic for arrays is available since 2.4.0.
   """,
-  group = "collection_funcs",
+  group = "array_funcs",
   since = "1.5.0")
 case class Concat(children: Seq[Expression]) extends ComplexTypeMergingExpression
   with QueryErrorsBase {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -158,7 +158,7 @@ object Size {
        4
   """,
   since = "3.3.0",
-  group = "collection_funcs")
+  group = "array_funcs")
 case class ArraySize(child: Expression)
   extends RuntimeReplaceable with ImplicitCastInputTypes with UnaryLike[Expression] {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change the function group in `collectionOperations.scala`:

-  ArraySize: `collection_funcs` -> `array_funcs` due to it only used for `Array`
- ElementAt: `array_funcs` -> `collection_funcs` due to it used for both `Array` and `Map`
- TryElementAt: `array_funcs` -> `collection_funcs` due to it used for both `Array` and `Map`

On the other hand, this pr corrects the description of `ExpressionDescription#group`, `collection_funcs` is divided into six sub-groups now:

- array_funcs
- csv_funcs
- generator_funcs
- json_funcs
- lambda_funcs
- map_funcs

### Why are the changes needed?
Correct group of collection_funcs




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions