### PR TITLE
[SPARK-41687][CONNECT] Deduplicate docstrings in pyspark.sql.connect.group

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -31,6 +31,7 @@ from pyspark.sql.connect.column import (
     scalar_function,
 )
 from pyspark.sql.connect.functions import col, lit
+from pyspark.sql.group import GroupedData as PySparkGroupedData
 
 if TYPE_CHECKING:
     from pyspark.sql.connect.dataframe import DataFrame
@@ -50,75 +51,6 @@ class GroupedData(object):
         ...
 
     def agg(self, *exprs: Union[Column, Dict[str, str]]) -> "DataFrame":
-        """Compute aggregates and returns the result as a :class:`DataFrame`.
-
-        The available aggregate functions can be:
-
-        1. built-in aggregation functions, such as `avg`, `max`, `min`, `sum`, `count`
-
-        2. group aggregate pandas UDFs, created with :func:`pyspark.sql.functions.pandas_udf`
-
-           .. note:: There is no partial aggregation with group aggregate UDFs, i.e.,
-               a full shuffle is required. Also, all the data of a group will be loaded into
-               memory, so the user should be aware of the potential OOM risk if data is skewed
-               and certain groups are too large to fit in memory.
-
-           .. seealso:: :func:`pyspark.sql.functions.pandas_udf`
-
-        If ``exprs`` is a single :class:`dict` mapping from string to string, then the key
-        is the column to perform aggregation on, and the value is the aggregate function.
-
-        Alternatively, ``exprs`` can also be a list of aggregate :class:`Column` expressions.
-
-        .. versionadded:: 3.4.0
-
-        Parameters
-        ----------
-        exprs : dict
-            a dict mapping from column name (string) to aggregate functions (string),
-            or a list of :class:`Column`.
-
-        Notes
-        -----
-        Built-in aggregation functions and group aggregate pandas UDFs cannot be mixed
-        in a single call to this function.
-
-        Examples
-        --------
-        >>> from pyspark.sql import functions as F
-        >>> from pyspark.sql.functions import pandas_udf, PandasUDFType
-        >>> df = spark.createDataFrame(
-        ...      [(2, "Alice"), (3, "Alice"), (5, "Bob"), (10, "Bob")], ["age", "name"])
-        >>> df.show()
-        +---+-----+
-        |age| name|
-        +---+-----+
-        |  2|Alice|
-        |  3|Alice|
-        |  5|  Bob|
-        | 10|  Bob|
-        +---+-----+
-
-        Group-by name, and count each group.
-
-        >>> df.groupBy(df.name).agg({"*": "count"}).sort("name").show()
-        +-----+--------+
-        | name|count(1)|
-        +-----+--------+
-        |Alice|       2|
-        |  Bob|       2|
-        +-----+--------+
-
-        Group-by name, and calculate the minimum age.
-
-        >>> df.groupBy(df.name).agg(F.min(df.age)).sort("name").show()
-        +-----+--------+
-        | name|min(age)|
-        +-----+--------+
-        |Alice|       2|
-        |  Bob|       5|
-        +-----+--------+
-        """
         from pyspark.sql.connect.dataframe import DataFrame
 
         assert exprs, "exprs should not be empty"
@@ -140,6 +72,8 @@ class GroupedData(object):
         )
         return res
 
+    agg.__doc__ = PySparkGroupedData.agg.__doc__
+
     def _map_cols_to_expression(self, fun: str, param: Union[Column, str]) -> Sequence[Column]:
         return [
             scalar_function(fun, col(param)) if isinstance(param, str) else param,
@@ -149,17 +83,30 @@ class GroupedData(object):
         expr = self._map_cols_to_expression("min", col)
         return self.agg(*expr)
 
+    min.__doc__ = PySparkGroupedData.min.__doc__
+
     def max(self, col: Union[Column, str]) -> "DataFrame":
         expr = self._map_cols_to_expression("max", col)
         return self.agg(*expr)
+
+    max.__doc__ = PySparkGroupedData.max.__doc__
 
     def sum(self, col: Union[Column, str]) -> "DataFrame":
         expr = self._map_cols_to_expression("sum", col)
         return self.agg(*expr)
 
+    sum.__doc__ = PySparkGroupedData.sum.__doc__
+
     def avg(self, col: Union[Column, str]) -> "DataFrame":
         expr = self._map_cols_to_expression("avg", col)
         return self.agg(*expr)
 
+    avg.__doc__ = PySparkGroupedData.avg.__doc__
+
     def count(self) -> "DataFrame":
         return self.agg(scalar_function("count", lit(1)))
+
+    count.__doc__ = PySparkGroupedData.count.__doc__
+
+
+GroupedData.__doc__ = PySparkGroupedData.__doc__

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -59,7 +59,10 @@ class GroupedData(PandasGroupedOpsMixin):
     A set of methods for aggregations on a :class:`DataFrame`,
     created by :func:`DataFrame.groupBy`.
 
-    .. versionadded:: 1.3
+    .. versionadded:: 1.3.0
+
+    .. versionchanged:: 3.4.0
+        Support Spark Connect.
     """
 
     def __init__(self, jgd: JavaObject, df: DataFrame):
@@ -97,6 +100,9 @@ class GroupedData(PandasGroupedOpsMixin):
         Alternatively, ``exprs`` can also be a list of aggregate :class:`Column` expressions.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -175,6 +181,9 @@ class GroupedData(PandasGroupedOpsMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Examples
         --------
         >>> df = spark.createDataFrame(
@@ -208,6 +217,9 @@ class GroupedData(PandasGroupedOpsMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         cols : str
@@ -221,6 +233,9 @@ class GroupedData(PandasGroupedOpsMixin):
         :func:`mean` is an alias for :func:`avg`.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -268,6 +283,9 @@ class GroupedData(PandasGroupedOpsMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Examples
         --------
         >>> df = spark.createDataFrame([
@@ -308,6 +326,9 @@ class GroupedData(PandasGroupedOpsMixin):
         """Computes the min value for each numeric column for each group.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------
@@ -354,6 +375,9 @@ class GroupedData(PandasGroupedOpsMixin):
         """Computes the sum for each numeric columns for each group.
 
         .. versionadded:: 1.3.0
+
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
 
         Parameters
         ----------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to deduplicate docstrings in `pyspark.sql.connect.group`.

### Why are the changes needed?

For easier maintenance

### Does this PR introduce _any_ user-facing change?

No, dev-only. There're mintor doc changes that mention about remote support in Apache Spark 3.4.

### How was this patch tested?

No test. It has to be manually verified until we resolve SPARK-41653.
