### PR TITLE
[SPARK-42046][TESTS] Add `connect-client-jvm` to `connect` module and fix port failure

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -98,9 +98,9 @@ class SparkConnectClientSuite
     TestPackURI("sc://host", isCorrect = true),
     TestPackURI("sc://localhost/", isCorrect = true, client => testClientConnection(client)),
     TestPackURI(
-      "sc://localhost:123/",
+      "sc://localhost:1234/",
       isCorrect = true,
-      client => testClientConnection(client, 123)),
+      client => testClientConnection(client, 1234)),
     TestPackURI("sc://localhost/;", isCorrect = true, client => testClientConnection(client)),
     TestPackURI("sc://host:123", isCorrect = true),
     TestPackURI(

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -279,6 +279,7 @@ connect = Module(
     ],
     sbt_test_goals=[
         "connect/test",
+        "connect-client-jvm/test",
     ],
 )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `connect-client-jvm` module to `connect` module.

### Why are the changes needed?

Currently, `connect-client-jvm` are not tested in CI because we only invoke the following for `connect` module.

https://github.com/apache/spark/blob/5e0a82e590d1c3c3c5fa7f347dddf450fabbf772/.github/workflows/build_and_test.yml#L155

And, it fails in GitHub Action environment.
```
[info] - Check URI: sc://localhost:123/, isCorrect: true *** FAILED *** (6 milliseconds)
[info]   java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0:123
...
Cause: java.net.SocketException: Permission denied
[info]   at sun.nio.ch.Net.bind0(Native Method)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check `SparkConnectClientSuite` from the log.

```
$ dev/run-tests.py -m connect
...
[info] SparkConnectClientSuite:
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[info] - Placeholder test: Create SparkConnectClient (100 milliseconds)
[info] - Test connection (114 milliseconds)
[info] - Test connection string (6 milliseconds)
[info] - Check URI: sc://host, isCorrect: true (0 milliseconds)
[info] - Check URI: sc://localhost/, isCorrect: true (4 milliseconds)
[info] - Check URI: sc://localhost:123/, isCorrect: true (12 milliseconds)
[info] - Check URI: sc://localhost/;, isCorrect: true (4 milliseconds)
[info] - Check URI: sc://host:123, isCorrect: true (1 millisecond)
[info] - Check URI: sc://host:123/;user_id=a94, isCorrect: true (1 millisecond)
[info] - Check URI: scc://host:12, isCorrect: false (1 millisecond)
[info] - Check URI: http://host, isCorrect: false (0 milliseconds)
[info] - Check URI: sc:/host:1234/path, isCorrect: false (0 milliseconds)
[info] - Check URI: sc://host/path, isCorrect: false (1 millisecond)
[info] - Check URI: sc://host/;parm1;param2, isCorrect: false (0 milliseconds)
[info] - Check URI: sc://host:123;user_id=a94, isCorrect: false (0 milliseconds)
[info] - Check URI: sc:///user_id=123, isCorrect: false (0 milliseconds)
[info] - Check URI: sc://host:-4, isCorrect: false (0 milliseconds)
[info] - Check URI: sc://:123/, isCorrect: false (0 milliseconds)
[info] - Non user-id parameters throw unsupported errors (1 millisecond)
[info] Run completed in 1 second, 75 milliseconds.
[info] Total number of tests run: 19
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 19, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 1 s, completed Jan 12, 2023, 10:10:49 PM
```