### PR TITLE
[SPARK-41689][CONNECT][TESTS] Enable doctests in pyspark.sql.connect.group

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -505,6 +505,7 @@ pyspark_connect = Module(
     python_test_goals=[
         # doctests
         "pyspark.sql.connect.catalog",
+        "pyspark.sql.connect.group",
         "pyspark.sql.connect.window",
         # unittests
         "pyspark.sql.tests.connect.test_connect_column_expressions",

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -323,7 +323,7 @@ def _test() -> None:
     if should_test_connect:
         import pyspark.sql.connect.catalog
 
-        globs = pyspark.sql.catalog.__dict__.copy()
+        globs = pyspark.sql.connect.catalog.__dict__.copy()
         # Works around to create a regular Spark session
         sc = SparkContext("local[4]", "sql.connect.catalog tests", conf=SparkConf())
         globs["_spark"] = PySparkSession(
@@ -347,9 +347,8 @@ def _test() -> None:
             | doctest.NORMALIZE_WHITESPACE
             | doctest.IGNORE_EXCEPTION_DETAIL,
         )
-        # TODO(SPARK-41529): Implement stop in RemoteSparkSession.
-        #  Stop the regular Spark session (server) too.
         globs["_spark"].stop()
+        globs["spark"].stop()
         if failure_count:
             sys.exit(-1)
     else:

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -331,6 +331,7 @@ def _test() -> None:
         )
 
         # Creates a remote Spark session.
+        os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
 
         # TODO(SPARK-41612): Support Catalog.isCached

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -188,19 +188,16 @@ def _test() -> None:
         globs = pyspark.sql.connect.group.__dict__.copy()
         # Works around to create a regular Spark session
         sc = SparkContext("local[4]", "sql.connect.group tests", conf=SparkConf())
-        globs["_spark"] = PySparkSession(
-            sc, options={"spark.app.name": "sql.connect.group tests"}
-        )
+        globs["_spark"] = PySparkSession(sc, options={"spark.app.name": "sql.connect.group tests"})
 
         # Creates a remote Spark session.
+        os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
 
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.group,
             globs=globs,
-            optionflags=doctest.ELLIPSIS
-            | doctest.NORMALIZE_WHITESPACE
-            | doctest.IGNORE_EXCEPTION_DETAIL,
+            optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF,
         )
         globs["_spark"].stop()
         globs["spark"].stop()

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -170,3 +170,48 @@ class GroupedData:
 
 
 GroupedData.__doc__ = PySparkGroupedData.__doc__
