### PR TITLE
[SPARK-42003][SQL] Reduce duplicate code in ResolveGroupByAll

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupByAll.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupByAll.scala
@@ -53,7 +53,7 @@ object ResolveGroupByAll extends Rule[LogicalPlan] {
    * Otherwise, it contains all the non-aggregate expressions from the project list of the input
    * Aggregate.
    */
-  private def getGroupingExprs(a: Aggregate): Option[Seq[Expression]] = {
+  private def getGroupingExpressions(a: Aggregate): Option[Seq[Expression]] = {
     val groupingExprs = a.aggregateExpressions.filter(!_.exists(AggregateExpression.isAggregate))
     // If the grouping exprs are empty, this could either be (1) a valid global aggregate, or
     // (2) we simply fail to infer the grouping columns. As an example, in "i + sum(j)", we will
@@ -72,7 +72,7 @@ object ResolveGroupByAll extends Rule[LogicalPlan] {
       // Only makes sense to do the rewrite once all the aggregate expressions have been resolved.
       // Otherwise, we might incorrectly pull an actual aggregate expression over to the grouping
       // expression list (because we don't know they would be aggregate expressions until resolved).
-      val groupingExprs = getGroupingExprs(a)
+      val groupingExprs = getGroupingExpressions(a)
 
       if (groupingExprs.isEmpty) {
         // Don't replace the ALL when we fail to infer the grouping columns. We will eventually
@@ -109,7 +109,7 @@ object ResolveGroupByAll extends Rule[LogicalPlan] {
    */
   def checkAnalysis(operator: LogicalPlan): Unit = operator match {
     case a: Aggregate if a.aggregateExpressions.forall(_.resolved) && matchToken(a) =>
-      if (getGroupingExprs(a).isEmpty) {
+      if (getGroupingExpressions(a).isEmpty) {
         operator.failAnalysis(
           errorClass = "UNRESOLVED_ALL_IN_GROUP_BY",
           messageParameters = Map.empty)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupByAll.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupByAll.scala
@@ -47,6 +47,24 @@ object ResolveGroupByAll extends Rule[LogicalPlan] {
     }
   }
 
+  /**
+   * Returns all the grouping expressions inferred from a GROUP BY ALL aggregate.
+   * The result is optional. If Spark fails to infer the grouping columns, it is None.
+   * Otherwise, it contains all the non-aggregate expressions from the project list of the input
+   * Aggregate.
+   */
+  private def getGroupingExprs(a: Aggregate): Option[Seq[Expression]] = {
+    val groupingExprs = a.aggregateExpressions.filter(!_.exists(AggregateExpression.isAggregate))
+    // If the grouping exprs are empty, this could either be (1) a valid global aggregate, or
+    // (2) we simply fail to infer the grouping columns. As an example, in "i + sum(j)", we will
+    // not automatically infer the grouping column to be "i".
+    if (groupingExprs.isEmpty && a.aggregateExpressions.exists(containsAttribute)) {
+      None
+    } else {
+      Some(groupingExprs)
+    }
+  }
+
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUpWithPruning(
     _.containsAllPatterns(UNRESOLVED_ATTRIBUTE, AGGREGATE), ruleId) {
     case a: Aggregate
@@ -54,18 +72,15 @@ object ResolveGroupByAll extends Rule[LogicalPlan] {
       // Only makes sense to do the rewrite once all the aggregate expressions have been resolved.
       // Otherwise, we might incorrectly pull an actual aggregate expression over to the grouping
       // expression list (because we don't know they would be aggregate expressions until resolved).
-      val groupingExprs = a.aggregateExpressions.filter(!_.exists(AggregateExpression.isAggregate))
+      val groupingExprs = getGroupingExprs(a)
 
-      // If the grouping exprs are empty, this could either be (1) a valid global aggregate, or
-      // (2) we simply fail to infer the grouping columns. As an example, in "i + sum(j)", we will
-      // not automatically infer the grouping column to be "i".
-      if (groupingExprs.isEmpty && a.aggregateExpressions.exists(containsAttribute)) {
-        // Case (2): don't replace the ALL. We will eventually tell the user in checkAnalysis
-        // that we cannot resolve the all in group by.
+      if (groupingExprs.isEmpty) {
+        // Don't replace the ALL when we fail to infer the grouping columns. We will eventually
+        // tell the user in checkAnalysis that we cannot resolve the all in group by.
         a
       } else {
-        // Case (1): this is a valid global aggregate.
-        a.copy(groupingExpressions = groupingExprs)
+        // This is a valid GROUP BY ALL aggregate.
+        a.copy(groupingExpressions = groupingExprs.get)
       }
   }
 
@@ -94,8 +109,7 @@ object ResolveGroupByAll extends Rule[LogicalPlan] {
    */
   def checkAnalysis(operator: LogicalPlan): Unit = operator match {
     case a: Aggregate if a.aggregateExpressions.forall(_.resolved) && matchToken(a) =>
-      val noAgg = a.aggregateExpressions.filter(!_.exists(AggregateExpression.isAggregate))
-      if (noAgg.isEmpty && a.aggregateExpressions.exists(containsAttribute)) {
+      if (getGroupingExprs(a).isEmpty) {
         operator.failAnalysis(
           errorClass = "UNRESOLVED_ALL_IN_GROUP_BY",
           messageParameters = Map.empty)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Reduce duplicate code in ResolveGroupByAll by moving the group by expression inference into a new method.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Code clean up

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT