### PR TITLE
[SPARK-41506][CONNECT][TESTS][FOLLOW-UP] Import BinaryType in pyspark.sql.tests.connect.test_connect_column

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -41,6 +41,7 @@ from pyspark.sql.types import (
     TimestampType,
     TimestampNTZType,
     ByteType,
+    BinaryType,
     ShortType,
     IntegerType,
     FloatType,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/39047 which import `BinaryType` that's removed in https://github.com/apache/spark/pull/39050. This was a logical conflict.

### Why are the changes needed?

To recover the build.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually verified by running `./dev/lint-python`.
