### PR TITLE
[SPARK-41432][UI][FOLLOWUP] Fix a bug in protobuf serializer of SparkPlanGraphNodeWrapper

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -435,8 +435,10 @@ message SparkPlanGraphClusterWrapper {
 }
 
 message SparkPlanGraphNodeWrapper {
-  SparkPlanGraphNode node = 1;
-  SparkPlanGraphClusterWrapper cluster = 2;
+  oneof wrapper {
+    SparkPlanGraphNode node = 1;
+    SparkPlanGraphClusterWrapper cluster = 2;
+  }
 }
 
 message SparkPlanGraphEdge {

--- a/sql/core/src/main/scala/org/apache/spark/status/protobuf/sql/SparkPlanGraphWrapperSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/protobuf/sql/SparkPlanGraphWrapperSerializer.scala
@@ -53,19 +53,27 @@ class SparkPlanGraphWrapperSerializer extends ProtobufSerDe {
     StoreTypes.SparkPlanGraphNodeWrapper = {
 
     val builder = StoreTypes.SparkPlanGraphNodeWrapper.newBuilder()
-    Option(input.node).foreach(node => builder.setNode(serializeSparkPlanGraphNode(node)))
-    Option(input.cluster)
-      .foreach(cluster => builder.setCluster(serializeSparkPlanGraphClusterWrapper(cluster)))
+    if (input.node != null) {
+      builder.setNode(serializeSparkPlanGraphNode(input.node))
+    } else {
+      builder.setCluster(serializeSparkPlanGraphClusterWrapper(input.cluster))
+    }
     builder.build()
   }
 
   private def deserializeSparkPlanGraphNodeWrapper(input: StoreTypes.SparkPlanGraphNodeWrapper):
     SparkPlanGraphNodeWrapper = {
-
-    new SparkPlanGraphNodeWrapper(
-      node = deserializeSparkPlanGraphNode(input.getNode),
-      cluster = deserializeSparkPlanGraphClusterWrapper(input.getCluster)
-    )
+    if (input.hasNode) {
+      new SparkPlanGraphNodeWrapper(
+        node = deserializeSparkPlanGraphNode(input.getNode),
+        cluster = null
+      )
+    } else {
+      new SparkPlanGraphNodeWrapper(
+        node = null,
+        cluster = deserializeSparkPlanGraphClusterWrapper(input.getCluster)
+      )
+    }
   }
 
   private def serializeSparkPlanGraphEdge(edge: SparkPlanGraphEdge):

--- a/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/KVStoreProtobufSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/KVStoreProtobufSerializerSuite.scala
@@ -112,24 +112,7 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
             )
           )
         ),
