### PR TITLE
[SPARK-41546][CONNECT][PYTHON] `pyspark_types_to_proto_types` should support StructType.

### DIFF
--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -88,6 +88,7 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
         raise Exception(f"Unsupported data type {data_type}")
     return ret
 
+
 def proto_schema_to_pyspark_data_type(schema: pb2.DataType) -> DataType:
     if schema.HasField("null"):
         return NullType()

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -75,10 +75,18 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
     elif isinstance(data_type, DayTimeIntervalType):
         ret.day_time_interval.start_field = data_type.startField
         ret.day_time_interval.end_field = data_type.endField
+    elif isinstance(data_type, StructType):
+        fields = []
+        for field in data_type.fields:
+            struct_field = pb2.DataType.StructField()
+            struct_field.name = field.name
+            struct_field.data_type.CopyFrom(pyspark_types_to_proto_types(field.dataType))
+            struct_field.nullable = field.nullable
+            fields.append(struct_field)
+        ret.struct.fields.extend(fields)
     else:
         raise Exception(f"Unsupported data type {data_type}")
     return ret
-
 
 def proto_schema_to_pyspark_data_type(schema: pb2.DataType) -> DataType:
     if schema.HasField("null"):

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -76,14 +76,13 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
         ret.day_time_interval.start_field = data_type.startField
         ret.day_time_interval.end_field = data_type.endField
     elif isinstance(data_type, StructType):
-        fields = []
         for field in data_type.fields:
             struct_field = pb2.DataType.StructField()
             struct_field.name = field.name
             struct_field.data_type.CopyFrom(pyspark_types_to_proto_types(field.dataType))
             struct_field.nullable = field.nullable
-            fields.append(struct_field)
-        ret.struct.fields.extend(fields)
+            ret.struct.fields.append(struct_field)
+
     else:
         raise Exception(f"Unsupported data type {data_type}")
     return ret

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -221,10 +221,12 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
         for schema in [
             StructType(
-                [StructField("col1", IntegerType(), True),
-                 StructField("col2", IntegerType(), True),
-                 StructField("col3", IntegerType(), True),
-                 StructField("col4", IntegerType(), True)]
+                [
+                    StructField("col1", IntegerType(), True),
+                    StructField("col2", IntegerType(), True),
+                    StructField("col3", IntegerType(), True),
+                    StructField("col4", IntegerType(), True),
+                ]
             ),
             "struct<col1 int, col2 int, col3 int, col4 int>",
             "col1 int, col2 int, col3 int, col4 int",

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -20,7 +20,7 @@ import tempfile
 
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.sql import SparkSession, Row
-from pyspark.sql.types import StructType, StructField, LongType, StringType
+from pyspark.sql.types import StructType, StructField, LongType, StringType, IntegerType
 import pyspark.sql.functions
 from pyspark.testing.utils import ReusedPySparkTestCase
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
@@ -219,8 +219,13 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertEqual(sdf.schema, cdf.schema)
         self.assert_eq(sdf.toPandas(), cdf.toPandas())
 
-        # TODO: add cases for StructType after 'pyspark_types_to_proto_types' support StructType
         for schema in [
+            StructType(
+                [StructField("col1", IntegerType(), True),
+                 StructField("col2", IntegerType(), True),
+                 StructField("col3", IntegerType(), True),
+                 StructField("col4", IntegerType(), True)]
+            ),
             "struct<col1 int, col2 int, col3 int, col4 int>",
             "col1 int, col2 int, col3 int, col4 int",
             "col1 int, col2 long, col3 string, col4 long",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, `pyspark_types_to_proto_types` used to transform pyspark datatypes to protobuffer datatypes.
But it only supports the primary data type, no struct type.
Many connect API need to transform pyspark struct type to protobuffer struct type. For example, `createDataFrame`, `DataFrame.to` and so on.


### Why are the changes needed?
This PR let `pyspark_types_to_proto_types` support `StructType`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New tests.
