### PR TITLE
[SPARK-41899][CONNECT][PYTHON] `createDataFrame` should respect user provided DDL schema

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import datetime
 import unittest
 import shutil
 import tempfile
@@ -562,6 +564,14 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             cdf.select(CF.pmod("a", "b")).toPandas(),
             sdf.select(SF.pmod("a", "b")).toPandas(),
         )
+
+    def test_cast_with_ddl(self):
+        data = [Row(date=datetime.date(2021, 12, 27), add=2)]
+
+        cdf = self.connect.createDataFrame(data, "date date, add integer")
+        sdf = self.spark.createDataFrame(data, "date date, add integer")
+
+        self.assertEqual(cdf.schema, sdf.schema)
 
     def test_create_empty_df(self):
         for schema in [

--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -53,16 +53,6 @@ class FunctionsParityTests(ReusedSQLTestCase, FunctionsTestsMixin):
     def test_basic_functions(self):
         super().test_basic_functions()
 
-    # TODO(SPARK-41899): DataFrame.createDataFrame converting int to bigint
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_date_add_function(self):
-        super().test_date_add_function()
-
-    # TODO(SPARK-41899): DataFrame.createDataFrame converting int to bigint
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_date_sub_function(self):
-        super().test_date_sub_function()
-
     # TODO(SPARK-41847): DataFrame mapfield,structlist invalid type
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_explode(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Make `createDataFrame` respect user provided DDL schema


### Why are the changes needed?
consistency


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
added UT and enabled tests
