### PR TITLE
[SPARK-41685][UI] Support Protobuf serializer for the KVStore in History server

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -79,6 +79,21 @@ private[spark] object History {
     .stringConf
     .createOptional
 
+  object LocalStoreSerializer extends Enumeration {
+    val JSON, PROTOBUF = Value
+  }
+
+  val LOCAL_STORE_SERIALIZER = ConfigBuilder("spark.history.store.serializer")
+    .doc("Serializer for writing/reading in-memory UI objects to/from disk-based KV Store; " +
+      "JSON or PROTOBUF. JSON serializer is the only choice before Spark 3.4.0, thus it is the " +
+      "default value. PROTOBUF serializer is fast and compact, and it is the default " +
+      "serializer for disk-based KV store of live UI.")
+    .version("3.4.0")
+    .stringConf
+    .transform(_.toUpperCase(Locale.ROOT))
+    .checkValues(LocalStoreSerializer.values.map(_.toString))
+    .createWithDefault(LocalStoreSerializer.JSON.toString)
+
   val MAX_LOCAL_DISK_USAGE = ConfigBuilder("spark.history.store.maxDiskUsage")
     .version("2.3.0")
     .bytesConf(ByteUnit.BYTE)

--- a/core/src/main/scala/org/apache/spark/status/KVUtils.scala
+++ b/core/src/main/scala/org/apache/spark/status/KVUtils.scala
@@ -112,7 +112,7 @@ private[spark] object KVUtils extends Logging {
   def serializerForHistoryServer(conf: SparkConf): KVStoreScalaSerializer = {
     History.LocalStoreSerializer.withName(conf.get(History.LOCAL_STORE_SERIALIZER)) match {
       case History.LocalStoreSerializer.JSON =>
-        new KVStoreScalaSerializer
+        new KVStoreScalaSerializer()
       case History.LocalStoreSerializer.PROTOBUF =>
         new KVStoreProtobufSerializer()
       case other =>

--- a/core/src/main/scala/org/apache/spark/status/KVUtils.scala
+++ b/core/src/main/scala/org/apache/spark/status/KVUtils.scala
@@ -45,8 +45,26 @@ private[spark] object KVUtils extends Logging {
   /** Use this to annotate constructor params to be used as KVStore indices. */
   type KVIndexParam = KVIndex @getter
 
-  private def backend(conf: SparkConf) =
-    HybridStoreDiskBackend.withName(conf.get(HYBRID_STORE_DISK_BACKEND))
+  private def backend(conf: SparkConf, live: Boolean) = {
+    if (live) {
+      // For the disk-based KV store of live UI, let's simply make it ROCKSDB only for now,
+      // instead of supporting both LevelDB and RocksDB. RocksDB is built based on LevelDB with
+      // improvements on writes and reads.
+      HybridStoreDiskBackend.ROCKSDB
+    } else {
+      HybridStoreDiskBackend.withName(conf.get(HYBRID_STORE_DISK_BACKEND))
+    }
+  }
+
+  private def serializer(conf: SparkConf, live: Boolean) = {
+    if (live) {
+      // For the disk-based KV store of live UI, let's simply use protobuf serializer only.
+      // The default serializer is slow since it is using JSON+GZip encoding.
+      new KVStoreProtobufSerializer()
+    } else {
+      serializerForHistoryServer(conf)
+    }
+  }
 
   /**
    * A KVStoreSerializer that provides Scala types serialization too, and uses the same options as
@@ -72,12 +90,11 @@ private[spark] object KVUtils extends Logging {
       path: File,
       metadata: M,
       conf: SparkConf,
-      diskBackend: Option[HybridStoreDiskBackend.Value] = None,
-      serializer: Option[KVStoreSerializer] = None): KVStore = {
+      live: Boolean): KVStore = {
     require(metadata != null, "Metadata is required.")
 
-    val kvSerializer = serializer.getOrElse(new KVStoreScalaSerializer())
-    val db = diskBackend.getOrElse(backend(conf)) match {
+    val kvSerializer = serializer(conf, live)
+    val db = backend(conf, live) match {
       case LEVELDB => new LevelDB(path, kvSerializer)
       case ROCKSDB => new RocksDB(path, kvSerializer)
     }
@@ -108,22 +125,7 @@ private[spark] object KVUtils extends Logging {
       live: Boolean,
       conf: SparkConf): KVStore = {
     storePath.map { path =>
-      val diskBackend = if (live) {
-        // For the disk-based KV store of live UI, let's simply make it ROCKSDB only for now,
-        // instead of supporting both LevelDB and RocksDB. RocksDB is built based on LevelDB with
-        // improvements on writes and reads.
-        HybridStoreDiskBackend.ROCKSDB
-      } else {
-        HybridStoreDiskBackend.withName(conf.get(History.HYBRID_STORE_DISK_BACKEND))
-      }
-
-      val serializer = if (live) {
-        // For the disk-based KV store of live UI, let's simply use protobuf serializer only.
-        // The default serializer is slow since it is using JSON+GZip encoding.
-        Some(new KVStoreProtobufSerializer())
-      } else {
-        Some(serializerForHistoryServer(conf))
-      }
+      val diskBackend = backend(conf, live)
 
       val dir = diskBackend match {
         case LEVELDB => "listing.ldb"
@@ -139,7 +141,7 @@ private[spark] object KVUtils extends Logging {
         conf.get(History.HISTORY_LOG_DIR))
 
       try {
-        open(dbPath, metadata, conf, Some(diskBackend), serializer)
+        open(dbPath, metadata, conf, live)
       } catch {
         // If there's an error, remove the listing database and any existing UI database
         // from the store directory, since it's extremely likely that they'll all contain
@@ -147,12 +149,12 @@ private[spark] object KVUtils extends Logging {
         case _: UnsupportedStoreVersionException | _: MetadataMismatchException =>
           logInfo("Detected incompatible DB versions, deleting...")
           path.listFiles().foreach(Utils.deleteRecursively)
-          open(dbPath, metadata, conf, Some(diskBackend), serializer)
+          open(dbPath, metadata, conf, live)
         case dbExc @ (_: NativeDB.DBException | _: RocksDBException) =>
           // Get rid of the corrupted data and re-create it.
           logWarning(s"Failed to load disk store $dbPath :", dbExc)
           Utils.deleteRecursively(dbPath)
-          open(dbPath, metadata, conf, Some(diskBackend), serializer)
+          open(dbPath, metadata, conf, live)
       }
     }.getOrElse(new InMemoryStore())
   }

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
@@ -50,7 +50,7 @@ abstract class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAn
 
   before {
     testDir = Utils.createTempDir()
-    store = KVUtils.open(new File(testDir, "listing"), "test", conf)
+    store = KVUtils.open(new File(testDir, "listing"), "test", conf, live = false)
   }
 
   after {

--- a/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
@@ -34,7 +34,6 @@ import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster._
 import org.apache.spark.status.ListenerEventsTestHelper._
 import org.apache.spark.status.api.v1
-import org.apache.spark.status.protobuf.KVStoreProtobufSerializer
 import org.apache.spark.storage._
 import org.apache.spark.tags.ExtendedLevelDBTest
 import org.apache.spark.util.Utils
@@ -53,7 +52,8 @@ abstract class AppStatusListenerSuite extends SparkFunSuite with BeforeAndAfter 
     .set(LIVE_ENTITY_UPDATE_PERIOD, 0L)
     .set(ASYNC_TRACKING_ENABLED, false)
 
-  protected def createKVStore: KVStore = KVUtils.open(testDir, getClass().getName(), conf)
+  protected def createKVStore: KVStore =
+    KVUtils.open(testDir, getClass().getName(), conf, live = false)
 
   before {
     time = 0L
@@ -1973,6 +1973,5 @@ class AppStatusListenerWithProtobufSerializerSuite extends AppStatusListenerSuit
       testDir,
       getClass().getName(),
       conf,
-      Some(HybridStoreDiskBackend.ROCKSDB),
-      Some(new KVStoreProtobufSerializer()))
+      live = true)
 }

--- a/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
@@ -106,7 +106,7 @@ class AppStatusStoreSuite extends SparkFunSuite {
     val store: KVStore = if (disk) {
       conf.set(HYBRID_STORE_DISK_BACKEND, diskStoreType.toString)
       val testDir = Utils.createTempDir()
-      val diskStore = KVUtils.open(testDir, getClass.getName, conf)
+      val diskStore = KVUtils.open(testDir, getClass.getName, conf, live = false)
       new ElementTrackingStore(diskStore, conf)
     } else {
       new ElementTrackingStore(new InMemoryStore, conf)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -342,6 +342,16 @@ Security options for the Spark History Server are covered more detail in the
     <td>2.3.0</td>
   </tr>
   <tr>
+    <td>spark.history.store.serializer</td>
+    <td>JSON</td>
+    <td>
+        Serializer for writing/reading in-memory UI objects to/from disk-based KV Store; JSON or PROTOBUF.
+        JSON serializer is the only choice before Spark 3.4.0, thus it is the default value.
+        PROTOBUF serializer is fast and compact, and it is the default serializer for disk-based KV store of live UI.
+    </td>
+    <td>3.4.0</td>
+  </tr>
+  <tr>
     <td>spark.history.custom.executor.log.url</td>
     <td>(none)</td>
     <td>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -347,7 +347,7 @@ Security options for the Spark History Server are covered more detail in the
     <td>
         Serializer for writing/reading in-memory UI objects to/from disk-based KV Store; JSON or PROTOBUF.
         JSON serializer is the only choice before Spark 3.4.0, thus it is the default value.
-        PROTOBUF serializer is fast and compact, and it is the default serializer for disk-based KV store of live UI.
+        PROTOBUF serializer is fast and compact, compared to the JSON serializer.
     </td>
     <td>3.4.0</td>
   </tr>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListenerSuite.scala
@@ -226,7 +226,7 @@ class StreamingQueryStatusListenerSuite extends StreamTest {
     val conf = new SparkConf()
       .set(HYBRID_STORE_DISK_BACKEND, HybridStoreDiskBackend.LEVELDB.toString)
     val testDir = Utils.createTempDir()
-    val kvStore = KVUtils.open(testDir, getClass.getName, conf)
+    val kvStore = KVUtils.open(testDir, getClass.getName, conf, live = false)
     try {
       testStreamingQueryData(kvStore)
     } finally {
@@ -239,7 +239,7 @@ class StreamingQueryStatusListenerSuite extends StreamTest {
     val conf = new SparkConf()
       .set(HYBRID_STORE_DISK_BACKEND, HybridStoreDiskBackend.ROCKSDB.toString)
     val testDir = Utils.createTempDir()
-    val kvStore = KVUtils.open(testDir, getClass.getName, conf)
+    val kvStore = KVUtils.open(testDir, getClass.getName, conf, live = false)
     try {
       testStreamingQueryData(kvStore)
     } finally {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support configurable(`spark.history.store.serializer`) serializer for the KVStore in History server. The value can be `JSON` or `PROTOBUF`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Support the fast and compact protobuf serializer in Spark history server(SHS), so that:
* Improve the performance of KVStore IO
* Make it possible for SHS to read the live UI rocksdb instance.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, introduce a new configuration `spark.history.store.serializer` for setting the serializer for the KVStore in History server, which can be `JSON` or `PROTOBUF`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT