### PR TITLE
[MINOR] Fix a typo "from from" -> "from"

### DIFF
--- a/dev/ansible-for-test-node/roles/jenkins-worker/README.md
+++ b/dev/ansible-for-test-node/roles/jenkins-worker/README.md
@@ -6,7 +6,7 @@ jenkins-worker -- set up the craziness of a jenkins worker to build and test Apa
 Requirements
 ------------
 
-Oh jeez.  This is just a framework to help others get started.  If you try and deploy this locally, you'll need a service account, auth set up, etc etc.
+Oh jeez.  This is just a framework to help others get started.  If you try and deploy this locally, you'll need a service account, auth set up, etc.
 
 Role Variables
 --------------

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -800,7 +800,7 @@ staging directory of the Spark application.
   <td><code>spark.yarn.kerberos.renewal.excludeHadoopFileSystems</code></td>
   <td>(none)</td>
   <td>
-    A comma-separated list of Hadoop filesystems for whose hosts will be excluded from from delegation
+    A comma-separated list of Hadoop filesystems for whose hosts will be excluded from delegation
     token renewal at resource scheduler. For example, <code>spark.yarn.kerberos.renewal.excludeHadoopFileSystems=hdfs://nn1.com:8032,
     hdfs://nn2.com:8032</code>. This is known to work under YARN for now, so YARN Resource Manager won't renew tokens for the application.
     Note that as resource scheduler does not renew token, so any application running longer than the original token expiration that tries


### PR DESCRIPTION
I just spotted this typo in the documentation, so I decided to fix it, please tell me if I should file an issue or something first