### PR TITLE
[SPARK-41740][CONNECT][PYTHON] Implement `Column.name`

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -266,6 +266,10 @@ class Column:
 
     alias.__doc__ = PySparkColumn.alias.__doc__
 
+    name = alias
+
+    name.__doc__ = PySparkColumn.name.__doc__
+
     def asc(self) -> "Column":
         return self.asc_nulls_first()
 
@@ -283,9 +287,6 @@ class Column:
 
     def desc_nulls_last(self) -> "Column":
         return Column(SortOrder(self._expr, ascending=False, nullsFirst=False))
-
-    def name(self) -> str:
-        return self._expr.name()
 
     def cast(self, dataType: Union[DataType, str]) -> "Column":
         if isinstance(dataType, (DataType, str)):

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -97,6 +97,10 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             df.select(df.name.substr(0, 1).alias("col")).toPandas(),
             df2.select(df2.name.substr(0, 1).alias("col")).toPandas(),
         )
+        self.assert_eq(
+            df.select(df.name.substr(0, 1).name("col")).toPandas(),
+            df2.select(df2.name.substr(0, 1).name("col")).toPandas(),
+        )
         df3 = self.connect.sql("SELECT cast(null as int) as name")
         df4 = self.spark.sql("SELECT cast(null as int) as name")
         self.assert_eq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Properly implement `Column.name`


### Why are the changes needed?
API coverage


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added ut