### PR TITLE
[SPARK-41757][SPARK-41901][CONNECT] Fix string representation for Column class

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -182,9 +182,6 @@ def _reverse_op(
     return _
 
 
-# TODO(SPARK-41757): Compatibility of string representation for Column
-
-
 class Column:
 
     """
@@ -203,16 +200,16 @@ class Column:
     ...      [(2, "Alice"), (5, "Bob")], ["age", "name"])
 
     Select a column out of a DataFrame
-    >>> df.name   # doctest: +SKIP
+    >>> df.name
     Column<'name'>
-    >>> df["name"]  # doctest: +SKIP
+    >>> df["name"]
     Column<'name'>
 
     Create from an expression
 
-    >>> df.age + 1  # doctest: +SKIP
+    >>> df.age + 1
     Column<'(age + 1)'>
-    >>> 1 / df.age  # doctest: +SKIP
+    >>> 1 / df.age
     Column<'(1 / age)'>
     """
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -208,9 +208,9 @@ class Column:
     Create from an expression
 
     >>> df.age + 1
-    Column<'(age + 1)'>
+    Column<...>
     >>> 1 / df.age
-    Column<'(1 / age)'>
+    Column<...>
     """
 
     def __init__(self, jc: JavaObject) -> None:

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -92,14 +92,6 @@ def _unary_op(name: str, doc: Optional[str] = "unary function") -> Callable[["Co
     return wrapped
 
 
-def scalar_function(op: str, *args: "Column") -> "Column":
-    return Column(UnresolvedFunction(op, [arg._expr for arg in args]))
-
-
-def sql_expression(expr: str) -> "Column":
-    return Column(SQLExpression(expr))
-
-
 class Column:
     def __init__(self, expr: "Expression") -> None:
         if not isinstance(expr, Expression):

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -43,6 +43,7 @@ from pyspark.sql.connect.expressions import (
     WindowExpression,
     WithField,
     DropField,
+    UnresolvedBinaryFunction,
 )
 
 
@@ -90,6 +91,16 @@ def _unary_op(name: str, doc: Optional[str] = "unary function") -> Callable[["Co
 
     wrapped.__doc__ = doc
     return wrapped
+
+
+def scalar_function(op: str, *args: "Column") -> "Column":
+    if len(args) == 2:
+        return Column(UnresolvedBinaryFunction(op, [arg._expr for arg in args]))
+    return Column(UnresolvedFunction(op, [arg._expr for arg in args]))
+
+
+def sql_expression(expr: str) -> "Column":
+    return Column(SQLExpression(expr))
 
 
 class Column:

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -43,7 +43,6 @@ from pyspark.sql.connect.expressions import (
     WindowExpression,
     WithField,
     DropField,
-    UnresolvedBinaryFunction,
 )
 
 
@@ -94,8 +93,6 @@ def _unary_op(name: str, doc: Optional[str] = "unary function") -> Callable[["Co
 
 
 def scalar_function(op: str, *args: "Column") -> "Column":
-    if len(args) == 2:
-        return Column(UnresolvedBinaryFunction(op, [arg._expr for arg in args]))
     return Column(UnresolvedFunction(op, [arg._expr for arg in args]))
 
 

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -327,7 +327,7 @@ class LiteralExpression(Expression):
         return expr
 
     def __repr__(self) -> str:
-        return f"Literal({self._value})"
+        return f"{self._value}"
 
 
 class ColumnReference(Expression):
@@ -352,7 +352,7 @@ class ColumnReference(Expression):
         return expr
 
     def __repr__(self) -> str:
-        return f"ColumnReference({self._unparsed_identifier})"
+        return f"{self._unparsed_identifier}"
 
 
 class SQLExpression(Expression):
@@ -437,6 +437,12 @@ class UnresolvedFunction(Expression):
             return f"{self._name}(distinct {', '.join([str(arg) for arg in self._args])})"
         else:
             return f"{self._name}({', '.join([str(arg) for arg in self._args])})"
+
+
+class UnresolvedBinaryFunction(UnresolvedFunction):
+    def __repr__(self) -> str:
+        assert len(self._args) == 2
+        return f"({self._args[0]} {self._name} {self._args[1]})"
 
 
 class WithField(Expression):

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -156,7 +156,7 @@ class ColumnAlias(Expression):
             return exp
 
     def __repr__(self) -> str:
-        return f"Alias({self._parent}, ({','.join(self._alias)}))"
+        return f"{self._parent} AS {','.join(self._alias)}"
 
 
 class LiteralExpression(Expression):
@@ -433,16 +433,16 @@ class UnresolvedFunction(Expression):
         return fun
 
     def __repr__(self) -> str:
+        # Special handling for certain infix operators that require slightly
+        # different printing.
+        if len(self._args) == 2 and len(self._name) == 1:
+            return f"{self._args[0]} {self._name} {self._args[1]}"
+
+        # Default print handling:
         if self._is_distinct:
             return f"{self._name}(distinct {', '.join([str(arg) for arg in self._args])})"
         else:
             return f"{self._name}({', '.join([str(arg) for arg in self._args])})"
-
-
-class UnresolvedBinaryFunction(UnresolvedFunction):
-    def __repr__(self) -> str:
-        assert len(self._args) == 2
-        return f"({self._args[0]} {self._name} {self._args[1]})"
 
 
 class WithField(Expression):

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -433,11 +433,6 @@ class UnresolvedFunction(Expression):
         return fun
 
     def __repr__(self) -> str:
-        # Special handling for certain infix operators that require slightly
-        # different printing.
-        if len(self._args) == 2 and len(self._name) == 1:
-            return f"{self._args[0]} {self._name} {self._args[1]}"
-
         # Default print handling:
         if self._is_distinct:
             return f"{self._name}(distinct {', '.join([str(arg) for arg in self._args])})"

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -814,7 +814,7 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
     def test_column_alias(self) -> None:
         # SPARK-40809: Support for Column Aliases
         col0 = col("a").alias("martin")
-        self.assertEqual("Column<'Alias(ColumnReference(a), (martin))'>", str(col0))
+        self.assertEqual("Column<'a AS martin'>", str(col0))
 
         col0 = col("a").alias("martin", metadata={"pii": True})
         plan = col0.to_plan(self.session.client)

--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -59,16 +59,6 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     def test_lit_np_scalar(self):
         super().test_lit_np_scalar()
 
-    # TODO(SPARK-41901): Parity in String representation of Column
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_overlay(self):
-        super().test_overlay()
-
-    # TODO(SPARK-41901): Parity in String representation of Column
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_percentile_approx(self):
-        super().test_percentile_approx()
-
     # TODO(SPARK-41897): Parity in Error types between pyspark and connect functions
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_raise_error(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

To reenable the doc tests for `Column`, this patch makes the string representation of the `Column` closer to the regular PySpark `Column`.

This PR takes over https://github.com/apache/spark/pull/39296 with fixing some nits. 

### Why are the changes needed?

Compatibility

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Reenabled doc tests.

Closes #39296