### PR TITLE
[SPARK-42082][SPARK-41598][PYTHON][CONNECT] Introduce `PySparkValueError` and `PySparkTypeError`

### DIFF
--- a/dev/tox.ini
+++ b/dev/tox.ini
@@ -27,6 +27,8 @@ ignore =
 per-file-ignores =
     # E501 is ignored as shared.py is auto-generated.
     python/pyspark/ml/param/shared.py: E501,
+    # E501 is ignored as we should keep the json string format in error_classes.py.
+    python/pyspark/errors/error_classes.py: E501,
     # Examples contain some unused variables.
     examples/src/main/python/sql/datasource.py: F841,
     # Exclude * imports in test files

--- a/python/pyspark/errors/__init__.py
+++ b/python/pyspark/errors/__init__.py
@@ -28,6 +28,7 @@ from pyspark.errors.exceptions import (  # noqa: F401
     PythonException,
     UnknownException,
     SparkUpgradeException,
+    PySparkTypeError,
     PySparkValueError,
 )
 
@@ -42,5 +43,6 @@ __all__ = [
     "PythonException",
     "UnknownException",
     "SparkUpgradeException",
+    "PySparkTypeError",
     "PySparkValueError",
 ]

--- a/python/pyspark/errors/__init__.py
+++ b/python/pyspark/errors/__init__.py
@@ -18,9 +18,29 @@
 """
 PySpark exceptions.
 """
-from pyspark.errors.exceptions import PySparkException
+from pyspark.errors.exceptions import (  # noqa: F401
+    PySparkException,
+    AnalysisException,
+    ParseException,
+    IllegalArgumentException,
+    StreamingQueryException,
+    QueryExecutionException,
+    PythonException,
+    UnknownException,
+    SparkUpgradeException,
+    PySparkValueError,
+)
 
 
 __all__ = [
     "PySparkException",
+    "AnalysisException",
+    "ParseException",
+    "IllegalArgumentException",
+    "StreamingQueryException",
+    "QueryExecutionException",
+    "PythonException",
+    "UnknownException",
+    "SparkUpgradeException",
+    "PySparkValueError",
 ]

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -23,6 +23,51 @@ ERROR_CLASSES_JSON = """
     "message": [
       "<func_name> does not allow a column in a list."
     ]
+  },
+  "HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN" : {
+    "message" : [
+      "Function `<func_name>` should return Column, got <return_type>"
+    ]
+  },
+  "NOT_A_COLUMN" : {
+    "message" : [
+      "Argument `<arg_name>` should be a column, got <arg_type>."
+    ]
+  },
+  "NOT_A_STRING" : {
+    "message" : [
+      "Argument `<arg_name>` should be a string, got <arg_type>."
+    ]
+  },
+  "NOT_COLUMN_OR_INTEGER" : {
+    "message" : [
+      "Argument `<arg_name>` should be a column or integer, got <arg_type>."
+    ]
+  },
+  "NOT_COLUMN_OR_INTEGER_OR_STRING" : {
+    "message" : [
+      "Argument `<arg_name>` should be a column or integer or string, got <arg_type>."
+    ]
+  },
+  "NOT_COLUMN_OR_STRING" : {
+    "message" : [
+      "Argument `<arg_name>` should be a column or string, got <arg_type>."
+    ]
+  },
+  "UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION" : {
+    "message" : [
+      "Function `<func_name>` should use only POSITIONAL or POSITIONAL OR KEYWORD arguments"
+    ]
+  },
+  "WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION" : {
+    "message" : [
+      "Function `<func_name>` should take between 1 and 3 arguments, but provided function takes <num_args>"
+    ]
+  },
+  "WRONG_NUM_COLUMNS" : {
+    "message" : [
+      "Function `<func_name>` should take at least <num_cols> columns"
+    ]
   }
 }
 """

--- a/python/pyspark/errors/exceptions.py
+++ b/python/pyspark/errors/exceptions.py
@@ -15,8 +15,13 @@
 # limitations under the License.
 #
 
-from typing import Dict, Optional, cast
+from typing import Any, Callable, Dict, Optional, cast
 
+import py4j
+from py4j.protocol import Py4JJavaError
+from py4j.java_gateway import is_instance_of
+
+from pyspark import SparkContext
 from pyspark.errors.utils import ErrorClassesReader
 
 
@@ -57,6 +62,7 @@ class PySparkException(Exception):
         See Also
         --------
         :meth:`PySparkException.getMessageParameters`
+        :meth:`PySparkException.getSqlState`
         """
         return self.error_class
 
@@ -69,8 +75,230 @@ class PySparkException(Exception):
         See Also
         --------
         :meth:`PySparkException.getErrorClass`
+        :meth:`PySparkException.getSqlState`
         """
         return self.message_parameters
 
