### PR TITLE
[SPARK-42077][CONNECT][PYTHON] Literal should throw TypeError for unsupported DataType

### DIFF
--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -240,7 +240,7 @@ class LiteralExpression(Expression):
                 value = DayTimeIntervalType().toInternal(value)
                 assert value is not None
             else:
-                raise ValueError(f"Unsupported Data Type {dataType}")
+                raise TypeError(f"Unsupported Data Type {dataType}")
 
         self._value = value
         self._dataType = dataType
@@ -277,7 +277,7 @@ class LiteralExpression(Expression):
                 dt = _from_numpy_type(value.dtype)
                 if dt is not None:
                     return dt
-            raise ValueError(f"Unsupported Data Type {type(value).__name__}")
+            raise TypeError(f"Unsupported Data Type {type(value).__name__}")
 
     @classmethod
     def _from_value(cls, value: Any) -> "LiteralExpression":

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -739,7 +739,7 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
     def test_uuid_literal(self):
 
         val = uuid.uuid4()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             lit(val)
 
     def test_column_literals(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `Literal` throw TypeError for unsupported DataType


### Why are the changes needed?
Literal should throw TypeError for unsupported DataType


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
updated UT
