### PR TITLE
[SPARK-41991][SQL] `CheckOverflowInTableInsert` should accept ExpressionProxy as child

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -2525,13 +2525,11 @@ case class CheckOverflowInTableInsert(child: Expression, columnName: String)
     copy(child = newChild)
   }
 
-  private def getCast: Cast = {
-    child match {
-      case c: Cast =>
-        c
-      case ExpressionProxy(c, _, _) =>
-        c.asInstanceOf[Cast]
-    }
+  private def getCast: Cast = child match {
+    case c: Cast =>
+      c
+    case ExpressionProxy(c, _, _) =>
+      c.asInstanceOf[Cast]
   }
 
   override def eval(input: InternalRow): Any = try {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -21,7 +21,7 @@ import java.time.{ZoneId, ZoneOffset}
 import java.util.Locale
 import java.util.concurrent.TimeUnit._
 
-import org.apache.spark.SparkArithmeticException
+import org.apache.spark.{SparkArithmeticException, SparkException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
@@ -2509,21 +2509,44 @@ case class UpCast(child: Expression, target: AbstractDataType, walkedTypePath: S
  * Casting a numeric value as another numeric type in store assignment. It can capture the
  * arithmetic errors and show proper error messages to users.
  */
-case class CheckOverflowInTableInsert(child: Cast, columnName: String) extends UnaryExpression {
-  override protected def withNewChildInternal(newChild: Expression): Expression =
-    copy(child = newChild.asInstanceOf[Cast])
+case class CheckOverflowInTableInsert(child: Expression, columnName: String)
+    extends UnaryExpression {
+  checkChild(child)
+
+  private def checkChild(child: Expression): Unit = child match {
+    case _: Cast =>
+    case ExpressionProxy(c, _, _) if c.isInstanceOf[Cast] =>
+    case _ =>
+      throw SparkException.internalError("Child is not Cast or ExpressionProxy of Cast")
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): Expression = {
+    checkChild(newChild)
+    copy(child = newChild)
+  }
+
+  private def getCast: Cast = {
+    child match {
+      case c: Cast =>
+        c
+      case ExpressionProxy(c, _, _) =>
+        c.asInstanceOf[Cast]
+    }
+  }
 
   override def eval(input: InternalRow): Any = try {
     child.eval(input)
   } catch {
     case e: SparkArithmeticException =>
+      val cast = getCast
       throw QueryExecutionErrors.castingCauseOverflowErrorInTableInsert(
-        child.child.dataType,
-        child.dataType,
+        cast.child.dataType,
+        cast.dataType,
         columnName)
   }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val child = getCast
     val childGen = child.genCode(ctx)
     val exceptionClass = classOf[SparkArithmeticException].getCanonicalName
     val fromDt =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1392,7 +1392,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     assert(expr.toString == cast.toString)
   }
 
-  test("CheckOverflowInTableInsert child must be Cast or ExpressionProxy of Cast") {
+  test("SPARK-41991: CheckOverflowInTableInsert child must be Cast or ExpressionProxy of Cast") {
     val runtime = new SubExprEvaluationRuntime(1)
     val cast = Cast(Literal(1.0), IntegerType)
     val expr = CheckOverflowInTableInsert(cast, "column_1")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -24,7 +24,7 @@ import java.util.{Calendar, Locale, TimeZone}
 
 import scala.collection.parallel.immutable.ParVector
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
@@ -1390,5 +1390,31 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     val expr = CheckOverflowInTableInsert(cast, "column_1")
     assert(expr.sql == cast.sql)
     assert(expr.toString == cast.toString)
+  }
+
+  test("CheckOverflowInTableInsert child must be Cast or ExpressionProxy of Cast") {
+    val runtime = new SubExprEvaluationRuntime(1)
+    val cast = Cast(Literal(1.0), IntegerType)
+    val expr = CheckOverflowInTableInsert(cast, "column_1")
+    val proxy = ExpressionProxy(Literal(1.0), 0, runtime)
+    checkError(
+      exception = intercept[SparkException] {
+        expr.withNewChildrenInternal(IndexedSeq(proxy))
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map(
+        "message" -> "Child is not Cast or ExpressionProxy of Cast"
+      )
+    )
+
+    checkError(
+      exception = intercept[SparkException] {
+        expr.withNewChildrenInternal(IndexedSeq(Literal(1)))
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map(
+        "message" -> "Child is not Cast or ExpressionProxy of Cast"
+      )
+    )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubExprEvaluationRuntimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubExprEvaluationRuntimeSuite.scala
@@ -127,5 +127,6 @@ class SubExprEvaluationRuntimeSuite extends SparkFunSuite {
     assert(runtime.cache.size() == 0)
     checkOverflow.eval()
     assert(runtime.cache.size() == 1)
+    assert(runtime.cache.get(proxy) == ResultProxy(1))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubExprEvaluationRuntimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubExprEvaluationRuntimeSuite.scala
@@ -119,7 +119,7 @@ class SubExprEvaluationRuntimeSuite extends SparkFunSuite {
     assert(proxys.forall(_.child.semanticEquals(mul2_1)))
   }
 
-  test("CheckOverflowInTableInsert with ExpressionProxy child") {
+  test("SPARK-41991: CheckOverflowInTableInsert with ExpressionProxy child") {
     val runtime = new SubExprEvaluationRuntime(1)
     val proxy = ExpressionProxy(Cast(Literal.apply(1), LongType), 0, runtime)
     val checkOverflow = CheckOverflowInTableInsert(Cast(Literal.apply(1), LongType), "col")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubExprEvaluationRuntimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubExprEvaluationRuntimeSuite.scala
@@ -127,6 +127,6 @@ class SubExprEvaluationRuntimeSuite extends SparkFunSuite {
     assert(runtime.cache.size() == 0)
     checkOverflow.eval()
     assert(runtime.cache.size() == 1)
-    assert(runtime.cache.get(proxy) == ResultProxy(1))
+    assert(runtime.cache.get(proxy) == ResultProxy(1L))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubExprEvaluationRuntimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubExprEvaluationRuntimeSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.LongType
 
 class SubExprEvaluationRuntimeSuite extends SparkFunSuite {
 
@@ -116,5 +117,15 @@ class SubExprEvaluationRuntimeSuite extends SparkFunSuite {
     // ( (one * two) * (one * two) )
     assert(proxys.size == 2)
     assert(proxys.forall(_.child.semanticEquals(mul2_1)))
+  }
+
+  test("CheckOverflowInTableInsert with ExpressionProxy child") {
+    val runtime = new SubExprEvaluationRuntime(1)
+    val proxy = ExpressionProxy(Cast(Literal.apply(1), LongType), 0, runtime)
+    val checkOverflow = CheckOverflowInTableInsert(Cast(Literal.apply(1), LongType), "col")
+      .withNewChildrenInternal(IndexedSeq(proxy))
+    assert(runtime.cache.size() == 0)
+    checkOverflow.eval()
+    assert(runtime.cache.size() == 1)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -193,7 +193,8 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest
     )
   }
 
-  test("interpreted CheckOverflowInTableInsert with ExpressionProxy should throw an exception") {
+  test("SPARK-41991: interpreted CheckOverflowInTableInsert with ExpressionProxy should " +
+    "throw an exception") {
     val runtime = new SubExprEvaluationRuntime(1)
     val proxy = ExpressionProxy(Cast(Literal.apply(12345678901234567890D), ByteType), 0, runtime)
     checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.errors
 
 import org.apache.spark._
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.catalyst.expressions.{Cast, CheckOverflowInTableInsert, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Cast, CheckOverflowInTableInsert, ExpressionProxy, Literal, SubExprEvaluationRuntime}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.ByteType
@@ -184,6 +184,21 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest
       exception = intercept[SparkArithmeticException] {
         CheckOverflowInTableInsert(
           Cast(Literal.apply(12345678901234567890D), ByteType), "col").eval(null)
+      }.asInstanceOf[SparkThrowable],
+      errorClass = "CAST_OVERFLOW_IN_TABLE_INSERT",
+      parameters = Map(
+        "sourceType" -> "\"DOUBLE\"",
+        "targetType" -> ("\"TINYINT\""),
+        "columnName" -> "`col`")
+    )
+  }
+
+  test("interpreted CheckOverflowInTableInsert with ExpressionProxy should throw an exception") {
+    val runtime = new SubExprEvaluationRuntime(1)
+    val proxy = ExpressionProxy(Cast(Literal.apply(12345678901234567890D), ByteType), 0, runtime)
+    checkError(
+      exception = intercept[SparkArithmeticException] {
+        CheckOverflowInTableInsert(proxy, "col").eval(null)
       }.asInstanceOf[SparkThrowable],
       errorClass = "CAST_OVERFLOW_IN_TABLE_INSERT",
       parameters = Map(

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -27,7 +27,6 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
-import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.DataSourceUtils
@@ -2313,27 +2312,6 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
               Row(4, Period.ofYears(5), Duration.ofDays(6)),
               Row(7, Period.ofYears(8), Duration.ofDays(9))))
         }
-      }
-    }
-  }
-
-  test("check overflow with expression proxy") {
-    val tabName = "tbl1"
-    withTable(tabName) {
-      spark.sql(
-        """
-          |CREATE TABLE `tbl1`
-          |(a int, b int)
-          |USING parquet
-        """.stripMargin)
-      withSQLConf(
-        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
-        SQLConf.CODEGEN_FACTORY_MODE.key -> CodegenObjectFactoryMode.NO_CODEGEN.toString) {
-        spark.sql(
-          """
-            |INSERT INTO `tbl1`
-            |select id as a, id as b from range(1, 5)
-        """.stripMargin)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.DataSourceUtils
@@ -2312,6 +2313,27 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
               Row(4, Period.ofYears(5), Duration.ofDays(6)),
               Row(7, Period.ofYears(8), Duration.ofDays(9))))
         }
+      }
+    }
+  }
+
+  test("check overflow with expression proxy") {
+    val tabName = "tbl1"
+    withTable(tabName) {
+      spark.sql(
+        """
+          |CREATE TABLE `tbl1`
+          |(a int, b int)
+          |USING parquet
+        """.stripMargin)
+      withSQLConf(
+        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+        SQLConf.CODEGEN_FACTORY_MODE.key -> CodegenObjectFactoryMode.NO_CODEGEN.toString) {
+        spark.sql(
+          """
+            |INSERT INTO `tbl1`
+            |select id as a, id as b from range(1, 5)
+        """.stripMargin)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `CheckOverflowInTableInsert` to accept a `Cast` wrapped by an `ExpressionProxy` as a child.

### Why are the changes needed?

This insert statement fails (in interpreted mode):
```
drop table if exists tbl1;
create table tbl1 (a int, b int) using parquet;

set spark.sql.codegen.wholeStage=false;
set spark.sql.codegen.factoryMode=NO_CODEGEN;

insert into tbl1
select id as a, id as b
from range(1, 5);
```
It gets the following exception:
```
java.lang.ClassCastException: org.apache.spark.sql.catalyst.expressions.ExpressionProxy cannot be cast to org.apache.spark.sql.catalyst.expressions.Cast
	at org.apache.spark.sql.catalyst.expressions.CheckOverflowInTableInsert.withNewChildInternal(Cast.scala:2514)
	at org.apache.spark.sql.catalyst.expressions.CheckOverflowInTableInsert.withNewChildInternal(Cast.scala:2512)
```
The query produces 2 bigint values, but the table's schema expects 2 int values, so Spark wraps each output field with a `Cast`.

Later, in `InterpretedUnsafeProjection`, `prepareExpressions` tries to wrap the two `Cast` expressions with an `ExpressionProxy`. However, the parent expression of each `Cast` is a `CheckOverflowInTableInsert` expression, which does not accept `ExpressionProxy` as a child.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit tests.
