### PR TITLE
[SPARK-41562][BUILD] Upgrade joda-time from 2.12.1 to 2.12.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -146,7 +146,7 @@ jetty-util/6.1.26//jetty-util-6.1.26.jar
 jetty-util/9.4.49.v20220914//jetty-util-9.4.49.v20220914.jar
 jetty/6.1.26//jetty-6.1.26.jar
 jline/2.14.6//jline-2.14.6.jar
-joda-time/2.12.1//joda-time-2.12.1.jar
+joda-time/2.12.2//joda-time-2.12.2.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -131,7 +131,7 @@ jettison/1.1//jettison-1.1.jar
 jetty-util-ajax/9.4.49.v20220914//jetty-util-ajax-9.4.49.v20220914.jar
 jetty-util/9.4.49.v20220914//jetty-util-9.4.49.v20220914.jar
 jline/2.14.6//jline-2.14.6.jar
-joda-time/2.12.1//joda-time-2.12.1.jar
+joda-time/2.12.2//joda-time-2.12.2.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
     <guava.version>14.0.1</guava.version>
     <janino.version>3.1.9</janino.version>
     <jersey.version>2.36</jersey.version>
-    <joda.version>2.12.1</joda.version>
+    <joda.version>2.12.2</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
     <libthrift.version>0.12.0</libthrift.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade joda-time from 2.12.1 to 2.12.2.

### Why are the changes needed?
https://github.com/JodaOrg/joda-time/compare/v2.12.1...2.12.2
[Update time zone data to 2022ggtz](https://github.com/JodaOrg/joda-time/commit/cbe049e6b7d47c36c109b8b200a484693586b38e)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.