### PR TITLE
[SPARK-43450][SQL][TESTS] Add more `_metadata` filter test cases

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -1055,4 +1055,67 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
       assert(dfWithMetadata.queryExecution.optimizedPlan.exists(isTaggedRelation))
     }
   }
+
+  test("SPARK-43450: Filter on full _metadata column struct") {
+    withTempPath { dir =>
+      val numRows = 10
+      spark.range(end = numRows)
+        .toDF()
+        .write
+        .format("parquet")
+        .save(dir.getAbsolutePath)
+
+      // Get the metadata of a random row. The metadata is unique per row because of row_index.
+      val metadataColumnRow = spark.read.load(dir.getAbsolutePath)
+        .select("_metadata")
+        .collect()
+        .head
+        .getStruct(0)
+
+      // Transform the result into a literal that can be used in an expression.
+      val metadataColumnFields = metadataColumnRow.schema.fields
+        .map(field => lit(metadataColumnRow.getAs[Any](field.name)).as(field.name))
+      val metadataColumnStruct = struct(metadataColumnFields: _*)
+
+      val selectSingleRowDf = spark.read.load(dir.getAbsolutePath)
+        .where(col("_metadata").equalTo(lit(metadataColumnStruct)))
+
+      assert(selectSingleRowDf.count() === 1)
+    }
+  }
+
+  test("SPARK-43450: Is not null filter on _metadata column") {
+    withTempPath { dir =>
+      val numRows = 10
+      spark.range(start = 0, end = numRows, step = 1, numPartitions = 1)
+        .toDF()
+        .write
+        .format("parquet")
+        .save(dir.getAbsolutePath)
+
+      // There is only one file, so we will select all rows.
+      val selectAllDf = spark.read.load(dir.getAbsolutePath)
+        .where(not(isnull(col("_metadata"))))
+
+      assert(selectAllDf.count() === numRows)
+    }
+  }
+
+  test("SPARK-43450: Filter on aliased _metadata.row_index") {
+    withTempPath { dir =>
+      val numRows = 10
+      spark.range(start = 0, end = numRows, step = 1, numPartitions = 1)
+        .toDF()
+        .write
+        .format("parquet")
+        .save(dir.getAbsolutePath)
+
+      // There is only one file, so row_index is unique.
+      val selectSingleRowDf = spark.read.load(dir.getAbsolutePath)
+        .select(col("_metadata"), col("_metadata.row_index").as("renamed_row_index"))
+        .where(col("renamed_row_index").equalTo(lit(0)))
+
+      assert(selectSingleRowDf.count() === 1)
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add additional tests for metadata filters following up after f0a901058aaec8496ec9426c5811d9dea66c195d


### Why are the changes needed?

To cover more edge cases in testing

### Does this PR introduce _any_ user-facing change?

 No

### How was this patch tested?

-