### PR TITLE
[SPARK-41779][SPARK-41771][CONNECT][PYTHON] Make `__getitem__` support filter and select

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -458,8 +458,6 @@ def _test() -> None:
         #  the row
         del pyspark.sql.connect.column.Column.isNotNull.__doc__
         del pyspark.sql.connect.column.Column.isNull.__doc__
-        del pyspark.sql.connect.column.Column.isin.__doc__
-        # TODO(SPARK-41771): __getitem__ does not work with Column.isin
         del pyspark.sql.connect.column.Column.getField.__doc__
         del pyspark.sql.connect.column.Column.getItem.__doc__
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make dataframe `__getitem__` support:
1, filter: `cdf[cdf.a.isin(1, 2, 3)]`
2, select: `cdf[["col1", cdf.a]]`
3, index: `cdf[0]`

### Why are the changes needed?
to be consistent with [PySpark](https://github.com/apache/spark/blob/master/python/pyspark/sql/dataframe.py#L2764-L2825)

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added UT
