### PR TITLE
[SPARK-41933][CONNECT] Provide local mode that automatically starts the server

### DIFF
--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -82,26 +82,14 @@ you should regenerate Python Protobuf client by running ``dev/connect-gen-protos
 Running PySpark Shell with Python Client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To run Spark Connect server you locally built:
+For Apache Spark you locally built:
 
 .. code-block:: bash
 
-    bin/spark-shell \
-      --jars `ls connector/connect/target/**/spark-connect*SNAPSHOT.jar | paste -sd ',' -` \
-      --conf spark.plugins=org.apache.spark.sql.connect.SparkConnectPlugin
+    bin/pyspark --remote "local[*]"
 
-To run the Spark Connect server from the Apache Spark release:
+For the Apache Spark release:
 
 .. code-block:: bash
 
-    bin/spark-shell \
-      --packages org.apache.spark:spark-connect_2.12:3.4.0 \
-      --conf spark.plugins=org.apache.spark.sql.connect.SparkConnectPlugin
-
-
-To run the PySpark Shell with the client for the Spark Connect server:
-
-.. code-block:: bash
-
-    bin/pyspark --remote sc://localhost
-
+    bin/pyspark --remote "local[*]" --packages org.apache.spark:spark-connect_2.12:3.4.0

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -179,7 +179,7 @@ class SparkContext:
         udf_profiler_cls: Type[UDFBasicProfiler] = UDFBasicProfiler,
         memory_profiler_cls: Type[MemoryProfiler] = MemoryProfiler,
     ):
-        if "SPARK_REMOTE" in os.environ and "SPARK_TESTING" not in os.environ:
+        if "SPARK_REMOTE" in os.environ and "SPARK_LOCAL_REMOTE" not in os.environ:
             raise RuntimeError(
                 "Remote client cannot create a SparkContext. Create SparkSession instead."
             )

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -28,7 +28,6 @@ from typing import (
     Optional,
 )
 
-from pyspark import SparkContext, SparkConf
 from pyspark.sql.types import DataType
 from pyspark.sql.column import Column as PySparkColumn
 
@@ -434,13 +433,12 @@ def _test() -> None:
         import pyspark.sql.connect.column
 
         globs = pyspark.sql.connect.column.__dict__.copy()
-        # Works around to create a regular Spark session
-        sc = SparkContext("local[4]", "sql.connect.column tests", conf=SparkConf())
-        globs["_spark"] = PySparkSession(sc, options={"spark.app.name": "sql.connect.column tests"})
+        globs["spark"] = (
+            PySparkSession.builder.appName("sql.connect.column tests")
+            .remote("local[4]")
+            .getOrCreate()
+        )
 
-        # Creates a remote Spark session.
-        os.environ["SPARK_REMOTE"] = "sc://localhost"
-        globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
         # Spark Connect has a different string representation for Column.
         del pyspark.sql.connect.column.Column.getItem.__doc__
 
@@ -456,7 +454,7 @@ def _test() -> None:
         )
 
         globs["spark"].stop()
-        globs["_spark"].stop()
+
         if failure_count:
             sys.exit(-1)
     else:

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -226,7 +226,6 @@ def _test() -> None:
     import os
     import sys
     import doctest
-    from pyspark import SparkContext, SparkConf
     from pyspark.sql import SparkSession as PySparkSession
     from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
@@ -236,21 +235,21 @@ def _test() -> None:
         import pyspark.sql.connect.group
 
         globs = pyspark.sql.connect.group.__dict__.copy()
-        # Works around to create a regular Spark session
-        sc = SparkContext("local[4]", "sql.connect.group tests", conf=SparkConf())
-        globs["_spark"] = PySparkSession(sc, options={"spark.app.name": "sql.connect.group tests"})
 
-        # Creates a remote Spark session.
-        os.environ["SPARK_REMOTE"] = "sc://localhost"
-        globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
+        globs["spark"] = (
+            PySparkSession.builder.appName("sql.connect.group tests")
+            .remote("local[4]")
+            .getOrCreate()
+        )
 
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.group,
             globs=globs,
             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF,
         )
-        globs["_spark"].stop()
+
         globs["spark"].stop()
+
         if failure_count:
             sys.exit(-1)
     else:

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -20,7 +20,6 @@ from typing import Dict
 from typing import Optional, Union, List, overload, Tuple, cast, Any
 from typing import TYPE_CHECKING
 
-from pyspark import SparkContext, SparkConf
 from pyspark.sql.connect.plan import Read, DataSource, LogicalPlan, WriteOperation
 from pyspark.sql.types import StructType
 from pyspark.sql.utils import to_str
@@ -497,11 +496,6 @@ def _test() -> None:
         import pyspark.sql.connect.readwriter
 
         globs = pyspark.sql.connect.readwriter.__dict__.copy()
-        # Works around to create a regular Spark session
-        sc = SparkContext("local[4]", "sql.connect.readwriter tests", conf=SparkConf())
-        globs["_spark"] = PySparkSession(
-            sc, options={"spark.app.name": "sql.connect.readwriter tests"}
-        )
 
         # TODO(SPARK-41817): Support reading with schema
         del pyspark.sql.connect.readwriter.DataFrameReader.load.__doc__
