### PR TITLE
[SPARK-41896][SQL] Filtering by row index returns empty results

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -259,9 +259,10 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
         partitionColumns ++ constantMetadataColumns
 
       // Rebind metadata attribute references in filters after the metadata attribute struct has
-      // been flattened. Only data filters can contain metadata references. The rebinding will
-      // categorize the references as either [[FileSourceConstantMetadataAttribute]] or
-      // [[FileSourceGeneratedMetadataAttribute]].
+      // been flattened. Only data filters can contain metadata references. After the rebinding
+      // all references will be bound to output attributes which are either
+      // [[FileSourceConstantMetadataAttribute]] or [[FileSourceGeneratedMetadataAttribute]] after
+      // the flattening from the metadata struct.
       def rebindFileSourceMetadataAttributesInFilters(
           filters: Seq[Expression]): Seq[Expression] =
         filters.map { filter =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -286,7 +286,7 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
           filter.transform {
             // Replace references to the _metadata column. This will affect references to the column
             // itself but also where fields from the metadata struct are used.
-            case attr @ MetadataStructColumn(AttributeReference(_, fields @ StructType(_), _, _)) =>
+            case MetadataStructColumn(AttributeReference(_, fields @ StructType(_), _, _)) =>
               CreateStruct(fields.map(
                 field => metadataColumns.find(attr => attr.name == newFieldName(field.name)).get))
           }.transform {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -258,6 +258,24 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
       val outputAttributes = readDataColumns ++ generatedMetadataColumns ++
         partitionColumns ++ constantMetadataColumns
 
+
+      // The metadata attribute references in the filters also have to be categorized as either
+      // constant or generated metadata attributes. Only data filters can contain metadata filters.
+      def categorizeFileSourceMetadataAttributesInFilters(
+          filters: Seq[Expression]): Seq[Expression] =
+        filters.map { filter =>
+          filter.transform {
+            case attr: AttributeReference if FileSourceMetadataAttribute.unapply(attr).isDefined =>
+              if (attr.dataType.asInstanceOf[StructType].fieldNames
+                .forall(fieldName => constantMetadataColumns.exists(fieldName == _.name))) {
+                // All references point to constant metadata attributes.
+                FileSourceConstantMetadataAttribute(attr.name, attr.dataType, attr.nullable)
+              } else {
+                FileSourceGeneratedMetadataAttribute(attr.name, attr.dataType, attr.nullable)
+              }
+          }
+        }
+
       val scan =
         FileSourceScanExec(
           fsRelation,
@@ -266,7 +284,7 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
           partitionKeyFilters.toSeq,
           bucketSet,
           None,
-          dataFilters,
+          categorizeFileSourceMetadataAttributesInFilters(dataFilters),
           table.map(_.identifier))
 
       // extra Project node: wrap flat metadata columns to a metadata struct

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -76,7 +76,7 @@ abstract class PartitioningAwareFileIndex(
     // be applied to files.
     val fileMetadataFilterOpt = dataFilters.filter { f =>
       f.references.nonEmpty && f.references.forall {
-        case FileSourceMetadataAttribute(_) => true
+        case FileSourceConstantMetadataAttribute(_) => true
         case _ => false
       }
     }.reduceOption(expressions.And)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -85,7 +85,6 @@ abstract class PartitioningAwareFileIndex(
     // - Bind all file constant metadata attribute references to their respective index
     val requiredMetadataColumnNames: mutable.Buffer[String] = mutable.Buffer.empty
     val boundedFilterMetadataStructOpt = fileMetadataFilterOpt.map { fileMetadataFilter =>
-      val metadataStruct = fileMetadataFilter.references.head
       Predicate.createInterpreted(fileMetadataFilter.transform {
         case attr: AttributeReference =>
           val existingMetadataColumnIndex = requiredMetadataColumnNames.indexOf(attr.name)
@@ -95,7 +94,7 @@ abstract class PartitioningAwareFileIndex(
             requiredMetadataColumnNames += attr.name
             requiredMetadataColumnNames.length - 1
           }
-          BoundReference(metadataColumnIndex, metadataStruct.dataType, nullable = true)
+          BoundReference(metadataColumnIndex, attr.dataType, nullable = true)
       })
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -103,7 +103,7 @@ abstract class PartitioningAwareFileIndex(
       // use option.forall, so if there is no filter no metadata struct, return true
       boundedFilterMetadataStructOpt.forall { boundedFilter =>
         val row =
-          createMetadataInternalRow(requiredMetadataColumnNames,
+          createMetadataInternalRow(requiredMetadataColumnNames.toSeq,
             f.getPath, f.getLen, f.getModificationTime)
         boundedFilter.eval(row)
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -678,8 +678,7 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
     assert(executedStruct.fields.forall(!_.nullable), executedStruct.fields.mkString(", "))
   }
 
-
-  test(s"Filter on row_index and a stored column at the same time") {
+  test("SPARK-41896: Filter on row_index and a stored column at the same time") {
     withTempPath { dir =>
       val storedIdName = "stored_id"
       val storedIdUpperLimitExclusive = 520
@@ -704,7 +703,7 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("Filter on constant and generated metadata attributes at the same time") {
+  test("SPARK-41896: Filter on constant and generated metadata attributes at the same time") {
     withTempPath { dir =>
       val idColumnName = "id"
       val partitionColumnName = "partition"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -677,4 +677,60 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
     assert(analyzedStruct.fields.forall(!_.nullable), analyzedStruct.fields.mkString(", "))
     assert(executedStruct.fields.forall(!_.nullable), executedStruct.fields.mkString(", "))
   }
+
+
+  test(s"Filter on row_index and a stored column at the same time") {
+    withTempPath { dir =>
+      val storedIdName = "stored_id"
+      val storedIdUpperLimitExclusive = 520
+      val rowIndexLowerLimitInclusive = 10
+
+      spark.range(start = 500, end = 600)
+        .toDF(storedIdName)
+        .write
+        .format("parquet")
+        .save(dir.getAbsolutePath)
+
+      // Select stored_id 510 to 519 via a stored_id and row_index filter.
+      val collectedRows = spark.read.load(dir.getAbsolutePath)
+        .select(storedIdName, METADATA_ROW_INDEX)
+        .where(col(storedIdName).lt(lit(storedIdUpperLimitExclusive)))
+        .where(col(METADATA_ROW_INDEX).geq(lit(rowIndexLowerLimitInclusive)))
+        .collect()
+
+      assert(collectedRows.length === 10)
+      assert(collectedRows.forall(_.getLong(0) < storedIdUpperLimitExclusive))
+      assert(collectedRows.forall(_.getLong(1) >= rowIndexLowerLimitInclusive))
+    }
+  }
+
+  test("Filter on constant and generated metadata attributes at the same time") {
+    withTempPath { dir =>
+      val idColumnName = "id"
+      val partitionColumnName = "partition"
+      val numFiles = 4
+      val totalNumRows = 40
+
+      spark.range(end = totalNumRows)
+        .toDF(idColumnName)
+        .withColumn(partitionColumnName, col(idColumnName).mod(lit(numFiles)))
+        .write
+        .partitionBy(partitionColumnName)
+        .format("parquet")
+        .save(dir.getAbsolutePath)
+
+      // Get one file path.
+      val randomTableFilePath = spark.read.load(dir.getAbsolutePath)
+        .select(METADATA_FILE_PATH).collect().head.getString(0)
+
+      val halfTheNumberOfRowsPerFile = totalNumRows / (numFiles * 2)
+      val collectedRows = spark.read.load(dir.getAbsolutePath)
+        .where(col(METADATA_FILE_PATH).equalTo(lit(randomTableFilePath)))
+        .where(col(METADATA_ROW_INDEX).leq(lit(halfTheNumberOfRowsPerFile)))
+        .collect()
+
+      // The query will match half the rows in one of the files.
+      assert(collectedRows.length === halfTheNumberOfRowsPerFile)
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When filtering by row index, the right number of rows must be returned. At the moment, all files are filtered out.

### Why are the changes needed?

Return correct results when filtering by row index

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added new tests