+    def getSqlState(self) -> None:
+        """
+        Returns an SQLSTATE as a string.
+
+        Errors generated in Python have no SQLSTATE, so it always returns None.
+
+        .. versionadded:: 3.4.0
+
+        See Also
+        --------
+        :meth:`PySparkException.getErrorClass`
+        :meth:`PySparkException.getMessageParameters`
+        """
+        return None
+
     def __str__(self) -> str:
         return f"[{self.getErrorClass()}] {self.message}"
+
+
+class CapturedException(PySparkException):
+    def __init__(
+        self,
+        desc: Optional[str] = None,
+        stackTrace: Optional[str] = None,
+        cause: Optional[Py4JJavaError] = None,
+        origin: Optional[Py4JJavaError] = None,
+    ):
+        # desc & stackTrace vs origin are mutually exclusive.
+        # cause is optional.
+        assert (origin is not None and desc is None and stackTrace is None) or (
+            origin is None and desc is not None and stackTrace is not None
+        )
+
+        self.desc = desc if desc is not None else cast(Py4JJavaError, origin).getMessage()
+        assert SparkContext._jvm is not None
+        self.stackTrace = (
+            stackTrace
+            if stackTrace is not None
+            else (SparkContext._jvm.org.apache.spark.util.Utils.exceptionString(origin))
+        )
+        self.cause = convert_exception(cause) if cause is not None else None
+        if self.cause is None and origin is not None and origin.getCause() is not None:
+            self.cause = convert_exception(origin.getCause())
+        self._origin = origin
+
+    def __str__(self) -> str:
+        assert SparkContext._jvm is not None
+
+        jvm = SparkContext._jvm
+        sql_conf = jvm.org.apache.spark.sql.internal.SQLConf.get()
+        debug_enabled = sql_conf.pysparkJVMStacktraceEnabled()
+        desc = self.desc
+        if debug_enabled:
+            desc = desc + "\n\nJVM stacktrace:\n%s" % self.stackTrace
+        return str(desc)
+
+    def getErrorClass(self) -> Optional[str]:
+        assert SparkContext._gateway is not None
+
+        gw = SparkContext._gateway
+        if self._origin is not None and is_instance_of(
+            gw, self._origin, "org.apache.spark.SparkThrowable"
+        ):
+            return self._origin.getErrorClass()
+        else:
+            return None
+
+    def getMessageParameters(self) -> Optional[Dict[str, str]]:
+        assert SparkContext._gateway is not None
+
+        gw = SparkContext._gateway
+        if self._origin is not None and is_instance_of(
+            gw, self._origin, "org.apache.spark.SparkThrowable"
+        ):
+            return self._origin.getMessageParameters()
+        else:
+            return None
+
+    def getSqlState(self) -> Optional[str]:  # type: ignore[override]
+        assert SparkContext._gateway is not None
+        gw = SparkContext._gateway
+        if self._origin is not None and is_instance_of(
+            gw, self._origin, "org.apache.spark.SparkThrowable"
+        ):
+            return self._origin.getSqlState()
+        else:
+            return None
+
+
+def convert_exception(e: Py4JJavaError) -> CapturedException:
+    assert e is not None
+    assert SparkContext._jvm is not None
+    assert SparkContext._gateway is not None
+
+    jvm = SparkContext._jvm
+    gw = SparkContext._gateway
+
+    if is_instance_of(gw, e, "org.apache.spark.sql.catalyst.parser.ParseException"):
+        return ParseException(origin=e)
+    # Order matters. ParseException inherits AnalysisException.
+    elif is_instance_of(gw, e, "org.apache.spark.sql.AnalysisException"):
+        return AnalysisException(origin=e)
+    elif is_instance_of(gw, e, "org.apache.spark.sql.streaming.StreamingQueryException"):
+        return StreamingQueryException(origin=e)
+    elif is_instance_of(gw, e, "org.apache.spark.sql.execution.QueryExecutionException"):
+        return QueryExecutionException(origin=e)
+    elif is_instance_of(gw, e, "java.lang.IllegalArgumentException"):
+        return IllegalArgumentException(origin=e)
+    elif is_instance_of(gw, e, "org.apache.spark.SparkUpgradeException"):
+        return SparkUpgradeException(origin=e)
+
+    c: Py4JJavaError = e.getCause()
+    stacktrace: str = jvm.org.apache.spark.util.Utils.exceptionString(e)
+    if c is not None and (
+        is_instance_of(gw, c, "org.apache.spark.api.python.PythonException")
+        # To make sure this only catches Python UDFs.
+        and any(
+            map(
+                lambda v: "org.apache.spark.sql.execution.python" in v.toString(), c.getStackTrace()
+            )
+        )
+    ):
+        msg = (
+            "\n  An exception was thrown from the Python worker. "
+            "Please see the stack trace below.\n%s" % c.getMessage()
+        )
+        return PythonException(msg, stacktrace)
+
+    return UnknownException(desc=e.toString(), stackTrace=stacktrace, cause=c)
+
+
+def capture_sql_exception(f: Callable[..., Any]) -> Callable[..., Any]:
+    def deco(*a: Any, **kw: Any) -> Any:
+        try:
+            return f(*a, **kw)
+        except Py4JJavaError as e:
+            converted = convert_exception(e.java_exception)
+            if not isinstance(converted, UnknownException):
+                # Hide where the exception came from that shows a non-Pythonic
+                # JVM exception message.
+                raise converted from None
+            else:
+                raise
+
+    return deco
+
+
+def install_exception_handler() -> None:
+    """
+    Hook an exception handler into Py4j, which could capture some SQL exceptions in Java.
+
+    When calling Java API, it will call `get_return_value` to parse the returned object.
+    If any exception happened in JVM, the result will be Java exception object, it raise
+    py4j.protocol.Py4JJavaError. We replace the original `get_return_value` with one that
+    could capture the Java exception and throw a Python one (with the same error message).
+
+    It's idempotent, could be called multiple times.
+    """
+    original = py4j.protocol.get_return_value
+    # The original `get_return_value` is not patched, it's idempotent.
+    patched = capture_sql_exception(original)
+    # only patch the one used in py4j.java_gateway (call Java API)
+    py4j.java_gateway.get_return_value = patched
+
+
+class AnalysisException(CapturedException):
+    """
+    Failed to analyze a SQL query plan.
+    """
+
+
+class ParseException(CapturedException):
+    """
+    Failed to parse a SQL command.
+    """
+
+
+class IllegalArgumentException(CapturedException):
+    """
+    Passed an illegal or inappropriate argument.
+    """
+
+
+class StreamingQueryException(CapturedException):
+    """
+    Exception that stopped a :class:`StreamingQuery`.
+    """
+
+
+class QueryExecutionException(CapturedException):
+    """
+    Failed to execute a query.
+    """
+
+
+class PythonException(CapturedException):
+    """
+    Exceptions thrown from Python workers.
+    """
+
+
+class UnknownException(CapturedException):
+    """
+    None of the above exceptions.
+    """
+
+
+class SparkUpgradeException(CapturedException):
+    """
+    Exception thrown because of Spark upgrade
+    """
+
+
+class PySparkValueError(PySparkException, ValueError):
+    """
+    Wrapper class for ValueError to support error classes.
+    """
+
+
+class PySparkTypeError(PySparkException, TypeError):
+    """
+    Wrapper class for TypeError to support error classes.
+    """

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2263,14 +2263,13 @@ def bucket(numBuckets: Union[Column, int], col: "ColumnOrName") -> Column:
     elif isinstance(numBuckets, Column):
         _numBuckets = numBuckets
     else:
