### PR TITLE
[SPARK-41784][CONNECT][PYTHON] Add missing `__rmod__` in Column

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -122,6 +122,7 @@ class Column:
     __rmul__ = _bin_op("*", reverse=True)
     __rdiv__ = _bin_op("/", reverse=True)
     __rtruediv__ = _bin_op("/", reverse=True)
+    __rmod__ = _bin_op("%", reverse=True)
     __pow__ = _bin_op("power")
     __rpow__ = _bin_op("power", reverse=True)
     __ge__ = _bin_op(">=")

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -760,8 +760,8 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         )
 
         self.assert_eq(
-            cdf.select(cdf.a % cdf["b"], cdf["a"] % 2).toPandas(),
-            sdf.select(sdf.a % sdf["b"], sdf["a"] % 2).toPandas(),
+            cdf.select(cdf.a % cdf["b"], cdf["a"] % 2, 12 % cdf.c).toPandas(),
+            sdf.select(sdf.a % sdf["b"], sdf["a"] % 2, 12 % sdf.c).toPandas(),
         )
 
         self.assert_eq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add missing `__rmod__` in Column


### Why are the changes needed?
to be consistent with PySpark


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing UT