### PR TITLE
[MINOR][PS] Workaround to remove several ignores

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6365,10 +6365,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, ps.DatetimeIndex):
             raise TypeError("'last' only supports a DatetimeIndex")
 
-        offset_: Optional[DateOffset] = to_offset(offset)
-        assert offset_ is not None
-
-        from_date = cast(datetime.datetime, self.index.max()) - offset_  # type: ignore[operator]
+        from_date = cast(
+            int,
+            cast(datetime.datetime, self.index.max()) - cast(datetime.timedelta, to_offset(offset)),
+        )
 
         return cast(DataFrame, self.loc[from_date:])
 
@@ -6422,12 +6422,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, ps.DatetimeIndex):
             raise TypeError("'first' only supports a DatetimeIndex")
 
-        offset_: Optional[DateOffset] = to_offset(offset)
-        assert offset_ is not None
+        to_date = cast(
+            int,
+            cast(datetime.datetime, self.index.min()) + cast(datetime.timedelta, to_offset(offset)),
+        )
 
-        to_date = cast(datetime.datetime, self.index.min()) + offset_  # type: ignore[operator]
-
-        return cast(DataFrame, self.loc[:to_date])  # type: ignore[misc]
+        return cast(DataFrame, self.loc[:to_date])
 
     def pivot_table(
         self,

--- a/python/pyspark/pandas/resample.py
+++ b/python/pyspark/pandas/resample.py
@@ -101,7 +101,7 @@ class Resampler(Generic[FrameLike], metaclass=ABCMeta):
         self._offset = to_offset(rule)
         if self._offset.rule_code not in ["A-DEC", "M", "D", "H", "T", "S"]:
             raise ValueError("rule code {} is not supported".format(self._offset.rule_code))
-        if not self._offset.n > 0:  # type: ignore[attr-defined]
+        if not getattr(self._offset, "n") > 0:
             raise ValueError("rule offset must be positive")
 
         if closed is None:
@@ -134,7 +134,7 @@ class Resampler(Generic[FrameLike], metaclass=ABCMeta):
     def _bin_time_stamp(self, origin: pd.Timestamp, ts_scol: Column) -> Column:
         sql_utils = SparkContext._active_spark_context._jvm.PythonSQLUtils
         origin_scol = F.lit(origin)
-        (rule_code, n) = (self._offset.rule_code, self._offset.n)  # type: ignore[attr-defined]
+        (rule_code, n) = (self._offset.rule_code, getattr(self._offset, "n"))
         left_closed, right_closed = (self._closed == "left", self._closed == "right")
         left_labeled, right_labeled = (self._label == "left", self._label == "right")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR workaround several `ignore`s in MyPy check

### Why are the changes needed?

To make MyPy happy.

In addition, It fails (in my local) although I use the exactly same MyPy version. 

```
annotations failed mypy checks:
python/pyspark/pandas/frame.py:6371: error: unused "type: ignore" comment
python/pyspark/pandas/frame.py:6428: error: unused "type: ignore" comment
python/pyspark/pandas/frame.py:6430: error: unused "type: ignore" comment
python/pyspark/pandas/resample.py:104: error: unused "type: ignore" comment
python/pyspark/pandas/resample.py:137: error: unused "type: ignore" comment
Found 5 errors in 2 files (checked 375 source files)
```

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested via `./dev/lint-python` in my local.