### PR TITLE
[MINOR][SQL][TESTS] Fix Typos 'e1 -> e2'

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -762,7 +762,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
     val e2 = intercept[IllegalArgumentException] {
       AnalyzeColumnCommand(TableIdentifier("test"), None, false).run(spark)
     }
-    assert(e1.getMessage.contains("Parameter `columnNames` or `allColumns` are" +
+    assert(e2.getMessage.contains("Parameter `columnNames` or `allColumns` are" +
       " mutually exclusive"))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix typos 'e1 -> e2' for `StatisticsSuite`.

### Why are the changes needed?
Fix typos.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.