### PR TITLE
[SPARK-41736][CONNECT][PYTHON] `pyspark_types_to_proto_types` should supports `ArrayType`

### DIFF
--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -99,6 +99,9 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
         ret.map.key_type.CopyFrom(pyspark_types_to_proto_types(data_type.keyType))
         ret.map.value_type.CopyFrom(pyspark_types_to_proto_types(data_type.valueType))
         ret.map.value_contains_null = data_type.valueContainsNull
+    elif isinstance(data_type, ArrayType):
+        ret.array.element_type.CopyFrom(pyspark_types_to_proto_types(data_type.elementType))
+        ret.array.contains_null = data_type.containsNull
     else:
         raise Exception(f"Unsupported data type {data_type}")
     return ret

--- a/python/pyspark/sql/tests/connect/test_connect_plan_only.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan_only.py
@@ -30,7 +30,14 @@ if should_test_connect:
     from pyspark.sql.connect.readwriter import DataFrameReader
     from pyspark.sql.connect.function_builder import UserDefinedFunction, udf
     from pyspark.sql.connect.types import pyspark_types_to_proto_types
-    from pyspark.sql.types import StringType, StructType, StructField, IntegerType, MapType
+    from pyspark.sql.types import (
+        StringType,
+        StructType,
+        StructField,
+        IntegerType,
+        MapType,
+        ArrayType,
+    )
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
@@ -547,6 +554,7 @@ class SparkConnectTestsPlanOnly(PlanOnlyTestFixture):
                 StructField("col1", IntegerType(), True),
                 StructField("col2", StringType(), True),
                 StructField("map1", MapType(StringType(), IntegerType(), True), True),
+                StructField("array1", ArrayType(IntegerType(), True), True),
             ]
         )
         new_plan = df.to(schema)._plan.to_proto(self.connect)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, `pyspark_types_to_proto_types` used to transform pyspark datatypes to protobuffer datatypes.
But it not supports the array type yet.
Many connect API need to transform pyspark array type to protobuffer array type. For example, `createDataFrame`, `DataFrame.to` and so on.


### Why are the changes needed?
This PR let `pyspark_types_to_proto_types` support `ArrayType`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New tests.
