### PR TITLE
[SPARK-41559][INFRA] Recover Codecov report in the scheduled job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -404,7 +404,7 @@ jobs:
         export PATH=$PATH:$HOME/miniconda/bin
         ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST"
     - name: Upload coverage to Codecov
-      if: inputs.type == 'pyspark-coverage-scheduled'
+      if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
       uses: codecov/codecov-action@v2
       with:
         files: ./python/coverage.xml


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a kind of a followup of https://github.com/apache/spark/pull/36940 which fixes a mistake of replacing `inputs.type`.

This PR changes it to use `PYSPARK_CODECOV` that's defined from https://github.com/apache/spark/blob/353df517f4d37aabbf807638385b0ab92dd95397/.github/workflows/build_coverage.yml#L39.

Similar approach is being used in https://github.com/apache/spark/blob/353df517f4d37aabbf807638385b0ab92dd95397/.github/workflows/build_ansi.yml#L39 with https://github.com/apache/spark/blob/919e556d182f86b3e1e22cd05a546e0f2fc3e307/.github/workflows/build_and_test.yml#L797

### Why are the changes needed?

To recover the Codecov site. It stopped working for few months (https://app.codecov.io/gh/apache/spark).

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the test cases. I am sure it works :-)