### PR TITLE
[SPARK-42011][SPARK-42012][CONNECT][PYTHON][TESTS][FOLLOW-UP] Enable csv, orc tests in connect/test_parity_datasources.py

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -439,9 +439,6 @@ def _test() -> None:
             .getOrCreate()
         )
 
-        # Spark Connect has a different string representation for Column.
-        del pyspark.sql.connect.column.Column.getItem.__doc__
-
         # TODO(SPARK-41772): Enable pyspark.sql.connect.column.Column.withField doctest
         del pyspark.sql.connect.column.Column.withField.__doc__
 

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -616,12 +616,8 @@ def _test() -> None:
         globs = pyspark.sql.connect.readwriter.__dict__.copy()
 
         # TODO(SPARK-41817): Support reading with schema
-        del pyspark.sql.connect.readwriter.DataFrameReader.load.__doc__
         del pyspark.sql.connect.readwriter.DataFrameReader.option.__doc__
-        del pyspark.sql.connect.readwriter.DataFrameReader.text.__doc__
-        del pyspark.sql.connect.readwriter.DataFrameWriter.csv.__doc__
         del pyspark.sql.connect.readwriter.DataFrameWriter.option.__doc__
-        del pyspark.sql.connect.readwriter.DataFrameWriter.text.__doc__
         del pyspark.sql.connect.readwriter.DataFrameWriter.bucketBy.__doc__
         del pyspark.sql.connect.readwriter.DataFrameWriter.sortBy.__doc__
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -506,7 +506,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         --------
         >>> df = spark.createDataFrame([(2, "Alice"), (5, "Bob")], schema=["age", "name"])
         >>> type(df.write)
-        <class 'pyspark.sql.readwriter.DataFrameWriter'>
+        <class '...readwriter.DataFrameWriter'>
 
         Write the DataFrame as a table.
 

--- a/python/pyspark/sql/tests/connect/test_parity_datasources.py
+++ b/python/pyspark/sql/tests/connect/test_parity_datasources.py
@@ -23,11 +23,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 class DataSourcesParityTests(DataSourcesTestsMixin, ReusedConnectTestCase):
 
-    # TODO(SPARK-42011): Implement DataFrameReader.csv
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_checking_csv_header(self):
-        super().test_checking_csv_header()
-
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_csv_sampling_ratio(self):
         super().test_csv_sampling_ratio()
@@ -35,16 +30,6 @@ class DataSourcesParityTests(DataSourcesTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_json_sampling_ratio(self):
         super().test_json_sampling_ratio()
-
-    # TODO(SPARK-42011): Implement DataFrameReader.csv
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_multiline_csv(self):
-        super().test_multiline_csv()
-
-    # TODO(SPARK-42012): Implement DataFrameReader.orc
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_read_multiple_orc_file(self):
-        super().test_read_multiple_orc_file()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_datasources.py
+++ b/python/pyspark/sql/tests/connect/test_parity_datasources.py
@@ -22,7 +22,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class DataSourcesParityTests(DataSourcesTestsMixin, ReusedConnectTestCase):
-
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_csv_sampling_ratio(self):
         super().test_csv_sampling_ratio()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable csv, orc tests in connect/test_parity_datasources.py


### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
enabled UT