### PR TITLE
[SPARK-42109][BUILD] Upgrade Kafka to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>2.3</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
-    <kafka.version>3.3.1</kafka.version>
+    <kafka.version>3.3.2</kafka.version>
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.3</parquet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Kafka from 3.3.1 to 3.3.2 for Apache Spark 3.4.0.

### Why are the changes needed?

To bring the latest bug fixes.
- [KAFKA-14303 Producer.send without record key and batch.size=0 goes into infinite loop](https://issues.apache.org/jira/browse/KAFKA-14303)
- [KAFKA-14496 Wrong Base64 encoder used by OIDC OAuthBearerLoginCallbackHandler](https://issues.apache.org/jira/browse/KAFKA-14496)
- [KAFKA-14532 Correctly handle failed fetch when partitions unassigned](https://issues.apache.org/jira/browse/KAFKA-14532)
- [KAFKA-14553 RecordAccumulator hangs in infinite NOP loop](https://issues.apache.org/jira/browse/KAFKA-14553)

### Does this PR introduce _any_ user-facing change?

No. Apache Spark 3.4.0 is not released yet.

### How was this patch tested?

Pass the CIs.