### PR TITLE
[SPARK-42087][SQL][TESTS] Use `--no-same-owner` when `HiveExternalCatalogVersionsSuite` untars

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -113,7 +113,8 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
         val targetDir = new File(sparkTestingDir, s"spark-$version").getCanonicalPath
 
         Seq("mkdir", targetDir).!
-        val exitCode = Seq("tar", "-xzf", downloaded, "-C", targetDir, "--strip-components=1").!
+        val exitCode = Seq("tar", "-xzf", downloaded, "-C", targetDir, "--strip-components=1",
+          "--no-same-owner").!
         Seq("rm", downloaded).!
 
         // For a corrupted file, `tar` returns non-zero values. However, we also need to check


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use a new parameter `--no-same-owner` when `HiveExternalCatalogVersionsSuite` untars

### Why are the changes needed?

**BEFORE**
```
root@edeccfee6d53:/spark# tar xfz spark-3.3.1-bin-hadoop3.tgz
root@edeccfee6d53:/spark# ls -al spark-3.3.1-bin-hadoop3
total 96
drwxr-xr-x  17 110302528 1000   544 Oct 15 10:32 .
drwxr-xr-x   4 root      root   128 Jan 16 07:30 ..
-rw-r--r--   1 root      root 22940 Oct 15 10:32 LICENSE
-rw-r--r--   1 root      root 57842 Oct 15 10:32 NOTICE
drwxr-xr-x   3 110302528 1000    96 Oct 15 10:32 R
-rw-r--r--   1 root      root  4461 Oct 15 10:32 README.md
-rw-r--r--   1 root      root   165 Oct 15 10:32 RELEASE
drwxr-xr-x  29 110302528 1000   928 Oct 15 10:32 bin
drwxr-xr-x   8 110302528 1000   256 Oct 15 10:32 conf
drwxr-xr-x   5 110302528 1000   160 Oct 15 10:32 data
drwxr-xr-x   4 110302528 1000   128 Oct 15 10:32 examples
drwxr-xr-x 250 110302528 1000  8000 Oct 15 10:32 jars
drwxr-xr-x   4 110302528 1000   128 Oct 15 10:32 kubernetes
drwxr-xr-x  60 110302528 1000  1920 Oct 15 10:32 licenses
drwxr-xr-x  19 110302528 1000   608 Oct 15 10:32 python
drwxr-xr-x  29 110302528 1000   928 Oct 15 10:32 sbin
drwxr-xr-x   3 110302528 1000    96 Oct 15 10:32 yarn
```

**AFTER**
```
root@edeccfee6d53:/spark# tar xfz spark-3.3.1-bin-hadoop3.tgz --no-same-owner
root@edeccfee6d53:/spark# ls -al spark-3.3.1-bin-hadoop3
total 96
drwxr-xr-x  17 root root   544 Oct 15 10:32 .
drwxr-xr-x   4 root root   128 Jan 16 07:34 ..
-rw-r--r--   1 root root 22940 Oct 15 10:32 LICENSE
-rw-r--r--   1 root root 57842 Oct 15 10:32 NOTICE
drwxr-xr-x   3 root root    96 Oct 15 10:32 R
-rw-r--r--   1 root root  4461 Oct 15 10:32 README.md
-rw-r--r--   1 root root   165 Oct 15 10:32 RELEASE
drwxr-xr-x  29 root root   928 Oct 15 10:32 bin
drwxr-xr-x   8 root root   256 Oct 15 10:32 conf
drwxr-xr-x   5 root root   160 Oct 15 10:32 data
drwxr-xr-x   4 root root   128 Oct 15 10:32 examples
drwxr-xr-x 250 root root  8000 Oct 15 10:32 jars
drwxr-xr-x   4 root root   128 Oct 15 10:32 kubernetes
drwxr-xr-x  60 root root  1920 Oct 15 10:32 licenses
drwxr-xr-x  19 root root   608 Oct 15 10:32 python
drwxr-xr-x  29 root root   928 Oct 15 10:32 sbin
drwxr-xr-x   3 root root    96 Oct 15 10:32 yarn
```

### Does this PR introduce _any_ user-facing change?

No. This is a test-only improvement.

### How was this patch tested?

Pass the CIs.