### PR TITLE
[SPARK-41563][SQL] Support partition filter in MSCK REPAIR TABLE statement

### DIFF
--- a/docs/sql-ref-syntax-ddl-repair-table.md
+++ b/docs/sql-ref-syntax-ddl-repair-table.md
@@ -28,7 +28,7 @@ If the table is cached, the command clears cached data of the table and all its 
 ### Syntax
 
 ```sql
-MSCK REPAIR TABLE table_identifier [{ADD|DROP|SYNC} PARTITIONS]
+MSCK REPAIR TABLE table_identifier [{ADD|DROP|SYNC} PARTITIONS [partition_spec]]
 ```
 
 ### Parameters
@@ -46,6 +46,12 @@ MSCK REPAIR TABLE table_identifier [{ADD|DROP|SYNC} PARTITIONS]
     * **ADD**, the command adds new partitions to the session catalog for all sub-folder in the base table folder that don't belong to any table partitions.
     * **DROP**, the command drops all partitions from the session catalog that have non-existing locations in the file system.
     * **SYNC** is the combination of **DROP** and **ADD**. 
+
+* **partition_spec**
+
+    An optional parameter that specifies a comma-seperated list of key and value pairs for partitions. Note that one can use a typed literal (e.g., date'2022-01-01') in the partition spec.
+
+    **Syntax:** ` ( partition_col_name = partition_col_val [ , ... ] )`
 
 ### Examples
 

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -204,7 +204,7 @@ statement
         multipartIdentifier partitionSpec?                             #loadData
     | TRUNCATE TABLE multipartIdentifier partitionSpec?                #truncateTable
     | MSCK REPAIR TABLE multipartIdentifier
-        (option=(ADD|DROP|SYNC) PARTITIONS)?                           #repairTable
+        (option=(ADD|DROP|SYNC) PARTITIONS partitionLists?)?           #repairTable
     | op=(ADD | LIST) identifier .*?                                   #manageResource
     | SET ROLE .*?                                                     #failNativeCommand
     | SET TIME ZONE interval                                           #setTimeZone
@@ -329,12 +329,16 @@ partitionSpecLocation
     ;
 
 partitionSpec
-    : PARTITION LEFT_PAREN partitionVal (COMMA partitionVal)* RIGHT_PAREN
+    : PARTITION partitionLists
     ;
 
 partitionVal
     : identifier (EQ constant)?
     | identifier EQ DEFAULT
