### PR TITLE
[SPARK-41774][PYTHON][TESTS] Remove duplicated `test_vectorized_udf_unsupported_types` test

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -676,15 +676,6 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
             res = df.select(f(col("id"), col("id")))
             self.assertEqual(df.collect(), res.collect())
 
-    def test_vectorized_udf_unsupported_types(self):
-        with QuietTest(self.sc):
-            for udf_type in [PandasUDFType.SCALAR, PandasUDFType.SCALAR_ITER]:
-                with self.assertRaisesRegex(
-                    NotImplementedError,
-                    "Invalid return type.*scalar Pandas UDF.*ArrayType.*TimestampType",
-                ):
-                    pandas_udf(lambda x: x, ArrayType(TimestampType()), udf_type)
-
     def test_vectorized_udf_dates(self):
         schema = StructType().add("idx", LongType()).add("date", DateType())
         data = [


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/spark/blob/18488158beee5435f99899f99b2e90fb6e37f3d5/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py#L603


```
def test_vectorized_udf_wrong_return_type(self):
        with QuietTest(self.sc):
            for udf_type in [PandasUDFType.SCALAR, PandasUDFType.SCALAR_ITER]:
                with self.assertRaisesRegex(
                    NotImplementedError,
                    "Invalid return type.*scalar Pandas UDF.*ArrayType.*TimestampType",
                ):
                    pandas_udf(lambda x: x, ArrayType(TimestampType()), udf_type)
```

is the same code as 

https://github.com/apache/spark/blob/18488158beee5435f99899f99b2e90fb6e37f3d5/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py#L679


```
def test_vectorized_udf_unsupported_types(self):
        with QuietTest(self.sc):
            for udf_type in [PandasUDFType.SCALAR, PandasUDFType.SCALAR_ITER]:
                with self.assertRaisesRegex(
                    NotImplementedError,
                    "Invalid return type.*scalar Pandas UDF.*ArrayType.*TimestampType",
                ):
                    pandas_udf(lambda x: x, ArrayType(TimestampType()), udf_type)
```


[Sonarcloud](https://sonarcloud.io/project/issues?languages=py&resolved=false&rules=python%3AS4144&id=spark-python&open=AYQdnW-FRrJbVxW9ZDO0)

### Why are the changes needed?
We don't need to have this double or we can fix one of them. 


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA
