### PR TITLE
[SPARK-41840][CONNECT][TESTS] Remove the invalid JIRA in the comment.

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -96,8 +96,7 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
     def test_generic_hints(self):
         super().test_generic_hints()
 
-    # Spark Connect does not support RDD but the tests depend on them.
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_help_command(self):
         super().test_help_command()
 
@@ -126,8 +125,7 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
     def test_pandas_api(self):
         super().test_pandas_api()
 
-    # TODO(SPARK-41840): DataFrame.show(): 'Column' object is not callable
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_repartitionByRange_dataframe(self):
         super().test_repartitionByRange_dataframe()
 
@@ -161,8 +159,7 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
     def test_to(self):
         super().test_to()
 
-    # Spark Connect does not support RDD but the tests depend on them.
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_toDF_with_schema_string(self):
         super().test_toDF_with_schema_string()
 

--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -49,8 +49,7 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
     def test_assert_true(self):
         super().test_assert_true()
 
-    # Spark Connect does not support Spark Context but the test depends on that.
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    @unittest.skip("Spark Connect does not support Spark Context but the test depends on that.")
     def test_basic_functions(self):
         super().test_basic_functions()
 
@@ -69,18 +68,17 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
     def test_explode(self):
         super().test_explode()
 
-    # Spark Connect does not support Spark Context but the test depends on that.
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    @unittest.skip("Spark Connect does not support Spark Context but the test depends on that.")
     def test_function_parity(self):
         super().test_function_parity()
 
-    # Spark Connect does not support Spark Context, _jdf but the test depends on that.
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    @unittest.skip(
+        "Spark Connect does not support Spark Context, _jdf but the test depends on that."
+    )
     def test_functions_broadcast(self):
         super().test_functions_broadcast()
 
-    # Spark Connect does not support Spark Context but the test depends on that.
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    @unittest.skip("Spark Connect does not support Spark Context but the test depends on that.")
     def test_input_file_name_reset_for_rdd(self):
         super().test_input_file_name_reset_for_rdd()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`test_repartitionByRange_dataframe` depends on RDD API which Spark Connect does not support.
This PR proposes to remove that JIRA.

While I am here, I converted some comments in the tests to the skipped messages which we won't likely enable.

### Why are the changes needed?

For better trackability.

### Does this PR introduce _any_ user-facing change?
No, comment-only.

### How was this patch tested?
Manually ran the test via IDE.