### PR TITLE
[SPARK-42091][BUILD] Upgrade jetty to 9.4.50.v20221201

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -143,7 +143,7 @@ jersey-hk2/2.36//jersey-hk2-2.36.jar
 jersey-server/2.36//jersey-server-2.36.jar
 jetty-sslengine/6.1.26//jetty-sslengine-6.1.26.jar
 jetty-util/6.1.26//jetty-util-6.1.26.jar
-jetty-util/9.4.49.v20220914//jetty-util-9.4.49.v20220914.jar
+jetty-util/9.4.50.v20221201//jetty-util-9.4.50.v20221201.jar
 jetty/6.1.26//jetty-6.1.26.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.12.2//joda-time-2.12.2.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -128,8 +128,8 @@ jersey-container-servlet/2.36//jersey-container-servlet-2.36.jar
 jersey-hk2/2.36//jersey-hk2-2.36.jar
 jersey-server/2.36//jersey-server-2.36.jar
 jettison/1.1//jettison-1.1.jar
-jetty-util-ajax/9.4.49.v20220914//jetty-util-ajax-9.4.49.v20220914.jar
-jetty-util/9.4.49.v20220914//jetty-util-9.4.49.v20220914.jar
+jetty-util-ajax/9.4.50.v20221201//jetty-util-ajax-9.4.50.v20221201.jar
+jetty-util/9.4.50.v20221201//jetty-util-9.4.50.v20221201.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.12.2//joda-time-2.12.2.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <parquet.version>1.12.3</parquet.version>
     <orc.version>1.8.2</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>9.4.49.v20220914</jetty.version>
+    <jetty.version>9.4.50.v20221201</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
     <ivy.version>2.5.1</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade jetty to 9.4.50.v20221201

### Why are the changes needed?
This version include a bug fix:

- https://github.com/eclipse/jetty.project/issues/8678

The release note as follows:

- https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.50.v20221201


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions