### PR TITLE
[SPARK-41700][CONNECT][PYTHON] Remove `FunctionBuilder`

### DIFF
--- a/python/pyspark/sql/connect/_typing.py
+++ b/python/pyspark/sql/connect/_typing.py
@@ -42,11 +42,6 @@ DecimalLiteral = decimal.Decimal
 DateTimeLiteral = Union[datetime.datetime, datetime.date]
 
 
-class FunctionBuilderCallable(Protocol):
-    def __call__(self, *_: ColumnOrName) -> Column:
-        ...
-
-
 class UserDefinedFunctionCallable(Protocol):
     def __call__(self, *_: ColumnOrName) -> Column:
         ...

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -202,8 +202,7 @@ class Column:
         ...
 
     def substr(self, startPos: Union[int, "Column"], length: Union[int, "Column"]) -> "Column":
-        from pyspark.sql.connect.function_builder import functions as F
-        from pyspark.sql.connect.functions import lit
+        from pyspark.sql.connect.functions import lit, substring
 
         if type(startPos) != type(length):
             raise TypeError(
@@ -226,7 +225,7 @@ class Column:
         else:
             start_exp = startPos
 
-        return F.substr(self, start_exp, length_exp)
+        return substring(self, start_exp, length_exp)
 
     substr.__doc__ = PySparkColumn.substr.__doc__
 

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -261,6 +261,10 @@ class LiteralExpression(Expression):
         else:
             raise ValueError(f"Unsupported Data Type {type(value).__name__}")
 
+    @classmethod
+    def _from_value(cls, value: Any) -> "LiteralExpression":
+        return LiteralExpression(value=value, dataType=LiteralExpression._infer_type(value))
+
     def to_plan(self, session: "SparkConnectClient") -> "proto.Expression":
         """Converts the literal expression to the literal in proto."""
 

--- a/python/pyspark/sql/connect/function_builder.py
+++ b/python/pyspark/sql/connect/function_builder.py
@@ -29,7 +29,6 @@ from pyspark.sql.connect.functions import col
 if TYPE_CHECKING:
     from pyspark.sql.connect._typing import (
         ColumnOrName,
-        FunctionBuilderCallable,
         UserDefinedFunctionCallable,
     )
     from pyspark.sql.connect.client import SparkConnectClient
@@ -49,20 +48,6 @@ def _build(name: str, *args: "ColumnOrName") -> Column:
     """
     cols = [arg if isinstance(arg, Column) else col(arg) for arg in args]
     return Column(UnresolvedFunction(name, [col._expr for col in cols]))
-
-
-class FunctionBuilder:
-    """This class is used to build arbitrary functions used in expressions"""
-
-    def __getattr__(self, name: str) -> "FunctionBuilderCallable":
-        def _(*args: "ColumnOrName") -> Column:
-            return _build(name, *args)
-
-        _.__doc__ = f"""Function to apply {name}"""
-        return _
-
-
-functions = FunctionBuilder()
 
 
 class UserDefinedFunction(Expression):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1118,13 +1118,13 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assertEqual(5.0, res[1][1])
 
         # Additional GroupBy tests with 3 rows
-        from pyspark.sql.connect.function_builder import functions as FB
+        import pyspark.sql.connect.functions as CF
         import pyspark.sql.functions as PF
 
         df_a = self.connect.range(10).groupBy((col("id") % lit(3)).alias("moded"))
         df_b = self.spark.range(10).groupBy((PF.col("id") % PF.lit(3)).alias("moded"))
         self.assertEqual(
-            set(df_b.agg(PF.sum("id")).collect()), set(df_a.agg(FB.sum("id")).collect())
+            set(df_b.agg(PF.sum("id")).collect()), set(df_a.agg(CF.sum("id")).collect())
         )
 
         # Dict agg


### PR DESCRIPTION

### What changes were proposed in this pull request?
Remove `FunctionBuilder`


### Why are the changes needed?
since we had supported almost all the functions

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
updated UT