### PR TITLE
[SPARK-41655][CONNECT] Enable doctests in pyspark.sql.connect.column

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -505,6 +505,7 @@ pyspark_connect = Module(
     python_test_goals=[
         # doctests
         "pyspark.sql.connect.catalog",
+        "pyspark.sql.connect.column",
         # unittests
         "pyspark.sql.tests.connect.test_connect_column_expressions",
         "pyspark.sql.tests.connect.test_connect_plan_only",

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -200,7 +200,7 @@ class Column:
     ...      [(2, "Alice"), (5, "Bob")], ["age", "name"])
 
     Select a column out of a DataFrame
-
+    # TODO(SPARK-41757): Compatibility of string representation
     >>> df.name   # doctest: +SKIP
     Column<'name'>
     >>> df["name"]  # doctest: +SKIP

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -1258,7 +1258,7 @@ class Column:
         >>> from pyspark.sql import Window
         >>> window = Window.partitionBy("name").orderBy("age") \
                 .rowsBetween(Window.unboundedPreceding, Window.currentRow)
-        >>> from pyspark.sql.functions import rank,min,desc
+        >>> from pyspark.sql.functions import rank, min, desc
         >>> df = spark.createDataFrame(
         ...      [(2, "Alice"), (5, "Bob")], ["age", "name"])
         >>> df.withColumn("rank", rank().over(window)) \

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -181,6 +181,7 @@ def _reverse_op(
     _.__doc__ = doc
     return _
 
+
 # TODO(SPARK-41757): Compatibility of string representation for Column
 
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -1258,8 +1258,7 @@ class Column:
         >>> from pyspark.sql import Window
         >>> window = Window.partitionBy("name").orderBy("age") \
                 .rowsBetween(Window.unboundedPreceding, Window.currentRow)
-        >>> from pyspark.sql.functions import rank, min
-        >>> from pyspark.sql.functions import desc
+        >>> from pyspark.sql.functions import rank,min,desc
         >>> df = spark.createDataFrame(
         ...      [(2, "Alice"), (5, "Bob")], ["age", "name"])
         >>> df.withColumn("rank", rank().over(window)) \

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -181,6 +181,8 @@ def _reverse_op(
     _.__doc__ = doc
     return _
 
+# TODO(SPARK-41757): Compatibility of string representation for Column
+
 
 class Column:
 
@@ -200,7 +202,6 @@ class Column:
     ...      [(2, "Alice"), (5, "Bob")], ["age", "name"])
 
     Select a column out of a DataFrame
-    # TODO(SPARK-41757): Compatibility of string representation
     >>> df.name   # doctest: +SKIP
     Column<'name'>
     >>> df["name"]  # doctest: +SKIP

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -201,16 +201,16 @@ class Column:
 
     Select a column out of a DataFrame
 
-    >>> df.name
+    >>> df.name   # doctest: +SKIP
     Column<'name'>
-    >>> df["name"]
+    >>> df["name"]  # doctest: +SKIP
     Column<'name'>
 
     Create from an expression
 
-    >>> df.age + 1
+    >>> df.age + 1  # doctest: +SKIP
     Column<'(age + 1)'>
-    >>> 1 / df.age
+    >>> 1 / df.age  # doctest: +SKIP
     Column<'(1 / age)'>
     """
 

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -403,7 +403,7 @@ def _test() -> None:
     if should_test_connect:
         import pyspark.sql.connect.column
 
-        globs = pyspark.sql.column.__dict__.copy()
+        globs = pyspark.sql.connect.column.__dict__.copy()
         # Works around to create a regular Spark session
         sc = SparkContext("local[4]", "sql.connect.column tests", conf=SparkConf())
         globs["_spark"] = PySparkSession(sc, options={"spark.app.name": "sql.connect.column tests"})

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -389,7 +389,6 @@ class Column:
 
     __bool__ = __nonzero__
 
-
 Column.__doc__ = PySparkColumn.__doc__
 
 
@@ -422,7 +421,7 @@ def _test() -> None:
         del pyspark.sql.connect.column.Column.isNotNull.__doc__
         del pyspark.sql.connect.column.Column.isNull.__doc__
         del pyspark.sql.connect.column.Column.isin.__doc__
-        # TODO: Fix createDataFrame
+        # TODO(SPARK-41756): Fix createDataFrame
         del pyspark.sql.connect.column.Column.getField.__doc__
         del pyspark.sql.connect.column.Column.getItem.__doc__
         # TODO(SPARK-41292): Support Window functions

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -425,7 +425,7 @@ def _test() -> None:
         # TODO(SPARK-41756): Fix createDataFrame
         del pyspark.sql.connect.column.Column.getField.__doc__
         del pyspark.sql.connect.column.Column.getItem.__doc__
-        # TODO(SPARK-41292): Support Window functions
+        # TODO(SPARK-41758): Support Window functions
         del pyspark.sql.connect.column.Column.over.__doc__
 
         (failure_count, test_count) = doctest.testmod(

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -414,7 +414,8 @@ def _test() -> None:
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
 
-        # TODO(SPARK-41751): Support Column.bitwiseAND,bitwiseOR,bitwiseXOR,eqNullSafe,isNotNull,isNull,isin
+        # TODO(SPARK-41751): Support Column.bitwiseAND,bitwiseOR,bitwiseXOR,eqNullSafe,isNotNull,
+        # isNull,isin
         del pyspark.sql.connect.column.Column.bitwiseAND.__doc__
         del pyspark.sql.connect.column.Column.bitwiseOR.__doc__
         del pyspark.sql.connect.column.Column.bitwiseXOR.__doc__

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -28,6 +28,7 @@ from typing import (
     Optional,
 )
 
+from pyspark import SparkContext, SparkConf
 from pyspark.sql.types import DataType
 from pyspark.sql.column import Column as PySparkColumn
 
@@ -413,12 +414,26 @@ def _test() -> None:
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
 
+        # TODO(SPARK-41751): Support bitwiseAND
+        del pyspark.sql.connect.column.Column.bitwiseAND.__doc__
+        del pyspark.sql.connect.column.Column.bitwiseOR.__doc__
+        del pyspark.sql.connect.column.Column.bitwiseXOR.__doc__
+        del pyspark.sql.connect.column.Column.eqNullSafe.__doc__
+        del pyspark.sql.connect.column.Column.isNotNull.__doc__
+        del pyspark.sql.connect.column.Column.isNull.__doc__
+        del pyspark.sql.connect.column.Column.isin.__doc__
+        # TODO: Fix createDataFrame
+        del pyspark.sql.connect.column.Column.getField.__doc__
+        del pyspark.sql.connect.column.Column.getItem.__doc__
+        # TODO(SPARK-41292): Support Window functions
+        del pyspark.sql.connect.column.Column.over.__doc__
+
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.column,
             globs=globs,
             optionflags=doctest.ELLIPSIS
-                        | doctest.NORMALIZE_WHITESPACE
-                        | doctest.IGNORE_EXCEPTION_DETAIL,
+            | doctest.NORMALIZE_WHITESPACE
+            | doctest.IGNORE_EXCEPTION_DETAIL,
         )
 
         globs["spark"].stop()

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -409,6 +409,7 @@ def _test() -> None:
         globs["_spark"] = PySparkSession(sc, options={"spark.app.name": "sql.connect.column tests"})
 
         # Creates a remote Spark session.
+        os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
 
         (failure_count, test_count) = doctest.testmod(

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -414,7 +414,7 @@ def _test() -> None:
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
 
-        # TODO(SPARK-41751): Support bitwiseAND
+        # TODO(SPARK-41751): Support Column.bitwiseAND,bitwiseOR,bitwiseXOR,eqNullSafe,isNotNull,isNull,isin
         del pyspark.sql.connect.column.Column.bitwiseAND.__doc__
         del pyspark.sql.connect.column.Column.bitwiseOR.__doc__
         del pyspark.sql.connect.column.Column.bitwiseXOR.__doc__

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -389,6 +389,7 @@ class Column:
 
     __bool__ = __nonzero__
 
+
 Column.__doc__ = PySparkColumn.__doc__
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to enable doctests in pyspark.sql.connect.column that is virtually the same as pyspark.sql.column.

### Why are the changes needed?
To make sure on the PySpark compatibility and test coverage.

### Does this PR introduce any user-facing change?
No, doctest's only.

### How was this patch tested?
New Doctests Added