### PR TITLE
[SPARK-41934][CONNECT][PYTHON] Add the unsupported function list for `session`

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -358,6 +358,33 @@ class SparkSession:
     def register_udf(self, function: Any, return_type: Union[str, DataType]) -> str:
         return self._client.register_udf(function, return_type)
 
+    @classmethod
+    def getActiveSession(cls) -> Any:
+        raise NotImplementedError("getActiveSession() is not implemented.")
+
+    def newSession(self) -> Any:
+        raise NotImplementedError("newSession() is not implemented.")
+
+    @property
+    def conf(self) -> Any:
+        raise NotImplementedError("conf() is not implemented.")
+
+    @property
+    def sparkContext(self) -> Any:
+        raise NotImplementedError("sparkContext() is not implemented.")
+
+    @property
+    def streams(self) -> Any:
+        raise NotImplementedError("streams() is not implemented.")
+
+    @property
+    def udf(self) -> Any:
+        raise NotImplementedError("udf() is not implemented.")
+
+    @property
+    def version(self) -> str:
+        raise NotImplementedError("version() is not implemented.")
+
 
 SparkSession.__doc__ = PySparkSession.__doc__
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2039,6 +2039,23 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             with self.assertRaises(NotImplementedError):
                 getattr(cg, f)()
 
+    def test_unsupported_session_functions(self):
+        # SPARK-41934: Disable unsupported functions.
+
+        with self.assertRaises(NotImplementedError):
+            RemoteSparkSession.getActiveSession()
+
+        for f in (
+            "newSession",
+            "conf",
+            "sparkContext",
+            "streams",
+            "udf",
+            "version",
+        ):
+            with self.assertRaises(NotImplementedError):
+                getattr(self.connect, f)()
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class ChannelBuilderTests(ReusedPySparkTestCase):

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -209,7 +209,13 @@ class CatalogTestsMixin:
             self.assertEqual(functions, functionsDefault)
 
             with self.function("func1", "some_db.func2"):
-                if hasattr(spark, "udf") and hasattr(spark.udf, "register"):
+                try:
+                    spark.udf
+                    support_udf = True
+                except Exception:
+                    support_udf = False
+
+                if support_udf:
                     spark.udf.register("temp_func", lambda x: str(x))
                 spark.sql("CREATE FUNCTION func1 AS 'org.apache.spark.data.bricks'").collect()
                 spark.sql(
@@ -221,11 +227,11 @@ class CatalogTestsMixin:
                 )
                 self.assertTrue(set(functions).issubset(set(newFunctions)))
                 self.assertTrue(set(functions).issubset(set(newFunctionsSomeDb)))
-                if hasattr(spark, "udf"):
+                if support_udf:
                     self.assertTrue("temp_func" in newFunctions)
                 self.assertTrue("func1" in newFunctions)
                 self.assertTrue("func2" not in newFunctions)
-                if hasattr(spark, "udf"):
+                if support_udf:
                     self.assertTrue("temp_func" in newFunctionsSomeDb)
                 self.assertTrue("func1" not in newFunctionsSomeDb)
                 self.assertTrue("func2" in newFunctionsSomeDb)

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -209,7 +209,7 @@ class CatalogTestsMixin:
             self.assertEqual(functions, functionsDefault)
 
             with self.function("func1", "some_db.func2"):
-                if hasattr(spark, "udf"):
+                if hasattr(spark, "udf") and hasattr(spark.udf, "register"):
                     spark.udf.register("temp_func", lambda x: str(x))
                 spark.sql("CREATE FUNCTION func1 AS 'org.apache.spark.data.bricks'").collect()
                 spark.sql(


### PR DESCRIPTION


### What changes were proposed in this pull request?
Add the unsupported function list for `session`


### Why are the changes needed?
to explictly tell users they are not implemented



### Does this PR introduce _any_ user-facing change?
yes, `NotImplementedError`


### How was this patch tested?
added UT
