### PR TITLE
[SPARK-41506][CONNECT][PYTHON][FOLLOWUP] Support typed null

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/LiteralValueProtoConverter.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/LiteralValueProtoConverter.scala
@@ -96,6 +96,9 @@ object LiteralValueProtoConverter {
       case proto.Expression.Literal.LiteralTypeCase.DAY_TIME_INTERVAL =>
         expressions.Literal(lit.getDayTimeInterval, DayTimeIntervalType())
 
+      case proto.Expression.Literal.LiteralTypeCase.TYPED_NULL =>
+        expressions.Literal(null, DataTypeProtoConverter.toCatalystType(lit.getTypedNull))
+
       case _ =>
         throw InvalidPlanInput(
           s"Unsupported Literal Type: ${lit.getLiteralTypeCase.getNumber}" +

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -294,7 +294,7 @@ class LiteralExpression(Expression):
         if isinstance(self._dataType, NullType):
             expr.literal.null = True
         elif self._value is None:
-            expr.typed_null.CopyFrom(pyspark_types_to_proto_types(self._dataType))
+            expr.literal.typed_null.CopyFrom(pyspark_types_to_proto_types(self._dataType))
         elif isinstance(self._dataType, BinaryType):
             expr.literal.binary = bytes(self._value)
         elif isinstance(self._dataType, BooleanType):

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -26,6 +26,7 @@ from pyspark.sql.types import (
     FloatType,
     DateType,
     TimestampType,
+    TimestampNTZType,
     DayTimeIntervalType,
     MapType,
     StringType,
@@ -65,6 +66,12 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
         ret.double.CopyFrom(pb2.DataType.Double())
     elif isinstance(data_type, DecimalType):
         ret.decimal.CopyFrom(pb2.DataType.Decimal())
+    elif isinstance(data_type, DateType):
+        ret.date.CopyFrom(pb2.DataType.Date())
+    elif isinstance(data_type, TimestampType):
+        ret.timestamp.CopyFrom(pb2.DataType.Timestamp())
+    elif isinstance(data_type, TimestampNTZType):
+        ret.timestamp_ntz.CopyFrom(pb2.DataType.TimestampNTZ())
     elif isinstance(data_type, DayTimeIntervalType):
         ret.day_time_interval.start_field = data_type.startField
         ret.day_time_interval.end_field = data_type.endField
@@ -106,6 +113,8 @@ def proto_schema_to_pyspark_data_type(schema: pb2.DataType) -> DataType:
         return DateType()
     elif schema.HasField("timestamp"):
         return TimestampType()
+    elif schema.HasField("timestamp_ntz"):
+        return TimestampNTZType()
     elif schema.HasField("day_time_interval"):
         start: Optional[int] = (
             schema.day_time_interval.start_field

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -20,6 +20,7 @@ import datetime
 
 from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
 from pyspark.sql.connect.column import (
+    Column,
     LiteralExpression,
     JVM_BYTE_MIN,
     JVM_BYTE_MAX,
@@ -201,6 +202,9 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             lit_null = LiteralExpression(value=None, dataType=dataType)
             self.assertTrue(lit_null._value is None)
             self.assertEqual(dataType, lit_null._dataType)
+
+            cdf = self.connect.range(0, 1).select(Column(lit_null))
+            self.assertEqual(dataType, cdf.schema.fields[0].dataType)
 
         for value, dataType in [
             ("123", NullType()),


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/spark/pull/39047 forgot to deal with typed_null in the server side,

this PR fix it and add e2e tests for each supported types 


### Why are the changes needed?
to make sure typed null works


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
added tests