### PR TITLE
[MINOR][CONNECT][DOCS] Fix typo in `connect/README.md`

### DIFF
--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -20,9 +20,9 @@ user experience across all languages. Please follow the below guidelines:
 * [Connection string configuration](docs/client-connection-string.md)
 * [Adding new messages](docs/adding-proto-messages.md) in the Spark Connect protocol.
 
-### Python client developement
+### Python client development
 
-Python-specific developement guidelines are located in [python/docs/source/development/testing.rst](https://github.com/apache/spark/blob/master/python/docs/source/development/testing.rst) that is published at [Development tab](https://spark.apache.org/docs/latest/api/python/development/index.html) in PySpark documentation.
+Python-specific development guidelines are located in [python/docs/source/development/testing.rst](https://github.com/apache/spark/blob/master/python/docs/source/development/testing.rst) that is published at [Development tab](https://spark.apache.org/docs/latest/api/python/development/index.html) in PySpark documentation.
 
 ### Build with user-defined `protoc` and `protoc-gen-grpc-java`
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr fix typo in `connect/README.md`


### Why are the changes needed?
Fix typo in `connect/README.md`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions
