### PR TITLE
[SPARK-41897][CONNECT][TESTS] Enable tests with error mismatch in connect/test_parity_functions.py

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -22,11 +22,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
-    # TODO(SPARK-41897): Parity in Error types between pyspark and connect functions
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_assert_true(self):
-        super().test_assert_true()
-
     @unittest.skip("Spark Connect does not support Spark Context but the test depends on that.")
     def test_basic_functions(self):
         super().test_basic_functions()
@@ -58,11 +53,6 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_lit_np_scalar(self):
         super().test_lit_np_scalar()
-
-    # TODO(SPARK-41897): Parity in Error types between pyspark and connect functions
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_raise_error(self):
-        super().test_raise_error()
 
     # Comparing column type of connect and pyspark
     @unittest.skip("Fails in Spark Connect, should enable.")

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1015,46 +1015,42 @@ class FunctionsTestsMixin:
             [Row(val=None), Row(val=None), Row(val=None)],
         )
 
-        with self.assertRaises((Py4JJavaError, SparkConnectException)) as cm:
+        with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "too big"):
             df.select(assert_true(df.id < 2, "too big")).toDF("val").collect()
-        self.assertIn("java.lang.RuntimeException", str(cm.exception))
-        self.assertIn("too big", str(cm.exception))
 
-        with self.assertRaises((Py4JJavaError, SparkConnectException)) as cm:
+        with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "2000000"):
             df.select(assert_true(df.id < 2, df.id * 1e6)).toDF("val").collect()
-        self.assertIn("java.lang.RuntimeException", str(cm.exception))
-        self.assertIn("2000000", str(cm.exception))
 
-        with self.assertRaises(PySparkTypeError) as pe:
+        with self.assertRaises((PySparkTypeError, TypeError)) as pe:
             df.select(assert_true(df.id < 2, 5))
 
-        self.check_error(
-            exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STRING",
-            message_parameters={"arg_name": "errMsg", "arg_type": "int"},
-        )
+        if isinstance(pe, PySparkTypeError):
+            self.check_error(
+                exception=pe.exception,
+                error_class="NOT_COLUMN_OR_STRING",
+                message_parameters={"arg_name": "errMsg", "arg_type": "int"},
+            )
 
     def test_raise_error(self):
         from pyspark.sql.functions import raise_error
 
         df = self.spark.createDataFrame([Row(id="foobar")])
 
-        with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "foobar") as cm:
+        with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "foobar"):
             df.select(raise_error(df.id)).collect()
-        self.assertIn("foobar", str(cm.exception))
 
-        with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "barfoo") as cm:
+        with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "barfoo"):
             df.select(raise_error("barfoo")).collect()
-        self.assertIn("barfoo", str(cm.exception))
 
-        with self.assertRaises(PySparkTypeError) as pe:
+        with self.assertRaises((PySparkTypeError, TypeError)) as pe:
             df.select(raise_error(None))
 
-        self.check_error(
-            exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STRING",
-            message_parameters={"arg_name": "errMsg", "arg_type": "NoneType"},
-        )
+        if isinstance(pe, PySparkTypeError):
+            self.check_error(
+                exception=pe.exception,
+                error_class="NOT_COLUMN_OR_STRING",
+                message_parameters={"arg_name": "errMsg", "arg_type": "NoneType"},
+            )
 
     def test_sum_distinct(self):
         self.spark.range(10).select(

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1041,9 +1041,11 @@ class FunctionsTestsMixin:
 
         with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "foobar") as cm:
             df.select(raise_error(df.id)).collect()
+        self.assertIn("foobar", str(cm.exception))
 
         with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "barfoo") as cm:
             df.select(raise_error("barfoo")).collect()
+        self.assertIn("barfoo", str(cm.exception))
 
         with self.assertRaises(PySparkTypeError) as pe:
             df.select(raise_error(None))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix tests with error mismatch in connect/test_parity_functions.py


### Why are the changes needed?
Tests coverage


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Enabling new tests
