### PR TITLE
[SPARK-41925][SQL] Enable `spark.sql.orc.enableNestedColumnVectorizedReader` by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1160,7 +1160,7 @@ object SQLConf {
       .doc("Enables vectorized orc decoding for nested column.")
       .version("3.2.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val ORC_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.orc.filterPushdown")
     .doc("When true, enable filter pushdown for ORC files.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Like SPARK-38840, this PR aims to enable `spark.sql.orc.enableNestedColumnVectorizedReader` by default in Apache Spark 3.4.0.

### Why are the changes needed?

To achieve a feature parity.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.