### PR TITLE
[SPARK-41518][SQL] Assign a name to the error class `_LEGACY_ERROR_TEMP_2422`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -496,9 +496,9 @@
     ],
     "sqlState" : "42000"
   },
-  "GROUPING_EXPRESSIONS_NOT_FOUND" : {
+  "GROUPING_EXPRESSION_WITHOUT_GROUP_BY" : {
     "message" : [
-      "Not found any GROUP BY expressions, and <sqlExpr> is not an aggregate function. Wrap <aggExprs> by windowing function(s) or wrap <sqlExpr> by `first()` (or `first_value()`) if you don't care which value you get."
+      "The query including grouping and aggregate expressions does not include a GROUP BY clause. Add GROUP BY, aggregate, or turn into the window functions using OVER clauses."
     ]
   },
   "GROUPING_ID_COLUMN_MISMATCH" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,9 +1,4 @@
 {
-  "AGGREGATION_WITHOUT_GROUP_BY" : {
-    "message" : [
-      "The query including the aggregate expression <aggExprs> does not include a GROUP BY clause. Add GROUP BY or turn this into the window functions using OVER clauses, or wrap by `first()` (or `first_value()`) if you don't care which value you get."
-    ]
-  },
   "AMBIGUOUS_COLUMN_OR_FIELD" : {
     "message" : [
       "Column or field <name> is ambiguous and has <n> matches."
@@ -857,6 +852,11 @@
       "Add the columns or the expression to the GROUP BY, aggregate the expression, or use <expressionAnyValue> if you do not care which of the values within a group is returned."
     ],
     "sqlState" : "42000"
+  },
+  "MISSING_GROUP_BY" : {
+    "message" : [
+      "The query does not include a GROUP BY clause. Add GROUP BY or turn it into the window functions using OVER clauses."
+    ]
   },
   "MISSING_STATIC_PARTITION_COLUMN" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -496,6 +496,11 @@
     ],
     "sqlState" : "42000"
   },
+  "GROUPING_EXPRESSIONS_NOT_FOUND" : {
+    "message" : [
+      "Not found any GROUP BY expressions, and <sqlExpr> is not an aggregate function. Wrap <aggExprs> by windowing function(s) or wrap <sqlExpr> by `first()` (or `first_value()`) if you don't care which value you get."
+    ]
+  },
   "GROUPING_ID_COLUMN_MISMATCH" : {
     "message" : [
       "Columns of grouping_id (<groupingIdColumn>) does not match grouping columns (<groupByColumns>)"
@@ -5106,11 +5111,6 @@
   "_LEGACY_ERROR_TEMP_2421" : {
     "message" : [
       "nondeterministic expression <sqlExpr> should not appear in the arguments of an aggregate function."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2422" : {
-    "message" : [
-      "grouping expressions sequence is empty, and '<sqlExpr>' is not an aggregate function. Wrap '<aggExprs>' in windowing function(s) or wrap '<sqlExpr>' in first() (or first_value) if you don't care which value you get."
     ]
   },
   "_LEGACY_ERROR_TEMP_2423" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,4 +1,9 @@
 {
+  "AGGREGATION_WITHOUT_GROUP_BY" : {
+    "message" : [
+      "The query including the aggregate expression <aggExprs> does not include a GROUP BY clause. Add GROUP BY or turn this into the window functions using OVER clauses, or wrap by `first()` (or `first_value()`) if you don't care which value you get."
+    ]
+  },
   "AMBIGUOUS_COLUMN_OR_FIELD" : {
     "message" : [
       "Column or field <name> is ambiguous and has <n> matches."
@@ -495,11 +500,6 @@
       "Column of grouping (<grouping>) can't be found in grouping columns <groupingColumns>"
     ],
     "sqlState" : "42000"
-  },
-  "GROUPING_EXPRESSION_WITHOUT_GROUP_BY" : {
-    "message" : [
-      "The query including grouping and aggregate expressions does not include a GROUP BY clause. Add GROUP BY, aggregate, or turn into the window functions using OVER clauses."
-    ]
   },
   "GROUPING_ID_COLUMN_MISMATCH" : {
     "message" : [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -398,9 +398,13 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   }
                 }
               case e: Attribute if groupingExprs.isEmpty =>
+                // Collect all [[AggregateExpressions]]s.
+                val aggExprs = aggregateExprs.filter(_.collect {
+                  case a: AggregateExpression => a
+                }.nonEmpty)
                 e.failAnalysis(
-                  errorClass = "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
-                  messageParameters = Map.empty)
+                  errorClass = "AGGREGATION_WITHOUT_GROUP_BY",
+                  messageParameters = Map("aggExprs" -> aggExprs.map(toSQLExpr).mkString(", ")))
               case e: Attribute if !groupingExprs.exists(_.semanticEquals(e)) =>
                 throw QueryCompilationErrors.columnNotInGroupByClauseError(e)
               case s: ScalarSubquery

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -397,7 +397,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                       messageParameters = Map("sqlExpr" -> expr.sql))
                   }
                 }
