### PR TITLE
[SPARK-42081][SQL] Improve the plan change validation

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1151,6 +1151,16 @@
     ],
     "sqlState" : "42K09"
   },
+  "PLAN_VALIDATION_FAILED_RULE_EXECUTOR" : {
+    "message" : [
+      "The input plan of <ruleExecutor> is invalid: <reason>"
+    ]
+  },
+  "PLAN_VALIDATION_FAILED_RULE_IN_BATCH" : {
+    "message" : [
+      "Rule <rule> in batch <batch> generated an invalid plan: <reason>"
+    ]
+  },
   "PROTOBUF_DEPENDENCY_NOT_FOUND" : {
     "message" : [
       "Could not find dependency: <dependencyName>."

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -4380,16 +4380,6 @@
       "<plan>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2173" : {
-    "message" : [
-      "The structural integrity of the input plan is broken in <className>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2174" : {
-    "message" : [
-      "After applying rule <ruleName> in batch <batchName>, the structural integrity of the plan is broken."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2175" : {
     "message" : [
       "Rule id not found for <ruleName>. Please modify RuleIdCollection.scala if you are adding a new rule."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -56,7 +56,6 @@ import org.apache.spark.sql.internal.connector.V1Function
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType.DAY
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, SchemaUtils}
-import org.apache.spark.util.Utils
 import org.apache.spark.util.collection.{Utils => CUtils}
 
 /**
@@ -191,13 +190,10 @@ class Analyzer(override val catalogManager: CatalogManager)
 
   private val v1SessionCatalog: SessionCatalog = catalogManager.v1SessionCatalog
 
-  override protected def isPlanIntegral(
+  override protected def validate(
       previousPlan: LogicalPlan,
-      currentPlan: LogicalPlan): Boolean = {
-    import org.apache.spark.sql.catalyst.util._
-    !Utils.isTesting || (LogicalPlanIntegrity.checkIfExprIdsAreGloballyUnique(currentPlan) &&
-      (!LogicalPlanIntegrity.canGetOutputAttrs(currentPlan) ||
-        !currentPlan.output.exists(_.qualifiedAccessOnly)))
+      currentPlan: LogicalPlan): Unit = {
+    LogicalPlanIntegrity.validateExprIdUniqueness(currentPlan)
   }
 
   override def isView(nameParts: Seq[String]): Boolean = v1SessionCatalog.isView(nameParts)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -190,9 +190,9 @@ class Analyzer(override val catalogManager: CatalogManager)
 
   private val v1SessionCatalog: SessionCatalog = catalogManager.v1SessionCatalog
 
-  override protected def validate(
+  override protected def validatePlanChanges(
       previousPlan: LogicalPlan,
-      currentPlan: LogicalPlan): Unit = {
+      currentPlan: LogicalPlan): Option[String] = {
     LogicalPlanIntegrity.validateExprIdUniqueness(currentPlan)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -43,9 +43,9 @@ import org.apache.spark.util.Utils
 abstract class Optimizer(catalogManager: CatalogManager)
   extends RuleExecutor[LogicalPlan] with SQLConfHelper {
 
-  override protected def validate(
+  override protected def validatePlanChanges(
       previousPlan: LogicalPlan,
-      currentPlan: LogicalPlan): Unit = {
+      currentPlan: LogicalPlan): Option[String] = {
     LogicalPlanIntegrity.validateOptimizedPlan(previousPlan, currentPlan)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -43,19 +43,10 @@ import org.apache.spark.util.Utils
 abstract class Optimizer(catalogManager: CatalogManager)
   extends RuleExecutor[LogicalPlan] with SQLConfHelper {
 
-  // Check for structural integrity of the plan in test mode.
-  // Currently we check after the execution of each rule if a plan:
-  // - is still resolved
-  // - only host special expressions in supported operators
-  // - has globally-unique attribute IDs
-  // - optimized plan have same schema with previous plan.
-  override protected def isPlanIntegral(
+  override protected def validate(
       previousPlan: LogicalPlan,
-      currentPlan: LogicalPlan): Boolean = {
-    !Utils.isTesting || (currentPlan.resolved &&
-      !currentPlan.exists(PlanHelper.specialExpressionsInUnsupportedOperator(_).nonEmpty) &&
-      LogicalPlanIntegrity.checkIfExprIdsAreGloballyUnique(currentPlan) &&
-      DataType.equalsIgnoreNullability(previousPlan.schema, currentPlan.schema))
+      currentPlan: LogicalPlan): Unit = {
+    LogicalPlanIntegrity.validateOptimizedPlan(previousPlan, currentPlan)
   }
 
   override protected val excludedOnceBatches: Set[String] =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -225,7 +225,7 @@ object LogicalPlanIntegrity {
   /**
    * Since some logical plans (e.g., `Union`) can build `AttributeReference`s in their `output`,
    * this method checks if the same `ExprId` refers to attributes having the same data type
-   * in plan output.
+   * in plan output. Returns the error message if the check does not pass.
    */
   def hasUniqueExprIdsForOutput(plan: LogicalPlan): Option[String] = {
     val exprIds = plan.collect { case p if canGetOutputAttrs(p) =>
@@ -259,15 +259,15 @@ object LogicalPlanIntegrity {
   /**
    * This method checks if reference `ExprId`s are not reused when assigning a new `ExprId`.
    * For example, it returns false if plan transformers create an alias having the same `ExprId`
-   * with one of reference attributes, e.g., `a#1 + 1 AS a#1`.
+   * with one of reference attributes, e.g., `a#1 + 1 AS a#1`. Returns the error message if the
+   * check does not pass.
    */
   def checkIfSameExprIdNotReused(plan: LogicalPlan): Option[String] = {
     plan.collectFirst { case p if p.resolved =>
       p.expressions.collectFirst {
         // Even if a plan is resolved, `a.references` can return unresolved references,
         // e.g., in `Grouping`/`GroupingID`, so we need to filter out them and
-        // check if the same `exprId` in `Alias` does not exist
-        // among reference `exprId`s.
+        // check if the same `exprId` in `Alias` does not exist among reference `exprId`s.
         case a: Alias if a.references.filter(_.resolved).map(_.exprId).exists(_ == a.exprId) =>
           "An alias reuses the same expression ID as previously present in an attribute, " +
             s"which is invalid: ${a.sql}. The plan tree:\n" + plan.treeString
@@ -278,7 +278,7 @@ object LogicalPlanIntegrity {
   /**
    * This method checks if the same `ExprId` refers to an unique attribute in a plan tree.
    * Some plan transformers (e.g., `RemoveNoopOperators`) rewrite logical
-   * plans based on this assumption.
+   * plans based on this assumption. Returns the error message if the check does not pass.
    */
   def validateExprIdUniqueness(plan: LogicalPlan): Option[String] = {
     LogicalPlanIntegrity.checkIfSameExprIdNotReused(plan).orElse(
@@ -291,7 +291,7 @@ object LogicalPlanIntegrity {
    * - is still resolved
    * - only host special expressions in supported operators
    * - has globally-unique attribute IDs
-   * - optimized plan have same schema with previous plan.
+   * - has the same result schema as the previous plan
    * - has no dangling attribute references
    */
   def validateOptimizedPlan(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.rules
 
-import org.apache.spark.{SparkException, SparkThrowableHelper}
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.trees.TreeNode
@@ -152,14 +152,14 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
   protected val excludedOnceBatches: Set[String] = Set.empty
 
   /**
-   * Defines a validate function that validates the plan after the execution of each rule, to make
-   * sure these rule still keep the structural integrity of the plan. For example, we can check
-   * whether a plan is still resolved after each rule in `Optimizer`, so we can catch rules that
-   * return invalid plans.
-   *
-   * Implementations should throw `SparkException.internalError`.
+   * Defines a validate function that validates the plan changes after the execution of each rule,
+   * to make sure these rules make valid changes to the plan. For example, we can check whether
+   * a plan is still resolved after each rule in `Optimizer`, so that we can catch rules that
+   * turn the plan into unresolved.
    */
-  protected def validate(previousPlan: TreeType, currentPlan: TreeType): Unit = {}
+  protected def validatePlanChanges(
+      previousPlan: TreeType,
+      currentPlan: TreeType): Option[String] = None
 
   /**
    * Util method for checking whether a plan remains the same if re-optimized.
@@ -194,14 +194,18 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
     val tracker: Option[QueryPlanningTracker] = QueryPlanningTracker.get
     val beforeMetrics = RuleExecutor.getCurrentMetrics()
 
-    // Validate the initial input
-    try {
-      validate(plan, plan)
-    } catch {
-      case e: SparkException if SparkThrowableHelper.isInternalError(e.getErrorClass) =>
-        val ruleExecutorName = this.getClass.getName.stripSuffix("$")
-        throw SparkException.internalError(
-          "The structural integrity of the input plan is broken in " + ruleExecutorName, e)
+    val enableValidation = SQLConf.get.getConf(SQLConf.PLAN_CHANGE_VALIDATION)
+    // Validate the initial input.
+    if (Utils.isTesting || enableValidation) {
+      validatePlanChanges(plan, plan) match {
+        case Some(msg) =>
+          val ruleExecutorName = this.getClass.getName.stripSuffix("$")
+          throw new SparkException(
+            errorClass = "PLAN_VALIDATION_FAILED_RULE_EXECUTOR",
+            messageParameters = Map("ruleExecutor" -> ruleExecutorName, "reason" -> msg),
+            cause = null)
+        case _ =>
+      }
     }
 
     batches.foreach { batch =>
@@ -223,24 +227,26 @@ abstract class RuleExecutor[TreeType <: TreeNode[_]] extends Logging {
               queryExecutionMetrics.incNumEffectiveExecution(rule.ruleName)
               queryExecutionMetrics.incTimeEffectiveExecutionBy(rule.ruleName, runTime)
               planChangeLogger.logRule(rule.ruleName, plan, result)
+              // Run the plan changes validation after each rule.
+              if (Utils.isTesting || enableValidation) {
+                validatePlanChanges(plan, result) match {
+                  case Some(msg) =>
+                    throw new SparkException(
+                      errorClass = "PLAN_VALIDATION_FAILED_RULE_IN_BATCH",
+                      messageParameters = Map(
+                        "rule" -> rule.ruleName,
+                        "batch" -> batch.name,
+                        "reason" -> msg),
+                      cause = null)
+                  case _ =>
+                }
+              }
             }
             queryExecutionMetrics.incExecutionTimeBy(rule.ruleName, runTime)
             queryExecutionMetrics.incNumExecution(rule.ruleName)
 
             // Record timing information using QueryPlanningTracker
             tracker.foreach(_.recordRuleInvocation(rule.ruleName, runTime, effective))
-
-            // Run the structural integrity checker against the plan after each rule.
-            if (effective) {
-              try {
-                validate(plan, result)
-              } catch {
-                case e: SparkException if SparkThrowableHelper.isInternalError(e.getErrorClass) =>
-                  throw SparkException.internalError(
-                  s"After applying rule ${rule.ruleName} in batch ${batch.name}, " +
-                    "the structural integrity of the plan is broken.", e)
-              }
-            }
 
             result
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1737,23 +1737,6 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "plan" -> sideBySide(plan.treeString, reOptimized.treeString).mkString("\n")))
   }
 
-  def structuralIntegrityOfInputPlanIsBrokenInClassError(
-      className: String): SparkRuntimeException = {
-    new SparkRuntimeException(
-      errorClass = "_LEGACY_ERROR_TEMP_2173",
-      messageParameters = Map(
-        "className" -> className))
-  }
-
-  def structuralIntegrityIsBrokenAfterApplyingRuleError(
-      ruleName: String, batchName: String): SparkRuntimeException = {
-    new SparkRuntimeException(
-      errorClass = "_LEGACY_ERROR_TEMP_2174",
-      messageParameters = Map(
-        "ruleName" -> ruleName,
-        "batchName" -> batchName))
-  }
-
   def ruleIdNotFoundForRuleError(ruleName: String): Throwable = {
     new SparkException(
       errorClass = "_LEGACY_ERROR_TEMP_2175",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -304,6 +304,14 @@ object SQLConf {
     .stringConf
     .createOptional
 
+  val PLAN_CHANGE_VALIDATION = buildConf("spark.sql.planChangeValidation")
+    .internal()
+    .doc("If true, Spark will validate all the plan changes made by analyzer/optimizer and other " +
+      "catalyst rules, to make sure every rule returns a valid plan")
+    .version("3.4.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val DYNAMIC_PARTITION_PRUNING_ENABLED =
     buildConf("spark.sql.optimizer.dynamicPartitionPruning.enabled")
       .doc("When true, we will generate predicate for partition column when it's used as join key")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerStructuralIntegrityCheckerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerStructuralIntegrityCheckerSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.{EmptyFunctionRegistry, FakeV2SessionCatalog, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -52,7 +53,7 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
   test("check for invalid plan after execution of rule - unresolved attribute") {
     val analyzed = Project(Alias(Literal(10), "attr")() :: Nil, OneRowRelation()).analyze
     assert(analyzed.resolved)
-    val message = intercept[RuntimeException] {
+    val message = intercept[SparkException] {
       Optimize.execute(analyzed)
     }.getMessage
     val ruleName = OptimizeRuleBreakSI.ruleName
@@ -67,7 +68,7 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
     assert(analyzed.resolved)
 
     // Should fail verification with the OptimizeRuleBreakSI rule
-    val message = intercept[RuntimeException] {
+    val message = intercept[SparkException] {
       Optimize.execute(analyzed)
     }.getMessage
     val ruleName = OptimizeRuleBreakSI.ruleName
@@ -85,7 +86,7 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
     val invalidPlan = OptimizeRuleBreakSI.apply(analyzed)
 
     // Should fail verification right at the beginning
-    val message = intercept[RuntimeException] {
+    val message = intercept[SparkException] {
       Optimize.execute(invalidPlan)
     }.getMessage
     assert(message.contains("The structural integrity of the input plan is broken"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerStructuralIntegrityCheckerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerStructuralIntegrityCheckerSuite.scala
@@ -57,8 +57,8 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
       Optimize.execute(analyzed)
     }.getMessage
     val ruleName = OptimizeRuleBreakSI.ruleName
-    assert(message.contains(s"After applying rule $ruleName in batch OptimizeRuleBreakSI"))
-    assert(message.contains("the structural integrity of the plan is broken"))
+    assert(message.contains(s"Rule $ruleName in batch OptimizeRuleBreakSI"))
+    assert(message.contains("generated an invalid plan"))
   }
 
   test("check for invalid plan after execution of rule - special expression in wrong operator") {
@@ -72,8 +72,8 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
       Optimize.execute(analyzed)
     }.getMessage
     val ruleName = OptimizeRuleBreakSI.ruleName
-    assert(message.contains(s"After applying rule $ruleName in batch OptimizeRuleBreakSI"))
-    assert(message.contains("the structural integrity of the plan is broken"))
+    assert(message.contains(s"Rule $ruleName in batch OptimizeRuleBreakSI"))
+    assert(message.contains("generated an invalid plan"))
 
     // Should not fail verification with the regular optimizer
     SimpleTestOptimizer.execute(analyzed)
@@ -89,6 +89,6 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
     val message = intercept[SparkException] {
       Optimize.execute(invalidPlan)
     }.getMessage
-    assert(message.contains("The structural integrity of the input plan is broken"))
+    assert(message.contains("The input plan of"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanIntegritySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlanIntegritySuite.scala
@@ -34,20 +34,20 @@ class LogicalPlanIntegritySuite extends PlanTest {
 
   test("Checks if the same `ExprId` refers to a semantically-equal attribute in a plan output") {
     val t = LocalRelation($"a".int, $"b".int)
-    assert(hasUniqueExprIdsForOutput(OutputTestPlan(t, t.output)))
-    assert(!hasUniqueExprIdsForOutput(OutputTestPlan(t, t.output.zipWithIndex.map {
+    assert(hasUniqueExprIdsForOutput(OutputTestPlan(t, t.output)).isEmpty)
+    assert(hasUniqueExprIdsForOutput(OutputTestPlan(t, t.output.zipWithIndex.map {
       case (a, i) => AttributeReference(s"c$i", LongType)(a.exprId)
-    })))
+    })).isDefined)
   }
 
   test("Checks if reference ExprIds are not reused when assigning a new ExprId") {
     val t = LocalRelation($"a".int, $"b".int)
     val Seq(a, b) = t.output
-    assert(checkIfSameExprIdNotReused(t.select(Alias(a + 1, "a")())))
-    assert(!checkIfSameExprIdNotReused(t.select(Alias(a + 1, "a")(exprId = a.exprId))))
-    assert(checkIfSameExprIdNotReused(t.select(Alias(a + 1, "a")(exprId = b.exprId))))
-    assert(checkIfSameExprIdNotReused(t.select(Alias(a + b, "ab")())))
-    assert(!checkIfSameExprIdNotReused(t.select(Alias(a + b, "ab")(exprId = a.exprId))))
-    assert(!checkIfSameExprIdNotReused(t.select(Alias(a + b, "ab")(exprId = b.exprId))))
+    assert(checkIfSameExprIdNotReused(t.select(Alias(a + 1, "a")())).isEmpty)
+    assert(checkIfSameExprIdNotReused(t.select(Alias(a + 1, "a")(exprId = a.exprId))).isDefined)
+    assert(checkIfSameExprIdNotReused(t.select(Alias(a + 1, "a")(exprId = b.exprId))).isEmpty)
+    assert(checkIfSameExprIdNotReused(t.select(Alias(a + b, "ab")())).isEmpty)
+    assert(checkIfSameExprIdNotReused(t.select(Alias(a + b, "ab")(exprId = a.exprId))).isDefined)
+    assert(checkIfSameExprIdNotReused(t.select(Alias(a + b, "ab")(exprId = b.exprId))).isDefined)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/RuleExecutorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/RuleExecutorSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.trees
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.catalyst.expressions.{Expression, IntegerLiteral, Literal}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 
@@ -71,43 +71,45 @@ class RuleExecutorSuite extends SparkFunSuite {
     assert(message.contains("Max iterations (10) reached for batch fixedPoint"))
   }
 
-  test("structural integrity checker - verify initial input") {
+  test("structural integrity validation - verify initial input") {
     object WithSIChecker extends RuleExecutor[Expression] {
-      override protected def isPlanIntegral(
+      override protected def validate(
           previousPlan: Expression,
-          currentPlan: Expression): Boolean = currentPlan match {
-        case IntegerLiteral(_) => true
-        case _ => false
+          currentPlan: Expression): Unit = currentPlan match {
+        case IntegerLiteral(_) =>
+        case _ => throw SparkException.internalError("not integer")
       }
       val batches = Batch("once", FixedPoint(1), DecrementLiterals) :: Nil
     }
 
     assert(WithSIChecker.execute(Literal(10)) === Literal(9))
 
-    val message = intercept[RuntimeException] {
+    val e = intercept[SparkException] {
       // The input is already invalid as determined by WithSIChecker.isPlanIntegral
       WithSIChecker.execute(Literal(10.1))
-    }.getMessage
-    assert(message.contains("The structural integrity of the input plan is broken"))
+    }
+    assert(e.getMessage.contains("The structural integrity of the input plan is broken"))
+    assert(e.getCause.getMessage.contains("not integer"))
   }
 
   test("structural integrity checker - verify rule execution result") {
     object WithSICheckerForPositiveLiteral extends RuleExecutor[Expression] {
-      override protected def isPlanIntegral(
+      override protected def validate(
           previousPlan: Expression,
-          currentPlan: Expression): Boolean = currentPlan match {
-        case IntegerLiteral(i) if i > 0 => true
-        case _ => false
+          currentPlan: Expression): Unit = currentPlan match {
+        case IntegerLiteral(i) if i > 0 =>
+        case _ => throw SparkException.internalError("not positive integer")
       }
       val batches = Batch("once", FixedPoint(1), DecrementLiterals) :: Nil
     }
 
     assert(WithSICheckerForPositiveLiteral.execute(Literal(2)) === Literal(1))
 
-    val message = intercept[RuntimeException] {
+    val e = intercept[SparkException] {
       WithSICheckerForPositiveLiteral.execute(Literal(1))
-    }.getMessage
-    assert(message.contains("the structural integrity of the plan is broken"))
+    }
+    assert(e.getMessage.contains("the structural integrity of the plan is broken"))
+    assert(e.getCause.getMessage.contains("not positive integer"))
   }
 
   test("SPARK-27243: dumpTimeSpent when no rule has run") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
@@ -19,10 +19,9 @@ package org.apache.spark.sql.execution.adaptive
 
 import org.apache.spark.sql.catalyst.analysis.UpdateAttributeNullability
 import org.apache.spark.sql.catalyst.optimizer.{ConvertToLocalRelation, EliminateLimits, OptimizeOneRowPlan}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, LogicalPlanIntegrity, PlanHelper}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, LogicalPlanIntegrity}
 import org.apache.spark.sql.catalyst.rules.{Rule, RuleExecutor}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.DataType
 import org.apache.spark.util.Utils
 
 /**
@@ -69,12 +68,9 @@ class AQEOptimizer(conf: SQLConf, extendedRuntimeOptimizerRules: Seq[Rule[Logica
     }
   }
 
-  override protected def isPlanIntegral(
+  override protected def validate(
       previousPlan: LogicalPlan,
-      currentPlan: LogicalPlan): Boolean = {
-    !Utils.isTesting || (currentPlan.resolved &&
-      !currentPlan.exists(PlanHelper.specialExpressionsInUnsupportedOperator(_).nonEmpty) &&
-      LogicalPlanIntegrity.checkIfExprIdsAreGloballyUnique(currentPlan) &&
-      DataType.equalsIgnoreNullability(previousPlan.schema, currentPlan.schema))
+      currentPlan: LogicalPlan): Unit = {
+    LogicalPlanIntegrity.validateOptimizedPlan(previousPlan, currentPlan)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
@@ -68,9 +68,9 @@ class AQEOptimizer(conf: SQLConf, extendedRuntimeOptimizerRules: Seq[Rule[Logica
     }
   }
 
-  override protected def validate(
+  override protected def validatePlanChanges(
       previousPlan: LogicalPlan,
-      currentPlan: LogicalPlan): Unit = {
+      currentPlan: LogicalPlan): Option[String] = {
     LogicalPlanIntegrity.validateOptimizedPlan(previousPlan, currentPlan)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Today, we validate the plan change after each rule execution, which is very useful to find issues in the rule. However, it has 2 problems:
1. it can only be used in the tests
2. it just returns a boolean, making it hard to known what's wrong with the rule

This PR addresses these 2 problems:
1. adds a new config to allow people to turn on it to debug production workloads
2. throws an exception immediately if a violation is found.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  4. If you fix a bug, you can clarify why it is a bug.
-->
To make it easier to debug queries using plan change validation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the new config is internal.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
updated tests