### PR TITLE
[SPARK-41378][SQL][FOLLOWUP] Fix compilation warning about `[unchecked] unchecked conversion`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Statistics.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Statistics.java
@@ -36,6 +36,6 @@ public interface Statistics {
   OptionalLong sizeInBytes();
   OptionalLong numRows();
   default Map<NamedReference, ColumnStatistics> columnStats() {
-    return new HashMap();
+    return new HashMap<>();
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just fix compilation warning about `[unchecked] unchecked conversion`:

```
/home/disk0/spark-source/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Statistics.java:39: warning: [unchecked] unchecked conversion
    return new HashMap();
           ^
  required: Map<NamedReference,ColumnStatistics>
  found:    HashMap
```


### Why are the changes needed?
Fix compilation warning


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions