### PR TITLE
[SPARK-41672][CONNECT][PYTHON] Enable the deprecated functions

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -16,6 +16,7 @@
 #
 
 import inspect
+import warnings
 
 from pyspark.sql.connect.column import (
     Column,
@@ -32,9 +33,6 @@ from typing import Any, TYPE_CHECKING, Union, List, overload, Optional, Tuple, C
 
 if TYPE_CHECKING:
     from pyspark.sql.connect._typing import ColumnOrName, DataFrameType
-
-
-# TODO(SPARK-40538) Add support for the missing PySpark functions.
 
 
 def _to_col(col: "ColumnOrName") -> Column:
@@ -175,17 +173,17 @@ def lit(col: Any) -> Column:
         return Column(LiteralExpression(col, dataType))
 
 
-# def bitwiseNOT(col: "ColumnOrName") -> Column:
-#     """
-#     Computes bitwise not.
-#
-#     .. versionadded:: 1.4.0
-#
-#     .. deprecated:: 3.2.0
-#         Use :func:`bitwise_not` instead.
-#     """
-#     warnings.warn("Deprecated in 3.2, use bitwise_not instead.", FutureWarning)
-#     return bitwise_not(col)
+def bitwiseNOT(col: "ColumnOrName") -> Column:
+    """
+    Computes bitwise not.
+
+    .. versionadded:: 3.4.0
+
+    .. deprecated:: 3.4.0
+        Use :func:`bitwise_not` instead.
+    """
+    warnings.warn("Deprecated in 3.4, use bitwise_not instead.", FutureWarning)
+    return bitwise_not(col)
 
 
 def bitwise_not(col: "ColumnOrName") -> Column:
@@ -1868,16 +1866,16 @@ def sec(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("sec", col)
 
 
-# def shiftLeft(col: "ColumnOrName", numBits: int) -> Column:
-#     """Shift the given value numBits left.
-#
-#     .. versionadded:: 1.5.0
-#
-#     .. deprecated:: 3.2.0
-#         Use :func:`shiftleft` instead.
-#     """
-#     warnings.warn("Deprecated in 3.2, use shiftleft instead.", FutureWarning)
-#     return shiftleft(col, numBits)
+def shiftLeft(col: "ColumnOrName", numBits: int) -> Column:
+    """Shift the given value numBits left.
+
+    .. versionadded:: 3.4.0
+
+    .. deprecated:: 3.4.0
+        Use :func:`shiftleft` instead.
+    """
+    warnings.warn("Deprecated in 3.4, use shiftleft instead.", FutureWarning)
+    return shiftleft(col, numBits)
 
 
 def shiftleft(col: "ColumnOrName", numBits: int) -> Column:
@@ -1905,16 +1903,16 @@ def shiftleft(col: "ColumnOrName", numBits: int) -> Column:
     return _invoke_function("shiftleft", _to_col(col), lit(numBits))
 
 
-# def shiftRight(col: "ColumnOrName", numBits: int) -> Column:
-#     """(Signed) shift the given value numBits right.
-#
-#     .. versionadded:: 1.5.0
-#
-#     .. deprecated:: 3.2.0
-#         Use :func:`shiftright` instead.
-#     """
-#     warnings.warn("Deprecated in 3.2, use shiftright instead.", FutureWarning)
-#     return shiftright(col, numBits)
+def shiftRight(col: "ColumnOrName", numBits: int) -> Column:
+    """(Signed) shift the given value numBits right.
+
+    .. versionadded:: 3.4.0
+
+    .. deprecated:: 3.4.0
+        Use :func:`shiftright` instead.
+    """
+    warnings.warn("Deprecated in 3.4, use shiftright instead.", FutureWarning)
+    return shiftright(col, numBits)
 
 
 def shiftright(col: "ColumnOrName", numBits: int) -> Column:
@@ -1942,16 +1940,16 @@ def shiftright(col: "ColumnOrName", numBits: int) -> Column:
     return _invoke_function("shiftright", _to_col(col), lit(numBits))
 
 
-# def shiftRightUnsigned(col: "ColumnOrName", numBits: int) -> Column:
-#     """Unsigned shift the given value numBits right.
-#
-#     .. versionadded:: 1.5.0
-#
-#     .. deprecated:: 3.2.0
-#         Use :func:`shiftrightunsigned` instead.
-#     """
-#     warnings.warn("Deprecated in 3.2, use shiftrightunsigned instead.", FutureWarning)
-#     return shiftrightunsigned(col, numBits)
+def shiftRightUnsigned(col: "ColumnOrName", numBits: int) -> Column:
+    """Unsigned shift the given value numBits right.
+
+    .. versionadded:: 3.4.0
+
+    .. deprecated:: 3.4.0
+        Use :func:`shiftrightunsigned` instead.
+    """
+    warnings.warn("Deprecated in 3.4, use shiftrightunsigned instead.", FutureWarning)
+    return shiftrightunsigned(col, numBits)
 
 
 def shiftrightunsigned(col: "ColumnOrName", numBits: int) -> Column:
@@ -2150,26 +2148,26 @@ def tanh(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("tanh", col)
 
 
-# def toDegrees(col: "ColumnOrName") -> Column:
-#     """
-#     .. versionadded:: 1.4.0
-#
-#     .. deprecated:: 2.1.0
-#         Use :func:`degrees` instead.
-#     """
-#     warnings.warn("Deprecated in 2.1, use degrees instead.", FutureWarning)
-#     return degrees(col)
-#
-#
-# def toRadians(col: "ColumnOrName") -> Column:
-#     """
-#     .. versionadded:: 1.4.0
-#
-#     .. deprecated:: 2.1.0
-#         Use :func:`radians` instead.
-#     """
-#     warnings.warn("Deprecated in 2.1, use radians instead.", FutureWarning)
-#     return radians(col)
+def toDegrees(col: "ColumnOrName") -> Column:
+    """
+    .. versionadded:: 3.4.0
+
+    .. deprecated:: 3.4.0
+        Use :func:`degrees` instead.
+    """
+    warnings.warn("Deprecated in 3.4, use degrees instead.", FutureWarning)
+    return degrees(col)
+
+
+def toRadians(col: "ColumnOrName") -> Column:
+    """
+    .. versionadded:: 3.4.0
+
+    .. deprecated:: 3.4.0
+        Use :func:`radians` instead.
+    """
+    warnings.warn("Deprecated in 3.4, use radians instead.", FutureWarning)
+    return radians(col)
 
 
 def unhex(col: "ColumnOrName") -> Column:
@@ -2199,15 +2197,15 @@ def unhex(col: "ColumnOrName") -> Column:
 # Aggregate Functions
 
 
-# def approxCountDistinct(col: "ColumnOrName", rsd: Optional[float] = None) -> Column:
-#     """
-#     .. versionadded:: 1.3.0
-#
-#     .. deprecated:: 2.1.0
-#         Use :func:`approx_count_distinct` instead.
-#     """
-#     warnings.warn("Deprecated in 2.1, use approx_count_distinct instead.", FutureWarning)
-#     return approx_count_distinct(col, rsd)
+def approxCountDistinct(col: "ColumnOrName", rsd: Optional[float] = None) -> Column:
+    """
+    .. versionadded:: 3.4.0
+
+    .. deprecated:: 3.4.0
+        Use :func:`approx_count_distinct` instead.
+    """
+    warnings.warn("Deprecated in 3.4, use approx_count_distinct instead.", FutureWarning)
+    return approx_count_distinct(col, rsd)
 
 
 def approx_count_distinct(col: "ColumnOrName", rsd: Optional[float] = None) -> Column:
@@ -2393,15 +2391,15 @@ def count(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("count", col)
 
 
-# def countDistinct(col: "ColumnOrName", *cols: "ColumnOrName") -> Column:
-#     """Returns a new :class:`~pyspark.sql.Column` for distinct count of ``col`` or ``cols``.
-#
-#     An alias of :func:`count_distinct`, and it is encouraged to use :func:`count_distinct`
-#     directly.
-#
-#     .. versionadded:: 1.3.0
-#     """
-#     return count_distinct(col, *cols)
+def countDistinct(col: "ColumnOrName", *cols: "ColumnOrName") -> Column:
+    """Returns a new :class:`~pyspark.sql.Column` for distinct count of ``col`` or ``cols``.
+
+    An alias of :func:`count_distinct`, and it is encouraged to use :func:`count_distinct`
+    directly.
+
+    .. versionadded:: 3.4.0
+    """
+    return count_distinct(col, *cols)
 
 
 def count_distinct(col: "ColumnOrName", *cols: "ColumnOrName") -> Column:
@@ -3163,17 +3161,17 @@ def sum(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("sum", col)
 
 
-# def sumDistinct(col: "ColumnOrName") -> Column:
-#     """
-#     Aggregate function: returns the sum of distinct values in the expression.
-#
-#     .. versionadded:: 1.3.0
-#
-#     .. deprecated:: 3.2.0
-#         Use :func:`sum_distinct` instead.
-#     """
-#     warnings.warn("Deprecated in 3.2, use sum_distinct instead.", FutureWarning)
-#     return sum_distinct(col)
+def sumDistinct(col: "ColumnOrName") -> Column:
+    """
+    Aggregate function: returns the sum of distinct values in the expression.
+
+    .. versionadded:: 3.4.0
+
+    .. deprecated:: 3.4.0
+        Use :func:`sum_distinct` instead.
+    """
+    warnings.warn("Deprecated in 3.4, use sum_distinct instead.", FutureWarning)
+    return sum_distinct(col)
 
 
 # TODO(SPARK-41381): add isDistinct in UnresolvedFunction

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -3174,7 +3174,6 @@ def sumDistinct(col: "ColumnOrName") -> Column:
     return sum_distinct(col)
 
 
-# TODO(SPARK-41381): add isDistinct in UnresolvedFunction
 def sum_distinct(col: "ColumnOrName") -> Column:
     """
     Aggregate function: returns the sum of distinct values in the expression.

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -137,6 +137,10 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
             sdf.select(SF.bitwise_not(sdf.a)).toPandas(),
         )
         self.assert_eq(
+            cdf.select(CF.bitwiseNOT(cdf.a)).toPandas(),
+            sdf.select(SF.bitwiseNOT(sdf.a)).toPandas(),
+        )
+        self.assert_eq(
             cdf.select(CF.coalesce(cdf.a, "b", cdf.c)).toPandas(),
             sdf.select(SF.coalesce(sdf.a, "b", sdf.c)).toPandas(),
         )
@@ -416,6 +420,7 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
             (CF.cot, SF.cot),
             (CF.csc, SF.csc),
             (CF.degrees, SF.degrees),
+            (CF.toDegrees, SF.toDegrees),
             (CF.exp, SF.exp),
             (CF.expm1, SF.expm1),
             (CF.factorial, SF.factorial),
@@ -426,6 +431,7 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
             (CF.log1p, SF.log1p),
             (CF.log2, SF.log2),
             (CF.radians, SF.radians),
+            (CF.toRadians, SF.toRadians),
             (CF.rint, SF.rint),
             (CF.sec, SF.sec),
             (CF.signum, SF.signum),
@@ -474,12 +480,24 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
             sdf.select(SF.shiftleft("b", 1)).toPandas(),
         )
         self.assert_eq(
+            cdf.select(CF.shiftLeft("b", 1)).toPandas(),
+            sdf.select(SF.shiftLeft("b", 1)).toPandas(),
+        )
+        self.assert_eq(
             cdf.select(CF.shiftright("b", 1)).toPandas(),
             sdf.select(SF.shiftright("b", 1)).toPandas(),
         )
         self.assert_eq(
+            cdf.select(CF.shiftRight("b", 1)).toPandas(),
+            sdf.select(SF.shiftRight("b", 1)).toPandas(),
+        )
+        self.assert_eq(
             cdf.select(CF.shiftrightunsigned("b", 1)).toPandas(),
             sdf.select(SF.shiftrightunsigned("b", 1)).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.shiftRightUnsigned("b", 1)).toPandas(),
+            sdf.select(SF.shiftRightUnsigned("b", 1)).toPandas(),
         )
 
     def test_aggregation_functions(self):
@@ -506,6 +524,7 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
         # TODO(SPARK-41383): add tests for grouping, grouping_id after DataFrame.cube is supported.
         for cfunc, sfunc in [
             (CF.approx_count_distinct, SF.approx_count_distinct),
+            (CF.approxCountDistinct, SF.approxCountDistinct),
             (CF.avg, SF.avg),
             (CF.collect_list, SF.collect_list),
             (CF.collect_set, SF.collect_set),
@@ -525,6 +544,7 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
             (CF.stddev_samp, SF.stddev_samp),
             (CF.sum, SF.sum),
             (CF.sum_distinct, SF.sum_distinct),
+            (CF.sumDistinct, SF.sumDistinct),
             (CF.var_pop, SF.var_pop),
             (CF.var_samp, SF.var_samp),
             (CF.variance, SF.variance),
@@ -576,6 +596,10 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
         self.assert_eq(
             cdf.select(CF.count_distinct("b"), CF.count_distinct(cdf.c)).toPandas(),
             sdf.select(SF.count_distinct("b"), SF.count_distinct(sdf.c)).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.countDistinct("b"), CF.countDistinct(cdf.c)).toPandas(),
+            sdf.select(SF.countDistinct("b"), SF.countDistinct(sdf.c)).toPandas(),
         )
         # The output column names of 'groupBy.agg(count_distinct)' in PySpark
         # are incorrect, see SPARK-41391.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable the deprecated functions in Connect


### Why are the changes needed?
they are still used by users


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added UT