### PR TITLE
[SPARK-41860][SQL] Make AvroScanBuilder and JsonScanBuilder case classes

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScanBuilder.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/v2/avro/AvroScanBuilder.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class AvroScanBuilder (
+case class AvroScanBuilder (
     sparkSession: SparkSession,
     fileIndex: PartitioningAwareFileIndex,
     schema: StructType,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/json/JsonScanBuilder.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-class JsonScanBuilder (
+case class JsonScanBuilder (
     sparkSession: SparkSession,
     fileIndex: PartitioningAwareFileIndex,
     schema: StructType,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make `AvroScanBuilder` and `JsonScanBuilder` case classes from normal classes.

All the other existing `ScanBuilder`s inheriting from `FileScanBuilder` are case classes which is very nice and useful. However the Json and the Avro ones aren't, which makes it quite inconvenient when working with those. I don't see any particular reason why these two would not be case classes as well given they are very similar to the other ones and very simple and stateless. Especially when `AvroScan` and `JsonScan` are also already case classes like the other scans.


### Why are the changes needed?
When working on using different possible `FileScanBuilder` is really problematic that these 2 ScanBuilders are not case classes, especially given all the others are. This is a very simple change that helps development greatly and allows for more flexibility / feature deelopment when working with ScanBuilders.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No need for testing as it's a simple change from `class` to `case class`
