### PR TITLE
[SPARK-41995][SQL] Accept non-foldable expressions in schema_of_json

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -796,16 +796,8 @@ case class SchemaOfJson(
   @transient
   private lazy val jsonInferSchema = new JsonInferSchema(jsonOptions)
 
-  override def eval(v: InternalRow): Any = {
-    val json: UTF8String = if (child.foldable) {
-      child.eval().asInstanceOf[UTF8String]
-    } else {
-      v.getUTF8String(0)
-    }
-
-    if (json == null) {
-      return null
-    }
+  override def nullSafeEval(input: Any): Any = {
+    val json = input.asInstanceOf[UTF8String]
 
     val dt = Utils.tryWithResource(CreateJacksonParser.utf8String(jsonFactory, json)) { parser =>
       parser.nextToken()

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -583,6 +583,17 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df, Seq(Row("STRUCT<a: BIGINT>")))
   }
 
+  test("schema_of_json works on non-foldable columns") {
+    val in = Seq("""{"a": [1, 2, 3]}""").toDS()
+    val out = in.select(schema_of_json($"value") as "parsed_schema")
+    checkAnswer(out, Row("STRUCT<a: ARRAY<BIGINT>>"))
+  }
+
+  test("schema_of_json returns null on null input") {
+    val out = spark.range(1).select(schema_of_json(lit(null)))
+    checkAnswer(out, Row(null))
+  }
+
   test("from_json - array of primitive types") {
     val df = Seq("[1, 2, 3]").toDF("a")
     val schema = new ArrayType(IntegerType, false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -583,13 +583,13 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df, Seq(Row("STRUCT<a: BIGINT>")))
   }
 
-  test("schema_of_json works on non-foldable columns") {
+  test("SPARK-41995: schema_of_json works on non-foldable columns") {
     val in = Seq("""{"a": [1, 2, 3]}""").toDS()
     val out = in.select(schema_of_json($"value") as "parsed_schema")
     checkAnswer(out, Row("STRUCT<a: ARRAY<BIGINT>>"))
   }
 
-  test("schema_of_json returns null on null input") {
+  test("SPARK-41995: schema_of_json returns null on null input") {
     val out = spark.range(1).select(schema_of_json(lit(null)))
     checkAnswer(out, Row(null))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Presently, only foldable expressions can be passed in to schema_of_json, e.g. `SCHEMA_OF_JSON(CONCAT('', ''))`.

With this change, we accept _any_ string expression and infer the JSON schema if possible.

### Why are the changes needed?
Users may have a column containing JSON strings, but today they can't find the schema of each record. With this change, finding the schema of a given column is possible.

### Does this PR introduce _any_ user-facing change?
Yes, schema_of_json will now accept string expressions which are not foldable.


### How was this patch tested?
New tests were added in `JsonFunctionsSuite`
