### PR TITLE
[SPARK-41567][BUILD] Move configuration of `versions-maven-plugin` to parent pom

### DIFF
--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -33,7 +33,6 @@ export LC_ALL=C
 HADOOP_MODULE_PROFILES="-Phive-thriftserver -Pmesos -Pkubernetes -Pyarn -Phive \
     -Pspark-ganglia-lgpl -Pkinesis-asl -Phadoop-cloud"
 MVN="build/mvn"
-VERSIONS_MAVEN_PLUGIN="org.codehaus.mojo:versions-maven-plugin:2.14.1"
 HADOOP_HIVE_PROFILES=(
     hadoop-2-hive-2.3
     hadoop-3-hive-2.3
@@ -77,11 +76,11 @@ function reset_version {
   find "$HOME/.m2/" | grep "$TEMP_VERSION" | xargs rm -rf
 
   # Restore the original version number:
-  $MVN -q $VERSIONS_MAVEN_PLUGIN:set -DnewVersion=$OLD_VERSION -DgenerateBackupPoms=false > /dev/null
+  $MVN -q versions:set -DnewVersion=$OLD_VERSION -DgenerateBackupPoms=false > /dev/null
 }
 trap reset_version EXIT
 
-$MVN -q $VERSIONS_MAVEN_PLUGIN:set -DnewVersion=$TEMP_VERSION -DgenerateBackupPoms=false > /dev/null
+$MVN -q versions:set -DnewVersion=$TEMP_VERSION -DgenerateBackupPoms=false > /dev/null
 
 # Generate manifests for each Hadoop profile:
 for HADOOP_HIVE_PROFILE in "${HADOOP_HIVE_PROFILES[@]}"; do

--- a/pom.xml
+++ b/pom.xml
@@ -3428,10 +3428,6 @@
         <version>4.2.0</version>
         <extensions>true</extensions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
       See: SPARK-36547, SPARK-38394.
        -->
     <scala-maven-plugin.version>4.8.0</scala-maven-plugin.version>
+    <versions-maven-plugin.version>2.14.1</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>
@@ -3187,6 +3188,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${versions-maven-plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -3421,6 +3427,10 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>4.2.0</version>
         <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-41544 make `test-dependencies.sh` to use specified version of `versions-maven-plugin` to run `build/mvn versions:set` command,  but except for
`test-dependencies.sh`, `release-build.sh` and `release-tag.sh` also use the `build/mvn versions:set` command. 

**release-build.sh**:

https://github.com/apache/spark/blob/90120f0ae4b472e2517c8288ea53baf6bcb38c22/dev/create-release/release-build.sh#L420

https://github.com/apache/spark/blob/90120f0ae4b472e2517c8288ea53baf6bcb38c22/dev/create-release/release-build.sh#L445

**release-tag.sh**:

https://github.com/apache/spark/blob/90120f0ae4b472e2517c8288ea53baf6bcb38c22/dev/create-release/release-tag.sh#L77

https://github.com/apache/spark/blob/90120f0ae4b472e2517c8288ea53baf6bcb38c22/dev/create-release/release-tag.sh#L99

So this pr move the configuration of `versions-maven-plugin` to parent pom to make the whole Spark project use same version of `versions-maven-plugin`.


### Why are the changes needed?
Make the whole Spark project use same version of `versions-maven-plugin`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions and manually check the script is executable