### PR TITLE
[SPARK-41585][YARN] The Spark exclude node functionality for YARN should work independently of dynamic allocation

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -167,8 +167,6 @@ private[yarn] class YarnAllocator(
 
   private val memoryOverheadFactor = sparkConf.get(EXECUTOR_MEMORY_OVERHEAD_FACTOR)
 
-  private val excludeNodes = sparkConf.get(YARN_EXCLUDE_NODES).toSet
-
   private val launcherPool = ThreadUtils.newDaemonCachedThreadPool(
     "ContainerLauncher", sparkConf.get(CONTAINER_LAUNCH_MAX_THREADS))
 
@@ -565,7 +563,6 @@ private[yarn] class YarnAllocator(
           }
         }
 
-        allocatorNodeHealthTracker.setSchedulerExcludedNodes(excludeNodes)
         newLocalityRequests.foreach { request =>
           amClient.addContainerRequest(request)
         }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -167,6 +167,8 @@ private[yarn] class YarnAllocator(
 
   private val memoryOverheadFactor = sparkConf.get(EXECUTOR_MEMORY_OVERHEAD_FACTOR)
 
+  private val excludeNodes = sparkConf.get(YARN_EXCLUDE_NODES).toSet
+
   private val launcherPool = ThreadUtils.newDaemonCachedThreadPool(
     "ContainerLauncher", sparkConf.get(CONTAINER_LAUNCH_MAX_THREADS))
 
@@ -563,6 +565,7 @@ private[yarn] class YarnAllocator(
           }
         }
 
+        allocatorNodeHealthTracker.setSchedulerExcludedNodes(excludeNodes)
         newLocalityRequests.foreach { request =>
           amClient.addContainerRequest(request)
         }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocatorNodeHealthTracker.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocatorNodeHealthTracker.scala
@@ -144,6 +144,8 @@ private[spark] class YarnAllocatorNodeHealthTracker(
     val now = failureTracker.clock.getTimeMillis()
     allocatorExcludedNodeList.retain { (_, expiryTime) => expiryTime > now }
   }
+
+  refreshExcludedNodes
 }
 
 /**

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorHealthTrackerSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorHealthTrackerSuite.scala
@@ -97,6 +97,16 @@ class YarnAllocatorHealthTrackerSuite extends SparkFunSuite with Matchers
     verify(amClientMock, times(0)).updateBlacklist(Collections.emptyList(), Collections.emptyList())
   }
 
+  test("SPARK-41585 YARN Exclude Nodes should work independently of dynamic allocation") {
+    sparkConf.set(YARN_EXCLUDE_NODES, Seq("host1", "host2"))
+    val yarnHealthTracker = createYarnAllocatorHealthTracker(sparkConf)
+
+    // Check that host1 and host2 are in the exclude list
+    // Note, this covers also non-dynamic allocation
+    verify(amClientMock)
+      .updateBlacklist(Arrays.asList("host1", "host2"), Collections.emptyList())
+  }
+
   test("combining scheduler and allocation excluded node list") {
     sparkConf.set(YARN_EXCLUDE_NODES, Seq("initial1", "initial2"))
     val yarnHealthTracker = createYarnAllocatorHealthTracker(sparkConf)


### PR DESCRIPTION
### What changes were proposed in this pull request?
The Spark exclude node functionality for Spark on YARN, introduced in [SPARK-26688](https://issues.apache.org/jira/browse/SPARK-26688), allows users to specify a list of node names that are excluded from resource allocation. This is done using the configuration parameter: `spark.yarn.exclude.nodes`
The feature currently works only for executors allocated via dynamic allocation. To use the feature on Spark 3.3.1, for example, one may need also to configure `spark.dynamicAllocation.minExecutors=0` and `spark.executor.instances=0`, therefore relying on executor resource allocation only via dynamic allocation.

### Why are the changes needed?
This proposes to extend the use of Spark exclude node functionality for YARN beyond dynamic allocation, which I believe makes it more consistent also with what the documentation reports for this feature/configuration parameter.

### Does this PR introduce _any_ user-facing change?
Yes, this allows using the executor exclude nodes feature for Spark on YARN also when not using dynamical allocation.

### How was this patch tested?
A unit test has been added for this + manual tests on a YARN cluster.
