### PR TITLE
[SPARK-42010][CONNECT][TESTS] Reuse pyspark.sql.tests.test_column test cases

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -521,6 +521,7 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.test_parity_catalog",
         "pyspark.sql.tests.connect.test_parity_functions",
         "pyspark.sql.tests.connect.test_parity_dataframe",
+        "pyspark.sql.tests.connect.test_parity_column",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/python/pyspark/sql/tests/connect/test_parity_column.py
+++ b/python/pyspark/sql/tests/connect/test_parity_column.py
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from pyspark.testing.connectutils import should_test_connect
+
+if should_test_connect:
+    from pyspark import sql
+    from pyspark.sql.connect.column import Column
+
+    # This is a hack to make the Column instance comparison works in `ColumnTestsMixin`.
+    # e.g., `isinstance(col, pyspark.sql.Column)`.
+    sql.Column = Column
+
+from pyspark.sql.tests.test_column import ColumnTestsMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+
+
+class ColumnParityTests(ColumnTestsMixin, ReusedConnectTestCase):
+    # TODO(SPARK-42017): Different error type AnalysisException vs SparkConnectAnalysisException
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_access_column(self):
+        super().test_access_column()
+
+    # TODO(SPARK-42016): Type inconsistency of struct and map when accessing the nested column
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_field_accessor(self):
+        super().test_field_accessor()
+
+    @unittest.skip("Requires JVM access.")
+    def test_validate_column_types(self):
+        super().test_validate_column_types()
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.sql.tests.connect.test_parity_column import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -22,7 +22,7 @@ from pyspark.sql.utils import AnalysisException
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 
-class ColumnTests(ReusedSQLTestCase):
+class ColumnTestsMixin:
     def test_column_name_encoding(self):
         """Ensure that created columns has `str` type consistently."""
         columns = self.spark.createDataFrame([("Alice", 1)], ["name", "age"]).columns
@@ -125,7 +125,7 @@ class ColumnTests(ReusedSQLTestCase):
         self.assertTrue(columnName in repr(df[columnName]))
 
     def test_field_accessor(self):
-        df = self.sc.parallelize([Row(l=[1], r=Row(a=1, b="b"), d={"k": "v"})]).toDF()
+        df = self.spark.createDataFrame([Row(l=[1], r=Row(a=1, b="b"), d={"k": "v"})])
         self.assertEqual(1, df.select(df.l[0]).first()[0])
         self.assertEqual(1, df.select(df.r["a"]).first()[0])
         self.assertEqual(1, df.select(df["r.a"]).first()[0])
@@ -185,6 +185,10 @@ class ColumnTests(ReusedSQLTestCase):
         self.assertTrue("b" not in result["a1"] and "c" in result["a1"] and "d" in result["a1"])
 
         self.assertTrue("e" not in result["a2"]["d"] and "f" in result["a2"]["d"])
+
+
+class ColumnTests(ColumnTestsMixin, ReusedSQLTestCase):
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reuses PySpark `pyspark.sql.tests.test_column` tests in Spark Connect that pass for now.

### Why are the changes needed?

To make sure on the test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran it in my local.