-        if not isinstance(numBuckets, (int, Column)):
-            raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_INTEGER",
-                message_parameters={
-                    "arg_name": "numBuckets",
-                    "arg_type": type(numBuckets).__name__,
-                },
-            )
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_INTEGER",
+            message_parameters={
+                "arg_name": "numBuckets",
+                "arg_type": type(numBuckets).__name__,
+            },
+        )
 
     return _invoke_function("bucket", _numBuckets, _to_col(col))
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -38,7 +38,10 @@ from typing import (
 )
 
 from pyspark import SparkContext
-from pyspark.errors import PySparkException
+from pyspark.errors.exceptions import (
+    PySparkTypeError,
+    PySparkValueError,
+)
 from pyspark.rdd import PythonEvalType
 from pyspark.sql.column import Column, _to_java_column, _to_seq, _create_column_from_literal
 from pyspark.sql.dataframe import DataFrame
@@ -173,7 +176,7 @@ def lit(col: Any) -> Column:
         return col
     elif isinstance(col, list):
         if any(isinstance(c, Column) for c in col):
-            raise PySparkException(
+            raise PySparkValueError(
                 error_class="COLUMN_IN_LIST", message_parameters={"func_name": "lit"}
             )
         return array(*[lit(item) for item in col])
@@ -3740,7 +3743,10 @@ def greatest(*cols: "ColumnOrName") -> Column:
     [Row(greatest=4)]
     """
     if len(cols) < 2:
-        raise ValueError("greatest should take at least two columns")
+        raise PySparkValueError(
+            error_class="WRONG_NUM_COLUMNS",
+            message_parameters={"func_name": "greatest", "num_cols": "2"},
+        )
     return _invoke_function_over_seq_of_columns("greatest", cols)
 
 
@@ -3772,7 +3778,10 @@ def least(*cols: "ColumnOrName") -> Column:
     [Row(least=1)]
     """
     if len(cols) < 2:
-        raise ValueError("least should take at least two columns")
+        raise PySparkValueError(
+            error_class="WRONG_NUM_COLUMNS",
+            message_parameters={"func_name": "least", "num_cols": "2"},
+        )
     return _invoke_function_over_seq_of_columns("least", cols)
 
 
@@ -3822,7 +3831,10 @@ def when(condition: Column, value: Any) -> Column:
     """
     # Explicitly not using ColumnOrName type here to make reading condition less opaque
     if not isinstance(condition, Column):
-        raise TypeError("condition should be a Column")
+        raise PySparkTypeError(
+            error_class="NOT_A_COLUMN",
+            message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+        )
     v = value._jc if isinstance(value, Column) else value
 
     return _invoke_function("when", condition._jc, v)
@@ -5457,7 +5469,10 @@ def window(
 
     def check_string_field(field, fieldName):  # type: ignore[no-untyped-def]
         if not field or type(field) is not str:
-            raise TypeError("%s should be provided as a string" % fieldName)
+            raise PySparkTypeError(
+                error_class="NOT_A_STRING",
+                message_parameters={"arg_name": fieldName, "arg_type": type(field).__name__},
+            )
 
     time_col = _to_java_column(timeColumn)
     check_string_field(windowDuration, "windowDuration")
@@ -5573,7 +5588,10 @@ def session_window(timeColumn: "ColumnOrName", gapDuration: Union[Column, str]) 
 
     def check_field(field: Union[Column, str], fieldName: str) -> None:
         if field is None or not isinstance(field, (str, Column)):
-            raise TypeError("%s should be provided as a string or Column" % fieldName)
+            raise PySparkTypeError(
+                error_class="NOT_COLUMN_OR_STRING",
+                message_parameters={"arg_name": fieldName, "arg_type": type(field).__name__},
+            )
 
     time_col = _to_java_column(timeColumn)
     check_field(gapDuration, "gapDuration")
@@ -5834,7 +5852,10 @@ def assert_true(col: "ColumnOrName", errMsg: Optional[Union[Column, str]] = None
     if errMsg is None:
         return _invoke_function_over_columns("assert_true", col)
     if not isinstance(errMsg, (str, Column)):
-        raise TypeError("errMsg should be a Column or a str, got {}".format(type(errMsg)))
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
+        )
 
     errMsg = (
         _create_column_from_literal(errMsg) if isinstance(errMsg, str) else _to_java_column(errMsg)
@@ -5871,7 +5892,10 @@ def raise_error(errMsg: Union[Column, str]) -> Column:
     ...
     """
     if not isinstance(errMsg, (str, Column)):
-        raise TypeError("errMsg should be a Column or a str, got {}".format(type(errMsg)))
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
+        )
 
     errMsg = (
         _create_column_from_literal(errMsg) if isinstance(errMsg, str) else _to_java_column(errMsg)
@@ -6410,12 +6434,14 @@ def overlay(
     [Row(overlayed='SPARK_COREL')]
     """
     if not isinstance(pos, (int, str, Column)):
-        raise TypeError(
-            "pos should be an integer or a Column / column name, got {}".format(type(pos))
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_INTEGER_OR_STRING",
+            message_parameters={"arg_name": "pos", "arg_type": type(pos).__name__},
         )
     if len is not None and not isinstance(len, (int, str, Column)):
-        raise TypeError(
-            "len should be an integer or a Column / column name, got {}".format(type(len))
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_INTEGER_OR_STRING",
+            message_parameters={"arg_name": "len", "arg_type": type(len).__name__},
         )
 
     pos = _create_column_from_literal(pos) if isinstance(pos, int) else _to_java_column(pos)
@@ -8314,7 +8340,10 @@ def schema_of_json(json: "ColumnOrName", options: Optional[Dict[str, str]] = Non
     elif isinstance(json, Column):
         col = _to_java_column(json)
     else:
-        raise TypeError("schema argument should be a column or string")
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "json", "arg_type": type(json).__name__},
+        )
 
     return _invoke_function("schema_of_json", col, _options_to_str(options))
 
@@ -8358,7 +8387,10 @@ def schema_of_csv(csv: "ColumnOrName", options: Optional[Dict[str, str]] = None)
     elif isinstance(csv, Column):
         col = _to_java_column(csv)
     else:
-        raise TypeError("schema argument should be a column or string")
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "csv", "arg_type": type(csv).__name__},
+        )
 
     return _invoke_function("schema_of_csv", col, _options_to_str(options))
 
@@ -9090,7 +9122,10 @@ def from_csv(
     elif isinstance(schema, Column):
         schema = _to_java_column(schema)
     else:
-        raise TypeError("schema argument should be a column or string")
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+        )
 
     return _invoke_function("from_csv", _to_java_column(col), schema, _options_to_str(options))
 
@@ -9129,15 +9164,17 @@ def _get_lambda_parameters(f: Callable) -> ValuesView[inspect.Parameter]:
     # Validate that
     # function arity is between 1 and 3
     if not (1 <= len(parameters) <= 3):
-        raise ValueError(
-            "f should take between 1 and 3 arguments, but provided function takes {}".format(
-                len(parameters)
-            )
+        raise PySparkValueError(
+            error_class="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
+            message_parameters={"func_name": f.__name__, "num_args": str(len(parameters))},
         )
 
     # and all arguments can be used as positional
     if not all(p.kind in supported_parameter_types for p in parameters):
-        raise ValueError("f should use only POSITIONAL or POSITIONAL OR KEYWORD arguments")
+        raise PySparkValueError(
+            error_class="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
+            message_parameters={"func_name": f.__name__},
+        )
 
     return parameters
 
@@ -9169,7 +9206,10 @@ def _create_lambda(f: Callable) -> Callable:
     result = f(*args)
 
     if not isinstance(result, Column):
-        raise ValueError("f should return Column, got {}".format(type(result)))
+        raise PySparkValueError(
+            error_class="HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN",
+            message_parameters={"func_name": f.__name__, "return_type": type(result).__name__},
+        )
 
     jexpr = result._jc.expr()
     jargs = _to_seq(sc, [arg._jc.expr() for arg in args])
@@ -9893,7 +9933,10 @@ def bucket(numBuckets: Union[Column, int], col: "ColumnOrName") -> Column:
 
     """
     if not isinstance(numBuckets, (int, Column)):
-        raise TypeError("numBuckets should be a Column or an int, got {}".format(type(numBuckets)))
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_INTEGER",
+            message_parameters={"arg_name": "numBuckets", "arg_type": type(numBuckets).__name__},
+        )
 
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -17,6 +17,7 @@
 import unittest
 import tempfile
 
+from pyspark.errors import PySparkException
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, ArrayType, IntegerType
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
@@ -305,11 +306,14 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
         ):
             CF.when(cdf.a == 0, 1.0).otherwise(1.0).otherwise(1.0)
 
-        with self.assertRaisesRegex(
-            TypeError,
-            """condition should be a Column""",
-        ):
+        with self.assertRaises(PySparkException) as pe:
             CF.when(True, 1.0).otherwise(1.0)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_A_COLUMN",
+            message_parameters={"arg_name": "condition", "arg_type": "bool"},
+        )
 
     def test_sorting_functions_with_column(self):
         from pyspark.sql.connect import functions as CF

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -17,7 +17,7 @@
 import unittest
 import tempfile
 
-from pyspark.errors import PySparkException
+from pyspark.errors import PySparkTypeError
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, ArrayType, IntegerType
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
@@ -306,7 +306,7 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
         ):
             CF.when(cdf.a == 0, 1.0).otherwise(1.0).otherwise(1.0)
 
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             CF.when(True, 1.0).otherwise(1.0)
 
         self.check_error(

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -69,6 +69,14 @@ from pyspark.sql.functions import (
     map_concat,
     map_from_entries,
     expr,
+    schema_of_json,
+    schema_of_csv,
+    from_csv,
+    greatest,
+    when,
+    window,
+    session_window,
+    bucket,
 )
 from pyspark.sql import functions
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
@@ -647,6 +655,15 @@ class FunctionsTestsMixin:
             )
         )
 
+        with self.assertRaises(PySparkException) as pe:
+            df.select(least(df.a).alias("least")).collect()
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="WRONG_NUM_COLUMNS",
+            message_parameters={"func_name": "least", "num_cols": "2"},
+        )
+
     def test_overlay(self):
         from pyspark.sql.functions import col, lit, overlay
         from itertools import chain
@@ -690,6 +707,24 @@ class FunctionsTestsMixin:
                     df.select(overlay("x", "y", "pos", "len").alias("ol")).collect() == exp,
                 ]
             )
+        )
+
+        with self.assertRaises(PySparkException) as pe:
+            df.select(overlay(df.x, df.y, 7.5, 0).alias("ol")).collect()
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_INTEGER_OR_STRING",
+            message_parameters={"arg_name": "pos", "arg_type": "float"},
+        )
+
+        with self.assertRaises(PySparkException) as pe:
+            df.select(overlay(df.x, df.y, 7, 0.5).alias("ol")).collect()
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_INTEGER_OR_STRING",
+            message_parameters={"arg_name": "len", "arg_type": "float"},
         )
 
     def test_percentile_approx(self):
@@ -763,24 +798,54 @@ class FunctionsTestsMixin:
         from pyspark.sql.functions import col, transform
 
         # Should fail with varargs
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PySparkException) as pe:
             transform(col("foo"), lambda *x: lit(1))
 
+        self.check_error(
+            exception=pe.exception,
+            error_class="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
+            message_parameters={"func_name": "<lambda>"},
+        )
+
         # Should fail with kwargs
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PySparkException) as pe:
             transform(col("foo"), lambda **x: lit(1))
 
