### PR TITLE
[3.3][SPARK-41350][SQL][FOLLOWUP] Allow simple name access of join hidden columns after alias 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
 import org.apache.spark.sql.catalyst.trees.TreePattern
 import org.apache.spark.sql.catalyst.trees.TreePattern._
-import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, METADATA_COL_ATTR_KEY}
+import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
 import org.apache.spark.util.collection.BitSet
@@ -191,7 +191,10 @@ case class Alias(child: Expression, name: String)(
 
   override def toAttribute: Attribute = {
     if (resolved) {
-      AttributeReference(name, child.dataType, child.nullable, metadata)(exprId, qualifier)
+      val a = AttributeReference(name, child.dataType, child.nullable, metadata)(exprId, qualifier)
+      // Alias has its own qualifier. It doesn't make sense to still restrict the hidden columns
+      // of natural/using join to be accessed by qualified name only.
+      if (a.qualifiedAccessOnly) a.markAsAllowAnyAccess() else a
     } else {
       UnresolvedAttribute.quoted(name)
     }

--- a/sql/core/src/test/resources/sql-tests/inputs/natural-join.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/natural-join.sql
@@ -52,6 +52,8 @@ SELECT nt1.k, nt2.k FROM nt1 natural join nt2;
 
 SELECT k FROM (SELECT nt2.k FROM nt1 natural join nt2);
 
+SELECT nt2.k AS key FROM nt1 natural join nt2 ORDER BY key;
+
 SELECT nt1.k, nt2.k FROM nt1 natural join nt2 where k = "one";
 
 SELECT * FROM (SELECT * FROM nt1 natural join nt2);

--- a/sql/core/src/test/resources/sql-tests/inputs/using-join.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/using-join.sql
@@ -21,6 +21,8 @@ SELECT nt1.k, nt2.k FROM nt1 left outer join nt2 using (k);
 
 SELECT k FROM (SELECT nt2.k FROM nt1 left outer join nt2 using (k));
 
+SELECT nt2.k AS key FROM nt1 left outer join nt2 using (k) ORDER BY key;
+
 SELECT nt1.k, nt2.k FROM nt1 left outer join nt2 using (k) ORDER BY nt2.k;
 
 SELECT k, nt1.k FROM nt1 left outer join nt2 using (k);
@@ -47,6 +49,8 @@ SELECT nt1.k, nt2.k FROM nt1 right outer join nt2 using (k);
 
 SELECT k FROM (SELECT nt1.k FROM nt1 right outer join nt2 using (k));
 
+SELECT nt1.k AS key FROM nt1 right outer join nt2 using (k) ORDER BY key;
+
 SELECT k, nt1.k FROM nt1 right outer join nt2 using (k);
 
 SELECT k, nt2.k FROM nt1 right outer join nt2 using (k);
@@ -61,6 +65,8 @@ SELECT nt1.k, nt2.k FROM nt1 full outer join nt2 using (k);
 
 SELECT k FROM (SELECT nt2.k FROM nt1 full outer join nt2 using (k));
 
+SELECT nt2.k AS key FROM nt1 full outer join nt2 using (k) ORDER BY key;
+
 SELECT k, nt1.k FROM nt1 full outer join nt2 using (k);
 
 SELECT k, nt2.k FROM nt1 full outer join nt2 using (k);
@@ -74,6 +80,8 @@ SELECT nt1.*, nt2.* FROM nt1 inner join nt2 using (k);
 SELECT nt1.k, nt2.k FROM nt1 inner join nt2 using (k);
 
 SELECT k FROM (SELECT nt2.k FROM nt1 inner join nt2 using (k));
+
+SELECT nt2.k AS key FROM nt1 inner join nt2 using (k) ORDER BY key;
 
 SELECT k, nt1.k FROM nt1 inner join nt2 using (k);
 

--- a/sql/core/src/test/resources/sql-tests/results/natural-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/natural-join.sql.out
@@ -198,6 +198,16 @@ two
 
 
 -- !query
+SELECT nt2.k AS key FROM nt1 natural join nt2 ORDER BY key
+-- !query schema
+struct<key:string>
+-- !query output
+one
+one
+two
+
+
+-- !query
 SELECT nt1.k, nt2.k FROM nt1 natural join nt2 where k = "one"
 -- !query schema
 struct<k:string,k:string>

--- a/sql/core/src/test/resources/sql-tests/results/using-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/using-join.sql.out
@@ -83,6 +83,17 @@ two
 
 
 -- !query
+SELECT nt2.k AS key FROM nt1 left outer join nt2 using (k) ORDER BY key
+-- !query schema
+struct<key:string>
+-- !query output
+NULL
+one
+one
+two
+
+
+-- !query
 SELECT nt1.k, nt2.k FROM nt1 left outer join nt2 using (k) ORDER BY nt2.k
 -- !query schema
 struct<k:string,k:string>
@@ -216,6 +227,17 @@ two
 
 
 -- !query
+SELECT nt1.k AS key FROM nt1 right outer join nt2 using (k) ORDER BY key
+-- !query schema
+struct<key:string>
+-- !query output
+NULL
+one
+one
+two
+
+
+-- !query
 SELECT k, nt1.k FROM nt1 right outer join nt2 using (k)
 -- !query schema
 struct<k:string,k:string>
@@ -298,6 +320,18 @@ two
 
 
 -- !query
+SELECT nt2.k AS key FROM nt1 full outer join nt2 using (k) ORDER BY key
+-- !query schema
+struct<key:string>
+-- !query output
+NULL
+four
+one
+one
+two
+
+
+-- !query
 SELECT k, nt1.k FROM nt1 full outer join nt2 using (k)
 -- !query schema
 struct<k:string,k:string>
@@ -367,6 +401,16 @@ two	two
 SELECT k FROM (SELECT nt2.k FROM nt1 inner join nt2 using (k))
 -- !query schema
 struct<k:string>
+-- !query output
+one
+one
+two
+
+
+-- !query
+SELECT nt2.k AS key FROM nt1 inner join nt2 using (k) ORDER BY key
+-- !query schema
+struct<key:string>
 -- !query output
 one
 one


### PR DESCRIPTION
backport https://github.com/apache/spark/pull/39077 to 3.3