### PR TITLE
[SPARK-41801][CORE][PYTHON][PS] Remove `*args: Any, **kwargs: Any` for `def transpose`

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -3822,7 +3822,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     agg = aggregate
 
-    def transpose(self, *args: Any, **kwargs: Any) -> "Series":
+    def transpose(self) -> "Series":
         """
         Return the transpose, which is self.
 

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2765,6 +2765,21 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         psser = ps.from_pandas(pser)
         self.assert_eq(pser.first_valid_index(), psser.first_valid_index())
 
+    def test_transpose_int(self):
+        pser = pd.Series([1, 2, 3])
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.transpose(), psser.transpose())
+
+    def test_transpose_char(self):
+        pser = pd.Series(['a', 'b', 'c'])
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.transpose(), psser.transpose())
+
+    def test_transpose_emty(self):
+        pser = pd.Series([])
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.transpose(), psser.transpose())
+
     def test_factorize(self):
         pser = pd.Series(["a", "b", "a", "b"])
         psser = ps.from_pandas(pser)

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2771,7 +2771,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(pser.transpose(), psser.transpose())
 
     def test_transpose_char(self):
-        pser = pd.Series(['a', 'b', 'c'])
+        pser = pd.Series(["a", "b", "c"])
         psser = ps.from_pandas(pser)
         self.assert_eq(pser.transpose(), psser.transpose())
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change `def transpose(self, *args: Any, **kwargs: Any) -> "Series":`
to
`def transpose(self) -> "Series":`


### Why are the changes needed?
`def transpose(self, *args: Any, **kwargs: Any) -> "Series":`

This function only `return self.copy()`

[Sonar](https://sonarcloud.io/project/issues?languages=py&resolved=false&severities=BLOCKER&id=spark-python&open=AYQdnWmTRrJbVxW9ZCsf)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.