### PR TITLE
[WIP][SPARK-41940][SQL] Infer IsNotNull constraints for complex join expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -100,6 +100,13 @@ trait ConstraintHelper {
     // operator's output
     val nonNullableAttributes = output.filterNot(_.nullable)
     isNotNullConstraints ++= nonNullableAttributes.map(IsNotNull)
+    isNotNullConstraints ++= constraints.collect {
+      case BinaryComparison(left, _) if left.references.subsetOf(AttributeSet(output)) =>
+        IsNotNull(left)
+
+      case BinaryComparison(_, right) if right.references.subsetOf(AttributeSet(output)) =>
+        IsNotNull(right)
+    }
 
     isNotNullConstraints -- constraints
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Infer IsNotNull constraints for complex join expressions along with IsNotNull constraints for the attribute.
For example,
```sql
CREATE TABLE t(id int, text string) using parquet;

SELECT *
FROM t as t1
LEFT JOIN t as t2
ON t1.text = get_json_object(t2.text, '$.not_exists_col');
```
Before this PR
```
Join LeftOuter, (text#282 = get_json_object(text#284, $.not_exists_col))
:- Relation default.t[id#281L,text#282] parquet
+- Relation default.t[id#283L,text#284] parquet
```

After this PR
```
Join LeftOuter, (text#282 = get_json_object(text#284, $.not_exists_col))
:- Relation default.t[id#281L,text#282] parquet
+- Filter isnotnull(get_json_object(text#284, $.not_exists_col))
   +- Relation default.t[id#283L,text#284] parquet
```

### Why are the changes needed?

For the rows which the result of complex join expression is null will cause data skew, and will be filtered out until the join.
That would be very slow.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added UT