+        self.check_error(
+            exception=pe.exception,
+            error_class="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
+            message_parameters={"func_name": "<lambda>"},
+        )
+
         # Should fail with nullary function
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PySparkException) as pe:
             transform(col("foo"), lambda: lit(1))
 
+        self.check_error(
+            exception=pe.exception,
+            error_class="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
+            message_parameters={"func_name": "<lambda>", "num_args": "0"},
+        )
+
         # Should fail with quaternary function
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PySparkException) as pe:
             transform(col("foo"), lambda x1, x2, x3, x4: lit(1))
 
+        self.check_error(
+            exception=pe.exception,
+            error_class="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
+            message_parameters={"func_name": "<lambda>", "num_args": "4"},
+        )
+
         # Should fail if function doesn't return Column
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PySparkException) as pe:
             transform(col("foo"), lambda x: 1)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN",
+            message_parameters={"func_name": "<lambda>", "return_type": "int"},
+        )
 
     def test_nested_higher_order_function(self):
         # SPARK-35382: lambda vars must be resolved properly in nested higher order functions
@@ -960,9 +1025,14 @@ class FunctionsTestsMixin:
         self.assertIn("java.lang.RuntimeException", str(cm.exception))
         self.assertIn("2000000", str(cm.exception))
 
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(PySparkException) as pe:
             df.select(assert_true(df.id < 2, 5))
-        self.assertEqual("errMsg should be a Column or a str, got <class 'int'>", str(cm.exception))
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "errMsg", "arg_type": "int"},
+        )
 
     def test_raise_error(self):
         from pyspark.sql.functions import raise_error
@@ -979,10 +1049,13 @@ class FunctionsTestsMixin:
         self.assertIn("java.lang.RuntimeException", str(cm.exception))
         self.assertIn("barfoo", str(cm.exception))
 
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(PySparkException) as pe:
             df.select(raise_error(None))
-        self.assertEqual(
-            "errMsg should be a Column or a str, got <class 'NoneType'>", str(cm.exception)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "errMsg", "arg_type": "NoneType"},
         )
 
     def test_sum_distinct(self):
@@ -1158,6 +1231,88 @@ class FunctionsTestsMixin:
         self.assertEqual(expected, dict(actual["items"]))
         self.assertEqual({**expected, **expected2}, dict(actual["merged"]))
         self.assertEqual(expected, actual["from_items"])
+
+    def test_schema_of_json(self):
+        with self.assertRaises(PySparkException) as pe:
+            schema_of_json(1)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "json", "arg_type": "int"},
+        )
+
+    def test_schema_of_csv(self):
+        with self.assertRaises(PySparkException) as pe:
+            schema_of_csv(1)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "csv", "arg_type": "int"},
+        )
+
+    def test_from_csv(self):
+        df = self.spark.range(10)
+        with self.assertRaises(PySparkException) as pe:
+            from_csv(df.id, 1)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "schema", "arg_type": "int"},
+        )
+
+    def test_greatest(self):
+        df = self.spark.range(10)
+        with self.assertRaises(PySparkException) as pe:
+            greatest(df.id)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="WRONG_NUM_COLUMNS",
+            message_parameters={"func_name": "greatest", "num_cols": "2"},
+        )
+
+    def test_when(self):
+        with self.assertRaises(PySparkException) as pe:
+            when("id", 1)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_A_COLUMN",
+            message_parameters={"arg_name": "condition", "arg_type": "str"},
+        )
+
+    def test_window(self):
+        with self.assertRaises(PySparkException) as pe:
+            window("date", 5)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_A_STRING",
+            message_parameters={"arg_name": "windowDuration", "arg_type": "int"},
+        )
+
+    def test_session_window(self):
+        with self.assertRaises(PySparkException) as pe:
+            session_window("date", 5)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "gapDuration", "arg_type": "int"},
+        )
+
+    def test_bucket(self):
+        with self.assertRaises(PySparkException) as pe:
+            bucket("5", "id")
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_INTEGER",
+            message_parameters={"arg_name": "numBuckets", "arg_type": "str"},
+        )
 
 
 class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1110,11 +1110,11 @@ class FunctionsTestsMixin:
         with self.assertRaises(PySparkException) as pe:
             lit([df.id, df.id])
 
