### PR TITLE
[SPARK-41721][CONNECT][TESTS] Enable doctests in pyspark.sql.connect.catalog

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -504,7 +504,7 @@ pyspark_connect = Module(
     source_file_regexes=["python/pyspark/sql/connect"],
     python_test_goals=[
         # doctests
-        # No doctests yet.
+        "pyspark.sql.connect.catalog",
         # unittests
         "pyspark.sql.tests.connect.test_connect_column_expressions",
         "pyspark.sql.tests.connect.test_connect_plan_only",

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -246,6 +246,8 @@ class Catalog:
             locationUri=jdb.locationUri(),
         )
 
+    # TODO(SPARK-41725): we don't have to `collect` for every `sql` but
+    #  Spark Connect requires it. We should remove them out.
     def databaseExists(self, dbName: str) -> bool:
         """Check if the database with the specified name exists.
 

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -273,7 +273,7 @@ class Catalog:
 
         >>> spark.catalog.databaseExists("test_new_database")
         False
-        >>> _ = spark.sql("CREATE DATABASE test_new_database")
+        >>> _ = spark.sql("CREATE DATABASE test_new_database").collect()
         >>> spark.catalog.databaseExists("test_new_database")
         True
 
@@ -281,7 +281,7 @@ class Catalog:
 
         >>> spark.catalog.databaseExists("spark_catalog.test_new_database")
         True
-        >>> _ = spark.sql("DROP DATABASE test_new_database")
+        >>> _ = spark.sql("DROP DATABASE test_new_database").collect()
         """
         return self._jcatalog.databaseExists(dbName)
 
@@ -370,8 +370,8 @@ class Catalog:
 
         Examples
         --------
-        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet")
+        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet").collect()
         >>> spark.catalog.getTable("tbl1")
         Table(name='tbl1', catalog='spark_catalog', namespace=['default'], ...
 
@@ -381,14 +381,14 @@ class Catalog:
         Table(name='tbl1', catalog='spark_catalog', namespace=['default'], ...
         >>> spark.catalog.getTable("spark_catalog.default.tbl1")
         Table(name='tbl1', catalog='spark_catalog', namespace=['default'], ...
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
 
         Throw an analysis exception when the table does not exist.
 
-        >>> spark.catalog.getTable("tbl1")
+        >>> spark.catalog.getTable("tbl1")  # doctest: +SKIP
         Traceback (most recent call last):
             ...
-        pyspark.sql.utils.AnalysisException: ...
+        AnalysisException: ...
         """
         jtable = self._jcatalog.getTable(tableName)
         jnamespace = jtable.namespace()
@@ -532,7 +532,8 @@ class Catalog:
 
         Examples
         --------
-        >>> func = spark.sql("CREATE FUNCTION my_func1 AS 'test.org.apache.spark.sql.MyDoubleAvg'")
+        >>> _ = spark.sql(
+        ...     "CREATE FUNCTION my_func1 AS 'test.org.apache.spark.sql.MyDoubleAvg'").collect()
         >>> spark.catalog.getFunction("my_func1")
         Function(name='my_func1', catalog='spark_catalog', namespace=['default'], ...
 
@@ -545,10 +546,10 @@ class Catalog:
 
         Throw an analysis exception when the function does not exists.
 
-        >>> spark.catalog.getFunction("my_func2")
+        >>> spark.catalog.getFunction("my_func2")  # doctest: +SKIP
         Traceback (most recent call last):
             ...
-        pyspark.sql.utils.AnalysisException: ...
+        AnalysisException: ...
         """
         jfunction = self._jcatalog.getFunction(functionName)
         jnamespace = jfunction.namespace()
@@ -599,11 +600,11 @@ class Catalog:
 
         Examples
         --------
-        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        >>> _ = spark.sql("CREATE TABLE tblA (name STRING, age INT) USING parquet")
+        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        >>> _ = spark.sql("CREATE TABLE tblA (name STRING, age INT) USING parquet").collect()
         >>> spark.catalog.listColumns("tblA")
         [Column(name='name', description=None, dataType='string', nullable=True, ...
-        >>> _ = spark.sql("DROP TABLE tblA")
+        >>> _ = spark.sql("DROP TABLE tblA").collect()
         """
         if dbName is None:
             iter = self._jcatalog.listColumns(tableName).toLocalIterator()
@@ -664,8 +665,8 @@ class Catalog:
 
         >>> spark.catalog.tableExists("unexisting_table")
         False
-        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet")
+        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet").collect()
         >>> spark.catalog.tableExists("tbl1")
         True
 
@@ -677,13 +678,13 @@ class Catalog:
         True
         >>> spark.catalog.tableExists("tbl1", "default")
         True
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
 
         Check if views exist:
 
         >>> spark.catalog.tableExists("view1")
         False
-        >>> _ = spark.sql("CREATE VIEW view1 AS SELECT 1")
+        >>> _ = spark.sql("CREATE VIEW view1 AS SELECT 1").collect()
         >>> spark.catalog.tableExists("view1")
         True
 
@@ -695,14 +696,14 @@ class Catalog:
         True
         >>> spark.catalog.tableExists("view1", "default")
         True
-        >>> _ = spark.sql("DROP VIEW view1")
+        >>> _ = spark.sql("DROP VIEW view1").collect()
 
         Check if temporary views exist:
 
-        >>> _ = spark.sql("CREATE TEMPORARY VIEW view1 AS SELECT 1")
+        >>> _ = spark.sql("CREATE TEMPORARY VIEW view1 AS SELECT 1").collect()
         >>> spark.catalog.tableExists("view1")
         True
-        >>> df = spark.sql("DROP VIEW view1")
+        >>> df = spark.sql("DROP VIEW view1").collect()
         >>> spark.catalog.tableExists("view1")
         False
         """
@@ -803,7 +804,7 @@ class Catalog:
         Creating a managed table.
 
         >>> _ = spark.catalog.createTable("tbl1", schema=spark.range(1).schema, source='parquet')
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
 
         Creating an external table
 
@@ -811,7 +812,7 @@ class Catalog:
         >>> with tempfile.TemporaryDirectory() as d:
         ...     _ = spark.catalog.createTable(
         ...         "tbl2", schema=spark.range(1).schema, path=d, source='parquet')
-        >>> _ = spark.sql("DROP TABLE tbl2")
+        >>> _ = spark.sql("DROP TABLE tbl2").collect()
         """
         if path is not None:
             options["path"] = path
@@ -864,7 +865,7 @@ class Catalog:
 
         Throw an exception if the temporary view does not exists.
 
-        >>> spark.table("my_table")
+        >>> spark.table("my_table")  # doctest: +SKIP
         Traceback (most recent call last):
             ...
         AnalysisException: ...
@@ -904,7 +905,7 @@ class Catalog:
 
         Throw an exception if the global view does not exists.
 
-        >>> spark.table("global_temp.my_table")
+        >>> spark.table("global_temp.my_table")  # doctest: +SKIP
         Traceback (most recent call last):
             ...
         AnalysisException: ...
@@ -945,8 +946,8 @@ class Catalog:
 
         Examples
         --------
-        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet")
+        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet").collect()
         >>> spark.catalog.cacheTable("tbl1")
         >>> spark.catalog.isCached("tbl1")
         True
@@ -956,14 +957,14 @@ class Catalog:
         >>> spark.catalog.isCached("not_existing_table")
         Traceback (most recent call last):
             ...
-        pyspark.sql.utils.AnalysisException: ...
+        AnalysisException: ...
 
         Using the fully qualified name for the table.
 
         >>> spark.catalog.isCached("spark_catalog.default.tbl1")
         True
         >>> spark.catalog.uncacheTable("tbl1")
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
         """
         return self._jcatalog.isCached(tableName)
 
@@ -982,8 +983,8 @@ class Catalog:
 
         Examples
         --------
-        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet")
+        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet").collect()
         >>> spark.catalog.cacheTable("tbl1")
 
         Throw an analysis exception when the table does not exist.
@@ -991,13 +992,13 @@ class Catalog:
         >>> spark.catalog.cacheTable("not_existing_table")
         Traceback (most recent call last):
             ...
-        pyspark.sql.utils.AnalysisException: ...
+        AnalysisException: ...
 
         Using the fully qualified name for the table.
 
         >>> spark.catalog.cacheTable("spark_catalog.default.tbl1")
         >>> spark.catalog.uncacheTable("tbl1")
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
         """
         self._jcatalog.cacheTable(tableName)
 
@@ -1016,8 +1017,8 @@ class Catalog:
 
         Examples
         --------
-        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet")
+        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet").collect()
         >>> spark.catalog.cacheTable("tbl1")
         >>> spark.catalog.uncacheTable("tbl1")
         >>> spark.catalog.isCached("tbl1")
@@ -1028,14 +1029,14 @@ class Catalog:
         >>> spark.catalog.uncacheTable("not_existing_table")  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
             ...
-        pyspark.sql.utils.AnalysisException: ...
+        AnalysisException: ...
 
         Using the fully qualified name for the table.
 
         >>> spark.catalog.uncacheTable("spark_catalog.default.tbl1")
         >>> spark.catalog.isCached("tbl1")
         False
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
         """
         self._jcatalog.uncacheTable(tableName)
 
@@ -1049,12 +1050,12 @@ class Catalog:
 
         Examples
         --------
-        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet")
+        >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet").collect()
         >>> spark.catalog.clearCache()
         >>> spark.catalog.isCached("tbl1")
         False
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
         """
         self._jcatalog.clearCache()
 
@@ -1080,9 +1081,10 @@ class Catalog:
 
         >>> import tempfile
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        ...     _ = spark.sql("CREATE TABLE tbl1 (col STRING) USING TEXT LOCATION '{}'".format(d))
-        ...     _ = spark.sql("INSERT INTO tbl1 SELECT 'abc'")
+        ...     _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        ...     _ = spark.sql(
+        ...         "CREATE TABLE tbl1 (col STRING) USING TEXT LOCATION '{}'".format(d)).collect()
+        ...     _ = spark.sql("INSERT INTO tbl1 SELECT 'abc'").collect()
         ...     spark.catalog.cacheTable("tbl1")
         ...     spark.table("tbl1").show()
         +---+
@@ -1105,7 +1107,7 @@ class Catalog:
         Using the fully qualified name for the table.
 
         >>> spark.catalog.refreshTable("spark_catalog.default.tbl1")
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
         """
         self._jcatalog.refreshTable(tableName)
 
@@ -1133,12 +1135,12 @@ class Catalog:
 
         >>> import tempfile
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     _ = spark.sql("DROP TABLE IF EXISTS tbl1")
+        ...     _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
         ...     spark.range(1).selectExpr(
         ...         "id as key", "id as value").write.partitionBy("key").mode("overwrite").save(d)
         ...     _ = spark.sql(
         ...          "CREATE TABLE tbl1 (key LONG, value LONG)"
-        ...          "USING parquet OPTIONS (path '{}') PARTITIONED BY (key)".format(d))
+        ...          "USING parquet OPTIONS (path '{}') PARTITIONED BY (key)".format(d)).collect()
         ...     spark.table("tbl1").show()
         ...     spark.catalog.recoverPartitions("tbl1")
         ...     spark.table("tbl1").show()
@@ -1151,7 +1153,7 @@ class Catalog:
         +-----+---+
         |    0|  0|
         +-----+---+
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
         """
         self._jcatalog.recoverPartitions(tableName)
 
@@ -1175,9 +1177,10 @@ class Catalog:
 
         >>> import tempfile
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     _ = spark.sql("DROP TABLE IF EXISTS tbl1")
-        ...     _ = spark.sql("CREATE TABLE tbl1 (col STRING) USING TEXT LOCATION '{}'".format(d))
-        ...     _ = spark.sql("INSERT INTO tbl1 SELECT 'abc'")
+        ...     _ = spark.sql("DROP TABLE IF EXISTS tbl1").collect()
+        ...     _ = spark.sql(
+        ...         "CREATE TABLE tbl1 (col STRING) USING TEXT LOCATION '{}'".format(d)).collect()
+        ...     _ = spark.sql("INSERT INTO tbl1 SELECT 'abc'").collect()
         ...     spark.catalog.cacheTable("tbl1")
         ...     spark.table("tbl1").show()
         +---+
@@ -1197,7 +1200,7 @@ class Catalog:
         >>> spark.table("tbl1").count()
         0
 
-        >>> _ = spark.sql("DROP TABLE tbl1")
+        >>> _ = spark.sql("DROP TABLE tbl1").collect()
         """
         self._jcatalog.refreshByPath(path)
 

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -18,6 +18,7 @@ from typing import List, Optional, TYPE_CHECKING
 
 import pandas as pd
 
+from pyspark import SparkContext, SparkConf
 from pyspark.sql.types import StructType
 from pyspark.sql.connect import DataFrame
 from pyspark.sql.catalog import (
@@ -116,8 +117,8 @@ class Catalog:
             Table(
                 name=row.iloc[0],
                 catalog=row.iloc[1],
-                # If empty or None, returns None.
-                namespace=None if row.iloc[2] is None else list(row.iloc[2]) or None,
+                # If None, returns None.
+                namespace=None if row.iloc[2] is None else list(row.iloc[2]),
                 description=row.iloc[3],
                 tableType=row.iloc[4],
                 isTemporary=row.iloc[5],
@@ -134,8 +135,8 @@ class Catalog:
         return Table(
             name=row.iloc[0],
             catalog=row.iloc[1],
-            # If empty or None, returns None.
-            namespace=None if row.iloc[2] is None else list(row.iloc[2]) or None,
+            # If None, returns None.
+            namespace=None if row.iloc[2] is None else list(row.iloc[2]),
             description=row.iloc[3],
             tableType=row.iloc[4],
             isTemporary=row.iloc[5],
@@ -149,8 +150,8 @@ class Catalog:
             Function(
                 name=row.iloc[0],
                 catalog=row.iloc[1],
-                # If empty or None, returns None.
-                namespace=None if row.iloc[2] is None else list(row.iloc[2]) or None,
+                # If None, returns None.
+                namespace=None if row.iloc[2] is None else list(row.iloc[2]),
                 description=row.iloc[3],
                 className=row.iloc[4],
                 isTemporary=row.iloc[5],
@@ -176,8 +177,8 @@ class Catalog:
         return Function(
             name=row.iloc[0],
             catalog=row.iloc[1],
-            # If empty or None, returns None.
-            namespace=None if row.iloc[2] is None else list(row.iloc[2]) or None,
+            # If None, returns None.
+            namespace=None if row.iloc[2] is None else list(row.iloc[2]),
             description=row.iloc[3],
             className=row.iloc[4],
             isTemporary=row.iloc[5],
@@ -307,24 +308,37 @@ class Catalog:
     refreshByPath.__doc__ = PySparkCatalog.refreshByPath.__doc__
 
 
+Catalog.__doc__ = PySparkCatalog.__doc__
+
+
 def _test() -> None:
     import os
     import sys
     import doctest
-    from pyspark.sql import SparkSession
+    from pyspark.sql import SparkSession as PySparkSession
     from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
-    import pyspark.sql.connect.catalog
+
+    os.chdir(os.environ["SPARK_HOME"])
 
     if should_test_connect:
+        import pyspark.sql.connect.catalog
+
         globs = pyspark.sql.catalog.__dict__.copy()
-        globs["_spark"] = (
-            SparkSession.builder.master("local[4]")
-            .appName("sql.connect.catalog tests")
-            .getOrCreate()
+        # Works around to create a regular Spark session
+        sc = SparkContext("local[4]", "sql.connect.catalog tests", conf=SparkConf())
+        globs["_spark"] = PySparkSession(
+            sc, options={"spark.app.name": "sql.connect.catalog tests"}
         )
 
-        os.environ["SPARK_REMOTE"] = "sc://localhost"
-        globs["spark"] = SparkSession.builder.remote("sc://localhost").getOrCreate()
+        # Creates a remote Spark session.
+        globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
+
+        # TODO(SPARK-41612): Support Catalog.isCached
+        # TODO(SPARK-41600): Support Catalog.cacheTable
+        del pyspark.sql.connect.catalog.Catalog.clearCache.__doc__
+        del pyspark.sql.connect.catalog.Catalog.refreshTable.__doc__
+        del pyspark.sql.connect.catalog.Catalog.refreshByPath.__doc__
+        del pyspark.sql.connect.catalog.Catalog.recoverPartitions.__doc__
 
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.catalog,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable doctests in `pyspark.sql.connect.catalog` that is virtually the same as `pyspark.sql.catalog`.

### Why are the changes needed?

To make sure on the PySpark compatibility and test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should test this out.