### PR TITLE
[SPARK-42055][BUILD] Upgrade scalatest-maven-plugin to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
     <commons.collections4.version>4.4</commons.collections4.version>
     <scala.version>2.12.17</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scalatest-maven-plugin.version>2.1.0</scalatest-maven-plugin.version>
+    <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
     <!--
       This needs to be managed in different profiles to avoid
       errors building different Hadoop versions.


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade scalatest-maven-plugin from 2.1.0 to 2.2.0

### Why are the changes needed?
Release notes: https://github.com/scalatest/scalatest-maven-plugin/releases/tag/release-2.2.0
<img width="513" alt="image" src="https://user-images.githubusercontent.com/15246973/212302923-c534de0d-f3a3-4e7d-9b11-5b92782552e4.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.