### PR TITLE
[SPARK-41863][INFRA][PYTHON][TESTS] Skip `flake8` tests if the command is not available

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -175,9 +175,8 @@ function flake8_test {
     local FLAKE8_STATUS=
 
     if ! hash "$FLAKE8_BUILD" 2> /dev/null; then
-        echo "The flake8 command was not found."
-        echo "flake8 checks failed."
-        exit 1
+        echo "The flake8 command was not found. Skipping for now."
+        return
     fi
 
     _FLAKE8_VERSION=($($FLAKE8_BUILD --version))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `flake8` tests if the command is not available.

### Why are the changes needed?

Linters are optional modules and we can be skip in some systems like `mypy`.
```
$ dev/lint-python
starting python compilation test...
python compilation succeeded.

The Python library providing 'black' module was not found. Skipping black checks for now.

The flake8 command was not found. Skipping for now.
The mypy command was not found. Skipping for now.

all lint-python tests passed!
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual tests.