### PR TITLE
[SPARK-41760][BUILD][CONNECT] Enforce scalafmt for Connect Client module

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -23,7 +23,8 @@ class SparkConnectClient(private val userContext: proto.UserContext) {
 
   /**
    * Placeholder method.
-   * @return User ID.
+   * @return
+   *   User ID.
    */
   def userId: String = userContext.getUserId()
 }

--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -30,13 +30,14 @@ ERRORS=$(./build/mvn \
     -Dscalafmt.validateOnly=true \
     -Dscalafmt.changedOnly=false \
     -pl connector/connect/server \
+    -pl connector/connect/client/jvm \
     2>&1 | grep -e "^Requires formatting" \
 )
 
 if test ! -z "$ERRORS"; then
   echo -e "The scalafmt check failed on connector/connect at following occurrences:\n\n$ERRORS\n"
   echo "Before submitting your change, please make sure to format your code using the following command:"
-  echo "./build/mvn -Pscala-2.12 scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect/server"
+  echo "./build/mvn -Pscala-2.12 scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect/server -pl connector/connect/client/jvm"
   exit 1
 else
   echo -e "Scalafmt checks passed."


### PR DESCRIPTION

### What changes were proposed in this pull request?
1. This changes enables enforcing `scalafmt` for the Connect client module since it's a new module.
2. This change applies `scalafmt` on the existing code-base.


### Why are the changes needed?
Faster, focussed code reviews.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Faster, focussed code reviews.
