### PR TITLE
[SPARK-41800][BUILD] Upgrade commons-compress to 1.22

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -183,6 +183,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -39,7 +39,7 @@ commons-codec/1.15//commons-codec-1.15.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
-commons-compress/1.21//commons-compress-1.21.jar
+commons-compress/1.22//commons-compress-1.22.jar
 commons-configuration/1.6//commons-configuration-1.6.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -40,7 +40,7 @@ commons-codec/1.15//commons-codec-1.15.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
-commons-compress/1.21//commons-compress-1.21.jar
+commons-compress/1.22//commons-compress-1.22.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.11.0//commons-io-2.11.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <snappy.version>1.1.8.4</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.22</commons-compress.version>
     <commons-io.version>2.11.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade commons-compress from 1.21 to 1.22

### Why are the changes needed?
This will bring the latest improvements.
<img width="503" alt="image" src="https://user-images.githubusercontent.com/15246973/210133282-18ae7d50-9076-4c95-a9e3-9ac6a266cda0.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.