### PR TITLE
[SPARK-41923][CONNECT][PYTHON] Add `DataFrame.writeTo` to the unsupported list

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1369,6 +1369,9 @@ class DataFrame:
     def sameSemantics(self, *args: Any, **kwargs: Any) -> None:
         raise NotImplementedError("sameSemantics() is not implemented.")
 
+    def writeTo(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("writeTo() is not implemented.")
+
     # SparkConnect specific API
     def offset(self, n: int) -> "DataFrame":
         """Returns a new :class: `DataFrame` by skipping the first `n` rows.

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1989,6 +1989,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             "_repr_html_",
             "semanticHash",
             "sameSemantics",
+            "writeTo",
         ):
             with self.assertRaises(NotImplementedError):
                 getattr(df, f)()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `DataFrame.writeTo` to the unsupported list

### Why are the changes needed?
to track the unsupported API

### Does this PR introduce _any_ user-facing change?
yes, `NotImplementedError`


### How was this patch tested?
added ut