### PR TITLE
[SPARK-41683][CORE] Fix issue of getting incorrect property numActiveStages in jobs API

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -507,7 +507,6 @@ private[spark] class AppStatusListener(
             stage.status = v1.StageStatus.SKIPPED
             job.skippedStages += stage.info.stageId
             job.skippedTasks += stage.info.numTasks
-            job.activeStages -= 1
 
             pools.get(stage.schedulingPool).foreach { pool =>
               pool.stageIds = pool.stageIds - stage.info.stageId

--- a/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
@@ -1910,7 +1910,7 @@ abstract class AppStatusListenerSuite extends SparkFunSuite with BeforeAndAfter 
 
     assert(listener.deadExecutors.size === 0)
   }
-  
+
   test("SPARK-41683: Should correctly calculate numActiveStages if some stages are not submitted") {
     val stage1 = new StageInfo( 0, 0, "stage1", 0, Seq.empty, Seq.empty, "", resourceProfileId = 0)
     val stage2 = new StageInfo( 1, 0, "stage2", 0, Seq.empty, Seq.empty, "", resourceProfileId = 0)
@@ -1929,7 +1929,6 @@ abstract class AppStatusListenerSuite extends SparkFunSuite with BeforeAndAfter 
     val job = jobs.head
     assert(job.numActiveStages == 0)
   }
-
 
   private def key(stage: StageInfo): Array[Int] = Array(stage.stageId, stage.attemptNumber)
 

--- a/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
@@ -1910,6 +1910,26 @@ abstract class AppStatusListenerSuite extends SparkFunSuite with BeforeAndAfter 
 
     assert(listener.deadExecutors.size === 0)
   }
+  
+  test("SPARK-41683: Should correctly calculate numActiveStages if some stages are not submitted") {
+    val stage1 = new StageInfo( 0, 0, "stage1", 0, Seq.empty, Seq.empty, "", resourceProfileId = 0)
+    val stage2 = new StageInfo( 1, 0, "stage2", 0, Seq.empty, Seq.empty, "", resourceProfileId = 0)
+    val stage3 = new StageInfo( 2, 0, "stage3", 0, Seq.empty, Seq.empty, "", resourceProfileId = 0)
+
+    val listener = new AppStatusListener(store, conf, true)
+    listener.onApplicationStart(SparkListenerApplicationStart("app", Some("app"), 0L, "none", None))
+    listener.onJobStart(SparkListenerJobStart(0, 0L, Seq(stage1, stage2, stage3)))
+    listener.onStageSubmitted(SparkListenerStageSubmitted(stage1))
+    listener.onStageCompleted(SparkListenerStageCompleted(stage1))
+    listener.onJobEnd(SparkListenerJobEnd(0, 10000L, JobSucceeded))
+    listener.onApplicationEnd(SparkListenerApplicationEnd(1L))
+
+    val jobs = KVUtils.mapToSeq(store.view(classOf[JobDataWrapper]))(_.info)
+    assert(jobs.length == 1)
+    val job = jobs.head
+    assert(job.numActiveStages == 0)
+  }
+
 
   private def key(stage: StageInfo): Array[Int] = Array(stage.stageId, stage.attemptNumber)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Update `onJobEnd` method of `AppStatusListener`, removing the logic of reducing `job.activeStages` for each pending stage.
- Add UT to verify whether `numActiveStages` of jobs data is correct.

### Why are the changes needed?

For property `activeStages` of `LiveJob`, it is updated when:
- A job is started: `activeStages = 0`
- A stage is submitted: `activeStages += 1`
- A stage is completed: `activeStages -= 1`
- A job is ended: `activeStages -= 1` for each pending stages

According to the implementation of `AppStatusListener` and `LiveStage`:
- When a job is created, all of its stages in job info will be created with state set to pending without updating `activeStages`.
- When a stage is submitted, its state will be immediately set to active with `activeStages` increased by `1`.

So for pending stages, they won't affect `activeStages`. Therefore, when job is ended, `activeStages` shouldn't be decreased by `1` for each pending stage.

Here's an example:
- Job 0 starts with stage 0, 1, 2
- Stage 0 submitted
- Stage 0 completed
- Job 0 ends

In this case, when job 0 ends, its `numActiveStages` will be `-2`, which is obviously incorrect.

### Does this PR introduce _any_ user-facing change?

For jobs API, property `activeStages` will be different if a job has pending stages when it ends. In these cases, previously the number is incorrect. This PR fixes it.

### How was this patch tested?

This PR adds a UT of the example mentioned above, to make sure `numActiveStages` should be `0` instead of `-2`.