### PR TITLE
[SPARK-41334][CONNECT][FOLLOWUP] Handle SortOrder Expression

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -480,6 +480,7 @@ class SparkConnectPlanner(session: SparkSession) {
       case proto.Expression.ExprTypeCase.CAST => transformCast(exp.getCast)
       case proto.Expression.ExprTypeCase.UNRESOLVED_REGEX =>
         transformUnresolvedRegex(exp.getUnresolvedRegex)
+      case proto.Expression.ExprTypeCase.SORT_ORDER => transformSortOrder(exp.getSortOrder)
       case _ =>
         throw InvalidPlanInput(
           s"Expression with ID: ${exp.getExprTypeCase.getNumber} is not supported")
@@ -699,10 +700,10 @@ class SparkConnectPlanner(session: SparkSession) {
     logical.Sort(
       child = transformRelation(sort.getInput),
       global = sort.getIsGlobal,
-      order = sort.getOrderList.asScala.toSeq.map(transformSortOrderExpression))
+      order = sort.getOrderList.asScala.toSeq.map(transformSortOrder))
   }
 
-  private def transformSortOrderExpression(order: proto.Expression.SortOrder) = {
+  private def transformSortOrder(order: proto.Expression.SortOrder) = {
     expressions.SortOrder(
       child = transformExpression(order.getChild),
       direction = order.getDirection match {


### PR DESCRIPTION

### What changes were proposed in this pull request?
in #39090 we moved `SortOrder` proto from relations to expressions, in this PR we add logic to handle it.

### Why are the changes needed?
[<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->](https://github.com/dengziming/spark/pull/new/SortOrder)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
A unit test and existing tests.