### PR TITLE
[WIP][SPARK-41277] Auto infer bucketing info for shuffled actions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import java.net.URI
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog._


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR proposes to auto-infer bucketing information from actions that contain a shuffle.

### Why are the changes needed?
Seems like the bucketing potential is missed in many scenarios.
Analysts/Data Scientists often do not bother to use this feature and concentrate mostly on SQL code.
A seemingly low-hanging fruit is auto-inferring bucketing information for actions that shuffle and manage the data anyways - like group-by and join.
It is very common in a process to create many intermediate tables and reuse them to create more downstream tables. Often these tables are joined/grouped by the same keys and have the same number of partitions (from `spark.sql.shuffle.partitions`).


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Did not add dedicated tests yet. want your general opinion first.
I used this locally
```
(1 to 30).map(i => ("k_" + (i-(1-i%2)), "v_" + i))
  .toDF("id", "val").createOrReplaceTempView("t")

spark.sql(s"create table tbl1 select id,max(val) val, count(1) cnt from t group by id")
// verify that indeed tbl1 is save as bucketed table
spark.sql("desc formatted tbl1").show(100, false)

spark.table("t").write.bucketBy(3, "id").saveAsTable("tbl2")

// verify a bucket-join
spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
val dfPlan = spark.sql("create table tbl3 as select tbl1.* from tbl1 join tbl2 on tbl1.id=tbl2.id")
dfPlan.explain(true)
```



