### PR TITLE
[SPARK-41649][CONNECT][FOLLOWUP] Deduplicate docstrings in pyspark.sql.connect.window

### DIFF
--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -241,4 +241,4 @@ class Window:
     rangeBetween.__doc__ = PySparkWindow.rangeBetween.__doc__
 
 
-Window.__doc__ = Window.__doc__
+Window.__doc__ = PySparkWindowSpec.Window.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is a followup of https://github.com/apache/spark/pull/39180 that addresses a typo. 

`Window.__doc__ = Window.__doc__`

### Why are the changes needed?
For easier maintenance


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA
