### PR TITLE
[SPARK-41631][FOLLOWUP][SQL] Fix two issues in implicit lateral column alias resolution on Aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
@@ -176,10 +176,10 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
           def eligibleToLiftUp(exp: Expression): Boolean = {
             exp match {
               case e if AggregateExpression.isAggregate(e) => true
-              case e: Attribute if !groupingExpressions.exists(_.semanticEquals(e)) => false
+              case e if groupingExpressions.exists(_.semanticEquals(e)) => true
+              case a: Attribute => false
               case s: ScalarSubquery if s.children.nonEmpty
                 && !groupingExpressions.exists(_.semanticEquals(s)) => false
-              case e if groupingExpressions.exists(_.semanticEquals(e)) => true
               case e => e.children.forall(eligibleToLiftUp)
             }
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeMap, Expression, LateralColumnAliasReference, LeafExpression, Literal, NamedExpression, ScalarSubquery}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, Expression, LateralColumnAliasReference, NamedExpression, ScalarSubquery}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -168,19 +168,18 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
             && aggregateExpressions.exists(_.containsPattern(LATERAL_COLUMN_ALIAS_REFERENCE)) =>
 
           // Check if current Aggregate is eligible to lift up with Project: the aggregate
-          // expression only contains: 1) aggregate functions, 2) grouping expressions, 3) lateral
-          // column alias reference or 4) literals.
+          // expression only contains: 1) aggregate functions, 2) grouping expressions, 3) leaf
+          // expressions excluding attributes not in grouping expressions
           // This check is to prevent unnecessary transformation on invalid plan, to guarantee it
           // throws the same exception. For example, cases like non-aggregate expressions not
           // in group by, once transformed, will throw a different exception: missing input.
           def eligibleToLiftUp(exp: Expression): Boolean = {
             exp match {
               case e if AggregateExpression.isAggregate(e) => true
-              case e if groupingExpressions.exists(_.semanticEquals(e)) => true
-              case _: Literal | _: LateralColumnAliasReference => true
+              case e: Attribute if !groupingExpressions.exists(_.semanticEquals(e)) => false
               case s: ScalarSubquery if s.children.nonEmpty
-                  && !groupingExpressions.exists(_.semanticEquals(s)) => false
-              case _: LeafExpression => false
+                && !groupingExpressions.exists(_.semanticEquals(s)) => false
+              case e if groupingExpressions.exists(_.semanticEquals(e)) => true
               case e => e.children.forall(eligibleToLiftUp)
             }
           }
@@ -210,14 +209,10 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
                 ne.toAttribute
             }.asInstanceOf[NamedExpression]
           }
-          if (newAggExprs.isEmpty) {
-            agg
-          } else {
-            Project(
-              projectList = projectExprs,
-              child = agg.copy(aggregateExpressions = newAggExprs.toSeq)
-            )
-          }
+          Project(
+            projectList = projectExprs,
+            child = agg.copy(aggregateExpressions = newAggExprs.toSeq)
+          )
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix two issues in implicit lateral column alias resolution of Aggregate; added related test cases.
* The check condition whether to lift up in Aggregate is incorrect. Leaf expressions, e.g. `now()` will fail the check and won't be lift up. Changed to follow the code pattern in checkAnalysis.
* Another condition that requires the new Aggregate expressions to be non-empty to lift up in Aggregate is unnecessary. Think about the Aggregate on expressions without any grouping expressions or aggregate expressions, e.g. `select 1 as a, a + 1 .. group by ..`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix the bug mentioned above.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New tests.