### PR TITLE
[SPARK-41825][CONNECT][PYTHON] Enable doctests related to `DataFrame.show`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1427,11 +1427,7 @@ def _test() -> None:
         del pyspark.sql.connect.dataframe.DataFrame.explain.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.hint.__doc__
 
-        # TODO(SPARK-41825): Dataframe.show formatting int as double
-        del pyspark.sql.connect.dataframe.DataFrame.fillna.__doc__
-        del pyspark.sql.connect.dataframe.DataFrameNaFunctions.replace.__doc__
-        del pyspark.sql.connect.dataframe.DataFrameNaFunctions.fill.__doc__
-        del pyspark.sql.connect.dataframe.DataFrame.replace.__doc__
+        # TODO(SPARK-41886): The doctest output has different order
         del pyspark.sql.connect.dataframe.DataFrame.intersect.__doc__
 
         # TODO(SPARK-41625): Support Structured Streaming

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2360,10 +2360,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.date_trunc.__doc__
         del pyspark.sql.connect.functions.from_utc_timestamp.__doc__
 
-        # TODO(SPARK-41825): Dataframe.show formatting int as double
-        del pyspark.sql.connect.functions.coalesce.__doc__
-        del pyspark.sql.connect.functions.sum_distinct.__doc__
-
         # TODO(SPARK-41834): implement Dataframe.conf
         del pyspark.sql.connect.functions.from_unixtime.__doc__
         del pyspark.sql.connect.functions.timestamp_seconds.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?
enable a group of doctests


### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
enabled tests
