### PR TITLE
[SPARK-41810][CONNECT] Infer names from a list of dictionaries in SparkSession.createDataFrame

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -220,7 +220,7 @@ class SparkSession:
             _data = list(data)
             pdf = pd.DataFrame(_data)
 
-            if _schema is None and isinstance(_data[0], Row):
+            if _schema is None and (isinstance(_data[0], Row) or isinstance(_data[0], dict)):
                 _schema = self._inferSchemaFromList(_data, _cols)
                 if _cols is not None:
                     for i, name in enumerate(_cols):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -391,12 +391,12 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
     def test_with_local_rows(self):
         # SPARK-41789, SPARK-41810: Test creating a dataframe with list of rows and dictionaries
         rows = [
-            Row(course="dotNET", earnings=10000, year=2012),
-            Row(course="Java", earnings=20000, year=2012),
-            Row(course="dotNET", earnings=5000, year=2012),
-            Row(course="dotNET", earnings=48000, year=2013),
-            Row(course="Java", earnings=30000, year=2013),
-            Row(course="Scala", earnings=None, year=2022),
+            Row(course="dotNET", year=2012, earnings=10000),
+            Row(course="Java", year=2012, earnings=20000),
+            Row(course="dotNET", year=2012, earnings=5000),
+            Row(course="dotNET", year=2013, earnings=48000),
+            Row(course="Java", year=2013, earnings=30000),
+            Row(course="Scala", year=2022, earnings=None),
         ]
         dicts = [row.asDict() for row in rows]
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -389,28 +389,30 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.connect.createDataFrame(data, "col1 int, col2 int, col3 int").show()
 
     def test_with_local_rows(self):
-        # SPARK-41789: Test creating a dataframe with list of Rows
-        data = [
-            Row(course="dotNET", year=2012, earnings=10000),
-            Row(course="Java", year=2012, earnings=20000),
-            Row(course="dotNET", year=2012, earnings=5000),
-            Row(course="dotNET", year=2013, earnings=48000),
-            Row(course="Java", year=2013, earnings=30000),
-            Row(course="Scala", year=2022, earnings=None),
+        # SPARK-41789, SPARK-41810: Test creating a dataframe with list of rows and dictionaries
+        rows = [
+            Row(course="dotNET", earnings=10000, year=2012),
+            Row(course="Java", earnings=20000, year=2012),
+            Row(course="dotNET", earnings=5000, year=2012),
+            Row(course="dotNET", earnings=48000, year=2013),
+            Row(course="Java", earnings=30000, year=2013),
+            Row(course="Scala", earnings=None, year=2022),
         ]
+        dicts = [row.asDict() for row in rows]
 
-        sdf = self.spark.createDataFrame(data)
-        cdf = self.connect.createDataFrame(data)
+        for data in [rows, dicts]:
+            sdf = self.spark.createDataFrame(data)
+            cdf = self.connect.createDataFrame(data)
 
-        self.assertEqual(sdf.schema, cdf.schema)
-        self.assert_eq(sdf.toPandas(), cdf.toPandas())
+            self.assertEqual(sdf.schema, cdf.schema)
+            self.assert_eq(sdf.toPandas(), cdf.toPandas())
 
-        # test with rename
-        sdf = self.spark.createDataFrame(data, schema=["a", "b", "c"])
-        cdf = self.connect.createDataFrame(data, schema=["a", "b", "c"])
+            # test with rename
+            sdf = self.spark.createDataFrame(data, schema=["a", "b", "c"])
+            cdf = self.connect.createDataFrame(data, schema=["a", "b", "c"])
 
-        self.assertEqual(sdf.schema, cdf.schema)
-        self.assert_eq(sdf.toPandas(), cdf.toPandas())
+            self.assertEqual(sdf.schema, cdf.schema)
+            self.assert_eq(sdf.toPandas(), cdf.toPandas())
 
     def test_with_atom_type(self):
         for data in [[(1), (2), (3)], [1, 2, 3]]:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to support to infer field names when the input data is the list of dictionaries in `SparkSession.createDataFrame`.

For example,

```python
spark.createDataFrame([{"course": "dotNET", "earnings": 10000, "year": 2012}]).show()
```

**Before**:

```
+------+-----+----+
|    _1|   _2|  _3|
+------+-----+----+
|dotNET|10000|2012|
+------+-----+----+
```

**After**:

```
+------+--------+----+
|course|earnings|year|
+------+--------+----+
|dotNET|   10000|2012|
+------+--------+----+
```

### Why are the changes needed?

To match the behaviour with the regular PySpark.

### Does this PR introduce _any_ user-facing change?

No to end users because Spark Connect has not been released.

### How was this patch tested?

Unittest was added.