### PR TITLE
[SPARK-41589][PYTHON][ML][BUILD][FOLLOW-UP] Add pyspark.ml.torch to setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -231,6 +231,7 @@ try:
             "pyspark.ml",
             "pyspark.ml.linalg",
             "pyspark.ml.param",
+            "pyspark.ml.torch",
             "pyspark.sql",
             "pyspark.sql.avro",
             "pyspark.sql.connect",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/39146 that adds `pyspark.ml.torch` to `setup.py`.

### Why are the changes needed?

In order for PyPI users to be able to use `pyspark.ml.torch` package.

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released yet.
It adds the package into PyPI-packaged PySpark.

### How was this patch tested?

CI in pip packaging test should check the change.
