### PR TITLE
[SPARK-41645][CONNECT] Deduplicate docstrings in pyspark.sql.connect.dataframe

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -49,7 +49,11 @@ from pyspark.sql.connect.column import (
 )
 from pyspark.sql.connect.expressions import UnresolvedRegex
 from pyspark.sql.connect.functions import col, lit
-
+from pyspark.sql.dataframe import (
+    DataFrame as PySparkDataFrame,
+    DataFrameNaFunctions as PySparkDataFrameNaFunctions,
+    DataFrameStatFunctions as PySparkDataFrameStatFunctions,
+)
 
 if TYPE_CHECKING:
     from pyspark.sql.connect._typing import ColumnOrName, LiteralType, OptionalPrimitiveType
@@ -57,11 +61,6 @@ if TYPE_CHECKING:
 
 
 class DataFrame(object):
-    """Every DataFrame object essentially is a Relation that is refined using the
-    member functions. Calling a method on a dataframe will essentially return a copy
-    of the DataFrame with the changes applied.
-    """
-
     def __init__(
         self,
         session: "SparkSession",
@@ -81,40 +80,19 @@ class DataFrame(object):
         assert self._plan is not None
         return DataFrameWriter(self._plan, self._session)
 
-    @classmethod
-    def withPlan(cls, plan: plan.LogicalPlan, session: "SparkSession") -> "DataFrame":
-        """Main initialization method used to construct a new data frame with a child plan."""
-        new_frame = DataFrame(session=session)
-        new_frame._plan = plan
-        return new_frame
+    write.__doc__ = PySparkDataFrame.write.__doc__
 
     def isEmpty(self) -> bool:
-        """Returns ``True`` if this :class:`DataFrame` is empty.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        bool
-            Whether it's empty DataFrame or not.
-        """
         return len(self.take(1)) == 0
+
+    isEmpty.__doc__ = PySparkDataFrame.isEmpty.__doc__
 
     def select(self, *cols: "ColumnOrName") -> "DataFrame":
         return DataFrame.withPlan(plan.Project(self._plan, *cols), session=self._session)
 
+    select.__doc__ = PySparkDataFrame.select.__doc__
+
     def selectExpr(self, *expr: Union[str, List[str]]) -> "DataFrame":
-        """Projects a set of SQL expressions and returns a new :class:`DataFrame`.
-
-        This is a variant of :func:`select` that accepts SQL expressions.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        :class:`DataFrame`
-            A DataFrame with new/old columns transformed by expressions.
-        """
         sql_expr = []
         if len(expr) == 1 and isinstance(expr[0], list):
             expr = expr[0]  # type: ignore[assignment]
@@ -125,6 +103,8 @@ class DataFrame(object):
                 sql_expr.extend([sql_expression(e) for e in element])
 
         return DataFrame.withPlan(plan.Project(self._plan, *sql_expr), session=self._session)
+
+    selectExpr.__doc__ = PySparkDataFrame.selectExpr.__doc__
 
     def agg(self, *exprs: Union[Column, Dict[str, str]]) -> "DataFrame":
         if not exprs:
@@ -139,91 +119,46 @@ class DataFrame(object):
             exprs = cast(Tuple[Column, ...], exprs)
             return self.groupBy().agg(*exprs)
 
+    agg.__doc__ = PySparkDataFrame.agg.__doc__
+
     def alias(self, alias: str) -> "DataFrame":
         return DataFrame.withPlan(plan.SubqueryAlias(self._plan, alias), session=self._session)
 
-    def approxQuantile(self, col: Column, probabilities: Any, relativeError: Any) -> "DataFrame":
-        ...
+    alias.__doc__ = PySparkDataFrame.alias.__doc__
 
     def colRegex(self, colName: str) -> Column:
-        """
-        Selects column based on the column name specified as a regex and returns it
-        as :class:`Column`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        colName : str
-            string, column name specified as a regex.
-
-        Returns
-        -------
-        :class:`Column`
-        """
         return Column(UnresolvedRegex(colName))
+
+    colRegex.__doc__ = PySparkDataFrame.colRegex.__doc__
 
     @property
     def dtypes(self) -> List[Tuple[str, str]]:
-        """Returns all column names and their data types as a list.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        list
-            List of columns as tuple pairs.
-        """
         return [(str(f.name), f.dataType.simpleString()) for f in self.schema.fields]
+
+    dtypes.__doc__ = PySparkDataFrame.dtypes.__doc__
 
     @property
     def columns(self) -> List[str]:
-        """Returns the list of columns of the current data frame."""
         if self._plan is None:
             return []
 
         return self.schema.names
 
+    columns.__doc__ = PySparkDataFrame.columns.__doc__
+
+    @property
     def sparkSession(self) -> "SparkSession":
-        """Returns Spark session that created this :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        :class:`SparkSession`
-        """
         return self._session
 
+    sparkSession.__doc__ = PySparkDataFrame.sparkSession.__doc__
+
     def count(self) -> int:
-        """Returns the number of rows in this :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        int
-            Number of rows.
-        """
         pdd = self.agg(scalar_function("count", lit(1))).toPandas()
         return pdd.iloc[0, 0]
 
+    count.__doc__ = PySparkDataFrame.count.__doc__
+
     def crossJoin(self, other: "DataFrame") -> "DataFrame":
-        """
-        Returns the cartesian product with another :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        other : :class:`DataFrame`
-            Right side of the cartesian product.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Joined DataFrame.
-        """
         if self._plan is None:
             raise Exception("Cannot cartesian join when self._plan is empty.")
         if other._plan is None:
@@ -234,23 +169,9 @@ class DataFrame(object):
             session=self._session,
         )
 
+    crossJoin.__doc__ = PySparkDataFrame.crossJoin.__doc__
+
     def coalesce(self, numPartitions: int) -> "DataFrame":
-        """
-        Returns a new :class:`DataFrame` that has exactly `numPartitions` partitions.
-
-        Coalesce does not trigger a shuffle.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        numPartitions : int
-            specify the target number of partitions
-
-        Returns
-        -------
-        :class:`DataFrame`
-        """
         if not numPartitions > 0:
             raise ValueError("numPartitions must be positive.")
         return DataFrame.withPlan(
@@ -258,23 +179,9 @@ class DataFrame(object):
             self._session,
         )
 
+    coalesce.__doc__ = PySparkDataFrame.coalesce.__doc__
+
     def repartition(self, numPartitions: int) -> "DataFrame":
-        """
-        Returns a new :class:`DataFrame` that has exactly `numPartitions` partitions.
-
-        Repartition will shuffle source partition into partitions specified by numPartitions.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        numPartitions : int
-            specify the target number of partitions
-
-        Returns
-        -------
-        :class:`DataFrame`
-        """
         if not numPartitions > 0:
             raise ValueError("numPartitions must be positive.")
         return DataFrame.withPlan(
@@ -282,22 +189,9 @@ class DataFrame(object):
             self._session,
         )
 
+    repartition.__doc__ = PySparkDataFrame.repartition.__doc__
+
     def dropDuplicates(self, subset: Optional[List[str]] = None) -> "DataFrame":
-        """Return a new :class:`DataFrame` with duplicate rows removed,
-        optionally only deduplicating based on certain columns.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        subset : List of column names, optional
-            List of columns to use for duplicate comparison (default All columns).
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame without duplicated rows.
-        """
         if subset is None:
             return DataFrame.withPlan(
                 plan.Deduplicate(child=self._plan, all_columns_as_keys=True), session=self._session
@@ -307,38 +201,18 @@ class DataFrame(object):
                 plan.Deduplicate(child=self._plan, column_names=subset), session=self._session
             )
 
+    dropDuplicates.__doc__ = PySparkDataFrame.dropDuplicates.__doc__
+
     drop_duplicates = dropDuplicates
 
     def distinct(self) -> "DataFrame":
-        """Returns a new :class:`DataFrame` containing the distinct rows in this :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with distinct rows.
-        """
         return DataFrame.withPlan(
             plan.Deduplicate(child=self._plan, all_columns_as_keys=True), session=self._session
         )
 
+    distinct.__doc__ = PySparkDataFrame.distinct.__doc__
+
     def drop(self, *cols: "ColumnOrName") -> "DataFrame":
-        """Returns a new :class:`DataFrame` without specified columns.
-        This is a no-op if schema doesn't contain the given column name(s).
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        cols: str or :class:`Column`
-            a name of the column, or the :class:`Column` to drop
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame without given columns.
-        """
         _cols = list(cols)
         if any(not isinstance(c, (str, Column)) for c in _cols):
             raise TypeError(
@@ -355,44 +229,26 @@ class DataFrame(object):
             session=self._session,
         )
 
+    drop.__doc__ = PySparkDataFrame.drop.__doc__
+
     def filter(self, condition: Union[Column, str]) -> "DataFrame":
-        """Filters rows using the given condition.
-
-        :func:`where` is an alias for :func:`filter`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        condition : :class:`Column` or str
-            a :class:`Column` of :class:`types.BooleanType`
-            or a string of SQL expression.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Filtered DataFrame.
-        """
         if isinstance(condition, str):
             expr = sql_expression(condition)
         else:
             expr = condition
         return DataFrame.withPlan(plan.Filter(child=self._plan, filter=expr), session=self._session)
 
+    filter.__doc__ = PySparkDataFrame.filter.__doc__
+
     def first(self) -> Optional[Row]:
-        """Returns the first row as a :class:`Row`.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        :class:`Row`
-           First row if :class:`DataFrame` is not empty, otherwise ``None``.
-        """
         return self.head()
+
+    first.__doc__ = PySparkDataFrame.first.__doc__
 
     def groupBy(self, *cols: "ColumnOrName") -> GroupedData:
         return GroupedData(self, *cols)
+
+    groupBy.__doc__ = PySparkDataFrame.groupBy.__doc__
 
     @overload
     def head(self) -> Optional[Row]:
@@ -403,42 +259,17 @@ class DataFrame(object):
         ...
 
     def head(self, n: Optional[int] = None) -> Union[Optional[Row], List[Row]]:
-        """Returns the first ``n`` rows.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        n : int, optional
-            default 1. Number of rows to return.
-
-        Returns
-        -------
-        If n is greater than 1, return a list of :class:`Row`.
-        If n is 1, return a single Row.
-        """
         if n is None:
             rs = self.head(1)
             return rs[0] if rs else None
         return self.take(n)
 
+    head.__doc__ = PySparkDataFrame.head.__doc__
+
     def take(self, num: int) -> List[Row]:
-        """Returns the first ``num`` rows as a :class:`list` of :class:`Row`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        num : int
-            Number of records to return. Will return this number of records
-            or all records if the DataFrame contains less than this number of records..
-
-        Returns
-        -------
-        list
-            List of rows
-        """
         return self.limit(num).collect()
+
+    take.__doc__ = PySparkDataFrame.take.__doc__
 
     # TODO: extend `on` to also be type List[Column].
     def join(
@@ -457,79 +288,35 @@ class DataFrame(object):
             session=self._session,
         )
 
+    join.__doc__ = PySparkDataFrame.join.__doc__
+
     def limit(self, n: int) -> "DataFrame":
-        """Limits the result count to the number specified.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        num : int
-            Number of records to return. Will return this number of records
-            or all records if the DataFrame contains less than this number of records.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Subset of the records
-        """
         return DataFrame.withPlan(plan.Limit(child=self._plan, limit=n), session=self._session)
 
-    def offset(self, n: int) -> "DataFrame":
-        """Returns a new :class: `DataFrame` by skipping the first `n` rows.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        num : int
-            Number of records to return. Will return this number of records
-            or all records if the DataFrame contains less than this number of records.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Subset of the records
-        """
-        return DataFrame.withPlan(plan.Offset(child=self._plan, offset=n), session=self._session)
+    limit.__doc__ = PySparkDataFrame.limit.__doc__
 
     def tail(self, num: int) -> List[Row]:
-        """
-        Returns the last ``num`` rows as a :class:`list` of :class:`Row`.
-
-        Running tail requires moving data into the application's driver process, and doing so with
-        a very large ``num`` can crash the driver process with OutOfMemoryError.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        num : int
-            Number of records to return. Will return this number of records
-            or all records if the DataFrame contains less than this number of records.
-
-        Returns
-        -------
-        list
-            List of rows
-        """
         return DataFrame.withPlan(
             plan.Tail(child=self._plan, limit=num), session=self._session
         ).collect()
 
+    tail.__doc__ = PySparkDataFrame.tail.__doc__
+
     def sort(self, *cols: "ColumnOrName") -> "DataFrame":
-        """Sort by a specific column"""
         return DataFrame.withPlan(
             plan.Sort(self._plan, columns=list(cols), is_global=True), session=self._session
         )
 
+    sort.__doc__ = PySparkDataFrame.sort.__doc__
+
     orderBy = sort
 
     def sortWithinPartitions(self, *cols: "ColumnOrName") -> "DataFrame":
-        """Sort within each partition by a specific column"""
         return DataFrame.withPlan(
             plan.Sort(self._plan, columns=list(cols), is_global=False), session=self._session
         )
+
+    sortWithinPartitions.__doc__ = PySparkDataFrame.sortWithinPartitions.__doc__
 
     def sample(
         self,
@@ -538,31 +325,6 @@ class DataFrame(object):
         withReplacement: bool = False,
         seed: Optional[int] = None,
     ) -> "DataFrame":
