### PR TITLE
[SPARK-41751][CONNECT][PYTHON] Fix `Column.{bitwiseAND, bitwiseOR, bitwiseXOR}`

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -144,9 +144,9 @@ class Column:
         )
 
     # bitwise operators
-    bitwiseOR = _bin_op("bitwiseOR", PySparkColumn.bitwiseOR.__doc__)
-    bitwiseAND = _bin_op("bitwiseAND", PySparkColumn.bitwiseAND.__doc__)
-    bitwiseXOR = _bin_op("bitwiseXOR", PySparkColumn.bitwiseXOR.__doc__)
+    bitwiseOR = _bin_op("|", PySparkColumn.bitwiseOR.__doc__)
+    bitwiseAND = _bin_op("&", PySparkColumn.bitwiseAND.__doc__)
+    bitwiseXOR = _bin_op("^", PySparkColumn.bitwiseXOR.__doc__)
 
     isNull = _unary_op("isNull", PySparkColumn.isNull.__doc__)
     isNotNull = _unary_op("isNotNull", PySparkColumn.isNotNull.__doc__)

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -542,6 +542,46 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             ).toPandas(),
         )
 
+    def test_column_bitwise_ops(self):
+        # SPARK-41751: test bitwiseAND, bitwiseOR, bitwiseXOR
+        from pyspark.sql import functions as SF
+        from pyspark.sql.connect import functions as CF
+
+        query = """
+            SELECT * FROM VALUES
+            (1, 1, 0), (2, NULL, 1), (3, 3, 4)
+            AS tab(a, b, c)
+            """
+
+        # +---+----+---+
+        # |  a|   b|  c|
+        # +---+----+---+
+        # |  1|   1|  0|
+        # |  2|null|  1|
+        # |  3|   3|  4|
+        # +---+----+---+
+
+        cdf = self.connect.sql(query)
+        sdf = self.spark.sql(query)
+
+        # test bitwiseAND
+        self.assert_eq(
+            cdf.select(cdf.a.bitwiseAND(cdf.b), cdf["a"].bitwiseAND(CF.col("c"))).toPandas(),
+            sdf.select(sdf.a.bitwiseAND(sdf.b), sdf["a"].bitwiseAND(SF.col("c"))).toPandas(),
+        )
+
+        # test bitwiseOR
+        self.assert_eq(
+            cdf.select(cdf.a.bitwiseOR(cdf.b), cdf["a"].bitwiseOR(CF.col("c"))).toPandas(),
+            sdf.select(sdf.a.bitwiseOR(sdf.b), sdf["a"].bitwiseOR(SF.col("c"))).toPandas(),
+        )
+
+        # test bitwiseXOR
+        self.assert_eq(
+            cdf.select(cdf.a.bitwiseXOR(cdf.b), cdf["a"].bitwiseXOR(CF.col("c"))).toPandas(),
+            sdf.select(sdf.a.bitwiseXOR(sdf.b), sdf["a"].bitwiseXOR(SF.col("c"))).toPandas(),
+        )
+
     def test_column_accessor(self):
         from pyspark.sql import functions as SF
         from pyspark.sql.connect import functions as CF


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Implement `Column.{bitwiseAND, bitwiseOR, bitwiseXOR}`


### Why are the changes needed?
fix


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added ut
