### PR TITLE
[SPARK-41658][CONNECT][TESTS] Enable doctests in pyspark.sql.connect.functions

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -509,6 +509,7 @@ pyspark_connect = Module(
         "pyspark.sql.connect.session",
         "pyspark.sql.connect.window",
         "pyspark.sql.connect.column",
+        "pyspark.sql.connect.functions",
         # unittests
         "pyspark.sql.tests.connect.test_connect_plan",
         "pyspark.sql.tests.connect.test_connect_basic",

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2367,7 +2367,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.to_utc_timestamp.__doc__
         del pyspark.sql.connect.functions.unhex.__doc__
 
-
         # TODO(SPARK-41825): Dataframe.show formatting int as double
         del pyspark.sql.connect.functions.coalesce.__doc__
         del pyspark.sql.connect.functions.sum_distinct.__doc__
@@ -2427,8 +2426,8 @@ def _test() -> None:
             pyspark.sql.connect.functions,
             globs=globs,
             optionflags=doctest.ELLIPSIS
-                        | doctest.NORMALIZE_WHITESPACE
-                        | doctest.IGNORE_EXCEPTION_DETAIL,
+            | doctest.NORMALIZE_WHITESPACE
+            | doctest.IGNORE_EXCEPTION_DETAIL,
         )
 
         globs["spark"].stop()

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2339,6 +2339,78 @@ def _test() -> None:
             sc, options={"spark.app.name": "sql.connect.functions tests"}
         )
 
+        # TODO(SPARK-41833): fix collect() output
+        del pyspark.sql.connect.functions.array.__doc__
+        del pyspark.sql.connect.functions.array_distinct.__doc__
+        del pyspark.sql.connect.functions.array_except.__doc__
+        del pyspark.sql.connect.functions.array_intersect.__doc__
+        del pyspark.sql.connect.functions.array_remove.__doc__
+        del pyspark.sql.connect.functions.array_repeat.__doc__
+        del pyspark.sql.connect.functions.array_sort.__doc__
+        del pyspark.sql.connect.functions.array_union.__doc__
+
+        del pyspark.sql.connect.functions.broadcast.__doc__
+        del pyspark.sql.connect.functions.call_udf.__doc__
+        del pyspark.sql.connect.functions.coalesce.__doc__
+        del pyspark.sql.connect.functions.col.__doc__
+        del pyspark.sql.connect.functions.collect_list.__doc__
+        del pyspark.sql.connect.functions.collect_set.__doc__
+        del pyspark.sql.connect.functions.concat.__doc__
+        del pyspark.sql.connect.functions.count.__doc__
+        del pyspark.sql.connect.functions.count_distinct.__doc__
+        del pyspark.sql.connect.functions.create_map.__doc__
+        del pyspark.sql.connect.functions.cume_dist.__doc__
+        del pyspark.sql.connect.functions.date_trunc.__doc__
+        del pyspark.sql.connect.functions.dense_rank.__doc__
+        del pyspark.sql.connect.functions.element_at.__doc__
+        del pyspark.sql.connect.functions.explode.__doc__
+        del pyspark.sql.connect.functions.explode_outer.__doc__
+        del pyspark.sql.connect.functions.first.__doc__
+        del pyspark.sql.connect.functions.from_csv.__doc__
+        del pyspark.sql.connect.functions.from_json.__doc__
+        del pyspark.sql.connect.functions.from_unixtime.__doc__
+        del pyspark.sql.connect.functions.from_utc_timestamp.__doc__
+        del pyspark.sql.connect.functions.hour.__doc__
+        del pyspark.sql.connect.functions.inline.__doc__
+        del pyspark.sql.connect.functions.inline_outer.__doc__
+        del pyspark.sql.connect.functions.input_file_name.__doc__
+        del pyspark.sql.connect.functions.isnan.__doc__
+        del pyspark.sql.connect.functions.isnull.__doc__
+        del pyspark.sql.connect.functions.last.__doc__
+        del pyspark.sql.connect.functions.map_filter.__doc__
+        del pyspark.sql.connect.functions.map_zip_with.__doc__
+        del pyspark.sql.connect.functions.max_by.__doc__
+        del pyspark.sql.connect.functions.median.__doc__
+        del pyspark.sql.connect.functions.min_by.__doc__
+        del pyspark.sql.connect.functions.minute.__doc__
+        del pyspark.sql.connect.functions.mode.__doc__
+        del pyspark.sql.connect.functions.monotonically_increasing_id.__doc__
+        del pyspark.sql.connect.functions.nanvl.__doc__
+        del pyspark.sql.connect.functions.percent_rank.__doc__
+        del pyspark.sql.connect.functions.pmod.__doc__
+        del pyspark.sql.connect.functions.posexplode.__doc__
+        del pyspark.sql.connect.functions.posexplode_outer.__doc__
+        del pyspark.sql.connect.functions.rank.__doc__
+        del pyspark.sql.connect.functions.reverse.__doc__
+        del pyspark.sql.connect.functions.second.__doc__
+        del pyspark.sql.connect.functions.sequence.__doc__
+        del pyspark.sql.connect.functions.slice.__doc__
+        del pyspark.sql.connect.functions.sort_array.__doc__
+        del pyspark.sql.connect.functions.split.__doc__
+        del pyspark.sql.connect.functions.struct.__doc__
+        del pyspark.sql.connect.functions.sum_distinct.__doc__
+        del pyspark.sql.connect.functions.timestamp_seconds.__doc__
+        del pyspark.sql.connect.functions.to_csv.__doc__
+        del pyspark.sql.connect.functions.to_json.__doc__
+        del pyspark.sql.connect.functions.to_timestamp.__doc__
+        del pyspark.sql.connect.functions.to_utc_timestamp.__doc__
+        del pyspark.sql.connect.functions.transform_keys.__doc__
+        del pyspark.sql.connect.functions.transform_values.__doc__
+        del pyspark.sql.connect.functions.unhex.__doc__
+        del pyspark.sql.connect.functions.unix_timestamp.__doc__
+        del pyspark.sql.connect.functions.window.__doc__
+        del pyspark.sql.connect.functions.window_time.__doc__
+
         # Creates a remote Spark session.
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2372,6 +2372,11 @@ def _test() -> None:
         del pyspark.sql.connect.functions.coalesce.__doc__
         del pyspark.sql.connect.functions.sum_distinct.__doc__
 
+        # TODO(SPARK-41834): implement Dataframe.conf
+        del pyspark.sql.connect.functions.from_unixtime.__doc__
+        del pyspark.sql.connect.functions.timestamp_seconds.__doc__
+        del pyspark.sql.connect.functions.unix_timestamp.__doc__
+
         del pyspark.sql.connect.functions.broadcast.__doc__
         del pyspark.sql.connect.functions.call_udf.__doc__
         del pyspark.sql.connect.functions.col.__doc__
@@ -2383,7 +2388,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.explode.__doc__
         del pyspark.sql.connect.functions.explode_outer.__doc__
         del pyspark.sql.connect.functions.first.__doc__
-        del pyspark.sql.connect.functions.from_unixtime.__doc__
         del pyspark.sql.connect.functions.hour.__doc__
         del pyspark.sql.connect.functions.inline.__doc__
         del pyspark.sql.connect.functions.inline_outer.__doc__
@@ -2405,12 +2409,10 @@ def _test() -> None:
         del pyspark.sql.connect.functions.posexplode_outer.__doc__
         del pyspark.sql.connect.functions.rank.__doc__
         del pyspark.sql.connect.functions.second.__doc__
-        del pyspark.sql.connect.functions.timestamp_seconds.__doc__
         del pyspark.sql.connect.functions.to_csv.__doc__
         del pyspark.sql.connect.functions.to_json.__doc__
         del pyspark.sql.connect.functions.transform_keys.__doc__
         del pyspark.sql.connect.functions.transform_values.__doc__
-        del pyspark.sql.connect.functions.unix_timestamp.__doc__
         del pyspark.sql.connect.functions.window.__doc__
         del pyspark.sql.connect.functions.window_time.__doc__
 

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2386,6 +2386,30 @@ def _test() -> None:
         del pyspark.sql.connect.functions.window.__doc__
         del pyspark.sql.connect.functions.window_time.__doc__
 
