### PR TITLE
[SPARK-42047][SPARK-41900][CONNECT][PYTHON] Literal should support Numpy datatypes

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -59,7 +59,7 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     def test_lit_list(self):
         super().test_lit_list()
 
-    # TODO(SPARK-41900): support Data Type int8
+    # TODO(SPARK-41283): Different column names of `lit(np.int8(1))`
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_lit_np_scalar(self):
         super().test_lit_np_scalar()
@@ -78,11 +78,6 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_nested_higher_order_function(self):
         super().test_nested_higher_order_function()
-
-    # TODO(SPARK-41900): support Data Type int8
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_np_scalar_input(self):
-        super().test_np_scalar_input()
 
     # TODO(SPARK-41901): Parity in String representation of Column
     @unittest.skip("Fails in Spark Connect, should enable.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `Literal` support numpy datatypes


### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
enabled tests
