### PR TITLE
[SPARK-41947][CORE][DOCS] Update the contents of error class guidelines

### DIFF
--- a/core/src/main/resources/error/README.md
+++ b/core/src/main/resources/error/README.md
@@ -39,6 +39,8 @@ Throw with arbitrary error message:
       extends TestException(SparkThrowableHelper.getMessage(errorClass, messageParameters))
         with SparkThrowable {
         
+      override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+
       override def getErrorClass: String = errorClass
     }
 

--- a/core/src/main/resources/error/README.md
+++ b/core/src/main/resources/error/README.md
@@ -8,9 +8,9 @@ and message parameters rather than an arbitrary error message.
 1. Check if the error is an internal error.
    Internal errors are bugs in the code that we do not expect users to encounter; this does not include unsupported operations.
    If true, use the error class `INTERNAL_ERROR` and skip to step 4.
-2. Check if an appropriate error class already exists in `error-class.json`.
+2. Check if an appropriate error class already exists in `error-classes.json`.
    If true, use the error class and skip to step 4.
-3. Add a new class to `error-class.json`; keep in mind the invariants below.
+3. Add a new class to `error-classes.json`; keep in mind the invariants below.
 4. Check if the exception type already extends `SparkThrowable`.
    If true, skip to step 6.
 5. Mix `SparkThrowable` into the exception.
@@ -24,10 +24,10 @@ Throw with arbitrary error message:
 
 ### After
 
-`error-class.json`
+`error-classes.json`
 
     "PROBLEM_BECAUSE": {
-      "message": ["Problem %s because %s"],
+      "message": ["Problem <problem> because <cause>"],
       "sqlState": "XXXXX"
     }
 
@@ -35,16 +35,16 @@ Throw with arbitrary error message:
 
     class SparkTestException(
         errorClass: String,
-        messageParameters: Seq[String])
+        messageParameters: Map[String, String])
       extends TestException(SparkThrowableHelper.getMessage(errorClass, messageParameters))
         with SparkThrowable {
         
-      def getErrorClass: String = errorClass
+      override def getErrorClass: String = errorClass
     }
 
 Throw with error class and message parameters:
 
-    throw new SparkTestException("PROBLEM_BECAUSE", Seq("A", "B"))
+    throw new SparkTestException("PROBLEM_BECAUSE", Map("problem" -> "A", "cause" -> "B"))
 
 ## Access fields
 

--- a/core/src/main/resources/error/pyspark-error-classes.json
+++ b/core/src/main/resources/error/pyspark-error-classes.json
@@ -1,0 +1,7 @@
+{
+  "COLUMN_IN_LIST" : {
+    "message" : [
+      "<funcName> does not allow a column in a list"
+    ]
+  }
+}

--- a/core/src/main/resources/error/pyspark-error-classes.json
+++ b/core/src/main/resources/error/pyspark-error-classes.json
@@ -1,7 +1,0 @@
-{
-  "COLUMN_IN_LIST" : {
-    "message" : [
-      "<funcName> does not allow a column in a list"
-    ]
-  }
-}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to update error class guidelines for `core/src/main/resources/error/README.md`.

### Why are the changes needed?

Because some of contents are out of date, and no longer valid for current behavior.




### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. It fixed the developer guidelines for error class.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

The existing CI should pass.