### PR TITLE
[SPARK-41506][CONNECT][PYTHON] Refactor LiteralExpression to support DataType

### DIFF
--- a/connector/connect/common/src/main/protobuf/spark/connect/expressions.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/expressions.proto
@@ -77,9 +77,7 @@ message Expression {
       int32 year_month_interval = 20;
       int64 day_time_interval = 21;
 
-      Array array = 22;
-      Struct struct = 23;
-      Map map = 24;
+      DataType typed_null = 22;
     }
 
     // whether the literal type should be treated as a nullable type. Applies to
@@ -106,25 +104,6 @@ message Expression {
       int32 months = 1;
       int32 days = 2;
       int64 microseconds = 3;
-    }
-
-    message Struct {
-      // A possibly heterogeneously typed list of literals
-      repeated Literal fields = 1;
-    }
-
-    message Array {
-      // A homogeneously typed list of literals
-      repeated Literal values = 1;
-    }
-
-    message Map {
-      repeated Pair pairs = 1;
-
-      message Pair {
-        Literal key = 1;
-        Literal value = 2;
-      }
     }
   }
 

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -21,7 +21,24 @@ import json
 import decimal
 import datetime
 
-from pyspark.sql.types import TimestampType, DayTimeIntervalType, DataType, DateType
+from pyspark.sql.types import (
+    DateType,
+    NullType,
+    BooleanType,
+    BinaryType,
+    ByteType,
+    ShortType,
+    IntegerType,
+    LongType,
+    FloatType,
+    DoubleType,
+    DecimalType,
+    StringType,
+    DataType,
+    TimestampType,
+    TimestampNTZType,
+    DayTimeIntervalType,
+)
 
 import pyspark.sql.connect.proto as proto
 from pyspark.sql.connect.types import pyspark_types_to_proto_types
@@ -31,7 +48,10 @@ if TYPE_CHECKING:
     from pyspark.sql.connect.client import SparkConnectClient
     import pyspark.sql.connect.proto as proto
 
-
+JVM_BYTE_MIN = -(1 << 7)
+JVM_BYTE_MAX = (1 << 7) - 1
+JVM_SHORT_MIN = -(1 << 15)
+JVM_SHORT_MAX = (1 << 15) - 1
 JVM_INT_MIN = -(1 << 31)
 JVM_INT_MAX = (1 << 31) - 1
 JVM_LONG_MIN = -(1 << 63)
