### PR TITLE
[SPARK-41751][CONNECT][PYTHON] Fix `Column.{isNull, isNotNull, eqNullSafe}`

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -124,7 +124,7 @@ class Column:
     __ge__ = _bin_op(">=")
     __le__ = _bin_op("<=")
 
-    eqNullSafe = _bin_op("eqNullSafe", PySparkColumn.eqNullSafe.__doc__)
+    eqNullSafe = _bin_op("<=>", PySparkColumn.eqNullSafe.__doc__)
 
     __neg__ = _func_op("negate")
 
@@ -148,8 +148,8 @@ class Column:
     bitwiseAND = _bin_op("bitwiseAND", PySparkColumn.bitwiseAND.__doc__)
     bitwiseXOR = _bin_op("bitwiseXOR", PySparkColumn.bitwiseXOR.__doc__)
 
-    isNull = _unary_op("isNull", PySparkColumn.isNull.__doc__)
-    isNotNull = _unary_op("isNotNull", PySparkColumn.isNotNull.__doc__)
+    isNull = _unary_op("isnull", PySparkColumn.isNull.__doc__)
+    isNotNull = _unary_op("isnotnull", PySparkColumn.isNotNull.__doc__)
 
     def __ne__(  # type: ignore[override]
         self,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix `Column.{isNull, isNotNull, eqNullSafe}`


### Why are the changes needed?
they were wrongly implemented


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added UT
