### PR TITLE
[SPARK-41790][SQL] Set TRANSFORM reader and writer's format correctly

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -751,14 +751,14 @@ class SparkSqlAstBuilder extends AstBuilder {
           (Nil, Option(name), props, recordHandler)
       }
 
-      val (inFormat, inSerdeClass, inSerdeProps, reader) =
+      val (outFormat, outSerdeClass, outSerdeProps, reader) =
         format(
-          inRowFormat, "hive.script.recordreader",
+          outRowFormat, "hive.script.recordreader",
           "org.apache.hadoop.hive.ql.exec.TextRecordReader")
 
-      val (outFormat, outSerdeClass, outSerdeProps, writer) =
+      val (inFormat, inSerdeClass, inSerdeProps, writer) =
         format(
-          outRowFormat, "hive.script.recordwriter",
+          inRowFormat, "hive.script.recordwriter",
           "org.apache.hadoop.hive.ql.exec.TextRecordWriter")
 
       ScriptInputOutputSchema(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -751,6 +751,9 @@ class SparkSqlAstBuilder extends AstBuilder {
           (Nil, Option(name), props, recordHandler)
       }
 
+      // The Writer uses inFormat to feed input data into the running script and
+      // the reader uses outFormat to read the output from the running script,
+      // this behavior is same with hive.
       val (inFormat, inSerdeClass, inSerdeProps, writer) =
         format(
           inRowFormat, "hive.script.recordwriter",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -751,15 +751,15 @@ class SparkSqlAstBuilder extends AstBuilder {
           (Nil, Option(name), props, recordHandler)
       }
 
-      val (outFormat, outSerdeClass, outSerdeProps, reader) =
-        format(
-          outRowFormat, "hive.script.recordreader",
-          "org.apache.hadoop.hive.ql.exec.TextRecordReader")
-
       val (inFormat, inSerdeClass, inSerdeProps, writer) =
         format(
           inRowFormat, "hive.script.recordwriter",
           "org.apache.hadoop.hive.ql.exec.TextRecordWriter")
+
+      val (outFormat, outSerdeClass, outSerdeProps, reader) =
+        format(
+          outRowFormat, "hive.script.recordreader",
+          "org.apache.hadoop.hive.ql.exec.TextRecordReader")
 
       ScriptInputOutputSchema(
         inFormat, outFormat,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -670,26 +670,6 @@ abstract class BaseScriptTransformationSuite extends SparkPlanTest with SQLTestU
       ),
       df.select($"col").collect())
   }
-
-  test("SPARK-41790: Set TRANSFORM reader and writer's format correctly") {
-    withTempView("v") {
-      val df = Seq(
-        (1, 2)
-      ).toDF("a", "b")
-      df.createTempView("v")
-
-      checkAnswer(
-        sql(
-          s"""
-             |SELECT TRANSFORM(a, b)
-             |  ROW FORMAT DELIMITED
-             |  FIELDS TERMINATED BY ','
-             |  USING 'cat'
-             |  AS (c)
-             |FROM v
-        """.stripMargin), identity, Row("1,2") :: Nil)
-    }
-  }
 }
 
 case class ExceptionInjectingOperator(child: SparkPlan) extends UnaryExecNode {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BaseScriptTransformationSuite.scala
@@ -670,6 +670,26 @@ abstract class BaseScriptTransformationSuite extends SparkPlanTest with SQLTestU
       ),
       df.select($"col").collect())
   }
+
+  test("SPARK-41790: Set TRANSFORM reader and writer's format correctly") {
+    withTempView("v") {
+      val df = Seq(
+        (1, 2)
+      ).toDF("a", "b")
+      df.createTempView("v")
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT TRANSFORM(a, b)
+             |  ROW FORMAT DELIMITED
+             |  FIELDS TERMINATED BY ','
+             |  USING 'cat'
+             |  AS (c)
+             |FROM v
+        """.stripMargin), identity, Row("1,2") :: Nil)
+    }
+  }
 }
 
 case class ExceptionInjectingOperator(child: SparkPlan) extends UnaryExecNode {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -638,4 +638,24 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
         Row("1") :: Row("2") :: Row("3") :: Nil)
     }
   }
+
+  test("SPARK-41790: Set TRANSFORM reader and writer's format correctly") {
+    withTempView("v") {
+      val df = Seq(
+        (1, 2)
+      ).toDF("a", "b")
+      df.createTempView("v")
+
+      checkAnswer(
+        sql(
+          s"""
+             |SELECT TRANSFORM(a, b)
+             |  ROW FORMAT DELIMITED
+             |  FIELDS TERMINATED BY ','
+             |  USING 'cat'
+             |  AS (c)
+             |FROM v
+          """.stripMargin), identity, Row("1,2") :: Nil)
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We'll get wrong data when transform only specify reader or writer 's row format delimited, the reason is using the wrong format to feed/fetch data to/from running script now. we should set the format correctly.

Currently in Spark:
```sql
spark-sql> CREATE TABLE t1 (a string, b string); 

spark-sql> INSERT OVERWRITE t1 VALUES("1", "2"), ("3", "4");

spark-sql> SELECT TRANSFORM(a, b)
         >   ROW FORMAT DELIMITED
         >   FIELDS TERMINATED BY ','
         >   USING 'cat'
         >   AS (c)
         > FROM t1;
c

spark-sql> SELECT TRANSFORM(a, b)
         >   USING 'cat'
         >   AS (c)
         >   ROW FORMAT DELIMITED
         >   FIELDS TERMINATED BY ','
         > FROM t1;
c
1    23    4
```

The same sql in hive:
```sql
hive> SELECT TRANSFORM(a, b)
    >   ROW FORMAT DELIMITED
    >   FIELDS TERMINATED BY ','
    >   USING 'cat'
    >   AS (c)
    > FROM t1;
c
1,2
3,4

hive> SELECT TRANSFORM(a, b)
    >   USING 'cat'
    >   AS (c)
    >   ROW FORMAT DELIMITED
    >   FIELDS TERMINATED BY ','
    > FROM t1;
c
1    2
3    4
```
 
### Why are the changes needed?
Fix transform writer format and reader format.

### Does this PR introduce _any_ user-facing change?
When we set transform's row format delimited in the sql, we may get the wrong data.

### How was this patch tested?
New tests.
