### PR TITLE
[SQL][MINOR] Use Diamond operator for constructing HashMap

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaBeanDeserializationSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaBeanDeserializationSuite.java
@@ -590,9 +590,9 @@ public class JavaBeanDeserializationSuite implements Serializable {
             .reduceGroups(rf);
 
     List<Tuple2<String, Item>> expectedRecords = Arrays.asList(
-            new Tuple2("a", new Item("a", 8)),
-            new Tuple2("b", new Item("b", 3)),
-            new Tuple2("c", new Item("c", 2)));
+            new Tuple2<>("a", new Item("a", 8)),
+            new Tuple2<>("b", new Item("b", 3)),
+            new Tuple2<>("c", new Item("c", 2)));
 
     List<Tuple2<String, Item>> result = finalDs.collectAsList();
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaColumnExpressionSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaColumnExpressionSuite.java
@@ -86,7 +86,7 @@ public class JavaColumnExpressionSuite {
     AnalysisException e = Assert.assertThrows(AnalysisException.class,
       () -> df.filter(df.col("a").isInCollection(Arrays.asList(new Column("b")))));
     Assert.assertTrue(e.getErrorClass().equals("DATATYPE_MISMATCH.DATA_DIFF_TYPES"));
-    Map<String, String> messageParameters = new HashMap();
+    Map<String, String> messageParameters = new HashMap<>();
     messageParameters.put("functionName", "`in`");
     messageParameters.put("dataType", "[\"INT\", \"ARRAY<INT>\"]");
     messageParameters.put("sqlExpr", "\"(a IN (b))\"");


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR uses Diamond operator for constructing HashMap and Tuple2 for type inference.

### Why are the changes needed?
The change follows Java practices for creating new HashMap.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing test suite.