### PR TITLE
[SPARK-41957][CONNECT][PYTHON] Enable the doctest for `DataFrame.hint`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1627,8 +1627,6 @@ def _test() -> None:
         del pyspark.sql.connect.dataframe.DataFrame.drop.__doc__
         del pyspark.sql.connect.dataframe.DataFrame.join.__doc__
 
-        del pyspark.sql.connect.dataframe.DataFrame.hint.__doc__
-
         # TODO(SPARK-41886): The doctest output has different order
         del pyspark.sql.connect.dataframe.DataFrame.intersect.__doc__
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1116,7 +1116,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         --------
         >>> df = spark.createDataFrame([(2, "Alice"), (5, "Bob")], schema=["age", "name"])
         >>> df2 = spark.createDataFrame([Row(height=80, name="Tom"), Row(height=85, name="Bob")])
-        >>> df.join(df2, "name").explain()
+        >>> df.join(df2, "name").explain()  # doctest: +SKIP
         == Physical Plan ==
         ...
         ... +- SortMergeJoin ...


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, Enable the doctest for `DataFrame.hint`
2, add additional test for JOIN hint

### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
updated test and added UT