-              case e: Attribute if groupingExprs.isEmpty =>
+              case _: Attribute if groupingExprs.isEmpty =>
                 operator.failAnalysis(
                   errorClass = "MISSING_GROUP_BY",
                   messageParameters = Map.empty)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -398,13 +398,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   }
                 }
               case e: Attribute if groupingExprs.isEmpty =>
-                // Collect all [[AggregateExpressions]]s.
-                val aggExprs = aggregateExprs.filter(_.collect {
-                  case a: AggregateExpression => a
-                }.nonEmpty)
-                e.failAnalysis(
-                  errorClass = "AGGREGATION_WITHOUT_GROUP_BY",
-                  messageParameters = Map("aggExprs" -> aggExprs.map(toSQLExpr).mkString(", ")))
+                operator.failAnalysis(
+                  errorClass = "MISSING_GROUP_BY",
+                  messageParameters = Map.empty)
               case e: Attribute if !groupingExprs.exists(_.semanticEquals(e)) =>
                 throw QueryCompilationErrors.columnNotInGroupByClauseError(e)
               case s: ScalarSubquery

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -403,10 +403,10 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   case a: AggregateExpression => a
                 }.nonEmpty)
                 e.failAnalysis(
-                  errorClass = "_LEGACY_ERROR_TEMP_2422",
+                  errorClass = "GROUPING_EXPRESSIONS_NOT_FOUND",
                   messageParameters = Map(
-                    "sqlExpr" -> e.sql,
-                    "aggExprs" -> aggExprs.map(_.sql).mkString("(", ", ", ")")))
+                    "sqlExpr" -> toSQLExpr(e),
+                    "aggExprs" -> aggExprs.map(toSQLExpr).mkString(", ")))
               case e: Attribute if !groupingExprs.exists(_.semanticEquals(e)) =>
                 throw QueryCompilationErrors.columnNotInGroupByClauseError(e)
               case s: ScalarSubquery

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -398,15 +398,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   }
                 }
               case e: Attribute if groupingExprs.isEmpty =>
-                // Collect all [[AggregateExpressions]]s.
-                val aggExprs = aggregateExprs.filter(_.collect {
-                  case a: AggregateExpression => a
-                }.nonEmpty)
                 e.failAnalysis(
-                  errorClass = "GROUPING_EXPRESSIONS_NOT_FOUND",
-                  messageParameters = Map(
-                    "sqlExpr" -> toSQLExpr(e),
-                    "aggExprs" -> aggExprs.map(toSQLExpr).mkString(", ")))
+                  errorClass = "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+                  messageParameters = Map.empty)
               case e: Attribute if !groupingExprs.exists(_.semanticEquals(e)) =>
                 throw QueryCompilationErrors.columnNotInGroupByClauseError(e)
               case s: ScalarSubquery

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -49,16 +49,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : "\"count(b) FILTER (WHERE (a >= 2)) AS `count(b) FILTER (WHERE (a >= 2))`\""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 8,
-    "stopIndex" : 8,
-    "fragment" : "a"
+    "startIndex" : 1,
+    "stopIndex" : 54,
+    "fragment" : "SELECT a, COUNT(b) FILTER (WHERE a >= 2) FROM testData"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -49,11 +49,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "\"count(b) FILTER (WHERE (a >= 2)) AS `count(b) FILTER (WHERE (a >= 2))`\"",
-    "sqlExpr" : "\"a\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -49,7 +49,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : "\"count(b) FILTER (WHERE (a >= 2)) AS `count(b) FILTER (WHERE (a >= 2))`\""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -49,10 +49,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "(count(testdata.b) FILTER (WHERE (testdata.a >= 2)) AS `count(b) FILTER (WHERE (a >= 2))`)",
-    "sqlExpr" : "testdata.a"
+    "aggExprs" : "\"count(b) FILTER (WHERE (a >= 2)) AS `count(b) FILTER (WHERE (a >= 2))`\"",
+    "sqlExpr" : "\"a\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -16,11 +16,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "\"count(b) AS `count(b)`\"",
-    "sqlExpr" : "\"a\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
@@ -355,11 +351,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "",
-    "sqlExpr" : "\"id\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -16,10 +16,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "(count(testdata.b) AS `count(b)`)",
-    "sqlExpr" : "testdata.a"
+    "aggExprs" : "\"count(b) AS `count(b)`\"",
+    "sqlExpr" : "\"a\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -355,10 +355,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "()",
-    "sqlExpr" : "id"
+    "aggExprs" : "",
+    "sqlExpr" : "\"id\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -16,7 +16,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : "\"count(b) AS `count(b)`\""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
@@ -351,7 +354,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : ""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -16,16 +16,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : "\"count(b) AS `count(b)`\""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 8,
-    "stopIndex" : 8,
-    "fragment" : "a"
+    "startIndex" : 1,
+    "stopIndex" : 32,
+    "fragment" : "SELECT a, COUNT(b) FROM testData"
   } ]
 }
 
