### PR TITLE
[SPARK-41516] [SQL] Allow jdbc dialects to override the query used to create a table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.connector.expressions.{Expression, Literal, NamedRef
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc
 import org.apache.spark.sql.connector.util.V2ExpressionSQLBuilder
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions, JdbcUtils}
+import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions, JdbcOptionsInWrite, JdbcUtils}
 import org.apache.spark.sql.execution.datasources.jdbc.connection.ConnectionProvider
 import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
 import org.apache.spark.sql.internal.SQLConf
@@ -133,6 +133,25 @@ abstract class JdbcDialect extends Serializable with Logging {
    */
   def quoteIdentifier(colName: String): String = {
     s""""$colName""""
+  }
+
+  /**
+   * Create the table if the table does not exist.
+   * To allow certain options to append when create a new table, which can be
+   * table_options or partition_options.
+   * E.g., "CREATE TABLE t (name string) ENGINE=InnoDB DEFAULT CHARSET=utf8"
+   * @param statement
+   * @param tableName
+   * @param strSchema
+   * @param options
+   */
+  def createTable(
+      statement: Statement,
+      tableName: String,
+      strSchema: String,
+      options: JdbcOptionsInWrite): Unit = {
+    val createTableOptions = options.createTableOptions
+    statement.executeUpdate(s"CREATE TABLE $tableName ($strSchema) $createTableOptions")
   }
 
   /**


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Allow jdbc dialects to override the query used to create a table, which is convenient for different databases to implement their own syntax for creating tables


### Why are the changes needed?
Users need to implement their own jdbc dialect according to the database used in the business scenario. Currently, the jdbc dialect in spark cannot customize the way of creating tables, so it cannot support the syntax of specific databases for creating tables. For example, in clickhouse, users may need to specify the name of the cluster when creating a table, using the syntax `on cluster`.
`CREATE TABLE IF NOT EXISTS all_hits ON CLUSTER cluster (p Date, i Int32) ENGINE = Distributed(cluster, default, hits)`
https://clickhouse.com/docs/en/sql-reference/distributed-ddl



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test case added
