### PR TITLE
[SPARK-41708][SQL][FOLLOWUP]  Override `toString` method of `FileIndex`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
@@ -82,4 +82,6 @@ trait FileIndex {
    * to update the metrics.
    */
   def metadataOpsTimeNs: Option[Long] = None
+
+  override def toString: String = s"${getClass.getName}(${rootPaths.mkString(",")})"
 }

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -1086,20 +1086,20 @@ struct<plan:string>
    +- 'UnresolvedRelation [explain_temp4], [], false
 
 == Analyzed Logical Plan ==
-InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex, [key, val]
+InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- Project [key#x, val#x]
    +- SubqueryAlias spark_catalog.default.explain_temp4
       +- Relation spark_catalog.default.explain_temp4[key#x,val#x] parquet
 
 == Optimized Logical Plan ==
-InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex, [key, val]
+InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- WriteFiles
    +- Sort [val#x ASC NULLS FIRST], false
       +- Project [key#x, empty2null(val#x) AS val#x]
          +- Relation spark_catalog.default.explain_temp4[key#x,val#x] parquet
 
 == Physical Plan ==
-Execute InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex, [key, val]
+Execute InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- WriteFiles
    +- *Sort [val#x ASC NULLS FIRST], false, 0
       +- *Project [key#x, empty2null(val#x) AS val#x]

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -1086,20 +1086,20 @@ struct<plan:string>
    +- 'UnresolvedRelation [explain_temp4], [], false
 
 == Analyzed Logical Plan ==
-InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
+InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=file:[not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(file:[not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- Project [key#x, val#x]
    +- SubqueryAlias spark_catalog.default.explain_temp4
       +- Relation spark_catalog.default.explain_temp4[key#x,val#x] parquet
 
 == Optimized Logical Plan ==
-InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
+InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=file:[not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(file:[not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- WriteFiles
    +- Sort [val#x ASC NULLS FIRST], false
       +- Project [key#x, empty2null(val#x) AS val#x]
          +- Relation spark_catalog.default.explain_temp4[key#x,val#x] parquet
 
 == Physical Plan ==
-Execute InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
+Execute InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=file:[not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(file:[not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- WriteFiles
    +- *Sort [val#x ASC NULLS FIRST], false, 0
       +- *Project [key#x, empty2null(val#x) AS val#x]

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -1028,20 +1028,20 @@ struct<plan:string>
    +- 'UnresolvedRelation [explain_temp4], [], false
 
 == Analyzed Logical Plan ==
-InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
+InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=file:[not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(file:[not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- Project [key#x, val#x]
    +- SubqueryAlias spark_catalog.default.explain_temp4
       +- Relation spark_catalog.default.explain_temp4[key#x,val#x] parquet
 
 == Optimized Logical Plan ==
-InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
+InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=file:[not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(file:[not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- WriteFiles
    +- Sort [val#x ASC NULLS FIRST], false
       +- Project [key#x, empty2null(val#x) AS val#x]
          +- Relation spark_catalog.default.explain_temp4[key#x,val#x] parquet
 
 == Physical Plan ==
-Execute InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
+Execute InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=file:[not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(file:[not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- WriteFiles
    +- *Sort [val#x ASC NULLS FIRST], false, 0
       +- *Project [key#x, empty2null(val#x) AS val#x]

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -1028,20 +1028,20 @@ struct<plan:string>
    +- 'UnresolvedRelation [explain_temp4], [], false
 
 == Analyzed Logical Plan ==
-InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex, [key, val]
+InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- Project [key#x, val#x]
    +- SubqueryAlias spark_catalog.default.explain_temp4
       +- Relation spark_catalog.default.explain_temp4[key#x,val#x] parquet
 
 == Optimized Logical Plan ==
-InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex, [key, val]
+InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- WriteFiles
    +- Sort [val#x ASC NULLS FIRST], false
       +- Project [key#x, empty2null(val#x) AS val#x]
          +- Relation spark_catalog.default.explain_temp4[key#x,val#x] parquet
 
 == Physical Plan ==
-Execute InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex, [key, val]
+Execute InsertIntoHadoopFsRelationCommand Location [not included in comparison]/{warehouse_dir}/explain_temp5, false, [val#x], Parquet, [path=Location [not included in comparison]/{warehouse_dir}/explain_temp5], Append, `spark_catalog`.`default`.`explain_temp5`, org.apache.spark.sql.execution.datasources.CatalogFileIndex(Location [not included in comparison]/{warehouse_dir}/explain_temp5), [key, val]
 +- WriteFiles
    +- *Sort [val#x ASC NULLS FIRST], false, 0
       +- *Project [key#x, empty2null(val#x) AS val#x]

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
@@ -41,13 +41,12 @@ trait SQLQueryTestHelper {
       .replaceAll(
         s"Location.*$clsName/",
         s"Location $notIncludedMsg/{warehouse_dir}/")
-      .replaceAll(s"file:.*$clsName", s"Location $notIncludedMsg/{warehouse_dir}")
+      .replaceAll(s"file:.*?$clsName", s"Location $notIncludedMsg/{warehouse_dir}")
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")
       .replaceAll("Last Access.*", s"Last Access $notIncludedMsg")
       .replaceAll("Partition Statistics\t\\d+", s"Partition Statistics\t$notIncludedMsg")
       .replaceAll("\\*\\(\\d+\\) ", "*") // remove the WholeStageCodegen codegenStageIds
-      .replaceAll("@[0-9a-z]+,", ",") // remove hashCode
   }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
@@ -41,7 +41,7 @@ trait SQLQueryTestHelper {
       .replaceAll(
         s"Location.*$clsName/",
         s"Location $notIncludedMsg/{warehouse_dir}/")
-      .replaceAll(s"file:.*?$clsName", s"Location $notIncludedMsg/{warehouse_dir}")
+      .replaceAll(s"file:.*?$clsName", s"file:$notIncludedMsg/{warehouse_dir}")
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")
       .replaceAll("Last Access.*", s"Last Access $notIncludedMsg")


### PR DESCRIPTION
### What changes were proposed in this pull request?
The main change of this pr is to fix suggestions of https://github.com/apache/spark/pull/39598#discussion_r1071213911:

- revert the change of https://github.com/apache/spark/pull/39598
- override `toString` method of `FileIndex` to print className with `rootPaths`
- change the replacement rule of `SQLQueryTestHelper#replaceNotIncludedMsg` method for `file://xxx/clsName/` path to replace one by one instead of replacing the longest match




### Why are the changes needed?
Fix suggestions of https://github.com/apache/spark/pull/39598#discussion_r1071213911


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manually  test `build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite" -Pscala-2.13` , run successful