### PR TITLE
[SPARK-41697][CONNECT][TESTS][FOLLOW-UP] Disable test_toDF_with_schema_string back, and fix test_freqItems

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -86,6 +86,10 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
         super().test_fillna()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_freqItems(self):
+        super().test_freqItems()
+
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_generic_hints(self):
         super().test_generic_hints()
 
@@ -144,6 +148,10 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to(self):
         super().test_to()
+
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_toDF_with_schema_string(self):
+        super().test_toDF_with_schema_string()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_local_iterator(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/39193 that:
1. Disables `test_toDF_with_schema_string` back because it aims to test `RDD.toDF` which does not exist in Spark Connect.
2. Disables `test_freqItems` back because `DataFrame.freqItems` does not exist in Spark Connect yet. It was testing regular PySpark's `SparkContext`.


### Why are the changes needed?

To avoid having mixed test cases.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran this via IDE.