### PR TITLE
[SPARK-42007][CONNECT][TESTS] Reuse pyspark.sql.tests.test_group test cases

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -520,6 +520,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.test_connect_column",
         "pyspark.sql.tests.connect.test_parity_catalog",
         "pyspark.sql.tests.connect.test_parity_functions",
+        "pyspark.sql.tests.connect.test_parity_group",
         "pyspark.sql.tests.connect.test_parity_dataframe",
     ],
     excluded_python_implementations=[

--- a/python/pyspark/sql/tests/connect/test_parity_group.py
+++ b/python/pyspark/sql/tests/connect/test_parity_group.py
@@ -15,37 +15,20 @@
 # limitations under the License.
 #
 
-from pyspark.sql import Row
-from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.sql.tests.test_group import GroupTestsMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class GroupTestsMixin:
-    def test_aggregator(self):
-        df = self.df
-        g = df.groupBy()
-        self.assertEqual([99, 100], sorted(g.agg({"key": "max", "value": "count"}).collect()[0]))
-        self.assertEqual([Row(**{"AVG(key#0)": 49.5})], g.mean().collect())
-
-        from pyspark.sql import functions
-
-        self.assertEqual(
-            (0, "99"), tuple(g.agg(functions.first(df.key), functions.last(df.value)).first())
-        )
-        self.assertTrue(95 < g.agg(functions.approx_count_distinct(df.key)).first()[0])
-        # test deprecated countDistinct
-        self.assertEqual(100, g.agg(functions.countDistinct(df.value)).first()[0])
-
-
-class GroupTests(GroupTestsMixin, ReusedSQLTestCase):
+class GroupParityTests(GroupTestsMixin, ReusedConnectTestCase):
     pass
 
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.sql.tests.test_group import *  # noqa: F401
+    from pyspark.sql.tests.connect.test_parity_group import *  # noqa: F401
 
     try:
-        import xmlrunner
+        import xmlrunner  # type: ignore[import]
 
         testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
     except ImportError:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reuses PySpark `pyspark.sql.tests.test_group` tests in Spark Connect that pass for now.

### Why are the changes needed?

To make sure on the test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran it in my local.