### PR TITLE
[SPARK-41966][PYTHON][DOCS] Add `CharType` and `TimestampNTZType` to PySpark API references

### DIFF
--- a/python/docs/source/reference/pyspark.sql/data_types.rst
+++ b/python/docs/source/reference/pyspark.sql/data_types.rst
@@ -40,8 +40,10 @@ Data Types
     NullType
     ShortType
     StringType
+    CharType
     VarcharType
     StructField
     StructType
     TimestampType
+    TimestampNTZType
     DayTimeIntervalType


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `CharType` and `TimestampNTZType` to PySpark API references


### Why are the changes needed?
They are missing in the doc

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
existing UT