@@ -517,9 +511,11 @@ def _test() -> None:
         del pyspark.sql.connect.readwriter.DataFrameWriter.insertInto.__doc__
         del pyspark.sql.connect.readwriter.DataFrameWriter.saveAsTable.__doc__
 
-        # Creates a remote Spark session.
-        os.environ["SPARK_REMOTE"] = "sc://localhost"
-        globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
+        globs["spark"] = (
+            PySparkSession.builder.appName("sql.connect.readwriter tests")
+            .remote("local[4]")
+            .getOrCreate()
+        )
 
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.readwriter,
@@ -530,7 +526,7 @@ def _test() -> None:
         )
 
         globs["spark"].stop()
-        globs["_spark"].stop()
+
         if failure_count:
             sys.exit(-1)
     else:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -350,13 +350,14 @@ class SparkSession:
             pass
 
     def stop(self) -> None:
-        # Stopping the session will only stop the current session by closing the connection,
-        # whereas the regular PySpark session closes the Spark Context itself, meaning that
-        # closing all Spark sessions. It is controversial to follow the existing
-        # the regular Spark session's behavior specifically in Spark Connect
-        # the Spark Connect server is designed for multi-tenancy - the remote client side
-        # cannot just stop the server and close other remote clients being used from other
-        # users.
+        # Stopping the session will only close the connection to the current session (and
+        # the life cycle of the session is maintained by the server),
+        # whereas the regular PySpark session immediately terminates the Spark Context
+        # itself, meaning that stopping all Spark sessions.
+        # It is controversial to follow the existing the regular Spark session's behavior
+        # specifically in Spark Connect the Spark Connect server is designed for
+        # multi-tenancy - the remote client side cannot just stop the server and stop
+        # other remote clients being used from other users.
         self.client.close()
 
         if "SPARK_LOCAL_REMOTE" in os.environ:
@@ -462,8 +463,8 @@ class SparkSession:
             if is_dev_version:
                 from pyspark.testing.utils import search_jar
 
-                # Note that, in production, spark.packages configuration should be set by users.
-                # Here we're automatically searching the jars locally built.
+                # Note that, in production, spark.jars.packages configuration should be
+                # set by users. Here we're automatically searching the jars locally built.
                 connect_jar = search_jar(
                     "connector/connect/server", "spark-connect-assembly-", "spark-connect"
                 )

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -18,7 +18,6 @@
 import sys
 from typing import TYPE_CHECKING, Union, Sequence, List, Optional
 
-from pyspark import SparkContext, SparkConf
 from pyspark.sql.connect.column import Column
 from pyspark.sql.connect.expressions import (
     ColumnReference,
@@ -240,13 +239,11 @@ def _test() -> None:
         import pyspark.sql.connect.window
 
         globs = pyspark.sql.connect.window.__dict__.copy()
-        # Works around to create a regular Spark session
-        sc = SparkContext("local[4]", "sql.connect.window tests", conf=SparkConf())
-        globs["_spark"] = PySparkSession(sc, options={"spark.app.name": "sql.connect.window tests"})
-
-        # Creates a remote Spark session.
-        os.environ["SPARK_REMOTE"] = "sc://localhost"
-        globs["spark"] = PySparkSession.builder.remote("sc://localhost").getOrCreate()
+        globs["spark"] = (
+            PySparkSession.builder.appName("sql.connect.window tests")
+            .remote("local[4]")
+            .getOrCreate()
+        )
 
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.window,
@@ -257,7 +254,7 @@ def _test() -> None:
         )
 
         globs["spark"].stop()
-        globs["_spark"].stop()
+
         if failure_count:
             sys.exit(-1)
     else:

--- a/python/pyspark/sql/tests/connect/test_parity_catalog.py
+++ b/python/pyspark/sql/tests/connect/test_parity_catalog.py
@@ -16,31 +16,12 @@
 #
 
 import unittest
-import os
 
-from pyspark.sql import SparkSession
 from pyspark.sql.tests.test_catalog import CatalogTestsMixin