-        cluster = new SparkPlanGraphClusterWrapper(
-          id = 15,
-          name = "name_15",
-          desc = "desc_15",
-          nodes = Seq(),
-          metrics = Seq(
-            SQLPlanMetric(
-              name = "name_16",
-              accumulatorId = 16,
-              metricType = "metric_16"
-            ),
-            SQLPlanMetric(
-              name = "name_17",
-              accumulatorId = 17,
-              metricType = "metric_17"
-            )
-          )
-        )
+        cluster = null
       )),
       metrics = Seq(
         SQLPlanMetric(
@@ -145,23 +128,7 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       )
     )
     val node = new SparkPlanGraphNodeWrapper(
-      node = new SparkPlanGraphNode(
-        id = 2,
-        name = "name_1",
-        desc = "desc_1",
-        metrics = Seq(
-          SQLPlanMetric(
-            name = "name_2",
-            accumulatorId = 3,
-            metricType = "metric_1"
-          ),
-          SQLPlanMetric(
-            name = "name_3",
-            accumulatorId = 4,
-            metricType = "metric_2"
-          )
-        )
-      ),
+      node = null,
       cluster = cluster
     )
     val input = new SparkPlanGraphWrapper(
@@ -179,28 +146,33 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     assert(result.nodes.size == input.nodes.size)
 
     def compareNodes(n1: SparkPlanGraphNodeWrapper, n2: SparkPlanGraphNodeWrapper): Unit = {
-      assert(n1.node.id == n2.node.id)
-      assert(n1.node.name == n2.node.name)
-      assert(n1.node.desc == n2.node.desc)
+      if (n1.node != null) {
+        assert(n2.node != null)
+        assert(n1.node.id == n2.node.id)
+        assert(n1.node.name == n2.node.name)
+        assert(n1.node.desc == n2.node.desc)
 
-      assert(n1.node.metrics.size == n2.node.metrics.size)
-      n1.node.metrics.zip(n2.node.metrics).foreach { case (m1, m2) =>
-        assert(m1.name == m2.name)
-        assert(m1.accumulatorId == m2.accumulatorId)
-        assert(m1.metricType == m2.metricType)
-      }
-
-      assert(n1.cluster.id == n2.cluster.id)
-      assert(n1.cluster.name == n2.cluster.name)
-      assert(n1.cluster.desc == n2.cluster.desc)
-      assert(n1.cluster.nodes.size == n2.cluster.nodes.size)
-      n1.cluster.nodes.zip(n2.cluster.nodes).foreach { case (n3, n4) =>
-        compareNodes(n3, n4)
-      }
-      n1.cluster.metrics.zip(n2.cluster.metrics).foreach { case (m1, m2) =>
-        assert(m1.name == m2.name)
-        assert(m1.accumulatorId == m2.accumulatorId)
-        assert(m1.metricType == m2.metricType)
+        assert(n1.node.metrics.size == n2.node.metrics.size)
+        n1.node.metrics.zip(n2.node.metrics).foreach { case (m1, m2) =>
+          assert(m1.name == m2.name)
+          assert(m1.accumulatorId == m2.accumulatorId)
+          assert(m1.metricType == m2.metricType)
+        }
+      } else {
+        assert(n2.node == null)
+        assert(n1.cluster != null && n2.cluster != null)
+        assert(n1.cluster.id == n2.cluster.id)
+        assert(n1.cluster.name == n2.cluster.name)
+        assert(n1.cluster.desc == n2.cluster.desc)
+        assert(n1.cluster.nodes.size == n2.cluster.nodes.size)
+        n1.cluster.nodes.zip(n2.cluster.nodes).foreach { case (n3, n4) =>
+          compareNodes(n3, n4)
+        }
+        n1.cluster.metrics.zip(n2.cluster.metrics).foreach { case (m1, m2) =>
+          assert(m1.name == m2.name)
+          assert(m1.accumulatorId == m2.accumulatorId)
+          assert(m1.metricType == m2.metricType)
+        }
       }
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/KVStoreProtobufSerializerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/KVStoreProtobufSerializerSuite.scala
@@ -174,6 +174,9 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
           assert(m1.metricType == m2.metricType)
         }
       }
+      val metrics = Map(6L -> "a", 7L -> "b", 13L -> "c", 14L -> "d")
+      assert(n1.toSparkPlanGraphNode().makeDotNode(metrics) ==
+        n2.toSparkPlanGraphNode().makeDotNode(metrics))
     }
 
     result.nodes.zip(input.nodes).foreach { case (n1, n2) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SparkPlanGraphNodeWrapper can only contain either a node or a cluster. In the current implementation, both the node and cluster fields are not null. It breaks the assertion of the method `toSparkPlanGraphNode`:
```scala
class SparkPlanGraphNodeWrapper(
    val node: SparkPlanGraphNode,
    val cluster: SparkPlanGraphClusterWrapper) {

  def toSparkPlanGraphNode(): SparkPlanGraphNode = {
    assert(node == null ^ cluster == null, "Exactly one of node, cluster values to be set.")
    if (node != null) node else cluster.toSparkPlanGraphCluster()
  }

}
```
This PR is to fix the bug by using `oneof` in the protobuf definition of `SparkPlanGraphNodeWrapper`
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Update related UT. Also run SQLMetricsSuite with RocksDB backend enabled.