### PR TITLE
[MINOR][CORE][TESTS] Suppress unchecked warnings in OneForOneStreamManagerSuite

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
@@ -98,6 +98,7 @@ public class OneForOneStreamManagerSuite {
     Assert.assertEquals(0, manager.numStreamStates());
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void streamStatesAreFreedWhenConnectionIsClosedEvenIfBufferIteratorThrowsException() {
     OneForOneStreamManager manager = new OneForOneStreamManager();
@@ -127,6 +128,7 @@ public class OneForOneStreamManagerSuite {
     Assert.assertEquals(0, manager.numStreamStates());
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void streamStatesAreFreeOrNotWhenConnectionIsClosed() {
     OneForOneStreamManager manager = new OneForOneStreamManager();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to suppress the two test code compilation warnings in `network-common` module.
```
[warn] /Users/dongjoon/APACHE/spark-merge/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java:105:1:  [unchecked] unchecked conversion
[warn]     Iterator<ManagedBuffer> buffers = Mockito.mock(Iterator.class);
[warn]                                                   ^  required: Iterator<ManagedBuffer>
[warn]   found:    Iterator
[warn] /Users/dongjoon/APACHE/spark-merge/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java:111:1:  [unchecked] unchecked conversion
[warn]     Iterator<ManagedBuffer> buffers2 = Mockito.mock(Iterator.class);
[warn]                                                    ^  required: Iterator<ManagedBuffer>
[warn]   found:    Iterator
```

### Why are the changes needed?

To suppress warnings in `network-common` directory.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually check the output with the following.
```
$ build/sbt "network-common/test"
```