### PR TITLE
[SPARK-41981][SQL] Merge percentile functions if possible

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -102,6 +102,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.analysis.UpdateAttributeNullability" ::
       // Catalyst Optimizer rules
       "org.apache.spark.sql.catalyst.optimizer.BooleanSimplification" ::
+      "org.apache.spark.sql.catalyst.optimizer.CollapsePercentiles" ::
       "org.apache.spark.sql.catalyst.optimizer.CollapseProject" ::
       "org.apache.spark.sql.catalyst.optimizer.CollapseRepartition" ::
       "org.apache.spark.sql.catalyst.optimizer.CollapseWindow" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapsePercentileSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapsePercentileSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.aggregate.Percentile
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types.{ArrayType, DoubleType}
+
+class CollapsePercentileSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("CollapsePercentile", FixedPoint(10), CollapsePercentiles, CollapseProject) :: Nil
+  }
+
+  val testRelation = LocalRelation($"a".double, $"b".double, $"c".string)
+  val a = testRelation.output(0)
+  val b = testRelation.output(1)
+
+  test("collapse percentiles if possible") {
+    val query =
+      testRelation.select(
+        max(a).as("max_a"),
+        Percentile(b, 0.3d, 1L).toAggregateExpression().as("p1"),
+        (Percentile(b, 0.4d, 1L).toAggregateExpression() +
+          Percentile(b, 0.5d, 1L).toAggregateExpression()).as("p2"),
+        Percentile(b, 0.6d, 1L).toAggregateExpression().as("p3"))
+    val optimized = Optimize.execute(query.analyze)
+    val correctAnswer =
+      testRelation
+        .select(
+          max(a).as("max_a"),
+          (Percentile(b, 0.4d, 1L).toAggregateExpression() +
+            Percentile(b, 0.5d, 1L).toAggregateExpression()).as("p2"),
+          Percentile(b, Literal.create(Seq(0.3d, 0.6d), ArrayType(DoubleType, false)), 1L)
+            .toAggregateExpression()
+            .as("_combined_percentile_0"))
+        .select(
+          $"max_a",
+          $"_combined_percentile_0".getItem(0).as("p1"),
+          $"p2",
+          $"_combined_percentile_0".getItem(1).as("p3"))
+        .analyze
+    comparePlans(optimized, correctAnswer)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

**percentile** function will put all the target elements into a Hashset and then compute the result. We can try to combine percentile functions into one and compute the result with only one Hashset.
For example:
```
SELECT max(value1) as max_value1, percentile(value2, 0.3) as p1,
        percentile(value3, 0.4) + percentile(value3, 0.5) as p2,
        percentile(value2, 0.6) as p3
FROM t1
```
can be optimized to

```
SELECT max_value1, _combined_percentile_0[0] as p1, p2, _combined_percentile_0[1] as p3
FROM (
   SELECT  max(value1) as max_value1,
           percentile(value3, 0.4) + percentile(value3, 0.5) as p2,
           percentile(value2, array(0.3, 0.6)) as _combined_percentile_0
   FROM t1) as t1
```

Benchmark for this change:
```
object CollapsePercentileBenchmark extends SqlBasedBenchmark {

  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
    runBenchmark("Collapse percentiles") {
      spark.range(1, 3000000, 1, 100)
        .selectExpr("id", "id as c1")
        .createOrReplaceTempView("tab")

      val benchmark = new Benchmark("Test CollapsePercentiles", 1000, output = output)

      def runQuery(): Unit = {
        val df = spark.sql(
          s"""SELECT id,
             |       percentile(c1, 0.1) as p1,
             |       percentile(c1, 0.2) as p2,
             |       percentile(c1, 0.3) as p3,
             |       percentile(c1, 0.4) as p4,
             |       percentile(c1, 0.5) as p5,
             |       percentile(c1, 0.6) as p6,
             |       percentile(c1, 0.7) as p7,
             |       percentile(c1, 0.8) as p8,
             |       percentile(c1, 0.9) as p9
             |FROM tab
             |GROUP BY id
             |""".stripMargin)
        df.noop()
      }
      benchmark.addCase(s"Without CollapsePercentiles rule ", numIters = 2) { _ =>
        withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
          "org.apache.spark.sql.catalyst.optimizer.CollapsePercentiles") {
          runQuery()
        }
      }
      benchmark.addCase(s"With CollapsePercentiles rule ", numIters = 2) { _ =>
        runQuery()
      }
      benchmark.run()
    }
  }
}
```

Benchmark result :
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_281-b09 on Mac OS X 10.16
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Test CollapsePercentiles:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Without CollapsePercentiles rule                  49410          49949         762          0.0    49410389.9       1.0X
With CollapsePercentiles rule                     13000          13000           0          0.0    13000355.1       3.8X
```


### Why are the changes needed?

Optimize percentile functions in SQL

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added UT