### PR TITLE
[SPARK-41859][SQL] CreateHiveTableAsSelectCommand should set the overwrite flag correctly

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -60,7 +60,7 @@ case class CreateHiveTableAsSelectCommand(
         return Seq.empty
       }
 
-      val command = getWritingCommand(catalog, tableDesc, tableExists = true)
+      val command = getWritingCommand(tableDesc, tableExists = true)
       val qe = sparkSession.sessionState.executePlan(command)
       qe.assertCommandExecuted()
     } else {
@@ -74,13 +74,12 @@ case class CreateHiveTableAsSelectCommand(
       val tableSchema = CharVarcharUtils.getRawSchema(
         outputColumns.toStructType, sparkSession.sessionState.conf)
       assert(tableDesc.schema.isEmpty)
-      catalog.createTable(
-        tableDesc.copy(schema = tableSchema), ignoreIfExists = false)
+      catalog.createTable(tableDesc.copy(schema = tableSchema), ignoreIfExists = false)
 
       try {
         // Read back the metadata of the table which was created just now.
         val createdTableMeta = catalog.getTableMetadata(tableDesc.identifier)
-        val command = getWritingCommand(catalog, createdTableMeta, tableExists = false)
+        val command = getWritingCommand(createdTableMeta, tableExists = false)
         val qe = sparkSession.sessionState.executePlan(command)
         qe.assertCommandExecuted()
       } catch {
@@ -95,7 +94,6 @@ case class CreateHiveTableAsSelectCommand(
   }
 
   private def getWritingCommand(
-      catalog: SessionCatalog,
       tableDesc: CatalogTable,
       tableExists: Boolean): DataWritingCommand = {
     // For CTAS, there is no static partition values to insert.
@@ -104,7 +102,7 @@ case class CreateHiveTableAsSelectCommand(
       tableDesc,
       partition,
       query,
-      overwrite = if (tableExists) false else true,
+      overwrite = false,
       ifPartitionNotExists = false,
       outputColumnNames = outputColumnNames)
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.hive.execution
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
-import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.errors.QueryCompilationErrors


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`CreateHiveTableAsSelectCommand` is used in two APIs:
1. SQL CTAS
2. `DataFrameWriter.saveAsTable`

For SQL CTAS, if the table already exists, we either do nothing if `IF NOT EXISTS` is specified, or fail otherwise. This means, `CreateHiveTableAsSelectCommand` from SQL CTAS should only trigger table insertion if table not exists.

For `DataFrameWriter.saveAsTable`, it can create the table if it doesn't exist, or append data to the table if `SaveMode` is `Append`. `DataFrameWriter.saveAsTable` will drop the table first if `SaveMode` is `Overwrite`. This means, `CreateHiveTableAsSelectCommand` from `DataFrameWriter.saveAsTable` either appends data to an existing table, or creates a new table.

In summary, the table insertion command triggered by `CreateHiveTableAsSelectCommand` should always set `overwrite` to false.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix a mistake

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. If the table does not exist, the `overwrite` flag doesn't matter. But it could be a potential bug in the future.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests