### PR TITLE
[SPARK-41548][CONNECT][TESTS] Disable ANSI mode in pyspark.sql.tests.connect.test_connect_functions

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -1411,7 +1411,11 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
 
 
 if __name__ == "__main__":
+    import os
     from pyspark.sql.tests.connect.test_connect_function import *  # noqa: F401
+
+    # TODO(SPARK-41547): Enable ANSI mode in this file.
+    os.environ["SPARK_ANSI_SQL_MODE"] = "false"
 
     try:
         import xmlrunner  # type: ignore


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to disable ANSI mode in `pyspark.sql.tests.connect.test_connect_functions` temporarily.

This PR is sort of a followup of https://github.com/apache/spark/pull/38946 and https://github.com/apache/spark/pull/39071

### Why are the changes needed?

There are failures in `test_connect_functions` with ANSI mode on (https://github.com/apache/spark/actions/runs/3709431687/jobs/6288067223). I tried to fix but they are tricky to fix because Spark Connect does not respect the runtime configuration at the server side.

It is also tricky to fix the test to pass in both ANSI mode on and off. Therefore, it disables temporarily to make other tests pass. Note that PySpark tests stop in the middle if one fails.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually verified that:

```bash
SPARK_ANSI_SQL_MODE=true ./python/run-tests --modules pyspark-connect -p 1
```
passes fine.
