### PR TITLE
[SPARK-42029][CONNECT] Add Guava Shading rules to `connect-common` to avoid startup failure

### DIFF
--- a/connector/connect/common/pom.xml
+++ b/connector/connect/common/pom.xml
@@ -156,6 +156,43 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Shade all GRPC / Guava / Protobuf dependencies of this build -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <artifactSet>
+                        <includes>
+                            <include>com.google.guava:*</include>
+                        </includes>
+                    </artifactSet>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>${spark.shade.packageName}.connect.guava</shadedPattern>
+                            <includes>
+                                <include>com.google.common.**</include>
+                            </includes>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.google.thirdparty</pattern>
+                            <shadedPattern>${spark.shade.packageName}.connect.guava</shadedPattern>
+                            <includes>
+                                <include>com.google.thirdparty.**</include>
+                            </includes>
+                        </relocation>
+                        <relocation>
+                            <pattern>android.annotation</pattern>
+                            <shadedPattern>${spark.shade.packageName}.connect.android_annotation</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.google.errorprone.annotations</pattern>
+                            <shadedPattern>${spark.shade.packageName}.connect.errorprone_annotations</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
### What changes were proposed in this pull request?
When building a release package for PySpark and manually adding the `spark-connect_2.12-3.4.0-SNAPSHOT.jar` jar to the distribution. The PySpark shell will not start when started using the following option:

```
> psypark --remote local
py4j.protocol.Py4JJavaError: An error occurred while calling None.org.apache.spark.api.java.JavaSparkContext.
: java.lang.NoClassDefFoundError: org/sparkproject/guava/util/concurrent/internal/InternalFutureFailureAccess
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
```

The reason is that the `connect-common` package applies the default shading rules of Spark and thus we dont pickup the right dependency for the connect package. This patch fixes this issue by applying the same shading rules for `guava` to `connect-common`.

### Why are the changes needed?
Release distribution

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual testing