+        # TODO(SPARK-41838): fix dataset.show
+        del pyspark.sql.connect.functions.posexplode_outer.__doc__
+        del pyspark.sql.connect.functions.explode_outer.__doc__
+
+        # TODO(SPARK-41837): createDataFrame datatype conversion error
+        del pyspark.sql.connect.functions.to_csv.__doc__
+        del pyspark.sql.connect.functions.to_json.__doc__
+
+        # TODO(SPARK-41835): Implement `transform_keys` function
+        del pyspark.sql.connect.functions.transform_keys.__doc__
+
+        # TODO(SPARK-41836): Implement `transform_values` function
+        del pyspark.sql.connect.functions.transform_values.__doc__
+
+        # TODO(SPARK-41839): Implement SparkSession.sparkContext
+        del pyspark.sql.connect.functions.monotonically_increasing_id.__doc__
+
+        # TODO(SPARK-41840): Fix 'Column' object is not callable
+        del pyspark.sql.connect.functions.first.__doc__
+        del pyspark.sql.connect.functions.last.__doc__
+        del pyspark.sql.connect.functions.max_by.__doc__
+        del pyspark.sql.connect.functions.median.__doc__
+        del pyspark.sql.connect.functions.min_by.__doc__
+
         del pyspark.sql.connect.functions.broadcast.__doc__
         del pyspark.sql.connect.functions.call_udf.__doc__
         del pyspark.sql.connect.functions.count.__doc__
@@ -2394,30 +2418,19 @@ def _test() -> None:
         del pyspark.sql.connect.functions.dense_rank.__doc__
         del pyspark.sql.connect.functions.element_at.__doc__
         del pyspark.sql.connect.functions.explode.__doc__
-        del pyspark.sql.connect.functions.explode_outer.__doc__
-        del pyspark.sql.connect.functions.first.__doc__
         del pyspark.sql.connect.functions.inline.__doc__
         del pyspark.sql.connect.functions.inline_outer.__doc__
         del pyspark.sql.connect.functions.input_file_name.__doc__
         del pyspark.sql.connect.functions.isnan.__doc__
-        del pyspark.sql.connect.functions.last.__doc__
         del pyspark.sql.connect.functions.map_filter.__doc__
         del pyspark.sql.connect.functions.map_zip_with.__doc__
-        del pyspark.sql.connect.functions.max_by.__doc__
-        del pyspark.sql.connect.functions.median.__doc__
-        del pyspark.sql.connect.functions.min_by.__doc__
         del pyspark.sql.connect.functions.mode.__doc__
-        del pyspark.sql.connect.functions.monotonically_increasing_id.__doc__
         del pyspark.sql.connect.functions.nanvl.__doc__
         del pyspark.sql.connect.functions.percent_rank.__doc__
         del pyspark.sql.connect.functions.pmod.__doc__
         del pyspark.sql.connect.functions.posexplode.__doc__
-        del pyspark.sql.connect.functions.posexplode_outer.__doc__
         del pyspark.sql.connect.functions.rank.__doc__
-        del pyspark.sql.connect.functions.to_csv.__doc__
-        del pyspark.sql.connect.functions.to_json.__doc__
-        del pyspark.sql.connect.functions.transform_keys.__doc__
-        del pyspark.sql.connect.functions.transform_values.__doc__
+
         # Creates a remote Spark session.
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2379,7 +2379,7 @@ def _test() -> None:
         # TODO(SPARK-41757): Fix String representation for Column class
         del pyspark.sql.connect.functions.col.__doc__
 
-        # TODO: support data type: Timestamp(NANOSECOND, null)
+        # TODO(SPARK-41842): support data type: Timestamp(NANOSECOND, null)
         del pyspark.sql.connect.functions.hour.__doc__
         del pyspark.sql.connect.functions.minute.__doc__
         del pyspark.sql.connect.functions.second.__doc__
@@ -2394,7 +2394,7 @@ def _test() -> None:
         del pyspark.sql.connect.functions.to_csv.__doc__
         del pyspark.sql.connect.functions.to_json.__doc__
 
-        # TODO(SPARK-41835): Implement `transform_keys` function
+        # TODO(SPARK-41835): Fix `transform_keys` function
         del pyspark.sql.connect.functions.transform_keys.__doc__
 
         # TODO(SPARK-41836): Implement `transform_values` function
