### PR TITLE
[SPARK-41775][PYTHON][ML] Adding support for PyTorch functions

### DIFF
--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -563,6 +563,9 @@ class TorchDistributor(Distributor):
         self.logger.info(
             f"Finished distributed training with {self.num_processes} executor proceses"
         )
+        self.logger.info(
+            f"Finished distributed training with {self.num_processes} executor proceses"
+        )
         return result
 
     @staticmethod

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -679,7 +679,9 @@ class TorchDistributor(Distributor):
         if isinstance(train_object, str):
             framework_wrapper_fn = TorchDistributor._run_training_on_pytorch_file
         else:
-            framework_wrapper_fn = TorchDistributor._run_training_on_pytorch_function
+            framework_wrapper_fn = (
+                TorchDistributor._run_training_on_pytorch_function  # type: ignore
+            )
         if self.local_mode:
             output = self._run_local_training(framework_wrapper_fn, train_object, *args)
         else:

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -592,8 +592,8 @@ class TorchDistributor(Distributor):
             training_command, log_streaming_client=log_streaming_client
         )
 
-    @contextmanager
     @staticmethod
+    @contextmanager
     def _setup_files(train_fn: Callable, *args: Any) -> Generator[Tuple[str, str], None, None]:
         save_dir = TorchDistributor._create_save_dir()
         pickle_file_path = TorchDistributor._save_pickled_function(save_dir, train_fn, *args)

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -563,9 +563,6 @@ class TorchDistributor(Distributor):
         self.logger.info(
             f"Finished distributed training with {self.num_processes} executor proceses"
         )
-        self.logger.info(
-            f"Finished distributed training with {self.num_processes} executor proceses"
-        )
         return result
 
     @staticmethod

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -25,7 +25,7 @@ import sys
 import time
 import tempfile
 import threading
-from typing import Callable, Dict, Any
+from typing import Callable, Dict, Any, Tuple
 import unittest
 from unittest.mock import patch
 
@@ -48,10 +48,10 @@ def patch_stdout() -> StringIO:
         sys.stdout = sys_stdout
 
 
-def create_training_function() -> Callable:
+def create_training_function() -> Tuple[Callable, str]:
     import torch.nn as nn
     import torch.nn.functional as F
-    from torchvision import transforms, datasets
+    from torchvision import transforms, datasets  # type: ignore
 
     batch_size = 100
     num_epochs = 1
@@ -97,7 +97,7 @@ def create_training_function() -> Callable:
 
         train_sampler = DistributedSampler(dataset=train_dataset)
         data_loader = torch.utils.data.DataLoader(
-            train_dataset, batch_size=batch_size, sampler=train_sampler
+            train_dataset, batch_size=batch_size, sampler=train_sampler  # type: ignore
         )
 
         model = Net()

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -94,7 +94,7 @@ def create_training_function(mnist_dir_path: str) -> Callable:
         dist.init_process_group("gloo")
 
         train_sampler = DistributedSampler(dataset=train_dataset)  # type: ignore
-        data_loader = torch.utils.data.DataLoader(  # type: ignore
+        data_loader = torch.utils.data.DataLoader(
             train_dataset, batch_size=batch_size, sampler=train_sampler
         )
 

--- a/python/pyspark/ml/torch/torch_run_process_wrapper.py
+++ b/python/pyspark/ml/torch/torch_run_process_wrapper.py
@@ -55,6 +55,8 @@ if __name__ == "__main__":
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=os.environ,
     )
     t = threading.Thread(target=check_parent_alive, args=(task,), daemon=True)

--- a/python/pyspark/ml/torch/torch_run_process_wrapper.py
+++ b/python/pyspark/ml/torch/torch_run_process_wrapper.py
@@ -55,8 +55,6 @@ if __name__ == "__main__":
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
         env=os.environ,
     )
     t = threading.Thread(target=check_parent_alive, args=(task,), daemon=True)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

NOTE: If you want to only view the diff from the other WIP PR regarding the baseline changes, look at the LAST COMMIT in this PR's commit history (titled "WIP adding notebook functionality"). Since I am sending out parallel PRs that are related, you should view this commit to see the diff pertaining to this ticket.


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This is an addition to https://github.com/apache/spark/pull/39299 to add support for using functions as the input for distributed training. The users would follow the first workflow in the [design document](https://docs.google.com/document/d/1QPO1Ly8WteL6aIPvVcR7Xne9qVtJiB3fdrRn7NwBcpA/edit#heading=h.8yvw9xq428fh) to run training.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We want to make it easier for users to run distributed training from a notebook setting.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Users can now input a training function into the `PyTorchDistributor().run(...)` api. This will require a lot of additional documentation though since since we are internally using cloudpickle to run training so we need to be able to have the user's train() function be picklable.  

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This is a WIP PR so it hasn't been tested yet.
