### PR TITLE
[SPARK-41722][CONNECT][PYTHON] Implement 3 missing time window functions

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2070,6 +2070,73 @@ def timestamp_seconds(col: "ColumnOrName") -> Column:
 timestamp_seconds.__doc__ = pysparkfuncs.timestamp_seconds.__doc__
 
 
+def window(
+    timeColumn: "ColumnOrName",
+    windowDuration: str,
+    slideDuration: Optional[str] = None,
+    startTime: Optional[str] = None,
+) -> Column:
+    if windowDuration is None or not isinstance(windowDuration, str):
+        raise TypeError(
+            f"windowDuration should be as a string, "
+            f"but got {type(windowDuration).__name__} {windowDuration}"
+        )
+    if slideDuration is not None and not isinstance(slideDuration, str):
+        raise TypeError(
+            f"slideDuration should be as a string, "
+            f"but got {type(slideDuration).__name__} {slideDuration}"
+        )
+    if startTime is not None and not isinstance(startTime, str):
+        raise TypeError(
+            f"startTime should be as a string, " f"but got {type(startTime).__name__} {startTime}"
+        )
+
+    time_col = _to_col(timeColumn)
+
+    if slideDuration is not None and startTime is not None:
+        return _invoke_function(
+            "window", time_col, lit(windowDuration), lit(slideDuration), lit(startTime)
+        )
+    elif slideDuration is not None:
+        return _invoke_function("window", time_col, lit(windowDuration), lit(slideDuration))
+    elif startTime is not None:
+        return _invoke_function(
+            "window", time_col, lit(windowDuration), lit(windowDuration), lit(startTime)
+        )
+    else:
+        return _invoke_function("window", time_col, lit(windowDuration))
+
+
+window.__doc__ = pysparkfuncs.window.__doc__
+
+
+def window_time(
+    windowColumn: "ColumnOrName",
+) -> Column:
+    return _invoke_function("window_time", _to_col(windowColumn))
+
+
+window_time.__doc__ = pysparkfuncs.window_time.__doc__
+
+
+def session_window(timeColumn: "ColumnOrName", gapDuration: Union[Column, str]) -> Column:
+    if gapDuration is None or not isinstance(gapDuration, (Column, str)):
+        raise TypeError(
+            f"gapDuration should be as a string or Column, "
+            f"but got {type(gapDuration).__name__} {gapDuration}"
+        )
+
+    time_col = _to_col(timeColumn)
+
+    if isinstance(gapDuration, Column):
+        return _invoke_function("session_window", time_col, gapDuration)
+    else:
+        return _invoke_function("session_window", time_col, lit(gapDuration))
+
+
+session_window.__doc__ = pysparkfuncs.session_window.__doc__
+
+
 # Partition Transformation Functions
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Implement 3 missing time window functions

### Why are the changes needed?
For API coverage

after this PR, following ones are missing:
1, `call_udf`
2, `pandas_udf`
3, `sequence` - SPARK-41723
4, `format_number` - SPARK-41473
5, `unwrap_udt`
6, `udf`

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added UT
