### PR TITLE
[SPARK-41869][CONNECT] Reject single string in dropDuplicates

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -194,6 +194,9 @@ class DataFrame:
     repartition.__doc__ = PySparkDataFrame.repartition.__doc__
 
     def dropDuplicates(self, subset: Optional[List[str]] = None) -> "DataFrame":
+        if subset is not None and (not isinstance(subset, Iterable) or isinstance(subset, str)):
+            raise TypeError("Parameter 'subset' must be a list of columns")
+
         if subset is None:
             return DataFrame.withPlan(
                 plan.Deduplicate(child=self._plan, all_columns_as_keys=True), session=self._session

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -71,11 +71,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
     def test_create_nan_decimal_dataframe(self):
         super().test_create_nan_decimal_dataframe()
 
-    # TODO(SPARK-41869): DataFrame dropDuplicates should throw error on non list argument
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_drop_duplicates(self):
-        super().test_drop_duplicates()
-
     # TODO(SPARK-41870): Handle duplicate columns in `createDataFrame`
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_duplicated_column_names(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to reject the single string column in `dropDuplicates` to match the behaviour with regular PySpark.

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No, it's has not been released yet.

### How was this patch tested?

Reenable the skipped test.