@@ -2409,27 +2409,44 @@ def _test() -> None:
         del pyspark.sql.connect.functions.max_by.__doc__
         del pyspark.sql.connect.functions.median.__doc__
         del pyspark.sql.connect.functions.min_by.__doc__
+        del pyspark.sql.connect.functions.mode.__doc__
 
+        # TODO(SPARK-41812): Proper column names after join
         del pyspark.sql.connect.functions.broadcast.__doc__
-        del pyspark.sql.connect.functions.call_udf.__doc__
-        del pyspark.sql.connect.functions.count.__doc__
         del pyspark.sql.connect.functions.count_distinct.__doc__
+
+        # TODO(SPARK-41843): Implement SparkSession.udf
+        del pyspark.sql.connect.functions.call_udf.__doc__
+
+        # TODO(SPARK-41845): Fix count bug
+        del pyspark.sql.connect.functions.count.__doc__
+
+        # TODO(SPARK-41846): window functions : unresolved columns
+        del pyspark.sql.connect.functions.rank.__doc__
         del pyspark.sql.connect.functions.cume_dist.__doc__
         del pyspark.sql.connect.functions.dense_rank.__doc__
+        del pyspark.sql.connect.functions.percent_rank.__doc__
+
+        # TODO(SPARK-41847): mapfield,structlist invalid type
         del pyspark.sql.connect.functions.element_at.__doc__
         del pyspark.sql.connect.functions.explode.__doc__
         del pyspark.sql.connect.functions.inline.__doc__
         del pyspark.sql.connect.functions.inline_outer.__doc__
-        del pyspark.sql.connect.functions.input_file_name.__doc__
-        del pyspark.sql.connect.functions.isnan.__doc__
         del pyspark.sql.connect.functions.map_filter.__doc__
         del pyspark.sql.connect.functions.map_zip_with.__doc__
-        del pyspark.sql.connect.functions.mode.__doc__
-        del pyspark.sql.connect.functions.nanvl.__doc__
-        del pyspark.sql.connect.functions.percent_rank.__doc__
-        del pyspark.sql.connect.functions.pmod.__doc__
         del pyspark.sql.connect.functions.posexplode.__doc__
-        del pyspark.sql.connect.functions.rank.__doc__
+
+        # TODO(SPARK-41849): implement DataFrameReader.text
+        del pyspark.sql.connect.functions.input_file_name.__doc__
+
+        # TODO(SPARK-41850): fix isnan
+        del pyspark.sql.connect.functions.isnan.__doc__
+
+        # TODO(SPARK-41851): fix nanvl
+        del pyspark.sql.connect.functions.nanvl.__doc__
+
+        # TODO(SPARK-41852): fix pmod
+        del pyspark.sql.connect.functions.pmod.__doc__
 
         # Creates a remote Spark session.
         os.environ["SPARK_REMOTE"] = "sc://localhost"

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2348,34 +2348,47 @@ def _test() -> None:
         del pyspark.sql.connect.functions.array_repeat.__doc__
         del pyspark.sql.connect.functions.array_sort.__doc__
         del pyspark.sql.connect.functions.array_union.__doc__
-
-        del pyspark.sql.connect.functions.broadcast.__doc__
-        del pyspark.sql.connect.functions.call_udf.__doc__
-        del pyspark.sql.connect.functions.coalesce.__doc__
-        del pyspark.sql.connect.functions.col.__doc__
         del pyspark.sql.connect.functions.collect_list.__doc__
         del pyspark.sql.connect.functions.collect_set.__doc__
         del pyspark.sql.connect.functions.concat.__doc__
+        del pyspark.sql.connect.functions.create_map.__doc__
+        del pyspark.sql.connect.functions.date_trunc.__doc__
+        del pyspark.sql.connect.functions.from_utc_timestamp.__doc__
+        del pyspark.sql.connect.functions.from_csv.__doc__
+        del pyspark.sql.connect.functions.from_json.__doc__
+        del pyspark.sql.connect.functions.isnull.__doc__
+        del pyspark.sql.connect.functions.reverse.__doc__
+        del pyspark.sql.connect.functions.sequence.__doc__
+        del pyspark.sql.connect.functions.slice.__doc__
+        del pyspark.sql.connect.functions.sort_array.__doc__
+        del pyspark.sql.connect.functions.split.__doc__
+        del pyspark.sql.connect.functions.struct.__doc__
+        del pyspark.sql.connect.functions.to_timestamp.__doc__
+        del pyspark.sql.connect.functions.to_utc_timestamp.__doc__
+        del pyspark.sql.connect.functions.unhex.__doc__
+
+
+        # TODO(SPARK-41825): Dataframe.show formatting int as double
+        del pyspark.sql.connect.functions.coalesce.__doc__
+        del pyspark.sql.connect.functions.sum_distinct.__doc__
+
+        del pyspark.sql.connect.functions.broadcast.__doc__
+        del pyspark.sql.connect.functions.call_udf.__doc__
+        del pyspark.sql.connect.functions.col.__doc__
         del pyspark.sql.connect.functions.count.__doc__
         del pyspark.sql.connect.functions.count_distinct.__doc__
-        del pyspark.sql.connect.functions.create_map.__doc__
         del pyspark.sql.connect.functions.cume_dist.__doc__
-        del pyspark.sql.connect.functions.date_trunc.__doc__
         del pyspark.sql.connect.functions.dense_rank.__doc__
         del pyspark.sql.connect.functions.element_at.__doc__
         del pyspark.sql.connect.functions.explode.__doc__
         del pyspark.sql.connect.functions.explode_outer.__doc__
         del pyspark.sql.connect.functions.first.__doc__
-        del pyspark.sql.connect.functions.from_csv.__doc__
-        del pyspark.sql.connect.functions.from_json.__doc__
         del pyspark.sql.connect.functions.from_unixtime.__doc__
-        del pyspark.sql.connect.functions.from_utc_timestamp.__doc__
         del pyspark.sql.connect.functions.hour.__doc__
         del pyspark.sql.connect.functions.inline.__doc__
         del pyspark.sql.connect.functions.inline_outer.__doc__
         del pyspark.sql.connect.functions.input_file_name.__doc__
         del pyspark.sql.connect.functions.isnan.__doc__
-        del pyspark.sql.connect.functions.isnull.__doc__
         del pyspark.sql.connect.functions.last.__doc__
         del pyspark.sql.connect.functions.map_filter.__doc__
         del pyspark.sql.connect.functions.map_zip_with.__doc__
@@ -2391,22 +2404,12 @@ def _test() -> None:
         del pyspark.sql.connect.functions.posexplode.__doc__
         del pyspark.sql.connect.functions.posexplode_outer.__doc__
         del pyspark.sql.connect.functions.rank.__doc__
-        del pyspark.sql.connect.functions.reverse.__doc__
         del pyspark.sql.connect.functions.second.__doc__
-        del pyspark.sql.connect.functions.sequence.__doc__
-        del pyspark.sql.connect.functions.slice.__doc__
-        del pyspark.sql.connect.functions.sort_array.__doc__
-        del pyspark.sql.connect.functions.split.__doc__
-        del pyspark.sql.connect.functions.struct.__doc__
-        del pyspark.sql.connect.functions.sum_distinct.__doc__
         del pyspark.sql.connect.functions.timestamp_seconds.__doc__
         del pyspark.sql.connect.functions.to_csv.__doc__
         del pyspark.sql.connect.functions.to_json.__doc__
-        del pyspark.sql.connect.functions.to_timestamp.__doc__
-        del pyspark.sql.connect.functions.to_utc_timestamp.__doc__
         del pyspark.sql.connect.functions.transform_keys.__doc__
         del pyspark.sql.connect.functions.transform_values.__doc__
-        del pyspark.sql.connect.functions.unhex.__doc__
         del pyspark.sql.connect.functions.unix_timestamp.__doc__
         del pyspark.sql.connect.functions.window.__doc__
         del pyspark.sql.connect.functions.window_time.__doc__

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2377,9 +2377,18 @@ def _test() -> None:
         del pyspark.sql.connect.functions.timestamp_seconds.__doc__
         del pyspark.sql.connect.functions.unix_timestamp.__doc__
 
