### PR TITLE
[SPARK-41875][CONNECT][PYTHON] Add test cases for `Dataset.to()`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -38,7 +38,7 @@ from collections.abc import Iterable
 
 from pyspark import _NoValue, SparkContext, SparkConf
 from pyspark._globals import _NoValueType
-from pyspark.sql.types import DataType, StructType, Row
+from pyspark.sql.types import StructType, Row
 
 import pyspark.sql.connect.plan as plan
 from pyspark.sql.connect.group import GroupedData

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1180,7 +1180,7 @@ class DataFrame:
 
     inputFiles.__doc__ = PySparkDataFrame.inputFiles.__doc__
 
-    def to(self, schema: DataType) -> "DataFrame":
+    def to(self, schema: StructType) -> "DataFrame":
         assert schema is not None
         return DataFrame.withPlan(
             plan.ToSchema(child=self._plan, schema=schema),

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -707,7 +707,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertRaisesRegex(
             SparkConnectAnalysisException,
             "NULLABLE_COLUMN_OR_FIELD",
-            lambda: self.connect.read.table(self.tbl_name).to(schema).toPandas(),
+            lambda: cdf.to(schema).toPandas(),
         )
 
         # field cannot upcast
@@ -715,7 +715,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertRaisesRegex(
             SparkConnectAnalysisException,
             "INVALID_COLUMN_OR_FIELD_DATA_TYPE",
-            lambda: self.connect.read.table(self.tbl_name).to(schema).toPandas(),
+            lambda: cdf.to(schema).toPandas(),
         )
 
         schema = StructType(
@@ -727,7 +727,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertRaisesRegex(
             SparkConnectAnalysisException,
             "INVALID_COLUMN_OR_FIELD_DATA_TYPE",
-            lambda: self.connect.read.table(self.tbl_name).to(schema).toPandas(),
+            lambda: cdf.to(schema).toPandas(),
         )
 
         # Test map type and array type


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. This PR let the parameter of `Dataset.to()` the same as pyspark.

2. The connect's `Dataset.to()` lost some test cases.
This PR adds these test cases that refer https://github.com/apache/spark/blob/89666d44a39c48df841a0102ff6f54eaeb4c6140/python/pyspark/sql/tests/test_dataframe.py#L1464

### Why are the changes needed?
This PR adds these test cases for connect's `Dataset.to()`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New test cases.
