### PR TITLE
[SPARK-42012][CONNECT][PYTHON] Implement DataFrameReader.orc

### DIFF
--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -240,8 +240,27 @@ class DataFrameReader(OptionUtils):
     def csv(self, *args: Any, **kwargs: Any) -> None:
         raise NotImplementedError("csv() is not implemented.")
 
-    def orc(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError("orc() is not implemented.")
+    def orc(
+        self,
+        path: PathOrPaths,
+        mergeSchema: Optional[bool] = None,
+        pathGlobFilter: Optional[Union[bool, str]] = None,
+        recursiveFileLookup: Optional[Union[bool, str]] = None,
+        modifiedBefore: Optional[Union[bool, str]] = None,
+        modifiedAfter: Optional[Union[bool, str]] = None,
+    ) -> "DataFrame":
+        self._set_opts(
+            mergeSchema=mergeSchema,
+            pathGlobFilter=pathGlobFilter,
+            modifiedBefore=modifiedBefore,
+            modifiedAfter=modifiedAfter,
+            recursiveFileLookup=recursiveFileLookup,
+        )
+        if isinstance(path, str):
+            path = [path]
+        return self.load(path=path, format="orc")
+
+    orc.__doc__ = PySparkDataFrameReader.orc.__doc__
 
     def jdbc(self, *args: Any, **kwargs: Any) -> None:
         raise NotImplementedError("jdbc() not supported for DataFrameWriter")

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -761,6 +761,9 @@ class DataFrameReader(OptionUtils):
 
         .. versionadded:: 1.5.0
 
+        .. versionchanged:: 3.4.0
+            Support Spark Connect.
+
         Parameters
         ----------
         path : str or list

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -284,7 +284,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             )
 
     def test_orc(self):
-        # SPARK-42011: Implement DataFrameReader.csv
+        # SPARK-42012: Implement DataFrameReader.orc
         with tempfile.TemporaryDirectory() as d:
             # Write a DataFrame into a text file
             self.spark.createDataFrame(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR implements `DataFrameReader.orc` alias in Spark Connect.

### Why are the changes needed?
For API feature parity.

### Does this PR introduce any user-facing change?
This PR adds a user-facing API but Spark Connect has not been released yet.

### How was this patch tested?
Unittest was added.