### PR TITLE
[CORE][MINOR] Correct spelling for RPC in log

### DIFF
--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -170,7 +170,7 @@ parallelize <- function(sc, coll, numSlices = 1) {
   serializedSlices <- lapply(slices, serialize, connection = NULL)
 
   # The RPC backend cannot handle arguments larger than 2GB (INT_MAX)
-  # If serialized data is safely less than that threshold we send it over the PRC channel.
+  # If serialized data is safely less than that threshold we send it over the RPC channel.
   # Otherwise, we write it to a file and send the file name
   if (objectSize < sizeLimit) {
     jrdd <- callJStatic("org.apache.spark.api.r.RRDD", "createRDDFromArray", sc, serializedSlices)

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClient.java
@@ -274,7 +274,7 @@ public class TransportClient implements Closeable {
           copy.flip();
           result.set(copy);
         } catch (Throwable t) {
-          logger.warn("Error in responding PRC callback", t);
+          logger.warn("Error in responding RPC callback", t);
           result.setException(t);
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR corrects spelling mistake for `RPC` in log for `sendRpc`.
Similar error in context.R is also fixed.

### Why are the changes needed?
The spelling mistake confuses users.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing test suite