### PR TITLE
[SPARK-41424][UI] Protobuf serializer for TaskDataWrapper

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -55,3 +55,54 @@ message JobDataWrapper {
   repeated int32 skipped_stages = 2;
   optional int64 sql_execution_id = 3;
 }
+
+message AccumulableInfo {
+  int64 id = 1;
+  string name = 2;
+  optional string update = 3;
+  string value = 4;
+}
+
+message TaskDataWrapper {
+  int64 task_id = 1;
+  int32 index = 2;
+  int32 attempt = 3;
+  int32 partition_id = 4;
+  int64 launch_time = 5;
+  int64 result_fetch_start = 6;
+  int64 duration = 7;
+  string executor_id = 8;
+  string host = 9;
+  string status = 10;
+  string task_locality = 11;
+  bool speculative = 12;
+  repeated AccumulableInfo accumulator_updates = 13;
+  optional string error_message = 14;
+  bool has_metrics = 15;
+  int64 executor_deserialize_time = 16;
+  int64 executor_deserialize_cpu_time = 17;
+  int64 executor_run_time = 18;
+  int64 executor_cpu_time = 19;
+  int64 result_size = 20;
+  int64 jvm_gc_time = 21;
+  int64 result_serialization_time = 22;
+  int64 memory_bytes_spilled = 23;
+  int64 disk_bytes_spilled = 24;
+  int64 peak_execution_memory = 25;
+  int64 input_bytes_read = 26;
+  int64 input_records_read = 27;
+  int64 output_bytes_written = 28;
+  int64 output_records_written = 29;
+  int64 shuffle_remote_blocks_fetched = 30;
+  int64 shuffle_local_blocks_fetched = 31;
+  int64 shuffle_fetch_wait_time = 32;
+  int64 shuffle_remote_bytes_read = 33;
+  int64 shuffle_remote_bytes_read_to_disk = 34;
+  int64 shuffle_local_bytes_read = 35;
+  int64 shuffle_records_read = 36;
+  int64 shuffle_bytes_written = 37;
+  int64 shuffle_write_time = 38;
+  int64 shuffle_records_written = 39;
+  int64 stage_id = 40;
+  int32 stage_attempt_id = 41;
+}

--- a/core/src/main/scala/org/apache/spark/status/protobuf/JobDataWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/JobDataWrapperSerializer.scala
@@ -23,6 +23,7 @@ import java.util.Date
 import org.apache.spark.JobExecutionStatus
 import org.apache.spark.status.JobDataWrapper
 import org.apache.spark.status.api.v1.JobData
