### PR TITLE
[SPARK-41969][TESTS] Fix flaky test: StreamingQueryStatusListenerSuite.test small retained queries

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListenerSuite.scala
@@ -181,9 +181,13 @@ class StreamingQueryStatusListenerSuite extends StreamTest {
     val terminateEvent1 = new StreamingQueryListener.QueryTerminatedEvent(id1, runId1, None)
     listener.onQueryTerminated(terminateEvent1)
     checkInactiveQueryStatus(1, Seq(id1))
+    Thread.sleep(1)
+
     val terminateEvent2 = new StreamingQueryListener.QueryTerminatedEvent(id2, runId2, None)
     listener.onQueryTerminated(terminateEvent2)
     checkInactiveQueryStatus(2, Seq(id1, id2))
+    Thread.sleep(1)
+    
     val terminateEvent3 = new StreamingQueryListener.QueryTerminatedEvent(id3, runId3, None)
     listener.onQueryTerminated(terminateEvent3)
     checkInactiveQueryStatus(2, Seq(id2, id3))


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix flaky test: StreamingQueryStatusListenerSuite.test small retained queries.

### Why are the changes needed?
When I run it 100 times, I reproduce issue.
Why?
Run1 - id: 017350a8-fb82-475a-86d5-c39e25a3410e, runId: b09905df-70d5-4659-94f5-7a2f88385317
Run2 - id: fabdb4cc-7849-4a46-aef0-92fcc5879a2c, runId: 524ecd20-b351-40ae-9f7b-8d6aa6032f42
Run3 - id: 331a07fa-8195-44a6-a4ce-12036d63c19f, runId: fec57472-c1be-4552-8d31-aa1982675322

log as follow:
delete runId: List(524ecd20-b351-40ae-9f7b-8d6aa6032f42), inactiveQueries: 
524ecd20-b351-40ae-9f7b-8d6aa6032f42, fabdb4cc-7849-4a46-aef0-92fcc5879a2c, Some(1673428448998)
b09905df-70d5-4659-94f5-7a2f88385317, 017350a8-fb82-475a-86d5-c39e25a3410e, Some(1673428448998)
fec57472-c1be-4552-8d31-aa1982675322, 331a07fa-8195-44a6-a4ce-12036d63c19f, Some(1673428448998)

when StreamingQueryData.endTimestamp ...


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.