### PR TITLE
[SPARK-42057][SQL][PROTOBUF] Fix how exception is handled in error reporting.

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufUtils.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufUtils.scala
@@ -229,7 +229,7 @@ private[sql] object ProtobufUtils extends Logging {
       fileDescriptorSet = DescriptorProtos.FileDescriptorSet.parseFrom(dscFile)
     } catch {
       case ex: InvalidProtocolBufferException =>
-        throw QueryCompilationErrors.descrioptorParseError(descFilePath, ex)
+        throw QueryCompilationErrors.descriptorParseError(descFilePath, ex)
       case ex: IOException =>
         throw QueryCompilationErrors.cannotFindDescriptorFileError(descFilePath, ex)
     }

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1261,6 +1261,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
           functions.from_protobuf($"value", "SomeMessage", invalidDescPath)
         ).collect()
     }
+    checkError(ex, "PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND")
     assert(ex.getCause != null)
     assert(ex.getCause.getMessage.matches(".*No such file.*"), ex.getCause.getMessage())
   }

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1261,7 +1261,11 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
           functions.from_protobuf($"value", "SomeMessage", invalidDescPath)
         ).collect()
     }
-    checkError(ex, "PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND")
+    checkError(
+      ex,
+      errorClass = "PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND",
+      parameters = Map("filePath" -> "/non/existent/path.desc")
+    )
     assert(ex.getCause != null)
     assert(ex.getCause.getMessage.matches(".*No such file.*"), ex.getCause.getMessage())
   }

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1248,6 +1248,23 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     testFromProtobufWithOptions(df, expectedDfTwo, optionsTwo)
   }
 
+  test("Verify exceptions are correctly propagated with errors") {
+    // This triggers an query compilation error and ensures that original exception is
+    // also included in in the exception.
+
+    val invalidDescPath = "/non/existent/path.desc"
+
+    val ex = intercept[AnalysisException] {
+      Seq(Array[Byte]())
+        .toDF()
+        .select(
+          functions.from_protobuf($"value", "SomeMessage", invalidDescPath)
+        ).collect()
+    }
+    assert(ex.getCause != null)
+    assert(ex.getCause.getMessage.matches(".*No such file.*"), ex.getCause.getMessage())
+  }
+
   def testFromProtobufWithOptions(
     df: DataFrame,
     expectedDf: DataFrame,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3239,7 +3239,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       messageParameters = Map(
         "protobufType" -> protobufType,
         "toType" -> toSQLType(sqlType)),
-      cause = Option(cause.getCause))
+      cause = Option(cause))
   }
 
   def cannotConvertSqlTypeToProtobufError(
@@ -3251,7 +3251,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       messageParameters = Map(
         "protobufType" -> protobufType,
         "toType" -> toSQLType(sqlType)),
-      cause = Option(cause.getCause))
+      cause = Option(cause))
   }
 
   def protobufTypeUnsupportedYetError(protobufType: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3301,25 +3301,25 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       messageParameters = Map("messageName" -> messageName))
   }
 
-  def descrioptorParseError(descFilePath: String, cause: Throwable): Throwable = {
+  def descriptorParseError(descFilePath: String, cause: Throwable): Throwable = {
     new AnalysisException(
       errorClass = "CANNOT_PARSE_PROTOBUF_DESCRIPTOR",
       messageParameters = Map("descFilePath" -> descFilePath),
-      cause = Option(cause.getCause))
+      cause = Option(cause))
   }
 
   def cannotFindDescriptorFileError(filePath: String, cause: Throwable): Throwable = {
     new AnalysisException(
       errorClass = "PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND",
       messageParameters = Map("filePath" -> filePath),
-      cause = Option(cause.getCause))
+      cause = Option(cause))
   }
 
   def failedParsingDescriptorError(descFilePath: String, cause: Throwable): Throwable = {
     new AnalysisException(
       errorClass = "CANNOT_CONSTRUCT_PROTOBUF_DESCRIPTOR",
       messageParameters = Map("descFilePath" -> descFilePath),
-      cause = Option(cause.getCause))
+      cause = Option(cause))
   }
 
   def foundRecursionInProtobufSchema(fieldDescriptor: String): Throwable = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Protobuf connector related error handlers incorrectly report the exception. This is makes it hard for users to see actual issue. E.g. if there is a `FileNotFoundException` these error handlers use pass `exception.getCause()` rather than passing `exception`. As result, we lose the information that it was a `FileNotFoundException`

This PR fixes that.

### Why are the changes needed?
 This improves error reporting. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
 -  A new test is added.