### PR TITLE
[SPARK-41939][CONNECT][PYTHON] Add the unsupported list for `catalog` functions

### DIFF
--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, TYPE_CHECKING
 
 import pandas as pd
 
@@ -306,6 +306,18 @@ class Catalog:
         self._catalog_to_pandas(plan.RefreshByPath(path=path))
 
     refreshByPath.__doc__ = PySparkCatalog.refreshByPath.__doc__
+
+    def isCached(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("isCached() is not implemented.")
+
+    def cacheTable(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("cacheTable() is not implemented.")
+
+    def uncacheTable(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("uncacheTable() is not implemented.")
+
+    def registerFunction(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("registerFunction() is not implemented.")
 
 
 Catalog.__doc__ = PySparkCatalog.__doc__

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2056,6 +2056,18 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             with self.assertRaises(NotImplementedError):
                 getattr(self.connect, f)()
 
+    def test_unsupported_catalog_functions(self):
+        # SPARK-41939: Disable unsupported functions.
+
+        for f in (
+            "isCached",
+            "cacheTable",
+            "uncacheTable",
+            "registerFunction",
+        ):
+            with self.assertRaises(NotImplementedError):
+                getattr(self.connect.catalog, f)()
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class ChannelBuilderTests(ReusedPySparkTestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the unsupported list for `catalog` functions

### Why are the changes needed?
to explictly tell users they are not implemented



### Does this PR introduce _any_ user-facing change?
yes, `NotImplementedError`


### How was this patch tested?
added UT
