### PR TITLE
[SPARK-42031][CORE][SQL] Clean up `remove` methods that do not need override

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -469,11 +469,6 @@ public class InMemoryStore implements KVStore {
     }
 
     @Override
-    public void remove() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public List<T> next(int max) {
       List<T> list = new ArrayList<>(max);
       while (hasNext() && list.size() < max) {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -144,11 +144,6 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
   }
 
   @Override
-  public void remove() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public List<T> next(int max) {
     List<T> list = new ArrayList<>(max);
     while (hasNext() && list.size() < max) {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
@@ -135,11 +135,6 @@ class RocksDBIterator<T> implements KVStoreIterator<T> {
   }
 
   @Override
-  public void remove() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public List<T> next(int max) {
     List<T> list = new ArrayList<>(max);
     while (hasNext() && list.size() < max) {

--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -387,11 +387,6 @@ public final class BytesToBytesMap extends MemoryConsumer {
       return released;
     }
 
-    @Override
-    public void remove() {
-      throw new UnsupportedOperationException();
-    }
-
     private void handleFailedDelete() {
       if (spillWriters.size() > 0) {
         // remove the spill file from disk

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatch.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatch.java
@@ -67,11 +67,6 @@ public class ColumnarBatch implements AutoCloseable {
         row.rowId = rowId++;
         return row;
       }
-
-      @Override
-      public void remove() {
-        throw new UnsupportedOperationException();
-      }
     };
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1347,10 +1347,6 @@ class ColumnarBatchSuite extends SparkFunSuite {
           rowId += 1
           row
         }
-
-        override def remove(): Unit = {
-          throw new UnsupportedOperationException
-        }
       }
     }
   }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/ColumnBasedSet.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/ColumnBasedSet.java
@@ -179,11 +179,6 @@ public class ColumnBasedSet implements RowSet {
         index++;
         return convey;
       }
-
-      @Override
-      public void remove() {
-        throw new UnsupportedOperationException("remove");
-      }
     };
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Java 8 began to provide the default remove method implementation for the `java.util.Iterator` interface.


https://github.com/openjdk/jdk/blob/9a9add8825a040565051a09010b29b099c2e7d49/jdk/src/share/classes/java/util/Iterator.java#L92-L94

```java
default void remove() {
    throw new UnsupportedOperationException("remove");
}
```

So this pr cleans up unnecessary remove method `overrdie` in Spark code.


### Why are the changes needed?
Code cleanup


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions