### PR TITLE
[SPARK-41731][CONNECT][TESTS] Disable ANSI mode in pyspark.sql.tests.connect.test_connect_column

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -966,8 +966,12 @@ class SparkConnectTests(SparkConnectSQLTestCase):
 
 
 if __name__ == "__main__":
+    import os
     import unittest
     from pyspark.sql.tests.connect.test_connect_column import *  # noqa: F401
+
+    # TODO(SPARK-41794): Enable ANSI mode in this file.
+    os.environ["SPARK_ANSI_SQL_MODE"] = "false"
 
     try:
         import xmlrunner


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to disable ANSI mode in `pyspark.sql.tests.connect.test_connect_column` temporarily.

This is a sort of a followup of https://github.com/apache/spark/pull/39241 and https://github.com/apache/spark/pull/39276.

### Why are the changes needed?

To recover the broken ASNI build https://github.com/apache/spark/actions/runs/3791006074/jobs/6446116146. This is similar with https://github.com/apache/spark/pull/39092.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested via:

```bash
SPARK_ANSI_SQL_MODE=true ./python/run-tests --testnames 'pyspark.sql.tests.connect.test_connect_column'
```