### PR TITLE
[SPARK-41410][K8S][FOLLOWUP] Skip splitSlots and requestNewExecutors in case of 0 snapshot

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -152,6 +152,7 @@ class ExecutorPodsAllocator(
       applicationId: String,
       schedulerBackend: KubernetesClusterSchedulerBackend,
       snapshots: Seq[ExecutorPodsSnapshot]): Unit = {
+    logDebug(s"Received ${snapshots.size} snapshots")
     val k8sKnownExecIds = snapshots.flatMap(_.executorPods.keys).distinct
     newlyCreatedExecutors --= k8sKnownExecIds
     schedulerKnownNewlyCreatedExecs --= k8sKnownExecIds
@@ -353,7 +354,8 @@ class ExecutorPodsAllocator(
     }
 
     val remainingSlotFromPendingPods = maxPendingPods - totalNotRunningPodCount
-    if (remainingSlotFromPendingPods > 0 && podsToAllocateWithRpId.size > 0) {
+    if (remainingSlotFromPendingPods > 0 && podsToAllocateWithRpId.size > 0 &&
+        !(snapshots.isEmpty && podAllocOnPVC && maxPVCs <= PVC_COUNTER.get())) {
       ExecutorPodsAllocator.splitSlots(podsToAllocateWithRpId, remainingSlotFromPendingPods)
         .foreach { case ((rpId, podCountForRpId, targetNum), sharedSlotFromPendingPods) =>
         val numMissingPodsForRpId = targetNum - podCountForRpId

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -353,6 +353,9 @@ class ExecutorPodsAllocator(
       }
     }
 
+    // Try to request new executors only when there exist remaining slots within the maximum
+    // number of pending pods and new snapshot arrives in case of waiting for releasing of the
+    // existing PVCs
     val remainingSlotFromPendingPods = maxPendingPods - totalNotRunningPodCount
     if (remainingSlotFromPendingPods > 0 && podsToAllocateWithRpId.size > 0 &&
         !(snapshots.isEmpty && podAllocOnPVC && maxPVCs <= PVC_COUNTER.get())) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up to skip allocation code block (`splitSlots` and `requestNewExecutors`) completely when the notified snapshots are an empty array.

### Why are the changes needed?

When there is no change from K8s control plane side, the notified snapshot is empty like the following. In that case, we still need to do executor clean up, but we don't need to try to create a new executor if we are waiting for new PVCs.
```
22/12/15 18:08:24 INFO ExecutorPodsAllocator: Going to request 1 executors from Kubernetes for ResourceProfile Id: 0, target: 15, known: 14, sharedSlotFromPendingPods: 2147483646.
22/12/15 18:08:24 INFO ExecutorPodsAllocator: Found 0 reusable PVCs from 15 PVCs
22/12/15 18:08:24 INFO ExecutorPodsAllocator: Wait to reuse one of the existing 15 PVCs.
22/12/15 18:08:25 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:26 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:27 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:28 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:29 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:30 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:31 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:32 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:33 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:34 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:35 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:36 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:37 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:38 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:39 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:40 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:41 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:42 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:43 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:44 INFO ExecutorPodsAllocator: Received 0 snapshots
22/12/15 18:08:45 INFO ExecutorPodsAllocator: Received 0 snapshots
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.