### PR TITLE
when spark job had ran in k8s is finished ,it register to shutdown ho…

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -250,6 +250,8 @@ private[spark] class DiskBlockManager(
     Utils.getConfiguredLocalDirs(conf).flatMap { rootDir =>
       try {
         val localDir = Utils.createDirectory(rootDir, "blockmgr")
+        // SPARK-41946: to clearup remained dir.
+        ShutdownHookManager.registerShutdownDeleteDir(localDir)
         logInfo(s"Created local directory at $localDir")
         Some(localDir)
       } catch {


### PR DESCRIPTION
What changes were proposed in this pull request?
In k8s the host-path config to spark-local-dir ,Spark job clearup the shuffle tmp dirs when it is finished.

Why are the changes needed?
The shuffle data will filled the disks of tmp dirs.

Does this PR introduce any user-facing change?

How was this patch tested?
In yaml config:

```
driver:
    volumeMounts:
      - name: "spark-local-dir-1"
        mountPath: "/shuff/data"
executor:
    volumeMounts:
      - name: "spark-local-dir-1"
        mountPath: "/shuff/data"
```

