### PR TITLE
[SPARK-41866][CONNECT][TESTS] Enable test_create_dataframe_from_array_of_long in dataframe parity test

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -27,11 +27,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_cache(self):
         super().test_cache()
 
-    # TODO(SPARK-41866): createDataframe support array type
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_create_dataframe_from_array_of_long(self):
-        super().test_create_dataframe_from_array_of_long()
-
     # TODO(SPARK-41868): Support data type Duration(NANOSECOND)
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_create_dataframe_from_pandas_with_day_time_interval(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables `test_create_dataframe_from_array_of_long`.  https://github.com/apache/spark/pull/39602 fixed this.

### Why are the changes needed?

For test coverage and feature parity.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Fixed unittests.