### PR TITLE
[SPARK-41867][SQL] Selective predicate should respect InMemoryRelation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -33,7 +33,8 @@ import org.apache.spark.sql.types._
  * The filter could be an IN subquery (converted to a semi join), a bloom filter, or something
  * else in the future.
  */
-object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with JoinSelectionHelper {
+object InjectRuntimeFilter extends Rule[LogicalPlan]
+  with SelectivePredicateHelper with JoinSelectionHelper {
 
   // Wraps `expr` with a hash function if its byte size is larger than an integer.
   private def mayWrapWithHash(expr: Expression): Expression = {
@@ -146,7 +147,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
           predicateReference ++ condition.references,
           hasHitFilter = true,
           hasHitSelectiveFilter = hasHitSelectiveFilter || isLikelySelective(condition))
-      case _: LeafNode => hasHitSelectiveFilter
+      case l: LeafNode => hasHitSelectiveFilter || hasSelectivePredicate(l)
       case _ => false
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/optimizer/SelectivePredicateHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/optimizer/SelectivePredicateHelper.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.PredicateHelper
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
+import org.apache.spark.sql.execution.FilterExec
+import org.apache.spark.sql.execution.columnar.InMemoryRelation
+
+/**
+ * [[InMemoryRelation]] is at sql/core module, so this helper trait also places in sql/core.
+ */
+trait SelectivePredicateHelper extends PredicateHelper {
+
+  /**
+   * Search a filtering predicate in a given logical plan
+   */
+  def hasSelectivePredicate(plan: LogicalPlan): Boolean = {
+    plan.exists {
+      // We do not actually need a selective predicate if the `InMemoryRelation` is materialized,
+      // because its statistics is correct enough. The call side would validate if the statistics
+      // is bigger than requirements.
+      case relation: InMemoryRelation if relation.isMaterialized => true
+      case relation: InMemoryRelation =>
+        relation.cachedPlan.exists {
+          case f: FilterExec => isLikelySelective(f.condition)
+          case _ => false
+        }
+      case f: Filter => isLikelySelective(f.condition)
+      case _ => false
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryRelation.scala
@@ -388,6 +388,7 @@ case class InMemoryRelation(
   @transient val partitionStatistics = new PartitionStatistics(output)
 
   def cachedPlan: SparkPlan = cacheBuilder.cachedPlan
+  def isMaterialized: Boolean = cacheBuilder.isCachedColumnBuffersLoaded
 
   private[sql] def updateStats(
       rowCount: Long,
@@ -400,7 +401,7 @@ case class InMemoryRelation(
   }
 
   override def computeStats(): Statistics = {
-    if (!cacheBuilder.isCachedColumnBuffersLoaded) {
+    if (!isMaterialized) {
       // Underlying columnar RDD hasn't been materialized, use the stats from the plan to cache.
       statsOfPlanToCache
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -481,6 +481,7 @@ abstract class DynamicPartitionPruningSuiteBase
               |FROM fact_sk f WHERE store_id < 5
             """.stripMargin)
             .write
+            .format(tableFormat)
             .partitionBy("store_id")
             .saveAsTable("fact_aux")
 
@@ -513,6 +514,7 @@ abstract class DynamicPartitionPruningSuiteBase
                 |FROM fact_sk f WHERE store_id < 5
               """.stripMargin)
               .write
+              .format(tableFormat)
               .partitionBy("store_id")
               .saveAsTable("fact_aux")
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr add a new trait `SelectivePredicateHelper` at `sql/core` module that provide a method to find if the plan has selective predicate even if the predicate is in `InMemoryRelation`. The reason why it should be placed in `sql/core` module is the `InMemoryRelation` is at `sql/core`.

Then, move the `InjectRuntimeFilter` from `sql/catalyst` module to `sql/core` module so it can use the new trait.
Also make `PartitionPruning` use `SelectivePredicateHelper` instead of `PredicateHelper`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
DPP and Runtime Filter require the build side has a selective predicate. It should also work if the filter is inside the cached relation.
Besides, the runtime filter should consider the overhead of cached plan.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, more cases can be optimized

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test