### PR TITLE
[SPARK-41541][SQL] Fix call to wrong child method in SQLShuffleWriteMetricsReporter.decRecordsWritten()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLShuffleMetricsReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLShuffleMetricsReporter.scala
@@ -117,7 +117,7 @@ class SQLShuffleWriteMetricsReporter(
     _bytesWritten.add(v)
   }
   override def decRecordsWritten(v: Long): Unit = {
-    metricsReporter.decBytesWritten(v)
+    metricsReporter.decRecordsWritten(v)
     _recordsWritten.set(_recordsWritten.value - v)
   }
   override def incRecordsWritten(v: Long): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a bug in `SQLShuffleWriteMetricsReporter.decRecordsWritten()`: this method is supposed to call the delegate `metricsReporter`'s `decRecordsWritten` method but due to a typo it calls the `decBytesWritten` method instead.


### Why are the changes needed?

One of the situations where `decRecordsWritten(v)` is called while reverting shuffle writes from failed/canceled tasks. Due to the mixup in these calls, the _recordsWritten_ metric ends up being _v_ records too high (since it wasn't decremented) and the _bytesWritten_ metric ends up _v_ records too low, causing some failed tasks' write metrics to look like

> {"Shuffle Bytes Written":-2109,"Shuffle Write Time":2923270,"Shuffle Records Written":2109} 

instead of

> {"Shuffle Bytes Written":0,"Shuffle Write Time":2923270,"Shuffle Records Written":0} 


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Existing tests / manual code review only. The existing SQLMetricsSuite contains end-to-end tests which exercise this class but they don't exercise the decrement path because they don't exercise the shuffle write failure paths. In theory I could add new unit tests but I don't think the ROI is worth it given that this class is intended to be a simple wrapper and it ~never changes (this PR is the first change to the file in 5 years).
