### PR TITLE
[SPARK-41816][SQL] Not close filesystem when log out ThriftServer

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImplwithUGI.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImplwithUGI.java
@@ -19,7 +19,6 @@ package org.apache.hive.service.cli.session;
 
 import java.io.IOException;
 
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImplwithUGI.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImplwithUGI.java
@@ -95,7 +95,6 @@ public class HiveSessionImplwithUGI extends HiveSessionImpl {
   }
 
   /**
-   * Close the file systems for the session and remove it from the FileSystem cache.
    * Cancel the session's delegation token and close the metastore connection
    */
   @Override
@@ -104,16 +103,7 @@ public class HiveSessionImplwithUGI extends HiveSessionImpl {
       acquire(true);
       cancelDelegationToken();
     } finally {
-      try {
-        super.close();
-      } finally {
-        try {
-          FileSystem.closeAllForUGI(sessionUgi);
-        } catch (IOException ioe) {
-          throw new HiveSQLException("Could not clean up file-system handles for UGI: "
-              + sessionUgi, ioe);
-        }
-      }
+      super.close();
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Not close FileSystem instances when log out a sts session. The FileSystem instances will remain in FileSystem#CACHE, and the total size should be on the same order of magnitude as all usernames once connected, so the total memory consumption should be acceptable.

### Why are the changes needed?

Currently when enabled impersonation, Spark Thriftserver will close filesystem instance for the user logged in when logout. If there are two sessions with the same user, the remaining session will become corrupted.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Tested in dev and production environment.

