### PR TITLE
[SPARK-41781][K8S] Add the ability to create pvc before creating driver/executor pod

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesExecutorSpec.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesExecutorSpec.scala
@@ -20,4 +20,5 @@ import io.fabric8.kubernetes.api.model.HasMetadata
 
 private[spark] case class KubernetesExecutorSpec(
     pod: SparkPod,
+    executorPreKubernetesResources: Seq[HasMetadata],
     executorKubernetesResources: Seq[HasMetadata])

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -418,7 +418,7 @@ object KubernetesUtils extends Logging {
   /**
    * Create pre-resource in need before pod creation
    */
-  @Since("3.4.0")
+  @Since("3.5.0")
   def createPreResource(
       client: KubernetesClient,
       resource: HasMetadata,
@@ -435,7 +435,7 @@ object KubernetesUtils extends Logging {
    * Refresh OwnerReference in the given resource
    * making the driver or executor pod an owner of them
    */
-  @Since("3.4.0")
+  @Since("3.5.0")
   def refreshOwnerReferenceInResource(
       client: KubernetesClient,
       resource: HasMetadata,
@@ -450,13 +450,13 @@ object KubernetesUtils extends Logging {
             .withName(pvc.getMetadata.getName)
             .get()
         addOwnerReference(pod, Seq(createdPVC))
-        logDebug(s"Trying to refresh PersistentVolumeClaim ${pvc.getMetadata.getName} with " +
-          s"OwnerReference ${pvc.getMetadata.getOwnerReferences}")
+        logDebug(s"Trying to refresh PersistentVolumeClaim ${createdPVC.getMetadata.getName}" +
+          s"with OwnerReference ${createdPVC.getMetadata.getOwnerReferences}")
         client
           .persistentVolumeClaims()
           .inNamespace(namespace)
-          .withName(pvc.getMetadata.getName)
-          .patch(pvc)
+          .withName(createdPVC.getMetadata.getName)
+          .patch(createdPVC)
       case other =>
         addOwnerReference(pod, Seq(other))
         client.resourceList(Seq(other): _*).createOrReplace()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
@@ -29,7 +29,7 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
   extends KubernetesFeatureConfigStep {
   import MountVolumesFeatureStep._
 
-  val additionalResources = ArrayBuffer.empty[HasMetadata]
+  val additionalPreResources = ArrayBuffer.empty[HasMetadata]
 
   override def configurePod(pod: SparkPod): SparkPod = {
     val (volumeMounts, volumes) = constructVolumes(conf.volumes).unzip
@@ -82,7 +82,7 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
                 .replaceAll(PVC_ON_DEMAND, s"${conf.resourceNamePrefix}-driver$PVC_POSTFIX-$i")
           }
           if (storageClass.isDefined && size.isDefined) {
-            additionalResources.append(new PersistentVolumeClaimBuilder()
+            additionalPreResources.append(new PersistentVolumeClaimBuilder()
               .withKind(PVC)
               .withApiVersion("v1")
               .withNewMetadata()
@@ -119,8 +119,8 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
     }
   }
 
-  override def getAdditionalKubernetesResources(): Seq[HasMetadata] = {
-    additionalResources.toSeq
+  override def getAdditionalPreKubernetesResources(): Seq[HasMetadata] = {
+    additionalPreResources.toSeq
   }
 
   private def checkPVCClaimName(claimName: String): Unit = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -468,14 +468,10 @@ class ExecutorPodsAllocator(
       // Refresh all pre-resources' owner references
       preResources.foreach { resource =>
         try {
-          if (resource.isInstanceOf[PersistentVolumeClaim]) {
-            if (conf.get(KUBERNETES_DRIVER_OWN_PVC) && driverPod.nonEmpty) {
-              refreshOwnerReferenceInResource(kubernetesClient, resource, namespace,
-                driverPod.get)
-            } else {
-              refreshOwnerReferenceInResource(kubernetesClient, resource, namespace,
-                createdExecutorPod)
-            }
+          if (resource.isInstanceOf[PersistentVolumeClaim] &&
+            conf.get(KUBERNETES_DRIVER_OWN_PVC) && driverPod.nonEmpty) {
+            refreshOwnerReferenceInResource(kubernetesClient, resource, namespace,
+              driverPod.get)
           } else {
             refreshOwnerReferenceInResource(kubernetesClient, resource, namespace,
               createdExecutorPod)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -75,15 +75,18 @@ private[spark] class KubernetesExecutorBuilder {
 
     val spec = KubernetesExecutorSpec(
       initialPod,
+      executorPreKubernetesResources = Seq.empty,
       executorKubernetesResources = Seq.empty)
 
     // If using a template this will always get the resources from that and combine
     // them with any Spark conf or ResourceProfile resources.
     features.foldLeft(spec) { case (spec, feature) =>
       val configuredPod = feature.configurePod(spec.pod)
+      val addedPreResources = feature.getAdditionalPreKubernetesResources()
       val addedResources = feature.getAdditionalKubernetesResources()
       KubernetesExecutorSpec(
         configuredPod,
+        spec.executorPreKubernetesResources ++ addedPreResources,
         spec.executorKubernetesResources ++ addedResources)
     }
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/StatefulSetPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/StatefulSetPodsAllocator.scala
@@ -127,10 +127,10 @@ class StatefulSetPodsAllocator(
       val meta = executorPod.pod.getMetadata()
 
       // Resources that need to be created, volumes are per-pod which is all we care about here.
-      val resources = resolvedExecutorSpec.executorKubernetesResources
+      val preResources = resolvedExecutorSpec.executorPreKubernetesResources
       // We'll let PVCs be handled by the statefulset. Note user is responsible for
       // cleaning up PVCs. Future work: integrate with KEP1847 once stabilized.
-      val dynamicVolumeClaims = resources.filter(_.getKind == "PersistentVolumeClaim")
+      val dynamicVolumeClaims = preResources.filter(_.getKind == "PersistentVolumeClaim")
         .map(_.asInstanceOf[PersistentVolumeClaim])
       // Remove the dynamic volumes from our pod
       val dynamicVolumeClaimNames: Set[String] = dynamicVolumeClaims.map(_.getMetadata().getName())

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/StatefulSetAllocatorSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/StatefulSetAllocatorSuite.scala
@@ -103,7 +103,7 @@ class StatefulSetAllocatorSuite extends SparkFunSuite with BeforeAndAfter {
     (invocation: InvocationOnMock) => {
       val k8sConf: KubernetesExecutorConf = invocation.getArgument(0)
       KubernetesExecutorSpec(executorPodWithId(0,
-        k8sConf.resourceProfileId.toInt), Seq.empty)
+        k8sConf.resourceProfileId.toInt), Seq.empty, Seq.empty)
   }
 
   before {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This patch aims to make PVCs as pre-resources and setup them before driver/executor Pod creation. After this patch, the workflow looks like this:
* setup pre-resources (including PVCs) before Pod creation
* create Pod
* refresh all pre-resources' owner references as created Pod
* make the created Pod an owner of other resources and create them

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These pre-resources are usually necessary in Pod creation and scheduling, they should be ready before Pod creation, should be deleted when user delete Pod, the lifecycle of these resource is same with Pod.   

If PVCs are created after Pod creation, we will have warning event in Pod as follow:  
```plain
error getting PVC "spark/application-exec-1-pvc-0": could not find v1.PersistentVolumeClaim "spark/application-exec-1-pvc-0" 
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add new UTs.