### PR TITLE
[SPARK-42039][SQL] SPJ: Remove Option in KeyGroupedPartitioning#partitionValuesOpt

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -324,13 +324,13 @@ case class HashPartitioning(expressions: Seq[Expression], numPartitions: Int)
  *
  * @param expressions partition expressions for the partitioning.
  * @param numPartitions the number of partitions
- * @param partitionValuesOpt if set, the values for the cluster keys of the distribution, must be
- *                           in ascending order.
+ * @param partitionValues the values for the cluster keys of the distribution, must be
+ *                        in ascending order.
  */
 case class KeyGroupedPartitioning(
     expressions: Seq[Expression],
     numPartitions: Int,
-    partitionValuesOpt: Option[Seq[InternalRow]] = None) extends Partitioning {
+    partitionValues: Seq[InternalRow] = Seq.empty) extends Partitioning {
 
   override def satisfies0(required: Distribution): Boolean = {
     super.satisfies0(required) || {
@@ -360,7 +360,7 @@ object KeyGroupedPartitioning {
   def apply(
       expressions: Seq[Expression],
       partitionValues: Seq[InternalRow]): KeyGroupedPartitioning = {
-    KeyGroupedPartitioning(expressions, partitionValues.size, Some(partitionValues))
+    KeyGroupedPartitioning(expressions, partitionValues.size, partitionValues)
   }
 
   def supportsExpressions(expressions: Seq[Expression]): Boolean = {
@@ -692,14 +692,12 @@ case class KeyGroupedShuffleSpec(
     //        partition keys must share overlapping positions in their respective clustering keys.
     //    3.3 each pair of partition expressions at the same index must share compatible
     //        transform functions.
-    //  4. the partition values, if present on both sides, are following the same order.
+    //  4. the partition values from both sides are following the same order.
     case otherSpec @ KeyGroupedShuffleSpec(otherPartitioning, otherDistribution) =>
       distribution.clustering.length == otherDistribution.clustering.length &&
         numPartitions == other.numPartitions && areKeysCompatible(otherSpec) &&
-          partitioning.partitionValuesOpt.zip(otherPartitioning.partitionValuesOpt).forall {
-            case (left, right) => left.zip(right).forall { case (l, r) =>
-              ordering.compare(l, r) == 0
-            }
+          partitioning.partitionValues.zip(otherPartitioning.partitionValues).forall {
+            case (left, right) => ordering.compare(left, right) == 0
           }
     case ShuffleSpecCollection(specs) =>
       specs.exists(isCompatibleWith)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -84,7 +84,7 @@ case class BatchScanExec(
           val newRows = new InternalRowSet(p.expressions.map(_.dataType))
           newRows ++= newPartitions.map(_.asInstanceOf[HasPartitionKey].partitionKey())
 
-          val oldRows = p.partitionValuesOpt.get.toSet
+          val oldRows = p.partitionValues.toSet
           // We require the new number of partition keys to be equal or less than the old number
           // of partition keys here. In the case of less than, empty partitions will be added for
           // those missing keys that are not present in the new input partitions.
@@ -116,7 +116,7 @@ case class BatchScanExec(
     super.outputPartitioning match {
       case k: KeyGroupedPartitioning if commonPartitionValues.isDefined =>
         val values = commonPartitionValues.get
-        k.copy(numPartitions = values.length, partitionValuesOpt = Some(values))
+        k.copy(numPartitions = values.length, partitionValues = values)
       case p => p
     }
   }
@@ -134,7 +134,7 @@ case class BatchScanExec(
         case p: KeyGroupedPartitioning =>
           val partitionMapping = finalPartitions.map(s =>
             s.head.asInstanceOf[HasPartitionKey].partitionKey() -> s).toMap
-          finalPartitions = p.partitionValuesOpt.get.map { partValue =>
+          finalPartitions = p.partitionValues.map { partValue =>
             // Use empty partition for those partition values that are not present
             partitionMapping.getOrElse(partValue, Seq.empty)
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -97,7 +97,7 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
       keyGroupedPartitioning match {
         case Some(exprs) if KeyGroupedPartitioning.supportsExpressions(exprs) =>
           groupedPartitions.map { partitionValues =>
-            KeyGroupedPartitioning(exprs, partitionValues.size, Some(partitionValues.map(_._1)))
+            KeyGroupedPartitioning(exprs, partitionValues.size, partitionValues.map(_._1))
           }.getOrElse(super.outputPartitioning)
         case _ =>
           super.outputPartitioning

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -194,11 +194,8 @@ case class EnsureRequirements(
                 // Check if the two children are partition keys compatible. If so, find the
                 // common set of partition values, and adjust the plan accordingly.
                 if (leftSpec.areKeysCompatible(rightSpec)) {
-                  assert(leftSpec.partitioning.partitionValuesOpt.isDefined)
-                  assert(rightSpec.partitioning.partitionValuesOpt.isDefined)
-
-                  val leftPartValues = leftSpec.partitioning.partitionValuesOpt.get
-                  val rightPartValues = rightSpec.partitioning.partitionValuesOpt.get
+                  val leftPartValues = leftSpec.partitioning.partitionValues
+                  val rightPartValues = rightSpec.partitioning.partitionValues
 
                   val mergedPartValues = Utils.mergeOrdered(
                     Seq(leftPartValues, rightPartValues))(leftSpec.ordering).toSeq.distinct

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -987,11 +987,11 @@ class EnsureRequirementsSuite extends SharedSparkSession {
 
       var plan1 = DummySparkPlan(
         outputPartitioning = KeyGroupedPartitioning(bucket(4, exprB) :: bucket(8, exprC) :: Nil,
-          leftPartValues.length, Some(leftPartValues))
+          leftPartValues.length, leftPartValues)
       )
       var plan2 = DummySparkPlan(
         outputPartitioning = KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
-          rightPartValues.length, Some(rightPartValues))
+          rightPartValues.length, rightPartValues)
       )
 
       // simple case
@@ -1010,9 +1010,9 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       plan1 = DummySparkPlan(outputPartitioning =
         PartitioningCollection(
           Seq(KeyGroupedPartitioning(bucket(4, exprB) :: bucket(8, exprC) :: Nil,
-            leftPartValues.length, Some(leftPartValues)),
+            leftPartValues.length, leftPartValues),
             KeyGroupedPartitioning(bucket(4, exprB) :: bucket(8, exprC) :: Nil,
-              leftPartValues.length, Some(leftPartValues)))
+              leftPartValues.length, leftPartValues))
         )
       )
 
@@ -1037,15 +1037,15 @@ class EnsureRequirementsSuite extends SharedSparkSession {
             PartitioningCollection(
               Seq(
                 KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
-                  rightPartValues.length, Some(rightPartValues)),
+                  rightPartValues.length, rightPartValues),
                 KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
-                  rightPartValues.length, Some(rightPartValues)))),
+                  rightPartValues.length, rightPartValues))),
               PartitioningCollection(
                 Seq(
                   KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
-                    rightPartValues.length, Some(rightPartValues)),
+                    rightPartValues.length, rightPartValues),
                   KeyGroupedPartitioning(bucket(4, exprC) :: bucket(8, exprB) :: Nil,
-                    rightPartValues.length, Some(rightPartValues))))
+                    rightPartValues.length, rightPartValues)))
           )
         )
       )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Currently `KeyGroupedPartitioning#partitionValuesOpt` is of type: `Option[Seq[InternalRow]]`. This refactors it into 
`Seq[InternalRow]`. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It's unnecessary to use `Option` for the field. Originally I was thinking to use `None` for the case when all the input partitions are implicitly matched, so that we can skip comparing them in `EnsureRequirements`. However, I think it is not really a use case, and we can instead use `Seq.empty` for that if it comes up.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests.