### PR TITLE
[SPARK-41697][CONNECT][TESTS] Enable test_df_show, test_drop, test_dropna, test_toDF_with_schema_string and test_with_columns_renamed

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -72,20 +72,8 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
         super().test_create_nan_decimal_dataframe()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_df_show(self):
-        super().test_df_show()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_drop(self):
-        super().test_drop()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_drop_duplicates(self):
         super().test_drop_duplicates()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_dropna(self):
-        super().test_dropna()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_duplicated_column_names(self):
@@ -98,10 +86,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_fillna(self):
         super().test_fillna()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_freqItems(self):
-        super().test_freqItems()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_generic_hints(self):
@@ -164,10 +148,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
         super().test_to()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_toDF_with_schema_string(self):
-        super().test_toDF_with_schema_string()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_local_iterator(self):
         super().test_to_local_iterator()
 
@@ -218,10 +198,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_unpivot(self):
         super().test_unpivot()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_with_columns_renamed(self):
-        super().test_with_columns_renamed()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables the reused PySpark tests in Spark Connect that pass now.

### Why are the changes needed?

To make sure on the test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran it in my local.