### PR TITLE
[SPARK-41814][SPARK-41851][SPARK-41852][FOLLOW-UP] Reeanble skipped doctests

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -283,7 +283,6 @@ class Column:
     __gt__ = _bin_op("gt")
 
     # TODO(SPARK-41812): DataFrame.join: ambiguous column
-    # TODO(SPARK-41814): Column.eqNullSafe fails on NaN comparison
     _eqNullSafe_doc = """
     Equality test that is safe for null values.
 
@@ -332,7 +331,7 @@ class Column:
     ...     df2['value'].eqNullSafe(None),
     ...     df2['value'].eqNullSafe(float('NaN')),
     ...     df2['value'].eqNullSafe(42.0)
-    ... ).show()  # doctest: +SKIP
+    ... ).show()
     +----------------+---------------+----------------+
     |(value <=> NULL)|(value <=> NaN)|(value <=> 42.0)|
     +----------------+---------------+----------------+

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2447,12 +2447,6 @@ def _test() -> None:
         # TODO(SPARK-41850): fix isnan
         del pyspark.sql.connect.functions.isnan.__doc__
 
-        # TODO(SPARK-41851): fix nanvl
-        del pyspark.sql.connect.functions.nanvl.__doc__
-
-        # TODO(SPARK-41852): fix pmod
-        del pyspark.sql.connect.functions.pmod.__doc__
-
         # Creates a remote Spark session.
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/39360 that enables skipped doctests.

### Why are the changes needed?

To make sure on the test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually checked via:

```bash
./python/run-tests --testnames 'pyspark.sql.connect.functions'
./python/run-tests --testnames 'pyspark.sql.connect.column'
```