### PR TITLE
[SPARK-41880][CONNECT][PYTHON] Make function `from_json` accept non-literal schema

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -1640,6 +1640,27 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
                 sdf.select(SF.from_json("b", schema, {"mode": "FAILFAST"})),
             )
 
+        # SPARK-41880: from_json support non-literal expression
+        c_schema = CF.schema_of_json(CF.lit("""{"a": 2}"""))
+        s_schema = SF.schema_of_json(SF.lit("""{"a": 2}"""))
+
+        self.compare_by_show(
+            cdf.select(CF.from_json(cdf.a, c_schema)),
+            sdf.select(SF.from_json(sdf.a, s_schema)),
+        )
+        self.compare_by_show(
+            cdf.select(CF.from_json("a", c_schema)),
+            sdf.select(SF.from_json("a", s_schema)),
+        )
+        self.compare_by_show(
+            cdf.select(CF.from_json(cdf.a, c_schema, {"mode": "FAILFAST"})),
+            sdf.select(SF.from_json(sdf.a, s_schema, {"mode": "FAILFAST"})),
+        )
+        self.compare_by_show(
+            cdf.select(CF.from_json("a", c_schema, {"mode": "FAILFAST"})),
+            sdf.select(SF.from_json("a", s_schema, {"mode": "FAILFAST"})),
+        )
+
         # test get_json_object
         self.assert_eq(
             cdf.select(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make function `from_json` accept non-literal schema

before: all `from_json` calls are processed in `transformUnregisteredFunction`

after: only `from_json` with JSON-formatted literal schema (which is connect specific to support DataType schema) is handled in `transformUnregisteredFunction`, other cases will be handled by catalyst.


### Why are the changes needed?
to be consistent with PySpark


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added UT