-from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
-from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-@unittest.skipIf(not should_test_connect, connect_requirement_message)
-class CatalogParityTests(CatalogTestsMixin, ReusedSQLTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(CatalogParityTests, cls).setUpClass()
-        cls._spark = cls.spark  # Assign existing Spark session to run the server
-        # Sets the remote address. Now, we create a remote Spark Session.
-        # Note that this is only allowed in testing.
-        os.environ["SPARK_REMOTE"] = "sc://localhost"
-        cls.spark = SparkSession.builder.remote("sc://localhost").getOrCreate()
-
-    @classmethod
-    def tearDownClass(cls):
-        super(CatalogParityTests, cls).tearDownClass()
-        cls._spark.stop()
-        del os.environ["SPARK_REMOTE"]
-
+class CatalogParityTests(CatalogTestsMixin, ReusedConnectTestCase):
     # TODO(SPARK-41612): Support Catalog.isCached
     # TODO(SPARK-41600): Support Catalog.cacheTable
     # TODO(SPARK-41623): Support Catalog.uncacheTable

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -16,31 +16,12 @@
 #
 
 import unittest
-import os
 
-from pyspark.sql import SparkSession
 from pyspark.sql.tests.test_dataframe import DataFrameTestsMixin
-from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
-from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-@unittest.skipIf(not should_test_connect, connect_requirement_message)
-class DataFrameParityTests(DataFrameTestsMixin, ReusedSQLTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(DataFrameParityTests, cls).setUpClass()
-        cls._spark = cls.spark  # Assign existing Spark session to run the server
-        # Sets the remote address. Now, we create a remote Spark Session.
-        # Note that this is only allowed in testing.
-        os.environ["SPARK_REMOTE"] = "sc://localhost"
-        cls.spark = SparkSession.builder.remote("sc://localhost").getOrCreate()
-
-    @classmethod
-    def tearDownClass(cls):
-        super(DataFrameParityTests, cls).tearDownClass()
-        cls._spark.stop()
-        del os.environ["SPARK_REMOTE"]
-
+class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     # TODO(SPARK-41612): support Catalog.isCached
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_cache(self):

--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -16,34 +16,12 @@
 #
 
 import unittest
-import os
 
-from pyspark.sql import SparkSession
 from pyspark.sql.tests.test_functions import FunctionsTestsMixin
-from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
-from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-@unittest.skipIf(not should_test_connect, connect_requirement_message)
-class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
-    @classmethod
-    def setUpClass(cls):
-        from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
-
-        super(FunctionsParityTests, cls).setUpClass()
-        cls._spark = cls.spark  # Assign existing Spark session to run the server
-        # Sets the remote address. Now, we create a remote Spark Session.
-        # Note that this is only allowed in testing.
-        os.environ["SPARK_REMOTE"] = "sc://localhost"
-        cls.spark = SparkSession.builder.remote("sc://localhost").getOrCreate()
-        assert isinstance(cls.spark, RemoteSparkSession)
-
-    @classmethod
-    def tearDownClass(cls):
-        super(FunctionsParityTests, cls).tearDownClass()
-        cls.spark = cls._spark.stop()
-        del os.environ["SPARK_REMOTE"]
-
+class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     # TODO(SPARK-41897): Parity in Error types between pyspark and connect functions
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_assert_true(self):

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -531,7 +531,7 @@ class DataFrameTestsMixin:
 
         # Type check
         self.assertRaises(TypeError, self.df.withColumns, ["key"])
-        self.assertRaises(AssertionError, self.df.withColumns)
+        self.assertRaises(Exception, self.df.withColumns)
 
     def test_generic_hints(self):
         from pyspark.sql import DataFrame

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -20,6 +20,7 @@ import math
 import os
 import shutil
 import tempfile
+import unittest
 from contextlib import contextmanager
 
 from pyspark.sql import SparkSession

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -20,7 +20,6 @@ import math
 import os
 import shutil
 import tempfile
-import unittest
 from contextlib import contextmanager
 
 from pyspark.sql import SparkSession


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes local mode for Spark Connect. It automatically starts a Spark session (with bypassing `local*` master string) that launches the Spark Connect server, which introduces two user-facing changes below.

Notice that local mode exactly follows the regular PySpark session's stop behavior by terminating the server (whereas non-local mode would not close the server and other sessions). See also the newly added comments for `pyspark.sql.connect.SparkSession.stop`.

#### Local build of Apache Spark (for developers)

Automatically finds the jars for Spark Connect (because the jars for Spark Connect are not bundled in the regular Apache Spark release).

- PySpark shell 
    ```bash
    pyspark --remote local
    ```

- PySpark application submission
    ```bash
    spark-submit --remote "local[4]" app.py
    ```

- Use it as a Python library
    ```python
    from pyspark.sql import SparkSession
    SparkSession.builder.remote("local[*]").getOrCreate()
    ```

#### Official release of Apache Spark (for end-users)

Users must specify jars or packages. Jars aren't automatically searched.

- PySpark shell 
    ```bash
    pyspark --packages org.apache.spark:spark-connect_2.12:3.4.0 --remote local
    ```

- PySpark application submission
    ```bash
    spark-submit --packages org.apache.spark:spark-connect_2.12:3.4.0 --remote "local[4]" app.py
    ```

- Use it as a Python library
    ```python
    from pyspark.sql import SparkSession
    SparkSession.builder.config(
        "spark.jars.packages", "org.apache.spark:spark-connect_2.12:3.4.0"
    ).remote("local[*]").getOrCreate()
    ```

### Why are the changes needed?

In order to provide an easier mode to try Spark Connect for both developers and end-users.

### Does this PR introduce _any_ user-facing change?

No to end users because Spark Connect has not been released.
To the dev, yes. See the examples above.

### How was this patch tested?

Unittests were refactored to use/test this feature (that also deduplicated the codes).