### PR TITLE
[SPARK-41719][CORE] Skip SSLOptions sub-settings if `ssl` is disabled

### DIFF
--- a/core/src/main/scala/org/apache/spark/SSLOptions.scala
+++ b/core/src/main/scala/org/apache/spark/SSLOptions.scala
@@ -181,64 +181,62 @@ private[spark] object SSLOptions extends Logging {
       ns: String,
       defaults: Option[SSLOptions] = None): SSLOptions = {
     val enabled = conf.getBoolean(s"$ns.enabled", defaultValue = defaults.exists(_.enabled))
-    if (enabled) {
-      val port = conf.getWithSubstitution(s"$ns.port").map(_.toInt)
-      port.foreach { p =>
-        require(p >= 0, "Port number must be a non-negative value.")
-      }
+    if (!enabled) {
+      return new SSLOptions()
+    }
+    val port = conf.getWithSubstitution(s"$ns.port").map(_.toInt)
+    port.foreach { p =>
+      require(p >= 0, "Port number must be a non-negative value.")
+    }
 
-      val keyStore = conf.getWithSubstitution(s"$ns.keyStore").map(new File(_))
+    val keyStore = conf.getWithSubstitution(s"$ns.keyStore").map(new File(_))
         .orElse(defaults.flatMap(_.keyStore))
 
-      val keyStorePassword = conf.getWithSubstitution(s"$ns.keyStorePassword")
+    val keyStorePassword = conf.getWithSubstitution(s"$ns.keyStorePassword")
         .orElse(Option(hadoopConf.getPassword(s"$ns.keyStorePassword")).map(new String(_)))
         .orElse(defaults.flatMap(_.keyStorePassword))
 
-      val keyPassword = conf.getWithSubstitution(s"$ns.keyPassword")
+    val keyPassword = conf.getWithSubstitution(s"$ns.keyPassword")
         .orElse(Option(hadoopConf.getPassword(s"$ns.keyPassword")).map(new String(_)))
         .orElse(defaults.flatMap(_.keyPassword))
 
-      val keyStoreType = conf.getWithSubstitution(s"$ns.keyStoreType")
+    val keyStoreType = conf.getWithSubstitution(s"$ns.keyStoreType")
         .orElse(defaults.flatMap(_.keyStoreType))
 
-      val needClientAuth =
-        conf.getBoolean(s"$ns.needClientAuth", defaultValue = defaults.exists(_.needClientAuth))
+    val needClientAuth =
+      conf.getBoolean(s"$ns.needClientAuth", defaultValue = defaults.exists(_.needClientAuth))
 
-      val trustStore = conf.getWithSubstitution(s"$ns.trustStore").map(new File(_))
+    val trustStore = conf.getWithSubstitution(s"$ns.trustStore").map(new File(_))
         .orElse(defaults.flatMap(_.trustStore))
 
-      val trustStorePassword = conf.getWithSubstitution(s"$ns.trustStorePassword")
+    val trustStorePassword = conf.getWithSubstitution(s"$ns.trustStorePassword")
         .orElse(Option(hadoopConf.getPassword(s"$ns.trustStorePassword")).map(new String(_)))
         .orElse(defaults.flatMap(_.trustStorePassword))
 
-      val trustStoreType = conf.getWithSubstitution(s"$ns.trustStoreType")
+    val trustStoreType = conf.getWithSubstitution(s"$ns.trustStoreType")
         .orElse(defaults.flatMap(_.trustStoreType))
 
-      val protocol = conf.getWithSubstitution(s"$ns.protocol")
+    val protocol = conf.getWithSubstitution(s"$ns.protocol")
         .orElse(defaults.flatMap(_.protocol))
 
-      val enabledAlgorithms = conf.getWithSubstitution(s"$ns.enabledAlgorithms")
+    val enabledAlgorithms = conf.getWithSubstitution(s"$ns.enabledAlgorithms")
         .map(_.split(",").map(_.trim).filter(_.nonEmpty).toSet)
         .orElse(defaults.map(_.enabledAlgorithms))
         .getOrElse(Set.empty)
 
-      new SSLOptions(
-        enabled,
-        port,
-        keyStore,
-        keyStorePassword,
-        keyPassword,
-        keyStoreType,
-        needClientAuth,
-        trustStore,
-        trustStorePassword,
-        trustStoreType,
-        protocol,
-        enabledAlgorithms)
-    } else {
-      new SSLOptions(
-        enabled)
-    }
+    new SSLOptions(
+      enabled,
+      port,
+      keyStore,
+      keyStorePassword,
+      keyPassword,
+      keyStoreType,
+      needClientAuth,
+      trustStore,
+      trustStorePassword,
+      trustStoreType,
+      protocol,
+      enabledAlgorithms)
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/SSLOptions.scala
+++ b/core/src/main/scala/org/apache/spark/SSLOptions.scala
@@ -181,60 +181,64 @@ private[spark] object SSLOptions extends Logging {
       ns: String,
       defaults: Option[SSLOptions] = None): SSLOptions = {
     val enabled = conf.getBoolean(s"$ns.enabled", defaultValue = defaults.exists(_.enabled))
+    if (enabled) {
+      val port = conf.getWithSubstitution(s"$ns.port").map(_.toInt)
+      port.foreach { p =>
+        require(p >= 0, "Port number must be a non-negative value.")
+      }
 
-    val port = conf.getWithSubstitution(s"$ns.port").map(_.toInt)
-    port.foreach { p =>
-      require(p >= 0, "Port number must be a non-negative value.")
-    }
-
-    val keyStore = conf.getWithSubstitution(s"$ns.keyStore").map(new File(_))
+      val keyStore = conf.getWithSubstitution(s"$ns.keyStore").map(new File(_))
         .orElse(defaults.flatMap(_.keyStore))
 
-    val keyStorePassword = conf.getWithSubstitution(s"$ns.keyStorePassword")
+      val keyStorePassword = conf.getWithSubstitution(s"$ns.keyStorePassword")
         .orElse(Option(hadoopConf.getPassword(s"$ns.keyStorePassword")).map(new String(_)))
         .orElse(defaults.flatMap(_.keyStorePassword))
 
-    val keyPassword = conf.getWithSubstitution(s"$ns.keyPassword")
+      val keyPassword = conf.getWithSubstitution(s"$ns.keyPassword")
         .orElse(Option(hadoopConf.getPassword(s"$ns.keyPassword")).map(new String(_)))
         .orElse(defaults.flatMap(_.keyPassword))
 
-    val keyStoreType = conf.getWithSubstitution(s"$ns.keyStoreType")
+      val keyStoreType = conf.getWithSubstitution(s"$ns.keyStoreType")
         .orElse(defaults.flatMap(_.keyStoreType))
 
-    val needClientAuth =
-      conf.getBoolean(s"$ns.needClientAuth", defaultValue = defaults.exists(_.needClientAuth))
+      val needClientAuth =
+        conf.getBoolean(s"$ns.needClientAuth", defaultValue = defaults.exists(_.needClientAuth))
 
-    val trustStore = conf.getWithSubstitution(s"$ns.trustStore").map(new File(_))
+      val trustStore = conf.getWithSubstitution(s"$ns.trustStore").map(new File(_))
         .orElse(defaults.flatMap(_.trustStore))
 
-    val trustStorePassword = conf.getWithSubstitution(s"$ns.trustStorePassword")
+      val trustStorePassword = conf.getWithSubstitution(s"$ns.trustStorePassword")
         .orElse(Option(hadoopConf.getPassword(s"$ns.trustStorePassword")).map(new String(_)))
         .orElse(defaults.flatMap(_.trustStorePassword))
 
-    val trustStoreType = conf.getWithSubstitution(s"$ns.trustStoreType")
+      val trustStoreType = conf.getWithSubstitution(s"$ns.trustStoreType")
         .orElse(defaults.flatMap(_.trustStoreType))
 
-    val protocol = conf.getWithSubstitution(s"$ns.protocol")
+      val protocol = conf.getWithSubstitution(s"$ns.protocol")
         .orElse(defaults.flatMap(_.protocol))
 
-    val enabledAlgorithms = conf.getWithSubstitution(s"$ns.enabledAlgorithms")
+      val enabledAlgorithms = conf.getWithSubstitution(s"$ns.enabledAlgorithms")
         .map(_.split(",").map(_.trim).filter(_.nonEmpty).toSet)
         .orElse(defaults.map(_.enabledAlgorithms))
         .getOrElse(Set.empty)
 
-    new SSLOptions(
-      enabled,
-      port,
-      keyStore,
-      keyStorePassword,
-      keyPassword,
-      keyStoreType,
-      needClientAuth,
-      trustStore,
-      trustStorePassword,
-      trustStoreType,
-      protocol,
-      enabledAlgorithms)
+      new SSLOptions(
+        enabled,
+        port,
+        keyStore,
+        keyStorePassword,
+        keyPassword,
+        keyStoreType,
+        needClientAuth,
+        trustStore,
+        trustStorePassword,
+        trustStoreType,
+        protocol,
+        enabledAlgorithms)
+    } else {
+      new SSLOptions(
+        enabled)
+    }
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/SSLOptionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SSLOptionsSuite.scala
@@ -109,7 +109,7 @@ class SSLOptionsSuite extends SparkFunSuite {
     val conf = new SparkConf
     val hadoopConf = new Configuration()
     conf.set("spark.ssl.enabled", "true")
-    conf.set("spark.ssl.ui.enabled", "false")
+    conf.set("spark.ssl.ui.enabled", "true")
     conf.set("spark.ssl.ui.port", "4242")
     conf.set("spark.ssl.keyStore", keyStorePath)
     conf.set("spark.ssl.keyStorePassword", "password")
@@ -125,7 +125,7 @@ class SSLOptionsSuite extends SparkFunSuite {
     val defaultOpts = SSLOptions.parse(conf, hadoopConf, "spark.ssl", defaults = None)
     val opts = SSLOptions.parse(conf, hadoopConf, "spark.ssl.ui", defaults = Some(defaultOpts))
 
-    assert(opts.enabled === false)
+    assert(opts.enabled === true)
     assert(opts.port === Some(4242))
     assert(opts.trustStore.isDefined)
     assert(opts.trustStore.get.getName === "truststore")
@@ -138,6 +138,24 @@ class SSLOptionsSuite extends SparkFunSuite {
     assert(opts.keyPassword === Some("password"))
     assert(opts.protocol === Some("SSLv3"))
     assert(opts.enabledAlgorithms === Set("ABC", "DEF"))
+  }
+
+  test("test ssl settings are set only when ssl is enabled") {
+    val conf = new SparkConf
+    val hadoopConf = new Configuration()
+    conf.set("spark.ssl.enabled", "true")
+    conf.set("spark.ssl.keyStorePassword", "password")
+    conf.set("spark.ssl.ui.enabled", "false")
+    conf.set("spark.ssl.ui.keyStorePassword", "12345")
+
+
+    val defaultOpts = SSLOptions.parse(conf, hadoopConf, "spark.ssl", defaults = None)
+    val opts = SSLOptions.parse(conf, hadoopConf, "spark.ssl.ui", defaults = Some(defaultOpts))
+
+    assert(defaultOpts.enabled === true)
+    assert(opts.enabled === false)
+    assert(defaultOpts.keyStorePassword === Some("password"))
+    assert(opts.keyStorePassword === None)
   }
 
   test("variable substitution") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In SSLOptions rest of the settings should be set only when ssl is enabled.


### Why are the changes needed?
If spark.ssl.enabled is false, there is no use of setting rest of spark.ssl.* settings in SSLOptions as this requires unnecessary operations to be performed to set these properties. 
Additional implication of trying to set the rest of settings is if any error occurs in setting these properties it will cause job failure which otherwise should have worked since ssl is disabled. For example, if the user doesn't have access to the keystore path which is set in hadoop.security.credential.provider.path of hive-site.xml, it can result in failure while launching spark shell since SSLOptions won't be initialized due to error in accessing the keystore.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added new test. 