### PR TITLE
[SPARK-41964][CONNECT][PYTHON][FOLLOW-UP] Fix the jdbc writer not implemented Test

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2501,9 +2501,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             with self.assertRaises(NotImplementedError):
                 getattr(self.connect.read, f)()
 
-        for f in ("jdbc",):
-            with self.assertRaises(NotImplementedError):
-                getattr(self.df_text.write, f)()
+        with self.assertRaises(NotImplementedError):
+            self.df_text.write.jdbc("url", "table")
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2503,7 +2503,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         for f in ("jdbc",):
             with self.assertRaises(NotImplementedError):
-                getattr(self.connect.read, f)()
+                getattr(self.df_text.write, f)()
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2496,13 +2496,15 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
     def test_unsupported_io_functions(self):
         # SPARK-41964: Disable unsupported functions.
         # DataFrameWriterV2 is also not implemented yet
+        df = self.connect.createDataFrame([(x, f"{x}") for x in range(100)], ["id", "name"])
 
         for f in ("csv", "orc", "jdbc"):
             with self.assertRaises(NotImplementedError):
                 getattr(self.connect.read, f)()
 
-        with self.assertRaises(NotImplementedError):
-            self.df_text.write.jdbc("url", "table")
+        for f in ("jdbc",):
+            with self.assertRaises(NotImplementedError):
+                getattr(df.write, f)()
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the `jdbc` Writer function not implemented test


### Why are the changes needed?
Fixing a test


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing Test