### PR TITLE
[MINOR][PYTHON][DOCS] Correct the return type of `_to_java_cols`

### DIFF
--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 __all__ = ["Window", "WindowSpec"]
 
 
-def _to_java_cols(cols: Tuple[Union["ColumnOrName", List["ColumnOrName_"]], ...]) -> int:
+def _to_java_cols(cols: Tuple[Union["ColumnOrName", List["ColumnOrName_"]], ...]) -> JavaObject:
     sc = SparkContext._active_spark_context
     if len(cols) == 1 and isinstance(cols[0], list):
         cols = cols[0]  # type: ignore[assignment]


### PR DESCRIPTION
### What changes were proposed in this pull request?
the return type should be `JavaObject `


### Why are the changes needed?
the return type should be `JavaObject` according to https://github.com/apache/spark/blob/master/python/pyspark/sql/column.py#L74-L88



### Does this PR introduce _any_ user-facing change?
doc-only


### How was this patch tested?
existing test
