### PR TITLE
[SPARK-41987][CONNECT][PYTHON] Connect API: createDataFrame should supports column with map type

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2366,7 +2366,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.col.__doc__
 
         # TODO(SPARK-41838): fix dataset.show
-        del pyspark.sql.connect.functions.posexplode_outer.__doc__
         del pyspark.sql.connect.functions.explode_outer.__doc__
 
         # TODO(SPARK-41837): createDataFrame datatype conversion error

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2365,9 +2365,6 @@ def _test() -> None:
         # TODO(SPARK-41757): Fix String representation for Column class
         del pyspark.sql.connect.functions.col.__doc__
 
-        # TODO(SPARK-41838): fix dataset.show
-        del pyspark.sql.connect.functions.explode_outer.__doc__
-
         # TODO(SPARK-41837): createDataFrame datatype conversion error
         del pyspark.sql.connect.functions.to_csv.__doc__
         del pyspark.sql.connect.functions.to_json.__doc__

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2385,7 +2385,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.count.__doc__
 
         # TODO(SPARK-41847): mapfield,structlist invalid type
-        del pyspark.sql.connect.functions.element_at.__doc__
         del pyspark.sql.connect.functions.explode.__doc__
         del pyspark.sql.connect.functions.map_filter.__doc__
         del pyspark.sql.connect.functions.map_zip_with.__doc__

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2385,10 +2385,8 @@ def _test() -> None:
         del pyspark.sql.connect.functions.count.__doc__
 
         # TODO(SPARK-41847): mapfield,structlist invalid type
-        del pyspark.sql.connect.functions.explode.__doc__
         del pyspark.sql.connect.functions.map_filter.__doc__
         del pyspark.sql.connect.functions.map_zip_with.__doc__
-        del pyspark.sql.connect.functions.posexplode.__doc__
 
         globs["spark"] = (
             PySparkSession.builder.appName("sql.connect.functions tests")

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2384,7 +2384,7 @@ def _test() -> None:
         # TODO(SPARK-41845): Fix count bug
         del pyspark.sql.connect.functions.count.__doc__
 
-        # TODO(SPARK-41847): mapfield,structlist invalid type
+        # TODO(SPARK-41988): Fix map_filter and map_zip_with output order
         del pyspark.sql.connect.functions.map_filter.__doc__
         del pyspark.sql.connect.functions.map_zip_with.__doc__
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -298,8 +298,6 @@ class SparkSession:
                 result = convert_to_arrow_data(_cols, _data)
                 arrow_schema = to_arrow_schema(_inferred_schema)
                 _table = pa.Table.from_pylist(result, arrow_schema)
-#                 _table2 = pa.Table.from_pylist([dict(zip(_cols, [item])) for item in _data])
-#                 raise ValueError(f"---{arrow_schema}---{_table}---{_table2}")
             else:
                 # input data can be [1, 2, 3]
                 _table = pa.Table.from_pylist([dict(zip(_cols, [item])) for item in _data])

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -289,7 +289,10 @@ class SparkSession:
                     _cols = ["value"]
 
             if isinstance(_data[0], Row):
-                _table = pa.Table.from_pylist([row.asDict(recursive=True) for row in _data])
+                _dict = [tuple(row.asDict(recursive=True).values()) for row in _data]
+                result = convert_to_arrow_data(_cols, _dict)
+                arrow_schema = to_arrow_schema(_inferred_schema)
+                _table = pa.Table.from_pylist(result, arrow_schema)
             elif isinstance(_data[0], dict):
                 _table = pa.Table.from_pylist(_data)
             elif isinstance(_data[0], list):

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -187,7 +187,6 @@ class SparkSession:
         schema: Optional[Union[AtomicType, StructType, str, List[str], Tuple[str, ...]]] = None,
     ) -> "DataFrame":
         def convert_to_arrow_data(cols: List[str], data: Iterable[Any]):
-
             def convert(data: Iterable[Any]):
                 if isinstance(data, list):
                     return [convert(item) for item in data]
@@ -197,6 +196,7 @@ class SparkSession:
                     return [item for item in data.items()]
                 else:
                     return data
+
             return convert(data)
 
         assert data is not None
@@ -204,11 +204,14 @@ class SparkSession:
             raise TypeError("data is already a DataFrame")
 
         _schema: Optional[Union[AtomicType, StructType]] = None
+        _arrow_schema: Optional[pa.Schema] = None
         _schema_str: Optional[str] = None
         _cols: Optional[List[str]] = None
 
         if isinstance(schema, (AtomicType, StructType)):
             _schema = schema
