### PR TITLE
[SPARK-41849][CONNECT] Implement DataFrameReader.text

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2401,9 +2401,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.map_zip_with.__doc__
         del pyspark.sql.connect.functions.posexplode.__doc__
 
-        # TODO(SPARK-41849): implement DataFrameReader.text
-        del pyspark.sql.connect.functions.input_file_name.__doc__
-
         # Creates a remote Spark session.
         os.environ["SPARK_REMOTE"] = "sc://localhost"
         globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -199,13 +199,16 @@ class DataFrameReader(OptionUtils):
 
     parquet.__doc__ = PySparkDataFrameReader.parquet.__doc__
 
-    def text(self, path: str, **options: "OptionalPrimitiveType") -> "DataFrame":
-        wholetext = options.get("wholetext", None)
-        lineSep = options.get("lineSep", None)
-        pathGlobFilter = options.get("pathGlobFilter", None)
-        recursiveFileLookup = options.get("recursiveFileLookup", None)
-        modifiedBefore = options.get("modifiedBefore", None)
-        modifiedAfter = options.get("modifiedAfter", None)
+    def text(
+        self,
+        path: str,
+        wholetext: Optional[bool] = None,
+        lineSep: Optional[str] = None,
+        pathGlobFilter: Optional[Union[bool, str]] = None,
+        recursiveFileLookup: Optional[Union[bool, str]] = None,
+        modifiedBefore: Optional[Union[bool, str]] = None,
+        modifiedAfter: Optional[Union[bool, str]] = None,
+    ) -> "DataFrame":
         self._set_opts(
             wholetext=wholetext,
             lineSep=lineSep,
@@ -218,6 +221,7 @@ class DataFrameReader(OptionUtils):
         return self.load(path=path, format="text")
 
     text.__doc__ = PySparkDataFrameReader.text.__doc__
+
 
 DataFrameReader.__doc__ = PySparkDataFrameReader.__doc__
 

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -199,6 +199,25 @@ class DataFrameReader(OptionUtils):
 
     parquet.__doc__ = PySparkDataFrameReader.parquet.__doc__
 
+    def text(self, path: str, **options: "OptionalPrimitiveType") -> "DataFrame":
+        wholetext = options.get("wholetext", None)
+        lineSep = options.get("lineSep", None)
+        pathGlobFilter = options.get("pathGlobFilter", None)
+        recursiveFileLookup = options.get("recursiveFileLookup", None)
+        modifiedBefore = options.get("modifiedBefore", None)
+        modifiedAfter = options.get("modifiedAfter", None)
+        self._set_opts(
+            wholetext=wholetext,
+            lineSep=lineSep,
+            pathGlobFilter=pathGlobFilter,
+            recursiveFileLookup=recursiveFileLookup,
+            modifiedBefore=modifiedBefore,
+            modifiedAfter=modifiedAfter,
+        )
+
+        return self.load(path=path, format="text")
+
+    text.__doc__ = PySparkDataFrameReader.text.__doc__
 
 DataFrameReader.__doc__ = PySparkDataFrameReader.__doc__
 

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -502,6 +502,7 @@ def _test() -> None:
         # TODO(SPARK-41817): Support reading with schema
         del pyspark.sql.connect.readwriter.DataFrameReader.load.__doc__
         del pyspark.sql.connect.readwriter.DataFrameReader.option.__doc__
+        del pyspark.sql.connect.readwriter.DataFrameReader.text.__doc__
         del pyspark.sql.connect.readwriter.DataFrameWriter.csv.__doc__
         del pyspark.sql.connect.readwriter.DataFrameWriter.option.__doc__
         del pyspark.sql.connect.readwriter.DataFrameWriter.text.__doc__

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -552,6 +552,9 @@ class DataFrameReader(OptionUtils):
 
         .. versionadded:: 1.6.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         paths : str or list

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -232,6 +232,18 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
                 self.connect.read.parquet(d).toPandas(), self.spark.read.parquet(d).toPandas()
             )
 
+    def test_text(self):
+        # SPARK-41849: Implement DataFrameReader.text
+        with tempfile.TemporaryDirectory() as d:
+            # Write a DataFrame into a text file
+            self.spark.createDataFrame([{"name": "Sandeep Singh"}, {"name": "Hyukjin Kwon"}]).write.mode(
+                "overwrite"
+            ).format("text").save(d)
+            # Read the text file as a DataFrame.
+            self.assert_eq(
+                self.connect.read.text(d).toPandas(), self.spark.read.text(d).toPandas()
+            )
+
     def test_join_condition_column_list_columns(self):
         left_connect_df = self.connect.read.table(self.tbl_name)
         right_connect_df = self.connect.read.table(self.tbl_name2)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -236,13 +236,11 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         # SPARK-41849: Implement DataFrameReader.text
         with tempfile.TemporaryDirectory() as d:
             # Write a DataFrame into a text file
-            self.spark.createDataFrame([{"name": "Sandeep Singh"}, {"name": "Hyukjin Kwon"}]).write.mode(
-                "overwrite"
-            ).format("text").save(d)
+            self.spark.createDataFrame(
+                [{"name": "Sandeep Singh"}, {"name": "Hyukjin Kwon"}]
+            ).write.mode("overwrite").format("text").save(d)
             # Read the text file as a DataFrame.
-            self.assert_eq(
-                self.connect.read.text(d).toPandas(), self.spark.read.text(d).toPandas()
-            )
+            self.assert_eq(self.connect.read.text(d).toPandas(), self.spark.read.text(d).toPandas())
 
     def test_join_condition_column_list_columns(self):
         left_connect_df = self.connect.read.table(self.tbl_name)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR implements DataFrameReader.text alias in Spark Connect.

### Why are the changes needed?
For API feature parity.

### Does this PR introduce any user-facing change?
This PR adds a user-facing API but Spark Connect has not been released yet.

### How was this patch tested?
Unittest was added.