### PR TITLE
[SPARK-41989][PYTHON] Avoid breaking logging config from pyspark.pandas

### DIFF
--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -47,9 +47,7 @@ if (
     LooseVersion(pyarrow.__version__) >= LooseVersion("2.0.0")
     and "PYARROW_IGNORE_TIMEZONE" not in os.environ
 ):
-    import logging
-
-    logging.warning(
+    warnings.warn(
         "'PYARROW_IGNORE_TIMEZONE' environment variable was not set. It is required to "
         "set this environment variable to '1' in both driver and executor sides if you use "
         "pyarrow>=2.0.0. "


### PR DESCRIPTION
### What changes were proposed in this pull request?

See https://issues.apache.org/jira/browse/SPARK-41989 for in depth explanation

Short summary: `pyspark/pandas/__init__.py` uses, at import time,  `logging.warning()`  which might silently call `logging.basicConfig()`.
So by importing `pyspark.pandas` (directly or indirectly) a user might unknowingly break their own logging setup (e.g. when based on  `logging.basicConfig()` or related). `logging.getLogger(...).warning()`  does not trigger this behavior.


### Does this PR introduce _any_ user-facing change?

User-defined logging setups will be more predictable.


### How was this patch tested?

Manual testing so far. 
I'm not sure it's worthwhile to cover this with a unit test