### PR TITLE
[SPARK-41747][SPARK-41744][SPARK-41748][SPARK-41749][CONNECT][TESTS] Reeanble tests for multiple arguments in max, min, sum and avg in groupby

### DIFF
--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -230,7 +230,6 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
-    # TODO(SPARK-41747): Support multiple arguments in groupBy.avg(...)
     @df_varargs_api
     def avg(self, *cols: str) -> DataFrame:
         """Computes average values for each numeric columns for each group.
@@ -274,7 +273,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Calculate the mean of the age and height in all data.
 
-        >>> df.groupBy().avg('age', 'height').show()  # doctest: +SKIP
+        >>> df.groupBy().avg('age', 'height').show()
         +--------+-----------+
         |avg(age)|avg(height)|
         +--------+-----------+
@@ -283,7 +282,6 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
-    # TODO(SPARK-41744): Support multiple arguments in groupBy.max(...)
     @df_varargs_api
     def max(self, *cols: str) -> DataFrame:
         """Computes the max value for each numeric columns for each group.
@@ -320,7 +318,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Calculate the max of the age and height in all data.
 
-        >>> df.groupBy().max("age", "height").show()  # doctest: +SKIP
+        >>> df.groupBy().max("age", "height").show()
         +--------+-----------+
         |max(age)|max(height)|
         +--------+-----------+
@@ -329,7 +327,6 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
-    # TODO(SPARK-41748): Support multiple arguments in groupBy.min(...)
     @df_varargs_api
     def min(self, *cols: str) -> DataFrame:
         """Computes the min value for each numeric column for each group.
@@ -371,7 +368,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Calculate the min of the age and height in all data.
 
-        >>> df.groupBy().min("age", "height").show()  # doctest: +SKIP
+        >>> df.groupBy().min("age", "height").show()
         +--------+-----------+
         |min(age)|min(height)|
         +--------+-----------+
@@ -380,7 +377,6 @@ class GroupedData(PandasGroupedOpsMixin):
         """
 
     # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
-    # TODO(SPARK-41749): Support multiple arguments in groupBy.sum(...)
     @df_varargs_api
     def sum(self, *cols: str) -> DataFrame:
         """Computes the sum for each numeric columns for each group.
@@ -422,7 +418,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Calculate the sum of the age and height in all data.
 
-        >>> df.groupBy().sum("age", "height").show()  # doctest: +SKIP
+        >>> df.groupBy().sum("age", "height").show()
         +--------+-----------+
         |sum(age)|sum(height)|
         +--------+-----------+


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is technically a followup of https://github.com/apache/spark/pull/39254 that enables the related doctests back.

### Why are the changes needed?

To reenable skipped tests.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Enabling skipped tests. Manually ran this and checked it locally.