+
+
+def _test() -> None:
+    import os
+    import sys
+    import doctest
+    from pyspark import SparkContext, SparkConf
+    from pyspark.sql import SparkSession as PySparkSession
+    from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+    os.chdir(os.environ["SPARK_HOME"])
+
+    if should_test_connect:
+        import pyspark.sql.connect.group
+
+        globs = pyspark.sql.connect.group.__dict__.copy()
+        # Works around to create a regular Spark session
+        sc = SparkContext("local[4]", "sql.connect.group tests", conf=SparkConf())
+        globs["_spark"] = PySparkSession(
+            sc, options={"spark.app.name": "sql.connect.group tests"}
+        )
+
+        # Creates a remote Spark session.
+        globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
+
+        (failure_count, test_count) = doctest.testmod(
+            pyspark.sql.connect.group,
+            globs=globs,
+            optionflags=doctest.ELLIPSIS
+            | doctest.NORMALIZE_WHITESPACE
+            | doctest.IGNORE_EXCEPTION_DETAIL,
+        )
+        globs["_spark"].stop()
+        globs["spark"].stop()
+        if failure_count:
+            sys.exit(-1)
+    else:
+        print(
+            f"Skipping pyspark.sql.connect.group doctests: {connect_requirement_message}",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -257,7 +257,7 @@ def _test() -> None:
     if should_test_connect:
         import pyspark.sql.connect.window
 
-        globs = pyspark.sql.window.__dict__.copy()
+        globs = pyspark.sql.connect.window.__dict__.copy()
         # Works around to create a regular Spark session
         sc = SparkContext("local[4]", "sql.connect.window tests", conf=SparkConf())
         globs["_spark"] = PySparkSession(sc, options={"spark.app.name": "sql.connect.window tests"})

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -263,6 +263,7 @@ def _test() -> None:
         globs["_spark"] = PySparkSession(sc, options={"spark.app.name": "sql.connect.window tests"})
 
         # Creates a remote Spark session.
+        os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
 
         (failure_count, test_count) = doctest.testmod(

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -78,6 +78,8 @@ class GroupedData(PandasGroupedOpsMixin):
     def agg(self, __exprs: Dict[str, str]) -> DataFrame:
         ...
 
+    # TODO(SPARK-41279): Enable the doctest with supporting the star in Spark Connect.
+    # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
     def agg(self, *exprs: Union[Column, Dict[str, str]]) -> DataFrame:
         """Compute aggregates and returns the result as a :class:`DataFrame`.
 
@@ -133,7 +135,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Group-by name, and count each group.
 
-        >>> df.groupBy(df.name).agg({"*": "count"}).sort("name").show()
+        >>> df.groupBy(df.name).agg({"*": "count"}).sort("name").show()  # doctest: +SKIP
         +-----+--------+
         | name|count(1)|
         +-----+--------+
@@ -143,7 +145,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Group-by name, and calculate the minimum age.
 
-        >>> df.groupBy(df.name).agg(F.min(df.age)).sort("name").show()
+        >>> df.groupBy(df.name).agg(F.min(df.age)).sort("name").show()  # doctest: +SKIP
         +-----+--------+
         | name|min(age)|
         +-----+--------+
@@ -175,6 +177,7 @@ class GroupedData(PandasGroupedOpsMixin):
             jdf = self._jgd.agg(exprs[0]._jc, _to_seq(self.session._sc, [c._jc for c in exprs[1:]]))
         return DataFrame(jdf, self.session)
 
+    # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
     @dfapi
     def count(self) -> DataFrame:
         """Counts the number of records for each group.
@@ -200,7 +203,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Group-by name, and count each group.
 
-        >>> df.groupBy(df.name).count().sort("name").show()
+        >>> df.groupBy(df.name).count().sort("name").show()  # doctest: +SKIP
         +-----+-----+
         | name|count|
         +-----+-----+
@@ -226,6 +229,8 @@ class GroupedData(PandasGroupedOpsMixin):
             column names. Non-numeric columns are ignored.
         """
 
+    # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
+    # TODO(SPARK-41747): Support multiple arguments in groupBy.avg(...)
     @df_varargs_api
     def avg(self, *cols: str) -> DataFrame:
         """Computes average values for each numeric columns for each group.
@@ -259,7 +264,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Group-by name, and calculate the mean of the age in each group.
 
-        >>> df.groupBy("name").avg('age').sort("name").show()
+        >>> df.groupBy("name").avg('age').sort("name").show()  # doctest: +SKIP
         +-----+--------+
         | name|avg(age)|
         +-----+--------+
@@ -269,7 +274,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Calculate the mean of the age and height in all data.
 
-        >>> df.groupBy().avg('age', 'height').show()
+        >>> df.groupBy().avg('age', 'height').show()  # doctest: +SKIP
         +--------+-----------+
         |avg(age)|avg(height)|
         +--------+-----------+
@@ -277,6 +282,8 @@ class GroupedData(PandasGroupedOpsMixin):
         +--------+-----------+
         """
 
+    # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
+    # TODO(SPARK-41744): Support multiple arguments in groupBy.max(...)
     @df_varargs_api
     def max(self, *cols: str) -> DataFrame:
         """Computes the max value for each numeric columns for each group.
@@ -303,7 +310,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Group-by name, and calculate the max of the age in each group.
 
-        >>> df.groupBy("name").max("age").sort("name").show()
+        >>> df.groupBy("name").max("age").sort("name").show()  # doctest: +SKIP
         +-----+--------+
         | name|max(age)|
         +-----+--------+
@@ -313,7 +320,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Calculate the max of the age and height in all data.
 
-        >>> df.groupBy().max("age", "height").show()
+        >>> df.groupBy().max("age", "height").show()  # doctest: +SKIP
         +--------+-----------+
         |max(age)|max(height)|
         +--------+-----------+
@@ -321,6 +328,8 @@ class GroupedData(PandasGroupedOpsMixin):
         +--------+-----------+
         """
 
+    # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
+    # TODO(SPARK-41748): Support multiple arguments in groupBy.min(...)
     @df_varargs_api
     def min(self, *cols: str) -> DataFrame:
         """Computes the min value for each numeric column for each group.
@@ -352,7 +361,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Group-by name, and calculate the min of the age in each group.
 
-        >>> df.groupBy("name").min("age").sort("name").show()
+        >>> df.groupBy("name").min("age").sort("name").show()  # doctest: +SKIP
         +-----+--------+
         | name|min(age)|
         +-----+--------+
@@ -362,7 +371,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Calculate the min of the age and height in all data.
 
-        >>> df.groupBy().min("age", "height").show()
+        >>> df.groupBy().min("age", "height").show()  # doctest: +SKIP
         +--------+-----------+
         |min(age)|min(height)|
         +--------+-----------+
@@ -370,6 +379,8 @@ class GroupedData(PandasGroupedOpsMixin):
         +--------+-----------+
         """
 
+    # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
+    # TODO(SPARK-41749): Support multiple arguments in groupBy.sum(...)
     @df_varargs_api
     def sum(self, *cols: str) -> DataFrame:
         """Computes the sum for each numeric columns for each group.
@@ -401,7 +412,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Group-by name, and calculate the sum of the age in each group.
 
-        >>> df.groupBy("name").sum("age").sort("name").show()
+        >>> df.groupBy("name").sum("age").sort("name").show()  # doctest: +SKIP
         +-----+--------+
         | name|sum(age)|
         +-----+--------+
@@ -411,7 +422,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Calculate the sum of the age and height in all data.
 
-        >>> df.groupBy().sum("age", "height").show()
+        >>> df.groupBy().sum("age", "height").show()  # doctest: +SKIP
         +--------+-----------+
         |sum(age)|sum(height)|
         +--------+-----------+
@@ -419,6 +430,8 @@ class GroupedData(PandasGroupedOpsMixin):
         +--------+-----------+
         """
 
+    # TODO(SPARK-41745): SparkSession.createDataFrame does not respect the column names in the row
+    # TODO(SPARK-41746): SparkSession.createDataFrame does not support nested datatypes
     def pivot(self, pivot_col: str, values: Optional[List["LiteralType"]] = None) -> "GroupedData":
         """
         Pivots a column of the current :class:`DataFrame` and perform the specified aggregation.
@@ -446,7 +459,7 @@ class GroupedData(PandasGroupedOpsMixin):
         ...     Row(course="dotNET", year=2013, earnings=48000),
         ...     Row(course="Java", year=2013, earnings=30000),
         ... ])
