### PR TITLE
[SPARK-41711][BUILD] Upgrade protobuf-java to 3.21.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <protobuf.hadoopDependency.version>2.5.0</protobuf.hadoopDependency.version>
     <!-- Actual Protobuf version in Spark modules like Spark Connect, protobuf connector, etc. -->
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
-    <protobuf.version>3.21.11</protobuf.version>
+    <protobuf.version>3.21.12</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.6.3</zookeeper.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -88,7 +88,7 @@ object BuildCommons {
 
   // Google Protobuf version used for generating the protobuf.
   // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
-  val protoVersion = "3.21.11"
+  val protoVersion = "3.21.12"
   // GRPC version used for Spark Connect.
   val gprcVersion = "1.47.0"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade protobuf-java from 3.21.11 to 3.21.12


### Why are the changes needed?
The release notes as follows:

- https://github.com/protocolbuffers/protobuf/releases/tag/v21.12


### Does this PR introduce _any_ user-facing change?
 No


### How was this patch tested?
Pass Github Actions