### PR TITLE
[SPARK-41824][CONNECT][PYTHON] Ingore the doctest for explain of connect

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1503,7 +1503,6 @@ def _test() -> None:
         del pyspark.sql.connect.dataframe.DataFrame.join.__doc__
 
         # TODO(SPARK-41824): DataFrame.explain format is different
-        del pyspark.sql.connect.dataframe.DataFrame.explain.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.hint.__doc__
 
         # TODO(SPARK-41886): The doctest output has different order

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1502,7 +1502,6 @@ def _test() -> None:
         del pyspark.sql.connect.dataframe.DataFrame.drop.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.join.__doc__
 
-        # TODO(SPARK-41824): DataFrame.explain format is different
         del pyspark.sql.connect.dataframe.DataFrame.hint.__doc__
 
         # TODO(SPARK-41886): The doctest output has different order

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -639,7 +639,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Print out the physical plan only (default).
 
-        >>> df.explain()
+        >>> df.explain()  # doctest: +SKIP
         == Physical Plan ==
         *(1) Scan ExistingRDD[age...,name...]
 
@@ -657,7 +657,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Print out the plans with two sections: a physical plan outline and node details
 
-        >>> df.explain(mode="formatted")
+        >>> df.explain(mode="formatted")  # doctest: +SKIP
         == Physical Plan ==
         * Scan ExistingRDD (...)
         (1) Scan ExistingRDD [codegen id : ...]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, the output of explain API is different between pyspark, scala and connect.
There already created a dataframe with
`df = spark.createDataFrame([(14, "Tom"), (23, "Alice"), (16, "Bob")], ["age", "name"]) `
and then execute
`df.explain()`
The output of pyspark show below.
```
    == Physical Plan ==
    *(1) Scan ExistingRDD[age...,name...]
```
But the scala and connect API output different content.
```
    == Physical Plan ==
    LocalTableScan [age#1148L, name#1149]
    <BLANKLINE>
    <BLANKLINE>
```
The similar issue occurs when executing `df.explain(mode="formatted")` too.

It's actually implementation details in PySpark. It would be difficult to make it matched. So this PR want ignore the two doc tests.

### Why are the changes needed?
Currently, the output of explain API is different between pyspark, scala and connect.
This PR want ignore the two doc tests.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
Manual tests.
