### PR TITLE
[SPARK-41455][CONNECT][PYTHON] Make `DataFrame.collect` discard the timezone info

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -33,6 +33,7 @@ from typing import (
 import sys
 import random
 import pandas
+import datetime
 import warnings
 from collections.abc import Iterable
 
@@ -1116,10 +1117,14 @@ class DataFrame:
 
         rows: List[Row] = []
         for row in table.to_pylist():
-            _dict = {}
+            _dict: Dict[Any, Any] = {}
             for k, v in row.items():
                 if isinstance(v, bytes):
                     _dict[k] = bytearray(v)
+                elif isinstance(v, datetime.datetime) and v.tzinfo is not None:
+                    # TODO: Should be controlled by "spark.sql.timestampType"
+                    # always remove the time zone for now
+                    _dict[k] = v.replace(tzinfo=None)
                 else:
                     _dict[k] = v
             rows.append(Row(**_dict))

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2354,12 +2354,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.from_csv.__doc__
         del pyspark.sql.connect.functions.from_json.__doc__
 
-        # TODO(SPARK-41455): Resolve dtypes inconsistencies of date/timestamp functions
-        del pyspark.sql.connect.functions.to_timestamp.__doc__
-        del pyspark.sql.connect.functions.to_utc_timestamp.__doc__
-        del pyspark.sql.connect.functions.date_trunc.__doc__
-        del pyspark.sql.connect.functions.from_utc_timestamp.__doc__
-
         # TODO(SPARK-41834): implement Dataframe.conf
         del pyspark.sql.connect.functions.from_unixtime.__doc__
         del pyspark.sql.connect.functions.timestamp_seconds.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?
To follow the default behavior


### Why are the changes needed?
to be consistent with the default behavior of PySpark


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added UT, and enabled doctests
