### PR TITLE
[SPARK-41536][K8S][DOCS] Remove `Dynamic Resource Allocation` from K8s Future Work section

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -563,7 +563,7 @@ There are several Spark on Kubernetes features that are currently being worked o
 
 Some of these include:
 
-* Dynamic Resource Allocation and External Shuffle Service
+* External Shuffle Service
 * Job Queues and Resource Management
 
 # Configuration


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Dynamic Resource Allocation` from K8s document because Apache Spark has been supported it.
In addition, `Dynamic Resource Allocation` can be used with 3rd-party alternatives like storing the shuffle data to S3 directly. 

Note that the remaining future item, `External Shuffle Service`, is also a good and independent feature.

### Why are the changes needed?

Here is a brief history around `spark.dynamicAllocation.shuffleTracking.enabled`.
- Apache Spark 3.0.0 added it via SPARK-27963 for K8s environment.
- Apache Spark 3.1.1 made K8s GA via SPARK-33005 and started to used it in K8s widely.
- Apache Spark 3.2.0 started to support shuffle data recovery on the reused PVCs via SPARK-35593
- Apache Spark 3.3.0 removed `Experimental` tag from it via SPARK-39322.
- Apache Spark 3.4.0 will enable it by default via SPARK-39846
- This PR removes `Dynamic Allocation` from `Future Work` to improve its visibility.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because this is a documentation change.