### PR TITLE
[SPARK-41742] Support df.groupBy().agg({"*":"count"})

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -80,8 +80,14 @@ class GroupedData:
 
         assert exprs, "exprs should not be empty"
         if len(exprs) == 1 and isinstance(exprs[0], dict):
+            # There is a special case for count(*) which is rewritten into count(1).
             # Convert the dict into key value pairs
-            aggregate_cols = [scalar_function(exprs[0][k], col(k)) for k in exprs[0]]
+            aggregate_cols = [
+                scalar_function(
+                    exprs[0][k], lit(1) if exprs[0][k] == "count" and k == "*" else col(k)
+                )
+                for k in exprs[0]
+            ]
         else:
             # Columns
             assert all(isinstance(c, Column) for c in exprs), "all exprs should be Column"

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -78,8 +78,6 @@ class GroupedData(PandasGroupedOpsMixin):
     def agg(self, __exprs: Dict[str, str]) -> DataFrame:
         ...
 
-    # TODO(SPARK-41279): Enable the doctest with supporting the star in Spark Connect.
-    # TODO(SPARK-41743): groupBy(...).agg(...).sort does not actually sort the output
     def agg(self, *exprs: Union[Column, Dict[str, str]]) -> DataFrame:
         """Compute aggregates and returns the result as a :class:`DataFrame`.
 
@@ -135,7 +133,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
         Group-by name, and count each group.
 
-        >>> df.groupBy(df.name).agg({"*": "count"}).sort("name").show()  # doctest: +SKIP
+        >>> df.groupBy(df.name).agg({"*": "count"}).sort("name").show()
         +-----+--------+
         | name|count(1)|
         +-----+--------+


### PR DESCRIPTION
### What changes were proposed in this pull request?
Compatibility changes to support `count(*)` for DF operations that are rewritten into `count(1)`.

### Why are the changes needed?
Compatibility.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT