### PR TITLE
[SPARK-42030][CORE] Remove unused Constructor from RocksDB.TypeAliases and LevelDB.TypeAliases

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -393,11 +393,6 @@ public class LevelDB implements KVStore {
     TypeAliases(Map<String, byte[]> aliases) {
       this.aliases = aliases;
     }
-
-    TypeAliases() {
-      this(null);
-    }
-
   }
 
   private static class PrefixCache {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
@@ -426,11 +426,6 @@ public class RocksDB implements KVStore {
     TypeAliases(Map<String, byte[]> aliases) {
       this.aliases = aliases;
     }
-
-    TypeAliases() {
-      this(null);
-    }
-
   }
 
   private static class PrefixCache {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove unused Constructor from `RocksDB.TypeAliases` and `LevelDB.TypeAliases`.

### Why are the changes needed?
Code cleaning.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions