### PR TITLE
[SPARK-42088][PYTHON][WINDOWS][BUILD] Improve setup.py adaptation for Windows

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -109,8 +109,7 @@ def _supports_symlinks():
         (not hasattr(ctypes, "windll"))  # Non-Windows
         or (
             # In some Windows, `os.symlink` works only for admins.
-            hasattr(ctypes, "windll")
-            and hasattr(ctypes.windll, "shell32")
+            hasattr(ctypes.windll, "shell32")
             and hasattr(ctypes.windll.shell32, "IsUserAnAdmin")
             and ctypes.windll.shell32.IsUserAnAdmin() != 0
         )

--- a/python/setup.py
+++ b/python/setup.py
@@ -105,7 +105,16 @@ in_spark = os.path.isfile("../core/src/main/scala/org/apache/spark/SparkContext.
 
 def _supports_symlinks():
     """Check if the system supports symlinks (e.g. *nix) or not."""
-    return getattr(os, "symlink", None) is not None and ctypes.windll.shell32.IsUserAnAdmin() != 0 if sys.platform == "win32" else True
+    return hasattr(os, "symlink") and (
+        (not hasattr(ctypes, "windll"))  # Non-Windows
+        or (
+            # In some Windows, `os.symlink` works only for admins.
+            hasattr(ctypes, "windll")
+            and hasattr(ctypes.windll, "shell32")
+            and hasattr(ctypes.windll.shell32, "IsUserAnAdmin")
+            and ctypes.windll.shell32.IsUserAnAdmin() != 0
+        )
+    )
 
 
 if in_spark:

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,6 +20,7 @@ import importlib.util
 import glob
 import os
 import sys
+import ctypes
 from setuptools import setup
 from setuptools.command.install import install
 from shutil import copyfile, copytree, rmtree
@@ -104,7 +105,7 @@ in_spark = os.path.isfile("../core/src/main/scala/org/apache/spark/SparkContext.
 
 def _supports_symlinks():
     """Check if the system supports symlinks (e.g. *nix) or not."""
-    return getattr(os, "symlink", None) is not None
+    return getattr(os, "symlink", None) is not None and ctypes.windll.shell32.IsUserAnAdmin() != 0 if sys.platform == "win32" else True
 
 
 if in_spark:

--- a/python/setup.py
+++ b/python/setup.py
@@ -111,7 +111,7 @@ def _supports_symlinks():
             # In some Windows, `os.symlink` works only for admins.
             hasattr(ctypes.windll, "shell32")
             and hasattr(ctypes.windll.shell32, "IsUserAnAdmin")
-            and ctypes.windll.shell32.IsUserAnAdmin() != 0
+            and bool(ctypes.windll.shell32.IsUserAnAdmin())
         )
     )
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -108,7 +108,7 @@ def _supports_symlinks():
     return hasattr(os, "symlink") and (
         (not hasattr(ctypes, "windll"))  # Non-Windows
         or (
-            # In some Windows, `os.symlink` works only for admins.
+            # In some Windows, `os.symlink` works but only for admins.
             hasattr(ctypes.windll, "shell32")
             and hasattr(ctypes.windll.shell32, "IsUserAnAdmin")
             and bool(ctypes.windll.shell32.IsUserAnAdmin())


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Update the supports symlinks method in setup.py

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

My system version is windows 10, and I can run setup.py with administrator permissions, so there will be no error. However, it may be troublesome for us to upgrade permissions with Windows Server, so we need to modify the code of setup.py to ensure no error. To avoid the hassle of compiling for the user, I suggest modifying the following code to enable the out-of-the-box effect

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?

Such an update would allow users to build spark without dealing with windows specific situations

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?

need to run setup.py with and without administrator permissions in windows to eventually build python packages properly

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
