### PR TITLE
[SPARK-41542][CONNECT][TESTS] Set parallelism as 1 for coverage report in Spark Connect

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -384,7 +384,7 @@ def run_python_tests(test_modules, parallelism, with_coverage=False):
         # Coverage makes the PySpark tests flaky due to heavy parallelism.
         # When we run PySpark tests with coverage, it uses 4 for now as
         # workaround.
-        parallelism = 4
+        parallelism = 1
         script = "run-tests-with-coverage"
     else:
         script = "run-tests"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to set parallelism as 1 for coverage report in Spark Connect. Currently, the coverage report consistently fails for Spark Connect, see https://github.com/apache/spark/actions/runs/3663716955/jobs/6193686439

### Why are the changes needed?

To make Spark Connect build working (Spark Connect requires 1 parallelism). Note that this is consistent with our PR builder,  see
https://github.com/apache/spark/blob/919e556d182f86b3e1e22cd05a546e0f2fc3e307/.github/workflows/build_and_test.yml#L405

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the jobs and https://app.codecov.io/gh/apache/spark after merging this.