### PR TITLE
[SPARK-41674][SQL] Runtime filter should supports multi level shuffle join side as filter creation side

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -154,12 +154,10 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
         // Runtime filters use one side of the [[Join]] to build a set of join key values and prune
         // the other side of the [[Join]]. It's also OK to use a superset of the join key values to
         // do the pruning.
-        if (isLeftSideSuperset(joinType, left, filterCreationSideExp) &&
-          !hintToBroadcastLeft(hint) && !canBroadcastBySize(left, conf)) {
-           extractSelectiveFilterOverScan(left, filterCreationSideExp)
-        } else if (isRightSideSuperset(joinType, right, filterCreationSideExp) &&
-          !hintToBroadcastRight(hint) && !canBroadcastBySize(right, conf)) {
-            extractSelectiveFilterOverScan(right, filterCreationSideExp)
+        if (isLeftSideSuperset(joinType, left, filterCreationSideExp)) {
+          extractSelectiveFilterOverScan(left, filterCreationSideExp)
+        } else if (isRightSideSuperset(joinType, right, filterCreationSideExp)) {
+          extractSelectiveFilterOverScan(right, filterCreationSideExp)
         } else {
           None
         }

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -62,227 +62,227 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2))
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
 (5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,pale                ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
 (7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Condition : ((isnotnull(i_color#10) AND (i_color#10 = pale                )) AND isnotnull(i_item_sk#7))
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Condition : ((isnotnull(i_color#12) AND (i_color#12 = pale                )) AND isnotnull(i_item_sk#9))
 
 (8) BroadcastExchange
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
 (11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
 (14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
 (15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Condition : (isnotnull(c_customer_sk#13) AND isnotnull(c_birth_country#16))
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18))
 
 (16) Exchange
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(c_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
 
 (18) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#13]
+Right keys [1]: [c_customer_sk#15]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
 (20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+Output [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 
 (24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
-Condition : (isnotnull(sr_ticket_number#18) AND isnotnull(sr_item_sk#17))
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Condition : (isnotnull(sr_ticket_number#20) AND isnotnull(sr_item_sk#19))
 
 (25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#17, sr_ticket_number#18]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+Output [2]: [sr_item_sk#19, sr_ticket_number#20]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 
 (26) Exchange
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: hashpartitioning(sr_ticket_number#18, sr_item_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
 
 (28) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, sr_item_sk#17, sr_ticket_number#18]
+Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
 
 (30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
 (32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
-Condition : (((isnotnull(s_market_id#22) AND (s_market_id#22 = 8)) AND isnotnull(s_store_sk#20)) AND isnotnull(s_zip#24))
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
 
 (33) Project [codegen id : 10]
-Output [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
 (34) BroadcastExchange
-Input [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
+Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
 Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
 
 (35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
+Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (36) ColumnarToRow
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 
 (37) Filter
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
 
 (38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#24]
-Right keys [1]: [ca_zip#26]
+Left keys [1]: [s_zip#26]
+Right keys [1]: [ca_zip#28]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
-Output [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
-Input [7]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24, ca_state#25, ca_zip#26, ca_country#27]
+Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
 
 (40) BroadcastExchange
-Input [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
+Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
 
 (41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#16]
-Right keys [2]: [s_store_sk#20, upper(ca_country#27)]
+Left keys [2]: [ss_store_sk#3, c_birth_country#18]
+Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
+Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 
 (43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
+Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#28]
-Results [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
+Aggregate Attributes [1]: [sum#30]
+Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
 
 (44) Exchange
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#30]
-Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#30,17,2) AS netpaid#31]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
+Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
 
 (46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, netpaid#31]
-Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
-Functions [1]: [partial_sum(netpaid#31)]
-Aggregate Attributes [2]: [sum#32, isEmpty#33]
-Results [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
+Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
+Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
+Functions [1]: [partial_sum(netpaid#33)]
+Aggregate Attributes [2]: [sum#34, isEmpty#35]
+Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
 
 (47) Exchange
-Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
-Functions [1]: [sum(netpaid#31)]
-Aggregate Attributes [1]: [sum(netpaid#31)#36]
-Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, sum(netpaid#31)#36 AS paid#37]
+Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
+Functions [1]: [sum(netpaid#33)]
+Aggregate Attributes [1]: [sum(netpaid#33)#38]
+Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
 
 (49) Filter [codegen id : 14]
-Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, paid#37]
-Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#39] as decimal(33,8))))
+Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
+Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#38, [id=#39]
+Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
 * HashAggregate (96)
 +- Exchange (95)
    +- * HashAggregate (94)
@@ -333,219 +333,265 @@ Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquer
 
 
 (50) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
 (51) ColumnarToRow [codegen id : 2]
-Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 
 (52) Filter [codegen id : 2]
-Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
-Condition : (((isnotnull(ss_ticket_number#43) AND isnotnull(ss_item_sk#40)) AND isnotnull(ss_store_sk#42)) AND isnotnull(ss_customer_sk#41))
+Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Condition : (((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43))
 
 (53) Project [codegen id : 2]
-Output [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
-Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
+Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 
 (54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Output [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
 
 (56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
-Condition : (((isnotnull(s_market_id#48) AND (s_market_id#48 = 8)) AND isnotnull(s_store_sk#46)) AND isnotnull(s_zip#50))
+Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Condition : (((isnotnull(s_market_id#50) AND (s_market_id#50 = 8)) AND isnotnull(s_store_sk#48)) AND isnotnull(s_zip#52))
 
 (57) Project [codegen id : 1]
-Output [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
-Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Output [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
 
 (58) BroadcastExchange
-Input [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Input [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 (59) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#42]
-Right keys [1]: [s_store_sk#46]
+Left keys [1]: [ss_store_sk#44]
+Right keys [1]: [s_store_sk#48]
 Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
-Input [9]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Output [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
+Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
 
 (61) Exchange
-Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
-Arguments: hashpartitioning(ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
+Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
-Arguments: [ss_item_sk#40 ASC NULLS FIRST], false, 0
+Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
+Arguments: [ss_item_sk#42 ASC NULLS FIRST], false, 0
 
 (63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
 
 (65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Condition : isnotnull(i_item_sk#51)
+Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Condition : isnotnull(i_item_sk#53)
 
 (66) Exchange
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: hashpartitioning(i_item_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Arguments: hashpartitioning(i_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: [i_item_sk#51 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
 
 (68) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_item_sk#40]
-Right keys [1]: [i_item_sk#51]
+Left keys [1]: [ss_item_sk#42]
+Right keys [1]: [i_item_sk#53]
 Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Input [13]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Output [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Input [13]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
 
 (70) Exchange
-Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: hashpartitioning(ss_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: [ss_customer_sk#41 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
 
 (72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Output [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
 
 (73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: [c_customer_sk#59 ASC NULLS FIRST], false, 0
 
 (74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#41]
-Right keys [1]: [c_customer_sk#57]
+Left keys [1]: [ss_customer_sk#43]
+Right keys [1]: [c_customer_sk#59]
 Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [16]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Output [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Input [16]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
 
 (76) Exchange
-Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: hashpartitioning(ss_ticket_number#45, ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
+Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
 
 (78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#61, sr_ticket_number#62]
+Output [2]: [sr_item_sk#63, sr_ticket_number#64]
 
 (79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#61, sr_ticket_number#62]
-Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#63, sr_ticket_number#64]
+Arguments: [sr_ticket_number#64 ASC NULLS FIRST, sr_item_sk#63 ASC NULLS FIRST], false, 0
 
 (80) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
-Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
+Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
+Right keys [2]: [sr_ticket_number#64, sr_item_sk#63]
 Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [16]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, sr_item_sk#61, sr_ticket_number#62]
+Output [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Input [16]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, sr_item_sk#63, sr_ticket_number#64]
 
 (82) Exchange
-Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: hashpartitioning(c_birth_country#60, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: hashpartitioning(c_birth_country#62, s_zip#52, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [c_birth_country#60 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
+Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: [c_birth_country#62 ASC NULLS FIRST, s_zip#52 ASC NULLS FIRST], false, 0
 
 (84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Output [3]: [ca_state#65, ca_zip#66, ca_country#67]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
 
 (86) Filter [codegen id : 16]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Condition : (isnotnull(ca_country#65) AND isnotnull(ca_zip#64))
+Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Condition : (isnotnull(ca_country#67) AND isnotnull(ca_zip#66))
 
 (87) Exchange
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Arguments: hashpartitioning(upper(ca_country#65), ca_zip#64, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Arguments: hashpartitioning(upper(ca_country#67), ca_zip#66, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (88) Sort [codegen id : 17]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Arguments: [upper(ca_country#65) ASC NULLS FIRST, ca_zip#64 ASC NULLS FIRST], false, 0
+Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Arguments: [upper(ca_country#67) ASC NULLS FIRST, ca_zip#66 ASC NULLS FIRST], false, 0
 
 (89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#60, s_zip#50]
-Right keys [2]: [upper(ca_country#65), ca_zip#64]
+Left keys [2]: [c_birth_country#62, s_zip#52]
+Right keys [2]: [upper(ca_country#67), ca_zip#66]
 Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
-Input [15]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#63, ca_zip#64, ca_country#65]
+Output [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
+Input [15]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, ca_state#65, ca_zip#66, ca_country#67]
 
 (91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
-Aggregate Attributes [1]: [sum#66]
-Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Input [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
+Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
+Aggregate Attributes [1]: [sum#68]
+Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
 
 (92) Exchange
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
-Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#30]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#30,17,2) AS netpaid#68]
+Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
 
 (94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#68]
+Input [1]: [netpaid#70]
 Keys: []
-Functions [1]: [partial_avg(netpaid#68)]
-Aggregate Attributes [2]: [sum#69, count#70]
-Results [2]: [sum#71, count#72]
+Functions [1]: [partial_avg(netpaid#70)]
+Aggregate Attributes [2]: [sum#71, count#72]
+Results [2]: [sum#73, count#74]
 
 (95) Exchange
-Input [2]: [sum#71, count#72]
+Input [2]: [sum#73, count#74]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
 (96) HashAggregate [codegen id : 20]
-Input [2]: [sum#71, count#72]
+Input [2]: [sum#73, count#74]
 Keys: []
-Functions [1]: [avg(netpaid#68)]
-Aggregate Attributes [1]: [avg(netpaid#68)#73]
-Results [1]: [(0.05 * avg(netpaid#68)#73) AS (0.05 * avg(netpaid))#74]
+Functions [1]: [avg(netpaid#70)]
+Aggregate Attributes [1]: [avg(netpaid#70)#75]
+Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
+
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (103)
++- Exchange (102)
+   +- ObjectHashAggregate (101)
+      +- * Project (100)
+         +- * Filter (99)
+            +- * ColumnarToRow (98)
+               +- Scan parquet spark_catalog.default.store (97)
+
+
+(97) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
+ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
+
+(98) ColumnarToRow [codegen id : 1]
+Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+
+(99) Filter [codegen id : 1]
+Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
+
+(100) Project [codegen id : 1]
+Output [1]: [s_store_sk#22]
+Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+
+(101) ObjectHashAggregate
+Input [1]: [s_store_sk#22]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [buf#77]
+Results [1]: [buf#78]
+
+(102) Exchange
+Input [1]: [buf#78]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+
+(103) ObjectHashAggregate
+Input [1]: [buf#78]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79 AS bloomFilter#80]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -62,227 +62,227 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
+Condition : (((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
 (5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Output [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,pale                ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 
 (7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Condition : ((isnotnull(i_color#12) AND (i_color#12 = pale                )) AND isnotnull(i_item_sk#9))
+Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Condition : ((isnotnull(i_color#10) AND (i_color#10 = pale                )) AND isnotnull(i_item_sk#7))
 
 (8) BroadcastExchange
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#9]
+Right keys [1]: [i_item_sk#7]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 
 (11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Output [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
 (14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
 
 (15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18))
+Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Condition : (isnotnull(c_customer_sk#13) AND isnotnull(c_birth_country#16))
 
 (16) Exchange
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Arguments: hashpartitioning(c_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
 
 (18) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#15]
+Right keys [1]: [c_customer_sk#13]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
 
 (20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
 Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Output [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
 
 (24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
-Condition : (isnotnull(sr_ticket_number#20) AND isnotnull(sr_item_sk#19))
+Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+Condition : (isnotnull(sr_ticket_number#18) AND isnotnull(sr_item_sk#17))
 
 (25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#19, sr_ticket_number#20]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Output [2]: [sr_item_sk#17, sr_ticket_number#18]
+Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
 
 (26) Exchange
-Input [2]: [sr_item_sk#19, sr_ticket_number#20]
-Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [sr_item_sk#17, sr_ticket_number#18]
+Arguments: hashpartitioning(sr_ticket_number#18, sr_item_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#19, sr_ticket_number#20]
-Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#17, sr_ticket_number#18]
+Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST], false, 0
 
 (28) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
+Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
+Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, sr_item_sk#17, sr_ticket_number#18]
 
 (30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Output [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
 
 (32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
-Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
+Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+Condition : (((isnotnull(s_market_id#22) AND (s_market_id#22 = 8)) AND isnotnull(s_store_sk#20)) AND isnotnull(s_zip#24))
 
 (33) Project [codegen id : 10]
-Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Output [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
+Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
 
 (34) BroadcastExchange
-Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Input [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
 Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
 
 (35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (36) ColumnarToRow
-Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
 
 (37) Filter
-Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
-Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
+Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
+Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
 
 (38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#26]
-Right keys [1]: [ca_zip#28]
+Left keys [1]: [s_zip#24]
+Right keys [1]: [ca_zip#26]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
-Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
-Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
+Output [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
+Input [7]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24, ca_state#25, ca_zip#26, ca_country#27]
 
 (40) BroadcastExchange
-Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Input [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
 Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
 
 (41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#18]
-Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
+Left keys [2]: [ss_store_sk#3, c_birth_country#16]
+Right keys [2]: [s_store_sk#20, upper(ca_country#27)]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Output [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
+Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
 
 (43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
-Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Input [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
+Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#30]
-Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Aggregate Attributes [1]: [sum#28]
+Results [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
 
 (44) Exchange
-Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
+Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
+Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
-Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#30]
+Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#30,17,2) AS netpaid#31]
 
 (46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
-Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
-Functions [1]: [partial_sum(netpaid#33)]
-Aggregate Attributes [2]: [sum#34, isEmpty#35]
-Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, netpaid#31]
+Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
+Functions [1]: [partial_sum(netpaid#31)]
+Aggregate Attributes [2]: [sum#32, isEmpty#33]
+Results [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
 
 (47) Exchange
-Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
+Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
-Functions [1]: [sum(netpaid#33)]
-Aggregate Attributes [1]: [sum(netpaid#33)#38]
-Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
+Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
+Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
+Functions [1]: [sum(netpaid#31)]
+Aggregate Attributes [1]: [sum(netpaid#31)#36]
+Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, sum(netpaid#31)#36 AS paid#37]
 
 (49) Filter [codegen id : 14]
-Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
-Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
+Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, paid#37]
+Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#39] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#38, [id=#39]
 * HashAggregate (96)
 +- Exchange (95)
    +- * HashAggregate (94)
@@ -333,265 +333,219 @@ Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquer
 
 
 (50) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Output [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
 (51) ColumnarToRow [codegen id : 2]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 
 (52) Filter [codegen id : 2]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
-Condition : (((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43))
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Condition : (((isnotnull(ss_ticket_number#43) AND isnotnull(ss_item_sk#40)) AND isnotnull(ss_store_sk#42)) AND isnotnull(ss_customer_sk#41))
 
 (53) Project [codegen id : 2]
-Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Output [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 
 (54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Output [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 
 (56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
-Condition : (((isnotnull(s_market_id#50) AND (s_market_id#50 = 8)) AND isnotnull(s_store_sk#48)) AND isnotnull(s_zip#52))
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Condition : (((isnotnull(s_market_id#48) AND (s_market_id#48 = 8)) AND isnotnull(s_store_sk#46)) AND isnotnull(s_zip#50))
 
 (57) Project [codegen id : 1]
-Output [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Output [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 
 (58) BroadcastExchange
-Input [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+Input [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 (59) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#44]
-Right keys [1]: [s_store_sk#48]
+Left keys [1]: [ss_store_sk#42]
+Right keys [1]: [s_store_sk#46]
 Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+Output [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Input [9]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
 
 (61) Exchange
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Arguments: hashpartitioning(ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: [ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Arguments: [ss_item_sk#40 ASC NULLS FIRST], false, 0
 
 (63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 
 (65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Condition : isnotnull(i_item_sk#53)
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Condition : isnotnull(i_item_sk#51)
 
 (66) Exchange
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(i_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: hashpartitioning(i_item_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: [i_item_sk#51 ASC NULLS FIRST], false, 0
 
 (68) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_item_sk#42]
-Right keys [1]: [i_item_sk#53]
+Left keys [1]: [ss_item_sk#40]
+Right keys [1]: [i_item_sk#51]
 Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Input [13]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Input [13]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 
 (70) Exchange
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: hashpartitioning(ss_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: [ss_customer_sk#41 ASC NULLS FIRST], false, 0
 
 (72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
 
 (73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_customer_sk#59 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
 (74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#43]
-Right keys [1]: [c_customer_sk#59]
+Left keys [1]: [ss_customer_sk#41]
+Right keys [1]: [c_customer_sk#57]
 Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Output [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Input [16]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
 
 (76) Exchange
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(ss_ticket_number#45, ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
 
 (78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#63, sr_ticket_number#64]
+Output [2]: [sr_item_sk#61, sr_ticket_number#62]
 
 (79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#63, sr_ticket_number#64]
-Arguments: [sr_ticket_number#64 ASC NULLS FIRST, sr_item_sk#63 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#61, sr_ticket_number#62]
+Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
 
 (80) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
-Right keys [2]: [sr_ticket_number#64, sr_item_sk#63]
+Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
+Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
 Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, sr_item_sk#63, sr_ticket_number#64]
+Output [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Input [16]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, sr_item_sk#61, sr_ticket_number#62]
 
 (82) Exchange
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(c_birth_country#62, s_zip#52, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(c_birth_country#60, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_birth_country#62 ASC NULLS FIRST, s_zip#52 ASC NULLS FIRST], false, 0
+Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_birth_country#60 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
 
 (84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Output [3]: [ca_state#63, ca_zip#64, ca_country#65]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
 
 (86) Filter [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Condition : (isnotnull(ca_country#67) AND isnotnull(ca_zip#66))
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Condition : (isnotnull(ca_country#65) AND isnotnull(ca_zip#64))
 
 (87) Exchange
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: hashpartitioning(upper(ca_country#67), ca_zip#66, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Arguments: hashpartitioning(upper(ca_country#65), ca_zip#64, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (88) Sort [codegen id : 17]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: [upper(ca_country#67) ASC NULLS FIRST, ca_zip#66 ASC NULLS FIRST], false, 0
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Arguments: [upper(ca_country#65) ASC NULLS FIRST, ca_zip#64 ASC NULLS FIRST], false, 0
 
 (89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#62, s_zip#52]
-Right keys [2]: [upper(ca_country#67), ca_zip#66]
+Left keys [2]: [c_birth_country#60, s_zip#50]
+Right keys [2]: [upper(ca_country#65), ca_zip#64]
 Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Input [15]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, ca_state#65, ca_zip#66, ca_country#67]
+Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
+Input [15]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#63, ca_zip#64, ca_country#65]
 
 (91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum#68]
-Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
+Aggregate Attributes [1]: [sum#66]
+Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
 
 (92) Exchange
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#30]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#30,17,2) AS netpaid#68]
 
 (94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#70]
+Input [1]: [netpaid#68]
 Keys: []
-Functions [1]: [partial_avg(netpaid#70)]
-Aggregate Attributes [2]: [sum#71, count#72]
-Results [2]: [sum#73, count#74]
+Functions [1]: [partial_avg(netpaid#68)]
+Aggregate Attributes [2]: [sum#69, count#70]
+Results [2]: [sum#71, count#72]
 
 (95) Exchange
-Input [2]: [sum#73, count#74]
+Input [2]: [sum#71, count#72]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
 (96) HashAggregate [codegen id : 20]
-Input [2]: [sum#73, count#74]
+Input [2]: [sum#71, count#72]
 Keys: []
-Functions [1]: [avg(netpaid#70)]
-Aggregate Attributes [1]: [avg(netpaid#70)#75]
-Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
-
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (103)
-+- Exchange (102)
-   +- ObjectHashAggregate (101)
-      +- * Project (100)
-         +- * Filter (99)
-            +- * ColumnarToRow (98)
-               +- Scan parquet spark_catalog.default.store (97)
-
-
-(97) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
-ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
-
-(98) ColumnarToRow [codegen id : 1]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-
-(99) Filter [codegen id : 1]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
-
-(100) Project [codegen id : 1]
-Output [1]: [s_store_sk#22]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-
-(101) ObjectHashAggregate
-Input [1]: [s_store_sk#22]
-Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [buf#77]
-Results [1]: [buf#78]
-
-(102) Exchange
-Input [1]: [buf#78]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
-
-(103) ObjectHashAggregate
-Input [1]: [buf#78]
-Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79]
-Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79 AS bloomFilter#80]
+Functions [1]: [avg(netpaid#68)]
+Aggregate Attributes [1]: [avg(netpaid#68)#73]
+Results [1]: [(0.05 * avg(netpaid#68)#73) AS (0.05 * avg(netpaid))#74]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
@@ -1,15 +1,15 @@
 WholeStageCodegen (14)
   Filter [paid]
-    Subquery #1
+    Subquery #2
       WholeStageCodegen (20)
         HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
           InputAdapter
-            Exchange #10
+            Exchange #11
               WholeStageCodegen (19)
                 HashAggregate [netpaid] [sum,count,sum,count]
                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                     InputAdapter
-                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #11
+                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #12
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
@@ -18,7 +18,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (15)
                                     Sort [c_birth_country,s_zip]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #12
+                                        Exchange [c_birth_country,s_zip] #13
                                           WholeStageCodegen (14)
                                             Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                               SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
@@ -26,7 +26,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (11)
                                                     Sort [ss_ticket_number,ss_item_sk]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #13
+                                                        Exchange [ss_ticket_number,ss_item_sk] #14
                                                           WholeStageCodegen (10)
                                                             Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                                               SortMergeJoin [ss_customer_sk,c_customer_sk]
@@ -34,7 +34,7 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (7)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #14
+                                                                        Exchange [ss_customer_sk] #15
                                                                           WholeStageCodegen (6)
                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                               SortMergeJoin [ss_item_sk,i_item_sk]
@@ -42,7 +42,7 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (3)
                                                                                     Sort [ss_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #15
+                                                                                        Exchange [ss_item_sk] #16
                                                                                           WholeStageCodegen (2)
                                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
                                                                                               BroadcastHashJoin [ss_store_sk,s_store_sk]
@@ -52,7 +52,7 @@ WholeStageCodegen (14)
                                                                                                       InputAdapter
                                                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                                 InputAdapter
-                                                                                                  BroadcastExchange #16
+                                                                                                  BroadcastExchange #17
                                                                                                     WholeStageCodegen (1)
                                                                                                       Project [s_store_sk,s_store_name,s_state,s_zip]
                                                                                                         Filter [s_market_id,s_store_sk,s_zip]
@@ -63,7 +63,7 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (5)
                                                                                     Sort [i_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [i_item_sk] #17
+                                                                                        Exchange [i_item_sk] #18
                                                                                           WholeStageCodegen (4)
                                                                                             Filter [i_item_sk]
                                                                                               ColumnarToRow
@@ -73,17 +73,17 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (9)
                                                                     Sort [c_customer_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #6
+                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #7
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [sr_ticket_number,sr_item_sk]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #7
+                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
                                 InputAdapter
                                   WholeStageCodegen (17)
                                     Sort [ca_country,ca_zip]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #18
+                                        Exchange [ca_country,ca_zip] #19
                                           WholeStageCodegen (16)
                                             Filter [ca_country,ca_zip]
                                               ColumnarToRow
@@ -121,11 +121,21 @@ WholeStageCodegen (14)
                                                               BroadcastHashJoin [ss_item_sk,i_item_sk]
                                                                 Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                   Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                    Subquery #1
+                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
+                                                                        Exchange #5
+                                                                          ObjectHashAggregate [s_store_sk] [buf,buf]
+                                                                            WholeStageCodegen (1)
+                                                                              Project [s_store_sk]
+                                                                                Filter [s_market_id,s_store_sk,s_zip]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                 InputAdapter
-                                                                  BroadcastExchange #5
+                                                                  BroadcastExchange #6
                                                                     WholeStageCodegen (1)
                                                                       Filter [i_color,i_item_sk]
                                                                         ColumnarToRow
@@ -135,7 +145,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #6
+                                                        Exchange [c_customer_sk] #7
                                                           WholeStageCodegen (4)
                                                             Filter [c_customer_sk,c_birth_country]
                                                               ColumnarToRow
@@ -145,7 +155,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (9)
                                     Sort [sr_ticket_number,sr_item_sk]
                                       InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #7
+                                        Exchange [sr_ticket_number,sr_item_sk] #8
                                           WholeStageCodegen (8)
                                             Project [sr_item_sk,sr_ticket_number]
                                               Filter [sr_ticket_number,sr_item_sk]
@@ -153,12 +163,12 @@ WholeStageCodegen (14)
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                             InputAdapter
-                              BroadcastExchange #8
+                              BroadcastExchange #9
                                 WholeStageCodegen (11)
                                   Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
                                     BroadcastHashJoin [s_zip,ca_zip]
                                       InputAdapter
-                                        BroadcastExchange #9
+                                        BroadcastExchange #10
                                           WholeStageCodegen (10)
                                             Project [s_store_sk,s_store_name,s_state,s_zip]
                                               Filter [s_market_id,s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
@@ -1,15 +1,15 @@
 WholeStageCodegen (14)
   Filter [paid]
-    Subquery #2
+    Subquery #1
       WholeStageCodegen (20)
         HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
           InputAdapter
-            Exchange #11
+            Exchange #10
               WholeStageCodegen (19)
                 HashAggregate [netpaid] [sum,count,sum,count]
                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                     InputAdapter
-                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #12
+                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #11
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
@@ -18,7 +18,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (15)
                                     Sort [c_birth_country,s_zip]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #13
+                                        Exchange [c_birth_country,s_zip] #12
                                           WholeStageCodegen (14)
                                             Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                               SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
@@ -26,7 +26,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (11)
                                                     Sort [ss_ticket_number,ss_item_sk]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #14
+                                                        Exchange [ss_ticket_number,ss_item_sk] #13
                                                           WholeStageCodegen (10)
                                                             Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                                               SortMergeJoin [ss_customer_sk,c_customer_sk]
@@ -34,7 +34,7 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (7)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #15
+                                                                        Exchange [ss_customer_sk] #14
                                                                           WholeStageCodegen (6)
                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                               SortMergeJoin [ss_item_sk,i_item_sk]
@@ -42,7 +42,7 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (3)
                                                                                     Sort [ss_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #16
+                                                                                        Exchange [ss_item_sk] #15
                                                                                           WholeStageCodegen (2)
                                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
                                                                                               BroadcastHashJoin [ss_store_sk,s_store_sk]
@@ -52,7 +52,7 @@ WholeStageCodegen (14)
                                                                                                       InputAdapter
                                                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                                 InputAdapter
-                                                                                                  BroadcastExchange #17
+                                                                                                  BroadcastExchange #16
                                                                                                     WholeStageCodegen (1)
                                                                                                       Project [s_store_sk,s_store_name,s_state,s_zip]
                                                                                                         Filter [s_market_id,s_store_sk,s_zip]
@@ -63,7 +63,7 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (5)
                                                                                     Sort [i_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [i_item_sk] #18
+                                                                                        Exchange [i_item_sk] #17
                                                                                           WholeStageCodegen (4)
                                                                                             Filter [i_item_sk]
                                                                                               ColumnarToRow
@@ -73,17 +73,17 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (9)
                                                                     Sort [c_customer_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #7
+                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #6
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [sr_ticket_number,sr_item_sk]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
+                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #7
                                 InputAdapter
                                   WholeStageCodegen (17)
                                     Sort [ca_country,ca_zip]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #19
+                                        Exchange [ca_country,ca_zip] #18
                                           WholeStageCodegen (16)
                                             Filter [ca_country,ca_zip]
                                               ColumnarToRow
@@ -121,21 +121,11 @@ WholeStageCodegen (14)
                                                               BroadcastHashJoin [ss_item_sk,i_item_sk]
                                                                 Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                   Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                    Subquery #1
-                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
-                                                                        Exchange #5
-                                                                          ObjectHashAggregate [s_store_sk] [buf,buf]
-                                                                            WholeStageCodegen (1)
-                                                                              Project [s_store_sk]
-                                                                                Filter [s_market_id,s_store_sk,s_zip]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                 InputAdapter
-                                                                  BroadcastExchange #6
+                                                                  BroadcastExchange #5
                                                                     WholeStageCodegen (1)
                                                                       Filter [i_color,i_item_sk]
                                                                         ColumnarToRow
@@ -145,7 +135,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #7
+                                                        Exchange [c_customer_sk] #6
                                                           WholeStageCodegen (4)
                                                             Filter [c_customer_sk,c_birth_country]
                                                               ColumnarToRow
@@ -155,7 +145,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (9)
                                     Sort [sr_ticket_number,sr_item_sk]
                                       InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #8
+                                        Exchange [sr_ticket_number,sr_item_sk] #7
                                           WholeStageCodegen (8)
                                             Project [sr_item_sk,sr_ticket_number]
                                               Filter [sr_ticket_number,sr_item_sk]
@@ -163,12 +153,12 @@ WholeStageCodegen (14)
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                             InputAdapter
-                              BroadcastExchange #9
+                              BroadcastExchange #8
                                 WholeStageCodegen (11)
                                   Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
                                     BroadcastHashJoin [s_zip,ca_zip]
                                       InputAdapter
-                                        BroadcastExchange #10
+                                        BroadcastExchange #9
                                           WholeStageCodegen (10)
                                             Project [s_store_sk,s_store_name,s_state,s_zip]
                                               Filter [s_market_id,s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -62,227 +62,227 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : (((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2))
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
 (5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,chiffon             ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
 (7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Condition : ((isnotnull(i_color#10) AND (i_color#10 = chiffon             )) AND isnotnull(i_item_sk#7))
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Condition : ((isnotnull(i_color#12) AND (i_color#12 = chiffon             )) AND isnotnull(i_item_sk#9))
 
 (8) BroadcastExchange
-Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
 (11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
 (14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
 (15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Condition : (isnotnull(c_customer_sk#13) AND isnotnull(c_birth_country#16))
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18))
 
 (16) Exchange
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: hashpartitioning(c_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
-Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
 
 (18) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#13]
+Right keys [1]: [c_customer_sk#15]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
 
 (20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+Output [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 
 (24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
-Condition : (isnotnull(sr_ticket_number#18) AND isnotnull(sr_item_sk#17))
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Condition : (isnotnull(sr_ticket_number#20) AND isnotnull(sr_item_sk#19))
 
 (25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#17, sr_ticket_number#18]
-Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+Output [2]: [sr_item_sk#19, sr_ticket_number#20]
+Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
 
 (26) Exchange
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: hashpartitioning(sr_ticket_number#18, sr_item_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#17, sr_ticket_number#18]
-Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#19, sr_ticket_number#20]
+Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
 
 (28) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, sr_item_sk#17, sr_ticket_number#18]
+Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
 
 (30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
 (32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
-Condition : (((isnotnull(s_market_id#22) AND (s_market_id#22 = 8)) AND isnotnull(s_store_sk#20)) AND isnotnull(s_zip#24))
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
 
 (33) Project [codegen id : 10]
-Output [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
-Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
 (34) BroadcastExchange
-Input [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
+Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
 Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
 
 (35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
+Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (36) ColumnarToRow
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 
 (37) Filter
-Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
-Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
+Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
 
 (38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#24]
-Right keys [1]: [ca_zip#26]
+Left keys [1]: [s_zip#26]
+Right keys [1]: [ca_zip#28]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
-Output [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
-Input [7]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24, ca_state#25, ca_zip#26, ca_country#27]
+Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
 
 (40) BroadcastExchange
-Input [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
+Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
 
 (41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#16]
-Right keys [2]: [s_store_sk#20, upper(ca_country#27)]
+Left keys [2]: [ss_store_sk#3, c_birth_country#18]
+Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
+Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 
 (43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
+Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#28]
-Results [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
+Aggregate Attributes [1]: [sum#30]
+Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
 
 (44) Exchange
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
-Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
+Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#30]
-Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#30,17,2) AS netpaid#31]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
+Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
 
 (46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, netpaid#31]
-Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
-Functions [1]: [partial_sum(netpaid#31)]
-Aggregate Attributes [2]: [sum#32, isEmpty#33]
-Results [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
+Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
+Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
+Functions [1]: [partial_sum(netpaid#33)]
+Aggregate Attributes [2]: [sum#34, isEmpty#35]
+Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
 
 (47) Exchange
-Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
-Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
-Functions [1]: [sum(netpaid#31)]
-Aggregate Attributes [1]: [sum(netpaid#31)#36]
-Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, sum(netpaid#31)#36 AS paid#37]
+Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
+Functions [1]: [sum(netpaid#33)]
+Aggregate Attributes [1]: [sum(netpaid#33)#38]
+Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
 
 (49) Filter [codegen id : 14]
-Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, paid#37]
-Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#39] as decimal(33,8))))
+Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
+Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#38, [id=#39]
+Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
 * HashAggregate (96)
 +- Exchange (95)
    +- * HashAggregate (94)
@@ -333,219 +333,265 @@ Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquer
 
 
 (50) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
 (51) ColumnarToRow [codegen id : 2]
-Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 
 (52) Filter [codegen id : 2]
-Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
-Condition : (((isnotnull(ss_ticket_number#43) AND isnotnull(ss_item_sk#40)) AND isnotnull(ss_store_sk#42)) AND isnotnull(ss_customer_sk#41))
+Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Condition : (((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43))
 
 (53) Project [codegen id : 2]
-Output [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
-Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
+Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 
 (54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Output [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
 
 (56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
-Condition : (((isnotnull(s_market_id#48) AND (s_market_id#48 = 8)) AND isnotnull(s_store_sk#46)) AND isnotnull(s_zip#50))
+Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Condition : (((isnotnull(s_market_id#50) AND (s_market_id#50 = 8)) AND isnotnull(s_store_sk#48)) AND isnotnull(s_zip#52))
 
 (57) Project [codegen id : 1]
-Output [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
-Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Output [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
 
 (58) BroadcastExchange
-Input [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Input [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 (59) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#42]
-Right keys [1]: [s_store_sk#46]
+Left keys [1]: [ss_store_sk#44]
+Right keys [1]: [s_store_sk#48]
 Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
-Input [9]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Output [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
+Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
 
 (61) Exchange
-Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
-Arguments: hashpartitioning(ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
+Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
-Arguments: [ss_item_sk#40 ASC NULLS FIRST], false, 0
+Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
+Arguments: [ss_item_sk#42 ASC NULLS FIRST], false, 0
 
 (63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
 
 (65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Condition : isnotnull(i_item_sk#51)
+Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Condition : isnotnull(i_item_sk#53)
 
 (66) Exchange
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: hashpartitioning(i_item_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Arguments: hashpartitioning(i_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: [i_item_sk#51 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
 
 (68) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_item_sk#40]
-Right keys [1]: [i_item_sk#51]
+Left keys [1]: [ss_item_sk#42]
+Right keys [1]: [i_item_sk#53]
 Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Input [13]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Output [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Input [13]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
 
 (70) Exchange
-Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: hashpartitioning(ss_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
-Arguments: [ss_customer_sk#41 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
 
 (72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Output [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
 
 (73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: [c_customer_sk#59 ASC NULLS FIRST], false, 0
 
 (74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#41]
-Right keys [1]: [c_customer_sk#57]
+Left keys [1]: [ss_customer_sk#43]
+Right keys [1]: [c_customer_sk#59]
 Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [16]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Output [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Input [16]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
 
 (76) Exchange
-Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: hashpartitioning(ss_ticket_number#45, ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
+Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
 
 (78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#61, sr_ticket_number#62]
+Output [2]: [sr_item_sk#63, sr_ticket_number#64]
 
 (79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#61, sr_ticket_number#62]
-Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#63, sr_ticket_number#64]
+Arguments: [sr_ticket_number#64 ASC NULLS FIRST, sr_item_sk#63 ASC NULLS FIRST], false, 0
 
 (80) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
-Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
+Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
+Right keys [2]: [sr_ticket_number#64, sr_item_sk#63]
 Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Input [16]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, sr_item_sk#61, sr_ticket_number#62]
+Output [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Input [16]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, sr_item_sk#63, sr_ticket_number#64]
 
 (82) Exchange
-Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: hashpartitioning(c_birth_country#60, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: hashpartitioning(c_birth_country#62, s_zip#52, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
-Arguments: [c_birth_country#60 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
+Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+Arguments: [c_birth_country#62 ASC NULLS FIRST, s_zip#52 ASC NULLS FIRST], false, 0
 
 (84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Output [3]: [ca_state#65, ca_zip#66, ca_country#67]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
 
 (86) Filter [codegen id : 16]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Condition : (isnotnull(ca_country#65) AND isnotnull(ca_zip#64))
+Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Condition : (isnotnull(ca_country#67) AND isnotnull(ca_zip#66))
 
 (87) Exchange
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Arguments: hashpartitioning(upper(ca_country#65), ca_zip#64, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Arguments: hashpartitioning(upper(ca_country#67), ca_zip#66, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (88) Sort [codegen id : 17]
-Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
-Arguments: [upper(ca_country#65) ASC NULLS FIRST, ca_zip#64 ASC NULLS FIRST], false, 0
+Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Arguments: [upper(ca_country#67) ASC NULLS FIRST, ca_zip#66 ASC NULLS FIRST], false, 0
 
 (89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#60, s_zip#50]
-Right keys [2]: [upper(ca_country#65), ca_zip#64]
+Left keys [2]: [c_birth_country#62, s_zip#52]
+Right keys [2]: [upper(ca_country#67), ca_zip#66]
 Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
-Input [15]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#63, ca_zip#64, ca_country#65]
+Output [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
+Input [15]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, ca_state#65, ca_zip#66, ca_country#67]
 
 (91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
-Aggregate Attributes [1]: [sum#66]
-Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Input [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
+Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
+Aggregate Attributes [1]: [sum#68]
+Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
 
 (92) Exchange
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
-Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
-Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#30]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#30,17,2) AS netpaid#68]
+Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
 
 (94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#68]
+Input [1]: [netpaid#70]
 Keys: []
-Functions [1]: [partial_avg(netpaid#68)]
-Aggregate Attributes [2]: [sum#69, count#70]
-Results [2]: [sum#71, count#72]
+Functions [1]: [partial_avg(netpaid#70)]
+Aggregate Attributes [2]: [sum#71, count#72]
+Results [2]: [sum#73, count#74]
 
 (95) Exchange
-Input [2]: [sum#71, count#72]
+Input [2]: [sum#73, count#74]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
 (96) HashAggregate [codegen id : 20]
-Input [2]: [sum#71, count#72]
+Input [2]: [sum#73, count#74]
 Keys: []
-Functions [1]: [avg(netpaid#68)]
-Aggregate Attributes [1]: [avg(netpaid#68)#73]
-Results [1]: [(0.05 * avg(netpaid#68)#73) AS (0.05 * avg(netpaid))#74]
+Functions [1]: [avg(netpaid#70)]
+Aggregate Attributes [1]: [avg(netpaid#70)#75]
+Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
+
+Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (103)
++- Exchange (102)
+   +- ObjectHashAggregate (101)
+      +- * Project (100)
+         +- * Filter (99)
+            +- * ColumnarToRow (98)
+               +- Scan parquet spark_catalog.default.store (97)
+
+
+(97) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
+ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
+
+(98) ColumnarToRow [codegen id : 1]
+Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+
+(99) Filter [codegen id : 1]
+Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
+
+(100) Project [codegen id : 1]
+Output [1]: [s_store_sk#22]
+Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
+
+(101) ObjectHashAggregate
+Input [1]: [s_store_sk#22]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [buf#77]
+Results [1]: [buf#78]
+
+(102) Exchange
+Input [1]: [buf#78]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+
+(103) ObjectHashAggregate
+Input [1]: [buf#78]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79 AS bloomFilter#80]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -62,227 +62,227 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
+Condition : (((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
 (5) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Output [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,chiffon             ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (6) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 
 (7) Filter [codegen id : 1]
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Condition : ((isnotnull(i_color#12) AND (i_color#12 = chiffon             )) AND isnotnull(i_item_sk#9))
+Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Condition : ((isnotnull(i_color#10) AND (i_color#10 = chiffon             )) AND isnotnull(i_item_sk#7))
 
 (8) BroadcastExchange
-Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [6]: [i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#9]
+Right keys [1]: [i_item_sk#7]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
-Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#7, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 
 (11) Exchange
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (12) Sort [codegen id : 3]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12]
 Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
 (13) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Output [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_birth_country)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
 (14) ColumnarToRow [codegen id : 4]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
 
 (15) Filter [codegen id : 4]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_birth_country#18))
+Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Condition : (isnotnull(c_customer_sk#13) AND isnotnull(c_birth_country#16))
 
 (16) Exchange
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: hashpartitioning(c_customer_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Arguments: hashpartitioning(c_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (17) Sort [codegen id : 5]
-Input [4]: [c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
-Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
+Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
 
 (18) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
-Right keys [1]: [c_customer_sk#15]
+Right keys [1]: [c_customer_sk#13]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
-Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#15, c_first_name#16, c_last_name#17, c_birth_country#18]
+Output [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [14]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_customer_sk#13, c_first_name#14, c_last_name#15, c_birth_country#16]
 
 (20) Exchange
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
 Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (21) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Input [12]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
 Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Output [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
 (23) ColumnarToRow [codegen id : 8]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
 
 (24) Filter [codegen id : 8]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
-Condition : (isnotnull(sr_ticket_number#20) AND isnotnull(sr_item_sk#19))
+Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
+Condition : (isnotnull(sr_ticket_number#18) AND isnotnull(sr_item_sk#17))
 
 (25) Project [codegen id : 8]
-Output [2]: [sr_item_sk#19, sr_ticket_number#20]
-Input [3]: [sr_item_sk#19, sr_ticket_number#20, sr_returned_date_sk#21]
+Output [2]: [sr_item_sk#17, sr_ticket_number#18]
+Input [3]: [sr_item_sk#17, sr_ticket_number#18, sr_returned_date_sk#19]
 
 (26) Exchange
-Input [2]: [sr_item_sk#19, sr_ticket_number#20]
-Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [sr_item_sk#17, sr_ticket_number#18]
+Arguments: hashpartitioning(sr_ticket_number#18, sr_item_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (27) Sort [codegen id : 9]
-Input [2]: [sr_item_sk#19, sr_ticket_number#20]
-Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#17, sr_ticket_number#18]
+Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST], false, 0
 
 (28) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
-Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
+Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 12]
-Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
-Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
+Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16]
+Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, sr_item_sk#17, sr_ticket_number#18]
 
 (30) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Output [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (31) ColumnarToRow [codegen id : 10]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
 
 (32) Filter [codegen id : 10]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
-Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
+Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
+Condition : (((isnotnull(s_market_id#22) AND (s_market_id#22 = 8)) AND isnotnull(s_store_sk#20)) AND isnotnull(s_zip#24))
 
 (33) Project [codegen id : 10]
-Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
-Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
+Output [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
+Input [5]: [s_store_sk#20, s_store_name#21, s_market_id#22, s_state#23, s_zip#24]
 
 (34) BroadcastExchange
-Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
+Input [4]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24]
 Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
 
 (35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (36) ColumnarToRow
-Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
+Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
 
 (37) Filter
-Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
-Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
+Input [3]: [ca_state#25, ca_zip#26, ca_country#27]
+Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
 
 (38) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [s_zip#26]
-Right keys [1]: [ca_zip#28]
+Left keys [1]: [s_zip#24]
+Right keys [1]: [ca_zip#26]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
-Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
-Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
+Output [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
+Input [7]: [s_store_sk#20, s_store_name#21, s_state#23, s_zip#24, ca_state#25, ca_zip#26, ca_country#27]
 
 (40) BroadcastExchange
-Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Input [5]: [s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
 Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
 
 (41) BroadcastHashJoin [codegen id : 12]
-Left keys [2]: [ss_store_sk#3, c_birth_country#18]
-Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
+Left keys [2]: [ss_store_sk#3, c_birth_country#16]
+Right keys [2]: [s_store_sk#20, upper(ca_country#27)]
 Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
-Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
-Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Output [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
+Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, c_birth_country#16, s_store_sk#20, s_store_name#21, s_state#23, ca_state#25, ca_country#27]
 
 (43) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
-Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Input [11]: [ss_net_paid#5, s_store_name#21, s_state#23, i_current_price#8, i_size#9, i_color#10, i_units#11, i_manager_id#12, c_first_name#14, c_last_name#15, ca_state#25]
+Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum#30]
-Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
+Aggregate Attributes [1]: [sum#28]
+Results [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
 
 (44) Exchange
-Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
+Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Input [11]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9, sum#29]
+Keys [10]: [c_last_name#15, c_first_name#14, s_store_name#21, ca_state#25, s_state#23, i_color#10, i_current_price#8, i_manager_id#12, i_units#11, i_size#9]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
-Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#30]
+Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#30,17,2) AS netpaid#31]
 
 (46) HashAggregate [codegen id : 13]
-Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
-Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
-Functions [1]: [partial_sum(netpaid#33)]
-Aggregate Attributes [2]: [sum#34, isEmpty#35]
-Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
+Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, netpaid#31]
+Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
+Functions [1]: [partial_sum(netpaid#31)]
+Aggregate Attributes [2]: [sum#32, isEmpty#33]
+Results [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
 
 (47) Exchange
-Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
+Arguments: hashpartitioning(c_last_name#15, c_first_name#14, s_store_name#21, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (48) HashAggregate [codegen id : 14]
-Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
-Functions [1]: [sum(netpaid#33)]
-Aggregate Attributes [1]: [sum(netpaid#33)#38]
-Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
+Input [5]: [c_last_name#15, c_first_name#14, s_store_name#21, sum#34, isEmpty#35]
+Keys [3]: [c_last_name#15, c_first_name#14, s_store_name#21]
+Functions [1]: [sum(netpaid#31)]
+Aggregate Attributes [1]: [sum(netpaid#31)#36]
+Results [4]: [c_last_name#15, c_first_name#14, s_store_name#21, sum(netpaid#31)#36 AS paid#37]
 
 (49) Filter [codegen id : 14]
-Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
-Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
+Input [4]: [c_last_name#15, c_first_name#14, s_store_name#21, paid#37]
+Condition : (isnotnull(paid#37) AND (cast(paid#37 as decimal(33,8)) > cast(Subquery scalar-subquery#38, [id=#39] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#38, [id=#39]
 * HashAggregate (96)
 +- Exchange (95)
    +- * HashAggregate (94)
@@ -333,265 +333,219 @@ Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquer
 
 
 (50) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Output [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
 (51) ColumnarToRow [codegen id : 2]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 
 (52) Filter [codegen id : 2]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
-Condition : (((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43))
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
+Condition : (((isnotnull(ss_ticket_number#43) AND isnotnull(ss_item_sk#40)) AND isnotnull(ss_store_sk#42)) AND isnotnull(ss_customer_sk#41))
 
 (53) Project [codegen id : 2]
-Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
-Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
+Output [5]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44]
+Input [6]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, ss_sold_date_sk#45]
 
 (54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Output [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
 (55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 
 (56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
-Condition : (((isnotnull(s_market_id#50) AND (s_market_id#50 = 8)) AND isnotnull(s_store_sk#48)) AND isnotnull(s_zip#52))
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
+Condition : (((isnotnull(s_market_id#48) AND (s_market_id#48 = 8)) AND isnotnull(s_store_sk#46)) AND isnotnull(s_zip#50))
 
 (57) Project [codegen id : 1]
-Output [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+Output [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
+Input [5]: [s_store_sk#46, s_store_name#47, s_market_id#48, s_state#49, s_zip#50]
 
 (58) BroadcastExchange
-Input [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+Input [4]: [s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 (59) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#44]
-Right keys [1]: [s_store_sk#48]
+Left keys [1]: [ss_store_sk#42]
+Right keys [1]: [s_store_sk#46]
 Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+Output [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Input [9]: [ss_item_sk#40, ss_customer_sk#41, ss_store_sk#42, ss_ticket_number#43, ss_net_paid#44, s_store_sk#46, s_store_name#47, s_state#49, s_zip#50]
 
 (61) Exchange
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Arguments: hashpartitioning(ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: [ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [7]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50]
+Arguments: [ss_item_sk#40 ASC NULLS FIRST], false, 0
 
 (63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
 (64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 
 (65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Condition : isnotnull(i_item_sk#53)
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Condition : isnotnull(i_item_sk#51)
 
 (66) Exchange
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(i_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: hashpartitioning(i_item_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: [i_item_sk#51 ASC NULLS FIRST], false, 0
 
 (68) SortMergeJoin [codegen id : 6]
-Left keys [1]: [ss_item_sk#42]
-Right keys [1]: [i_item_sk#53]
+Left keys [1]: [ss_item_sk#40]
+Right keys [1]: [i_item_sk#51]
 Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Input [13]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+Output [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Input [13]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_item_sk#51, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
 
 (70) Exchange
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: hashpartitioning(ss_customer_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
+Input [12]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56]
+Arguments: [ss_customer_sk#41 ASC NULLS FIRST], false, 0
 
 (72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Output [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
 
 (73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_customer_sk#59 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 
 (74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#43]
-Right keys [1]: [c_customer_sk#59]
+Left keys [1]: [ss_customer_sk#41]
+Right keys [1]: [c_customer_sk#57]
 Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
+Output [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Input [16]: [ss_item_sk#40, ss_customer_sk#41, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_customer_sk#57, c_first_name#58, c_last_name#59, c_birth_country#60]
 
 (76) Exchange
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(ss_ticket_number#45, ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(ss_ticket_number#43, ss_item_sk#40, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
+Input [14]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [ss_ticket_number#43 ASC NULLS FIRST, ss_item_sk#40 ASC NULLS FIRST], false, 0
 
 (78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#63, sr_ticket_number#64]
+Output [2]: [sr_item_sk#61, sr_ticket_number#62]
 
 (79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#63, sr_ticket_number#64]
-Arguments: [sr_ticket_number#64 ASC NULLS FIRST, sr_item_sk#63 ASC NULLS FIRST], false, 0
+Input [2]: [sr_item_sk#61, sr_ticket_number#62]
+Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
 
 (80) SortMergeJoin [codegen id : 14]
-Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
-Right keys [2]: [sr_ticket_number#64, sr_item_sk#63]
+Left keys [2]: [ss_ticket_number#43, ss_item_sk#40]
+Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
 Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, sr_item_sk#63, sr_ticket_number#64]
+Output [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Input [16]: [ss_item_sk#40, ss_ticket_number#43, ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, sr_item_sk#61, sr_ticket_number#62]
 
 (82) Exchange
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(c_birth_country#62, s_zip#52, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: hashpartitioning(c_birth_country#60, s_zip#50, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_birth_country#62 ASC NULLS FIRST, s_zip#52 ASC NULLS FIRST], false, 0
+Input [12]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60]
+Arguments: [c_birth_country#60 ASC NULLS FIRST, s_zip#50 ASC NULLS FIRST], false, 0
 
 (84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Output [3]: [ca_state#63, ca_zip#64, ca_country#65]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
 (85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
 
 (86) Filter [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Condition : (isnotnull(ca_country#67) AND isnotnull(ca_zip#66))
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Condition : (isnotnull(ca_country#65) AND isnotnull(ca_zip#64))
 
 (87) Exchange
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: hashpartitioning(upper(ca_country#67), ca_zip#66, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Arguments: hashpartitioning(upper(ca_country#65), ca_zip#64, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (88) Sort [codegen id : 17]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: [upper(ca_country#67) ASC NULLS FIRST, ca_zip#66 ASC NULLS FIRST], false, 0
+Input [3]: [ca_state#63, ca_zip#64, ca_country#65]
+Arguments: [upper(ca_country#65) ASC NULLS FIRST, ca_zip#64 ASC NULLS FIRST], false, 0
 
 (89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#62, s_zip#52]
-Right keys [2]: [upper(ca_country#67), ca_zip#66]
+Left keys [2]: [c_birth_country#60, s_zip#50]
+Right keys [2]: [upper(ca_country#65), ca_zip#64]
 Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Input [15]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, ca_state#65, ca_zip#66, ca_country#67]
+Output [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
+Input [15]: [ss_net_paid#44, s_store_name#47, s_state#49, s_zip#50, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, c_birth_country#60, ca_state#63, ca_zip#64, ca_country#65]
 
 (91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum#68]
-Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Input [11]: [ss_net_paid#44, s_store_name#47, s_state#49, i_current_price#52, i_size#53, i_color#54, i_units#55, i_manager_id#56, c_first_name#58, c_last_name#59, ca_state#63]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#44))]
+Aggregate Attributes [1]: [sum#66]
+Results [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
 
 (92) Exchange
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Arguments: hashpartitioning(c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
+Input [11]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53, sum#67]
+Keys [10]: [c_last_name#59, c_first_name#58, s_store_name#47, ca_state#63, s_state#49, i_color#54, i_current_price#52, i_manager_id#56, i_units#55, i_size#53]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#44))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#44))#30]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#44))#30,17,2) AS netpaid#68]
 
 (94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#70]
+Input [1]: [netpaid#68]
 Keys: []
-Functions [1]: [partial_avg(netpaid#70)]
-Aggregate Attributes [2]: [sum#71, count#72]
-Results [2]: [sum#73, count#74]
+Functions [1]: [partial_avg(netpaid#68)]
+Aggregate Attributes [2]: [sum#69, count#70]
+Results [2]: [sum#71, count#72]
 
 (95) Exchange
-Input [2]: [sum#73, count#74]
+Input [2]: [sum#71, count#72]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
 (96) HashAggregate [codegen id : 20]
-Input [2]: [sum#73, count#74]
+Input [2]: [sum#71, count#72]
 Keys: []
-Functions [1]: [avg(netpaid#70)]
-Aggregate Attributes [1]: [avg(netpaid#70)#75]
-Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
-
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (103)
-+- Exchange (102)
-   +- ObjectHashAggregate (101)
-      +- * Project (100)
-         +- * Filter (99)
-            +- * ColumnarToRow (98)
-               +- Scan parquet spark_catalog.default.store (97)
-
-
-(97) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
-ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
-
-(98) ColumnarToRow [codegen id : 1]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-
-(99) Filter [codegen id : 1]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
-
-(100) Project [codegen id : 1]
-Output [1]: [s_store_sk#22]
-Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
-
-(101) ObjectHashAggregate
-Input [1]: [s_store_sk#22]
-Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [buf#77]
-Results [1]: [buf#78]
-
-(102) Exchange
-Input [1]: [buf#78]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
-
-(103) ObjectHashAggregate
-Input [1]: [buf#78]
-Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79]
-Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79 AS bloomFilter#80]
+Functions [1]: [avg(netpaid#68)]
+Aggregate Attributes [1]: [avg(netpaid#68)#73]
+Results [1]: [(0.05 * avg(netpaid#68)#73) AS (0.05 * avg(netpaid))#74]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
@@ -1,15 +1,15 @@
 WholeStageCodegen (14)
   Filter [paid]
-    Subquery #1
+    Subquery #2
       WholeStageCodegen (20)
         HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
           InputAdapter
-            Exchange #10
+            Exchange #11
               WholeStageCodegen (19)
                 HashAggregate [netpaid] [sum,count,sum,count]
                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                     InputAdapter
-                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #11
+                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #12
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
@@ -18,7 +18,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (15)
                                     Sort [c_birth_country,s_zip]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #12
+                                        Exchange [c_birth_country,s_zip] #13
                                           WholeStageCodegen (14)
                                             Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                               SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
@@ -26,7 +26,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (11)
                                                     Sort [ss_ticket_number,ss_item_sk]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #13
+                                                        Exchange [ss_ticket_number,ss_item_sk] #14
                                                           WholeStageCodegen (10)
                                                             Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                                               SortMergeJoin [ss_customer_sk,c_customer_sk]
@@ -34,7 +34,7 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (7)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #14
+                                                                        Exchange [ss_customer_sk] #15
                                                                           WholeStageCodegen (6)
                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                               SortMergeJoin [ss_item_sk,i_item_sk]
@@ -42,7 +42,7 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (3)
                                                                                     Sort [ss_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #15
+                                                                                        Exchange [ss_item_sk] #16
                                                                                           WholeStageCodegen (2)
                                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
                                                                                               BroadcastHashJoin [ss_store_sk,s_store_sk]
@@ -52,7 +52,7 @@ WholeStageCodegen (14)
                                                                                                       InputAdapter
                                                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                                 InputAdapter
-                                                                                                  BroadcastExchange #16
+                                                                                                  BroadcastExchange #17
                                                                                                     WholeStageCodegen (1)
                                                                                                       Project [s_store_sk,s_store_name,s_state,s_zip]
                                                                                                         Filter [s_market_id,s_store_sk,s_zip]
@@ -63,7 +63,7 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (5)
                                                                                     Sort [i_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [i_item_sk] #17
+                                                                                        Exchange [i_item_sk] #18
                                                                                           WholeStageCodegen (4)
                                                                                             Filter [i_item_sk]
                                                                                               ColumnarToRow
@@ -73,17 +73,17 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (9)
                                                                     Sort [c_customer_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #6
+                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #7
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [sr_ticket_number,sr_item_sk]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #7
+                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
                                 InputAdapter
                                   WholeStageCodegen (17)
                                     Sort [ca_country,ca_zip]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #18
+                                        Exchange [ca_country,ca_zip] #19
                                           WholeStageCodegen (16)
                                             Filter [ca_country,ca_zip]
                                               ColumnarToRow
@@ -121,11 +121,21 @@ WholeStageCodegen (14)
                                                               BroadcastHashJoin [ss_item_sk,i_item_sk]
                                                                 Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                   Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                    Subquery #1
+                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
+                                                                        Exchange #5
+                                                                          ObjectHashAggregate [s_store_sk] [buf,buf]
+                                                                            WholeStageCodegen (1)
+                                                                              Project [s_store_sk]
+                                                                                Filter [s_market_id,s_store_sk,s_zip]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                 InputAdapter
-                                                                  BroadcastExchange #5
+                                                                  BroadcastExchange #6
                                                                     WholeStageCodegen (1)
                                                                       Filter [i_color,i_item_sk]
                                                                         ColumnarToRow
@@ -135,7 +145,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #6
+                                                        Exchange [c_customer_sk] #7
                                                           WholeStageCodegen (4)
                                                             Filter [c_customer_sk,c_birth_country]
                                                               ColumnarToRow
@@ -145,7 +155,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (9)
                                     Sort [sr_ticket_number,sr_item_sk]
                                       InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #7
+                                        Exchange [sr_ticket_number,sr_item_sk] #8
                                           WholeStageCodegen (8)
                                             Project [sr_item_sk,sr_ticket_number]
                                               Filter [sr_ticket_number,sr_item_sk]
@@ -153,12 +163,12 @@ WholeStageCodegen (14)
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                             InputAdapter
-                              BroadcastExchange #8
+                              BroadcastExchange #9
                                 WholeStageCodegen (11)
                                   Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
                                     BroadcastHashJoin [s_zip,ca_zip]
                                       InputAdapter
-                                        BroadcastExchange #9
+                                        BroadcastExchange #10
                                           WholeStageCodegen (10)
                                             Project [s_store_sk,s_store_name,s_state,s_zip]
                                               Filter [s_market_id,s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
@@ -1,15 +1,15 @@
 WholeStageCodegen (14)
   Filter [paid]
-    Subquery #2
+    Subquery #1
       WholeStageCodegen (20)
         HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
           InputAdapter
-            Exchange #11
+            Exchange #10
               WholeStageCodegen (19)
                 HashAggregate [netpaid] [sum,count,sum,count]
                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                     InputAdapter
-                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #12
+                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #11
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
@@ -18,7 +18,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (15)
                                     Sort [c_birth_country,s_zip]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #13
+                                        Exchange [c_birth_country,s_zip] #12
                                           WholeStageCodegen (14)
                                             Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                               SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
@@ -26,7 +26,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (11)
                                                     Sort [ss_ticket_number,ss_item_sk]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #14
+                                                        Exchange [ss_ticket_number,ss_item_sk] #13
                                                           WholeStageCodegen (10)
                                                             Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
                                                               SortMergeJoin [ss_customer_sk,c_customer_sk]
@@ -34,7 +34,7 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (7)
                                                                     Sort [ss_customer_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #15
+                                                                        Exchange [ss_customer_sk] #14
                                                                           WholeStageCodegen (6)
                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                                               SortMergeJoin [ss_item_sk,i_item_sk]
@@ -42,7 +42,7 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (3)
                                                                                     Sort [ss_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #16
+                                                                                        Exchange [ss_item_sk] #15
                                                                                           WholeStageCodegen (2)
                                                                                             Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
                                                                                               BroadcastHashJoin [ss_store_sk,s_store_sk]
@@ -52,7 +52,7 @@ WholeStageCodegen (14)
                                                                                                       InputAdapter
                                                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                                 InputAdapter
-                                                                                                  BroadcastExchange #17
+                                                                                                  BroadcastExchange #16
                                                                                                     WholeStageCodegen (1)
                                                                                                       Project [s_store_sk,s_store_name,s_state,s_zip]
                                                                                                         Filter [s_market_id,s_store_sk,s_zip]
@@ -63,7 +63,7 @@ WholeStageCodegen (14)
                                                                                   WholeStageCodegen (5)
                                                                                     Sort [i_item_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [i_item_sk] #18
+                                                                                        Exchange [i_item_sk] #17
                                                                                           WholeStageCodegen (4)
                                                                                             Filter [i_item_sk]
                                                                                               ColumnarToRow
@@ -73,17 +73,17 @@ WholeStageCodegen (14)
                                                                   WholeStageCodegen (9)
                                                                     Sort [c_customer_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #7
+                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #6
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [sr_ticket_number,sr_item_sk]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
+                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #7
                                 InputAdapter
                                   WholeStageCodegen (17)
                                     Sort [ca_country,ca_zip]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #19
+                                        Exchange [ca_country,ca_zip] #18
                                           WholeStageCodegen (16)
                                             Filter [ca_country,ca_zip]
                                               ColumnarToRow
@@ -121,21 +121,11 @@ WholeStageCodegen (14)
                                                               BroadcastHashJoin [ss_item_sk,i_item_sk]
                                                                 Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
                                                                   Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                    Subquery #1
-                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
-                                                                        Exchange #5
-                                                                          ObjectHashAggregate [s_store_sk] [buf,buf]
-                                                                            WholeStageCodegen (1)
-                                                                              Project [s_store_sk]
-                                                                                Filter [s_market_id,s_store_sk,s_zip]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                 InputAdapter
-                                                                  BroadcastExchange #6
+                                                                  BroadcastExchange #5
                                                                     WholeStageCodegen (1)
                                                                       Filter [i_color,i_item_sk]
                                                                         ColumnarToRow
@@ -145,7 +135,7 @@ WholeStageCodegen (14)
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        Exchange [c_customer_sk] #7
+                                                        Exchange [c_customer_sk] #6
                                                           WholeStageCodegen (4)
                                                             Filter [c_customer_sk,c_birth_country]
                                                               ColumnarToRow
@@ -155,7 +145,7 @@ WholeStageCodegen (14)
                                   WholeStageCodegen (9)
                                     Sort [sr_ticket_number,sr_item_sk]
                                       InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #8
+                                        Exchange [sr_ticket_number,sr_item_sk] #7
                                           WholeStageCodegen (8)
                                             Project [sr_item_sk,sr_ticket_number]
                                               Filter [sr_ticket_number,sr_item_sk]
@@ -163,12 +153,12 @@ WholeStageCodegen (14)
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                             InputAdapter
-                              BroadcastExchange #9
+                              BroadcastExchange #8
                                 WholeStageCodegen (11)
                                   Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
                                     BroadcastHashJoin [s_zip,ca_zip]
                                       InputAdapter
-                                        BroadcastExchange #10
+                                        BroadcastExchange #9
                                           WholeStageCodegen (10)
                                             Project [s_store_sk,s_store_name,s_state,s_zip]
                                               Filter [s_market_id,s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
-Condition : isnotnull(cs_item_sk#11)
+Condition : (isnotnull(cs_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_item_sk#11, 42)))
 
 (20) Project [codegen id : 5]
 Output [1]: [cs_item_sk#11]
@@ -170,25 +170,71 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#13]
+Output [2]: [d_date_sk#10, d_date#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-01), LessThanOrEqual(d_date,2000-04-01), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#13]
+Input [2]: [d_date_sk#10, d_date#15]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#13]
-Condition : (((isnotnull(d_date#13) AND (d_date#13 >= 2000-02-01)) AND (d_date#13 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#10, d_date#15]
+Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-02-01)) AND (d_date#15 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#13]
+Input [2]: [d_date_sk#10, d_date#15]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (40)
++- Exchange (39)
+   +- ObjectHashAggregate (38)
+      +- * Project (37)
+         +- * Filter (36)
+            +- * ColumnarToRow (35)
+               +- Scan parquet spark_catalog.default.item (34)
+
+
+(34) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,68.00), LessThanOrEqual(i_current_price,98.00), In(i_manufact_id, [677,694,808,940]), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_manufact_id:int>
+
+(35) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
+
+(36) Filter [codegen id : 1]
+Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
+Condition : ((((isnotnull(i_current_price#4) AND (i_current_price#4 >= 68.00)) AND (i_current_price#4 <= 98.00)) AND i_manufact_id#5 IN (677,940,694,808)) AND isnotnull(i_item_sk#1))
+
+(37) Project [codegen id : 1]
+Output [1]: [i_item_sk#1]
+Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
+
+(38) ObjectHashAggregate
+Input [1]: [i_item_sk#1]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
+Aggregate Attributes [1]: [buf#16]
+Results [1]: [buf#17]
+
+(39) Exchange
+Input [1]: [buf#17]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+
+(40) ObjectHashAggregate
+Input [1]: [buf#17]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18 AS bloomFilter#19]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
-Condition : (isnotnull(cs_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_item_sk#11, 42)))
+Condition : isnotnull(cs_item_sk#11)
 
 (20) Project [codegen id : 5]
 Output [1]: [cs_item_sk#11]
@@ -170,71 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#15]
+Output [2]: [d_date_sk#10, d_date#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-01), LessThanOrEqual(d_date,2000-04-01), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#10, d_date#13]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
-Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-02-01)) AND (d_date#15 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#10, d_date#13]
+Condition : (((isnotnull(d_date#13) AND (d_date#13 >= 2000-02-01)) AND (d_date#13 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#10, d_date#13]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
-ObjectHashAggregate (40)
-+- Exchange (39)
-   +- ObjectHashAggregate (38)
-      +- * Project (37)
-         +- * Filter (36)
-            +- * ColumnarToRow (35)
-               +- Scan parquet spark_catalog.default.item (34)
-
-
-(34) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,68.00), LessThanOrEqual(i_current_price,98.00), In(i_manufact_id, [677,694,808,940]), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_manufact_id:int>
-
-(35) ColumnarToRow [codegen id : 1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-
-(36) Filter [codegen id : 1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-Condition : ((((isnotnull(i_current_price#4) AND (i_current_price#4 >= 68.00)) AND (i_current_price#4 <= 98.00)) AND i_manufact_id#5 IN (677,940,694,808)) AND isnotnull(i_item_sk#1))
-
-(37) Project [codegen id : 1]
-Output [1]: [i_item_sk#1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-
-(38) ObjectHashAggregate
-Input [1]: [i_item_sk#1]
-Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [buf#16]
-Results [1]: [buf#17]
-
-(39) Exchange
-Input [1]: [buf#17]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
-
-(40) ObjectHashAggregate
-Input [1]: [buf#17]
-Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18 AS bloomFilter#19]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
@@ -48,6 +48,16 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                             WholeStageCodegen (5)
                               Project [cs_item_sk]
                                 Filter [cs_item_sk]
+                                  Subquery #2
+                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 239, 6582, 0, 0),bloomFilter,buf]
+                                      Exchange #6
+                                        ObjectHashAggregate [i_item_sk] [buf,buf]
+                                          WholeStageCodegen (1)
+                                            Project [i_item_sk]
+                                              Filter [i_current_price,i_manufact_id,i_item_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_manufact_id]
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
@@ -48,16 +48,6 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                             WholeStageCodegen (5)
                               Project [cs_item_sk]
                                 Filter [cs_item_sk]
-                                  Subquery #2
-                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 239, 6582, 0, 0),bloomFilter,buf]
-                                      Exchange #6
-                                        ObjectHashAggregate [i_item_sk] [buf,buf]
-                                          WholeStageCodegen (1)
-                                            Project [i_item_sk]
-                                              Filter [i_current_price,i_manufact_id,i_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_manufact_id]
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+Condition : (isnotnull(ss_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ss_item_sk#11, 42)))
 
 (20) Project [codegen id : 5]
 Output [1]: [ss_item_sk#11]
@@ -170,25 +170,71 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#13]
+Output [2]: [d_date_sk#10, d_date#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-05-25), LessThanOrEqual(d_date,2000-07-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#13]
+Input [2]: [d_date_sk#10, d_date#15]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#13]
-Condition : (((isnotnull(d_date#13) AND (d_date#13 >= 2000-05-25)) AND (d_date#13 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#10, d_date#15]
+Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-05-25)) AND (d_date#15 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#13]
+Input [2]: [d_date_sk#10, d_date#15]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
+ObjectHashAggregate (40)
++- Exchange (39)
+   +- ObjectHashAggregate (38)
+      +- * Project (37)
+         +- * Filter (36)
+            +- * ColumnarToRow (35)
+               +- Scan parquet spark_catalog.default.item (34)
+
+
+(34) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,62.00), LessThanOrEqual(i_current_price,92.00), In(i_manufact_id, [129,270,423,821]), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_manufact_id:int>
+
+(35) ColumnarToRow [codegen id : 1]
+Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
+
+(36) Filter [codegen id : 1]
+Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
+Condition : ((((isnotnull(i_current_price#4) AND (i_current_price#4 >= 62.00)) AND (i_current_price#4 <= 92.00)) AND i_manufact_id#5 IN (129,270,821,423)) AND isnotnull(i_item_sk#1))
+
+(37) Project [codegen id : 1]
+Output [1]: [i_item_sk#1]
+Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
+
+(38) ObjectHashAggregate
+Input [1]: [i_item_sk#1]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
+Aggregate Attributes [1]: [buf#16]
+Results [1]: [buf#17]
+
+(39) Exchange
+Input [1]: [buf#17]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+
+(40) ObjectHashAggregate
+Input [1]: [buf#17]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18 AS bloomFilter#19]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : (isnotnull(ss_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ss_item_sk#11, 42)))
+Condition : isnotnull(ss_item_sk#11)
 
 (20) Project [codegen id : 5]
 Output [1]: [ss_item_sk#11]
@@ -170,71 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#15]
+Output [2]: [d_date_sk#10, d_date#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-05-25), LessThanOrEqual(d_date,2000-07-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#10, d_date#13]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
-Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-05-25)) AND (d_date#15 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#10, d_date#13]
+Condition : (((isnotnull(d_date#13) AND (d_date#13 >= 2000-05-25)) AND (d_date#13 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
 
 (32) Project [codegen id : 1]
 Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#10, d_date#13]
 
 (33) BroadcastExchange
 Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
-ObjectHashAggregate (40)
-+- Exchange (39)
-   +- ObjectHashAggregate (38)
-      +- * Project (37)
-         +- * Filter (36)
-            +- * ColumnarToRow (35)
-               +- Scan parquet spark_catalog.default.item (34)
-
-
-(34) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,62.00), LessThanOrEqual(i_current_price,92.00), In(i_manufact_id, [129,270,423,821]), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_manufact_id:int>
-
-(35) ColumnarToRow [codegen id : 1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-
-(36) Filter [codegen id : 1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-Condition : ((((isnotnull(i_current_price#4) AND (i_current_price#4 >= 62.00)) AND (i_current_price#4 <= 92.00)) AND i_manufact_id#5 IN (129,270,821,423)) AND isnotnull(i_item_sk#1))
-
-(37) Project [codegen id : 1]
-Output [1]: [i_item_sk#1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-
-(38) ObjectHashAggregate
-Input [1]: [i_item_sk#1]
-Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [buf#16]
-Results [1]: [buf#17]
-
-(39) Exchange
-Input [1]: [buf#17]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
-
-(40) ObjectHashAggregate
-Input [1]: [buf#17]
-Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18 AS bloomFilter#19]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
@@ -48,6 +48,16 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                             WholeStageCodegen (5)
                               Project [ss_item_sk]
                                 Filter [ss_item_sk]
+                                  Subquery #2
+                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 239, 6582, 0, 0),bloomFilter,buf]
+                                      Exchange #6
+                                        ObjectHashAggregate [i_item_sk] [buf,buf]
+                                          WholeStageCodegen (1)
+                                            Project [i_item_sk]
+                                              Filter [i_current_price,i_manufact_id,i_item_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_manufact_id]
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
@@ -48,16 +48,6 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                             WholeStageCodegen (5)
                               Project [ss_item_sk]
                                 Filter [ss_item_sk]
-                                  Subquery #2
-                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 239, 6582, 0, 0),bloomFilter,buf]
-                                      Exchange #6
-                                        ObjectHashAggregate [i_item_sk] [buf,buf]
-                                          WholeStageCodegen (1)
-                                            Project [i_item_sk]
-                                              Filter [i_current_price,i_manufact_id,i_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_manufact_id]
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sold_date_sk]

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -407,8 +407,13 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
       assertRewroteWithBloomFilter("select * from bf1 right outer join bf2 join bf3 on " +
         "bf1.c1 = bf2.c2 and bf3.c3 = bf1.c1 where bf1.a1 = 5", 2)
     }
+
     withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1200") {
+      assertRewroteWithBloomFilter("select * from (select * from bf1 left semi join bf2 on " +
+        "bf1.c1 = bf2.c2 where bf1.a1 = 5) as a join bf3 on bf3.c3 = a.c1", 2)
+      assertRewroteWithBloomFilter("select * from (select * from bf1 left anti join bf2 on " +
+        "bf1.c1 = bf2.c2 where bf1.a1 = 5) as a join bf3 on bf3.c3 = a.c1")
       assertRewroteWithBloomFilter("select * from (select * from bf1 left semi join bf2 on " +
         "(bf1.c1 = bf2.c2 and bf2.a2 = 5)) as a join bf3 on bf3.c3 = a.c1")
       assertRewroteWithBloomFilter("select * from (select * from bf1 left anti join bf2 on " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -235,7 +235,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
   }
 
   def checkWithAndWithoutFeatureEnabled(query: String, testSemiJoin: Boolean,
-      shouldReplace: Boolean): Unit = {
+      shouldReplace: Boolean, runtimeFilterNum: Int = 1): Unit = {
     var planDisabled: LogicalPlan = null
     var planEnabled: LogicalPlan = null
     var expectedAnswer: Array[Row] = null
@@ -260,7 +260,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         val agg = planEnabled.collect {
           case Join(_, agg: Aggregate, LeftSemi, _, _) => agg
         }
-        assert(agg.size == 1)
+        assert(agg.size == runtimeFilterNum)
         assert(agg.head.fastEquals(ColumnPruning(agg.head)))
       } else {
         comparePlans(planDisabled, planEnabled)
@@ -270,9 +270,10 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         SQLConf.RUNTIME_BLOOM_FILTER_ENABLED.key -> "true") {
         planEnabled = sql(query).queryExecution.optimizedPlan
         checkAnswer(sql(query), expectedAnswer)
+        assert(getNumBloomFilters(planDisabled) == 0)
         if (shouldReplace) {
           assert(!columnPruningTakesEffect(planEnabled))
-          assert(getNumBloomFilters(planEnabled) > getNumBloomFilters(planDisabled))
+          assert(getNumBloomFilters(planEnabled) == runtimeFilterNum)
         } else {
           assert(getNumBloomFilters(planEnabled) == getNumBloomFilters(planDisabled))
         }
@@ -319,16 +320,18 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
     }.nonEmpty
   }
 
-  def assertRewroteSemiJoin(query: String): Unit = {
-    checkWithAndWithoutFeatureEnabled(query, testSemiJoin = true, shouldReplace = true)
+  def assertRewroteSemiJoin(query: String, runtimeFilterNum: Int = 1): Unit = {
+    checkWithAndWithoutFeatureEnabled(
+      query, testSemiJoin = true, shouldReplace = true, runtimeFilterNum)
   }
 
   def assertDidNotRewriteSemiJoin(query: String): Unit = {
     checkWithAndWithoutFeatureEnabled(query, testSemiJoin = true, shouldReplace = false)
   }
 
-  def assertRewroteWithBloomFilter(query: String): Unit = {
-    checkWithAndWithoutFeatureEnabled(query, testSemiJoin = false, shouldReplace = true)
+  def assertRewroteWithBloomFilter(query: String, runtimeFilterNum: Int = 1): Unit = {
+    checkWithAndWithoutFeatureEnabled(
+      query, testSemiJoin = false, shouldReplace = true, runtimeFilterNum)
   }
 
   def assertDidNotRewriteWithBloomFilter(query: String): Unit = {
@@ -349,7 +352,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
     withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000") {
       assertRewroteSemiJoin("select * from bf1 join bf2 join bf3 on bf1.c1 = bf2.c2 " +
-        "and bf3.c3 = bf2.c2 where bf2.a2 = 5")
+        "and bf3.c3 = bf2.c2 where bf2.a2 = 5", 2)
     }
   }
 
@@ -381,6 +384,14 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
       assertRewroteWithBloomFilter("select * from bf1 join bf2 on bf1.c1 = bf2.c2 " +
         "where bf2.a2 = 62")
       assertDidNotRewriteWithBloomFilter("select * from bf1 join bf2 on bf1.c1 = bf2.c2")
+    }
+  }
+
+  test("Runtime bloom filter join: two joins") {
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000") {
+      assertRewroteWithBloomFilter("select * from bf1 join bf2 join bf3 on bf1.c1 = bf2.c2 " +
+        "and bf3.c3 = bf2.c2 where bf2.a2 = 5", 2)
     }
   }
 
@@ -518,7 +529,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "5000") {
         assertRewroteWithBloomFilter("select * from " +
           "(select * from bf5filtered union all select * from bf2) t " +
-          "join bf3 on t.c5 = bf3.c3 where bf3.a3 = 5")
+          "join bf3 on t.c5 = bf3.c3 where bf3.a3 = 5", 2)
       }
       withSQLConf(
         SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "15000") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -392,6 +392,27 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000") {
       assertRewroteWithBloomFilter("select * from bf1 join bf2 join bf3 on bf1.c1 = bf2.c2 " +
         "and bf3.c3 = bf2.c2 where bf2.a2 = 5", 2)
+      assertRewroteWithBloomFilter("select * from (select * from bf1 left semi join bf2 on " +
+        "bf1.c1 = bf2.c2 where bf1.a1 = 5) as a join bf3 on bf3.c3 = a.c1")
+      assertRewroteWithBloomFilter("select * from (select * from bf1 left anti join bf2 on " +
+        "bf1.c1 = bf2.c2 where bf1.a1 = 5) as a join bf3 on bf3.c3 = a.c1")
+      assertRewroteWithBloomFilter("select * from bf1 left outer join bf2 join bf3 on " +
+        "bf1.c1 = bf2.c2 and bf3.c3 = bf2.c2 where bf2.a2 = 5", 2)
+      assertRewroteWithBloomFilter("select * from bf1 right outer join bf2 join bf3 on " +
+        "bf1.c1 = bf2.c2 and bf3.c3 = bf2.c2 where bf2.a2 = 5", 2)
+      assertRewroteWithBloomFilter("select * from bf1 join bf2 join bf3 on bf1.c1 = bf2.c2 " +
+        "and bf3.c3 = bf1.c1 where bf1.a1 = 5", 2)
+      assertRewroteWithBloomFilter("select * from bf1 left outer join bf2 join bf3 on " +
+        "bf1.c1 = bf2.c2 and bf3.c3 = bf1.c1 where bf1.a1 = 5", 2)
+      assertRewroteWithBloomFilter("select * from bf1 right outer join bf2 join bf3 on " +
+        "bf1.c1 = bf2.c2 and bf3.c3 = bf1.c1 where bf1.a1 = 5", 2)
+    }
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "3000",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1200") {
+      assertRewroteWithBloomFilter("select * from (select * from bf1 left semi join bf2 on " +
+        "(bf1.c1 = bf2.c2 and bf2.a2 = 5)) as a join bf3 on bf3.c3 = a.c1")
+      assertRewroteWithBloomFilter("select * from (select * from bf1 left anti join bf2 on " +
+        "(bf1.c1 = bf2.c2 and bf2.a2 = 5)) as a join bf3 on bf3.c3 = a.c1", 0)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark already supported the runtime filter. The runtime filter is a very good feature to reduce shuffle size.
This feature is implemented through the following steps:

1. Finds joins with equality conditions that can be evaluated using equi-join. e.g. ==.

2. Check some prerequisites for this join.

     2.1. If there is already a DPP filter on the key, refuse to inject runtime filter.
     2.2 If there is already a runtime filter (Bloom filter or IN subquery) on the key, refuse to inject runtime filter.
     2.3 If the keys of two side of join are not simple cheap expressions, refuse to inject runtime filter.

3. Check the benefit if inject runtime filter.

     3.1 The join expression of filter application side can be pushed down through joins, aggregates and windows. This decide to reduce shuffle size.
     3.2 The filter creation side has a selective predicate. The better selective, the better to reduce data size.
           **Note**: This PR will change the the behavior here, from **has one** selective predicate to **exists one** selective predicate. Before, we find the selective predicate from Filter node and check the expressions on Project are cheap. Now, not only do this and will find the selective predicate from Join node's child node on the same way.
     3.3 The current join is a shuffle join or a broadcast join that has a shuffle below it.
     3.4 The max scan size of filter application side is greater than a configurable threshold.

According to 3.3, Spark runtime filter supports two scenes.
1. When the Join itself is a Shuffle Join;
![image](https://user-images.githubusercontent.com/8486025/211998351-b616d2ca-cba6-4fd8-9768-8ff1d11ad8d6.png)

5. When the join itself is a broadcast join and there is a Shuffle Join under one end of the join.
![image](https://user-images.githubusercontent.com/8486025/211998413-e28f053f-ee15-4e8b-9281-1115f46e5892.png)

In user scene, the join relation is very complicated, such as, multi level join. To facilitate understanding, the below SQL is taken as an example.
```
SELECT *
FROM T1
    JOIN T2
    JOIN T3
    ON T1.c1 = T2.c2
        AND T3.c3 = T2.c2
WHERE T2.a2 = 5
```
Suppose T1 and T3 is big table or subquery and T2 is the smallest one. The current optimization only injects runtime filter(subquery on T2) in T1 since the SQL match the first scene.
![image](https://user-images.githubusercontent.com/8486025/212867612-238a70e9-39e9-43a2-beac-f6b994830e71.png)


In fact, we could also inject the runtime filter(subquery on T2) in T3 too.
![image](https://user-images.githubusercontent.com/8486025/212868009-f4278e2b-86c8-4b03-92b7-65cabde52370.png)

This PR will improve q24a, q24b, q37 and q82 in TPC-DS and q17 in TPC-H.


### Why are the changes needed?
1. Improve the supported scene for runtime filter 
2. Reduct the data size for shuffle and improve the performance.

### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
New tests.
Micro benchmark for q24a, q24b, q37 and q82 in TPC-DS.

**2TB TPC-DS**

TPC-DS Query   | Before(Seconds)  | After(Seconds)  | Speedup(Percent)
----  | ----  | ----  | ----
 q24a | 196.791 | 190.808 | 3.14%
 q24b | 178.022 | 178.953 | -0.52% 
 q37 | 36.815 | 12.114 | 203.90% 
 q82 | 63.822 | 19.543 | 226.57% 

Micro benchmark for q17 in TPC-H.
**TPC-H 100**
Query | Master(ms) | PR(ms) | Difference(ms) | Percent
-- | -- | -- | -- | --
q17 | 29462.66667 | 7450 | -22012.66667 | 295.47%