+import org.apache.spark.status.protobuf.Utils.getOptional
 
 object JobDataWrapperSerializer {
   def serialize(j: JobDataWrapper): Array[Byte] = {
@@ -42,12 +43,6 @@ object JobDataWrapperSerializer {
       wrapper.getSkippedStagesList.asScala.map(_.toInt).toSet,
       sqlExecutionId
     )
-  }
-
-  private def getOptional[T](condition: Boolean, result: () => T): Option[T] = if (condition) {
-    Some(result())
-  } else {
-    None
   }
 
   private def serializeJobData(jobData: JobData): StoreTypes.JobData = {

--- a/core/src/main/scala/org/apache/spark/status/protobuf/TaskDataWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/TaskDataWrapperSerializer.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.status.protobuf
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.status.TaskDataWrapper
+import org.apache.spark.status.api.v1.AccumulableInfo
+import org.apache.spark.status.protobuf.Utils.getOptional
+
+object TaskDataWrapperSerializer {
+  def serialize(input: TaskDataWrapper): Array[Byte] = {
+    val builder = StoreTypes.TaskDataWrapper.newBuilder()
+      .setTaskId(input.taskId)
+      .setIndex(input.index)
+      .setAttempt(input.attempt)
+      .setPartitionId(input.partitionId)
+      .setLaunchTime(input.launchTime)
+      .setResultFetchStart(input.resultFetchStart)
+      .setDuration(input.duration)
+      .setExecutorId(input.executorId)
+      .setHost(input.host)
+      .setStatus(input.status)
+      .setTaskLocality(input.taskLocality)
+      .setSpeculative(input.speculative)
+      .setHasMetrics(input.hasMetrics)
+      .setExecutorDeserializeTime(input.executorDeserializeTime)
+      .setExecutorDeserializeCpuTime(input.executorDeserializeCpuTime)
+      .setExecutorRunTime(input.executorRunTime)
+      .setExecutorCpuTime(input.executorCpuTime)
+      .setResultSize(input.resultSize)
+      .setJvmGcTime(input.jvmGcTime)
+      .setResultSerializationTime(input.resultSerializationTime)
+      .setMemoryBytesSpilled(input.memoryBytesSpilled)
+      .setDiskBytesSpilled(input.diskBytesSpilled)
+      .setPeakExecutionMemory(input.peakExecutionMemory)
+      .setInputBytesRead(input.inputBytesRead)
+      .setInputRecordsRead(input.inputRecordsRead)
+      .setOutputBytesWritten(input.outputBytesWritten)
+      .setOutputRecordsWritten(input.outputRecordsWritten)
+      .setShuffleRemoteBlocksFetched(input.shuffleRemoteBlocksFetched)
+      .setShuffleLocalBlocksFetched(input.shuffleLocalBlocksFetched)
+      .setShuffleFetchWaitTime(input.shuffleFetchWaitTime)
+      .setShuffleRemoteBytesRead(input.shuffleRemoteBytesRead)
+      .setShuffleRemoteBytesReadToDisk(input.shuffleRemoteBytesReadToDisk)
+      .setShuffleLocalBytesRead(input.shuffleLocalBytesRead)
+      .setShuffleRecordsRead(input.shuffleRecordsRead)
+      .setShuffleBytesWritten(input.shuffleBytesWritten)
+      .setShuffleWriteTime(input.shuffleWriteTime)
+      .setShuffleRecordsWritten(input.shuffleRecordsWritten)
+      .setStageId(input.stageId)
+      .setStageAttemptId(input.stageAttemptId)
+    input.errorMessage.foreach(builder.setErrorMessage)
+    input.accumulatorUpdates.foreach { update =>
+      builder.addAccumulatorUpdates(serializeAccumulableInfo(update))
+    }
+    builder.build().toByteArray
+  }
+
+  def deserialize(bytes: Array[Byte]): TaskDataWrapper = {
+    val binary = StoreTypes.TaskDataWrapper.parseFrom(bytes)
+    val accumulatorUpdates = new ArrayBuffer[AccumulableInfo]()
+    binary.getAccumulatorUpdatesList.forEach { update =>
+      accumulatorUpdates.append(new AccumulableInfo(
+        id = update.getId,
+        name = update.getName,
+        update = getOptional(update.hasUpdate, update.getUpdate),
+        value = update.getValue))
+    }
+    new TaskDataWrapper(
+      taskId = binary.getTaskId,
+      index = binary.getIndex,
+      attempt = binary.getAttempt,
+      partitionId = binary.getPartitionId,
+      launchTime = binary.getLaunchTime,
+      resultFetchStart = binary.getResultFetchStart,
+      duration = binary.getDuration,
+      executorId = binary.getExecutorId,
+      host = binary.getHost,
+      status = binary.getStatus,
+      taskLocality = binary.getTaskLocality,
+      speculative = binary.getSpeculative,
+      accumulatorUpdates = accumulatorUpdates,
+      errorMessage = getOptional(binary.hasErrorMessage, binary.getErrorMessage),
+      hasMetrics = binary.getHasMetrics,
+      executorDeserializeTime = binary.getExecutorDeserializeTime,
+      executorDeserializeCpuTime = binary.getExecutorDeserializeCpuTime,
+      executorRunTime = binary.getExecutorRunTime,
+      executorCpuTime = binary.getExecutorCpuTime,
+      resultSize = binary.getResultSize,
+      jvmGcTime = binary.getJvmGcTime,
+      resultSerializationTime = binary.getResultSerializationTime,
+      memoryBytesSpilled = binary.getMemoryBytesSpilled,
+      diskBytesSpilled = binary.getDiskBytesSpilled,
+      peakExecutionMemory = binary.getPeakExecutionMemory,
+      inputBytesRead = binary.getInputBytesRead,
+      inputRecordsRead = binary.getInputRecordsRead,
+      outputBytesWritten = binary.getOutputBytesWritten,
+      outputRecordsWritten = binary.getOutputRecordsWritten,
+      shuffleRemoteBlocksFetched = binary.getShuffleRemoteBlocksFetched,
+      shuffleLocalBlocksFetched = binary.getShuffleLocalBlocksFetched,
+      shuffleFetchWaitTime = binary.getShuffleFetchWaitTime,
+      shuffleRemoteBytesRead = binary.getShuffleRemoteBytesRead,
+      shuffleRemoteBytesReadToDisk = binary.getShuffleRemoteBytesReadToDisk,
+      shuffleLocalBytesRead = binary.getShuffleLocalBytesRead,
+      shuffleRecordsRead = binary.getShuffleRecordsRead,
+      shuffleBytesWritten = binary.getShuffleBytesWritten,
+      shuffleWriteTime = binary.getShuffleWriteTime,
+      shuffleRecordsWritten = binary.getShuffleRecordsWritten,
+      stageId = binary.getStageId.toInt,
+      stageAttemptId = binary.getStageAttemptId
+    )
+  }
+
+  def serializeAccumulableInfo(input: AccumulableInfo): StoreTypes.AccumulableInfo = {
+    val builder = StoreTypes.AccumulableInfo.newBuilder()
+      .setId(input.id)
+      .setName(input.name)
+      .setValue(input.value)
+    input.update.foreach(builder.setUpdate)
+    builder.build()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/status/protobuf/TaskDataWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/TaskDataWrapperSerializer.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.status.TaskDataWrapper
 import org.apache.spark.status.api.v1.AccumulableInfo
 import org.apache.spark.status.protobuf.Utils.getOptional
+import org.apache.spark.util.Utils.weakIntern
 
 object TaskDataWrapperSerializer {
   def serialize(input: TaskDataWrapper): Array[Byte] = {
@@ -90,10 +91,10 @@ object TaskDataWrapperSerializer {
       launchTime = binary.getLaunchTime,
       resultFetchStart = binary.getResultFetchStart,
       duration = binary.getDuration,
-      executorId = binary.getExecutorId,
-      host = binary.getHost,
-      status = binary.getStatus,
-      taskLocality = binary.getTaskLocality,
+      executorId = weakIntern(binary.getExecutorId),
+      host = weakIntern(binary.getHost),
+      status = weakIntern(binary.getStatus),
+      taskLocality = weakIntern(binary.getTaskLocality),
       speculative = binary.getSpeculative,
       accumulatorUpdates = accumulatorUpdates.toSeq,
       errorMessage = getOptional(binary.hasErrorMessage, binary.getErrorMessage),

--- a/core/src/main/scala/org/apache/spark/status/protobuf/TaskDataWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/TaskDataWrapperSerializer.scala
@@ -95,7 +95,7 @@ object TaskDataWrapperSerializer {
       status = binary.getStatus,
       taskLocality = binary.getTaskLocality,
       speculative = binary.getSpeculative,
-      accumulatorUpdates = accumulatorUpdates,
+      accumulatorUpdates = accumulatorUpdates.toSeq,
       errorMessage = getOptional(binary.hasErrorMessage, binary.getErrorMessage),
       hasMetrics = binary.getHasMetrics,
       executorDeserializeTime = binary.getExecutorDeserializeTime,

--- a/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
@@ -17,21 +17,10 @@
 
 package org.apache.spark.status.protobuf
 
-import org.apache.spark.status.{JobDataWrapper, TaskDataWrapper}
-import org.apache.spark.status.KVUtils.KVStoreScalaSerializer
-
-private[spark] class KVStoreProtobufSerializer extends KVStoreScalaSerializer {
-  override def serialize(o: Object): Array[Byte] = o match {
-    case j: JobDataWrapper => JobDataWrapperSerializer.serialize(j)
-    case t: TaskDataWrapper => TaskDataWrapperSerializer.serialize(t)
-    case other => super.serialize(other)
-  }
-
-  override def deserialize[T](data: Array[Byte], klass: Class[T]): T = klass match {
-    case _ if classOf[JobDataWrapper].isAssignableFrom(klass) =>
-      JobDataWrapperSerializer.deserialize(data).asInstanceOf[T]
-    case _ if classOf[TaskDataWrapper].isAssignableFrom(klass) =>
-      TaskDataWrapperSerializer.deserialize(data).asInstanceOf[T]
-    case other => super.deserialize(data, klass)
+object Utils {
+  def getOptional[T](condition: Boolean, result: () => T): Option[T] = if (condition) {
+    Some(result())
+  } else {
+    None
   }
 }

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -20,8 +20,8 @@ package org.apache.spark.status.protobuf
 import java.util.Date
 
 import org.apache.spark.{JobExecutionStatus, SparkFunSuite}
-import org.apache.spark.status.JobDataWrapper
-import org.apache.spark.status.api.v1.JobData
+import org.apache.spark.status.{JobDataWrapper, TaskDataWrapper}
+import org.apache.spark.status.api.v1.{AccumulableInfo, JobData}
 
 class KVStoreProtobufSerializerSuite extends SparkFunSuite {
   private val serializer = new KVStoreProtobufSerializer()
@@ -77,5 +77,103 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     assert(result.skippedStages == input.skippedStages)
     assert(result.sqlExecutionId == input.sqlExecutionId)
   }
-}
 
+  test("Task Data") {
+    val accumulatorUpdates = Seq(
+      new AccumulableInfo(1L, "duration", Some("update"), "value1"),
+      new AccumulableInfo(2L, "duration2", None, "value2")
+    )
+    val input = new TaskDataWrapper(
+      taskId = 1,
+      index = 2,
+      attempt = 3,
+      partitionId = 4,
+      launchTime = 5L,
+      resultFetchStart = 6L,
+      duration = 10000L,
+      executorId = "executor_id_1",
+      host = "host_name",
+      status = "SUCCESS",
+      taskLocality = "LOCAL",
+      speculative = true,
+      accumulatorUpdates = accumulatorUpdates,
+      errorMessage = Some("error"),
+      hasMetrics = true,
+      executorDeserializeTime = 7L,
+      executorDeserializeCpuTime = 8L,
+      executorRunTime = 9L,
+      executorCpuTime = 10L,
+      resultSize = 11L,
+      jvmGcTime = 12L,
+      resultSerializationTime = 13L,
+      memoryBytesSpilled = 14L,
+      diskBytesSpilled = 15L,
+      peakExecutionMemory = 16L,
+      inputBytesRead = 17L,
+      inputRecordsRead = 18L,
+      outputBytesWritten = 19L,
+      outputRecordsWritten = 20L,
+      shuffleRemoteBlocksFetched = 21L,
+      shuffleLocalBlocksFetched = 22L,
+      shuffleFetchWaitTime = 23L,
+      shuffleRemoteBytesRead = 24L,
+      shuffleRemoteBytesReadToDisk = 25L,
+      shuffleLocalBytesRead = 26L,
+      shuffleRecordsRead = 27L,
+      shuffleBytesWritten = 28L,
+      shuffleWriteTime = 29L,
+      shuffleRecordsWritten = 30L,
+      stageId = 31,
+      stageAttemptId = 32)
+
+    val bytes = serializer.serialize(input)
+    val result = serializer.deserialize(bytes, classOf[TaskDataWrapper])
+    assert(result.accumulatorUpdates.length == input.accumulatorUpdates.length)
+    result.accumulatorUpdates.zip(input.accumulatorUpdates).foreach { case (a1, a2) =>
+      assert(a1.id == a2.id)
+      assert(a1.name == a2.name)
+      assert(a1.update.getOrElse("") == a2.update.getOrElse(""))
+      assert(a1.update == a2.update)
+    }
+    assert(result.taskId == input.taskId)
+    assert(result.index == input.index)
+    assert(result.attempt == input.attempt)
+    assert(result.partitionId == input.partitionId)
+    assert(result.launchTime == input.launchTime)
+    assert(result.resultFetchStart == input.resultFetchStart)
+    assert(result.duration == input.duration)
+    assert(result.executorId == input.executorId)
+    assert(result.host == input.host)
+    assert(result.status == input.status)
+    assert(result.taskLocality == input.taskLocality)
+    assert(result.speculative == input.speculative)
+    assert(result.errorMessage == input.errorMessage)
+    assert(result.hasMetrics == input.hasMetrics)
+    assert(result.executorDeserializeTime == input.executorDeserializeTime)
+    assert(result.executorDeserializeCpuTime == input.executorDeserializeCpuTime)
+    assert(result.executorRunTime == input.executorRunTime)
+    assert(result.executorCpuTime == input.executorCpuTime)
+    assert(result.resultSize == input.resultSize)
+    assert(result.jvmGcTime == input.jvmGcTime)
+    assert(result.resultSerializationTime == input.resultSerializationTime)
+    assert(result.memoryBytesSpilled == input.memoryBytesSpilled)
+    assert(result.diskBytesSpilled == input.diskBytesSpilled)
+    assert(result.peakExecutionMemory == input.peakExecutionMemory)
+    assert(result.inputBytesRead == input.inputBytesRead)
+    assert(result.inputRecordsRead == input.inputRecordsRead)
+    assert(result.outputBytesWritten == input.outputBytesWritten)
+    assert(result.outputRecordsWritten == input.outputRecordsWritten)
+    assert(result.shuffleRemoteBlocksFetched == input.shuffleRemoteBlocksFetched)
+    assert(result.shuffleLocalBlocksFetched == input.shuffleLocalBlocksFetched)
+    assert(result.shuffleFetchWaitTime == input.shuffleFetchWaitTime)
+    assert(result.shuffleRemoteBytesRead == input.shuffleRemoteBytesRead)
+    assert(result.shuffleRemoteBytesReadToDisk == input.shuffleRemoteBytesReadToDisk)
+    assert(result.shuffleLocalBytesRead == input.shuffleLocalBytesRead)
+    assert(result.shuffleRecordsRead == input.shuffleRecordsRead)
+    assert(result.shuffleBytesWritten == input.shuffleBytesWritten)
+    assert(result.shuffleWriteTime == input.shuffleWriteTime)
+    assert(result.shuffleRecordsWritten == input.shuffleRecordsWritten)
+    assert(result.stageId == input.stageId)
+    assert(result.stageAttemptId == input.stageAttemptId)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add Protobuf serializer for TaskDataWrapper

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Support fast and compact serialization/deserialization for TaskDataWrapper over RocksDB. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT