### PR TITLE
[SPARK-41427][UI][FOLLOWUP] Remove duplicate `getMetricValue` from `ExecutorMetricsSerializer#serialize`

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/protobuf/ExecutorMetricsSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/ExecutorMetricsSerializer.scala
@@ -25,7 +25,6 @@ object ExecutorMetricsSerializer {
     val builder = StoreTypes.ExecutorMetrics.newBuilder()
     ExecutorMetricType.metricToOffset.foreach { case (metric, _) =>
       builder.putMetrics(metric, e.getMetricValue(metric))
-      metric -> e.getMetricValue(metric)
     }
     builder.build()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims remove duplicate `getMetricValue` from `ExecutorMetricsSerializer#serialize`.


### Why are the changes needed?
Delete duplicate operations




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions