### PR TITLE
[SPARK-41649][CONNECT][FOLLOW-UP] Change `PySparkWindowSpec.Window` to `PySparkWindow`

### DIFF
--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -241,4 +241,4 @@ class Window:
     rangeBetween.__doc__ = PySparkWindow.rangeBetween.__doc__
 
 
-Window.__doc__ = PySparkWindowSpec.Window.__doc__
+Window.__doc__ = PySparkWindow.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/39238 that fixes the mistake on the deduplication of docs in Window.

### Why are the changes needed?

To fix the broken build.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested with `./dev/lint-python`.