### PR TITLE
[SPARK-41804][SQL] Choose correct element size in `InterpretedUnsafeProjection` for array of UDTs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -294,6 +294,8 @@ object InterpretedUnsafeProjection {
   private def getElementSize(dataType: DataType): Int = dataType match {
     case NullType | StringType | BinaryType | CalendarIntervalType |
          _: DecimalType | _: StructType | _: ArrayType | _: MapType => 8
+    case udt: UserDefinedType[_] =>
+      getElementSize(udt.sqlType)
     case _ => dataType.defaultSize
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
@@ -689,22 +689,18 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with PlanTestB
   }
 
   testBothCodegenAndInterpreted("SPARK-41804: Array of UDTs") {
-    val doubleArray1 = Array[Double](1.0, 3.0, 5.0)
-    val doubleArray2 = Array[Double](7.0, 9.0, 11.0)
-    val udt = new OddSizeStructUDT
-    val odd1 = udt.serialize(MyOddSizeStruct(doubleArray1))
-    val odd2 = udt.serialize(MyOddSizeStruct(doubleArray2))
-    val outerArray = new GenericArrayData(Seq(odd1, odd2))
-    val row = new GenericInternalRow(Array[Any](outerArray))
+    val udt = new ExampleBaseTypeUDT
+    val objs = Seq(
+      udt.serialize(new ExampleSubClass(1)),
+      udt.serialize(new ExampleSubClass(2)))
+    val arr = new GenericArrayData(objs)
+    val row = new GenericInternalRow(Array[Any](arr))
     val unsafeProj = UnsafeProjection.create(Array[DataType](ArrayType(udt)))
     val unsafeRow = unsafeProj.apply(row)
-    // get the outer array (the array of UDTs)
     val unsafeOuterArray = unsafeRow.getArray(0)
-    // get second element from the outer array (the second serialized MyOddSizeStruct instance)
-    val unsafeStruct = unsafeOuterArray.getStruct(1, 3)
-    // get the 3rd field from the serialized MyOddSizeStruct instance
-    val unsafeInnerArray = unsafeStruct.getArray(2)
-    val result = unsafeInnerArray.toDoubleArray
-    assert(result.toSeq == doubleArray2.toSeq)
+    // get second element from unsafe array
+    val unsafeStruct = unsafeOuterArray.getStruct(1, 1)
+    val result = unsafeStruct.getInt(0)
+    assert(result == 2)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/TestUDT.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/TestUDT.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.types
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeArrayData}
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 
 
@@ -131,48 +131,4 @@ private[spark] class ExampleSubTypeUDT extends UserDefinedType[IExampleSubType] 
   }
 
   override def userClass: Class[IExampleSubType] = classOf[IExampleSubType]
-}
-
-case class MyOddSizeStruct(data: Array[Double]) {
-  override def hashCode(): Int = java.util.Arrays.hashCode(data)
-
-  override def equals(other: Any): Boolean = other match {
-    case v: MyOddSizeStruct => java.util.Arrays.equals(this.data, v.data)
-    case _ => false
-  }
-
-  override def toString: String = data.mkString("(", ", ", ")")
-}
-
-class OddSizeStructUDT extends UserDefinedType[MyOddSizeStruct] {
-  override final def sqlType: StructType = {
-    StructType(
-      Array(
-      StructField("type", ByteType, nullable = false),
-      StructField("size", IntegerType, nullable = true),
-      StructField("data", ArrayType(DoubleType, containsNull = false), nullable = true)))
-  }
-
-  override def serialize(obj: MyOddSizeStruct): InternalRow = {
-    val mo = new MyOddSizeStruct(Array(0.1d))
-
-    val row = new GenericInternalRow(3)
-    row.setByte(0, 1)
-    row.setInt(1, obj.data.size)
-    row.update(2, UnsafeArrayData.fromPrimitiveArray(obj.data))
-    row
-  }
-
-  override def deserialize(datum: Any): MyOddSizeStruct = {
-    datum match {
-      case row: InternalRow =>
-        MyOddSizeStruct(row.getArray(2).toDoubleArray())
-    }
-  }
-
-  override def userClass: Class[MyOddSizeStruct] = classOf[MyOddSizeStruct]
-
-  override def hashCode(): Int = getClass.hashCode()
-
-  override def equals(other: Any): Boolean = other.isInstanceOf[MyOddSizeStruct]
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `InterpretedUnsafeProjection#getElementSize` to choose the appropriate element size for the underlying SQL type of a UDT, rather than simply using the the default size of the underlying SQL type.

### Why are the changes needed?

Consider this query:
```
// create a file of vector data
import org.apache.spark.ml.linalg.{DenseVector, Vector}

case class TestRow(varr: Array[Vector])
val values = Array(0.1d, 0.2d, 0.3d)
val dv = new DenseVector(values).asInstanceOf[Vector]

val ds = Seq(TestRow(Array(dv, dv))).toDS
ds.coalesce(1).write.mode("overwrite").format("parquet").save("vector_data")

// this works
spark.read.format("parquet").load("vector_data").collect

sql("set spark.sql.codegen.wholeStage=false")
sql("set spark.sql.codegen.factoryMode=NO_CODEGEN")

// this will get an error
spark.read.format("parquet").load("vector_data").collect
```
The failures vary, incuding
* `VectorUDT` attempting to deserialize to a `SparseVector` (rather than a `DenseVector`)
* negative array size (for one of the nested arrays)
* JVM crash (SIGBUS error).

This is because `InterpretedUnsafeProjection` initializes the outer-most array writer with an element size of 17 (the size of the UDT's underlying struct), rather than an element size of 8, which would be appropriate for an array of structs.

When the outer-most array is later accessed, `UnsafeArrayData` assumes an element size of 8, so it picks up a garbage offset/size tuple for the second element.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit test.
