### PR TITLE
[SPARK-42042][CONNECT][PYTHON] `DataFrameReader` should support StructType schema

### DIFF
--- a/connector/connect/common/src/main/protobuf/spark/connect/relations.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/relations.proto
@@ -119,6 +119,8 @@ message Read {
     string format = 1;
 
     // (Optional) If not set, Spark will infer the schema.
+    //
+    // This schema string should be either DDL-formatted or JSON-formatted.
     optional string schema = 2;
 
     // Options for the data source. The context of this map varies based on the

--- a/python/pyspark/sql/connect/proto/relations_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/relations_pb2.pyi
@@ -557,7 +557,10 @@ class Read(google.protobuf.message.Message):
         format: builtins.str
         """(Required) Supported formats include: parquet, orc, text, json, parquet, csv, avro."""
         schema: builtins.str
-        """(Optional) If not set, Spark will infer the schema."""
+        """(Optional) If not set, Spark will infer the schema.
+
+        This schema string should be either DDL-formatted or JSON-formatted.
+        """
         @property
         def options(
             self,

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -69,9 +69,13 @@ class DataFrameReader(OptionUtils):
 
     format.__doc__ = PySparkDataFrameReader.format.__doc__
 
-    # TODO(SPARK-40539): support StructType in python client and support schema as StructType.
-    def schema(self, schema: str) -> "DataFrameReader":
-        self._schema = schema
+    def schema(self, schema: Union[StructType, str]) -> "DataFrameReader":
+        if isinstance(schema, StructType):
+            self._schema = schema.json()
+        elif isinstance(schema, str):
+            self._schema = schema
+        else:
+            raise TypeError(f"schema must be a StructType or str, but got {schema}")
         return self
 
     schema.__doc__ = PySparkDataFrameReader.schema.__doc__
@@ -93,7 +97,7 @@ class DataFrameReader(OptionUtils):
         self,
         path: Optional[str] = None,
         format: Optional[str] = None,
-        schema: Optional[str] = None,
+        schema: Optional[Union[StructType, str]] = None,
         **options: "OptionalPrimitiveType",
     ) -> "DataFrame":
         if format is not None:
@@ -122,7 +126,7 @@ class DataFrameReader(OptionUtils):
     def json(
         self,
         path: str,
-        schema: Optional[str] = None,
+        schema: Optional[Union[StructType, str]] = None,
         primitivesAsString: Optional[Union[bool, str]] = None,
         prefersDecimal: Optional[Union[bool, str]] = None,
         allowComments: Optional[Union[bool, str]] = None,


### PR DESCRIPTION
### What changes were proposed in this pull request?
`DataFrameReader` should support StructType schema


### Why are the changes needed?
for parity

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
updated ut
