### PR TITLE
[SPARK-42064][SQL] Implement bloom filter join hint

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -127,7 +127,8 @@ object JoinStrategyHint {
     BROADCAST,
     SHUFFLE_MERGE,
     SHUFFLE_HASH,
-    SHUFFLE_REPLICATE_NL)
+    SHUFFLE_REPLICATE_NL,
+    BLOOM_FILTER_JOIN)
 }
 
 /**
@@ -169,6 +170,15 @@ case object SHUFFLE_REPLICATE_NL extends JoinStrategyHint {
   override def displayName: String = "shuffle_replicate_nl"
   override def hintAliases: Set[String] = Set(
     "SHUFFLE_REPLICATE_NL")
+}
+
+/**
+ * The hint for bloom filter join.
+ */
+case object BLOOM_FILTER_JOIN extends JoinStrategyHint {
+  override def displayName: String = "bloom_filter_join"
+  override def hintAliases: Set[String] = Set(
+    "BLOOM_FILTER_JOIN")
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -607,4 +607,13 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         "Missing or unexpected reused ReusedSubqueryExec in the plan")
     }
   }
+
+  test("SPARK-42064: bloom filter join hint") {
+    assertDidNotRewriteWithBloomFilter(
+      "SELECT * FROM bf1 JOIN bf2 ON bf1.c1 = bf2.c2")
+    assertRewroteWithBloomFilter(
+      "SELECT /*+ BLOOM_FILTER_JOIN(bf1) */ * FROM bf1 JOIN bf2 ON bf1.c1 = bf2.c2")
+    assertRewroteWithBloomFilter(
+      "SELECT /*+ BLOOM_FILTER_JOIN(bf2) */ * FROM bf1 JOIN bf2 ON bf1.c1 = bf2.c2")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements the bloom filter join hint. Usage:
```sql
SELECT /*+ BLOOM_FILTER_JOIN(bf1) */ * FROM records r JOIN src s ON r.key = s.key
```

### Why are the changes needed?

To improve the following cases:


Before | After this PR and use bloom filter join hint
-- | --
<img src="https://user-images.githubusercontent.com/5399861/212473884-9585f3b6-e103-4781-af10-7178ccd10f2b.png" width="200" height="730"> | <img src="https://user-images.githubusercontent.com/5399861/212590818-9d219fbf-61aa-444a-aa51-019855d4cb61.png" width="200" height="730">


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.