### PR TITLE
[SPARK-41633][SQL] Identify aggregation expressions in the nodePatterns of PythonUDF

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -64,16 +64,16 @@ case class PythonUDF(
 
   override def toString: String = s"$name(${children.mkString(", ")})#${resultId.id}$typeSuffix"
 
-  private def nodePatternsOfPythonFunction: Option[TreePattern] = {
+  private def nodePatternsOfPythonFunction: Seq[TreePattern] = {
     if (evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF) {
-      Some(AGGREGATE_EXPRESSION)
+      Seq(AGGREGATE_EXPRESSION)
     } else {
-      None
+      Seq.empty
     }
   }
 
   final override val nodePatterns: Seq[TreePattern] =
-    Seq(PYTHON_UDF) ++ nodePatternsOfPythonFunction.toSeq
+    Seq(PYTHON_UDF) ++ nodePatternsOfPythonFunction
 
   lazy val resultAttribute: Attribute = AttributeReference(toPrettySQL(this), dataType, nullable)(
     exprId = resultId)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -68,6 +68,7 @@ case class PythonUDF(
 
   override def toString: String = s"$name(${children.mkString(", ")})#${resultId.id}$typeSuffix"
 
+  // SPARK-41633: We should check whether to update the node patterns when adding a new eval type.
   private def nodePatternsOfPythonFunction: Seq[TreePattern] = {
     if (PythonUDF.isGroupedAggPandasUDFEvalType(evalType)) {
       Seq(AGGREGATE_EXPRESSION)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -36,9 +36,13 @@ object PythonUDF {
     e.isInstanceOf[PythonUDF] && SCALAR_TYPES.contains(e.asInstanceOf[PythonUDF].evalType)
   }
 
+  def isGroupedAggPandasUDFEvalType(evalType: Int): Boolean = {
+    evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
+  }
+
   def isGroupedAggPandasUDF(e: Expression): Boolean = {
     e.isInstanceOf[PythonUDF] &&
-      e.asInstanceOf[PythonUDF].evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
+      isGroupedAggPandasUDFEvalType(e.asInstanceOf[PythonUDF].evalType)
   }
 
   // This is currently same as GroupedAggPandasUDF, but we might support new types in the future,
@@ -65,7 +69,7 @@ case class PythonUDF(
   override def toString: String = s"$name(${children.mkString(", ")})#${resultId.id}$typeSuffix"
 
   private def nodePatternsOfPythonFunction: Seq[TreePattern] = {
-    if (evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF) {
+    if (PythonUDF.isGroupedAggPandasUDFEvalType(evalType)) {
       Seq(AGGREGATE_EXPRESSION)
     } else {
       Seq.empty


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
For Python UDF with aggregation functions, we can mark them as `AGGREGATE_EXPRESSION` in the `nodePatterns` of PythonUDF. So that we can check whether an expression contains aggregation in a handy way: `expr.containsPattern(AGGREGATE_EXPRESSION)` 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Address comment in https://github.com/apache/spark/pull/39134#discussion_r1052993548. This should provide a handy way for checking whether an expression contains aggregations.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT