### PR TITLE
[SPARK-41635][SQL] GROUP BY ALL - ansi mode test case

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/group-by-all.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/group-by-all.sql
@@ -80,3 +80,8 @@ select (select count(*) from data d1 where d1.country = d2.country), count(id) f
 -- make sure we report the right error when there's an attribute in correlated subquery
 -- that is, to report UNRESOLVED_ALL_IN_GROUP_BY, rather than some random subquery error.
 select coutnry, (select count(*) from data d1 where d1.country = d2.country), count(id) from data d2 group by all;
+
+-- make sure this still works in ansi mode; this is important because all is a reserved keyword
+-- in ansi, so we should make sure the analyzer rule still works.
+set spark.sql.ansi.enabled = true;
+select country, count(*) from data group by ALL;

--- a/sql/core/src/test/resources/sql-tests/results/group-by-all.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-all.sql.out
@@ -264,3 +264,22 @@ org.apache.spark.sql.AnalysisException
     "fragment" : "group by all"
   } ]
 }
+
+
+-- !query
+set spark.sql.ansi.enabled = true
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.ansi.enabled	true
+
+
+-- !query
+select country, count(*) from data group by ALL
+-- !query schema
+struct<country:string,count(1):bigint>
+-- !query output
+China	2
+Korea	1
+UK	1
+USA	3


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch adds a new test case with ANSI mode on for group by all.

### Why are the changes needed?
All is a reserved keyword when ANSI mode is on. It's important to have an explicit test case validating it because in the future we might parse reserved keyword tokens differently, leading to the analysis rule not capturing the group by all.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
This patch is only about adding a test case.
