### PR TITLE
[SPARK-41914][SQL] FileFormatWriter materializes AQE plan before accessing outputOrdering

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -225,6 +225,8 @@ case class AdaptiveSparkPlanExec(
       .map(_.toLong).filter(SQLExecution.getQueryExecution(_) eq context.qe)
   }
 
+  def finalPhysicalPlan: SparkPlan = withFinalPlanUpdate(identity)
+
   private def getFinalPhysicalPlan(): SparkPlan = lock.synchronized {
     if (isFinalPlan) return currentPhysicalPlan
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -231,7 +231,6 @@ object FileFormatWriter extends Logging {
 
       // In testing, this is the only way to get hold of the actually executed plan written to file
       if (Utils.isTesting) executedPlan = Some(planToExecute)
-      Console.println(f"executing planToExecute $planToExecute")
 
       val rdd = planToExecute.execute()
 
@@ -307,7 +306,6 @@ object FileFormatWriter extends Logging {
 
     // In testing, this is the only way to get hold of the actually executed plan written to file
     if (Utils.isTesting) executedPlan = Some(planForWrites)
-    Console.println(f"executing planForWrites $planForWrites")
 
     writeAndCommit(job, description, committer) {
       val rdd = planForWrites.executeWrite(writeFilesSpec)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -207,7 +207,6 @@ object FileFormatWriter extends Logging {
       partitionColumns: Seq[Attribute],
       sortColumns: Seq[Attribute],
       orderingMatched: Boolean): Set[String] = {
-    Console.println(f"Writing plan $plan")
     val hasEmpty2Null = plan.exists(p => V1WritesUtils.hasEmptyToNull(p.expressions))
     val empty2NullPlan = if (hasEmpty2Null) {
       plan
@@ -232,7 +231,7 @@ object FileFormatWriter extends Logging {
 
       // In testing, this is the only way to get hold of the actually executed plan written to file
       if (Utils.isTesting) executedPlan = Some(planToExecute)
-      Console.println(f"executing plan $planToExecute")
+      Console.println(f"executing planToExecute $planToExecute")
 
       val rdd = planToExecute.execute()
 
@@ -303,13 +302,12 @@ object FileFormatWriter extends Logging {
       planForWrites: SparkPlan,
       writeFilesSpec: WriteFilesSpec,
       job: Job): Set[String] = {
-    Console.println(f"Writing planForWrites $planForWrites")
     val committer = writeFilesSpec.committer
     val description = writeFilesSpec.description
 
     // In testing, this is the only way to get hold of the actually executed plan written to file
     if (Utils.isTesting) executedPlan = Some(planForWrites)
-    Console.println(f"executing plan $planForWrites")
+    Console.println(f"executing planForWrites $planForWrites")
 
     writeAndCommit(job, description, committer) {
       val rdd = planForWrites.executeWrite(writeFilesSpec)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
@@ -223,7 +223,7 @@ class V1WriteCommandSuite extends QueryTest with SharedSparkSession with V1Write
           }.exists {
             case SortExec(Seq(
             SortOrder(AttributeReference("key", IntegerType, _, _), Ascending, NullsFirst, _),
-            SortOrder(AttributeReference("value", StringType, _, _), Ascending, NullsFirst, _),
+            SortOrder(AttributeReference("value", StringType, _, _), Ascending, NullsFirst, _)
             ), false, _, _) => true
             case _ => false
           }, plan)
@@ -270,12 +270,12 @@ class V1WriteCommandSuite extends QueryTest with SharedSparkSession with V1Write
         }.map(s => (enabled, s)).exists {
           case (false, SortExec(Seq(
           SortOrder(AttributeReference("value", StringType, _, _), Ascending, NullsFirst, _),
-          SortOrder(AttributeReference("key", IntegerType, _, _), Ascending, NullsFirst, _),
+          SortOrder(AttributeReference("key", IntegerType, _, _), Ascending, NullsFirst, _)
           ), false, _, _)) => true
 
           // SPARK-40885: this bug removes the in-partition sort, which manifests here
           case (true, SortExec(Seq(
-          SortOrder(AttributeReference("value", StringType, _, _), Ascending, NullsFirst, _),
+          SortOrder(AttributeReference("value", StringType, _, _), Ascending, NullsFirst, _)
           ), false, _, _)) => true
           case _ => false
         }, plan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
@@ -58,7 +58,7 @@ trait V1WriteCommandSuiteBase extends SQLTestUtils {
   protected def executeAndCheckOrdering(
       hasLogicalSort: Boolean,
       orderingMatched: Boolean,
-      hasEmpty2Null: Boolean = false)(query: => Unit): Unit = {
+      hasEmpty2Null: Boolean = false)(query: => Unit): LogicalPlan = {
     var optimizedPlan: LogicalPlan = null
 
     val listener = new QueryExecutionListener {
@@ -97,6 +97,8 @@ trait V1WriteCommandSuiteBase extends SQLTestUtils {
       s"Expect hasEmpty2Null: $hasEmpty2Null, Actual: $empty2nullExpr. Plan:\n$optimizedPlan")
 
     spark.listenerManager.unregister(listener)
+
+    optimizedPlan
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
@@ -20,10 +20,10 @@ package org.apache.spark.sql.execution.datasources
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, NullsFirst, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Sort}
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.{QueryExecution, SortExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
+import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import org.apache.spark.sql.util.QueryExecutionListener
 
@@ -204,8 +204,7 @@ class V1WriteCommandSuite extends QueryTest with SharedSparkSession with V1Write
                 |""".stripMargin)
           }
 
-          print(s"executed plan: ${FileFormatWriter.executedPlan}")
-
+          // inspect the actually executed plan (that is different to executeAndCheckOrdering)
           assert(FileFormatWriter.executedPlan.isDefined)
           val executedPlan = FileFormatWriter.executedPlan.get
 
@@ -218,6 +217,7 @@ class V1WriteCommandSuite extends QueryTest with SharedSparkSession with V1Write
             }
           }
 
+          // assert the outer most sort in the executed plan
           assert(plan.collectFirst {
             case s: SortExec => s
           }.exists {
@@ -251,8 +251,7 @@ class V1WriteCommandSuite extends QueryTest with SharedSparkSession with V1Write
               |""".stripMargin)
         }
 
-        print(s"executed plan: ${FileFormatWriter.executedPlan}")
-
+        // inspect the actually executed plan (that is different to executeAndCheckOrdering)
         assert(FileFormatWriter.executedPlan.isDefined)
         val executedPlan = FileFormatWriter.executedPlan.get
 
@@ -265,6 +264,7 @@ class V1WriteCommandSuite extends QueryTest with SharedSparkSession with V1Write
           }
         }
 
+        // assert the outer most sort in the executed plan
         assert(plan.collectFirst {
           case s: SortExec => s
         }.map(s => (enabled, s)).exists {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `FileFormatWriter` materializes an `AdaptiveQueryPlan` before accessing the plan's `outputOrdering`. This is required when planned writing is disabled (`spark.sql.optimizer.plannedWrite.enabled` is `true` by default). With planned writing enabled `FileFormatWriter` gets the final plan already.

### Why are the changes needed?
`FileFormatWriter` enforces an ordering if the written plan does not provide that ordering. An `AdaptiveQueryPlan` does not know its final ordering, in which case `FileFormatWriter` enforces the ordering (e.g. by column `"a"`) even if the plan provides a compatible ordering (e.g. by columns `"a", "b"`). In case of spilling, that order (e.g. by columns `"a", "b"`) gets broken (see SPARK-40588).

### Does this PR introduce _any_ user-facing change?
This fixes SPARK-40588 for 3.4, which was introduced in 3.0. This restores behaviour from Spark 2.4.

### How was this patch tested?
The final plan that is written to files is now stored in `FileFormatWriter.executedPlan` (similar to existing `FileFormatWriter.outputOrderingMatched`). Unit tests assert the outermost sort order written to files.

The actual plan written into the files changed from (taken from `"SPARK-41914: v1 write with AQE and in-partition sorted - non-string partition column"`):

```
Sort [input[2, int, false] ASC NULLS FIRST], false, 0
+- *(3) Sort [key#13 ASC NULLS FIRST, value#14 ASC NULLS FIRST], false, 0
   +- *(3) Project [b#24, value#14, key#13]
      +- *(3) BroadcastHashJoin [key#13], [a#23], Inner, BuildLeft, false
         :- BroadcastQueryStage 2
         :  +- BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=376]
         :     +- AQEShuffleRead local
         :        +- ShuffleQueryStage 0
         :           +- Exchange hashpartitioning(key#13, 5), ENSURE_REQUIREMENTS, [plan_id=328]
         :              +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#13, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).value, true, false, true) AS value#14]
         :                 +- Scan[obj#12]
         +- AQEShuffleRead local
            +- ShuffleQueryStage 1
               +- Exchange hashpartitioning(a#23, 5), ENSURE_REQUIREMENTS, [plan_id=345]
                  +- *(2) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData2, true])).a AS a#23, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData2, true])).b AS b#24]
                     +- Scan[obj#22]
```

where `FileFormatWriter` enforces order with `Sort [input[2, int, false] ASC NULLS FIRST], false, 0`, to

```
*(3) Sort [key#13 ASC NULLS FIRST, value#14 ASC NULLS FIRST], false, 0
+- *(3) Project [b#24, value#14, key#13]
   +- *(3) BroadcastHashJoin [key#13], [a#23], Inner, BuildLeft, false
      :- BroadcastQueryStage 2
      :  +- BroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=375]
      :     +- AQEShuffleRead local
      :        +- ShuffleQueryStage 0
      :           +- Exchange hashpartitioning(key#13, 5), ENSURE_REQUIREMENTS, [plan_id=327]
      :              +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#13, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).value, true, false, true) AS value#14]
      :                 +- Scan[obj#12]
      +- AQEShuffleRead local
         +- ShuffleQueryStage 1
            +- Exchange hashpartitioning(a#23, 5), ENSURE_REQUIREMENTS, [plan_id=344]
               +- *(2) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData2, true])).a AS a#23, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData2, true])).b AS b#24]
                  +- Scan[obj#22]
```

where the sort given by the user is the outermost sort now.