### PR TITLE
[MINOR][SQL] Update the import order of scala package in class `SpecificParquetRecordReaderBase`

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/SpecificParquetRecordReaderBase.java
@@ -28,11 +28,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import scala.Option;
+
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.parquet.VersionParser;
 import org.apache.parquet.VersionParser.ParsedVersion;
 import org.apache.parquet.column.page.PageReadStore;
-import scala.Option;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adjust the scala package import order.


### Why are the changes needed?
There is a check style issue in class `SpecificParquetRecordReaderBase`. The import order of scala package is not correct. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No need
