### PR TITLE
[SPARK-41944][CONNECT] Pass configurations when local remote mode is on

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -245,7 +245,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     if (args.length == 0) {
       printUsageAndExit(-1)
     }
-    if (maybeRemote.isDefined && (maybeMaster.isDefined || deployMode != null)) {
+    if (!sparkProperties.contains("spark.local.connect") &&
+        maybeRemote.isDefined && (maybeMaster.isDefined || deployMode != null)) {
       error("Remote cannot be specified with master and/or deploy mode.")
     }
     if (primaryResource == null) {

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -45,6 +45,10 @@ public class SparkLauncher extends AbstractLauncher<SparkLauncher> {
   /** The Spark master. */
   public static final String SPARK_MASTER = "spark.master";
 
+  /** The Spark remote. */
+  public static final String SPARK_REMOTE = "spark.remote";
+  public static final String SPARK_LOCAL_REMOTE = "spark.local.connect";
+
   /** The Spark deploy mode. */
   public static final String DEPLOY_MODE = "spark.submit.deployMode";
 

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.*;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;
+import static org.apache.spark.launcher.CommandBuilderUtils.checkState;
 
 /**
  * Special command builder for handling a CLI invocation of SparkSubmit.
@@ -349,9 +350,18 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
       // pass conf spark.pyspark.python to python by environment variable.
       env.put("PYSPARK_PYTHON", conf.get(SparkLauncher.PYSPARK_PYTHON));
     }
-    if (remote != null) {
-      env.put("SPARK_REMOTE", remote);
+    String remoteStr = firstNonEmpty(remote, conf.getOrDefault(SparkLauncher.SPARK_REMOTE, null));
+    String masterStr = firstNonEmpty(master, conf.getOrDefault(SparkLauncher.SPARK_MASTER, null));
+    String deployStr = firstNonEmpty(
+      deployMode, conf.getOrDefault(SparkLauncher.DEPLOY_MODE, null));
+    if (!conf.containsKey(SparkLauncher.SPARK_LOCAL_REMOTE) &&
+        remoteStr != null && (masterStr != null || deployStr != null)) {
+      throw new IllegalStateException("Remote cannot be specified with master and/or deploy mode.");
     }
+    if (remoteStr != null) {
+      env.put("SPARK_REMOTE", remoteStr);
+    }
+
     if (!isEmpty(pyOpts)) {
       pyargs.addAll(parseOptionString(pyOpts));
     }
@@ -465,18 +475,12 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     protected boolean handle(String opt, String value) {
       switch (opt) {
         case MASTER:
-          checkArgument(remote == null,
-            "Both master (%s) and remote (%s) cannot be set together.", master, remote);
           master = value;
           break;
         case REMOTE:
-          checkArgument(remote == null,
-            "Both master (%s) and remote (%s) cannot be set together.", master, remote);
           remote = value;
           break;
         case DEPLOY_MODE:
-          checkArgument(remote == null,
-            "Both deploy-mode (%s) and remote (%s) cannot be set together.", deployMode, remote);
           deployMode = value;
           break;
         case PROPERTIES_FILE:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -428,8 +428,8 @@ class SparkSession:
         """
         Starts the Spark Connect server given the master.
 
-        At the high level, there are two cases. The first case is when you locally build
-        Apache Spark, and run ``SparkSession.builder.remote("local")``:
+        At the high level, there are two cases. The first case is development case, e.g.,
+        you locally build Apache Spark, and run ``SparkSession.builder.remote("local")``:
 
         1. This method automatically finds the jars for Spark Connect (because the jars for
           Spark Connect are not bundled in the regular Apache Spark release).
@@ -437,14 +437,14 @@ class SparkSession:
         2. Temporarily remove all states for Spark Connect, for example, ``SPARK_REMOTE``
           environment variable.
 
-            2.1. If we're in PySpark application submission, e.g., ``bin/spark-submit app.py``
-              starts a JVM (without Spark Context) first, and adds the Spark Connect server jars
-              into the current class loader. Otherwise, Spark Context with ``spark.plugins``
-              cannot be initialized because the JVM is already running without the jars in
-              the class path before executing this Python process for driver side.
+        3. Starts a JVM (without Spark Context) first, and adds the Spark Connect server jars
+           into the current class loader. Otherwise, Spark Context with ``spark.plugins``
+           cannot be initialized because the JVM is already running without the jars in
+           the class path before executing this Python process for driver side (in case of
+           PySpark application submission).
 
-        3. Starts a regular Spark session that automatically starts a Spark Connect server
-          with JVM (if it is not up) via ``spark.plugins`` feature.
+        4. Starts a regular Spark session that automatically starts a Spark Connect server
+           via ``spark.plugins`` feature.
 
         The second case is when you use Apache Spark release:
 
@@ -463,78 +463,67 @@ class SparkSession:
         session = PySparkSession._instantiatedSession
         if session is None or session._sc._jsc is None:
             conf = SparkConf()
+            # Do not need to worry about the existing configurations because
+            # Py4J gateway is not created yet, and `conf` instance is empty here.
+            #
+            # Note that existing or user-specified configurations have higher priority,
+            # that is respected in two ways below:
+            # - For PySpark shell, the configurations belows are prepended to 'PYSPARK_SUBMIT_ARGS'
+            #   environment variable, respecting the user configurations if same keys are set.
+            # - For PySpark application submission, the configurations belows are manually
+            #   manipulated later to respect the priority right after Py4J gateway creation.
+            conf.set("spark.master", master)
+            conf.set("spark.plugins", "org.apache.spark.sql.connect.SparkConnectPlugin")
+            conf.set("spark.local.connect", "1")
+
             # Check if we're using unreleased version that is in development.
             # Also checks SPARK_TESTING for RC versions.
             is_dev_mode = (
                 "dev" in LooseVersion(__version__).version or "SPARK_TESTING" in os.environ
             )
-            connect_jar = None
-
-            if is_dev_mode:
-                from pyspark.testing.utils import search_jar
-
-                # Note that, in production, spark.jars.packages configuration should be
-                # set by users. Here we're automatically searching the jars locally built.
-                connect_jar = search_jar(
-                    "connector/connect/server", "spark-connect-assembly-", "spark-connect"
-                )
-                if connect_jar is not None:
-                    origin_jars = conf.get("spark.jars")
-                    if origin_jars is not None:
-                        conf.set("spark.jars", f"{origin_jars},{connect_jar}")
-                    else:
-                        conf.set("spark.jars", connect_jar)
-                else:
-                    warnings.warn(
-                        "Attempted to automatically find the Spark Connect jars because "
-                        "'SPARK_TESTING' environment variable is set, or the current PySpark "
-                        f"version is dev version ({__version__}). However, the jar was not found. "
-                        "Manually locate the jars and specify them, e.g., 'spark.jars' "
-                        "configuration."
-                    )
-
-            conf.set("spark.master", master)
-
-            connect_plugin = "org.apache.spark.sql.connect.SparkConnectPlugin"
-            origin_plugin = conf.get("spark.plugins")
-            if origin_plugin is not None:
-                conf.set("spark.plugins", f"{origin_plugin},{connect_plugin}")
-            else:
-                conf.set("spark.plugins", connect_plugin)
-
             origin_remote = os.environ.get("SPARK_REMOTE", None)
-            origin_args = os.environ.get("PYSPARK_SUBMIT_ARGS", None)
             try:
                 if origin_remote is not None:
                     # So SparkSubmit thinks no remote is set in order to
                     # start the regular PySpark session.
                     del os.environ["SPARK_REMOTE"]
 
-                # PySpark shell launches Py4J server from Python.
-                # Remove "--remote" option specified, and use plain arguments.
-                # NOTE that this is not used in regular PySpark application
-                # submission because JVM at this point is already running.
-                os.environ["PYSPARK_SUBMIT_ARGS"] = '"--name" "PySparkShell" "pyspark-shell"'
+                if is_dev_mode:
+                    from pyspark.testing.utils import search_jar
 
-                if is_dev_mode and connect_jar is not None:
-                    # In the case of Python application submission, JVM is already up.
-                    # Therefore, we should manually manipulate the classpath in that case.
-                    # Otherwise, the jars are added but the driver would not be able to
-                    # find the server jars.
+                    # Note that, in production, spark.jars.packages configuration should be
+                    # set by users. Here we're automatically searching the jars locally built.
+                    connect_jar = search_jar(
+                        "connector/connect/server", "spark-connect-assembly-", "spark-connect"
+                    )
+                    if connect_jar is None:
+                        warnings.warn(
+                            "Attempted to automatically find the Spark Connect jars because "
+                            "'SPARK_TESTING' environment variable is set, or the current PySpark "
+                            f"version is dev version ({__version__}). However, the jar was not "
+                            "found. Manually locate the jars and specify them, e.g., 'spark.jars' "
+                            "configuration."
+                        )
+
+                    # In the case of Python application submission, JVM is already up at this
+                    # point. Therefore, we should manually manipulate the classpath.
                     with SparkContext._lock:
                         if not SparkContext._gateway:
                             SparkContext._gateway = launch_gateway(conf)
                             SparkContext._jvm = SparkContext._gateway.jvm
                             SparkContext._jvm.PythonSQLUtils.addJarToCurrentClassLoader(connect_jar)
 
+                            # Now, JVM is up, and respect the default set.
+                            prev = conf
+                            conf = SparkConf(_jvm=SparkContext._jvm)
+                            for k, v in prev.getAll():
+                                if not conf.contains(k):
+                                    conf.set(k, v)
+
                 # The regular PySpark session is registered as an active session
                 # so would not be garbage-collected.
                 PySparkSession(SparkContext.getOrCreate(conf))
             finally:
-                if origin_args is not None:
-                    os.environ["PYSPARK_SUBMIT_ARGS"] = origin_args
-                else:
-                    del os.environ["PYSPARK_SUBMIT_ARGS"]
                 if origin_remote is not None:
                     os.environ["SPARK_REMOTE"] = origin_remote
         else:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR mainly proposes to pass the user-specified configurations to local remote mode.

Previously, all user-specific configurations were ignored in case of PySpark shell such as`./bin/pyspark` or plain Python interpreter - PySpark application submission case was fine.

Now, configurations are properly passed to the server side, e.g., `./bin/pyspark --remote local --conf aaa=bbb` and `aaa=bbb` is properly passed to the server side.

For `spark.master` and `spark.plugins`, user-specific configurations are respected. If they are unset, they are automatically set, e.g., `org.apache.spark.sql.connect.SparkConnectPlugin`. If they are set, users have to provide the proper values to overwrite them, meaning that either:

```bash
./bin/pyspark --remote local --conf spark.plugins="other.Plugin,org.apache.spark.sql.connect.SparkConnectPlugin"
```

or

```bash
./bin/pyspark --remote local
```

In addition, this PR fixes the related code as below:
- Adds `spark.local.connect` internal configuration to be used in Spark Submit (so we don't have to parse and manipulate user specified arguments in Python in order to remove `--remote` or `spark.remote` configuration).
- Adds some more validation on arguments in `SparkSubmitCommandBuilder` so invalid combination can fail fast (e.g., setting both remote and master like `--master ...` and `--conf spark.remote=...`)
- In dev mode, do not set `spark.jars` anymore since it adds the jars into the class path of the JVM through `addJarToCurrentClassLoader`.

### Why are the changes needed?

To correctly pass the configurations specified from users.

### Does this PR introduce _any_ user-facing change?

No, Spark Connect has not been released yet.
This is kind of a followup of https://github.com/apache/spark/pull/39441 to complete its support.

### How was this patch tested?

Manually tested all combinations such as:

```bash
./bin/pyspark --conf spark.remote=local
./bin/pyspark --conf spark.remote=local --conf spark.jars=a
./bin/pyspark --conf spark.remote=local --jars /.../spark/connector/connect/server/target/scala-2.12/spark-connect-assembly-3.4.0-SNAPSHOT.jar
./bin/spark-submit --conf spark.remote=local --jars /.../spark/connector/connect/server/target/scala-2.12/spark-connect-assembly-3.4.0-SNAPSHOT.jar app.py
./bin/pyspark --conf spark.remote=local --conf spark.jars=/.../spark/connector/connect/server/target/scala-2.12/spark-connect-assembly-3.4.0-SNAPSHOT.jar
./bin/pyspark --master "local[*]" --remote "local"
./bin/spark-submit --conf spark.remote=local app.py
./bin/spark-submit --master="local[*]" --conf spark.remote=local app.py
./bin/spark-submit --master="local[*]" --remote=local app.py
./bin/pyspark --master "local[*]" --remote "local"
./bin/pyspark --master "local[*]" --remote "local"
./bin/pyspark --master "local[*]" --conf spark.remote="local"
./bin/spark-submit --master="local[*]" --remote=local app.py
./bin/pyspark --remote local
```
