### PR TITLE
[SPARK-42021][CONNECT][PYTHON] Make `createDataFrame` support `array.array`

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -167,7 +167,7 @@ class SparkSession:
         infer_dict_as_struct = False
         infer_array_from_first_element = False
         prefer_timestamp_ntz = False
-        schema = reduce(
+        return reduce(
             _merge_type,
             (
                 _infer_schema(
@@ -180,9 +180,6 @@ class SparkSession:
                 for row in data
             ),
         )
-        if _has_nulltype(schema):
-            raise ValueError("Some of types cannot be determined after inferring")
-        return schema
 
     def createDataFrame(
         self,
@@ -299,9 +296,9 @@ class SparkSession:
                 # we need to convert it to [[1], [2], [3]] to be able to infer schema.
                 _data = [[d] for d in _data]
 
-            try:
-                _inferred_schema = self._inferSchemaFromList(_data, _cols)
-            except Exception:
+            _inferred_schema = self._inferSchemaFromList(_data, _cols)
+
+            if _has_nulltype(schema):
                 # For cases like createDataFrame([("Alice", None, 80.1)], schema)
                 # we can not infer the schema from the data itself.
                 warnings.warn("failed to infer the schema from data")

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -298,7 +298,7 @@ class SparkSession:
 
             _inferred_schema = self._inferSchemaFromList(_data, _cols)
 
-            if _has_nulltype(schema):
+            if _has_nulltype(_inferred_schema):
                 # For cases like createDataFrame([("Alice", None, 80.1)], schema)
                 # we can not infer the schema from the data itself.
                 warnings.warn("failed to infer the schema from data")

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -39,11 +39,6 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
     def test_apply_schema_with_udt(self):
         super().test_apply_schema_with_udt()
 
-    # TODO(SPARK-42021): createDataFrame with array.array
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_array_types(self):
-        super().test_array_types()
-
     # TODO(SPARK-42020): createDataFrame with UDT
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_cast_to_string_with_udt(self):
@@ -105,7 +100,7 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
     def test_infer_schema_not_enough_names(self):
         super().test_infer_schema_not_enough_names()
 
-    # TODO(SPARK-42021): createDataFrame with array.array
+    # TODO(SPARK-42020): createDataFrame with UDT
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_infer_schema_specification(self):
         super().test_infer_schema_specification()


### PR DESCRIPTION

### What changes were proposed in this pull request?
Make `createDataFrame` support `array.array`


### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
enabled UT and added UT
