### PR TITLE
[SPARK-41745][CONNECT][TESTS][FOLLOW-UP] Reeanble related test cases

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -282,6 +282,8 @@ class Column:
     __ge__ = _bin_op("geq")
     __gt__ = _bin_op("gt")
 
+    # TODO(SPARK-41812): DataFrame.join: ambiguous column
+    # TODO(SPARK-41814): Column.eqNullSafe fails on NaN comparison
     _eqNullSafe_doc = """
     Equality test that is safe for null values.
 
@@ -317,9 +319,9 @@ class Column:
     ...     Row(value = 'bar'),
     ...     Row(value = None)
     ... ])
-    >>> df1.join(df2, df1["value"] == df2["value"]).count()
+    >>> df1.join(df2, df1["value"] == df2["value"]).count()  # doctest: +SKIP
     0
-    >>> df1.join(df2, df1["value"].eqNullSafe(df2["value"])).count()
+    >>> df1.join(df2, df1["value"].eqNullSafe(df2["value"])).count()  # doctest: +SKIP
     1
     >>> df2 = spark.createDataFrame([
     ...     Row(id=1, value=float('NaN')),
@@ -330,7 +332,7 @@ class Column:
     ...     df2['value'].eqNullSafe(None),
     ...     df2['value'].eqNullSafe(float('NaN')),
     ...     df2['value'].eqNullSafe(42.0)
-    ... ).show()
+    ... ).show()  # doctest: +SKIP
     +----------------+---------------+----------------+
     |(value <=> NULL)|(value <=> NaN)|(value <=> 42.0)|
     +----------------+---------------+----------------+

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -441,25 +441,17 @@ def _test() -> None:
         # Creates a remote Spark session.
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
+        # Spark Connect has a different string representation for Column.
+        del pyspark.sql.connect.column.Column.getItem.__doc__
 
         # TODO(SPARK-41746): SparkSession.createDataFrame does not support nested datatypes
         del pyspark.sql.connect.column.Column.dropFields.__doc__
         # TODO(SPARK-41772): Enable pyspark.sql.connect.column.Column.withField doctest
         del pyspark.sql.connect.column.Column.withField.__doc__
-        # TODO(SPARK-41745): SparkSession.createDataFrame does not respect the column names in
-        #  the row
-        del pyspark.sql.connect.column.Column.bitwiseAND.__doc__
-        del pyspark.sql.connect.column.Column.bitwiseOR.__doc__
-        del pyspark.sql.connect.column.Column.bitwiseXOR.__doc__
-        # TODO(SPARK-41745): SparkSession.createDataFrame does not respect the column names in
-        #  the row
-        del pyspark.sql.connect.column.Column.eqNullSafe.__doc__
-        # TODO(SPARK-41745): SparkSession.createDataFrame does not respect the column names in
-        #  the row
-        del pyspark.sql.connect.column.Column.isNotNull.__doc__
+        # TODO(SPARK-41815): Column.isNull returns nan instead of None
         del pyspark.sql.connect.column.Column.isNull.__doc__
+        # TODO(SPARK-41746): SparkSession.createDataFrame does not support nested datatypes
         del pyspark.sql.connect.column.Column.getField.__doc__
-        del pyspark.sql.connect.column.Column.getItem.__doc__
 
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.column,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/39313 that enables the skipped tests back.

### Why are the changes needed?

In order to make sure on the test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually checked locally, and CI in this PR should verify them.