### PR TITLE
[SPARK-41797][CONNECT][PYTHON][TESTS] Enable test for `array_repeat`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -969,13 +969,10 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
             cdf.select(CF.array_repeat("f", cdf.d)).toPandas(),
             sdf.select(SF.array_repeat("f", sdf.d)).toPandas(),
         )
-        # TODO: Make Literal contains DataType
-        #   Cannot resolve "array_repeat(f, 3)" due to data type mismatch:
-        #   Parameter 2 requires the "INT" type, however "3" has the type "BIGINT".
-        # self.assert_eq(
-        #     cdf.select(CF.array_repeat("f", 3)).toPandas(),
-        #     sdf.select(SF.array_repeat("f", 3)).toPandas(),
-        # )
+        self.assert_eq(
+            cdf.select(CF.array_repeat("f", 3)).toPandas(),
+            sdf.select(SF.array_repeat("f", 3)).toPandas(),
+        )
 
         # test arrays_zip
         # TODO: Make toPandas support complex nested types like Array<Struct>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable test for `array_repeat`, since the datatype mismatch issue had been resolved


### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
enabled test
