### PR TITLE
[SPARK-42065][PYTHON][CONNECT][TESTS] Remove duplicated `test_freqItems` test

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -331,24 +331,6 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         self.assertEqual(plan.root.freq_items.cols, ["col_a", "col_b"])
         self.assertEqual(plan.root.freq_items.support, 0.01)
 
-    def test_freqItems(self):
-        df = self.connect.readTable(table_name=self.tbl_name)
-        plan = (
-            df.filter(df.col_name > 3).freqItems(["col_a", "col_b"], 1)._plan.to_proto(self.connect)
-        )
-        self.assertEqual(plan.root.freq_items.cols, ["col_a", "col_b"])
-        self.assertEqual(plan.root.freq_items.support, 1)
-        plan = df.filter(df.col_name > 3).freqItems(["col_a", "col_b"])._plan.to_proto(self.connect)
-        self.assertEqual(plan.root.freq_items.cols, ["col_a", "col_b"])
-        self.assertEqual(plan.root.freq_items.support, 0.01)
-
-        plan = df.stat.freqItems(["col_a", "col_b"], 1)._plan.to_proto(self.connect)
-        self.assertEqual(plan.root.freq_items.cols, ["col_a", "col_b"])
-        self.assertEqual(plan.root.freq_items.support, 1)
-        plan = df.stat.freqItems(["col_a", "col_b"])._plan.to_proto(self.connect)
-        self.assertEqual(plan.root.freq_items.cols, ["col_a", "col_b"])
-        self.assertEqual(plan.root.freq_items.support, 0.01)
-
     def test_limit(self):
         df = self.connect.readTable(table_name=self.tbl_name)
         limit_plan = df.limit(10)._plan.to_proto(self.connect)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove one of the `test_freqItems` functions.

### Why are the changes needed?
The same code have be copied.

https://github.com/apache/spark/blob/e6c01cedbecebdc40863e552862beee1bd959710/python/pyspark/sql/tests/connect/test_connect_plan.py#L316

https://github.com/apache/spark/blob/e6c01cedbecebdc40863e552862beee1bd959710/python/pyspark/sql/tests/connect/test_connect_plan.py#L334

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA 
