### PR TITLE
[SPARK-41906][CONNECT][TESTS] Reenable rand test in Spark Connect.

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -164,11 +164,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
     def test_window_functions_without_partitionBy(self):
         super().test_window_functions_without_partitionBy()
 
-    # TODO(SPARK-41906): Handle Function `rand() `
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_rand_functions(self):
-        super().test_rand_functions()
-
     # TODO(SPARK-41907): sampleby returning wrong output
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_sampleby(self):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -294,8 +294,7 @@ class FunctionsTestsMixin:
         SQLTestUtils.assert_close(to_reciprocal_trig(math.tan), df.select(cot(df.value)).collect())
 
     def test_rand_functions(self):
-        df = self.df
-        from pyspark.sql import functions
+        df = self.spark.createDataFrame([Row(key=i, value=str(i)) for i in range(100)])
 
         rnd = df.select("key", functions.rand()).collect()
         for row in rnd:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to reeanble `test_rand_functions` test by fixing the regular PySpark tests.

Previously, it fails in Spark Connect because `self.df` is created before Spark Connect server is started. So `self.df` reminds as a regular PySpark DataFrame (not Spark Connect DataFrame).

This PR just moves the DataFrame creation into the test itself so Spark Connect server and client are properly started first (at `setUpClass`).

### Why are the changes needed?

For test parity.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran the test.