### PR TITLE
[SPARK-41903][CONNECT][PYTHON] `Literal` should support 1-dim ndarray

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -69,11 +69,6 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     def test_map_functions(self):
         super().test_map_functions()
 
-    # TODO(SPARK-41903): Support data type ndarray
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_ndarray_input(self):
-        super().test_ndarray_input()
-
     # TODO(SPARK-41902): Parity in String representation of higher_order_function's output
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_nested_higher_order_function(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
`Literal` should support 1-dim ndarray


### Why are the changes needed?
parity

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
enabled UT