### PR TITLE
[SPARK-41764][CONNECT][PYTHON] Make the internal string op name consistent with FunctionRegistry

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -160,8 +160,8 @@ class Column:
 
     # string methods
     contains = _bin_op("contains", PySparkColumn.contains.__doc__)
-    startswith = _bin_op("startsWith", PySparkColumn.startswith.__doc__)
-    endswith = _bin_op("endsWith", PySparkColumn.endswith.__doc__)
+    startswith = _bin_op("startswith", PySparkColumn.startswith.__doc__)
+    endswith = _bin_op("endswith", PySparkColumn.endswith.__doc__)
 
     def when(self, condition: "Column", value: Any) -> "Column":
         if not isinstance(condition, Column):

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -627,6 +627,52 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             for x in c:
                 pass
 
+    def test_column_string_ops(self):
+        # SPARK-41764: test string ops
+        query = """
+            SELECT * FROM VALUES
+            (1, 'abcdef', 'ghij', 'hello world', 'a'),
+            (2, 'abcd', 'efghij', 'how are you', 'd')
+            AS tab(a, b, c, d, e)
+            """
+
+        # +---+------+------+-----------+---+
+        # |  a|     b|     c|          d|  e|
+        # +---+------+------+-----------+---+
+        # |  1|abcdef|  ghij|hello world|  a|
+        # |  2|  abcd|efghij|how are you|  d|
+        # +---+------+------+-----------+---+
+
+        cdf = self.connect.sql(query)
+        sdf = self.spark.sql(query)
+
+        self.assert_eq(
+            cdf.select(
+                cdf.b.startswith("a"), cdf["c"].startswith("g"), cdf["b"].startswith(cdf.e)
+            ).toPandas(),
+            sdf.select(
+                sdf.b.startswith("a"), sdf["c"].startswith("g"), sdf["b"].startswith(sdf.e)
+            ).toPandas(),
+        )
+
+        self.assert_eq(
+            cdf.select(
+                cdf.b.endswith("a"), cdf["c"].endswith("j"), cdf["b"].endswith(cdf.e)
+            ).toPandas(),
+            sdf.select(
+                sdf.b.endswith("a"), sdf["c"].endswith("j"), sdf["b"].endswith(sdf.e)
+            ).toPandas(),
+        )
+
+        self.assert_eq(
+            cdf.select(
+                cdf.b.contains("a"), cdf["c"].contains("j"), cdf["b"].contains(cdf.e)
+            ).toPandas(),
+            sdf.select(
+                sdf.b.contains("a"), sdf["c"].contains("j"), sdf["b"].contains(sdf.e)
+            ).toPandas(),
+        )
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, Make the internal string op names `startswith`, `endswith` consistent with FunctionRegistry
2, add test for string ops

### Why are the changes needed?
1, for consistency
2, for test coverage


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added ut
