### PR TITLE
[SPARK-41765][SQL] Pull out v1 write metrics to WriteFiles

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
@@ -53,8 +53,8 @@ trait DataWritingCommand extends UnaryCommand {
 
   lazy val metrics: Map[String, SQLMetric] = {
     // If planned write is enable, we have pulled out write files metrics from `V1WriteCommand`
-    // from `V1WriteCommand` to `WriteFiles`. `DataWritingCommand` should only holds the
-    // task commit metric and driver commit metric.
+    // to `WriteFiles`. `DataWritingCommand` should only holds the task commit metric and driver
+    // commit metric.
     if (conf.getConf(SQLConf.PLANNED_WRITE_ENABLED)) {
       BasicWriteJobStatsTracker.writeCommitMetrics
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
@@ -21,14 +21,13 @@ import java.net.URI
 
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.spark.SparkContext
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryCommand}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.BasicWriteJobStatsTracker
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.SerializableConfiguration
 
@@ -52,11 +51,19 @@ trait DataWritingCommand extends UnaryCommand {
   def outputColumns: Seq[Attribute] =
     DataWritingCommand.logicalPlanOutputWithNames(query, outputColumnNames)
 
-  lazy val metrics: Map[String, SQLMetric] = BasicWriteJobStatsTracker.metrics
+  lazy val metrics: Map[String, SQLMetric] = {
+    // If planned write is enable, we have pulled out write files metrics from `V1WriteCommand`
+    // from `V1WriteCommand` to `WriteFiles`. `DataWritingCommand` should only holds the
+    // task commit metric and driver commit metric.
+    if (conf.getConf(SQLConf.PLANNED_WRITE_ENABLED)) {
+      BasicWriteJobStatsTracker.writeCommitMetrics
+    } else {
+      BasicWriteJobStatsTracker.metrics
+    }
+  }
 
   def basicWriteJobStatsTracker(hadoopConf: Configuration): BasicWriteJobStatsTracker = {
-    val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
-    new BasicWriteJobStatsTracker(serializableHadoopConf, metrics)
+    DataWritingCommand.basicWriteJobStatsTracker(metrics, hadoopConf)
   }
 
   def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row]
@@ -80,27 +87,6 @@ object DataWritingCommand {
   }
 
   /**
-   * When execute CTAS operators, Spark will use [[InsertIntoHadoopFsRelationCommand]]
-   * or [[InsertIntoHiveTable]] command to write data, they both inherit metrics from
-   * [[DataWritingCommand]], but after running [[InsertIntoHadoopFsRelationCommand]]
-   * or [[InsertIntoHiveTable]], we only update metrics in these two command through
-   * [[BasicWriteJobStatsTracker]], we also need to propogate metrics to the command
-   * that actually calls [[InsertIntoHadoopFsRelationCommand]] or [[InsertIntoHiveTable]].
-   *
-   * @param sparkContext Current SparkContext.
-   * @param command Command to execute writing data.
-   * @param metrics Metrics of real DataWritingCommand.
-   */
-  def propogateMetrics(
-      sparkContext: SparkContext,
-      command: DataWritingCommand,
-      metrics: Map[String, SQLMetric]): Unit = {
-    command.metrics.foreach { case (key, metric) => metrics(key).set(metric.value) }
-    SQLMetrics.postDriverMetricUpdates(sparkContext,
-      sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY),
-      metrics.values.toSeq)
-  }
-  /**
    * When execute CTAS operators, and the location is not empty, throw [[AnalysisException]].
    * For CTAS, the SaveMode is always [[ErrorIfExists]]
    *
@@ -119,5 +105,12 @@ object DataWritingCommand {
           tablePath.toString)
       }
     }
+  }
+
+  def basicWriteJobStatsTracker(
+      metrics: Map[String, SQLMetric],
+      hadoopConf: Configuration): BasicWriteJobStatsTracker = {
+    val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
+    new BasicWriteJobStatsTracker(serializableHadoopConf, metrics)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/BasicWriteStatsTracker.scala
@@ -197,6 +197,11 @@ class BasicWriteJobStatsTracker(
     this(serializableHadoopConf, metrics - TASK_COMMIT_TIME, metrics(TASK_COMMIT_TIME))
   }
 
+  def writeCommitMetrics(): Map[String, SQLMetric] = {
+    Map(TASK_COMMIT_TIME -> taskCommitTimeMetric,
+      JOB_COMMIT_TIME -> driverSideMetrics(JOB_COMMIT_TIME))
+  }
+
   override def newTaskInstance(): WriteTaskStatsTracker = {
     new BasicWriteTaskStatsTracker(serializableHadoopConf.value, Some(taskCommitTimeMetric))
   }
@@ -239,12 +244,22 @@ object BasicWriteJobStatsTracker {
   val FILE_LENGTH_XATTR = "header.x-hadoop-s3a-magic-data-length"
 
   def metrics: Map[String, SQLMetric] = {
+    writeFilesMetrics ++ writeCommitMetrics
+  }
+
+  def writeFilesMetrics: Map[String, SQLMetric] = {
     val sparkContext = SparkContext.getActive.get
     Map(
       NUM_FILES_KEY -> SQLMetrics.createMetric(sparkContext, "number of written files"),
       NUM_OUTPUT_BYTES_KEY -> SQLMetrics.createSizeMetric(sparkContext, "written output"),
       NUM_OUTPUT_ROWS_KEY -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
-      NUM_PARTS_KEY -> SQLMetrics.createMetric(sparkContext, "number of dynamic part"),
+      NUM_PARTS_KEY -> SQLMetrics.createMetric(sparkContext, "number of dynamic part")
+    )
+  }
+
+  def writeCommitMetrics: Map[String, SQLMetric] = {
+    val sparkContext = SparkContext.getActive.get
+    Map(
       TASK_COMMIT_TIME -> SQLMetrics.createTimingMetric(sparkContext, "task commit time"),
       JOB_COMMIT_TIME -> SQLMetrics.createTimingMetric(sparkContext, "job commit time")
     )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{ProjectExec, SortExec, SparkPlan, SQLExecution, UnsafeExternalRowSorter}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
@@ -122,6 +123,49 @@ object FileFormatWriter extends Logging {
     val outputWriterFactory =
       fileFormat.prepareWrite(sparkSession, job, caseInsensitiveOptions, dataSchema)
 
+    // SPARK-40588: when planned writing is disabled and AQE is enabled,
+    // plan contains an AdaptiveSparkPlanExec, which does not know
+    // its final plan's ordering, so we have to materialize that plan first
+    // it is fine to use plan further down as the final plan is cached in that plan
+    def materializeAdaptiveSparkPlan(plan: SparkPlan): SparkPlan = plan match {
+      case a: AdaptiveSparkPlanExec => a.finalPhysicalPlan
+      case p: SparkPlan => p.withNewChildren(p.children.map(materializeAdaptiveSparkPlan))
+    }
+
+    // We should first sort by dynamic partition columns, then bucket id, and finally sorting
+    // columns.
+    val requiredOrdering = partitionColumns.drop(numStaticPartitionCols) ++
+      writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns
+    val writeFilesOpt = V1WritesUtils.getWriteFilesOpt(plan)
+    // the sort order doesn't matter
+    val actualOrdering = writeFilesOpt.map(_.child)
+      .getOrElse(materializeAdaptiveSparkPlan(plan))
+      .outputOrdering
+    val orderingMatched = V1WritesUtils.isOrderingMatched(requiredOrdering, actualOrdering)
+
+    // When `PLANNED_WRITE_ENABLED` is true, the optimizer rule V1Writes will add logical sort
+    // operator based on the required ordering of the V1 write command. So the output
+    // ordering of the physical plan should always match the required ordering. Here
+    // we set the variable to verify this behavior in tests.
+    // There are two cases where FileFormatWriter still needs to add physical sort:
+    // 1) When the planned write config is disabled.
+    // 2) When the concurrent writers are enabled (in this case the required ordering of a
+    //    V1 write command will be empty).
+    if (Utils.isTesting) outputOrderingMatched = orderingMatched
+
+    SQLExecution.checkSQLExecutionId(sparkSession)
+
+    val finalStatsTrackers = if (writeFilesOpt.isDefined) {
+      val writeFilesMetrics = writeFilesOpt.get.metrics
+      val finalMetrics = statsTrackers match {
+        case Seq(tracker: BasicWriteJobStatsTracker) =>
+          writeFilesMetrics ++ tracker.writeCommitMetrics()
+        case _ => writeFilesMetrics
+      }
+      DataWritingCommand.basicWriteJobStatsTracker(finalMetrics, hadoopConf) :: Nil
+    } else {
+      statsTrackers
+    }
     val description = new WriteJobDescription(
       uuid = UUID.randomUUID.toString,
       serializableHadoopConf = new SerializableConfiguration(job.getConfiguration),
@@ -136,45 +180,12 @@ object FileFormatWriter extends Logging {
         .getOrElse(sparkSession.sessionState.conf.maxRecordsPerFile),
       timeZoneId = caseInsensitiveOptions.get(DateTimeUtils.TIMEZONE_OPTION)
         .getOrElse(sparkSession.sessionState.conf.sessionLocalTimeZone),
-      statsTrackers = statsTrackers
+      statsTrackers = finalStatsTrackers
     )
-
-    // We should first sort by dynamic partition columns, then bucket id, and finally sorting
-    // columns.
-    val requiredOrdering = partitionColumns.drop(numStaticPartitionCols) ++
-        writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns
-    val writeFilesOpt = V1WritesUtils.getWriteFilesOpt(plan)
-
-    // SPARK-40588: when planned writing is disabled and AQE is enabled,
-    // plan contains an AdaptiveSparkPlanExec, which does not know
-    // its final plan's ordering, so we have to materialize that plan first
-    // it is fine to use plan further down as the final plan is cached in that plan
-    def materializeAdaptiveSparkPlan(plan: SparkPlan): SparkPlan = plan match {
-      case a: AdaptiveSparkPlanExec => a.finalPhysicalPlan
-      case p: SparkPlan => p.withNewChildren(p.children.map(materializeAdaptiveSparkPlan))
-    }
-
-    // the sort order doesn't matter
-    val actualOrdering = writeFilesOpt.map(_.child)
-      .getOrElse(materializeAdaptiveSparkPlan(plan))
-      .outputOrdering
-    val orderingMatched = V1WritesUtils.isOrderingMatched(requiredOrdering, actualOrdering)
-
-    SQLExecution.checkSQLExecutionId(sparkSession)
 
     // propagate the description UUID into the jobs, so that committers
     // get an ID guaranteed to be unique.
     job.getConfiguration.set("spark.sql.sources.writeJobUUID", description.uuid)
-
-    // When `PLANNED_WRITE_ENABLED` is true, the optimizer rule V1Writes will add logical sort
-    // operator based on the required ordering of the V1 write command. So the output
-    // ordering of the physical plan should always match the required ordering. Here
-    // we set the variable to verify this behavior in tests.
-    // There are two cases where FileFormatWriter still needs to add physical sort:
-    // 1) When the planned write config is disabled.
-    // 2) When the concurrent writers are enabled (in this case the required ordering of a
-    //    V1 write command will be empty).
-    if (Utils.isTesting) outputOrderingMatched = orderingMatched
 
     if (writeFilesOpt.isDefined) {
       // build `WriteFilesSpec` for `WriteFiles`

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -157,12 +157,12 @@ object FileFormatWriter extends Logging {
 
     val finalStatsTrackers = if (writeFilesOpt.isDefined) {
       val writeFilesMetrics = writeFilesOpt.get.metrics
-      val finalMetrics = statsTrackers match {
-        case Seq(tracker: BasicWriteJobStatsTracker) =>
-          writeFilesMetrics ++ tracker.writeCommitMetrics()
-        case _ => writeFilesMetrics
+      statsTrackers.map {
+        case tracker: BasicWriteJobStatsTracker =>
+          val finalMetrics = writeFilesMetrics ++ tracker.writeCommitMetrics()
+          DataWritingCommand.basicWriteJobStatsTracker(finalMetrics, hadoopConf)
+        case other => other
       }
-      DataWritingCommand.basicWriteJobStatsTracker(finalMetrics, hadoopConf) :: Nil
     } else {
       statsTrackers
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriteFiles.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriteFiles.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.datasources.FileFormatWriter.ConcurrentOutputWriterSpec
+import org.apache.spark.sql.execution.metric.SQLMetric
 
 /**
  * The write files spec holds all information of [[V1WriteCommand]] if its provider is
@@ -68,6 +69,8 @@ case class WriteFilesExec(
     options: Map[String, String],
     staticPartitions: TablePartitionSpec) extends UnaryExecNode {
   override def output: Seq[Attribute] = Seq.empty
+
+  override lazy val metrics: Map[String, SQLMetric] = BasicWriteJobStatsTracker.writeFilesMetrics
 
   override protected def doExecuteWrite(
       writeFilesSpec: WriteFilesSpec): RDD[WriterCommitMessage] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
-import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, InsertIntoHadoopFsRelationCommand, SQLHadoopMapReduceCommitProtocol, V1WriteCommand}
+import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, SQLHadoopMapReduceCommitProtocol, WriteFilesExec}
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHashJoinExec}
 import org.apache.spark.sql.expressions.Window
@@ -830,29 +830,33 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
 
   test("SPARK-34567: Add metrics for CTAS operator") {
     withTable("t") {
-      var v1WriteCommand: V1WriteCommand = null
+      var dataWriting: DataWritingCommandExec = null
       val listener = new QueryExecutionListener {
         override def onFailure(f: String, qe: QueryExecution, e: Exception): Unit = {}
         override def onSuccess(funcName: String, qe: QueryExecution, duration: Long): Unit = {
           qe.executedPlan match {
             case dataWritingCommandExec: DataWritingCommandExec =>
-              val createTableAsSelect = dataWritingCommandExec.cmd
-              v1WriteCommand = createTableAsSelect.asInstanceOf[InsertIntoHadoopFsRelationCommand]
+              dataWriting = dataWritingCommandExec
             case _ =>
           }
         }
       }
       spark.listenerManager.register(listener)
       try {
-        val df = sql("CREATE TABLE t USING PARQUET AS SELECT 1 as a")
+        sql("CREATE TABLE t USING PARQUET AS SELECT 1 as a")
         sparkContext.listenerBus.waitUntilEmpty()
-        assert(v1WriteCommand != null)
-        assert(v1WriteCommand.metrics.contains("numFiles"))
-        assert(v1WriteCommand.metrics("numFiles").value == 1)
-        assert(v1WriteCommand.metrics.contains("numOutputBytes"))
-        assert(v1WriteCommand.metrics("numOutputBytes").value > 0)
-        assert(v1WriteCommand.metrics.contains("numOutputRows"))
-        assert(v1WriteCommand.metrics("numOutputRows").value == 1)
+        assert(dataWriting != null)
+        val metrics = if (conf.plannedWriteEnabled) {
+          dataWriting.child.asInstanceOf[WriteFilesExec].metrics
+        } else {
+          dataWriting.cmd.metrics
+        }
+        assert(metrics.contains("numFiles"))
+        assert(metrics("numFiles").value == 1)
+        assert(metrics.contains("numOutputBytes"))
+        assert(metrics("numOutputBytes").value > 0)
+        assert(metrics.contains("numOutputRows"))
+        assert(metrics("numOutputRows").value == 1)
       } finally {
         spark.listenerManager.unregister(listener)
       }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
@@ -59,6 +59,8 @@ case class InsertIntoHiveDirCommand(
     overwrite: Boolean,
     outputColumnNames: Seq[String]) extends SaveAsHiveFile with V1WritesHiveUtils {
 
+  // We did not pull out `InsertIntoHiveDirCommand` to `V1WriteCommand`,
+  // so there is no `WriteFiles`. It should always hold all metrics by itself.
   override lazy val metrics: Map[String, SQLMetric] =
     BasicWriteJobStatsTracker.metrics
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveDirCommand.scala
@@ -30,6 +30,8 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.DDLUtils
+import org.apache.spark.sql.execution.datasources.BasicWriteJobStatsTracker
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.hive.client.HiveClientImpl
 import org.apache.spark.sql.util.SchemaUtils
 
@@ -56,6 +58,9 @@ case class InsertIntoHiveDirCommand(
     query: LogicalPlan,
     overwrite: Boolean,
     outputColumnNames: Seq[String]) extends SaveAsHiveFile with V1WritesHiveUtils {
+
+  override lazy val metrics: Map[String, SQLMetric] =
+    BasicWriteJobStatsTracker.metrics
 
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {
     assert(storage.locationUri.nonEmpty)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Pull out the metrics which is in `InsertIntoHiveTable` and `InsertIntoHadoopFsRelationCommand` to `WriteFiles`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Move metrics to the right place.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, the SQL UI metrics changed from `V1WriteCommand` to `WriteFiles`

with `spark.sql.optimizer.plannedWrite.enabled` disable and enable:

// disable
<img width="314" alt="image" src="https://user-images.githubusercontent.com/12025282/220267296-62d2deef-f8d8-4e71-adc6-23e416f0777c.png">

// enable
<img width="319" alt="image" src="https://user-images.githubusercontent.com/12025282/220267151-dd1e7ed9-eb92-44a5-abdc-75f204ecf97e.png">


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
fix and improve test