### PR TITLE
[SPARK-41509][SQL] Only execute `Murmur3Hash` on aggregate expressions for semi-join runtime filter.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -99,8 +99,10 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       filterCreationSideExp: Expression,
       filterCreationSidePlan: LogicalPlan): LogicalPlan = {
     require(filterApplicationSideExp.dataType == filterCreationSideExp.dataType)
-    val alias = Alias(filterCreationSideExp, filterCreationSideExp.toString)()
-    val aggregate = ColumnPruning(Aggregate(Seq(alias), Seq(alias), filterCreationSidePlan))
+    val actualFilterKeyExpr = mayWrapWithHash(filterCreationSideExp)
+    val alias = Alias(actualFilterKeyExpr, actualFilterKeyExpr.toString)()
+    val aggregate =
+      ColumnPruning(Aggregate(Seq(filterCreationSideExp), Seq(alias), filterCreationSidePlan))
     if (!canBroadcastBySize(aggregate, conf)) {
       // Skip the InSubquery filter if the size of `aggregate` is beyond broadcast join threshold,
       // i.e., the semi-join will be a shuffled join, which is not worthwhile.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -108,10 +108,8 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       // i.e., the semi-join will be a shuffled join, which is not worthwhile.
       return filterApplicationSidePlan
     }
-    val project = Project(
-      aggregate.output.map(mayWrapWithHash).map(h => Alias(h, h.toString)()), aggregate)
     val filter = InSubquery(Seq(mayWrapWithHash(filterApplicationSideExp)),
-      ListQuery(project, childOutputs = project.output))
+      ListQuery(aggregate, childOutputs = aggregate.output))
     Filter(filter, filterApplicationSidePlan)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, BloomFilterMightContain
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, BloomFilterAggregate}
 import org.apache.spark.sql.catalyst.optimizer.{ColumnPruning, MergeScalarSubqueries}
 import org.apache.spark.sql.catalyst.plans.LeftSemi
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan}
 import org.apache.spark.sql.execution.{ReusedSubqueryExec, SubqueryExec}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, AQEPropagateEmptyRelation}
 import org.apache.spark.sql.internal.SQLConf
@@ -258,7 +258,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         ensureLeftSemiJoinExists(planEnabled)
         assert(normalizedEnabled != normalizedDisabled)
         val agg = planEnabled.collect {
-          case Join(_, Project(_, agg: Aggregate), LeftSemi, _, _) => agg
+          case Join(_, agg: Aggregate, LeftSemi, _, _) => agg
         }
         assert(agg.size == 1)
         assert(agg.head.fastEquals(ColumnPruning(agg.head)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, BloomFilterMightContain
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, BloomFilterAggregate}
 import org.apache.spark.sql.catalyst.optimizer.{ColumnPruning, MergeScalarSubqueries}
 import org.apache.spark.sql.catalyst.plans.LeftSemi
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan, Project}
 import org.apache.spark.sql.execution.{ReusedSubqueryExec, SubqueryExec}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, AQEPropagateEmptyRelation}
 import org.apache.spark.sql.internal.SQLConf
@@ -258,7 +258,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         ensureLeftSemiJoinExists(planEnabled)
         assert(normalizedEnabled != normalizedDisabled)
         val agg = planEnabled.collect {
-          case Join(_, agg: Aggregate, LeftSemi, _, _) => agg
+          case Join(_, Project(_, agg: Aggregate), LeftSemi, _, _) => agg
         }
         assert(agg.size == 1)
         assert(agg.head.fastEquals(ColumnPruning(agg.head)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark runtime filter supports bloom filter and in subquery filter.
The in subquery filter always execute `Murmur3Hash` before aggregate the join key.

Because the data size before aggregate lager than after, we can only execute `Murmur3Hash` for aggregation and it will reduce the number of calls to `Murmur3Hash` and improve performance.

### Why are the changes needed?
Improve performance for semi-join runtime filter.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
Manually test TPC-DS.
```
spark.sql.optimizer.runtime.bloomFilter.enabled=false
spark.sql.optimizer.runtimeFilter.semiJoinReduction.enabled=true
```

TPC-DS data size: 2TB.
This improvement is valid for below TPC-DS test cases and no regression for other test cases.

| TPC-DS Query   | Before(Seconds)  | After(Seconds)  | Speedup(Percent)  |
|  ----  | ----  | ----  | ----  |
| q23a | 542.03 | 539.06 | 0.55% |
| q23b | 776.7 | 769.74 | 0.90% |
| q24a | 442.25 | 436.75 | 1.26% |
| q24b | 436.16 | 432.86 | 0.76% |
| q50 | 200.92 | 193.36 | 3.91% |
| q64 | 426.73 | 421.03 | 1.35% |
| q67 | 987.79 | 956.82 | 3.24% |
| q93 | 397.26 | 393.9 | 0.85% |
| All TPC-DS | 8392.49 | 8302.56 | 1.08% |