@@ -354,16 +351,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : ""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 24,
-    "fragment" : "range(10)"
+    "startIndex" : 1,
+    "stopIndex" : 38,
+    "fragment" : "SELECT id FROM range(10) HAVING id > 0"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
@@ -141,7 +141,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : "\"min(a) AS `min(a#x)`\", \"max(a) AS `max(a#x)`\""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
@@ -141,10 +141,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "(min(spark_catalog.default.test_having.a) AS `min(a#x)`, max(spark_catalog.default.test_having.a) AS `max(a#x)`)",
-    "sqlExpr" : "spark_catalog.default.test_having.a"
+    "aggExprs" : "\"min(a) AS `min(a#x)`\", \"max(a) AS `max(a#x)`\"",
+    "sqlExpr" : "\"a\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
@@ -141,11 +141,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "\"min(a) AS `min(a#x)`\", \"max(a) AS `max(a#x)`\"",
-    "sqlExpr" : "\"a\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
@@ -141,10 +141,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : "\"min(a) AS `min(a#x)`\", \"max(a) AS `max(a#x)`\""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -44,16 +44,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : "\"avg(t2b) AS avg\""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 109,
-    "stopIndex" : 111,
-    "fragment" : "t2b"
+    "startIndex" : 100,
+    "stopIndex" : 203,
+    "fragment" : "SELECT   t2b, avg(t2b) avg\n                      FROM     t2\n                      WHERE    t2a = t1.t1b"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -44,7 +44,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : "\"avg(t2b) AS avg\""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -44,10 +44,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "(avg(t2.t2b) AS avg)",
-    "sqlExpr" : "t2.t2b"
+    "aggExprs" : "\"avg(t2b) AS avg\"",
+    "sqlExpr" : "\"t2b\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -44,11 +44,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "\"avg(t2b) AS avg\"",
-    "sqlExpr" : "\"t2b\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
@@ -390,11 +390,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "",
-    "sqlExpr" : "\"a\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
@@ -390,10 +390,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "()",
-    "sqlExpr" : "data.a"
+    "aggExprs" : "",
+    "sqlExpr" : "\"a\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
@@ -390,10 +390,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : ""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
@@ -390,7 +390,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : ""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
@@ -16,10 +16,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "()",
-    "sqlExpr" : "testdata.a"
+    "aggExprs" : "",
+    "sqlExpr" : "\"a\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
@@ -16,16 +16,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : ""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 8,
-    "stopIndex" : 8,
-    "fragment" : "a"
+    "startIndex" : 1,
+    "stopIndex" : 31,
+    "fragment" : "SELECT a, udaf(b) FROM testData"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
@@ -16,11 +16,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "",
-    "sqlExpr" : "\"a\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
@@ -16,7 +16,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : ""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
@@ -141,7 +141,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : "\"min(a) AS `min(a#x)`\", \"max(a) AS `max(a#x)`\""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
@@ -141,10 +141,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "(min(spark_catalog.default.test_having.a) AS `min(a#x)`, max(spark_catalog.default.test_having.a) AS `max(a#x)`)",
-    "sqlExpr" : "spark_catalog.default.test_having.a"
+    "aggExprs" : "\"min(a) AS `min(a#x)`\", \"max(a) AS `max(a#x)`\"",
+    "sqlExpr" : "\"a\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
@@ -141,11 +141,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "\"min(a) AS `min(a#x)`\", \"max(a) AS `max(a#x)`\"",
-    "sqlExpr" : "\"a\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
@@ -141,10 +141,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : "\"min(a) AS `min(a#x)`\", \"max(a) AS `max(a#x)`\""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -16,11 +16,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "\"udf(count(b)) AS `udf(count(b))`\"",
-    "sqlExpr" : "\"a\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
@@ -332,11 +328,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
-  "messageParameters" : {
-    "aggExprs" : "",
-    "sqlExpr" : "\"id\""
-  },
+  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -16,10 +16,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "(CAST(udf(cast(count(b) as string)) AS BIGINT) AS `udf(count(b))`)",
-    "sqlExpr" : "testdata.a"
+    "aggExprs" : "\"udf(count(b)) AS `udf(count(b))`\"",
+    "sqlExpr" : "\"a\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -332,10 +332,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2422",
+  "errorClass" : "GROUPING_EXPRESSIONS_NOT_FOUND",
   "messageParameters" : {
-    "aggExprs" : "()",
-    "sqlExpr" : "id"
+    "aggExprs" : "",
+    "sqlExpr" : "\"id\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -16,7 +16,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : "\"udf(count(b)) AS `udf(count(b))`\""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
@@ -328,7 +331,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "GROUPING_EXPRESSION_WITHOUT_GROUP_BY",
+  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
+  "messageParameters" : {
+    "aggExprs" : ""
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -16,10 +16,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : "\"udf(count(b)) AS `udf(count(b))`\""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
@@ -331,16 +328,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "AGGREGATION_WITHOUT_GROUP_BY",
-  "messageParameters" : {
-    "aggExprs" : ""
-  },
+  "errorClass" : "MISSING_GROUP_BY",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 21,
-    "stopIndex" : 29,
-    "fragment" : "range(10)"
+    "startIndex" : 1,
+    "stopIndex" : 43,
+    "fragment" : "SELECT udf(id) FROM range(10) HAVING id > 0"
   } ]
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to assign new name `MISSING_GROUP_BY` to the legacy error class `_LEGACY_ERROR_TEMP_2422`, improve its error message format, and regenerate the SQL golden files.

### Why are the changes needed?
To improve user experience with Spark SQL, and unify representation of error messages.

### Does this PR introduce _any_ user-facing change?
Yes, it changes an user-facing error message.

### How was this patch tested?
By running the affected test suites:
```
$ PYSPARK_PYTHON=python3 build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
```