@@ -166,78 +186,147 @@ class LiteralExpression(Expression):
     The Python types are converted best effort into the relevant proto types. On the Spark Connect
     server side, the proto types are converted to the Catalyst equivalents."""
 
-    def __init__(self, value: Any) -> None:
+    def __init__(self, value: Any, dataType: DataType) -> None:
         super().__init__()
+
+        assert isinstance(
+            dataType,
+            (
+                NullType,
+                BinaryType,
+                BooleanType,
+                ByteType,
+                ShortType,
+                IntegerType,
+                LongType,
+                FloatType,
+                DoubleType,
+                DecimalType,
+                StringType,
+                DateType,
+                TimestampType,
+                TimestampNTZType,
+                DayTimeIntervalType,
+            ),
+        )
+
+        if isinstance(dataType, NullType):
+            assert value is None
+
+        if value is not None:
+            if isinstance(dataType, BinaryType):
+                assert isinstance(value, (bytes, bytearray))
+            elif isinstance(dataType, BooleanType):
+                assert isinstance(value, bool)
+            elif isinstance(dataType, ByteType):
+                assert isinstance(value, int) and JVM_BYTE_MIN <= int(value) <= JVM_BYTE_MAX
+            elif isinstance(dataType, ShortType):
+                assert isinstance(value, int) and JVM_SHORT_MIN <= int(value) <= JVM_SHORT_MAX
+            elif isinstance(dataType, IntegerType):
+                assert isinstance(value, int) and JVM_INT_MIN <= int(value) <= JVM_INT_MAX
+            elif isinstance(dataType, LongType):
+                assert isinstance(value, int) and JVM_LONG_MIN <= int(value) <= JVM_LONG_MAX
+            elif isinstance(dataType, FloatType):
+                assert isinstance(value, float)
+            elif isinstance(dataType, DoubleType):
+                assert isinstance(value, float)
+            elif isinstance(dataType, DecimalType):
+                assert isinstance(value, decimal.Decimal)
+            elif isinstance(dataType, StringType):
+                assert isinstance(value, str)
+            elif isinstance(dataType, DateType):
+                assert isinstance(value, (datetime.date, datetime.datetime))
+                if isinstance(value, datetime.date):
+                    value = DateType().toInternal(value)
+                else:
+                    value = DateType().toInternal(value.date())
+            elif isinstance(dataType, TimestampType):
+                assert isinstance(value, datetime.datetime)
+                value = TimestampType().toInternal(value)
+            elif isinstance(dataType, TimestampNTZType):
+                assert isinstance(value, datetime.datetime)
+                value = TimestampNTZType().toInternal(value)
+            elif isinstance(dataType, DayTimeIntervalType):
+                assert isinstance(value, datetime.timedelta)
+                value = DayTimeIntervalType().toInternal(value)
+                assert value is not None
+            else:
+                raise ValueError(f"Unsupported Data Type {dataType}")
+
         self._value = value
+        self._dataType = dataType
+
+    @classmethod
+    def _infer_type(cls, value: Any) -> DataType:
+        if value is None:
+            return NullType()
+        elif isinstance(value, (bytes, bytearray)):
+            return BinaryType()
+        elif isinstance(value, bool):
+            return BooleanType()
+        elif isinstance(value, int):
+            if JVM_INT_MIN <= value <= JVM_INT_MAX:
+                return IntegerType()
+            elif JVM_LONG_MIN <= value <= JVM_LONG_MAX:
+                return LongType()
+            else:
+                raise ValueError(f"integer {value} out of bounds")
+        elif isinstance(value, float):
+            return DoubleType()
+        elif isinstance(value, str):
+            return StringType()
+        elif isinstance(value, decimal.Decimal):
+            return DecimalType()
+        elif isinstance(value, datetime.datetime):
+            return TimestampType()
+        elif isinstance(value, datetime.date):
+            return DateType()
+        elif isinstance(value, datetime.timedelta):
+            return DayTimeIntervalType()
+        else:
+            raise ValueError(f"Unsupported Data Type {type(value).__name__}")
 
     def to_plan(self, session: "SparkConnectClient") -> "proto.Expression":
-        """Converts the literal expression to the literal in proto.
-
-        TODO(SPARK-40533) This method always assumes the largest type and can thus
-             create weird interpretations of the literal."""
-
-        from pyspark.sql.connect.functions import lit
+        """Converts the literal expression to the literal in proto."""
 
         expr = proto.Expression()
-        if self._value is None:
+
+        if isinstance(self._dataType, NullType):
             expr.literal.null = True
-        elif isinstance(self._value, (bytes, bytearray)):
+        elif self._value is None:
+            expr.typed_null.CopyFrom(pyspark_types_to_proto_types(self._dataType))
+        elif isinstance(self._dataType, BinaryType):
             expr.literal.binary = bytes(self._value)
-        elif isinstance(self._value, bool):
+        elif isinstance(self._dataType, BooleanType):
             expr.literal.boolean = bool(self._value)
-        elif isinstance(self._value, int):
-            if JVM_INT_MIN <= self._value <= JVM_INT_MAX:
-                expr.literal.integer = int(self._value)
-            elif JVM_LONG_MIN <= self._value <= JVM_LONG_MAX:
-                expr.literal.long = int(self._value)
-            else:
-                raise ValueError(f"integer {self._value} out of bounds")
-        elif isinstance(self._value, float):
+        elif isinstance(self._dataType, ByteType):
+            expr.literal.byte = int(self._value)
+        elif isinstance(self._dataType, ShortType):
+            expr.literal.short = int(self._value)
+        elif isinstance(self._dataType, IntegerType):
+            expr.literal.integer = int(self._value)
+        elif isinstance(self._dataType, LongType):
+            expr.literal.long = int(self._value)
+        elif isinstance(self._dataType, FloatType):
+            expr.literal.float = float(self._value)
+        elif isinstance(self._dataType, DoubleType):
             expr.literal.double = float(self._value)
-        elif isinstance(self._value, str):
-            expr.literal.string = str(self._value)
-        elif isinstance(self._value, decimal.Decimal):
+        elif isinstance(self._dataType, DecimalType):
             expr.literal.decimal.value = str(self._value)
-            expr.literal.decimal.precision = int(decimal.getcontext().prec)
-        elif isinstance(self._value, datetime.datetime):
-            expr.literal.timestamp = TimestampType().toInternal(self._value)
-        elif isinstance(self._value, datetime.date):
-            expr.literal.date = DateType().toInternal(self._value)
-        elif isinstance(self._value, datetime.timedelta):
-            interval = DayTimeIntervalType().toInternal(self._value)
-            assert interval is not None
-            expr.literal.day_time_interval = int(interval)
-        elif isinstance(self._value, list):
-            expr.literal.array.SetInParent()
-            for item in list(self._value):
-                if isinstance(item, Column):
-                    expr.literal.array.values.append(item.to_plan(session).literal)
-                else:
-                    expr.literal.array.values.append(lit(item).to_plan(session).literal)
-        elif isinstance(self._value, tuple):
-            expr.literal.struct.SetInParent()
-            for item in list(self._value):
-                if isinstance(item, Column):
-                    expr.literal.struct.fields.append(item.to_plan(session).literal)
-                else:
-                    expr.literal.struct.fields.append(lit(item).to_plan(session).literal)
-        elif isinstance(self._value, dict):
-            expr.literal.map.SetInParent()
-            for key, value in dict(self._value).items():
-                pair = proto.Expression.Literal.Map.Pair()
-                if isinstance(key, Column):
-                    pair.key.CopyFrom(key.to_plan(session).literal)
-                else:
-                    pair.key.CopyFrom(lit(key).to_plan(session).literal)
-                if isinstance(value, Column):
-                    pair.value.CopyFrom(value.to_plan(session).literal)
-                else:
-                    pair.value.CopyFrom(lit(value).to_plan(session).literal)
-                expr.literal.map.pairs.append(pair)
-        elif isinstance(self._value, Column):
-            expr.CopyFrom(self._value.to_plan(session))
+            expr.literal.decimal.precision = self._dataType.precision
+            expr.literal.decimal.scale = self._dataType.scale
+        elif isinstance(self._dataType, StringType):
+            expr.literal.string = str(self._value)
+        elif isinstance(self._dataType, DateType):
+            expr.literal.date = int(self._value)
+        elif isinstance(self._dataType, TimestampType):
+            expr.literal.timestamp = int(self._value)
+        elif isinstance(self._dataType, TimestampNTZType):
+            expr.literal.timestamp_ntz = int(self._value)
+        elif isinstance(self._dataType, DayTimeIntervalType):
+            expr.literal.day_time_interval = int(self._value)
         else:
-            raise ValueError(f"Could not convert literal for type {type(self._value)}")
+            raise ValueError(f"Unsupported Data Type {self._dataType}")
 
         return expr
 

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -92,8 +92,19 @@ column = col
 def lit(col: Any) -> Column:
     if isinstance(col, Column):
         return col
+    elif isinstance(col, list):
+        return array(*[lit(c) for c in col])
+    elif isinstance(col, tuple):
+        return struct(*[lit(c) for c in col])
+    elif isinstance(col, dict):
+        cols = []
+        for k, v in col.items():
+            cols.append(lit(k))
+            cols.append(lit(v))
+        return create_map(*cols)
     else:
-        return Column(LiteralExpression(col))
+        dataType = LiteralExpression._infer_type(col)
+        return Column(LiteralExpression(col, dataType))
 
 
 # def bitwiseNOT(col: "ColumnOrName") -> Column:

--- a/python/pyspark/sql/connect/proto/expressions_pb2.py
+++ b/python/pyspark/sql/connect/proto/expressions_pb2.py
@@ -33,7 +33,7 @@ from pyspark.sql.connect.proto import types_pb2 as spark_dot_connect_dot_types__
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1fspark/connect/expressions.proto\x12\rspark.connect\x1a\x19spark/connect/types.proto"\xf4\x14\n\nExpression\x12=\n\x07literal\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x07literal\x12\x62\n\x14unresolved_attribute\x18\x02 \x01(\x0b\x32-.spark.connect.Expression.UnresolvedAttributeH\x00R\x13unresolvedAttribute\x12_\n\x13unresolved_function\x18\x03 \x01(\x0b\x32,.spark.connect.Expression.UnresolvedFunctionH\x00R\x12unresolvedFunction\x12Y\n\x11\x65xpression_string\x18\x04 \x01(\x0b\x32*.spark.connect.Expression.ExpressionStringH\x00R\x10\x65xpressionString\x12S\n\x0funresolved_star\x18\x05 \x01(\x0b\x32(.spark.connect.Expression.UnresolvedStarH\x00R\x0eunresolvedStar\x12\x37\n\x05\x61lias\x18\x06 \x01(\x0b\x32\x1f.spark.connect.Expression.AliasH\x00R\x05\x61lias\x12\x34\n\x04\x63\x61st\x18\x07 \x01(\x0b\x32\x1e.spark.connect.Expression.CastH\x00R\x04\x63\x61st\x1a\x91\x01\n\x04\x43\x61st\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12-\n\x04type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x04type\x12\x1b\n\x08type_str\x18\x03 \x01(\tH\x00R\x07typeStrB\x0e\n\x0c\x63\x61st_to_type\x1a\xb2\x0b\n\x07Literal\x12\x14\n\x04null\x18\x01 \x01(\x08H\x00R\x04null\x12\x18\n\x06\x62inary\x18\x02 \x01(\x0cH\x00R\x06\x62inary\x12\x1a\n\x07\x62oolean\x18\x03 \x01(\x08H\x00R\x07\x62oolean\x12\x14\n\x04\x62yte\x18\x04 \x01(\x05H\x00R\x04\x62yte\x12\x16\n\x05short\x18\x05 \x01(\x05H\x00R\x05short\x12\x1a\n\x07integer\x18\x06 \x01(\x05H\x00R\x07integer\x12\x14\n\x04long\x18\x07 \x01(\x03H\x00R\x04long\x12\x16\n\x05\x66loat\x18\n \x01(\x02H\x00R\x05\x66loat\x12\x18\n\x06\x64ouble\x18\x0b \x01(\x01H\x00R\x06\x64ouble\x12\x45\n\x07\x64\x65\x63imal\x18\x0c \x01(\x0b\x32).spark.connect.Expression.Literal.DecimalH\x00R\x07\x64\x65\x63imal\x12\x18\n\x06string\x18\r \x01(\tH\x00R\x06string\x12\x14\n\x04\x64\x61te\x18\x10 \x01(\x05H\x00R\x04\x64\x61te\x12\x1e\n\ttimestamp\x18\x11 \x01(\x03H\x00R\ttimestamp\x12%\n\rtimestamp_ntz\x18\x12 \x01(\x03H\x00R\x0ctimestampNtz\x12\x61\n\x11\x63\x61lendar_interval\x18\x13 \x01(\x0b\x32\x32.spark.connect.Expression.Literal.CalendarIntervalH\x00R\x10\x63\x61lendarInterval\x12\x30\n\x13year_month_interval\x18\x14 \x01(\x05H\x00R\x11yearMonthInterval\x12,\n\x11\x64\x61y_time_interval\x18\x15 \x01(\x03H\x00R\x0f\x64\x61yTimeInterval\x12?\n\x05\x61rray\x18\x16 \x01(\x0b\x32\'.spark.connect.Expression.Literal.ArrayH\x00R\x05\x61rray\x12\x42\n\x06struct\x18\x17 \x01(\x0b\x32(.spark.connect.Expression.Literal.StructH\x00R\x06struct\x12\x39\n\x03map\x18\x18 \x01(\x0b\x32%.spark.connect.Expression.Literal.MapH\x00R\x03map\x12\x1a\n\x08nullable\x18\x32 \x01(\x08R\x08nullable\x12\x38\n\x18type_variation_reference\x18\x33 \x01(\rR\x16typeVariationReference\x1au\n\x07\x44\x65\x63imal\x12\x14\n\x05value\x18\x01 \x01(\tR\x05value\x12!\n\tprecision\x18\x02 \x01(\x05H\x00R\tprecision\x88\x01\x01\x12\x19\n\x05scale\x18\x03 \x01(\x05H\x01R\x05scale\x88\x01\x01\x42\x0c\n\n_precisionB\x08\n\x06_scale\x1a\x62\n\x10\x43\x61lendarInterval\x12\x16\n\x06months\x18\x01 \x01(\x05R\x06months\x12\x12\n\x04\x64\x61ys\x18\x02 \x01(\x05R\x04\x64\x61ys\x12"\n\x0cmicroseconds\x18\x03 \x01(\x03R\x0cmicroseconds\x1a\x43\n\x06Struct\x12\x39\n\x06\x66ields\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06\x66ields\x1a\x42\n\x05\x41rray\x12\x39\n\x06values\x18\x01 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values\x1a\xbd\x01\n\x03Map\x12@\n\x05pairs\x18\x01 \x03(\x0b\x32*.spark.connect.Expression.Literal.Map.PairR\x05pairs\x1at\n\x04Pair\x12\x33\n\x03key\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x03key\x12\x37\n\x05value\x18\x02 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x05valueB\x0e\n\x0cliteral_type\x1a\x46\n\x13UnresolvedAttribute\x12/\n\x13unparsed_identifier\x18\x01 \x01(\tR\x12unparsedIdentifier\x1a\xcc\x01\n\x12UnresolvedFunction\x12#\n\rfunction_name\x18\x01 \x01(\tR\x0c\x66unctionName\x12\x37\n\targuments\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\targuments\x12\x1f\n\x0bis_distinct\x18\x03 \x01(\x08R\nisDistinct\x12\x37\n\x18is_user_defined_function\x18\x04 \x01(\x08R\x15isUserDefinedFunction\x1a\x32\n\x10\x45xpressionString\x12\x1e\n\nexpression\x18\x01 \x01(\tR\nexpression\x1a(\n\x0eUnresolvedStar\x12\x16\n\x06target\x18\x01 \x03(\tR\x06target\x1ax\n\x05\x41lias\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12\x12\n\x04name\x18\x02 \x03(\tR\x04name\x12\x1f\n\x08metadata\x18\x03 \x01(\tH\x00R\x08metadata\x88\x01\x01\x42\x0b\n\t_metadataB\x0b\n\texpr_typeB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
+    b'\n\x1fspark/connect/expressions.proto\x12\rspark.connect\x1a\x19spark/connect/types.proto"\xa5\x11\n\nExpression\x12=\n\x07literal\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralH\x00R\x07literal\x12\x62\n\x14unresolved_attribute\x18\x02 \x01(\x0b\x32-.spark.connect.Expression.UnresolvedAttributeH\x00R\x13unresolvedAttribute\x12_\n\x13unresolved_function\x18\x03 \x01(\x0b\x32,.spark.connect.Expression.UnresolvedFunctionH\x00R\x12unresolvedFunction\x12Y\n\x11\x65xpression_string\x18\x04 \x01(\x0b\x32*.spark.connect.Expression.ExpressionStringH\x00R\x10\x65xpressionString\x12S\n\x0funresolved_star\x18\x05 \x01(\x0b\x32(.spark.connect.Expression.UnresolvedStarH\x00R\x0eunresolvedStar\x12\x37\n\x05\x61lias\x18\x06 \x01(\x0b\x32\x1f.spark.connect.Expression.AliasH\x00R\x05\x61lias\x12\x34\n\x04\x63\x61st\x18\x07 \x01(\x0b\x32\x1e.spark.connect.Expression.CastH\x00R\x04\x63\x61st\x1a\x91\x01\n\x04\x43\x61st\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12-\n\x04type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x04type\x12\x1b\n\x08type_str\x18\x03 \x01(\tH\x00R\x07typeStrB\x0e\n\x0c\x63\x61st_to_type\x1a\xe3\x07\n\x07Literal\x12\x14\n\x04null\x18\x01 \x01(\x08H\x00R\x04null\x12\x18\n\x06\x62inary\x18\x02 \x01(\x0cH\x00R\x06\x62inary\x12\x1a\n\x07\x62oolean\x18\x03 \x01(\x08H\x00R\x07\x62oolean\x12\x14\n\x04\x62yte\x18\x04 \x01(\x05H\x00R\x04\x62yte\x12\x16\n\x05short\x18\x05 \x01(\x05H\x00R\x05short\x12\x1a\n\x07integer\x18\x06 \x01(\x05H\x00R\x07integer\x12\x14\n\x04long\x18\x07 \x01(\x03H\x00R\x04long\x12\x16\n\x05\x66loat\x18\n \x01(\x02H\x00R\x05\x66loat\x12\x18\n\x06\x64ouble\x18\x0b \x01(\x01H\x00R\x06\x64ouble\x12\x45\n\x07\x64\x65\x63imal\x18\x0c \x01(\x0b\x32).spark.connect.Expression.Literal.DecimalH\x00R\x07\x64\x65\x63imal\x12\x18\n\x06string\x18\r \x01(\tH\x00R\x06string\x12\x14\n\x04\x64\x61te\x18\x10 \x01(\x05H\x00R\x04\x64\x61te\x12\x1e\n\ttimestamp\x18\x11 \x01(\x03H\x00R\ttimestamp\x12%\n\rtimestamp_ntz\x18\x12 \x01(\x03H\x00R\x0ctimestampNtz\x12\x61\n\x11\x63\x61lendar_interval\x18\x13 \x01(\x0b\x32\x32.spark.connect.Expression.Literal.CalendarIntervalH\x00R\x10\x63\x61lendarInterval\x12\x30\n\x13year_month_interval\x18\x14 \x01(\x05H\x00R\x11yearMonthInterval\x12,\n\x11\x64\x61y_time_interval\x18\x15 \x01(\x03H\x00R\x0f\x64\x61yTimeInterval\x12\x38\n\ntyped_null\x18\x16 \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\ttypedNull\x12\x1a\n\x08nullable\x18\x32 \x01(\x08R\x08nullable\x12\x38\n\x18type_variation_reference\x18\x33 \x01(\rR\x16typeVariationReference\x1au\n\x07\x44\x65\x63imal\x12\x14\n\x05value\x18\x01 \x01(\tR\x05value\x12!\n\tprecision\x18\x02 \x01(\x05H\x00R\tprecision\x88\x01\x01\x12\x19\n\x05scale\x18\x03 \x01(\x05H\x01R\x05scale\x88\x01\x01\x42\x0c\n\n_precisionB\x08\n\x06_scale\x1a\x62\n\x10\x43\x61lendarInterval\x12\x16\n\x06months\x18\x01 \x01(\x05R\x06months\x12\x12\n\x04\x64\x61ys\x18\x02 \x01(\x05R\x04\x64\x61ys\x12"\n\x0cmicroseconds\x18\x03 \x01(\x03R\x0cmicrosecondsB\x0e\n\x0cliteral_type\x1a\x46\n\x13UnresolvedAttribute\x12/\n\x13unparsed_identifier\x18\x01 \x01(\tR\x12unparsedIdentifier\x1a\xcc\x01\n\x12UnresolvedFunction\x12#\n\rfunction_name\x18\x01 \x01(\tR\x0c\x66unctionName\x12\x37\n\targuments\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\targuments\x12\x1f\n\x0bis_distinct\x18\x03 \x01(\x08R\nisDistinct\x12\x37\n\x18is_user_defined_function\x18\x04 \x01(\x08R\x15isUserDefinedFunction\x1a\x32\n\x10\x45xpressionString\x12\x1e\n\nexpression\x18\x01 \x01(\tR\nexpression\x1a(\n\x0eUnresolvedStar\x12\x16\n\x06target\x18\x01 \x03(\tR\x06target\x1ax\n\x05\x41lias\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12\x12\n\x04name\x18\x02 \x03(\tR\x04name\x12\x1f\n\x08metadata\x18\x03 \x01(\tH\x00R\x08metadata\x88\x01\x01\x42\x0b\n\t_metadataB\x0b\n\texpr_typeB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
 )
 
 
@@ -42,10 +42,6 @@ _EXPRESSION_CAST = _EXPRESSION.nested_types_by_name["Cast"]
 _EXPRESSION_LITERAL = _EXPRESSION.nested_types_by_name["Literal"]
 _EXPRESSION_LITERAL_DECIMAL = _EXPRESSION_LITERAL.nested_types_by_name["Decimal"]
 _EXPRESSION_LITERAL_CALENDARINTERVAL = _EXPRESSION_LITERAL.nested_types_by_name["CalendarInterval"]
-_EXPRESSION_LITERAL_STRUCT = _EXPRESSION_LITERAL.nested_types_by_name["Struct"]
-_EXPRESSION_LITERAL_ARRAY = _EXPRESSION_LITERAL.nested_types_by_name["Array"]
-_EXPRESSION_LITERAL_MAP = _EXPRESSION_LITERAL.nested_types_by_name["Map"]
-_EXPRESSION_LITERAL_MAP_PAIR = _EXPRESSION_LITERAL_MAP.nested_types_by_name["Pair"]
 _EXPRESSION_UNRESOLVEDATTRIBUTE = _EXPRESSION.nested_types_by_name["UnresolvedAttribute"]
 _EXPRESSION_UNRESOLVEDFUNCTION = _EXPRESSION.nested_types_by_name["UnresolvedFunction"]
 _EXPRESSION_EXPRESSIONSTRING = _EXPRESSION.nested_types_by_name["ExpressionString"]
@@ -84,42 +80,6 @@ Expression = _reflection.GeneratedProtocolMessageType(
                         "DESCRIPTOR": _EXPRESSION_LITERAL_CALENDARINTERVAL,
                         "__module__": "spark.connect.expressions_pb2"
                         # @@protoc_insertion_point(class_scope:spark.connect.Expression.Literal.CalendarInterval)
-                    },
-                ),
-                "Struct": _reflection.GeneratedProtocolMessageType(
-                    "Struct",
-                    (_message.Message,),
-                    {
-                        "DESCRIPTOR": _EXPRESSION_LITERAL_STRUCT,
-                        "__module__": "spark.connect.expressions_pb2"
-                        # @@protoc_insertion_point(class_scope:spark.connect.Expression.Literal.Struct)
-                    },
-                ),
-                "Array": _reflection.GeneratedProtocolMessageType(
-                    "Array",
-                    (_message.Message,),
-                    {
-                        "DESCRIPTOR": _EXPRESSION_LITERAL_ARRAY,
-                        "__module__": "spark.connect.expressions_pb2"
-                        # @@protoc_insertion_point(class_scope:spark.connect.Expression.Literal.Array)
-                    },
-                ),
-                "Map": _reflection.GeneratedProtocolMessageType(
-                    "Map",
-                    (_message.Message,),
-                    {
-                        "Pair": _reflection.GeneratedProtocolMessageType(
-                            "Pair",
-                            (_message.Message,),
-                            {
-                                "DESCRIPTOR": _EXPRESSION_LITERAL_MAP_PAIR,
-                                "__module__": "spark.connect.expressions_pb2"
-                                # @@protoc_insertion_point(class_scope:spark.connect.Expression.Literal.Map.Pair)
-                            },
-                        ),
-                        "DESCRIPTOR": _EXPRESSION_LITERAL_MAP,
-                        "__module__": "spark.connect.expressions_pb2"
-                        # @@protoc_insertion_point(class_scope:spark.connect.Expression.Literal.Map)
                     },
                 ),
                 "DESCRIPTOR": _EXPRESSION_LITERAL,
@@ -182,10 +142,6 @@ _sym_db.RegisterMessage(Expression.Cast)
 _sym_db.RegisterMessage(Expression.Literal)
 _sym_db.RegisterMessage(Expression.Literal.Decimal)
 _sym_db.RegisterMessage(Expression.Literal.CalendarInterval)
-_sym_db.RegisterMessage(Expression.Literal.Struct)
-_sym_db.RegisterMessage(Expression.Literal.Array)
-_sym_db.RegisterMessage(Expression.Literal.Map)
-_sym_db.RegisterMessage(Expression.Literal.Map.Pair)
 _sym_db.RegisterMessage(Expression.UnresolvedAttribute)
 _sym_db.RegisterMessage(Expression.UnresolvedFunction)
 _sym_db.RegisterMessage(Expression.ExpressionString)
@@ -197,31 +153,23 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b"\n\036org.apache.spark.connect.protoP\001"
     _EXPRESSION._serialized_start = 78
-    _EXPRESSION._serialized_end = 2754
+    _EXPRESSION._serialized_end = 2291
     _EXPRESSION_CAST._serialized_start = 640
     _EXPRESSION_CAST._serialized_end = 785
     _EXPRESSION_LITERAL._serialized_start = 788
-    _EXPRESSION_LITERAL._serialized_end = 2246
-    _EXPRESSION_LITERAL_DECIMAL._serialized_start = 1684
-    _EXPRESSION_LITERAL_DECIMAL._serialized_end = 1801
-    _EXPRESSION_LITERAL_CALENDARINTERVAL._serialized_start = 1803
-    _EXPRESSION_LITERAL_CALENDARINTERVAL._serialized_end = 1901
-    _EXPRESSION_LITERAL_STRUCT._serialized_start = 1903
-    _EXPRESSION_LITERAL_STRUCT._serialized_end = 1970
-    _EXPRESSION_LITERAL_ARRAY._serialized_start = 1972
-    _EXPRESSION_LITERAL_ARRAY._serialized_end = 2038
-    _EXPRESSION_LITERAL_MAP._serialized_start = 2041
-    _EXPRESSION_LITERAL_MAP._serialized_end = 2230
-    _EXPRESSION_LITERAL_MAP_PAIR._serialized_start = 2114
-    _EXPRESSION_LITERAL_MAP_PAIR._serialized_end = 2230
-    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_start = 2248
-    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_end = 2318
-    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_start = 2321
-    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_end = 2525
-    _EXPRESSION_EXPRESSIONSTRING._serialized_start = 2527
-    _EXPRESSION_EXPRESSIONSTRING._serialized_end = 2577
-    _EXPRESSION_UNRESOLVEDSTAR._serialized_start = 2579
-    _EXPRESSION_UNRESOLVEDSTAR._serialized_end = 2619
-    _EXPRESSION_ALIAS._serialized_start = 2621
-    _EXPRESSION_ALIAS._serialized_end = 2741
+    _EXPRESSION_LITERAL._serialized_end = 1783
+    _EXPRESSION_LITERAL_DECIMAL._serialized_start = 1550
+    _EXPRESSION_LITERAL_DECIMAL._serialized_end = 1667
+    _EXPRESSION_LITERAL_CALENDARINTERVAL._serialized_start = 1669
+    _EXPRESSION_LITERAL_CALENDARINTERVAL._serialized_end = 1767
+    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_start = 1785
+    _EXPRESSION_UNRESOLVEDATTRIBUTE._serialized_end = 1855
+    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_start = 1858
+    _EXPRESSION_UNRESOLVEDFUNCTION._serialized_end = 2062
+    _EXPRESSION_EXPRESSIONSTRING._serialized_start = 2064
+    _EXPRESSION_EXPRESSIONSTRING._serialized_end = 2114
+    _EXPRESSION_UNRESOLVEDSTAR._serialized_start = 2116
+    _EXPRESSION_UNRESOLVEDSTAR._serialized_end = 2156
+    _EXPRESSION_ALIAS._serialized_start = 2158
+    _EXPRESSION_ALIAS._serialized_end = 2278
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/expressions_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/expressions_pb2.pyi
@@ -190,87 +190,6 @@ class Expression(google.protobuf.message.Message):
                 ],
             ) -> None: ...
 
-        class Struct(google.protobuf.message.Message):
-            DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-            FIELDS_FIELD_NUMBER: builtins.int
-            @property
-            def fields(
-                self,
-            ) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[
-                global___Expression.Literal
-            ]:
-                """A possibly heterogeneously typed list of literals"""
-            def __init__(
-                self,
-                *,
-                fields: collections.abc.Iterable[global___Expression.Literal] | None = ...,
-            ) -> None: ...
-            def ClearField(
-                self, field_name: typing_extensions.Literal["fields", b"fields"]
-            ) -> None: ...
-
-        class Array(google.protobuf.message.Message):
-            DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-            VALUES_FIELD_NUMBER: builtins.int
-            @property
-            def values(
-                self,
-            ) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[
-                global___Expression.Literal
-            ]:
-                """A homogeneously typed list of literals"""
-            def __init__(
-                self,
-                *,
-                values: collections.abc.Iterable[global___Expression.Literal] | None = ...,
-            ) -> None: ...
-            def ClearField(
-                self, field_name: typing_extensions.Literal["values", b"values"]
-            ) -> None: ...
-
-        class Map(google.protobuf.message.Message):
-            DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-            class Pair(google.protobuf.message.Message):
-                DESCRIPTOR: google.protobuf.descriptor.Descriptor
-
-                KEY_FIELD_NUMBER: builtins.int
-                VALUE_FIELD_NUMBER: builtins.int
-                @property
-                def key(self) -> global___Expression.Literal: ...
-                @property
-                def value(self) -> global___Expression.Literal: ...
-                def __init__(
-                    self,
-                    *,
-                    key: global___Expression.Literal | None = ...,
-                    value: global___Expression.Literal | None = ...,
-                ) -> None: ...
-                def HasField(
-                    self, field_name: typing_extensions.Literal["key", b"key", "value", b"value"]
-                ) -> builtins.bool: ...
-                def ClearField(
-                    self, field_name: typing_extensions.Literal["key", b"key", "value", b"value"]
-                ) -> None: ...
-
-            PAIRS_FIELD_NUMBER: builtins.int
-            @property
-            def pairs(
-                self,
-            ) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[
-                global___Expression.Literal.Map.Pair
-            ]: ...
-            def __init__(
-                self,
-                *,
-                pairs: collections.abc.Iterable[global___Expression.Literal.Map.Pair] | None = ...,
-            ) -> None: ...
-            def ClearField(
-                self, field_name: typing_extensions.Literal["pairs", b"pairs"]
-            ) -> None: ...
-
         NULL_FIELD_NUMBER: builtins.int
         BINARY_FIELD_NUMBER: builtins.int
         BOOLEAN_FIELD_NUMBER: builtins.int
@@ -288,9 +207,7 @@ class Expression(google.protobuf.message.Message):
         CALENDAR_INTERVAL_FIELD_NUMBER: builtins.int
         YEAR_MONTH_INTERVAL_FIELD_NUMBER: builtins.int
         DAY_TIME_INTERVAL_FIELD_NUMBER: builtins.int
-        ARRAY_FIELD_NUMBER: builtins.int
-        STRUCT_FIELD_NUMBER: builtins.int
-        MAP_FIELD_NUMBER: builtins.int
+        TYPED_NULL_FIELD_NUMBER: builtins.int
         NULLABLE_FIELD_NUMBER: builtins.int
         TYPE_VARIATION_REFERENCE_FIELD_NUMBER: builtins.int
         null: builtins.bool
@@ -316,11 +233,7 @@ class Expression(google.protobuf.message.Message):
         year_month_interval: builtins.int
         day_time_interval: builtins.int
         @property
-        def array(self) -> global___Expression.Literal.Array: ...
-        @property
-        def struct(self) -> global___Expression.Literal.Struct: ...
-        @property
-        def map(self) -> global___Expression.Literal.Map: ...
+        def typed_null(self) -> pyspark.sql.connect.proto.types_pb2.DataType: ...
         nullable: builtins.bool
         """whether the literal type should be treated as a nullable type. Applies to
         all members of union other than the Typed null (which should directly
@@ -351,17 +264,13 @@ class Expression(google.protobuf.message.Message):
             calendar_interval: global___Expression.Literal.CalendarInterval | None = ...,
             year_month_interval: builtins.int = ...,
             day_time_interval: builtins.int = ...,
-            array: global___Expression.Literal.Array | None = ...,
-            struct: global___Expression.Literal.Struct | None = ...,
-            map: global___Expression.Literal.Map | None = ...,
+            typed_null: pyspark.sql.connect.proto.types_pb2.DataType | None = ...,
             nullable: builtins.bool = ...,
             type_variation_reference: builtins.int = ...,
         ) -> None: ...
         def HasField(
             self,
             field_name: typing_extensions.Literal[
-                "array",
-                b"array",
                 "binary",
                 b"binary",
                 "boolean",
@@ -386,20 +295,18 @@ class Expression(google.protobuf.message.Message):
                 b"literal_type",
                 "long",
                 b"long",
-                "map",
-                b"map",
                 "null",
                 b"null",
                 "short",
                 b"short",
                 "string",
                 b"string",
-                "struct",
-                b"struct",
                 "timestamp",
                 b"timestamp",
                 "timestamp_ntz",
                 b"timestamp_ntz",
+                "typed_null",
+                b"typed_null",
                 "year_month_interval",
                 b"year_month_interval",
             ],
@@ -407,8 +314,6 @@ class Expression(google.protobuf.message.Message):
         def ClearField(
             self,
             field_name: typing_extensions.Literal[
-                "array",
-                b"array",
                 "binary",
                 b"binary",
                 "boolean",
@@ -433,8 +338,6 @@ class Expression(google.protobuf.message.Message):
                 b"literal_type",
                 "long",
                 b"long",
-                "map",
-                b"map",
                 "null",
                 b"null",
                 "nullable",
@@ -443,14 +346,14 @@ class Expression(google.protobuf.message.Message):
                 b"short",
                 "string",
                 b"string",
-                "struct",
-                b"struct",
                 "timestamp",
                 b"timestamp",
                 "timestamp_ntz",
                 b"timestamp_ntz",
                 "type_variation_reference",
                 b"type_variation_reference",
+                "typed_null",
+                b"typed_null",
                 "year_month_interval",
                 b"year_month_interval",
             ],
@@ -475,9 +378,7 @@ class Expression(google.protobuf.message.Message):
             "calendar_interval",
             "year_month_interval",
             "day_time_interval",
-            "array",
-            "struct",
-            "map",
+            "typed_null",
         ] | None: ...
 
     class UnresolvedAttribute(google.protobuf.message.Message):

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -14,9 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import decimal
+import datetime
+
 from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
-from pyspark.sql.types import StringType
+from pyspark.sql.connect.column import (
+    LiteralExpression,
+    JVM_BYTE_MIN,
+    JVM_BYTE_MAX,
+    JVM_SHORT_MIN,
+    JVM_SHORT_MAX,
+    JVM_INT_MIN,
+    JVM_INT_MAX,
+    JVM_LONG_MIN,
+    JVM_LONG_MAX,
+)
+
 from pyspark.sql.types import (
+    StructField,
+    StructType,
+    ArrayType,
+    MapType,
+    NullType,
+    DateType,
+    TimestampType,
+    TimestampNTZType,
     ByteType,
     ShortType,
     IntegerType,
@@ -93,13 +116,108 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         res = pd.DataFrame(data={"id": [0, 30, 60, 90]})
         self.assert_(pdf.equals(res), f"{pdf.to_string()} != {res.to_string()}")
 
+    def test_literal_with_acceptable_type(self):
+        for value, dataType in [
+            (b"binary\0\0asas", BinaryType()),
+            (True, BooleanType()),
+            (False, BooleanType()),
+            (0, ByteType()),
+            (JVM_BYTE_MIN, ByteType()),
+            (JVM_BYTE_MAX, ByteType()),
+            (0, ShortType()),
+            (JVM_SHORT_MIN, ShortType()),
+            (JVM_SHORT_MAX, ShortType()),
+            (0, IntegerType()),
+            (JVM_INT_MIN, IntegerType()),
+            (JVM_INT_MAX, IntegerType()),
+            (0, LongType()),
+            (JVM_LONG_MIN, LongType()),
+            (JVM_LONG_MAX, LongType()),
+            (0.0, FloatType()),
+            (1.234567, FloatType()),
+            (float("nan"), FloatType()),
+            (float("inf"), FloatType()),
+            (float("-inf"), FloatType()),
+            (0.0, DoubleType()),
+            (1.234567, DoubleType()),
+            (float("nan"), DoubleType()),
+            (float("inf"), DoubleType()),
+            (float("-inf"), DoubleType()),
+            (decimal.Decimal(0.0), DecimalType()),
+            (decimal.Decimal(1.234567), DecimalType()),
+            ("sss", StringType()),
+            (datetime.date(2022, 12, 13), DateType()),
+            (datetime.datetime.now(), DateType()),
+            (datetime.datetime.now(), TimestampType()),
+            (datetime.datetime.now(), TimestampNTZType()),
+            (datetime.timedelta(1, 2, 3), DayTimeIntervalType()),
+        ]:
+            lit = LiteralExpression(value=value, dataType=dataType)
+            self.assertEqual(dataType, lit._dataType)
+
+    def test_literal_with_unsupported_type(self):
+        for value, dataType in [
+            (b"binary\0\0asas", BooleanType()),
+            (True, StringType()),
+            (False, DoubleType()),
+            (JVM_BYTE_MIN - 1, ByteType()),
+            (JVM_BYTE_MAX + 1, ByteType()),
+            (JVM_SHORT_MIN - 1, ShortType()),
+            (JVM_SHORT_MAX + 1, ShortType()),
+            (JVM_INT_MIN - 1, IntegerType()),
+            (JVM_INT_MAX + 1, IntegerType()),
+            (JVM_LONG_MIN - 1, LongType()),
+            (JVM_LONG_MAX + 1, LongType()),
+            (0.1, DecimalType()),
+            (datetime.date(2022, 12, 13), TimestampType()),
+            (datetime.timedelta(1, 2, 3), DateType()),
+            ([1, 2, 3], ArrayType(IntegerType())),
+            ({1: 2}, MapType(IntegerType(), IntegerType())),
+            (
+                {"a": "xyz", "b": 1},
+                StructType([StructField("a", StringType()), StructField("b", IntegerType())]),
+            ),
+        ]:
+            with self.assertRaises(AssertionError):
+                LiteralExpression(value=value, dataType=dataType)
+
+    def test_literal_null(self):
+        for dataType in [
+            NullType(),
+            BinaryType(),
+            BooleanType(),
+            ByteType(),
+            ShortType(),
+            IntegerType(),
+            LongType(),
+            FloatType(),
+            DoubleType(),
+            DecimalType(),
+            DateType(),
+            TimestampType(),
+            TimestampNTZType(),
+            DayTimeIntervalType(),
+        ]:
+            lit_null = LiteralExpression(value=None, dataType=dataType)
+            self.assertTrue(lit_null._value is None)
+            self.assertEqual(dataType, lit_null._dataType)
+
+        for value, dataType in [
+            ("123", NullType()),
+            (123, NullType()),
+            (None, ArrayType(IntegerType())),
+            (None, MapType(IntegerType(), IntegerType())),
+            (None, StructType([StructField("a", StringType())])),
+        ]:
+            with self.assertRaises(AssertionError):
+                LiteralExpression(value=value, dataType=dataType)
+
     def test_literal_integers(self):
         cdf = self.connect.range(0, 1)
         sdf = self.spark.range(0, 1)
 
         from pyspark.sql import functions as SF
         from pyspark.sql.connect import functions as CF
-        from pyspark.sql.connect.column import JVM_INT_MIN, JVM_INT_MAX, JVM_LONG_MIN, JVM_LONG_MAX
 
         cdf1 = cdf.select(
             CF.lit(0),


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, existing `LiteralExpression` is a mixture of `Literal`, `CreateArray`, `CreateStruct` and `CreateMap`, since we have added collection functions `array`, `struct` and `create_map`, the `CreateXXX` expressions can be replaced with `UnresolvedFunction`; 
2, add field `dataType` in `LiteralExpression`, so we can specify the DataType if needed, a special case is the typed null;
3, it is up to the `lit` function to infer the DataType, not `LiteralExpression` itself;

### Why are the changes needed?
Refactor LiteralExpression to support DataType

### Does this PR introduce _any_ user-facing change?
No, `LiteralExpression` is a internal class, should not expose to end users

### How was this patch tested?
added UT