+    ;
+
+partitionLists
+    : LEFT_PAREN partitionVal (COMMA partitionVal)* RIGHT_PAREN
     ;
 
 namespace

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1076,7 +1076,8 @@ case class DropView(
 case class RepairTable(
     child: LogicalPlan,
     enableAddPartitions: Boolean,
-    enableDropPartitions: Boolean) extends UnaryCommand {
+    enableDropPartitions: Boolean,
+    partitionSpec: TablePartitionSpec) extends UnaryCommand {
   override protected def withNewChildInternal(newChild: LogicalPlan): RepairTable =
     copy(child = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -69,7 +69,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
     new ParseException(errorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION", ctx)
   }
 
-  def emptyPartitionKeyError(key: String, ctx: PartitionSpecContext): Throwable = {
+  def emptyPartitionKeyError(key: String, ctx: PartitionListsContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_SQL_SYNTAX",
       messageParameters = Map(

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -281,8 +281,10 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case AnalyzeColumn(ResolvedV1TableOrViewIdentifier(ident), columnNames, allColumns) =>
       AnalyzeColumnCommand(ident, columnNames, allColumns)
 
-    case RepairTable(ResolvedV1TableIdentifier(ident), addPartitions, dropPartitions) =>
-      RepairTableCommand(ident, addPartitions, dropPartitions)
+    case RepairTable(
+        ResolvedV1TableIdentifier(ident),
+        addPartitions, dropPartitions, partitionSpec) =>
+      RepairTableCommand(ident, addPartitions, dropPartitions, partitionSpec)
 
     case LoadData(ResolvedV1TableIdentifier(ident), path, isLocal, isOverwrite, partition) =>
       LoadDataCommand(
@@ -337,6 +339,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         ident,
         enableAddPartitions = true,
         enableDropPartitions = false,
+        partitionSpec = Map.empty,
         "ALTER TABLE RECOVER PARTITIONS")
 
     case AddPartitions(ResolvedV1TableIdentifier(ident), partSpecsAndLocs, ifNotExists) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -467,7 +467,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
         table,
         pattern.map(_.asInstanceOf[ResolvedPartitionSpec])) :: Nil
 
-    case RepairTable(_: ResolvedTable, _, _) =>
+    case RepairTable(_: ResolvedTable, _, _, _) =>
       throw QueryCompilationErrors.repairTableNotSupportedForV2TablesError()
 
     case r: CacheTable =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -325,8 +325,8 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlState = "23000",
       parameters = Map("keyColumn" -> "`p1`"),
       context = ExpectedContext(
-        fragment = "PARTITION(p1='1', p1='1')",
-        start = 29,
+        fragment = "(p1='1', p1='1')",
+        start = 38,
         stop = 53))
   }
 
@@ -438,8 +438,8 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlState = "42000",
       parameters = Map("inputString" -> "Partition key `grade` must set value (can't be empty)."),
       context = ExpectedContext(
-        fragment = "PARTITION (grade)",
-        start = 47,
+        fragment = "(grade)",
+        start = 57,
         stop = 63))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/MsckRepairTableParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/MsckRepairTableParserSuite.scala
@@ -28,7 +28,8 @@ class MsckRepairTableParserSuite extends AnalysisTest {
       RepairTable(
         UnresolvedTable(Seq("a", "b", "c"), "MSCK REPAIR TABLE", None),
         enableAddPartitions = true,
-        enableDropPartitions = false))
+        enableDropPartitions = false,
+        partitionSpec = Map.empty))
   }
 
   test("add partitions") {
@@ -40,7 +41,8 @@ class MsckRepairTableParserSuite extends AnalysisTest {
           "MSCK REPAIR TABLE ... ADD PARTITIONS",
           None),
         enableAddPartitions = true,
-        enableDropPartitions = false))
+        enableDropPartitions = false,
+        partitionSpec = Map.empty))
   }
 
   test("drop partitions") {
@@ -52,7 +54,8 @@ class MsckRepairTableParserSuite extends AnalysisTest {
           "MSCK REPAIR TABLE ... DROP PARTITIONS",
           None),
         enableAddPartitions = false,
-        enableDropPartitions = true))
+        enableDropPartitions = true,
+        partitionSpec = Map.empty))
   }
 
   test("sync partitions") {
@@ -64,6 +67,22 @@ class MsckRepairTableParserSuite extends AnalysisTest {
           "MSCK REPAIR TABLE ... SYNC PARTITIONS",
           None),
         enableAddPartitions = true,
-        enableDropPartitions = true))
+        enableDropPartitions = true,
+        partitionSpec = Map.empty))
+  }
+
+  test("sync partitions with static partitions") {
+    comparePlans(
+      parsePlan("MSCK REPAIR TABLE spark_catalog.ns.tbl SYNC PARTITIONS (part0='str', part1=10)"),
+      RepairTable(
+        UnresolvedTable(
+          Seq("spark_catalog", "ns", "tbl"),
+          "MSCK REPAIR TABLE ... SYNC PARTITIONS (part0=str,part1=10)",
+          None),
+        enableAddPartitions = true,
+        enableDropPartitions = true,
+        Map("part0" -> "str", "part1" -> "10")
+      )
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
@@ -51,8 +51,8 @@ class ShowPartitionsParserSuite extends AnalysisTest {
       sqlState = "42000",
       parameters = Map("inputString" -> "Partition key `b` must set value (can't be empty)."),
       context = ExpectedContext(
-        fragment = "PARTITION (a='1', b)",
-        start = 25,
+        fragment = "(a='1', b)",
+        start = 35,
         stop = 44))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
@@ -51,8 +51,8 @@ class TruncateTableParserSuite extends AnalysisTest {
       sqlState = "42000",
       parameters = Map("inputString" -> "Partition key `b` must set value (can't be empty)."),
       context = ExpectedContext(
-        fragment = "PARTITION (a='1', b)",
-        start = 24,
+        fragment = "(a='1', b)",
+        start = 34,
         stop = 43))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1141,8 +1141,8 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         errorClass = "_LEGACY_ERROR_TEMP_0059",
         parameters = Map.empty,
         context = ExpectedContext(
-          fragment = "partition(i=default)",
-          start = 14,
+          fragment = "(i=default)",
+          start = 23,
           stop = 33))
     }
     // The configuration option to append missing NULL values to the end of the INSERT INTO


### PR DESCRIPTION
### What changes were proposed in this pull request?

We would like to expand the `MSCK REPAIR TABLE` statement to support partition filter with new options:
 `MSCK REPAIR TABLE table_identifier [{ADD|DROP|SYNC} PARTITIONS [partition_spec]]`
**partition_spec**:  ` ( partition_col_name = partition_col_val [ , ... ] )`

### Why are the changes needed?
1. Listing all partitions may hit the request limit in some metastore like Hive metastore.
2. Partition filter can improve the performance if we only need repair the specific partitions.


### Does this PR introduce _any_ user-facing change?
Yes, we update the document of `MSCK REPAIR TABLE` for the new partition filter options.


### How was this patch tested?
UTs.
