### PR TITLE
[SPARK-41934][CONNECT][PYTHON][FOLLOWUP] Add `Session.readStream` to the unsupported list

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -401,6 +401,10 @@ class SparkSession:
         raise NotImplementedError("streams() is not implemented.")
 
     @property
+    def readStream(self) -> Any:
+        raise NotImplementedError("readStream() is not implemented.")
+
+    @property
     def udf(self) -> Any:
         raise NotImplementedError("udf() is not implemented.")
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2136,11 +2136,15 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         with self.assertRaises(NotImplementedError):
             RemoteSparkSession.getActiveSession()
 
+        with self.assertRaises(NotImplementedError):
+            RemoteSparkSession.builder.enableHiveSupport()
+
         for f in (
             "newSession",
             "conf",
             "sparkContext",
             "streams",
+            "readStream",
             "udf",
             "version",
         ):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `Session.readStream` to the unsupported list


### Why are the changes needed?
all missing API should throw `NotImplementedError`

### Does this PR introduce _any_ user-facing change?
yes, `NotImplementedError`


### How was this patch tested?
updated UT