-            self.check_error(
-                exception=pe.exception,
-                error_class="COLUMN_IN_LIST",
-                message_parameters={"funcName": "lit"},
-            )
+        self.check_error(
+            exception=pe.exception,
+            error_class="COLUMN_IN_LIST",
+            message_parameters={"func_name": "lit"},
+        )
 
     # Test added for SPARK-39832; change Python API to accept both col & str as input
     def test_regexp_replace(self):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -25,7 +25,7 @@ import math
 import unittest
 
 from py4j.protocol import Py4JJavaError
-from pyspark.errors import PySparkException
+from pyspark.errors import PySparkTypeError, PySparkValueError
 from pyspark.sql import Row, Window, types
 from pyspark.sql.functions import (
     udf,
@@ -655,7 +655,7 @@ class FunctionsTestsMixin:
             )
         )
 
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkValueError) as pe:
             df.select(least(df.a).alias("least")).collect()
 
         self.check_error(
@@ -709,7 +709,7 @@ class FunctionsTestsMixin:
             )
         )
 
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             df.select(overlay(df.x, df.y, 7.5, 0).alias("ol")).collect()
 
         self.check_error(
@@ -718,7 +718,7 @@ class FunctionsTestsMixin:
             message_parameters={"arg_name": "pos", "arg_type": "float"},
         )
 
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             df.select(overlay(df.x, df.y, 7, 0.5).alias("ol")).collect()
 
         self.check_error(
@@ -798,7 +798,7 @@ class FunctionsTestsMixin:
         from pyspark.sql.functions import col, transform
 
         # Should fail with varargs
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkValueError) as pe:
             transform(col("foo"), lambda *x: lit(1))
 
         self.check_error(
@@ -808,7 +808,7 @@ class FunctionsTestsMixin:
         )
 
         # Should fail with kwargs
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkValueError) as pe:
             transform(col("foo"), lambda **x: lit(1))
 
         self.check_error(
@@ -818,7 +818,7 @@ class FunctionsTestsMixin:
         )
 
         # Should fail with nullary function
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkValueError) as pe:
             transform(col("foo"), lambda: lit(1))
 
         self.check_error(
@@ -828,7 +828,7 @@ class FunctionsTestsMixin:
         )
 
         # Should fail with quaternary function
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkValueError) as pe:
             transform(col("foo"), lambda x1, x2, x3, x4: lit(1))
 
         self.check_error(
@@ -838,7 +838,7 @@ class FunctionsTestsMixin:
         )
 
         # Should fail if function doesn't return Column
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkValueError) as pe:
             transform(col("foo"), lambda x: 1)
 
         self.check_error(
@@ -1025,7 +1025,7 @@ class FunctionsTestsMixin:
         self.assertIn("java.lang.RuntimeException", str(cm.exception))
         self.assertIn("2000000", str(cm.exception))
 
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             df.select(assert_true(df.id < 2, 5))
 
         self.check_error(
@@ -1049,7 +1049,7 @@ class FunctionsTestsMixin:
         self.assertIn("java.lang.RuntimeException", str(cm.exception))
         self.assertIn("barfoo", str(cm.exception))
 
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             df.select(raise_error(None))
 
         self.check_error(
@@ -1107,7 +1107,7 @@ class FunctionsTestsMixin:
             self.assertEqual(actual, expected)
 
         df = self.spark.range(10)
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkValueError) as pe:
             lit([df.id, df.id])
 
         self.check_error(
@@ -1233,7 +1233,7 @@ class FunctionsTestsMixin:
         self.assertEqual(expected, actual["from_items"])
 
     def test_schema_of_json(self):
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             schema_of_json(1)
 
         self.check_error(
@@ -1243,7 +1243,7 @@ class FunctionsTestsMixin:
         )
 
     def test_schema_of_csv(self):
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             schema_of_csv(1)
 
         self.check_error(
@@ -1254,7 +1254,7 @@ class FunctionsTestsMixin:
 
     def test_from_csv(self):
         df = self.spark.range(10)
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             from_csv(df.id, 1)
 
         self.check_error(
@@ -1265,7 +1265,7 @@ class FunctionsTestsMixin:
 
     def test_greatest(self):
         df = self.spark.range(10)
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkValueError) as pe:
             greatest(df.id)
 
         self.check_error(
@@ -1275,7 +1275,7 @@ class FunctionsTestsMixin:
         )
 
     def test_when(self):
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             when("id", 1)
 
         self.check_error(
@@ -1285,7 +1285,7 @@ class FunctionsTestsMixin:
         )
 
     def test_window(self):
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             window("date", 5)
 
         self.check_error(
@@ -1295,7 +1295,7 @@ class FunctionsTestsMixin:
         )
 
     def test_session_window(self):
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             session_window("date", 5)
 
         self.check_error(
@@ -1305,7 +1305,7 @@ class FunctionsTestsMixin:
         )
 
     def test_bucket(self):
-        with self.assertRaises(PySparkException) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             bucket("5", "id")
 
         self.check_error(

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -22,6 +22,7 @@ import functools
 import unittest
 
 from pyspark import Row
+from pyspark.testing.utils import PySparkErrorTestUtils
 from pyspark.testing.sqlutils import (
     have_pandas,
     have_pyarrow,
@@ -162,7 +163,7 @@ class PlanOnlyTestFixture(unittest.TestCase):
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
-class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils):
+class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUtils):
     """
     Spark Connect version of :class:`pyspark.testing.sqlutils.ReusedSQLTestCase`.
     """

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 
 from pyspark.sql import SparkSession
 from pyspark.sql.types import ArrayType, DoubleType, UserDefinedType, Row
-from pyspark.testing.utils import ReusedPySparkTestCase
+from pyspark.testing.utils import ReusedPySparkTestCase, PySparkErrorTestUtils
 
 
 pandas_requirement_message = None
@@ -254,7 +254,7 @@ class SQLTestUtils:
         return sum(diff) == len(a)
 
 
-class ReusedSQLTestCase(ReusedPySparkTestCase, SQLTestUtils):
+class ReusedSQLTestCase(ReusedPySparkTestCase, SQLTestUtils, PySparkErrorTestUtils):
     @classmethod
     def setUpClass(cls):
         super(ReusedSQLTestCase, cls).setUpClass()

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -179,7 +179,8 @@ def search_jar(project_relative_path, sbt_jar_name_prefix, mvn_jar_name_prefix):
 
 class PySparkErrorTestUtils:
     """
-    This util provide functions to accurate and consistent error testing based on PySpark error classes.
+    This util provide functions to accurate and consistent error testing
+    based on PySpark error classes.
     """
 
     def check_error(

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -140,33 +140,6 @@ class ReusedPySparkTestCase(unittest.TestCase):
     def tearDownClass(cls):
         cls.sc.stop()
 
-    def check_error(
-        self,
-        exception: PySparkException,
-        error_class: str,
-        message_parameters: Optional[Dict[str, str]] = None,
-    ):
-        # Test if given error is an instance of PySparkException.
-        self.assertIsInstance(
-            exception,
-            PySparkException,
-            f"checkError requires 'PySparkException', got '{exception.__class__.__name__}'.",
-        )
-
-        # Test error class
-        expected = error_class
-        actual = exception.getErrorClass()
-        self.assertEqual(
-            expected, actual, f"Expected error class was '{expected}', got '{actual}'."
-        )
-
-        # Test message parameters
-        expected = message_parameters
-        actual = exception.getMessageParameters()
-        self.assertEqual(
-            expected, actual, f"Expected message parameters was '{expected}', got '{actual}'"
-        )
-
 
 class ByteArrayOutput:
     def __init__(self):
@@ -202,3 +175,36 @@ def search_jar(project_relative_path, sbt_jar_name_prefix, mvn_jar_name_prefix):
         raise RuntimeError("Found multiple JARs: %s; please remove all but one" % (", ".join(jars)))
     else:
         return jars[0]
+
+
+class PySparkErrorTestUtils:
+    """
+    This util provide functions to accurate and consistent error testing based on PySpark error classes.
+    """
+
+    def check_error(
+        self,
+        exception: PySparkException,
+        error_class: str,
+        message_parameters: Optional[Dict[str, str]] = None,
+    ):
+        # Test if given error is an instance of PySparkException.
+        self.assertIsInstance(
+            exception,
+            PySparkException,
+            f"checkError requires 'PySparkException', got '{exception.__class__.__name__}'.",
+        )
+
+        # Test error class
+        expected = error_class
+        actual = exception.getErrorClass()
+        self.assertEqual(
+            expected, actual, f"Expected error class was '{expected}', got '{actual}'."
+        )
+
+        # Test message parameters
+        expected = message_parameters
+        actual = exception.getMessageParameters()
+        self.assertEqual(
+            expected, actual, f"Expected message parameters was '{expected}', got '{actual}'"
+        )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR includes two JIRA tickets below:

SPARK-42082: This PR proposes to add `PySparkValueError` and `PySparkTypeError` to migrate the existing `ValueError` and `TypeError` into PySpark error framework.

SPARK-41598: This PR also migrate the errors from `pyspark/sql/functions.py` into error class by using `PySparkValueError` and `PySparkTypeError`.

### Why are the changes needed?

We should migrate all errors into PySpark error framework to provide actionable and consistent errors to end-users.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. It's an error improvement.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added UT, and manually tested.

Should pass the existing CI.