### PR TITLE
[SPARK-42072][CORE] `core` module requires `javax.servlet-api`

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -618,6 +618,8 @@ object Core {
   def buildenv = Process(Seq("uname")).!!.trim.replaceFirst("[^A-Za-z0-9].*", "").toLowerCase
   def bashpath = Process(Seq("where", "bash")).!!.split("[\r\n]+").head.replace('\\', '/')
   lazy val settings = Seq(
+    excludeDependencies --= Seq(
+      ExclusionRule("javax.servlet", "javax.servlet-api")),
     // Setting version for the protobuf compiler. This has to be propagated to every sub-project
     // even if the project is not using it.
     PB.protocVersion := BuildCommons.protoVersion,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `javax.servlet-api` from the exclusion list.

We exclude `servlet-api` globally.
https://github.com/apache/spark/blob/5f17a400a19e311a388d51dd7e1929ac02101c0f/project/SparkBuild.scala#L1092

And, add back it in `YARN` module.
https://github.com/apache/spark/blob/5f17a400a19e311a388d51dd7e1929ac02101c0f/project/SparkBuild.scala#L1207-L1209

### Why are the changes needed?

Currently, SBT build is broken.
```
$ build/sbt "core/test"
...
[error] 100 errors found
[error] (core / Test / compileIncremental) Compilation failed
[error] Total time: 34 s, completed Jan 15, 2023 3:52:43 AM
```

### Does this PR introduce _any_ user-facing change?

To recover Apache Spark 3.4 SBT build.

### How was this patch tested?

Pass the CIs and manual test.
```
$ build/sbt "core/test"
```