-        """Returns a sampled subset of this :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        withReplacement : bool, optional
-            Sample with replacement or not (default ``False``).
-        fraction : float
-            Fraction of rows to generate, range [0.0, 1.0].
-        seed : int, optional
-            Seed for sampling (default a random seed).
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Sampled rows from given DataFrame.
-
-        Notes
-        -----
-        This is not guaranteed to provide exactly the fraction specified of the total
-        count of the given :class:`DataFrame`.
-
-        `fraction` is required and, `withReplacement` and `seed` are optional.
-        """
         if not isinstance(fraction, float):
             raise TypeError(f"'fraction' must be float, but got {type(fraction).__name__}")
         if not isinstance(withReplacement, bool):
@@ -583,53 +345,20 @@ class DataFrame(object):
             session=self._session,
         )
 
+    sample.__doc__ = PySparkDataFrame.sample.__doc__
+
     def withColumnRenamed(self, existing: str, new: str) -> "DataFrame":
-        """Returns a new :class:`DataFrame` by renaming an existing column.
-        This is a no-op if schema doesn't contain the given column name.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        existing : str
-            string, name of the existing column to rename.
-        new : str
-            string, new name of the column.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with renamed column.
-        """
         return self.withColumnsRenamed({existing: new})
 
+    withColumnRenamed.__doc__ = PySparkDataFrame.withColumnRenamed.__doc__
+
     def withColumnsRenamed(self, colsMap: Dict[str, str]) -> "DataFrame":
-        """
-        Returns a new :class:`DataFrame` by renaming multiple columns.
-        This is a no-op if schema doesn't contain the given column names.
-
-        .. versionadded:: 3.4.0
-           Added support for multiple columns renaming
-
-        Parameters
-        ----------
-        colsMap : dict
-            a dict of existing column names and corresponding desired column names.
-            Currently, only single map is supported.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with renamed columns.
-
-        See Also
-        --------
-        :meth:`withColumnRenamed`
-        """
         if not isinstance(colsMap, dict):
             raise TypeError("colsMap must be dict of existing column name and new column name.")
 
         return DataFrame.withPlan(plan.RenameColumnsNameByName(self._plan, colsMap), self._session)
+
+    withColumnsRenamed.__doc__ = PySparkDataFrame.withColumnsRenamed.__doc__
 
     def _show_string(
         self, n: int = 20, truncate: Union[bool, int] = True, vertical: bool = False
@@ -658,25 +387,6 @@ class DataFrame(object):
         return pdf["show_string"][0]
 
     def withColumns(self, colsMap: Dict[str, Column]) -> "DataFrame":
-        """
-        Returns a new :class:`DataFrame` by adding multiple columns or replacing the
-        existing columns that have the same names.
-
-        The colsMap is a map of column name and column, the column must only refer to attributes
-        supplied by this Dataset. It is an error to add columns that refer to some other Dataset.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        colsMap : dict
-            a dict of column name and :class:`Column`.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with new or replaced columns.
-        """
         if not isinstance(colsMap, dict):
             raise TypeError("colsMap must be dict of column name and column.")
 
@@ -685,34 +395,17 @@ class DataFrame(object):
             session=self._session,
         )
 
+    withColumns.__doc__ = PySparkDataFrame.withColumns.__doc__
+
     def withColumn(self, colName: str, col: Column) -> "DataFrame":
-        """
-        Returns a new :class:`DataFrame` by adding a column or replacing the
-        existing column that has the same name.
-
-        The column expression must be an expression over this :class:`DataFrame`; attempting to add
-        a column from some other :class:`DataFrame` will raise an error.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        colName : str
-            string, name of the new column.
-        col : :class:`Column`
-            a :class:`Column` expression for the new column.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with new or replaced column.
-        """
         if not isinstance(col, Column):
             raise TypeError("col should be Column")
         return DataFrame.withPlan(
             plan.WithColumns(self._plan, {colName: col}),
             session=self._session,
         )
+
+    withColumn.__doc__ = PySparkDataFrame.withColumn.__doc__
 
     def unpivot(
         self,
@@ -721,28 +414,6 @@ class DataFrame(object):
         variableColumnName: str,
         valueColumnName: str,
     ) -> "DataFrame":
-        """
-        Returns a new :class:`DataFrame` by unpivot a DataFrame from wide format to long format,
-        optionally leaving identifier columns set.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        ids : list
-            Id columns.
-        values : list, optional
-            Value columns to unpivot.
-        variableColumnName : str
-            Name of the variable column.
-        valueColumnName : str
-            Name of the value column.
-
-        Returns
-        -------
-        :class:`DataFrame`
-        """
-
         def to_jcols(
             cols: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]]
         ) -> List["ColumnOrName"]:
@@ -763,57 +434,23 @@ class DataFrame(object):
             self._session,
         )
 
+    unpivot.__doc__ = PySparkDataFrame.unpivot.__doc__
+
     melt = unpivot
 
     def hint(self, name: str, *params: Any) -> "DataFrame":
-        """
-        Specifies some hint on the current DataFrame. As an example, the following code specifies
-        that one of the plan can be broadcasted: `df1.join(df2.hint("broadcast"))`
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        name: str
-            the name of the hint, for example, "broadcast", "SHUFFLE_MERGE" and "shuffle_hash".
-        params: tuple
-            the parameters of the hint, theoretically a parameter can be any type, however, at
-            present, we only support int and str since only a limited number of hints are available,
-            for example, in `REPARTITION(3, c)` the "REPARTITION" is hint name and "3" is partition
-            number and "c" is partition expression.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with the hint
-        """
         return DataFrame.withPlan(
             plan.Hint(self._plan, name, list(params)),
             session=self._session,
         )
+
+    hint.__doc__ = PySparkDataFrame.hint.__doc__
 
     def randomSplit(
         self,
         weights: List[float],
         seed: Optional[int] = None,
     ) -> List["DataFrame"]:
-        """Randomly splits this :class:`DataFrame` with the provided weights.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        weights : list
-            list of doubles as weights with which to split the :class:`DataFrame`.
-            Weights will be normalized if they don't sum up to 1.0.
-        seed : int, optional
-            The seed for sampling.
-
-        Returns
-        -------
-        list
-            List of DataFrames.
-        """
         for w in weights:
             if w < 0.0:
                 raise ValueError("Weights must be positive. Found weight value: %s" % w)
@@ -847,110 +484,28 @@ class DataFrame(object):
 
         return splits
 
+    randomSplit.__doc__ = PySparkDataFrame.randomSplit.__doc__
+
     def show(self, n: int = 20, truncate: Union[bool, int] = True, vertical: bool = False) -> None:
-        """
-        Prints the first ``n`` rows to the console.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        n : int, optional
-            Number of rows to show.
-        truncate : bool or int, optional
-            If set to ``True``, truncate strings longer than 20 chars by default.
-            If set to a number greater than one, truncates long strings to length ``truncate``
-            and align cells right.
-        vertical : bool, optional
-            If set to ``True``, print output rows vertically (one line
-            per column value).
-        """
         print(self._show_string(n, truncate, vertical))
 
+    show.__doc__ = PySparkDataFrame.show.__doc__
+
     def union(self, other: "DataFrame") -> "DataFrame":
