### PR TITLE
[SPARK-42092][BUILD] Upgrade RoaringBitmap to 0.9.38

### DIFF
--- a/core/benchmarks/MapStatusesConvertBenchmark-jdk11-results.txt
+++ b/core/benchmarks/MapStatusesConvertBenchmark-jdk11-results.txt
@@ -2,12 +2,12 @@
 MapStatuses Convert Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1023-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.17+8 on Linux 5.15.0-1030-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 MapStatuses Convert:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Num Maps: 50000 Fetch partitions:500               1176           1207          30          0.0  1176045296.0       1.0X
-Num Maps: 50000 Fetch partitions:1000              2388           2445          98          0.0  2387828874.0       0.5X
-Num Maps: 50000 Fetch partitions:1500              3465           3725         227          0.0  3464556405.0       0.3X
+Num Maps: 50000 Fetch partitions:500               1193           1256          60          0.0  1193082590.0       1.0X
+Num Maps: 50000 Fetch partitions:1000              2590           2626          59          0.0  2590497762.0       0.5X
+Num Maps: 50000 Fetch partitions:1500              3800           4011         183          0.0  3799891103.0       0.3X
 
 

--- a/core/benchmarks/MapStatusesConvertBenchmark-jdk17-results.txt
+++ b/core/benchmarks/MapStatusesConvertBenchmark-jdk17-results.txt
@@ -2,12 +2,12 @@
 MapStatuses Convert Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1023-azure
+OpenJDK 64-Bit Server VM 17.0.5+8 on Linux 5.15.0-1030-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 MapStatuses Convert:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Num Maps: 50000 Fetch partitions:500               1161           1178          18          0.0  1160681209.0       1.0X
-Num Maps: 50000 Fetch partitions:1000              2349           2394          47          0.0  2349393891.0       0.5X
-Num Maps: 50000 Fetch partitions:1500              3610           3651          39          0.0  3610385045.0       0.3X
+Num Maps: 50000 Fetch partitions:500               1116           1126           9          0.0  1115840641.0       1.0X
+Num Maps: 50000 Fetch partitions:1000              2325           2330           7          0.0  2324597259.0       0.5X
+Num Maps: 50000 Fetch partitions:1500              3477           3516          37          0.0  3476784419.0       0.3X
 
 

--- a/core/benchmarks/MapStatusesConvertBenchmark-results.txt
+++ b/core/benchmarks/MapStatusesConvertBenchmark-results.txt
@@ -2,12 +2,12 @@
 MapStatuses Convert Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1023-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_352-b08 on Linux 5.15.0-1030-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 MapStatuses Convert:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Num Maps: 50000 Fetch partitions:500               1315           1338          37          0.0  1315335462.0       1.0X
-Num Maps: 50000 Fetch partitions:1000              2304           2358          55          0.0  2304155859.0       0.6X
-Num Maps: 50000 Fetch partitions:1500              3644           3920         450          0.0  3643557139.0       0.4X
+Num Maps: 50000 Fetch partitions:500               1046           1051           5          0.0  1045588914.0       1.0X
+Num Maps: 50000 Fetch partitions:1000              2038           2072          41          0.0  2038116226.0       0.5X
+Num Maps: 50000 Fetch partitions:1500              3208           3440         378          0.0  3207647789.0       0.3X
 
 

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -1,7 +1,7 @@
 HikariCP/2.5.1//HikariCP-2.5.1.jar
 JLargeArrays/1.5//JLargeArrays-1.5.jar
 JTransforms/3.1//JTransforms-3.1.jar
-RoaringBitmap/0.9.36//RoaringBitmap-0.9.36.jar
+RoaringBitmap/0.9.38//RoaringBitmap-0.9.38.jar
 ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.21//aircompressor-0.21.jar
@@ -245,7 +245,7 @@ scala-library/2.12.17//scala-library-2.12.17.jar
 scala-parser-combinators_2.12/2.1.1//scala-parser-combinators_2.12-2.1.1.jar
 scala-reflect/2.12.17//scala-reflect-2.12.17.jar
 scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
-shims/0.9.36//shims-0.9.36.jar
+shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
 snappy-java/1.1.8.4//snappy-java-1.1.8.4.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -1,7 +1,7 @@
 HikariCP/2.5.1//HikariCP-2.5.1.jar
 JLargeArrays/1.5//JLargeArrays-1.5.jar
 JTransforms/3.1//JTransforms-3.1.jar
-RoaringBitmap/0.9.36//RoaringBitmap-0.9.36.jar
+RoaringBitmap/0.9.38//RoaringBitmap-0.9.38.jar
 ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.21//aircompressor-0.21.jar
@@ -232,7 +232,7 @@ scala-library/2.12.17//scala-library-2.12.17.jar
 scala-parser-combinators_2.12/2.1.1//scala-parser-combinators_2.12-2.1.1.jar
 scala-reflect/2.12.17//scala-reflect-2.12.17.jar
 scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
-shims/0.9.36//shims-0.9.36.jar
+shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
 snappy-java/1.1.8.4//snappy-java-1.1.8.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -834,7 +834,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.9.36</version>
+        <version>0.9.38</version>
       </dependency>
 
       <!-- Netty Begin -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade RoaringBitmap 0.9.38


### Why are the changes needed?
This version bring a bug fix:

- https://github.com/RoaringBitmap/RoaringBitmap/pull/613

a performance optimization:

- https://github.com/RoaringBitmap/RoaringBitmap/pull/612


other changes as follows:

https://github.com/RoaringBitmap/RoaringBitmap/compare/0.9.36...0.9.38

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions