### PR TITLE
[SPARK-41698][CONNECT][TESTS] Enable 16 tests in pyspark.sql.tests.connect.test_parity_functions

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -51,10 +51,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
         super().test_add_months_function()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_array_contains_function(self):
-        super().test_array_contains_function()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_array_repeat(self):
         super().test_array_repeat()
 
@@ -69,14 +65,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_between_function(self):
         super().test_between_function()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_bit_length_function(self):
-        super().test_bit_length_function()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_collect_functions(self):
-        super().test_collect_functions()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_date_add_function(self):
@@ -115,10 +103,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
         super().test_functions_broadcast()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_higher_order_function_failures(self):
-        super().test_higher_order_function_failures()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_inline(self):
         super().test_inline()
 
@@ -135,20 +119,12 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
         super().test_inverse_trig_functions()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_least(self):
-        super().test_least()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_lit_list(self):
         super().test_lit_list()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_lit_np_scalar(self):
         super().test_lit_np_scalar()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_make_date(self):
-        super().test_make_date()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_map_functions(self):
@@ -175,10 +151,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
         super().test_nth_value()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_octet_length_function(self):
-        super().test_octet_length_function()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_overlay(self):
         super().test_overlay()
 
@@ -191,40 +163,12 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
         super().test_raise_error()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_regexp_replace(self):
-        super().test_regexp_replace()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_shiftleft(self):
-        super().test_shiftleft()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_shiftright(self):
-        super().test_shiftright()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_shiftrightunsigned(self):
-        super().test_shiftrightunsigned()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_slice(self):
         super().test_slice()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_sort_with_nulls_order(self):
-        super().test_sort_with_nulls_order()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_sorting_functions_with_column(self):
         super().test_sorting_functions_with_column()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_string_functions(self):
-        super().test_string_functions()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_sum_distinct(self):
-        super().test_sum_distinct()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_window_functions(self):
@@ -243,10 +187,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
         super().test_window_time()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_binary_math_function(self):
-        super().test_binary_math_function()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_corr(self):
         super().test_corr()
 
@@ -257,10 +197,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_crosstab(self):
         super().test_crosstab()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_lit_day_time_interval(self):
-        super().test_lit_day_time_interval()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_rand_functions(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables the reused PySpark tests in Spark Connect that pass now.

### Why are the changes needed?

To make sure on the test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran it in my local.