### PR TITLE
[SPARK-41767][CONNECT][TESTS][FOLLOW-UP] Disable the doctests for dropFields and withField

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -443,6 +443,10 @@ def _test() -> None:
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
 
+        # TODO(SPARK-41746): SparkSession.createDataFrame does not support nested datatypes
+        del pyspark.sql.connect.column.Column.dropFields.__doc__
+        # TODO(SPARK-41772): Enable pyspark.sql.connect.column.Column.withField doctest
+        del pyspark.sql.connect.column.Column.withField.__doc__
         # TODO(SPARK-41751): Support Column.bitwiseAND,bitwiseOR,bitwiseXOR,eqNullSafe,isNotNull,
         # isNull,isin
         del pyspark.sql.connect.column.Column.bitwiseAND.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?

There is a logical conflict between https://github.com/apache/spark/pull/39249 and https://github.com/apache/spark/pull/39283. This PR fixes it with filing a related JIRA.

### Why are the changes needed?

To recover the build.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested via:

```bash
./python/run-tests --testnames 'pyspark.sql.connect.column'
```