### PR TITLE
[SPARK-42028][CONNECT][PYTHON] Truncating nanoseconds timestamps

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -224,29 +224,38 @@ class SparkSession:
                 _get_local_timezone,
             )
 
-            # Copying the frame to avoid modifying it.
-            data_copy = data.copy()
-            # We need double conversions for the truncation, first truncate to microseconds.
-            for col in data_copy:
-                if is_datetime64tz_dtype(data_copy[col].dtype):
-                    data_copy[col] = _check_series_convert_timestamps_internal(
-                        data_copy[col], _get_local_timezone()
-                    ).astype("datetime64[us, UTC]")
-                elif is_datetime64_dtype(data_copy[col].dtype):
-                    data_copy[col] = data_copy[col].astype("datetime64[us]")
+            # First, check if we need to create a copy of the input data to adjust
+            # the timestamps.
+            input_data = data
+            has_timestamp_data = any(
+                [is_datetime64_dtype(data[c]) or is_datetime64tz_dtype(data[c]) for c in data]
+            )
+            if has_timestamp_data:
+                input_data = data.copy()
+                # We need double conversions for the truncation, first truncate to microseconds.
+                for col in input_data:
+                    if is_datetime64tz_dtype(input_data[col].dtype):
+                        input_data[col] = _check_series_convert_timestamps_internal(
+                            input_data[col], _get_local_timezone()
+                        ).astype("datetime64[us, UTC]")
+                    elif is_datetime64_dtype(input_data[col].dtype):
+                        input_data[col] = input_data[col].astype("datetime64[us]")
 
-            # Create a new schema and change the types to the truncated microseconds.
-            pd_schema = pa.Schema.from_pandas(data_copy)
-            new_schema = pa.schema([])
-            for x in range(len(pd_schema.types)):
-                f = pd_schema.field(x)
-                if isinstance(f.type, pa.TimestampType) and f.type.unit == "ns":
-                    tmp = f.with_type(pa.timestamp("us"))
-                    new_schema = new_schema.append(tmp)
-                else:
-                    new_schema = new_schema.append(f)
-            new_schema = new_schema.with_metadata(pd_schema.metadata)
-            _table = pa.Table.from_pandas(data_copy, schema=new_schema)
+                # Create a new schema and change the types to the truncated microseconds.
+                pd_schema = pa.Schema.from_pandas(input_data)
+                new_schema = pa.schema([])
+                for x in range(len(pd_schema.types)):
+                    f = pd_schema.field(x)
+                    # TODO(SPARK-42027) Add support for struct types.
+                    if isinstance(f.type, pa.TimestampType) and f.type.unit == "ns":
+                        tmp = f.with_type(pa.timestamp("us"))
+                        new_schema = new_schema.append(tmp)
+                    else:
+                        new_schema = new_schema.append(f)
+                new_schema = new_schema.with_metadata(pd_schema.metadata)
+                _table = pa.Table.from_pandas(input_data, schema=new_schema)
+            else:
+                _table = pa.Table.from_pandas(data)
 
         elif isinstance(data, np.ndarray):
             if data.ndim not in [1, 2]:

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1091,13 +1091,13 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):
             self.assertEqual(
                 self.connect.createDataFrame(pdf).collect(),
-                self.spark.createDataFrame(pdf).collect()
+                self.spark.createDataFrame(pdf).collect(),
             )
 
         with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": True}):
             self.assertEqual(
                 self.connect.createDataFrame(pdf).collect(),
-                self.spark.createDataFrame(pdf).collect()
+                self.spark.createDataFrame(pdf).collect(),
             )
 
     def test_select_expr(self):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1071,6 +1071,25 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.spark.sql(query).toPandas(),
         )
 
+    def test_create_dataframe_from_pandas_with_ns_timestamp(self):
+        """Truncate the timestamps for nanoseconds."""
+        from datetime import datetime, timezone, timedelta
+        from pandas import Timestamp
+        import pandas as pd
+
+        pdf = pd.DataFrame(
+            {
+                "naive": [datetime(2019, 1, 1, 0)],
+                "aware": [
+                    Timestamp(
+                        year=2019, month=1, day=1, nanosecond=1, tz=timezone(timedelta(hours=-8))
+                    )
+                ],
+            }
+        )
+        rows = self.connect.createDataFrame(pdf).collect()
+        self.assertEqual(1, len(rows))
+
     def test_select_expr(self):
         # SPARK-41201: test selectExpr API.
         self.assert_eq(

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1082,13 +1082,23 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
                 "naive": [datetime(2019, 1, 1, 0)],
                 "aware": [
                     Timestamp(
-                        year=2019, month=1, day=1, nanosecond=1, tz=timezone(timedelta(hours=-8))
+                        year=2019, month=1, day=1, nanosecond=500, tz=timezone(timedelta(hours=-8))
                     )
                 ],
             }
         )
-        rows = self.connect.createDataFrame(pdf).collect()
-        self.assertEqual(1, len(rows))
+
+        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):
+            self.assertEqual(
+                self.connect.createDataFrame(pdf).collect(),
+                self.spark.createDataFrame(pdf).collect()
+            )
+
+        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": True}):
+            self.assertEqual(
+                self.connect.createDataFrame(pdf).collect(),
+                self.spark.createDataFrame(pdf).collect()
+            )
 
     def test_select_expr(self):
         # SPARK-41201: test selectExpr API.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch creates compatible behavior for truncating nanosecond timestamps to microseconds since Spark does not support nanosecond resolution.

### Why are the changes needed?
Compatibility.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT.