### PR TITLE
[MINOR][SQL] Remove redundant comment in CTESubstitution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
@@ -157,14 +157,6 @@ object CTESubstitution extends Rule[LogicalPlan] {
    *       SELECT * FROM t
    *     )
    *   SELECT * FROM t2
-   * - If a CTE definition contains a subquery that contains an inner WITH node then substitution
-   *   of inner should take precedence because it can shadow an outer CTE definition.
-   *   For example the following query should return 2:
-   *   WITH t AS (SELECT 1 AS c)
-   *   SELECT max(c) FROM (
-   *     WITH t AS (SELECT 2 AS c)
-   *     SELECT * FROM t
-   *   )
    * - If a CTE definition contains a subquery expression that contains an inner WITH node then
    *   substitution of inner should take precedence because it can shadow an outer CTE
    *   definition.


### PR DESCRIPTION
### What changes were proposed in this pull request?
I think the proposed removal is just a duplicate of the next point. I actually spent couple minutes trying to understand if there was a difference.

### Why are the changes needed?
See above.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
This is a code comment change.