-        """Return a new :class:`DataFrame` containing union of rows in this and another
-        :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        other : :class:`DataFrame`
-            Another :class:`DataFrame` that needs to be unioned
-
-        Returns
-        -------
-        :class:`DataFrame`
-
-        See Also
-        --------
-        DataFrame.unionAll
-
-        Notes
-        -----
-        This is equivalent to `UNION ALL` in SQL. To do a SQL-style set union
-        (that does deduplication of elements), use this function followed by :func:`distinct`.
-
-        Also as standard in SQL, this function resolves columns by position (not by name).
-        """
         return self.unionAll(other)
 
+    union.__doc__ = PySparkDataFrame.union.__doc__
+
     def unionAll(self, other: "DataFrame") -> "DataFrame":
-        """Return a new :class:`DataFrame` containing union of rows in this and another
-        :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        other : :class:`DataFrame`
-            Another :class:`DataFrame` that needs to be combined
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Combined DataFrame
-
-        Notes
-        -----
-        This is equivalent to `UNION ALL` in SQL. To do a SQL-style set union
-        (that does deduplication of elements), use this function followed by :func:`distinct`.
-
-        Also as standard in SQL, this function resolves columns by position (not by name).
-
-        :func:`unionAll` is an alias to :func:`union`
-
-        See Also
-        --------
-        DataFrame.union
-        """
         if other._plan is None:
             raise ValueError("Argument to Union does not contain a valid plan.")
         return DataFrame.withPlan(
             plan.SetOperation(self._plan, other._plan, "union", is_all=True), session=self._session
         )
 
+    unionAll.__doc__ = PySparkDataFrame.unionAll.__doc__
+
     def unionByName(self, other: "DataFrame", allowMissingColumns: bool = False) -> "DataFrame":
-        """Returns a new :class:`DataFrame` containing union of rows in this and another
-        :class:`DataFrame`.
-
-        This is different from both `UNION ALL` and `UNION DISTINCT` in SQL. To do a SQL-style set
-        union (that does deduplication of elements), use this function followed by :func:`distinct`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        other : :class:`DataFrame`
-            Another :class:`DataFrame` that needs to be combined.
-        allowMissingColumns : bool, optional, default False
-           Specify whether to allow missing columns.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Combined DataFrame.
-        """
         if other._plan is None:
             raise ValueError("Argument to UnionByName does not contain a valid plan.")
         return DataFrame.withPlan(
@@ -960,147 +515,55 @@ class DataFrame(object):
             session=self._session,
         )
 
+    unionByName.__doc__ = PySparkDataFrame.unionByName.__doc__
+
     def subtract(self, other: "DataFrame") -> "DataFrame":
-        """Return a new :class:`DataFrame` containing rows in this :class:`DataFrame`
-        but not in another :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        other : :class:`DataFrame`
-            Another :class:`DataFrame` that needs to be subtracted.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Subtracted DataFrame.
-
-        Notes
-        -----
-        This is equivalent to `EXCEPT DISTINCT` in SQL.
-        """
         return DataFrame.withPlan(
             plan.SetOperation(self._plan, other._plan, "except", is_all=False),
             session=self._session,
         )
 
+    subtract.__doc__ = PySparkDataFrame.subtract.__doc__
+
     def exceptAll(self, other: "DataFrame") -> "DataFrame":
-        """Return a new :class:`DataFrame` containing rows in this :class:`DataFrame` but
-        not in another :class:`DataFrame` while preserving duplicates.
-
-        This is equivalent to `EXCEPT ALL` in SQL.
-        As standard in SQL, this function resolves columns by position (not by name).
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        other : :class:`DataFrame`
-            The other :class:`DataFrame` to compare to.
-
-        Returns
-        -------
-        :class:`DataFrame`
-        """
         return DataFrame.withPlan(
             plan.SetOperation(self._plan, other._plan, "except", is_all=True), session=self._session
         )
 
+    exceptAll.__doc__ = PySparkDataFrame.exceptAll.__doc__
+
     def intersect(self, other: "DataFrame") -> "DataFrame":
-        """Return a new :class:`DataFrame` containing rows only in
-        both this :class:`DataFrame` and another :class:`DataFrame`.
-        Note that any duplicates are removed. To preserve duplicates
-        use :func:`intersectAll`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        other : :class:`DataFrame`
-            Another :class:`DataFrame` that needs to be combined.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Combined DataFrame.
-
-        Notes
-        -----
-        This is equivalent to `INTERSECT` in SQL.
-        """
         return DataFrame.withPlan(
             plan.SetOperation(self._plan, other._plan, "intersect", is_all=False),
             session=self._session,
         )
 
+    intersect.__doc__ = PySparkDataFrame.intersect.__doc__
+
     def intersectAll(self, other: "DataFrame") -> "DataFrame":
-        """Return a new :class:`DataFrame` containing rows in both this :class:`DataFrame`
-        and another :class:`DataFrame` while preserving duplicates.
-
-        This is equivalent to `INTERSECT ALL` in SQL. As standard in SQL, this function
-        resolves columns by position (not by name).
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        other : :class:`DataFrame`
-            Another :class:`DataFrame` that needs to be combined.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Combined DataFrame.
-        """
         return DataFrame.withPlan(
             plan.SetOperation(self._plan, other._plan, "intersect", is_all=True),
             session=self._session,
         )
 
+    intersectAll.__doc__ = PySparkDataFrame.intersectAll.__doc__
+
     def where(self, condition: Union[Column, str]) -> "DataFrame":
         return self.filter(condition)
 
+    where.__doc__ = PySparkDataFrame.where.__doc__
+
     @property
     def na(self) -> "DataFrameNaFunctions":
-        """Returns a :class:`DataFrameNaFunctions` for handling missing values.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        :class:`DataFrameNaFunctions`
-        """
         return DataFrameNaFunctions(self)
+
+    na.__doc__ = PySparkDataFrame.na.__doc__
 
     def fillna(
         self,
         value: Union["LiteralType", Dict[str, "LiteralType"]],
         subset: Optional[Union[str, Tuple[str, ...], List[str]]] = None,
     ) -> "DataFrame":
-        """Replace null values, alias for ``na.fill()``.
-        :func:`DataFrame.fillna` and :func:`DataFrameNaFunctions.fill` are aliases of each other.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        value : int, float, string, bool or dict
-            Value to replace null values with.
-            If the value is a dict, then `subset` is ignored and `value` must be a mapping
-            from column name (string) to replacement value. The replacement value must be
-            an int, float, boolean, or string.
-        subset : str, tuple or list, optional
-            optional list of column names to consider.
-            Columns specified in subset that do not have matching data type are ignored.
-            For example, if `value` is a string, and cols contains a non-string column,
-            then the non-string column is simply ignored.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with replaced null values.
-        """
         if not isinstance(value, (float, int, str, bool, dict)):
             raise TypeError(
                 f"value should be a float, int, string, bool or dict, "
@@ -1149,35 +612,14 @@ class DataFrame(object):
             session=self._session,
         )
 
