### PR TITLE
[SPARK-42067][CONNECT][BUILD] Upgrade buf from 1.11.0 to 1.12.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -561,7 +561,7 @@ jobs:
     - name: Install dependencies for Python code generation check
       run: |
         # See more in "Installation" https://docs.buf.build/installation#tarball
-        curl -LO https://github.com/bufbuild/buf/releases/download/v1.11.0/buf-Linux-x86_64.tar.gz
+        curl -LO https://github.com/bufbuild/buf/releases/download/v1.12.0/buf-Linux-x86_64.tar.gz
         mkdir -p $HOME/buf
         tar -xvzf buf-Linux-x86_64.tar.gz -C $HOME/buf --strip-components 1
     - name: Install R linter dependencies and SparkR

--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -120,7 +120,7 @@ Prerequisite
 
 PySpark development requires to build Spark that needs a proper JDK installed, etc. See `Building Spark <https://spark.apache.org/docs/latest/building-spark.html>`_ for more details.
 
-Note that if you intend to contribute to Spark Connect in Python, ``buf`` version ``1.11.0`` is required, see `Buf Installation <https://docs.buf.build/installation>`_ for more details.
+Note that if you intend to contribute to Spark Connect in Python, ``buf`` version ``1.12.0`` is required, see `Buf Installation <https://docs.buf.build/installation>`_ for more details.
 
 Conda
 ~~~~~


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade buf from 1.11.0 to 1.12.0.

### Why are the changes needed?
Release Notes: https://github.com/bufbuild/buf/releases/tag/v1.12.0
<img width="884" alt="image" src="https://user-images.githubusercontent.com/15246973/212508672-de051696-367a-4d9c-9ccb-af64a66982c7.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existed UT.