### PR TITLE
[SPARK-41894][SS][TESTS] Restore the write permission of `commitDir` after run `testAsyncWriteErrorsPermissionsIssue`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
@@ -750,6 +750,12 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
             }
             e.getCause.getCause.getMessage should include("Permission denied")
           }
+      },
+      Execute { _ =>
+        // SPARK-41894: Restore the write permission of `commitDir`
+        // so that `mvn clean` can run successfully.
+        val commitDir = new File(checkpointLocation + path)
+        commitDir.setWritable(true)
       }
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
@@ -722,42 +722,41 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
     val inputData = new MemoryStream[Int](id = 0, sqlContext = sqlContext)
     val ds = inputData.toDS()
     val checkpointLocation = Utils.createTempDir(namePrefix = "streaming.metadata").getCanonicalPath
+    val commitDir = new File(checkpointLocation + path)
 
-    testStream(
-      ds,
-      extraOptions = Map(
-        ASYNC_PROGRESS_TRACKING_ENABLED -> "true",
-        ASYNC_PROGRESS_TRACKING_CHECKPOINTING_INTERVAL_MS -> "0"
-      )
-    )(
-      StartStream(checkpointLocation = checkpointLocation),
-      AddData(inputData, 0),
-      CheckAnswer(0),
-      Execute { q =>
-        waitPendingOffsetWrites(q)
-        // to simulate write error
-        import java.io._
-        val commitDir = new File(checkpointLocation + path)
-        commitDir.setReadOnly()
+    try {
+      testStream(
+        ds,
+        extraOptions = Map(
+          ASYNC_PROGRESS_TRACKING_ENABLED -> "true",
+          ASYNC_PROGRESS_TRACKING_CHECKPOINTING_INTERVAL_MS -> "0"
+        )
+      )(
+        StartStream(checkpointLocation = checkpointLocation),
+        AddData(inputData, 0),
+        CheckAnswer(0),
+        Execute { q =>
+          waitPendingOffsetWrites(q)
+          // to simulate write error
+          commitDir.setReadOnly()
 
-      },
-      AddData(inputData, 1),
-      Execute {
-        q =>
-          eventually(timeout(Span(5, Seconds))) {
-            val e = intercept[StreamingQueryException] {
-              q.processAllAvailable()
+        },
+        AddData(inputData, 1),
+        Execute {
+          q =>
+            eventually(timeout(Span(5, Seconds))) {
+              val e = intercept[StreamingQueryException] {
+                q.processAllAvailable()
+              }
+              e.getCause.getCause.getMessage should include("Permission denied")
             }
-            e.getCause.getCause.getMessage should include("Permission denied")
-          }
-      },
-      Execute { _ =>
-        // SPARK-41894: Restore the write permission of `commitDir`
-        // so that `mvn clean` can run successfully.
-        val commitDir = new File(checkpointLocation + path)
-        commitDir.setWritable(true)
-      }
-    )
+        }
+      )
+    } finally {
+      // SPARK-41894: Restore the write permission of `commitDir`
+      // so that `mvn clean` can run successfully.
+      commitDir.setWritable(true)
+    }
   }
 
     // Tests that errors that occurred during async offset log write gets bubbled up


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to restore the write permission of `commitDir` after run `testAsyncWriteErrorsPermissionsIssue` in `AsyncProgressTrackingMicroBatchExecutionSuite` so that `mvn clean` can run successfully.


### Why are the changes needed?
Make `mvn clean` can run successfully after run `mvn test` with `AsyncProgressTrackingMicroBatchExecutionSuite`


### Does this PR introduce _any_ user-facing change?
No, just for test


### How was this patch tested?

- Pass Github Actions
- Manual test

```
build/mvn clean install -pl sql/core -am -DskipTests
build/mvn clean test -pl sql/core -Dtest=none -DwildcardSuites=org.apache.spark.sql.execution.streaming.AsyncProgressTrackingMicroBatchExecutionSuite
build/mvn clean -pl sql/core
```

**Before**

`build/mvn clean -pl sql/core` run failed

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-clean-plugin:3.1.0:clean (default-clean) on project spark-sql_2.12: Failed to clean project: Failed to delete /${basedir}/sql/core/target/tmp/streaming.metadata-4d41fbcc-d517-4159-961c-95688dadd2c8/offsets/0 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

**After**

All three commands run successfully.

