### PR TITLE
[SPARK-41898][CONNECT][PYTHON] Window.rowsBetween, Window.rangeBetween parameters typechecking parity with pyspark

### DIFF
--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -148,11 +148,6 @@ class WindowSpec:
         )
 
     def rowsBetween(self, start: int, end: int) -> "WindowSpec":
-        if not isinstance(start, int):
-            raise TypeError(f"start must be a int, but got {type(start).__name__}")
-        if not isinstance(end, int):
-            raise TypeError(f"end must be a int, but got {type(end).__name__}")
-
         if start <= Window._PRECEDING_THRESHOLD:
             start = Window.unboundedPreceding
         if end >= Window._FOLLOWING_THRESHOLD:
@@ -165,11 +160,6 @@ class WindowSpec:
         )
 
     def rangeBetween(self, start: int, end: int) -> "WindowSpec":
-        if not isinstance(start, int):
-            raise TypeError(f"start must be a int, but got {type(start).__name__}")
-        if not isinstance(end, int):
-            raise TypeError(f"end must be a int, but got {type(end).__name__}")
-
         if start <= Window._PRECEDING_THRESHOLD:
             start = Window.unboundedPreceding
         if end >= Window._FOLLOWING_THRESHOLD:

--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -147,16 +147,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
     def test_sorting_functions_with_column(self):
         super().test_sorting_functions_with_column()
 
-    # TODO(SPARK-41898): support float("-inf") Window.rowsBetween
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_window_functions(self):
-        super().test_window_functions()
-
-    # TODO(SPARK-41898): support float("-inf") Window.rowsBetween
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_window_functions_without_partitionBy(self):
-        super().test_window_functions_without_partitionBy()
-
     # TODO(SPARK-41907): sampleby returning wrong output
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_sampleby(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Window.rowsBetween, Window.rangeBetween can accept values outside the range of int, and are trimmed to Window.unboundedPreceding, Window.unboundedFollowing
Like float(-inf) and float(+inf)


### Why are the changes needed?
Bug Fix


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
Existing test