-        >>> df1.show()
+        >>> df1.show()  # doctest: +SKIP
         +------+----+--------+
         |course|year|earnings|
         +------+----+--------+
@@ -462,8 +475,8 @@ class GroupedData(PandasGroupedOpsMixin):
         ...     Row(training="expert", sales=Row(course="dotNET", year=2012, earnings=5000)),
         ...     Row(training="junior", sales=Row(course="dotNET", year=2013, earnings=48000)),
         ...     Row(training="expert", sales=Row(course="Java", year=2013, earnings=30000)),
-        ... ])
-        >>> df2.show()
+        ... ])  # doctest: +SKIP
+        >>> df2.show()  # doctest: +SKIP
         +--------+--------------------+
         |training|               sales|
         +--------+--------------------+
@@ -477,6 +490,7 @@ class GroupedData(PandasGroupedOpsMixin):
         Compute the sum of earnings for each year by course with each course as a separate column
 
         >>> df1.groupBy("year").pivot("course", ["dotNET", "Java"]).sum("earnings").show()
+        ... # doctest: +SKIP
         +----+------+-----+
         |year|dotNET| Java|
         +----+------+-----+
@@ -486,7 +500,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Or without specifying column values (less efficient)
 
-        >>> df1.groupBy("year").pivot("course").sum("earnings").show()
+        >>> df1.groupBy("year").pivot("course").sum("earnings").show()  # doctest: +SKIP
         +----+-----+------+
         |year| Java|dotNET|
         +----+-----+------+
@@ -494,6 +508,7 @@ class GroupedData(PandasGroupedOpsMixin):
         |2013|30000| 48000|
         +----+-----+------+
         >>> df2.groupBy("sales.year").pivot("sales.course").sum("sales.earnings").show()
+        ... # doctest: +SKIP
         +----+-----+------+
         |year| Java|dotNET|
         +----+-----+------+


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable doctests in `pyspark.sql.connect.group` that is virtually the same as `pyspark.sql.group`.

### Why are the changes needed?

To make sure on the PySpark compatibility and test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should test this out.