### PR TITLE
[SPARK-41965][PYTHON][DOCS][WIP] Add DataFrameWriterV2 to PySpark API references

### DIFF
--- a/python/docs/source/reference/pyspark.sql/core_classes.rst
+++ b/python/docs/source/reference/pyspark.sql/core_classes.rst
@@ -37,5 +37,6 @@ Core Classes
     Window
     DataFrameReader
     DataFrameWriter
+    DataFrameWriterV2
     UDFRegistration
     udf.UserDefinedFunction

--- a/python/docs/source/reference/pyspark.sql/io.rst
+++ b/python/docs/source/reference/pyspark.sql/io.rst
@@ -52,3 +52,14 @@ Input/Output
     DataFrameWriter.saveAsTable
     DataFrameWriter.sortBy
     DataFrameWriter.text
+    DataFrameWriterV2.using
+    DataFrameWriterV2.option
+    DataFrameWriterV2.options
+    DataFrameWriterV2.tableProperty
+    DataFrameWriterV2.partitionedBy
+    DataFrameWriterV2.create
+    DataFrameWriterV2.replace
+    DataFrameWriterV2.createOrReplace
+    DataFrameWriterV2.append
+    DataFrameWriterV2.overwrite
+    DataFrameWriterV2.overwritePartitions

--- a/python/pyspark/sql/__init__.py
+++ b/python/pyspark/sql/__init__.py
@@ -47,7 +47,7 @@ from pyspark.sql.catalog import Catalog
 from pyspark.sql.dataframe import DataFrame, DataFrameNaFunctions, DataFrameStatFunctions
 from pyspark.sql.group import GroupedData
 from pyspark.sql.observation import Observation
-from pyspark.sql.readwriter import DataFrameReader, DataFrameWriter
+from pyspark.sql.readwriter import DataFrameReader, DataFrameWriter, DataFrameWriterV2
 from pyspark.sql.window import Window, WindowSpec
 from pyspark.sql.pandas.group_ops import PandasCogroupedOps
 
@@ -69,5 +69,6 @@ __all__ = [
     "WindowSpec",
     "DataFrameReader",
     "DataFrameWriter",
+    "DataFrameWriterV2",
     "PandasCogroupedOps",
 ]

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from pyspark.sql.dataframe import DataFrame
     from pyspark.sql.streaming import StreamingQuery
 
-__all__ = ["DataFrameReader", "DataFrameWriter"]
+__all__ = ["DataFrameReader", "DataFrameWriter", "DataFrameWriterV2"]
 
 PathOrPaths = Union[str, List[str]]
 TupleOrListOfString = Union[List[str], Tuple[str, ...]]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add DataFrameWriterV2 to PySpark API references




### Why are the changes needed?
DataFrameWriterV2 was not added in the API references




### Does this PR introduce _any_ user-facing change?
doc-only


### How was this patch tested?
CI
