### PR TITLE
[SPARK-41578][SQL] Assign name to _LEGACY_ERROR_TEMP_2141

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -459,6 +459,11 @@
       "The index 0 is invalid. An index shall be either < 0 or > 0 (the first element has index 1)."
     ]
   },
+  "ENCODER_NOT_FOUND" : {
+    "message" : [
+      "Not found an encoder of the type <typeName> to Spark SQL internal representation. Consider to change the input type to one of supported at https://spark.apache.org/docs/latest/sql-ref-datatypes.html."
+    ]
+  },
   "FAILED_EXECUTE_UDF" : {
     "message" : [
       "Failed to execute user defined function (<functionName>: (<signature>) => <result>)"
@@ -4113,12 +4118,6 @@
   "_LEGACY_ERROR_TEMP_2140" : {
     "message" : [
       "`<fieldName>` is not a valid identifier of Java and cannot be used as field name",
-      "<walkedTypePath>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2141" : {
-    "message" : [
-      "No Encoder found for <tpe>",
       "<walkedTypePath>"
     ]
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -779,7 +779,7 @@ object ScalaReflection extends ScalaReflection {
         }
         ProductEncoder(ClassTag(getClassFromType(t)), params)
       case _ =>
-        throw QueryExecutionErrors.cannotFindEncoderForTypeError(tpe.toString, path)
+        throw QueryExecutionErrors.cannotFindEncoderForTypeError(tpe.toString)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1483,13 +1483,11 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "walkedTypePath" -> walkedTypePath.toString()))
   }
 
-  def cannotFindEncoderForTypeError(
-      tpe: String, walkedTypePath: WalkedTypePath): SparkUnsupportedOperationException = {
+  def cannotFindEncoderForTypeError(typeName: String): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(
-      errorClass = "_LEGACY_ERROR_TEMP_2141",
+      errorClass = "ENCODER_NOT_FOUND",
       messageParameters = Map(
-        "tpe" -> tpe,
-        "walkedTypePath" -> walkedTypePath.toString()))
+        "typeName" -> typeName))
   }
 
   def attributesForTypeUnsupportedError(schema: Schema): SparkUnsupportedOperationException = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderErrorMessageSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderErrorMessageSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.encoders
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkUnsupportedOperationException}
 import org.apache.spark.sql.Encoders
 
 class NonEncodable(i: Int)
@@ -52,50 +52,40 @@ class EncoderErrorMessageSuite extends SparkFunSuite {
   }
 
   test("nice error message for missing encoder") {
-    val errorMsg1 =
-      intercept[UnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable1]).getMessage
-    assert(errorMsg1.contains(
-      s"""root class: "${clsName[ComplexNonEncodable1]}""""))
-    assert(errorMsg1.contains(
-      s"""field (class: "${clsName[NonEncodable]}", name: "name1")"""))
+    checkError(
+      exception = intercept[
+        SparkUnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable1]),
+      errorClass = "ENCODER_NOT_FOUND",
+      parameters = Map("typeName" -> "org.apache.spark.sql.catalyst.encoders.NonEncodable")
+    )
 
-    val errorMsg2 =
-      intercept[UnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable2]).getMessage
-    assert(errorMsg2.contains(
-      s"""root class: "${clsName[ComplexNonEncodable2]}""""))
-    assert(errorMsg2.contains(
-      s"""field (class: "${clsName[ComplexNonEncodable1]}", name: "name2")"""))
-    assert(errorMsg1.contains(
-      s"""field (class: "${clsName[NonEncodable]}", name: "name1")"""))
+    checkError(
+      exception = intercept[
+        SparkUnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable2]),
+      errorClass = "ENCODER_NOT_FOUND",
+      parameters = Map("typeName" -> "org.apache.spark.sql.catalyst.encoders.NonEncodable")
+    )
 
-    val errorMsg3 =
-      intercept[UnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable3]).getMessage
-    assert(errorMsg3.contains(
-      s"""root class: "${clsName[ComplexNonEncodable3]}""""))
-    assert(errorMsg3.contains(
-      s"""field (class: "scala.Option", name: "name3")"""))
-    assert(errorMsg3.contains(
-      s"""option value class: "${clsName[NonEncodable]}""""))
+    checkError(
+      exception = intercept[
+        SparkUnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable3]),
+      errorClass = "ENCODER_NOT_FOUND",
+      parameters = Map("typeName" -> "org.apache.spark.sql.catalyst.encoders.NonEncodable")
+    )
 
-    val errorMsg4 =
-      intercept[UnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable4]).getMessage
-    assert(errorMsg4.contains(
-      s"""root class: "${clsName[ComplexNonEncodable4]}""""))
-    assert(errorMsg4.contains(
-      s"""field (class: "scala.Array", name: "name4")"""))
-    assert(errorMsg4.contains(
-      s"""array element class: "${clsName[NonEncodable]}""""))
+    checkError(
+      exception = intercept[
+        SparkUnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable4]),
+      errorClass = "ENCODER_NOT_FOUND",
+      parameters = Map("typeName" -> "org.apache.spark.sql.catalyst.encoders.NonEncodable")
+    )
 
-    val errorMsg5 =
-      intercept[UnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable5]).getMessage
-    assert(errorMsg5.contains(
-      s"""root class: "${clsName[ComplexNonEncodable5]}""""))
-    assert(errorMsg5.contains(
-      s"""field (class: "scala.Option", name: "name5")"""))
-    assert(errorMsg5.contains(
-      s"""option value class: "scala.Array""""))
-    assert(errorMsg5.contains(
-      s"""array element class: "${clsName[NonEncodable]}""""))
+    checkError(
+      exception = intercept[
+        SparkUnsupportedOperationException](ExpressionEncoder[ComplexNonEncodable5]),
+      errorClass = "ENCODER_NOT_FOUND",
+      parameters = Map("typeName" -> "org.apache.spark.sql.catalyst.encoders.NonEncodable")
+    )
   }
 
   private def clsName[T : ClassTag]: String = implicitly[ClassTag[T]].runtimeClass.getName


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR proposes to assign name to _LEGACY_ERROR_TEMP_2141, "ENCODER_NOT_FOUND".


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We should assign proper name to _LEGACY_ERROR_TEMP_*


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

`./build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite*`