### PR TITLE
[SPARK-41783][SPARK-41770][CONNECT][PYTHON] Make column op support None

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -72,7 +72,7 @@ def _bin_op(
     def wrapped(self: "Column", other: Any) -> "Column":
         from pyspark.sql.connect.functions import lit
 
-        if isinstance(
+        if other is None or isinstance(
             other, (bool, float, int, str, datetime.datetime, datetime.date, decimal.Decimal)
         ):
             other = lit(other)
@@ -255,7 +255,7 @@ class Column:
         """
         from pyspark.sql.connect.functions import lit
 
-        if isinstance(
+        if other is None or isinstance(
             other, (bool, float, int, str, datetime.datetime, datetime.date, decimal.Decimal)
         ):
             other = lit(other)
@@ -452,7 +452,8 @@ def _test() -> None:
         del pyspark.sql.connect.column.Column.bitwiseAND.__doc__
         del pyspark.sql.connect.column.Column.bitwiseOR.__doc__
         del pyspark.sql.connect.column.Column.bitwiseXOR.__doc__
-        # TODO(SPARK-41770): eqNullSafe does not support None as its argument
+        # TODO(SPARK-41745): SparkSession.createDataFrame does not respect the column names in
+        #  the row
         del pyspark.sql.connect.column.Column.eqNullSafe.__doc__
         # TODO(SPARK-41745): SparkSession.createDataFrame does not respect the column names in
         #  the row

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -228,8 +228,8 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         # |               null|2022-12-22|null|
         # +-------------------+----------+----+
 
-        cdf = self.spark.sql(query)
-        sdf = self.connect.sql(query)
+        cdf = self.connect.sql(query)
+        sdf = self.spark.sql(query)
 
         # datetime.date
         self.assert_eq(
@@ -286,8 +286,8 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         # |  3|   3|  4| 3.5|
         # +---+----+---+----+
 
-        cdf = self.spark.sql(query)
-        sdf = self.connect.sql(query)
+        cdf = self.connect.sql(query)
+        sdf = self.spark.sql(query)
 
         self.assert_eq(
             cdf.select(cdf.a < decimal.Decimal(3)).toPandas(),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make column op support None


### Why are the changes needed?
to be consistent with PySpark


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added UT
