### PR TITLE
[SPARK-42074][SQL] Enable `KryoSerializer` in `TPCDSQueryBenchmark` to enforce SQL class registration

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -57,6 +57,8 @@ object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
       .set("spark.executor.memory", "3g")
       .set("spark.sql.autoBroadcastJoinThreshold", (20 * 1024 * 1024).toString)
       .set("spark.sql.crossJoin.enabled", "true")
+      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .set("spark.kryo.registrationRequired", "true")
 
     SparkSession.builder.config(conf).getOrCreate()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `KryoSerializer` in `TPCDSQueryBenchmark` to enforce build-in SQL class registration.

### Why are the changes needed?

GitHub Action CI will ensure that all new SQL related classes to be registered .

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. I also manually tested like the following.

```
$ build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.TPCDSQueryBenchmark --data-location /tmp/tpcds-sf-1"
...
[success] Total time: 2050 s (34:10), completed Jan 15, 2023 4:06:12 PM
```