### PR TITLE
Patched()Fix Protobuf Java vulnerable to Uncontrolled Resource Consumption

### DIFF
--- a/connector/kinesis-asl-assembly/pom.xml
+++ b/connector/kinesis-asl-assembly/pom.xml
@@ -62,11 +62,11 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.6.1</version>
+      <version>3.16.3</version>
       <!-- 
          We are being explicit about version here and overriding the 
          spark default of 2.5.0 because KCL appears to have introduced 
-         a dependency on protobuf 2.6.1 somewhere between KCL 1.4.0 and 1.6.1.
+         a dependency on protobuf 3.16.3 somewhere between KCL 1.4.0 and 1.6.1.
        -->
     </dependency>
     <dependency>


### PR DESCRIPTION
## Changes:
Affected of this `apache-spark` are vulnerable to Denial of Service (DoS) when providing inputs containing multiple instances of non-repeated embedded messages, with repeated or unknown fields. The vulnerability exists due to a parsing issue in the Message-Type Extensions. Exploiting this vulnerability causes objects to be converted back and forth between mutable and immutable forms, resulting in potentially long garbage collection pauses.

```java
          input.readGroup(field.getNumber(), builder.getFieldBuilder(field), extensionRegistry);
          return;
      if (defaultInstance != null) {
        subBuilder = defaultInstance.newBuilderForType();
      } else {
        subBuilder = builder.newBuilderForField(field);
    const char* name = upb_EnumValueDef_Name(ev);
      String name = value.getName();
      if (Character.isUpperCase(name.codePointAt(0))) {
```


## Operational Impact
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`