### PR TITLE
[SPARK-42056][SQL][PROTOBUF] Add missing options for Protobuf functions

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/CatalystDataToProtobuf.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/CatalystDataToProtobuf.scala
@@ -26,7 +26,8 @@ import org.apache.spark.sql.types.{BinaryType, DataType}
 private[protobuf] case class CatalystDataToProtobuf(
     child: Expression,
     messageName: String,
-    descFilePath: Option[String] = None)
+    descFilePath: Option[String] = None,
+    options: Map[String, String] = Map.empty)
     extends UnaryExpression {
 
   override def dataType: DataType = BinaryType

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/functions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/functions.scala
@@ -36,7 +36,8 @@ object functions {
    * @param messageName
    *   the protobuf message name to look for in descriptorFile.
    * @param descFilePath
-   *   the protobuf descriptor in Message GeneratedMessageV3 format.
+   *   the protobuf descriptor file.
+   * @param options
    * @since 3.4.0
    */
   @Experimental
@@ -61,7 +62,7 @@ object functions {
    * @param messageName
    *   the protobuf MessageName to look for in descriptorFile.
    * @param descFilePath
-   *   the protobuf descriptor in Message GeneratedMessageV3 format.
+   *   the protobuf descriptor file.
    * @since 3.4.0
    */
   @Experimental
@@ -80,14 +81,37 @@ object functions {
    *
    * @param data
    *   the binary column.
-   * @param shadedMessageClassName
+   * @param messageClassName
    *   The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>.
    *   The jar with these classes needs to be shaded as described above.
    * @since 3.4.0
    */
   @Experimental
-  def from_protobuf(data: Column, shadedMessageClassName: String): Column = {
-    new Column(ProtobufDataToCatalyst(data.expr, shadedMessageClassName))
+  def from_protobuf(data: Column, messageClassName: String): Column = {
+    new Column(ProtobufDataToCatalyst(data.expr, messageClassName))
+  }
+
+  /**
+   * Converts a binary column of Protobuf format into its corresponding catalyst value. The
+   * specified Protobuf class must match the data, otherwise the behavior is
+   * undefined: it may fail or return arbitrary result. The jar containing Java class should be
+   * shaded. Specifically, `com.google.protobuf.*` should be shaded to
+   * `org.sparkproject.spark-protobuf.protobuf.*`.
+   *
+   * @param data
+   *   the binary column.
+   * @param messageClassName
+   *   The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>.
+   *   The jar with these classes needs to be shaded as described above.
+   * @param options
+   * @since 3.4.0
+   */
+  @Experimental
+  def from_protobuf(
+    data: Column,
+    messageClassName: String,
+    options: java.util.Map[String, String]): Column = {
+    new Column(ProtobufDataToCatalyst(data.expr, messageClassName, None, options.asScala.toMap))
   }
 
   /**
@@ -98,12 +122,35 @@ object functions {
    * @param messageName
    *   the protobuf MessageName to look for in descriptorFile.
    * @param descFilePath
-   *   the protobuf descriptor in Message GeneratedMessageV3 format.
+   *   the protobuf descriptor file.
    * @since 3.4.0
    */
   @Experimental
   def to_protobuf(data: Column, messageName: String, descFilePath: String): Column = {
     new Column(CatalystDataToProtobuf(data.expr, messageName, Some(descFilePath)))
+  }
+
+  /**
+   * Converts a column into binary of protobuf format.
+   *
+   * @param data
+   *   the data column.
+   * @param messageName
+   *   the protobuf MessageName to look for in descriptor file.
+   * @param descFilePath
+   *   the protobuf descriptor file.
+   * @param options
+   * @since 3.4.0
+   */
+  @Experimental
+  def to_protobuf(
+    data: Column,
+    messageName: String,
+    descFilePath: String,
+    options: java.util.Map[String, String]): Column = {
+    new Column(
+      CatalystDataToProtobuf(data.expr, messageName, Some(descFilePath), options.asScala.toMap)
+    )
   }
 
   /**
@@ -118,5 +165,21 @@ object functions {
   @Experimental
   def to_protobuf(data: Column, messageClassName: String): Column = {
     new Column(CatalystDataToProtobuf(data.expr, messageClassName))
+  }
+
+  /**
+   * Converts a column into binary of protobuf format.
+   *
+   * @param data
+   *   the data column.
+   * @param messageClassName
+   *   The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>.
+   * @param options
+   * @since 3.4.0
+   */
+  @Experimental
+  def to_protobuf(data: Column, messageClassName: String, options: java.util.Map[String, String])
+  : Column = {
+    new Column(CatalystDataToProtobuf(data.expr, messageClassName, None, options.asScala.toMap))
   }
 }

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/functions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/functions.scala
@@ -27,14 +27,12 @@ object functions {
 
   /**
    * Converts a binary column of Protobuf format into its corresponding catalyst value. The
-   * specified schema must match actual schema of the read data, otherwise the behavior is
-   * undefined: it may fail or return arbitrary result. To deserialize the data with a compatible
-   * and evolved schema, the expected Protobuf schema can be set via the option protoSchema.
+   * Protobuf definition is provided through Protobuf <i>descriptor file</i>.
    *
    * @param data
    *   the binary column.
    * @param messageName
-   *   the protobuf message name to look for in descriptorFile.
+   *   the protobuf message name to look for in descriptor file.
    * @param descFilePath
    *   the protobuf descriptor file.
    * @param options
@@ -53,14 +51,12 @@ object functions {
 
   /**
    * Converts a binary column of Protobuf format into its corresponding catalyst value. The
-   * specified schema must match actual schema of the read data, otherwise the behavior is
-   * undefined: it may fail or return arbitrary result. To deserialize the data with a compatible
-   * and evolved schema, the expected Protobuf schema can be set via the option protoSchema.
+   * Protobuf definition is provided through Protobuf <i>descriptor file</i>.
    *
    * @param data
    *   the binary column.
    * @param messageName
-   *   the protobuf MessageName to look for in descriptorFile.
+   *   the protobuf MessageName to look for in descriptor file.
    * @param descFilePath
    *   the protobuf descriptor file.
    * @since 3.4.0
@@ -73,16 +69,17 @@ object functions {
   }
 
   /**
-   * Converts a binary column of Protobuf format into its corresponding catalyst value. The
-   * specified Protobuf class must match the data, otherwise the behavior is
-   * undefined: it may fail or return arbitrary result. The jar containing Java class should be
+   * Converts a binary column of Protobuf format into its corresponding catalyst value.
+   * `messageClassName` points to Protobuf Java class. The jar containing Java class should be
    * shaded. Specifically, `com.google.protobuf.*` should be shaded to
    * `org.sparkproject.spark-protobuf.protobuf.*`.
+   * https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
+   * Protobuf files.
    *
    * @param data
    *   the binary column.
    * @param messageClassName
-   *   The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>.
+   *   The full name for Protobuf Java class. E.g. <code>com.example.protos.ExampleEvent</code>.
    *   The jar with these classes needs to be shaded as described above.
    * @since 3.4.0
    */
@@ -92,16 +89,17 @@ object functions {
   }
 
   /**
-   * Converts a binary column of Protobuf format into its corresponding catalyst value. The
-   * specified Protobuf class must match the data, otherwise the behavior is
-   * undefined: it may fail or return arbitrary result. The jar containing Java class should be
+   * Converts a binary column of Protobuf format into its corresponding catalyst value.
+   * `messageClassName` points to Protobuf Java class. The jar containing Java class should be
    * shaded. Specifically, `com.google.protobuf.*` should be shaded to
    * `org.sparkproject.spark-protobuf.protobuf.*`.
+   * https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
+   * Protobuf files.
    *
    * @param data
    *   the binary column.
    * @param messageClassName
-   *   The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>.
+   *   The full name for Protobuf Java class. E.g. <code>com.example.protos.ExampleEvent</code>.
    *   The jar with these classes needs to be shaded as described above.
    * @param options
    * @since 3.4.0
@@ -115,12 +113,13 @@ object functions {
   }
 
   /**
-   * Converts a column into binary of protobuf format.
+   * Converts a column into binary of protobuf format. The Protobuf definition is provided
+   * through Protobuf <i>descriptor file</i>.
    *
    * @param data
    *   the data column.
    * @param messageName
-   *   the protobuf MessageName to look for in descriptorFile.
+   *   the protobuf MessageName to look for in descriptor file.
    * @param descFilePath
    *   the protobuf descriptor file.
    * @since 3.4.0
@@ -131,7 +130,8 @@ object functions {
   }
 
   /**
-   * Converts a column into binary of protobuf format.
+   * Converts a column into binary of protobuf format. The Protobuf definition is provided
+   * through Protobuf <i>descriptor file</i>.
    *
    * @param data
    *   the data column.
@@ -155,11 +155,17 @@ object functions {
 
   /**
    * Converts a column into binary of protobuf format.
+   * `messageClassName` points to Protobuf Java class. The jar containing Java class should be
+   * shaded. Specifically, `com.google.protobuf.*` should be shaded to
+   * `org.sparkproject.spark-protobuf.protobuf.*`.
+   * https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
+   * Protobuf files.
    *
    * @param data
    *   the data column.
    * @param messageClassName
-   *   The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>.
+   *   The full name for Protobuf Java class. E.g. <code>com.example.protos.ExampleEvent</code>.
+   *   The jar with these classes needs to be shaded as described above.
    * @since 3.4.0
    */
   @Experimental
@@ -169,11 +175,17 @@ object functions {
 
   /**
    * Converts a column into binary of protobuf format.
+   * `messageClassName` points to Protobuf Java class. The jar containing Java class should be
+   * shaded. Specifically, `com.google.protobuf.*` should be shaded to
+   * `org.sparkproject.spark-protobuf.protobuf.*`.
+   * https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
+   * Protobuf files.
    *
    * @param data
    *   the data column.
    * @param messageClassName
-   *   The Protobuf class name. E.g. <code>org.spark.examples.protobuf.ExampleEvent</code>.
+   *   The full name for Protobuf Java class. E.g. <code>com.example.protos.ExampleEvent</code>.
+   *   The jar with these classes needs to be shaded as described above.
    * @param options
    * @since 3.4.0
    */

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -57,7 +57,7 @@ def from_protobuf(
         without descFilePath parameter.
         Using the spark-submit option --jars, add a messageClassName specific jar.
     descFilePath : str
-        the protobuf descriptor in Message GeneratedMessageV3 format.
+        The protobuf descriptor file.
     options : dict, optional
         options to control how the protobuf record is parsed.
 
@@ -125,7 +125,7 @@ def from_protobuf(
             )
         else:
             jc = sc._jvm.org.apache.spark.sql.protobuf.functions.from_protobuf(
-                _to_java_column(data), messageName
+                _to_java_column(data), messageName, options or {}
             )
     except TypeError as e:
         if str(e) == "'JavaPackage' object is not callable":
@@ -135,7 +135,10 @@ def from_protobuf(
 
 
 def to_protobuf(
-    data: "ColumnOrName", messageName: str, descFilePath: Optional[str] = None
+    data: "ColumnOrName",
+    messageName: str,
+    descFilePath: Optional[str] = None,
+    options: Optional[Dict[str, str]] = None,
 ) -> Column:
     """
     Converts a column into binary of protobuf format. The specified Protobuf class must match the
@@ -155,11 +158,11 @@ def to_protobuf(
         without descFilePath parameter.
         Using the spark-submit option --jars, add a messageClassName specific jar.
     descFilePath : str
-        the protobuf descriptor in Message GeneratedMessageV3 format.
+        the Protobuf descriptor file.
 
     Notes
     -----
-    Protobuf functionality is provided as an pluggable external module
+    Protobuf functionality is provided as a pluggable external module
 
     Examples
     --------
@@ -207,11 +210,11 @@ def to_protobuf(
     try:
         if descFilePath is not None:
             jc = sc._jvm.org.apache.spark.sql.protobuf.functions.to_protobuf(
-                _to_java_column(data), messageName, descFilePath
+                _to_java_column(data), messageName, descFilePath, options or {}
             )
         else:
             jc = sc._jvm.org.apache.spark.sql.protobuf.functions.to_protobuf(
-                _to_java_column(data), messageName
+                _to_java_column(data), messageName, options or {}
             )
 
     except TypeError as e:

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -37,13 +37,15 @@ def from_protobuf(
 ) -> Column:
     """
     Converts a binary column of Protobuf format into its corresponding catalyst value.
-    The specified schema must match the read data, otherwise the behavior is undefined:
-    it may fail or return arbitrary result. The jar containing Java class should be shaded.
-    Specifically, ``com.google.protobuf.*`` should be shaded to
-    ``org.sparkproject.spark-protobuf.protobuf.*``.
+    The Protobuf definition is provided in one of these two ways:
 
-    To deserialize the data with a compatible and evolved schema, the expected
-    Protobuf schema can be set via the option protobuf descriptor.
+       - Protobuf descriptor file: E.g. a descriptor file created with
+          `protoc --include_imports --descriptor_set_out=abc.desc abc.proto`
+       - Jar containing Protobuf Java class: The jar containing Java class should be shaded.
+         Specifically, `com.google.protobuf.*` should be shaded to
+         `org.sparkproject.spark-protobuf.protobuf.*`.
+         https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
+         Protobuf files. The jar file can be added with spark-submit option --jars.
 
     .. versionadded:: 3.4.0
 
@@ -52,11 +54,10 @@ def from_protobuf(
     data : :class:`~pyspark.sql.Column` or str
         the binary column.
     messageName: str, optional
-        the protobuf message name to look for in descriptor file. Or
-        The Protobuf class name. E.g. ``org.spark.examples.protobuf.ExampleEvent``,
-        without descFilePath parameter.
-        Using the spark-submit option --jars, add a messageClassName specific jar.
-    descFilePath : str
+        the protobuf message name to look for in descriptor file, or
+        The Protobuf class name when descFilePath parameter is not set.
+        E.g. `com.example.protos.ExampleEvent`.
+    descFilePath : str, optional
         The protobuf descriptor file.
     options : dict, optional
         options to control how the protobuf record is parsed.
@@ -141,10 +142,16 @@ def to_protobuf(
     options: Optional[Dict[str, str]] = None,
 ) -> Column:
     """
-    Converts a column into binary of protobuf format. The specified Protobuf class must match the
-    data, otherwise the behavior is undefined: it may fail or return arbitrary result. The jar
-    containing Java class should be shaded. Specifically, ``com.google.protobuf.*`` should be
-    shaded to ``org.sparkproject.spark-protobuf.protobuf.*``.
+    Converts a column into binary of protobuf format. The Protobuf definition is provided in one
+    of these two ways:
+
+       - Protobuf descriptor file: E.g. a descriptor file created with
+          `protoc --include_imports --descriptor_set_out=abc.desc abc.proto`
+       - Jar containing Protobuf Java class: The jar containing Java class should be shaded.
+         Specifically, `com.google.protobuf.*` should be shaded to
+         `org.sparkproject.spark-protobuf.protobuf.*`.
+         https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
+         Protobuf files. The jar file can be added with spark-submit option --jars.
 
     .. versionadded:: 3.4.0
 
@@ -153,12 +160,12 @@ def to_protobuf(
     data : :class:`~pyspark.sql.Column` or str
         the data column.
     messageName: str, optional
-        the protobuf message name to look for in descriptor file. Or
-        The Protobuf class name. E.g. ``org.spark.examples.protobuf.ExampleEvent``,
-        without descFilePath parameter.
-        Using the spark-submit option --jars, add a messageClassName specific jar.
-    descFilePath : str
+        the protobuf message name to look for in descriptor file, or
+        The Protobuf class name when descFilePath parameter is not set.
+        E.g. `com.example.protos.ExampleEvent`.
+    descFilePath : str, optional
         the Protobuf descriptor file.
+    options : dict, optional
 
     Notes
     -----


### PR DESCRIPTION


This adds missing options for Protobuf functions in both Scala & Python. We should be able to pass options for both `from_protobuf()` and `to_protobuf()`. 
This PR fixes various gaps: 
 
 - In Scala `to_protobuf()` didn't have a way to pass options.
 - In Scala `from_protobuf()` that takes Java class name didn't allow options. 
 - In Python, `from_protobuf()` that uses Java class name didn't propagate options.
 - In Python `to_protobuf()` didn't pass options.


### Why are the changes needed?

Options are important part of how Protobuf functions behave (e.g. we need to set recursive depth). We need to be able to pass them.

### Does this PR introduce _any_ user-facing change?

No. 

### How was this patch tested?
- Existing tests.