### PR TITLE
[SPARK-41821][CONNECT][PYTHON] Fix doc test for DataFrame.describe

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -829,7 +829,7 @@ class DataFrame:
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]  # type: ignore[assignment]
         return DataFrame.withPlan(
-            plan.StatDescribe(child=self._plan, cols=cols),
+            plan.StatDescribe(child=self._plan, cols=list(cols)),
             session=self._session,
         )
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -828,8 +828,15 @@ class DataFrame:
     def describe(self, *cols: Union[str, List[str]]) -> "DataFrame":
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]  # type: ignore[assignment]
+
+        _cols = []
+        for col in cols:
+            if isinstance(col, str):
+                _cols.append(col)
+            else:
+                _cols.extend([s for s in col])
         return DataFrame.withPlan(
-            plan.StatDescribe(child=self._plan, cols=list(cols)),
+            plan.StatDescribe(child=self._plan, cols=_cols),
             session=self._session,
         )
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1407,9 +1407,6 @@ def _test() -> None:
         del pyspark.sql.connect.dataframe.DataFrame.createOrReplaceGlobalTempView.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.createOrReplaceTempView.__doc__
 
-        # TODO(SPARK-41821): Fix DataFrame.describe
-        del pyspark.sql.connect.dataframe.DataFrame.describe.__doc__
-
         # TODO(SPARK-41823): ambiguous column names
         del pyspark.sql.connect.dataframe.DataFrame.drop.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.join.__doc__

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -830,11 +830,11 @@ class DataFrame:
             cols = cols[0]  # type: ignore[assignment]
 
         _cols = []
-        for col in cols:
-            if isinstance(col, str):
-                _cols.append(col)
+        for column in cols:
+            if isinstance(column, str):
+                _cols.append(column)
             else:
-                _cols.extend([s for s in col])
+                _cols.extend([s for s in column])
         return DataFrame.withPlan(
             plan.StatDescribe(child=self._plan, cols=_cols),
             session=self._session,

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -825,13 +825,11 @@ class DataFrame:
 
     summary.__doc__ = PySparkDataFrame.summary.__doc__
 
-    def describe(self, *cols: str) -> "DataFrame":
-        _cols: List[str] = list(cols)
-        for s in _cols:
-            if not isinstance(s, str):
-                raise TypeError(f"'cols' must be list[str], but got {type(s).__name__}")
+    def describe(self, *cols: Union[str, List[str]]) -> "DataFrame":
+        if len(cols) == 1 and isinstance(cols[0], list):
+            cols = cols[0]  # type: ignore[assignment]
         return DataFrame.withPlan(
-            plan.StatDescribe(child=self._plan, cols=_cols),
+            plan.StatDescribe(child=self._plan, cols=cols),
             session=self._session,
         )
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1208,6 +1208,21 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         expected = "+---+---+\n|  X|  Y|\n+---+---+\n|  1|  2|\n+---+---+\n"
         self.assertEqual(show_str, expected)
 
+    def test_describe(self):
+        # SPARK-41403: Test the describe method
+        self.assert_eq(
+            self.connect.read.table(self.tbl_name).describe("id").toPandas(),
+            self.spark.read.table(self.tbl_name).describe("id").toPandas(),
+        )
+        self.assert_eq(
+            self.connect.read.table(self.tbl_name).describe("id", "name").toPandas(),
+            self.spark.read.table(self.tbl_name).describe("id", "name").toPandas(),
+        )
+        self.assert_eq(
+            self.connect.read.table(self.tbl_name).describe(["id", "name"]).toPandas(),
+            self.spark.read.table(self.tbl_name).describe(["id", "name"]).toPandas(),
+        )
+
     def test_stat_cov(self):
         # SPARK-41067: Test the stat.cov method
         self.assertEqual(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, the python doc test failed caused by `DataFrame.describe`
```
File "/Users/s.singh/personal/spark-oss/python/pyspark/sql/connect/dataframe.py", line 898, in pyspark.sql.connect.dataframe.DataFrame.describe
Failed example:
    df.describe(['age']).show()
Exception raised:
    Traceback (most recent call last):
      File "/usr/local/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/doctest.py", line 1350, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest pyspark.sql.connect.dataframe.DataFrame.describe[1]>", line 1, in <module>
        df.describe(['age']).show()
      File "/Users/s.singh/personal/spark-oss/python/pyspark/sql/connect/dataframe.py", line 832, in describe
        raise TypeError(f"'cols' must be list[str], but got {type(s).__name__}")
    TypeError: 'cols' must be list[str], but got list
```

This PR also adds some tests into `test_connect_basic.py`.


### Why are the changes needed?
Let the python doc test success.
Adds test cases.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
N/A