+    fillna.__doc__ = PySparkDataFrame.fillna.__doc__
+
     def dropna(
         self,
         how: str = "any",
         thresh: Optional[int] = None,
         subset: Optional[Union[str, Tuple[str, ...], List[str]]] = None,
     ) -> "DataFrame":
-        """Returns a new :class:`DataFrame` omitting rows with null values.
-        :func:`DataFrame.dropna` and :func:`DataFrameNaFunctions.drop` are aliases of each other.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        how : str, optional
-            'any' or 'all'.
-            If 'any', drop a row if it contains any nulls.
-            If 'all', drop a row only if all its values are null.
-        thresh: int, optional
-            default None
-            If specified, drop rows that have less than `thresh` non-null values.
-            This overwrites the `how` parameter.
-        subset : str, tuple or list, optional
-            optional list of column names to consider.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with null only rows excluded.
-        """
         min_non_nulls: Optional[int] = None
 
         if how is not None:
@@ -1220,6 +662,8 @@ class DataFrame(object):
             session=self._session,
         )
 
+    dropna.__doc__ = PySparkDataFrame.dropna.__doc__
+
     def replace(
         self,
         to_replace: Union[
@@ -1230,40 +674,6 @@ class DataFrame(object):
         ] = _NoValue,
         subset: Optional[List[str]] = None,
     ) -> "DataFrame":
-        """Returns a new :class:`DataFrame` replacing a value with another value.
-        :func:`DataFrame.replace` and :func:`DataFrameNaFunctions.replace` are
-        aliases of each other.
-        Values to_replace and value must have the same type and can only be numerics, booleans,
-        or strings. Value can have None. When replacing, the new value will be cast
-        to the type of the existing column.
-        For numeric replacements all values to be replaced should have unique
-        floating point representation. In case of conflicts (for example with `{42: -1, 42.0: 1}`)
-        and arbitrary replacement will be used.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        to_replace : bool, int, float, string, list or dict
-            Value to be replaced.
-            If the value is a dict, then `value` is ignored or can be omitted, and `to_replace`
-            must be a mapping between a value and a replacement.
-        value : bool, int, float, string or None, optional
-            The replacement value must be a bool, int, float, string or None. If `value` is a
-            list, `value` should be of the same length and type as `to_replace`.
-            If `value` is a scalar and `to_replace` is a sequence, then `value` is
-            used as a replacement for each item in `to_replace`.
-        subset : list, optional
-            optional list of column names to consider.
-            Columns specified in subset that do not have matching data type are ignored.
-            For example, if `value` is a string, and subset contains a non-string column,
-            then the non-string column is simply ignored.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with replaced values.
-        """
         if value is _NoValue:
             if isinstance(to_replace, dict):
                 value = None
@@ -1351,51 +761,15 @@ class DataFrame(object):
             session=self._session,
         )
 
+    replace.__doc__ = PySparkDataFrame.replace.__doc__
+
     @property
     def stat(self) -> "DataFrameStatFunctions":
-        """Returns a :class:`DataFrameStatFunctions` for statistic functions.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        :class:`DataFrameStatFunctions`
-        """
         return DataFrameStatFunctions(self)
 
+    stat.__doc__ = PySparkDataFrame.stat.__doc__
+
     def summary(self, *statistics: str) -> "DataFrame":
-        """Computes specified statistics for numeric and string columns.
-
-        .. versionadded:: 3.4.0
-
-        Available statistics are:
-        count
-        mean
-        stddev
-        min
-        max
-        arbitrary approximate percentiles specified as a percentage (e.g. 75%)
-        count_distinct
-        approx_count_distinct
-
-        Notes
-        -----
-        If no statistics are given, this function computes 'count', 'mean', 'stddev', 'min',
-        'approximate quartiles' (percentiles at 25%, 50%, and 75%), and 'max'.
-        This function is meant for exploratory data analysis, as we make no guarantee about the
-        backward compatibility of the schema of the resulting :class:`DataFrame`. If you want to
-        programmatically compute summary statistics, use the `agg` function instead.
-
-        Parameters
-        ----------
-        statistics : str, list, optional
-             Statistics from above list to be computed.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            A new DataFrame that computes specified statistics for given DataFrame.
-        """
         _statistics: List[str] = list(statistics)
         for s in _statistics:
             if not isinstance(s, str):
@@ -1405,31 +779,9 @@ class DataFrame(object):
             session=self._session,
         )
 
+    summary.__doc__ = PySparkDataFrame.summary.__doc__
+
     def describe(self, *cols: str) -> "DataFrame":
-        """Computes basic statistics for numeric and string columns.
-
-        .. versionadded:: 3.4.0
-
-        This include count, mean, stddev, min, and max. If no columns are
-        given, this function computes statistics for all numerical or string columns.
-
-        Notes
-        -----
-        This function is meant for exploratory data analysis, as we make no
-        guarantee about the backward compatibility of the schema of the resulting
-        :class:`DataFrame`.
-        Use summary for expanded statistics and control over which statistics to compute.
-
-        Parameters
-        ----------
-        cols : str, list, optional
-             Column name or list of column names to describe by (default All columns).
-
-        Returns
-        -------
-        :class:`DataFrame`
-            A new DataFrame that describes (provides statistics) given DataFrame.
-        """
         _cols: List[str] = list(cols)
         for s in _cols:
             if not isinstance(s, str):
@@ -1439,32 +791,9 @@ class DataFrame(object):
             session=self._session,
         )
 
+    describe.__doc__ = PySparkDataFrame.describe.__doc__
+
     def crosstab(self, col1: str, col2: str) -> "DataFrame":
-        """
-        Computes a pair-wise frequency table of the given columns. Also known as a contingency
-        table. The number of distinct values for each column should be less than 1e4. At most 1e6
-        non-zero pair frequencies will be returned.
-        The first column of each row will be the distinct values of `col1` and the column names
-        will be the distinct values of `col2`. The name of the first column will be `$col1_$col2`.
-        Pairs that have no occurrences will have zero as their counts.
-        :func:`DataFrame.crosstab` and :func:`DataFrameStatFunctions.crosstab` are aliases.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        col1 : str
-            The name of the first column. Distinct items will make the first item of
-            each row.
-        col2 : str
-            The name of the second column. Distinct items will make the column names
-            of the :class:`DataFrame`.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Frequency matrix of two columns.
-        """
         if not isinstance(col1, str):
             raise TypeError(f"'col1' must be str, but got {type(col1).__name__}")
         if not isinstance(col2, str):
@@ -1473,6 +802,8 @@ class DataFrame(object):
             plan.StatCrosstab(child=self._plan, col1=col1, col2=col2),
             session=self._session,
         )
+
+    crosstab.__doc__ = PySparkDataFrame.crosstab.__doc__
 
     def _get_alias(self) -> Optional[str]:
         p = self._plan