+            if isinstance(schema, StructType):
+                _arrow_schema = to_arrow_schema(_schema)
 
         elif isinstance(schema, str):
             _schema_str = schema
@@ -274,6 +277,7 @@ class SparkSession:
                     for i, name in enumerate(_cols):
                         _inferred_schema.fields[i].name = name
                         _inferred_schema.names[i] = name
+                _arrow_schema = to_arrow_schema(_inferred_schema)
 
             if _cols is None:
                 if _schema is None and _inferred_schema is None:
@@ -289,18 +293,17 @@ class SparkSession:
                     _cols = ["value"]
 
             if isinstance(_data[0], Row):
-                _dict = [tuple(row.asDict(recursive=True).values()) for row in _data]
-                result = convert_to_arrow_data(_cols, _dict)
-                arrow_schema = to_arrow_schema(_inferred_schema)
-                _table = pa.Table.from_pylist(result, arrow_schema)
+                _dicts = [tuple(row.asDict(recursive=True).values()) for row in _data]
+                result = convert_to_arrow_data(_cols, _dicts)
+                _table = pa.Table.from_pylist(result, _arrow_schema)
             elif isinstance(_data[0], dict):
                 _table = pa.Table.from_pylist(_data)
             elif isinstance(_data[0], list):
                 _table = pa.Table.from_pylist([dict(zip(_cols, list(item))) for item in _data])
             elif isinstance(_data[0], tuple):
                 result = convert_to_arrow_data(_cols, _data)
-                arrow_schema = to_arrow_schema(_inferred_schema)
-                _table = pa.Table.from_pylist(result, arrow_schema)
+#                 print(f"---{_schema}---{_schema_str}---{_inferred_schema}---")
+                _table = pa.Table.from_pylist(result, _arrow_schema)
             else:
                 # input data can be [1, 2, 3]
                 _table = pa.Table.from_pylist([dict(zip(_cols, [item])) for item in _data])

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -186,8 +186,8 @@ class SparkSession:
         data: Union["pd.DataFrame", "np.ndarray", Iterable[Any]],
         schema: Optional[Union[AtomicType, StructType, str, List[str], Tuple[str, ...]]] = None,
     ) -> "DataFrame":
