### PR TITLE
[SPARK-41807][CORE] Remove non-existent error class: UNSUPPORTED_FEATURE.DISTRIBUTE_BY

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1356,11 +1356,6 @@
           "DESC TABLE COLUMN for a specific partition."
         ]
       },
-      "DISTRIBUTE_BY" : {
-        "message" : [
-          "DISTRIBUTE BY clause."
-        ]
-      },
       "INSERT_PARTITION_SPEC_IF_NOT_EXISTS" : {
         "message" : [
           "INSERT INTO <tableName> IF NOT EXISTS in the PARTITION spec."


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove non-existent error class: UNSUPPORTED_FEATURE.DISTRIBUTE_BY.

### Why are the changes needed?
When I want to add UT for error class: UNSUPPORTED_FEATURE.DISTRIBUTE_BY, I found it no longer in use.
<img width="752" alt="image" src="https://user-images.githubusercontent.com/15246973/210191953-7d896bd7-b552-4a7e-bda8-72237c25297d.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.