### PR TITLE
[SPARK-41785][CONNECT][PYTHON] Implement `GroupedData.mean`

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -168,8 +168,6 @@ class GroupedData:
 
     mean = avg
 
-    mean.__doc__ = PySparkGroupedData.mean.__doc__
-
     def count(self) -> "DataFrame":
         return self.agg(scalar_function("count", lit(1)))
 

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -166,6 +166,10 @@ class GroupedData:
 
     avg.__doc__ = PySparkGroupedData.avg.__doc__
 
+    mean = avg
+
+    mean.__doc__ = PySparkGroupedData.mean.__doc__
+
     def count(self) -> "DataFrame":
         return self.agg(scalar_function("count", lit(1)))
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1387,6 +1387,10 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             sdf.groupBy("name", sdf.department).avg("salary", "year").toPandas(),
         )
         self.assert_eq(
+            cdf.groupBy("name", cdf.department).mean("salary", "year").toPandas(),
+            sdf.groupBy("name", sdf.department).mean("salary", "year").toPandas(),
+        )
+        self.assert_eq(
             cdf.groupBy("name", cdf.department).sum("salary", "year").toPandas(),
             sdf.groupBy("name", sdf.department).sum("salary", "year").toPandas(),
         )
@@ -1409,6 +1413,10 @@ class SparkConnectTests(SparkConnectSQLTestCase):
             sdf.rollup("name", sdf.department).avg("salary", "year").toPandas(),
         )
         self.assert_eq(
+            cdf.rollup("name", cdf.department).mean("salary", "year").toPandas(),
+            sdf.rollup("name", sdf.department).mean("salary", "year").toPandas(),
+        )
+        self.assert_eq(
             cdf.rollup("name", cdf.department).sum("salary", "year").toPandas(),
             sdf.rollup("name", sdf.department).sum("salary", "year").toPandas(),
         )
@@ -1417,6 +1425,10 @@ class SparkConnectTests(SparkConnectSQLTestCase):
         self.assert_eq(
             cdf.cube("name").avg().toPandas(),
             sdf.cube("name").avg().toPandas(),
+        )
+        self.assert_eq(
+            cdf.cube("name").mean().toPandas(),
+            sdf.cube("name").mean().toPandas(),
         )
         self.assert_eq(
             cdf.cube("name").min("salary").toPandas(),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `GroupedData.mean` - the last missing API for grouped data


### Why are the changes needed?
for api coverage


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
added ut
