### PR TITLE
[SPARK-41865][INFRA][3.2] Use pycodestyle to 2.7.0 to fix pycodestyle errors

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -375,7 +375,7 @@ jobs:
         #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
         # Jinja2 3.0.0+ causes error when building with Sphinx.
         #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-        python3.9 -m pip install flake8 pydata_sphinx_theme 'mypy==0.910' numpydoc 'jinja2<3.0.0' 'black==21.5b2'
+        python3.9 -m pip install flake8 pydata_sphinx_theme 'mypy==0.910' numpydoc 'jinja2<3.0.0' 'black==21.5b2' 'pycodestyle==2.7.0'
     - name: Install R linter dependencies and SparkR
       run: |
         apt update


### PR DESCRIPTION
### What changes were proposed in this pull request?

`branch-3.2` has been broken for a while with false-positive failures.
- https://github.com/apache/spark/actions/runs/3833643461/jobs/6525303096
```
pycodestyle checks failed:
./python/pyspark/broadcast.py:102:23: E275 missing whitespace after keyword
./python/pyspark/sql/tests/test_context.py:166:19: E275 missing whitespace after keyword
./python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py:512:15: E275 missing whitespace after keyword
./python/pyspark/sql/pandas/conversion.py:174:20: E275 missing whitespace after keyword
./python/pyspark/sql/readwriter.py:662:60: E275 missing whitespace after keyword
./python/pyspark/sql/readwriter.py:694:60: E275 missing whitespace after keyword
./python/pyspark/ml/tests/test_tuning.py:203:23: E275 missing whitespace after keyword
./python/pyspark/worker.py:583:27: E275 missing whitespace after keyword
Error: Process completed with exit code 1.
```

### Why are the changes needed?

To fix `pycodestyle`.  Apache Spark expects `2.7.0` like the following.

https://github.com/apache/spark/blob/ad2d42709abfc8f8ad27f836c811a4b75ef32ee9/dev/lint-python#L25

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass `pycodestyle`.

![Screenshot 2023-01-03 at 5 20 57 PM](https://user-images.githubusercontent.com/9700541/210467357-63626c33-966d-44cb-876e-933499f086ad.png)