-        def convert_to_arrow_data(cols: List[str], data: Iterable[Any]):
-            def convert(data: Iterable[Any]):
+        def convert_to_arrow_data(cols: List[str], data: Iterable[Any]) -> Any:
+            def convert(data: Iterable[Any]) -> Any:
                 if isinstance(data, list):
                     return [convert(item) for item in data]
                 elif isinstance(data, tuple):

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -4608,11 +4608,9 @@ def hour(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> import datetime
-    >>> df = spark.createDataFrame(
-    ...     [(datetime.datetime(2015, 4, 8, 13, 8, 15, tzinfo=datetime.timezone.utc),)], ['ts']
-    ... )
+    >>> df = spark.createDataFrame([(datetime.datetime(2015, 4, 8, 13, 8, 15),)], ['ts'])
     >>> df.select(hour('ts').alias('hour')).collect()
-    [Row(hour=21)]
+    [Row(hour=13)]
     """
     return _invoke_function_over_columns("hour", col)
 
@@ -5446,12 +5444,12 @@ def window(
     --------
     >>> import datetime
     >>> df = spark.createDataFrame(
-    ...     [(datetime.datetime(2016, 3, 11, 9, 0, 7, tzinfo=datetime.timezone.utc), 1)],
+    ...     [(datetime.datetime(2016, 3, 11, 9, 0, 7), 1)],
     ... ).toDF("date", "val")
     >>> w = df.groupBy(window("date", "5 seconds")).agg(sum("val").alias("sum"))
     >>> w.select(w.window.start.cast("string").alias("start"),
     ...          w.window.end.cast("string").alias("end"), "sum").collect()
-    [Row(start='2016-03-11 17:00:05', end='2016-03-11 17:00:10', sum=1)]
+    [Row(start='2016-03-11 09:00:05', end='2016-03-11 09:00:10', sum=1)]
     """
 
     def check_string_field(field, fieldName):  # type: ignore[no-untyped-def]
@@ -5501,7 +5499,7 @@ def window_time(
     --------
     >>> import datetime
     >>> df = spark.createDataFrame(
-    ...     [(datetime.datetime(2016, 3, 11, 9, 0, 7, tzinfo=datetime.timezone.utc), 1)],
+    ...     [(datetime.datetime(2016, 3, 11, 9, 0, 7), 1)],
     ... ).toDF("date", "val")
 
     Group the data into 5 second time windows and aggregate as sum.
@@ -5515,7 +5513,7 @@ def window_time(
     ...     window_time(w.window).cast("string").alias("window_time"),
     ...     "sum"
     ... ).collect()
-    [Row(end='2016-03-11 17:00:10', window_time='2016-03-11 17:00:09.999999', sum=1)]
+    [Row(end='2016-03-11 09:00:10', window_time='2016-03-11 09:00:09.999999', sum=1)]
     """
     window_col = _to_java_column(windowColumn)
     return _invoke_function("window_time", window_col)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -4608,9 +4608,11 @@ def hour(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> import datetime
-    >>> df = spark.createDataFrame([(datetime.datetime(2015, 4, 8, 13, 8, 15),)], ['ts'])
+    >>> df = spark.createDataFrame(
+    ...     [(datetime.datetime(2015, 4, 8, 13, 8, 15, tzinfo=datetime.timezone.utc),)], ['ts']
+    ... )
     >>> df.select(hour('ts').alias('hour')).collect()
-    [Row(hour=13)]
+    [Row(hour=21)]
     """
     return _invoke_function_over_columns("hour", col)
 
@@ -5444,12 +5446,12 @@ def window(
     --------
     >>> import datetime
     >>> df = spark.createDataFrame(
-    ...     [(datetime.datetime(2016, 3, 11, 9, 0, 7), 1)],
+    ...     [(datetime.datetime(2016, 3, 11, 9, 0, 7, tzinfo=datetime.timezone.utc), 1)],
     ... ).toDF("date", "val")
     >>> w = df.groupBy(window("date", "5 seconds")).agg(sum("val").alias("sum"))
     >>> w.select(w.window.start.cast("string").alias("start"),
     ...          w.window.end.cast("string").alias("end"), "sum").collect()
-    [Row(start='2016-03-11 09:00:05', end='2016-03-11 09:00:10', sum=1)]
+    [Row(start='2016-03-11 17:00:05', end='2016-03-11 17:00:10', sum=1)]
     """
 
     def check_string_field(field, fieldName):  # type: ignore[no-untyped-def]
@@ -5499,7 +5501,7 @@ def window_time(
     --------
     >>> import datetime
     >>> df = spark.createDataFrame(
-    ...     [(datetime.datetime(2016, 3, 11, 9, 0, 7), 1)],
+    ...     [(datetime.datetime(2016, 3, 11, 9, 0, 7, tzinfo=datetime.timezone.utc), 1)],
     ... ).toDF("date", "val")
 
     Group the data into 5 second time windows and aggregate as sum.
@@ -5513,7 +5515,7 @@ def window_time(
     ...     window_time(w.window).cast("string").alias("window_time"),
     ...     "sum"
     ... ).collect()
-    [Row(end='2016-03-11 09:00:10', window_time='2016-03-11 09:00:09.999999', sum=1)]
+    [Row(end='2016-03-11 17:00:10', window_time='2016-03-11 17:00:09.999999', sum=1)]
     """
     window_col = _to_java_column(windowColumn)
     return _invoke_function("window_time", window_col)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Connect API createDataFrame does not support create dataframe with map type.
For example, 
```
    >>> df = spark.createDataFrame(
    ...     [(1, ["foo", "bar"], {"x": 1.0}), (2, [], {}), (3, None, None)],
    ...     ("id", "an_array", "a_map")
    ... )
```

The above code want create a dataframe with column 'a_map' which is map type.
But pyarrow recognize `{"x": 1.0}` as a struct not map.
pyarrow supports map with format `[('x', 1.0)]`

Because the schema of dataframe is not correct, so the other subsequent operator will be impacted.
For example:
`df.select("id", "a_map", posexplode_outer("an_array")).show()`

Expected:
```
    +---+----------+----+----+
    | id|     a_map| pos| col|
    +---+----------+----+----+
    |  1|{x -> 1.0}|   0| foo|
    |  1|{x -> 1.0}|   1| bar|
    |  2|        {}|null|null|
    |  3|      null|null|null|
    +---+----------+----+----+
```

But got:
```
    +---+------+----+----+
    | id| a_map| pos| col|
    +---+------+----+----+
    |  1| {1.0}|   0| foo|
    |  1| {1.0}|   1| bar|
    |  2|{null}|null|null|
    |  3|  null|null|null|
    +---+------+----+----+
    <BLANKLINE>
```

### Why are the changes needed?
Let createDataFrame supports column with map type and fix some bugs.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
Manual test and doc test.
