### PR TITLE
[SPARK-41364][CONNECT][PYTHON][FOLLOWUP] Remove the unnecessary `DataFrameType`

### DIFF
--- a/python/pyspark/sql/connect/_typing.py
+++ b/python/pyspark/sql/connect/_typing.py
@@ -28,7 +28,6 @@ import decimal
 
 from pyspark.sql.connect.column import Column
 
-from pyspark.sql.connect.dataframe import DataFrame
 
 ColumnOrName = Union[Column, str]
 
@@ -41,8 +40,6 @@ LiteralType = PrimitiveType
 DecimalLiteral = decimal.Decimal
 
 DateTimeLiteral = Union[datetime.datetime, datetime.date]
-
-DataFrameType = DataFrame
 
 
 class FunctionBuilderCallable(Protocol):

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -32,7 +32,8 @@ from pyspark.sql.connect.column import (
 from typing import Any, TYPE_CHECKING, Union, List, overload, Optional, Tuple, Callable, ValuesView
 
 if TYPE_CHECKING:
-    from pyspark.sql.connect._typing import ColumnOrName, DataFrameType
+    from pyspark.sql.connect._typing import ColumnOrName
+    from pyspark.sql.connect.dataframe import DataFrame
 
 
 def _to_col(col: "ColumnOrName") -> Column:
@@ -221,7 +222,7 @@ def bitwise_not(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("~", col)
 
 
-def broadcast(df: "DataFrameType") -> "DataFrameType":
+def broadcast(df: "DataFrame") -> "DataFrame":
     """
     Marks a DataFrame as small enough for use in broadcast joins.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
remove the `DataFrameType`


### Why are the changes needed?
do not need it


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing ut