### PR TITLE
[SPARK-41292][CONNECT] Support Window in pyspark.sql.window namespace

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -462,8 +462,6 @@ def _test() -> None:
         # TODO(SPARK-41771): __getitem__ does not work with Column.isin
         del pyspark.sql.connect.column.Column.getField.__doc__
         del pyspark.sql.connect.column.Column.getItem.__doc__
-        # TODO(SPARK-41758): Support Window functions
-        del pyspark.sql.connect.column.Column.over.__doc__
 
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.column,

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -113,8 +113,6 @@ class WindowSpec:
             frame=self._frame,
         )
 
-    partitionBy.__doc__ = PySparkWindowSpec.partitionBy.__doc__
-
     def orderBy(self, *cols: Union["ColumnOrName", List["ColumnOrName"]]) -> "WindowSpec":
         _cols: List[ColumnOrName] = []
         for col in cols:
@@ -149,8 +147,6 @@ class WindowSpec:
             frame=self._frame,
         )
 
-    orderBy.__doc__ = PySparkWindowSpec.orderBy.__doc__
-
     def rowsBetween(self, start: int, end: int) -> "WindowSpec":
         if not isinstance(start, int):
             raise TypeError(f"start must be a int, but got {type(start).__name__}")
@@ -167,8 +163,6 @@ class WindowSpec:
             orderSpec=self._orderSpec,
             frame=WindowFrame(isRowFrame=True, start=start, end=end),
         )
-
-    rowsBetween.__doc__ = PySparkWindowSpec.rowsBetween.__doc__
 
     def rangeBetween(self, start: int, end: int) -> "WindowSpec":
         if not isinstance(start, int):
@@ -187,8 +181,6 @@ class WindowSpec:
             frame=WindowFrame(isRowFrame=False, start=start, end=end),
         )
 
-    rangeBetween.__doc__ = PySparkWindowSpec.rangeBetween.__doc__
-
     def __repr__(self) -> str:
         strs: List[str] = []
         if len(self._partitionSpec) > 0:
@@ -202,6 +194,10 @@ class WindowSpec:
         return "WindowSpec(" + ", ".join(strs) + ")"
 
 
+WindowSpec.rangeBetween.__doc__ = PySparkWindowSpec.rangeBetween.__doc__
+WindowSpec.rowsBetween.__doc__ = PySparkWindowSpec.rowsBetween.__doc__
+WindowSpec.orderBy.__doc__ = PySparkWindowSpec.orderBy.__doc__
+WindowSpec.partitionBy.__doc__ = PySparkWindowSpec.partitionBy.__doc__
 WindowSpec.__doc__ = PySparkWindowSpec.__doc__
 
 
@@ -221,27 +217,23 @@ class Window:
     def partitionBy(*cols: Union["ColumnOrName", List["ColumnOrName"]]) -> "WindowSpec":
         return Window._spec.partitionBy(*cols)
 
-    partitionBy.__doc__ = PySparkWindow.partitionBy.__doc__
-
     @staticmethod
     def orderBy(*cols: Union["ColumnOrName", List["ColumnOrName"]]) -> "WindowSpec":
         return Window._spec.orderBy(*cols)
-
-    orderBy.__doc__ = PySparkWindow.orderBy.__doc__
 
     @staticmethod
     def rowsBetween(start: int, end: int) -> "WindowSpec":
         return Window._spec.rowsBetween(start, end)
 
-    rowsBetween.__doc__ = PySparkWindow.rowsBetween.__doc__
-
     @staticmethod
     def rangeBetween(start: int, end: int) -> "WindowSpec":
         return Window._spec.rangeBetween(start, end)
 
-    rangeBetween.__doc__ = PySparkWindow.rangeBetween.__doc__
 
-
+Window.orderBy.__doc__ = PySparkWindow.orderBy.__doc__
+Window.rowsBetween.__doc__ = PySparkWindow.rowsBetween.__doc__
+Window.rangeBetween.__doc__ = PySparkWindow.rangeBetween.__doc__
+Window.partitionBy.__doc__ = PySparkWindow.partitionBy.__doc__
 Window.__doc__ = PySparkWindow.__doc__
 
 

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -341,10 +341,29 @@ def try_remote_window(f: FuncT) -> FuncT:
 
     @functools.wraps(f)
     def wrapped(*args: Any, **kwargs: Any) -> Any:
-        # TODO(SPARK-41292): Support Window functions
+
         if is_remote():
-            raise NotImplementedError()
-        return f(*args, **kwargs)
+            from pyspark.sql.connect.window import Window
+
+            return getattr(Window, f.__name__)(*args, **kwargs)
+        else:
+            return f(*args, **kwargs)
+
+    return cast(FuncT, wrapped)
+
+
+def try_remote_windowspec(f: FuncT) -> FuncT:
+    """Mark API supported from Spark Connect."""
+
+    @functools.wraps(f)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+
+        if is_remote():
+            from pyspark.sql.connect.window import WindowSpec
+
+            return getattr(WindowSpec, f.__name__)(*args, **kwargs)
+        else:
+            return f(*args, **kwargs)
 
     return cast(FuncT, wrapped)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to support Spark Connect's Window in `pyspark.sql.window` namespace.

https://github.com/apache/spark/pull/39041 implemented the base, and https://github.com/apache/spark/pull/39149 implemented Spark Connect's Window.

This PR connects them.

### Why are the changes needed?

To provide the users the same usage, see also https://github.com/apache/spark/pull/39041.

### Does this PR introduce _any_ user-facing change?

Yes, see also https://github.com/apache/spark/pull/39041.
Spark Connect can use Window functions via the same namespace `pyspark.sql.window`.

### How was this patch tested?

Manually checked the related unittests.