@@ -1505,6 +836,8 @@ class DataFrame(object):
         else:
             return []
 
+    collect.__doc__ = PySparkDataFrame.collect.__doc__
+
     def toPandas(self) -> "pandas.DataFrame":
         if self._plan is None:
             raise Exception("Cannot collect on empty plan.")
@@ -1513,16 +846,10 @@ class DataFrame(object):
         query = self._plan.to_proto(self._session.client)
         return self._session.client._to_pandas(query)
 
+    toPandas.__doc__ = PySparkDataFrame.toPandas.__doc__
+
     @property
     def schema(self) -> StructType:
-        """Returns the schema of this :class:`DataFrame` as a :class:`pyspark.sql.types.StructType`.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        :class:`StructType`
-        """
         if self._schema is None:
             if self._plan is not None:
                 query = self._plan.to_proto(self._session.client)
@@ -1535,46 +862,24 @@ class DataFrame(object):
         else:
             return self._schema
 
-    @property
+    schema.__doc__ = PySparkDataFrame.schema.__doc__
+
     def isLocal(self) -> bool:
-        """Returns ``True`` if the :func:`collect` and :func:`take` methods can be run locally
-        (without any Spark executors).
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        bool
-        """
         if self._plan is None:
             raise Exception("Cannot analyze on empty plan.")
         query = self._plan.to_proto(self._session.client)
         return self._session.client._analyze(query).is_local
 
+    isLocal.__doc__ = PySparkDataFrame.isLocal.__doc__
+
     @property
     def isStreaming(self) -> bool:
-        """Returns ``True`` if this :class:`DataFrame` contains one or more sources that
-        continuously return data as it arrives. A :class:`DataFrame` that reads data from a
-        streaming source must be executed as a :class:`StreamingQuery` using the :func:`start`
-        method in :class:`DataStreamWriter`.  Methods that return a single answer, (e.g.,
-        :func:`count` or :func:`collect`) will throw an :class:`AnalysisException` when there
-        is a streaming source present.
-
-        .. versionadded:: 3.4.0
-
-        Notes
-        -----
-        This API is evolving.
-
-        Returns
-        -------
-        bool
-            Whether it's streaming DataFrame or not.
-        """
         if self._plan is None:
             raise Exception("Cannot analyze on empty plan.")
         query = self._plan.to_proto(self._session.client)
         return self._session.client._analyze(query).is_streaming
+
+    isStreaming.__doc__ = PySparkDataFrame.isStreaming.__doc__
 
     def _tree_string(self) -> str:
         if self._plan is None:
@@ -1583,145 +888,40 @@ class DataFrame(object):
         return self._session.client._analyze(query).tree_string
 
     def printSchema(self) -> None:
-        """Prints out the schema in the tree format.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        None
-        """
         print(self._tree_string())
 
+    printSchema.__doc__ = PySparkDataFrame.printSchema.__doc__
+
     def inputFiles(self) -> List[str]:
-        """
-        Returns a best-effort snapshot of the files that compose this :class:`DataFrame`.
-        This method simply asks each constituent BaseRelation for its respective files and
-        takes the union of all results. Depending on the source relations, this may not find
-        all input files. Duplicates are removed.
-
-        .. versionadded:: 3.4.0
-
-        Returns
-        -------
-        list
-            List of file paths.
-        """
         if self._plan is None:
             raise Exception("Cannot analyze on empty plan.")
         query = self._plan.to_proto(self._session.client)
         return self._session.client._analyze(query).input_files
 
+    inputFiles.__doc__ = PySparkDataFrame.inputFiles.__doc__
+
     def to(self, schema: DataType) -> "DataFrame":
-        """
-        Returns a new :class:`DataFrame` where each row is reconciled to match the specified
-        schema.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        schema : :class:`StructType`
-            Specified schema.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Reconciled DataFrame.
-
-        Notes
-        -----
-        * Reorder columns and/or inner fields by name to match the specified schema.
-
-        * Project away columns and/or inner fields that are not needed by the specified schema.
-            Missing columns and/or inner fields (present in the specified schema but not input
-            DataFrame) lead to failures.
-
-        * Cast the columns and/or inner fields to match the data types in the specified schema,
-            if the types are compatible, e.g., numeric to numeric (error if overflows), but
-            not string to int.
-
-        * Carry over the metadata from the specified schema, while the columns and/or inner fields
-            still keep their own metadata if not overwritten by the specified schema.
-
-        * Fail if the nullability is not compatible. For example, the column and/or inner field
-            is nullable but the specified schema requires them to be not nullable.
-        """
         assert schema is not None
         return DataFrame.withPlan(
             plan.ToSchema(child=self._plan, schema=schema),
             session=self._session,
         )
 
+    to.__doc__ = PySparkDataFrame.to.__doc__
+
     def toDF(self, *cols: str) -> "DataFrame":
-        """Returns a new :class:`DataFrame` that with new specified column names
-
-        Parameters
-        ----------
-        *cols : tuple
-            a tuple of string new column name or :class:`Column`. The length of the
-            list needs to be the same as the number of columns in the initial
-            :class:`DataFrame`
-
-        Returns
-        -------
-        :class:`DataFrame`
-            DataFrame with new column names.
-        """
         return DataFrame.withPlan(plan.RenameColumns(self._plan, list(cols)), self._session)
 
+    toDF.__doc__ = PySparkDataFrame.toDF.__doc__
+
     def transform(self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any) -> "DataFrame":
-        """Returns a new :class:`DataFrame`. Concise syntax for chaining custom transformations.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        func : function
-            a function that takes and returns a :class:`DataFrame`.
-        *args
-            Positional arguments to pass to func.
-
-        **kwargs
-            Keyword arguments to pass to func.
-
-        Returns
-        -------
-        :class:`DataFrame`
-            Transformed DataFrame.
-
-        Examples
-        --------
-        >>> from pyspark.sql.connect.functions import col
-        >>> df = spark.createDataFrame([(1, 1.0), (2, 2.0)], ["int", "float"])
-        >>> def cast_all_to_int(input_df):
-        ...     return input_df.select([col(col_name).cast("int") for col_name in input_df.columns])
-        >>> def sort_columns_asc(input_df):
-        ...     return input_df.select(*sorted(input_df.columns))
-        >>> df.transform(cast_all_to_int).transform(sort_columns_asc).show()
-        +-----+---+
-        |float|int|
-        +-----+---+
-        |    1|  1|
-        |    2|  2|
-        +-----+---+
-
-        >>> def add_n(input_df, n):
-        ...     return input_df.select([(col(col_name) + n).alias(col_name)
-        ...                             for col_name in input_df.columns])
-        >>> df.transform(add_n, 1).transform(add_n, n=10).show()
-        +---+-----+
-        |int|float|
-        +---+-----+
-        | 12| 12.0|
-        | 13| 13.0|
-        +---+-----+
-        """
         result = func(self, *args, **kwargs)
         assert isinstance(
             result, DataFrame
         ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)
         return result
