### PR TITLE
[SPARK-41905][CONNECT] Support name as strings in slice

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -1517,21 +1517,21 @@ size.__doc__ = pysparkfuncs.size.__doc__
 def slice(
     col: "ColumnOrName", start: Union["ColumnOrName", int], length: Union["ColumnOrName", int]
 ) -> Column:
-    if isinstance(start, Column):
+    if isinstance(start, (Column, str)):
         _start = start
     elif isinstance(start, int):
         _start = lit(start)
     else:
-        raise TypeError(f"start should be a Column or int, but got {type(start).__name__}")
+        raise TypeError(f"start should be a Column, str or int, but got {type(start).__name__}")
 
-    if isinstance(length, Column):
+    if isinstance(length, (Column, str)):
         _length = length
     elif isinstance(length, int):
         _length = lit(length)
     else:
-        raise TypeError(f"start should be a Column or int, but got {type(length).__name__}")
+        raise TypeError(f"start should be a Column, str or int, but got {type(length).__name__}")
 
-    return _invoke_function("slice", _to_col(col), _start, _length)
+    return _invoke_function_over_columns("slice", col, _start, _length)
 
 
 slice.__doc__ = pysparkfuncs.slice.__doc__

--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -144,11 +144,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
     def test_raise_error(self):
         super().test_raise_error()
 
-    # TODO(SPARK-41905): Function `slice` should expect string
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_slice(self):
-        super().test_slice()
-
     # Comparing column type of connect and pyspark
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_sorting_functions_with_column(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to `slice` in Spark Connect to strings as column names as the regular PySpark does.

### Why are the changes needed?

For feature parity.

### Does this PR introduce _any_ user-facing change?

No, Spark Connect has not been released out yet.

### How was this patch tested?

Ran the enabled tests it via IDE
