### PR TITLE
[SPARK-41935][INFRA] Skip snapshot check and transfer progress log during publishing snapshots

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -424,11 +424,11 @@ if [[ "$1" == "publish-snapshot" ]]; then
   echo "<password>$ASF_PASSWORD</password>" >> $tmp_settings
   echo "</server></servers></settings>" >> $tmp_settings
 
-  $MVN --settings $tmp_settings -DskipTests $SCALA_2_12_PROFILES $PUBLISH_PROFILES clean deploy
+  $MVN --settings $tmp_settings -DskipTests $SCALA_2_12_PROFILES $PUBLISH_PROFILES -nsu -ntp clean deploy
 
   if [[ $PUBLISH_SCALA_2_13 = 1 ]]; then
     ./dev/change-scala-version.sh 2.13
-    $MVN --settings $tmp_settings -DskipTests $SCALA_2_13_PROFILES $PUBLISH_PROFILES clean deploy
+    $MVN --settings $tmp_settings -DskipTests $SCALA_2_13_PROFILES $PUBLISH_PROFILES -nsu -ntp clean deploy
   fi
 
   rm $tmp_settings


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve snapshot publishing GitHub Action job by skiping `snapshot` check and hiding transfer progress log.

**Snapshot Publish GitHub Action Job**: https://github.com/apache/spark/actions/workflows/publish_snapshot.yml

### Why are the changes needed?

Snapshot publishing GitHub Action job doesn't not need to check and update snapshot jars because it always generates new snapshots by itself.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.