+
+    transform.__doc__ = PySparkDataFrame.transform.__doc__
 
     def _explain_string(
         self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None
@@ -1773,99 +973,41 @@ class DataFrame(object):
     def explain(
         self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None
     ) -> None:
-        """Retruns plans in string for debugging purpose.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        extended : bool, optional
-            default ``False``. If ``False``, returns only the physical plan.
-            When this is a string without specifying the ``mode``, it works as the mode is
-            specified.
-        mode : str, optional
-            specifies the expected output format of plans.
-
-            * ``simple``: Print only a physical plan.
-            * ``extended``: Print both logical and physical plans.
-            * ``codegen``: Print a physical plan and generated codes if they are available.
-            * ``cost``: Print a logical plan and statistics if they are available.
-            * ``formatted``: Split explain output into two sections: a physical plan outline \
-                and node details.
-        """
         print(self._explain_string(extended=extended, mode=mode))
 
+    explain.__doc__ = PySparkDataFrame.explain.__doc__
+
     def createTempView(self, name: str) -> None:
-        """Creates a local temporary view with this :class:`DataFrame`.
-
-        The lifetime of this temporary table is tied to the :class:`SparkSession`
-        that was used to create this :class:`DataFrame`.
-        throws :class:`TempTableAlreadyExistsException`, if the view name already exists in the
-        catalog.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        name : str
-            Name of the view.
-        """
         command = plan.CreateView(
             child=self._plan, name=name, is_global=False, replace=False
         ).command(session=self._session.client)
         self._session.client.execute_command(command)
 
+    createTempView.__doc__ = PySparkDataFrame.createTempView.__doc__
+
     def createOrReplaceTempView(self, name: str) -> None:
-        """Creates or replaces a local temporary view with this :class:`DataFrame`.
-
-        The lifetime of this temporary table is tied to the :class:`SparkSession`
-        that was used to create this :class:`DataFrame`.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        name : str
-            Name of the view.
-        """
         command = plan.CreateView(
             child=self._plan, name=name, is_global=False, replace=True
         ).command(session=self._session.client)
         self._session.client.execute_command(command)
 
+    createOrReplaceTempView.__doc__ = PySparkDataFrame.createOrReplaceTempView.__doc__
+
     def createGlobalTempView(self, name: str) -> None:
-        """Creates a global temporary view with this :class:`DataFrame`.
-
-        The lifetime of this temporary view is tied to this Spark application.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        name : str
-            Name of the view.
-        """
         command = plan.CreateView(
             child=self._plan, name=name, is_global=True, replace=False
         ).command(session=self._session.client)
         self._session.client.execute_command(command)
 
+    createGlobalTempView.__doc__ = PySparkDataFrame.createGlobalTempView.__doc__
+
     def createOrReplaceGlobalTempView(self, name: str) -> None:
-        """Creates or replaces a global temporary view using the given name.
-
-        The lifetime of this temporary view is tied to this Spark application.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        name : str
-            Name of the view.
-        """
         command = plan.CreateView(
             child=self._plan, name=name, is_global=True, replace=True
         ).command(session=self._session.client)
         self._session.client.execute_command(command)
+
+    createOrReplaceGlobalTempView.__doc__ = PySparkDataFrame.createOrReplaceGlobalTempView.__doc__
 
     def rdd(self, *args: Any, **kwargs: Any) -> None:
         raise NotImplementedError("RDD Support for Spark Connect is not implemented.")
@@ -1933,13 +1075,37 @@ class DataFrame(object):
     def sameSemantics(self, *args: Any, **kwargs: Any) -> None:
         raise NotImplementedError("sameSemantics() is not implemented.")
 
+    # SparkConnect specific API
+    def offset(self, n: int) -> "DataFrame":
+        """Returns a new :class: `DataFrame` by skipping the first `n` rows.
+
+        .. versionadded:: 3.4.0
+
+        Parameters
+        ----------
+        num : int
+            Number of records to return. Will return this number of records
+            or all records if the DataFrame contains less than this number of records.
+
+        Returns
+        -------
+        :class:`DataFrame`
+            Subset of the records
+        """
+        return DataFrame.withPlan(plan.Offset(child=self._plan, offset=n), session=self._session)
+
+    @classmethod
+    def withPlan(cls, plan: plan.LogicalPlan, session: "SparkSession") -> "DataFrame":
+        """
+        Main initialization method used to construct a new data frame with a child plan.
+        This is for internal purpose.
+        """
+        new_frame = DataFrame(session=session)
+        new_frame._plan = plan
+        return new_frame
+
 
 class DataFrameNaFunctions:
-    """Functionality for working with missing data in :class:`DataFrame`.
-
-    .. versionadded:: 3.4.0
-    """
-
     def __init__(self, df: DataFrame):
         self.df = df
 
@@ -1975,12 +1141,10 @@ class DataFrameNaFunctions:
     replace.__doc__ = DataFrame.replace.__doc__
 
 
+DataFrameNaFunctions.__doc__ = PySparkDataFrameNaFunctions.__doc__
+
+
 class DataFrameStatFunctions:
-    """Functionality for statistic functions with :class:`DataFrame`.
-
-    .. versionadded:: 3.4.0
-    """
-
     def __init__(self, df: DataFrame):
         self.df = df
 
@@ -1988,3 +1152,6 @@ class DataFrameStatFunctions:
         return self.df.crosstab(col1, col2)
 
     crosstab.__doc__ = DataFrame.crosstab.__doc__
+
+
+DataFrameStatFunctions.__doc__ = PySparkDataFrameStatFunctions.__doc__

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -81,6 +81,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
     .. versionadded:: 1.3.0
 
+    .. versionchanged:: 3.4.0
+        Support Spark Connect.
+
     Examples
     --------
     A :class:`DataFrame` is equivalent to a relational table in Spark SQL,
@@ -175,6 +178,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 3.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         :class:`SparkSession`
@@ -216,6 +222,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.1
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         :class:`DataFrameNaFunctions`
@@ -242,6 +251,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Returns a :class:`DataFrameStatFunctions` for statistic functions.
 
         .. versionadded:: 1.4.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Returns
         -------
@@ -323,6 +335,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.0.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         name : str
@@ -357,6 +372,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         that was used to create this :class:`DataFrame`.
 
         .. versionadded:: 2.0.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -396,6 +414,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.1.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         name : str
@@ -434,6 +455,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.2.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         name : str
@@ -470,6 +494,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         storage.
 
         .. versionadded:: 1.4.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Returns
         -------
@@ -526,6 +553,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         :class:`StructType`
@@ -555,6 +585,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         None
@@ -576,6 +609,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Prints the (logical and physical) plans to the console for debugging purposes.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -683,6 +719,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.4.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         other : :class:`DataFrame`
@@ -716,6 +755,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         bool
@@ -739,6 +781,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.0.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Notes
         -----
         This API is evolving.
@@ -761,6 +806,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 3.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         bool
@@ -781,6 +829,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Prints the first ``n`` rows to the console.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -1046,6 +1097,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.2.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         name : str
@@ -1099,6 +1153,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         int
@@ -1120,6 +1177,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Returns all the records as a list of :class:`Row`.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Returns
         -------
@@ -1172,6 +1232,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         num : int
@@ -1207,6 +1270,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         num : int
@@ -1238,6 +1304,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         a very large ``num`` can crash the driver process with OutOfMemoryError.
 
         .. versionadded:: 3.0.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -1462,6 +1531,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.4.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         numPartitions : int
@@ -1495,6 +1567,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         resulting :class:`DataFrame` is hash partitioned.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -1620,6 +1695,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         :class:`DataFrame`
@@ -1659,6 +1737,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Returns a sampled subset of this :class:`DataFrame`.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -1799,6 +1880,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.4.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         weights : list
@@ -1843,6 +1927,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         list
@@ -1862,6 +1949,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Returns all column names as a list.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Returns
         -------
@@ -1883,6 +1973,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         as :class:`Column`.
 
         .. versionadded:: 2.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -1916,6 +2009,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         schema.
 
         .. versionadded:: 3.4.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -1972,6 +2068,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         alias : str
@@ -2007,6 +2106,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Returns the cartesian product with another :class:`DataFrame`.
 
         .. versionadded:: 2.1.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -2050,6 +2152,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Joins with another :class:`DataFrame`, using the given join expression.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -2285,6 +2390,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.6.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         cols : str, list or :class:`Column`, optional
@@ -2317,6 +2425,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Returns a new :class:`DataFrame` sorted by the specified column(s).
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -2449,6 +2560,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.1
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         This includes count, mean, stddev, min, and max. If no columns are
         given, this function computes statistics for all numerical or string columns.
 
@@ -2521,6 +2635,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         statistics : str, optional
@@ -2590,6 +2707,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Notes
         -----
         This method should only be used if the resulting array is expected
@@ -2623,6 +2743,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Returns the first row as a :class:`Row`.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Returns
         -------
@@ -2751,6 +2874,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         cols : str, :class:`Column`, or list
@@ -2806,6 +2932,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Returns
         -------
         :class:`DataFrame`
@@ -2834,6 +2963,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         :func:`where` is an alias for :func:`filter`.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -2905,6 +3037,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         :func:`groupby` is an alias for :func:`groupBy`.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -3092,6 +3227,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 3.4.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         ids : str, Column, tuple, list
@@ -3205,6 +3343,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         (shorthand for ``df.groupBy().agg()``).
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -3351,6 +3492,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.0.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         other : :class:`DataFrame`
@@ -3398,6 +3542,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         other : :class:`DataFrame`
@@ -3431,6 +3578,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         union (that does deduplication of elements), use this function followed by :func:`distinct`.
 
         .. versionadded:: 2.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -3486,6 +3636,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         other : :class:`DataFrame`
@@ -3523,6 +3676,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.4.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         other : :class:`DataFrame`
@@ -3553,6 +3709,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         but not in another :class:`DataFrame`.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -3594,6 +3753,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         :func:`drop_duplicates` is an alias for :func:`dropDuplicates`.
 
         .. versionadded:: 1.4.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -3652,6 +3814,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         :func:`DataFrame.dropna` and :func:`DataFrameNaFunctions.drop` are aliases of each other.
 
         .. versionadded:: 1.3.1
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -3723,6 +3888,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         :func:`DataFrame.fillna` and :func:`DataFrameNaFunctions.fill` are aliases of each other.
 
         .. versionadded:: 1.3.1
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -3864,6 +4032,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         and arbitrary replacement will be used.
 
         .. versionadded:: 1.4.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -4225,6 +4396,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.4.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         col1 : str
@@ -4320,6 +4494,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. versionadded:: 3.3.0
            Added support for multiple columns adding
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         colsMap : dict
@@ -4366,6 +4543,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         colName : str
@@ -4406,6 +4586,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         existing : str
@@ -4438,6 +4621,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 3.4.0
            Added support for multiple columns renaming
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -4516,6 +4702,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.4.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         cols: str or :class:`Column`
@@ -4578,6 +4767,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     def toDF(self, *cols: str) -> "DataFrame":
         """Returns a new :class:`DataFrame` that with new specified column names
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         *cols : tuple
@@ -4610,6 +4802,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """Returns a new :class:`DataFrame`. Concise syntax for chaining custom transformations.
 
         .. versionadded:: 3.0.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -4740,6 +4935,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         all input files. Duplicates are removed.
 
         .. versionadded:: 3.1.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Returns
         -------
@@ -4897,7 +5095,10 @@ def _to_scala_map(sc: SparkContext, jm: Dict) -> JavaObject:
 class DataFrameNaFunctions:
     """Functionality for working with missing data in :class:`DataFrame`.
 
-    .. versionadded:: 1.4
+    .. versionadded:: 1.4.0
+
+    .. versionchanged:: 3.4.0
+        Support Spark Connect.
     """
 
     def __init__(self, df: DataFrame):
@@ -4972,7 +5173,10 @@ class DataFrameNaFunctions:
 class DataFrameStatFunctions:
     """Functionality for statistic functions with :class:`DataFrame`.
 
-    .. versionadded:: 1.4
+    .. versionadded:: 1.4.0
+
+    .. versionchanged:: 3.4.0
+        Support Spark Connect.
     """
 
     def __init__(self, df: DataFrame):

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -63,6 +63,9 @@ class PandasConversionMixin:
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Notes
         -----
         This method should only be used if the resulting Pandas ``pandas.DataFrame`` is

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -467,8 +467,8 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
     def test_is_local(self):
         # SPARK-41216: Test is local
-        self.assertTrue(self.connect.sql("SHOW DATABASES").isLocal)
-        self.assertFalse(self.connect.read.table(self.tbl_name).isLocal)
+        self.assertTrue(self.connect.sql("SHOW DATABASES").isLocal())
+        self.assertFalse(self.connect.read.table(self.tbl_name).isLocal())
 
     def test_is_streaming(self):
         # SPARK-41216: Test is streaming
@@ -957,7 +957,7 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertTrue(self.connect.sql("SELECT 1 AS X LIMIT 0").isEmpty())
 
     def test_session(self):
-        self.assertEqual(self.connect, self.connect.sql("SELECT 1").sparkSession())
+        self.assertEqual(self.connect, self.connect.sql("SELECT 1").sparkSession)
 
     def test_show(self):
         # SPARK-41111: Test the show method


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to deduplicate docstrings in `pyspark.sql.connect.dataframe`.

### Why are the changes needed?

For easier maintenance

### Does this PR introduce _any_ user-facing change?

No, dev-only. There're mintor doc changes that mention about remote support in Apache Spark 3.4.

### How was this patch tested?

No test. It has to be manually verified until we resolve SPARK-41653.
