### PR TITLE
[SPARK-41656][CONNECT][TESTS] Enable doctests in pyspark.sql.connect.dataframe

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -509,6 +509,7 @@ pyspark_connect = Module(
         "pyspark.sql.connect.session",
         "pyspark.sql.connect.window",
         "pyspark.sql.connect.column",
+        "pyspark.sql.connect.dataframe",
         # unittests
         "pyspark.sql.tests.connect.test_connect_plan",
         "pyspark.sql.tests.connect.test_connect_basic",

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1394,34 +1394,56 @@ def _test() -> None:
             sc, options={"spark.app.name": "sql.connect.dataframe tests"}
         )
 
+        # TODO(SPARK-41819): Implement RDD.getNumPartitions
         del pyspark.sql.connect.dataframe.DataFrame.coalesce.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.createGlobalTempView.__doc__
+        del pyspark.sql.connect.dataframe.DataFrame.repartition.__doc__
+
+        # TODO(SPARK-41820): Fix SparkConnectException: requirement failed
         del pyspark.sql.connect.dataframe.DataFrame.createOrReplaceGlobalTempView.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.createOrReplaceTempView.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.createTempView.__doc__
+
+        # TODO(SPARK-41821): Fix DataFrame.describe
         del pyspark.sql.connect.dataframe.DataFrame.describe.__doc__
+
+        # TODO(SPARK-41823): ambiguous column names
         del pyspark.sql.connect.dataframe.DataFrame.drop.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.explain.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.fillna.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.groupBy.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.hint.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.intersect.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.isEmpty.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.isStreaming.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.join.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.na.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.repartition.__doc__
+
+        # TODO(SPARK-41824): DataFrame.explain format is different
+        del pyspark.sql.connect.dataframe.DataFrame.explain.__doc__
+        del pyspark.sql.connect.dataframe.DataFrame.hint.__doc__
+
+        # TODO(SPARK-41825): Dataframe.show formatting int as double
+        del pyspark.sql.connect.dataframe.DataFrame.fillna.__doc__
+        del pyspark.sql.connect.dataframe.DataFrameNaFunctions.replace.__doc__
+        del pyspark.sql.connect.dataframe.DataFrameNaFunctions.fill.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.replace.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.sample.__doc__
+        del pyspark.sql.connect.dataframe.DataFrame.intersect.__doc__
+
+        # TODO(SPARK-41826): Implement Dataframe.readStream
+        del pyspark.sql.connect.dataframe.DataFrame.isStreaming.__doc__
+
+        # TODO(SPARK-41827): groupBy requires all cols be Column or str
+        del pyspark.sql.connect.dataframe.DataFrame.groupBy.__doc__
+
+        # TODO(SPARK-41828): Implement creating empty DataFrame
+        del pyspark.sql.connect.dataframe.DataFrame.isEmpty.__doc__
+
+        # TODO(SPARK-41829): Add Dataframe sort ordering
         del pyspark.sql.connect.dataframe.DataFrame.sort.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.sortWithinPartitions.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.sparkSession.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.stat.__doc__
+
+        # TODO(SPARK-41830): fix sample parameters
+        del pyspark.sql.connect.dataframe.DataFrame.sample.__doc__
+
+        # TODO(SPARK-41831): fix transform to accept ColumnReference
         del pyspark.sql.connect.dataframe.DataFrame.transform.__doc__
+
+        # TODO(SPARK-41832): fix unionByName
         del pyspark.sql.connect.dataframe.DataFrame.unionByName.__doc__
+
+        # TODO(SPARK-41818): Support saveAsTable
         del pyspark.sql.connect.dataframe.DataFrame.write.__doc__
-        del pyspark.sql.connect.dataframe.DataFrameNaFunctions.fill.__doc__
-        del pyspark.sql.connect.dataframe.DataFrameNaFunctions.replace.__doc__
 
         # Creates a remote Spark session.
         os.environ["SPARK_REMOTE"] = "sc://localhost"

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -189,7 +189,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         --------
         >>> df = spark.range(1)
         >>> type(df.sparkSession)
-        <class 'pyspark.sql.session.SparkSession'>
+        <class '...session.SparkSession'>
         """
         return self._session
 
@@ -233,7 +233,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         --------
         >>> df = spark.sql("SELECT 1 AS c1, int(NULL) AS c2")
         >>> type(df.na)
-        <class 'pyspark.sql.dataframe.DataFrameNaFunctions'>
+        <class '...dataframe.DataFrameNaFunctions'>
 
         Replace the missing values as 2.
 
@@ -264,7 +264,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> import pyspark.sql.functions as f
         >>> df = spark.range(3).withColumn("c", f.expr("id + 1"))
         >>> type(df.stat)
-        <class 'pyspark.sql.dataframe.DataFrameStatFunctions'>
+        <class '...dataframe.DataFrameStatFunctions'>
         >>> df.stat.corr("id", "c")
         1.0
         """
@@ -355,7 +355,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Throw an exception if the table already exists.
 
-        >>> df.createTempView("people")  # doctest: +IGNORE_EXCEPTION_DETAIL
+        >>> df.createTempView("people")  # doctest: +IGNORE_EXCEPTION_DETAIL, +SKIP
         Traceback (most recent call last):
         ...
         AnalysisException: "Temporary table 'people' already exists;"
@@ -438,7 +438,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Throws an exception if the global temporary view already exists.
 
-        >>> df.createGlobalTempView("people")  # doctest: +IGNORE_EXCEPTION_DETAIL
+        >>> df.createGlobalTempView("people")  # doctest: +IGNORE_EXCEPTION_DETAIL, +SKIP
         Traceback (most recent call last):
         ...
         AnalysisException: "Temporary table 'people' already exists;"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to enable doctests in pyspark.sql.connect.dataframe that is virtually the same as pyspark.sql.dataframe.

### Why are the changes needed?
To make sure on the PySpark compatibility and test coverage.

### Does this PR introduce any user-facing change?
No, doctest's only.

### How was this patch tested?
New Doctests Added