### PR TITLE
[SPARK-41856][CONNECT][TESTS] Enable test_create_nan_decimal_dataframe, test_freqItems, test_input_files, test_to_pandas_required_pandas_not_found

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -138,6 +138,10 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
         super().test_to()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_toDF_with_schema_string(self):
+        super().test_toDF_with_schema_string()
+
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_local_iterator(self):
         super().test_to_local_iterator()
 

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -66,6 +66,10 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
         super().test_create_dataframe_required_pandas_not_found()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_create_nan_decimal_dataframe(self):
+        super().test_create_nan_decimal_dataframe()
+
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_drop_duplicates(self):
         super().test_drop_duplicates()
 

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -66,10 +66,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
         super().test_create_dataframe_required_pandas_not_found()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_create_nan_decimal_dataframe(self):
-        super().test_create_nan_decimal_dataframe()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_drop_duplicates(self):
         super().test_drop_duplicates()
 
@@ -86,20 +82,12 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
         super().test_fillna()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_freqItems(self):
-        super().test_freqItems()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_generic_hints(self):
         super().test_generic_hints()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_help_command(self):
         super().test_help_command()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_input_files(self):
-        super().test_input_files()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_invalid_join_method(self):
@@ -150,10 +138,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
         super().test_to()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_toDF_with_schema_string(self):
-        super().test_toDF_with_schema_string()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_local_iterator(self):
         super().test_to_local_iterator()
 
@@ -192,10 +176,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_pandas_on_cross_join(self):
         super().test_to_pandas_on_cross_join()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_to_pandas_required_pandas_not_found(self):
-        super().test_to_pandas_required_pandas_not_found()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_pandas_with_duplicated_column_names(self):

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -873,7 +873,7 @@ class DataFrameTestsMixin:
 
     def test_toDF_with_schema_string(self):
         data = [Row(key=i, value=str(i)) for i in range(100)]
-        rdd = self.spark.createDataFrame(data, 5)
+        rdd = self.spark.createDataFrame(data)
 
         df = rdd.toDF("key: int, value: string")
         self.assertEqual(df.schema.simpleString(), "struct<key:int,value:string>")

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -74,7 +74,7 @@ class DataFrameTestsMixin:
 
     def test_freqItems(self):
         vals = [Row(a=1, b=-2.0) if i % 2 == 0 else Row(a=i, b=i * 1.0) for i in range(100)]
-        df = self.sc.parallelize(vals).toDF()
+        df = self.spark.createDataFrame(vals)
         items = df.stat.freqItems(("a", "b"), 0.4).collect()[0]
         self.assertTrue(1 in items[0])
         self.assertTrue(-2.0 in items[1])
@@ -873,7 +873,7 @@ class DataFrameTestsMixin:
 
     def test_toDF_with_schema_string(self):
         data = [Row(key=i, value=str(i)) for i in range(100)]
-        rdd = self.sc.parallelize(data, 5)
+        rdd = self.spark.createDataFrame(data, 5)
 
         df = rdd.toDF("key: int, value: string")
         self.assertEqual(df.schema.simpleString(), "struct<key:int,value:string>")

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -873,7 +873,7 @@ class DataFrameTestsMixin:
 
     def test_toDF_with_schema_string(self):
         data = [Row(key=i, value=str(i)) for i in range(100)]
-        rdd = self.spark.createDataFrame(data)
+        rdd = self.sc.parallelize(data, 5)
 
         df = rdd.toDF("key: int, value: string")
         self.assertEqual(df.schema.simpleString(), "struct<key:int,value:string>")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR enables the reused PySpark tests in Spark Connect that pass now.

### Why are the changes needed?
To make sure on the test coverage.

### Does this PR introduce any user-facing change?
No, test-only.

### How was this patch tested?
Manually ran it in my local.