### PR TITLE
[SPARK-41766][CORE] Handle decommission request sent before executor registration

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2242,6 +2242,16 @@ package object config {
       .checkValue(_ >= 0, "needs to be a non-negative value")
       .createWithDefault(0)
 
+  private[spark] val SCHEDULER_MAX_RETAINED_UNKNOWN_EXECUTORS =
+    ConfigBuilder("spark.scheduler.maxRetainedUnknownDecommissionExecutors")
+      .internal()
+      .doc("Max number of unknown executors by decommission to retain. This affects " +
+        "whether executor could receive decommission request sent before its registration.")
+      .version("3.4.0")
+      .intConf
+      .checkValue(_ >= 0, "needs to be a non-negative value")
+      .createWithDefault(0)
+
   private[spark] val PUSH_BASED_SHUFFLE_ENABLED =
     ConfigBuilder("spark.shuffle.push.enabled")
       .doc("Set to true to enable push-based shuffle on the client side and this works in " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2247,7 +2247,7 @@ package object config {
       .internal()
       .doc("Max number of unknown executors by decommission to retain. This affects " +
         "whether executor could receive decommission request sent before its registration.")
-      .version("3.4.0")
+      .version("3.5.0")
       .intConf
       .checkValue(_ >= 0, "needs to be a non-negative value")
       .createWithDefault(0)

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -555,6 +555,11 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         None
       }
     }
+
+    if (executorsToDecommission.isEmpty) {
+      return executorsToDecommission
+    }
+
     logInfo(s"Decommission executors: ${executorsToDecommission.mkString(", ")}")
 
     // If we don't want to replace the executors we are decommissioning

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -109,7 +109,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   // triggeredByExecutor).
   protected val unknownExecutorsPendingDecommission =
     CacheBuilder.newBuilder()
-      .maximumSize(1000)
+      .maximumSize(conf.get(SCHEDULER_MAX_RETAINED_UNKNOWN_EXECUTORS))
       .build[String, (ExecutorDecommissionInfo, Boolean, Boolean)]()
 
   // A map of ResourceProfile id to map of hostname with its possible task number running on it

--- a/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
@@ -498,6 +498,7 @@ class CoarseGrainedSchedulerBackendSuite extends SparkFunSuite with LocalSparkCo
     val conf = new SparkConf()
       .setMaster("local-cluster[0, 3, 1024]")
       .setAppName("test")
+      .set(SCHEDULER_MAX_RETAINED_UNKNOWN_EXECUTORS.key, "1")
 
     sc = new SparkContext(conf)
     val backend = sc.schedulerBackend.asInstanceOf[CoarseGrainedSchedulerBackend]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Handle decommission request sent before executor registration. When decom request is triggered from worker, executor should be decommissioned and not accept new tasks, but if scheduler backend got decom request before executor registration, the executor won't be decommissioned. So cache the unknown executors and resent decommission request after executor registration.

### Why are the changes needed?
Current behavior is such requests will be ignored

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added test in CoarseGrainedSchedulerBackendSuite
