### PR TITLE
[SPARK-41831][CONNECT] DataFrame.select to take a single list of columns

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -89,7 +89,9 @@ class DataFrame:
 
     isEmpty.__doc__ = PySparkDataFrame.isEmpty.__doc__
 
-    def select(self, *cols: "ColumnOrName") -> "DataFrame":
+    def select(self, *cols: Union["ColumnOrName", List["ColumnOrName"]]) -> "DataFrame":
+        if len(cols) == 1 and isinstance(cols[0], list):
+            cols = cols[0]  # type: ignore[assignment]
         return DataFrame.withPlan(plan.Project(self._plan, *cols), session=self._session)
 
     select.__doc__ = PySparkDataFrame.select.__doc__
@@ -1514,9 +1516,6 @@ def _test() -> None:
 
         # TODO(SPARK-41625): Support Structured Streaming
         del pyspark.sql.connect.dataframe.DataFrame.isStreaming.__doc__
-
-        # TODO(SPARK-41831): fix transform to accept ColumnReference
-        del pyspark.sql.connect.dataframe.DataFrame.transform.__doc__
 
         # TODO(SPARK-41832): fix unionByName
         del pyspark.sql.connect.dataframe.DataFrame.unionByName.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make `DataFrame.select` to take a single list of columns that regular PySpark supports.
Before this fix, the doctest fails as below:

```
File "/.../spark/python/pyspark/sql/connect/dataframe.py", line 1269, in pyspark.sql.connect.dataframe.DataFrame.transform
Failed example:
    df.transform(cast_all_to_int).transform(sort_columns_asc).show()
Exception raised:
    Traceback (most recent call last):
      File "/.../miniconda3/envs/python3.9/lib/python3.9/doctest.py", line 1336, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest pyspark.sql.connect.dataframe.DataFrame.transform[4]>", line 1, in <module>
        df.transform(cast_all_to_int).transform(sort_columns_asc).show()
      File "/.../spark/python/pyspark/sql/connect/dataframe.py", line 1203, in transform
        result = func(self, *args, **kwargs)
      File "<doctest pyspark.sql.connect.dataframe.DataFrame.transform[2]>", line 2, in cast_all_to_int
        return input_df.select([col(col_name).cast("int") for col_name in input_df.columns])
      File "/.../spark/python/pyspark/sql/connect/dataframe.py", line 95, in select
        return DataFrame.withPlan(plan.Project(self._plan, *cols), session=self._session)
      File "/.../spark/python/pyspark/sql/connect/plan.py", line 348, in __init__
        self._verify_expressions()
      File "/.../spark/python/pyspark/sql/connect/plan.py", line 354, in _verify_expressions
        raise InputValidationError(
    pyspark.sql.connect.plan.InputValidationError: Only Column or String can be used for projections: '[Column<'(ColumnReference(int) (int))'>, Column<'(ColumnReference(float) (int))'>]'.
```

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

Manually tested as below:

```bash
./python/run-tests --testnames 'pyspark.sql.connect.dataframe'
```