### PR TITLE
[SPARK-41728][CONNECT][PYTHON] Implement `unwrap_udt` function

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -752,6 +752,9 @@ class SparkConnectPlanner(session: SparkSession) {
       case "hours" if fun.getArgumentsCount == 1 =>
         Some(Hours(transformExpression(fun.getArguments(0))))
 
+      case "unwrap_udt" if fun.getArgumentsCount == 1 =>
+        Some(UnwrapUDT(transformExpression(fun.getArguments(0))))
+
       case _ => None
     }
   }

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2260,8 +2260,18 @@ def sha2(col: "ColumnOrName", numBits: int) -> Column:
 sha2.__doc__ = pysparkfuncs.sha2.__doc__
 
 
+# User Defined Function
+
+
 def call_udf(udfName: str, *cols: "ColumnOrName") -> Column:
     return _invoke_function(udfName, *[_to_col(c) for c in cols])
 
 
 call_udf.__doc__ = pysparkfuncs.call_udf.__doc__
+
+
+def unwrap_udt(col: "ColumnOrName") -> Column:
+    return _invoke_function("unwrap_udt", _to_col(col))
+
+
+unwrap_udt.__doc__ = pysparkfuncs.unwrap_udt.__doc__

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -9939,6 +9939,8 @@ def unwrap_udt(col: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.4.0
 
+    .. versionchanged:: 3.4.0
+        Support Spark Connect.
     """
     return _invoke_function("unwrap_udt", _to_java_column(col))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `unwrap_udt` function


### Why are the changes needed?
for API coverage

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
no added test, since `unwrap_udt` [requires a UDT ](https://github.com/apache/spark/blob/bf4981fd4adfe96d3962e2e165c5a5d307a0033d/python/pyspark/ml/tests/test_linalg.py#L355-L366)which is not supported yet 