### PR TITLE
[SPARK-41964][CONNECT][PYTHON] Add the list of unsupported IO functions

### DIFF
--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -221,6 +221,15 @@ class DataFrameReader(OptionUtils):
 
     text.__doc__ = PySparkDataFrameReader.text.__doc__
 
+    def csv(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("csv() is not implemented.")
+
+    def orc(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("orc() is not implemented.")
+
+    def jdbc(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("jdbc() not supported for DataFrameWriter")
+
 
 DataFrameReader.__doc__ = PySparkDataFrameReader.__doc__
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2159,6 +2159,18 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             with self.assertRaises(NotImplementedError):
                 getattr(self.connect.catalog, f)()
 
+    def test_unsupported_io_functions(self):
+        # SPARK-41964: Disable unsupported functions.
+        # DataFrameWriterV2 is also not implemented yet
+
+        for f in ("csv", "orc", "jdbc"):
+            with self.assertRaises(NotImplementedError):
+                getattr(self.connect.read, f)()
+
+        for f in ("jdbc",):
+            with self.assertRaises(NotImplementedError):
+                getattr(self.connect.read, f)()
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class ChannelBuilderTests(ReusedPySparkTestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the list of unsupported IO functions


### Why are the changes needed?
missing APIs should throw `NotImplementedError` other than `AttributeError`


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
added UT
