### PR TITLE
[SPARK-41453][CONNECT][PYTHON] Implement `DataFrame.subtract`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1025,7 +1025,8 @@ class DataFrame(object):
         This is equivalent to `EXCEPT DISTINCT` in SQL.
         """
         return DataFrame.withPlan(
-            plan.SetOperation(self._plan, other._plan, "except", is_all=False), session=self._session
+            plan.SetOperation(self._plan, other._plan, "except", is_all=False),
+            session=self._session,
         )
 
     def exceptAll(self, other: "DataFrame") -> "DataFrame":

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1004,6 +1004,30 @@ class DataFrame(object):
             session=self._session,
         )
 
+    def subtract(self, other: "DataFrame") -> "DataFrame":
+        """Return a new :class:`DataFrame` containing rows in this :class:`DataFrame`
+        but not in another :class:`DataFrame`.
+
+        .. versionadded:: 3.4.0
+
+        Parameters
+        ----------
+        other : :class:`DataFrame`
+            Another :class:`DataFrame` that needs to be subtracted.
+
+        Returns
+        -------
+        :class:`DataFrame`
+            Subtracted DataFrame.
+
+        Notes
+        -----
+        This is equivalent to `EXCEPT DISTINCT` in SQL.
+        """
+        return DataFrame.withPlan(
+            plan.SetOperation(self._plan, other._plan, "except", is_all=False), session=self._session
+        )
+
     def exceptAll(self, other: "DataFrame") -> "DataFrame":
         """Return a new :class:`DataFrame` containing rows in this :class:`DataFrame` but
         not in another :class:`DataFrame` while preserving duplicates.

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -962,6 +962,18 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             self.spark.read.table(self.tbl_name).agg({"name": "min", "id": "max"}).toPandas(),
         )
 
+    def test_subtract(self):
+        # SPARK-41453: test dataframe.subtract()
+        ndf1 = self.connect.read.table(self.tbl_name)
+        ndf2 = self.connect.read.table(self.tbl_name).filter("id > 3")
+        df1 = self.spark.read.table(self.tbl_name)
+        df2 = self.spark.read.table(self.tbl_name).filter("id > 3")
+
+        self.assert_eq(
+            ndf1.subtract(ndf2).toPandas(),
+            df1.subtract(df2).toPandas(),
+        )
+
     def test_write_operations(self):
         with tempfile.TemporaryDirectory() as d:
             df = self.connect.range(50)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -965,9 +965,9 @@ class SparkConnectTests(SparkConnectSQLTestCase):
     def test_subtract(self):
         # SPARK-41453: test dataframe.subtract()
         ndf1 = self.connect.read.table(self.tbl_name)
-        ndf2 = self.connect.read.table(self.tbl_name).filter("id > 3")
+        ndf2 = ndf1.filter("id > 3")
         df1 = self.spark.read.table(self.tbl_name)
-        df2 = self.spark.read.table(self.tbl_name).filter("id > 3")
+        df2 = df1.filter("id > 3")
 
         self.assert_eq(
             ndf1.subtract(ndf2).toPandas(),

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -468,7 +468,7 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
         df1 = self.connect.readTable(table_name=self.tbl_name)
         df2 = self.connect.readTable(table_name=self.tbl_name)
         plan1 = df1.subtract(df2)._plan.to_proto(self.connect)
-        self.assertTrue(plan1.root.set_op.is_all == False)
+        self.assertTrue(not plan1.root.set_op.is_all)
         self.assertEqual(proto.SetOperation.SET_OP_TYPE_EXCEPT, plan1.root.set_op.set_op_type)
 
     def test_except(self):

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -463,6 +463,14 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
         self.assertTrue(plan3.root.set_op.by_name)
         self.assertEqual(proto.SetOperation.SET_OP_TYPE_UNION, plan3.root.set_op.set_op_type)
 
+    def test_subtract(self):
+        # SPARK-41453: test `subtract` API for Python client.
+        df1 = self.connect.readTable(table_name=self.tbl_name)
+        df2 = self.connect.readTable(table_name=self.tbl_name)
+        plan1 = df1.subtract(df2)._plan.to_proto(self.connect)
+        self.assertTrue(plan1.root.set_op.is_all==False)
+        self.assertEqual(proto.SetOperation.SET_OP_TYPE_EXCEPT, plan1.root.set_op.set_op_type)
+
     def test_except(self):
         # SPARK-41010: test `except` API for Python client.
         df1 = self.connect.readTable(table_name=self.tbl_name)

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -468,7 +468,7 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
         df1 = self.connect.readTable(table_name=self.tbl_name)
         df2 = self.connect.readTable(table_name=self.tbl_name)
         plan1 = df1.subtract(df2)._plan.to_proto(self.connect)
-        self.assertTrue(plan1.root.set_op.is_all==False)
+        self.assertTrue(plan1.root.set_op.is_all == False)
         self.assertEqual(proto.SetOperation.SET_OP_TYPE_EXCEPT, plan1.root.set_op.set_op_type)
 
     def test_except(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `DataFrame.subtract` for python API

### Why are the changes needed?
for Connect API coverage

### Does this PR introduce _any_ user-facing change?
'No'. New API

### How was this patch tested?
New test cases.