+        # TODO(SPARK-41757): Fix String representation for Column class
+        del pyspark.sql.connect.functions.col.__doc__
+
+        # TODO: support data type: Timestamp(NANOSECOND, null)
+        del pyspark.sql.connect.functions.hour.__doc__
+        del pyspark.sql.connect.functions.minute.__doc__
+        del pyspark.sql.connect.functions.second.__doc__
+        del pyspark.sql.connect.functions.window.__doc__
+        del pyspark.sql.connect.functions.window_time.__doc__
+
         del pyspark.sql.connect.functions.broadcast.__doc__
         del pyspark.sql.connect.functions.call_udf.__doc__
-        del pyspark.sql.connect.functions.col.__doc__
         del pyspark.sql.connect.functions.count.__doc__
         del pyspark.sql.connect.functions.count_distinct.__doc__
         del pyspark.sql.connect.functions.cume_dist.__doc__
@@ -2388,7 +2397,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.explode.__doc__
         del pyspark.sql.connect.functions.explode_outer.__doc__
         del pyspark.sql.connect.functions.first.__doc__
-        del pyspark.sql.connect.functions.hour.__doc__
         del pyspark.sql.connect.functions.inline.__doc__
         del pyspark.sql.connect.functions.inline_outer.__doc__
         del pyspark.sql.connect.functions.input_file_name.__doc__
@@ -2399,7 +2407,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.max_by.__doc__
         del pyspark.sql.connect.functions.median.__doc__
         del pyspark.sql.connect.functions.min_by.__doc__
-        del pyspark.sql.connect.functions.minute.__doc__
         del pyspark.sql.connect.functions.mode.__doc__
         del pyspark.sql.connect.functions.monotonically_increasing_id.__doc__
         del pyspark.sql.connect.functions.nanvl.__doc__
@@ -2408,14 +2415,10 @@ def _test() -> None:
         del pyspark.sql.connect.functions.posexplode.__doc__
         del pyspark.sql.connect.functions.posexplode_outer.__doc__
         del pyspark.sql.connect.functions.rank.__doc__
-        del pyspark.sql.connect.functions.second.__doc__
         del pyspark.sql.connect.functions.to_csv.__doc__
         del pyspark.sql.connect.functions.to_json.__doc__
         del pyspark.sql.connect.functions.transform_keys.__doc__
         del pyspark.sql.connect.functions.transform_values.__doc__
-        del pyspark.sql.connect.functions.window.__doc__
-        del pyspark.sql.connect.functions.window_time.__doc__
-
         # Creates a remote Spark session.
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3208,7 +3208,7 @@ def monotonically_increasing_id() -> Column:
 
     Examples
     --------
-    >>> df0 = spark.sparkContext.parallelize(range(2), 2).mapPartitions(lambda x: [(1,), (2,), (3,)]).toDF(['col1'])
+    >>> df0 = sc.parallelize(range(2), 2).mapPartitions(lambda x: [(1,), (2,), (3,)]).toDF(['col1'])
     >>> df0.select(monotonically_increasing_id().alias('id')).collect()
     [Row(id=0), Row(id=1), Row(id=2), Row(id=8589934592), Row(id=8589934593), Row(id=8589934594)]
     """

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -3208,7 +3208,7 @@ def monotonically_increasing_id() -> Column:
 
     Examples
     --------
-    >>> df0 = sc.parallelize(range(2), 2).mapPartitions(lambda x: [(1,), (2,), (3,)]).toDF(['col1'])
+    >>> df0 = spark.sparkContext.parallelize(range(2), 2).mapPartitions(lambda x: [(1,), (2,), (3,)]).toDF(['col1'])
     >>> df0.select(monotonically_increasing_id().alias('id')).collect()
     [Row(id=0), Row(id=1), Row(id=2), Row(id=8589934592), Row(id=8589934593), Row(id=8589934594)]
     """


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to enable doctests in pyspark.sql.connect.functions that is virtually the same as pyspark.sql.functions.

### Why are the changes needed?
To make sure on the PySpark compatibility and test coverage.

### Does this PR introduce any user-facing change?
No, doctest's only.

### How was this patch tested?
New Doctests Added