### PR TITLE
[SPARK-41930][INFRA] Remove `branch-3.1` from publish_snapshot GitHub Action job

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -34,7 +34,6 @@ jobs:
           - master
           - branch-3.3
           - branch-3.2
-          - branch-3.1
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?

Since Apache Spark 3.1 reached EOL last year, this PR aims to remove `branch-3.1` from `publish_snapshot` Daily GitHub Action job.

### Why are the changes needed?

This will save the community resource. Currently, `branch-3.2/3.3/master` failed due to `504 Gateway Timeout`.

https://github.com/apache/spark/actions/runs/3859454509/jobs/6578987085
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy (default-deploy) on project spark-catalyst_2.13: ArtifactDeployerException: Failed to deploy artifacts: Could not transfer artifact org.apache.spark:spark-catalyst_2.13:jar:3.2.4-20230107.005643-48 from/to apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots): transfer failed for https://repository.apache.org/content/repositories/snapshots/org/apache/spark/spark-catalyst_2.13/3.2.4-SNAPSHOT/spark-catalyst_2.13-3.2.4-20230107.005643-48.jar, status: 504 Gateway Timeout -> [Help 1]
```

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Only manual review because this is a daily job.