### PR TITLE
[SPARK-41803][CONNECT][PYTHON] Add missing function `log(arg1, arg2)`

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -551,6 +551,24 @@ def log(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("ln", col)
 
 
+@overload  # type: ignore[no-redef]
+def log(arg1: "ColumnOrName") -> Column:
+    ...
+
+
+@overload
+def log(arg1: float, arg2: "ColumnOrName") -> Column:
+    ...
+
+
+def log(arg1: Union["ColumnOrName", float], arg2: Optional["ColumnOrName"] = None) -> Column:
+    _arg1 = lit(arg1) if isinstance(arg1, float) else _to_col(arg1)
+    if arg2 is None:
+        return _invoke_function("ln", _arg1)
+    else:
+        return _invoke_function("log", _arg1, _to_col(arg2))
+
+
 log.__doc__ = pysparkfuncs.log.__doc__
 
 

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -28,6 +28,7 @@ from typing import (
     Tuple,
     Callable,
     ValuesView,
+    cast,
 )
 
 from pyspark.sql.connect.column import Column
@@ -547,26 +548,13 @@ def hypot(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]
 hypot.__doc__ = pysparkfuncs.hypot.__doc__
 
 
-def log(col: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns("ln", col)
-
-
-@overload  # type: ignore[no-redef]
-def log(arg1: "ColumnOrName") -> Column:
-    ...
-
-
-@overload
-def log(arg1: float, arg2: "ColumnOrName") -> Column:
-    ...
-
-
 def log(arg1: Union["ColumnOrName", float], arg2: Optional["ColumnOrName"] = None) -> Column:
-    _arg1 = lit(arg1) if isinstance(arg1, float) else _to_col(arg1)
     if arg2 is None:
-        return _invoke_function("ln", _arg1)
+        # in this case, arg1 should be "ColumnOrName"
+        return _invoke_function("ln", _to_col(cast("ColumnOrName", arg1)))
     else:
-        return _invoke_function("log", _arg1, _to_col(arg2))
+        # in this case, arg1 should be a float
+        return _invoke_function("log", lit(cast(float, arg1)), _to_col(arg2))
 
 
 log.__doc__ = pysparkfuncs.log.__doc__

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -447,6 +447,12 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
                 sdf.select(sfunc("b"), sfunc(sdf.c)).toPandas(),
             )
 
+        # test log(arg1, arg2)
+        self.assert_eq(
+            cdf.select(CF.log(1.1, "b"), CF.log(1.2, cdf.c)).toPandas(),
+            sdf.select(SF.log(1.1, "b"), SF.log(1.2, sdf.c)).toPandas(),
+        )
+
         self.assert_eq(
             cdf.select(CF.atan2("b", cdf.c)).toPandas(),
             sdf.select(SF.atan2("b", sdf.c)).toPandas(),


### PR DESCRIPTION


### What changes were proposed in this pull request?
Add missing function `log(arg1, arg2)`


### Why are the changes needed?
for API coverage


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added ut