### PR TITLE
[SPARK-41802][BUILD] Upgrade Apache httpcore to 4.4.16

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -106,7 +106,7 @@ hk2-locator/2.6.1//hk2-locator-2.6.1.jar
 hk2-utils/2.6.1//hk2-utils-2.6.1.jar
 htrace-core/3.1.0-incubating//htrace-core-3.1.0-incubating.jar
 httpclient/4.5.14//httpclient-4.5.14.jar
-httpcore/4.4.14//httpcore-4.4.14.jar
+httpcore/4.4.16//httpcore-4.4.16.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.5.1//ivy-2.5.1.jar
 jackson-annotations/2.14.1//jackson-annotations-2.14.1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -93,7 +93,7 @@ hk2-api/2.6.1//hk2-api-2.6.1.jar
 hk2-locator/2.6.1//hk2-locator-2.6.1.jar
 hk2-utils/2.6.1//hk2-utils-2.6.1.jar
 httpclient/4.5.14//httpclient-4.5.14.jar
-httpcore/4.4.14//httpcore-4.4.14.jar
+httpcore/4.4.16//httpcore-4.4.16.jar
 ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.5.1//ivy-2.5.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <gcs-connector.version>hadoop3-2.2.7</gcs-connector.version>
     <!--  org.apache.httpcomponents/httpclient-->
     <commons.httpclient.version>4.5.14</commons.httpclient.version>
-    <commons.httpcore.version>4.4.14</commons.httpcore.version>
+    <commons.httpcore.version>4.4.16</commons.httpcore.version>
     <commons.math3.version>3.6.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade Apache httpcore from 4.4.14 to 4.4.16.

### Why are the changes needed?
The new version bring some bugs fix:

- HTTPCORE-695: Unhandled CancelledKeyException during processPendingInterestOps leads to a shutdown of the underlying IOReactor.
- HTTPCORE-687: Non-blocking SSL I/O session can enter a tight loop if the SSL session gets closed by the protocol layer while there is still unprocessed data stuck in the protocol session buffer.
- HTTPCORE-660: Convert RuntimeExceptions thrown by SSLSetupHandler#verify to SSLExceptions.
- HTTPCORE-730: Non-blocking SSL I/O session incorrectly sets read interest when the session is being closed even if the application layer has cleared interest in input causing a busy loop in the I/O event loop and excessive CPU utilization.
- HTTPCORE-720: Discard any remaining decrypted application data after the TLS session has been closed by the local endpoint.
- HTTPCORE-716: Evict remaining decrypted input data from SSL I/O session buffers upon session closure. With unexpected input in the session buffers I/O reactors could end up in a tight loop causing excessive CPU utilization.


The release notes as follows:

- https://downloads.apache.org/httpcomponents/httpcore/RELEASE_NOTES-4.4.x.txt

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions