### PR TITLE
[SPARK-42051][SQL] Codegen Support for HiveGenericUDF

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -156,7 +156,7 @@ private[hive] case class HiveGenericUDF(
 
   // Visible for codegen
   @transient
-  lazy val unwrapper = unwrapperFor(returnInspector)
+  lazy val unwrapper: Any => Any = unwrapperFor(returnInspector)
 
   @transient
   private lazy val isUDFDeterministic = {
@@ -166,8 +166,8 @@ private[hive] case class HiveGenericUDF(
 
   // Visible for codegen
   @transient
-  lazy val deferredObjects = argumentInspectors.zip(children).map { case (inspect, child) =>
-    new DeferredObjectAdapter(inspect, child.dataType)
+  lazy val deferredObjects: Array[DeferredObject] = argumentInspectors.zip(children).map {
+    case (inspect, child) => new DeferredObjectAdapter(inspect, child.dataType)
   }.toArray[DeferredObject]
 
   override lazy val dataType: DataType = inspectorToDataType(returnInspector)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -207,7 +207,6 @@ private[hive] case class HiveGenericUDF(
            |} else {
            |  (($deferredObjectAdapterClz) $refTerm.deferredObjects()[$i]).set(${eval.value});
            |}
-           |
            |""".stripMargin
     }
 
@@ -216,9 +215,7 @@ private[hive] case class HiveGenericUDF(
     ev.copy(code =
       code"""
          |${childrenEvals.map(_.code).mkString("\n")}
-         |
          |${setDeferredObjects.mkString("\n")}
-         |
          |$resultType $resultTerm = null;
          |boolean ${ev.isNull} = false;
          |try {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -211,7 +211,7 @@ private[hive] case class HiveGenericUDF(
            |""".stripMargin
     }
 
-    val resultType = CodeGenerator.javaType(dataType)
+    val resultType = CodeGenerator.boxedType(dataType)
     ev.copy(code =
       code"""
          |${childrenEvals.map(_.code).mkString("\n")}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -35,7 +35,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, CodegenFallback, ExprCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 import org.apache.spark.sql.hive.HiveShim._
 import org.apache.spark.sql.types._
 
@@ -128,11 +129,10 @@ private[hive] class DeferredObjectAdapter(oi: ObjectInspector, dataType: DataTyp
   override def get(): AnyRef = wrapper(func()).asInstanceOf[AnyRef]
 }
 
-private[hive] case class HiveGenericUDF(
+case class HiveGenericUDF(
     name: String, funcWrapper: HiveFunctionWrapper, children: Seq[Expression])
   extends Expression
   with HiveInspectors
-  with CodegenFallback
   with Logging
   with UserDefinedExpression {
 
@@ -154,8 +154,9 @@ private[hive] case class HiveGenericUDF(
     function.initializeAndFoldConstants(argumentInspectors.toArray)
   }
 
+  // Visible for codegen
   @transient
-  private lazy val unwrapper = unwrapperFor(returnInspector)
+  lazy val unwrapper = unwrapperFor(returnInspector)
 
   @transient
   private lazy val isUDFDeterministic = {
@@ -163,10 +164,13 @@ private[hive] case class HiveGenericUDF(
     udfType != null && udfType.deterministic() && !udfType.stateful()
   }
 
+  // Visible for codegen
   @transient
-  private lazy val deferredObjects = argumentInspectors.zip(children).map { case (inspect, child) =>
-    new DeferredObjectAdapter(inspect, child.dataType)
-  }.toArray[DeferredObject]
+  lazy val deferredObjects = {
+    argumentInspectors.zip(children).map { case (inspect, child) =>
+      new DeferredObjectAdapter(inspect, child.dataType)
+    }.toArray[DeferredObject]
+  }
 
   override lazy val dataType: DataType = inspectorToDataType(returnInspector)
 
@@ -192,6 +196,49 @@ private[hive] case class HiveGenericUDF(
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
     copy(children = newChildren)
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val refTerm = ctx.addReferenceObj("this", this)
+    val childrenEvals = children.map(_.genCode(ctx))
+
+    val setDeferredObjects = childrenEvals.zipWithIndex.zip(children.map(_.dataType)).map {
+      case ((eval, i), dt) =>
+        val funcTerm = ctx.freshName("func")
+        val ft = CodeGenerator.boxedType(dt)
+        val deferredObjectAdapterClz = classOf[DeferredObjectAdapter].getCanonicalName
+        s"""
+           |scala.Function0<$ft> $funcTerm = new scala.Function0() {
+           |  @Override
+           |  public $ft apply() {
+           |    return ${eval.isNull} ? null : ${eval.value};
+           |  }
+           |};
+           |(($deferredObjectAdapterClz) $refTerm.deferredObjects()[$i]).set($funcTerm);
+           |""".stripMargin
+    }
+
+    val resultType = CodeGenerator.javaType(dataType)
+    ev.copy(code =
+      code"""
+         |${childrenEvals.map(_.code).mkString("\n")}
+         |
+         |${setDeferredObjects.mkString("\n")}
+         |
+         |$resultType ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
+         |boolean ${ev.isNull} = false;
+         |try {
+         |  ${ev.value} = ($resultType) $refTerm.unwrapper().apply(
+         |    $refTerm.function().evaluate($refTerm.deferredObjects()));
+         |  ${ev.isNull} = ${ev.value} == null;
+         |} catch (Throwable e) {
+         |  throw QueryExecutionErrors.failedExecuteUserDefinedFunctionError(
+         |    "${funcWrapper.functionClassName}",
+         |    "${children.map(_.dataType.catalogString).mkString(", ")}",
+         |    "${dataType.catalogString}",
+         |    e);
+         |}
+         |""".stripMargin
+    )
+  }
 }
 
 /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -166,10 +166,9 @@ case class HiveGenericUDF(
 
   // Visible for codegen
   @transient
-  lazy val deferredObjects =
-    argumentInspectors.zip(children).map { case (inspect, child) =>
-      new DeferredObjectAdapter(inspect, child.dataType)
-    }.toArray[DeferredObject]
+  lazy val deferredObjects = argumentInspectors.zip(children).map { case (inspect, child) =>
+    new DeferredObjectAdapter(inspect, child.dataType)
+  }.toArray[DeferredObject]
 
   override lazy val dataType: DataType = inspectorToDataType(returnInspector)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -166,11 +166,10 @@ case class HiveGenericUDF(
 
   // Visible for codegen
   @transient
-  lazy val deferredObjects = {
+  lazy val deferredObjects =
     argumentInspectors.zip(children).map { case (inspect, child) =>
       new DeferredObjectAdapter(inspect, child.dataType)
     }.toArray[DeferredObject]
-  }
 
   override lazy val dataType: DataType = inspectorToDataType(returnInspector)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -198,8 +198,8 @@ private[hive] case class HiveGenericUDF(
     val refTerm = ctx.addReferenceObj("this", this)
     val childrenEvals = children.map(_.genCode(ctx))
 
-    val setDeferredObjects = childrenEvals.zipWithIndex.zip(children.map(_.dataType)).map {
-      case ((eval, i), dt) =>
+    val setDeferredObjects = childrenEvals.zipWithIndex.map {
+      case (eval, i) =>
         val deferredObjectAdapterClz = classOf[DeferredObjectAdapter].getCanonicalName
         s"""
            |if (${eval.isNull}) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -716,10 +716,13 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
   test("SPARK-42051: HiveGenericUDF Codegen Support") {
     withUserDefinedFunction("CodeGenHiveGenericUDF" -> false) {
       sql(s"CREATE FUNCTION CodeGenHiveGenericUDF AS '${classOf[GenericUDFMaskHash].getName}'")
-      val df = sql("SELECT CodeGenHiveGenericUDF('Spark SQL')")
-      val plan = df.queryExecution.executedPlan
-      assert(plan.isInstanceOf[WholeStageCodegenExec])
-      checkAnswer(df, Seq(Row("14ab8df5135825bc9f5ff7c30609f02f")))
+      withTable("CodeGenHiveGenericUDF") {
+        sql(s"create table HiveGenericUDFTable as select 'Spark SQL' as v")
+        val df = sql("SELECT CodeGenHiveGenericUDF(v) from HiveGenericUDFTable")
+        val plan = df.queryExecution.executedPlan
+        assert(plan.isInstanceOf[WholeStageCodegenExec])
+        checkAnswer(df, Seq(Row("14ab8df5135825bc9f5ff7c30609f02f")))
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

As a subtask of SPARK-42050, this PR adds Codegen Support for `HiveGenericUDF`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

improve codegen coverage and performance

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new UT added
