### PR TITLE
[SPARK-41941][BUILD] Upgrade `scalatest` related test dependencies to 3.2.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1129,25 +1129,25 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.2.14</version>
+        <version>3.2.15</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>scalacheck-1-17_${scala.binary.version}</artifactId>
-        <version>3.2.14.0</version>
+        <version>3.2.15.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
-        <version>3.2.14.0</version>
+        <version>3.2.15.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>selenium-4-7_${scala.binary.version}</artifactId>
-        <version>3.2.14.0</version>
+        <version>3.2.15.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -207,8 +207,8 @@
     <!-- Please don't upgrade the version to 4.10+, it depends on JDK 11 -->
     <antlr4.version>4.9.3</antlr4.version>
     <jpam.version>1.1</jpam.version>
-    <selenium.version>4.7.1</selenium.version>
-    <htmlunit-driver.version>4.7.0</htmlunit-driver.version>
+    <selenium.version>4.7.2</selenium.version>
+    <htmlunit-driver.version>4.7.2</htmlunit-driver.version>
     <htmlunit.version>2.67.0</htmlunit.version>
     <maven-antrun.version>1.8</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `scalatest` related test dependencies to 3.2.15:

- scalatest: upgrade scalatest to 3.2.15
- scalatestplus
   - scalacheck: upgrade to `scalacheck-1-17` 3.2.15.0
   - mockito: upgrade to `mockito-4-6` to 3.2.15.0
   - selenium: uprade to `selenium-4-7` to 3.2.15.0 and `selenium-java` to 4.7.2, `htmlunit-driver` to 4.7.2

### Why are the changes needed?
The release notes as follows:

- scalatest:https://github.com/scalatest/scalatest/releases/tag/release-3.2.15
- scalatestplus
   - scalacheck-1-17: https://github.com/scalatest/scalatestplus-scalacheck/releases/tag/release-3.2.15.0-for-scalacheck-1.17
   - mockito-4-6: https://github.com/scalatest/scalatestplus-mockito/releases/tag/release-3.2.15.0-for-mockito-4.6
   - selenium-4-7: https://github.com/scalatest/scalatestplus-selenium/releases/tag/release-3.2.15.0-for-selenium-4.7


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Manual test:
   - ChromeUISeleniumSuite
   - RocksDBBackendChromeUIHistoryServerSuite

```
build/sbt -Dguava.version=31.1-jre -Dspark.test.webdriver.chrome.driver=/path/to/chromedriver -Dtest.default.exclude.tags="" -Phive -Phive-thriftserver "core/testOnly org.apache.spark.ui.ChromeUISeleniumSuite"

build/sbt -Dguava.version=31.1-jre -Dspark.test.webdriver.chrome.driver=/path/to/chromedriver -Dtest.default.exclude.tags="" -Phive -Phive-thriftserver "core/testOnly org.apache.spark.deploy.history.RocksDBBackendChromeUIHistoryServerSuite"
```   

```
ChromeDriver was started successfully.
[info] - SPARK-31534: text for tooltip should be escaped (3 seconds, 421 milliseconds)
[info] - SPARK-31882: Link URL for Stage DAGs should not depend on paged table. (945 milliseconds)
[info] - SPARK-31886: Color barrier execution mode RDD correctly (310 milliseconds)
[info] - Search text for paged tables should not be saved (1 second, 761 milliseconds)
[info] Run completed in 10 seconds, 809 milliseconds.
[info] Total number of tests run: 4
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 123 s (02:03), completed 2023-1-8 21:33:56
```

```
ChromeDriver was started successfully.
[info] - ajax rendered relative links are prefixed with uiRoot (spark.ui.proxyBase) (2 seconds, 341 milliseconds)
[info] Run completed in 8 seconds, 792 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 23 s, completed 2023-1-8 21:34:48
```