### PR TITLE
[SPARK-41876][CONNECT][PYTHON] `test_dataframe` should catch both `AnalysisException` and `SparkConnectAnalysisException`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -120,10 +120,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_sample(self):
         super().test_sample()
 
-    @unittest.skip("Spark Connect convert AnalysisException to SparkConnectAnalysisException.")
-    def test_to(self):
-        super().test_to()
-
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_toDF_with_schema_string(self):
         super().test_toDF_with_schema_string()

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -120,8 +120,7 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_sample(self):
         super().test_sample()
 
-    # TODO(SPARK-41875): throw proper errors in Dataset.to()
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    @unittest.skip("Spark Connect convert AnalysisException to SparkConnectAnalysisException.")
     def test_to(self):
         super().test_to()
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -42,6 +42,7 @@ from pyspark.sql.types import (
     DayTimeIntervalType,
 )
 from pyspark.sql.utils import AnalysisException, IllegalArgumentException
+from pyspark.sql.connect.client import SparkConnectAnalysisException
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
     SQLTestUtils,
@@ -1495,13 +1496,17 @@ class DataFrameTestsMixin:
         # incompatible field nullability
         schema4 = StructType([StructField("j", LongType(), False)])
         self.assertRaisesRegex(
-            AnalysisException, "NULLABLE_COLUMN_OR_FIELD", lambda: df.to(schema4)
+            (AnalysisException, SparkConnectAnalysisException),
+            "NULLABLE_COLUMN_OR_FIELD",
+            lambda: df.to(schema4).collect(),
         )
 
         # field cannot upcast
         schema5 = StructType([StructField("i", LongType())])
         self.assertRaisesRegex(
-            AnalysisException, "INVALID_COLUMN_OR_FIELD_DATA_TYPE", lambda: df.to(schema5)
+            (AnalysisException, SparkConnectAnalysisException),
+            "INVALID_COLUMN_OR_FIELD_DATA_TYPE",
+            lambda: df.to(schema5).collect(),
         )
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When using `test_dataframe.py` to test spark connect's python API, an error occurs.
```
Traceback (most recent call last):
  File "/Users/s.singh/personal/spark-oss/python/pyspark/sql/tests/test_dataframe.py", line 1486, in test_to
    self.assertRaisesRegex(
AssertionError: AnalysisException not raised by <lambda> 
```

The root reason is Spark connect covert `AnalysisException` to `SparkConnectAnalysisException`.
This PR lets `test_dataframe` catch both `AnalysisException` and `SparkConnectAnalysisException`.

### Why are the changes needed?
Lets `test_dataframe` catch both `AnalysisException` and `SparkConnectAnalysisException`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
Manual tests.
