### PR TITLE
[SPARK-42026][CORE] Protobuf serializer for `AppSummary` and `PoolData`

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -750,3 +750,13 @@ message ExecutorPeakMetricsDistributions {
   repeated double quantiles = 1;
   repeated ExecutorMetrics executor_metrics = 2;
 }
+
+message AppSummary {
+  int32 num_completed_jobs = 1;
+  int32 num_completed_stages = 2;
+}
+
+message PoolData {
+  string name = 1;
+  repeated int64 stage_ids = 2;
+}

--- a/core/src/main/resources/META-INF/services/org.apache.spark.status.protobuf.ProtobufSerDe
+++ b/core/src/main/resources/META-INF/services/org.apache.spark.status.protobuf.ProtobufSerDe
@@ -29,3 +29,5 @@ org.apache.spark.status.protobuf.ExecutorSummaryWrapperSerializer
 org.apache.spark.status.protobuf.ProcessSummaryWrapperSerializer
 org.apache.spark.status.protobuf.RDDOperationGraphWrapperSerializer
 org.apache.spark.status.protobuf.StageDataWrapperSerializer
+org.apache.spark.status.protobuf.AppSummarySerializer
+org.apache.spark.status.protobuf.PoolDataSerializer

--- a/core/src/main/scala/org/apache/spark/status/protobuf/AppSummarySerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/AppSummarySerializer.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.status.protobuf
+
+import org.apache.spark.status.AppSummary
+
+class AppSummarySerializer extends ProtobufSerDe[AppSummary] {
+
+  override def serialize(input: AppSummary): Array[Byte] = {
+    val builder = StoreTypes.AppSummary.newBuilder()
+      .setNumCompletedJobs(input.numCompletedJobs)
+      .setNumCompletedStages(input.numCompletedStages)
+    builder.build().toByteArray
+  }
+
+  override def deserialize(bytes: Array[Byte]): AppSummary = {
+    val summary = StoreTypes.AppSummary.parseFrom(bytes)
+    new AppSummary(
+      numCompletedJobs = summary.getNumCompletedJobs,
+      numCompletedStages = summary.getNumCompletedStages
+    )
+  }
+}

--- a/core/src/main/scala/org/apache/spark/status/protobuf/PoolDataSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/PoolDataSerializer.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.status.protobuf
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.status.PoolData
+import org.apache.spark.util.Utils.weakIntern
+
+class PoolDataSerializer extends ProtobufSerDe[PoolData] {
+
+  override def serialize(input: PoolData): Array[Byte] = {
+    val builder = StoreTypes.PoolData.newBuilder()
+    builder.setName(input.name)
+    input.stageIds.foreach(id => builder.addStageIds(id.toLong))
+    builder.build().toByteArray
+  }
+
+  override def deserialize(bytes: Array[Byte]): PoolData = {
+    val poolData = StoreTypes.PoolData.parseFrom(bytes)
+    new PoolData(
+      name = weakIntern(poolData.getName),
+      stageIds = poolData.getStageIdsList.asScala.map(_.toInt).toSet
+    )
+  }
+}

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -1277,6 +1277,28 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     assert(result.info.shuffleMergersCount == input.info.shuffleMergersCount)
   }
 
+  test("AppSummary") {
+    val input = new AppSummary(
+      numCompletedJobs = 10,
+      numCompletedStages = 20
+    )
+    val bytes = serializer.serialize(input)
+    val result = serializer.deserialize(bytes, classOf[AppSummary])
+    assert(result.numCompletedJobs == input.numCompletedJobs)
+    assert(result.numCompletedStages == input.numCompletedStages)
+  }
+
+  test("PoolData") {
+    val input = new PoolData(
+      name = "big-pool",
+      stageIds = Set(11, 13, 15, 17)
+    )
+    val bytes = serializer.serialize(input)
+    val result = serializer.deserialize(bytes, classOf[PoolData])
+    assert(result.name == input.name)
+    assert(result.stageIds == input.stageIds)
+  }
+
   private def checkAnswer(result: TaskMetrics, expected: TaskMetrics): Unit = {
     assert(result.executorDeserializeTime == expected.executorDeserializeTime)
     assert(result.executorDeserializeCpuTime == expected.executorDeserializeCpuTime)

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.version>3.8.6</maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>11</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.version>3.8.6</maven.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add Protobuf serializer for `AppSummary` and `PoolData`



### Why are the changes needed?
Support fast and compact serialization/deserialization for `AppSummary` and `PoolData` over RocksDB.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add new UT