### PR TITLE
[SPARK-41705][CONNECT] Move generate_protos.sh to dev/

### DIFF
--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -91,7 +91,7 @@ To use the release version of Spark Connect:
 ### Generate proto generated files for the Python client
 1. Install `buf version 1.11.0`: https://docs.buf.build/installation
 2. Run `pip install grpcio==1.48.1 protobuf==3.19.5 mypy-protobuf==3.3.0`
-3. Run `./connector/connect/dev/generate_protos.sh`
+3. Run `dev/generate_protos.sh`
 4. Optional Check `./dev/check-codegen-python.py`
 
 ### Guidelines for new clients

--- a/dev/check-codegen-python.py
+++ b/dev/check-codegen-python.py
@@ -46,7 +46,7 @@ def run_cmd(cmd):
 def check_connect_protos():
     print("Start checking the generated codes in pyspark-connect.")
     with tempfile.TemporaryDirectory() as tmp:
-        run_cmd(f"{SPARK_HOME}/connector/connect/dev/generate_protos.sh {tmp}")
+        run_cmd(f"{SPARK_HOME}/dev/generate_protos.sh {tmp}")
         result = filecmp.dircmp(
             f"{SPARK_HOME}/python/pyspark/sql/connect/proto/",
             tmp,
@@ -76,7 +76,7 @@ def check_connect_protos():
             fail(
                 "Generated files for pyspark-connect are out of sync! "
                 "If you have touched files under connector/connect/src/main/protobuf, "
-                "please run ./connector/connect/dev/generate_protos.sh. "
+                "please run ./dev/generate_protos.sh. "
                 "If you haven't touched any file above, please rebase your PR against main branch."
             )
 

--- a/dev/generate_protos.sh
+++ b/dev/generate_protos.sh
@@ -20,7 +20,7 @@ set -ex
 
 if [[ $# -gt 1 ]]; then
   echo "Illegal number of parameters."
-  echo "Usage: ./connector/connect/dev/generate_protos.sh [path]"
+  echo "Usage: ./dev/generate_protos.sh [path]"
   exit -1
 fi
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR moves generate_protos.sh from `connector/connect/dev` to `dev` directory.

### Why are the changes needed?
`connector/connect/dev` only contains one script. Moving generate_protos.sh to `dev` follows practice for other scripts.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing test suite.