### PR TITLE
[SPARK-41657][CONNECT][DOCS][TESTS] Enable doctests in pyspark.sql.connect.session

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -506,6 +506,7 @@ pyspark_connect = Module(
         # doctests
         "pyspark.sql.connect.catalog",
         "pyspark.sql.connect.group",
+        "pyspark.sql.connect.session",
         "pyspark.sql.connect.window",
         "pyspark.sql.connect.column",
         # unittests

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -676,7 +676,7 @@ class SparkSession(SparkConversionMixin):
         Examples
         --------
         >>> spark.catalog
-        <pyspark.sql.catalog.Catalog object ...>
+        <...Catalog object ...>
 
         Create a temp view, show the list, and drop it.
 
@@ -1460,7 +1460,7 @@ class SparkSession(SparkConversionMixin):
         Examples
         --------
         >>> spark.read
-        <pyspark.sql.readwriter.DataFrameReader object ...>
+        <...DataFrameReader object ...>
 
         Write a DataFrame into a JSON file and read it back.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable doctests in `pyspark.sql.connect.session` that is virtually the same as `pyspark.sql.session`.

### Why are the changes needed?

To make sure on the PySpark compatibility and test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should test this out.