### PR TITLE
[SPARK-42075][DSTREAM] Deprecate DStream API

### DIFF
--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -52,7 +52,7 @@ class StreamingContext:
         data will be divided into batches
     .. deprecated:: Spark 3.4.0
        This is deprecated as of Spark 3.4.0.
-       There are no longer updates to DStream and it’s a legacy project.
+       There are no longer updates to DStream and it's a legacy project.
        There is a newer and easier to use streaming engine in Spark called Structured Streaming.
        You should use Spark Structured Streaming for your streaming applications.
     """

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -26,6 +26,8 @@ from pyspark.streaming.dstream import DStream
 from pyspark.streaming.listener import StreamingListener
 from pyspark.streaming.util import TransformFunction, TransformFunctionSerializer
 
+import warnings
+
 __all__ = ["StreamingContext"]
 
 T = TypeVar("T")

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -48,6 +48,11 @@ class StreamingContext:
     batchDuration : int, optional
         the time interval (in seconds) at which streaming
         data will be divided into batches
+    .. deprecated:: Spark 3.4.0
+       This is deprecated as of Spark 3.4.0.
+       There are no longer updates to DStream and it’s a legacy project.
+       There is a newer and easier to use streaming engine in Spark called Structured Streaming.
+       You should use Spark Structured Streaming for your streaming applications.
     """
 
     _transformerSerializer = None
@@ -61,6 +66,7 @@ class StreamingContext:
         batchDuration: Optional[int] = None,
         jssc: Optional[JavaObject] = None,
     ):
+        warnings.warn("DStream is deprecated. Migrate to Structured Streaming", FutureWarning)
         self._sc = sparkContext
         self._jvm = self._sc._jvm
         self._jssc = jssc or self._initialize_context(self._sc, batchDuration)

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -68,7 +68,10 @@ class StreamingContext:
         batchDuration: Optional[int] = None,
         jssc: Optional[JavaObject] = None,
     ):
-        warnings.warn("DStream is deprecated as of Spark 3.4.0. Migrate to Structured Streaming.", FutureWarning)
+        warnings.warn(
+            "DStream is deprecated as of Spark 3.4.0. Migrate to Structured Streaming.",
+            FutureWarning,
+        )
         self._sc = sparkContext
         self._jvm = self._sc._jvm
         self._jssc = jssc or self._initialize_context(self._sc, batchDuration)

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -68,7 +68,7 @@ class StreamingContext:
         batchDuration: Optional[int] = None,
         jssc: Optional[JavaObject] = None,
     ):
-        warnings.warn("DStream is deprecated. Migrate to Structured Streaming", FutureWarning)
+        warnings.warn("DStream is deprecated as of Spark 3.4.0. Migrate to Structured Streaming", FutureWarning)
         self._sc = sparkContext
         self._jvm = self._sc._jvm
         self._jssc = jssc or self._initialize_context(self._sc, batchDuration)

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -43,6 +43,12 @@ class StreamingContext:
     respectively. `context.awaitTermination()` allows the current thread
     to wait for the termination of the context by `stop()` or by an exception.
 
+    .. deprecated:: Spark 3.4.0
+       This is deprecated as of Spark 3.4.0.
+       There are no longer updates to DStream and it's a legacy project.
+       There is a newer and easier to use streaming engine in Spark called Structured Streaming.
+       You should use Spark Structured Streaming for your streaming applications.
+
     Parameters
     ----------
     sparkContext : :class:`SparkContext`
@@ -50,11 +56,6 @@ class StreamingContext:
     batchDuration : int, optional
         the time interval (in seconds) at which streaming
         data will be divided into batches
-    .. deprecated:: Spark 3.4.0
-       This is deprecated as of Spark 3.4.0.
-       There are no longer updates to DStream and it's a legacy project.
-       There is a newer and easier to use streaming engine in Spark called Structured Streaming.
-       You should use Spark Structured Streaming for your streaming applications.
     """
 
     _transformerSerializer = None

--- a/python/pyspark/streaming/context.py
+++ b/python/pyspark/streaming/context.py
@@ -68,7 +68,7 @@ class StreamingContext:
         batchDuration: Optional[int] = None,
         jssc: Optional[JavaObject] = None,
     ):
-        warnings.warn("DStream is deprecated as of Spark 3.4.0. Migrate to Structured Streaming", FutureWarning)
+        warnings.warn("DStream is deprecated as of Spark 3.4.0. Migrate to Structured Streaming.", FutureWarning)
         self._sc = sparkContext
         self._jvm = self._sc._jvm
         self._jssc = jssc or self._initialize_context(self._sc, batchDuration)

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -61,7 +61,10 @@ import org.apache.spark.util.{CallSite, ShutdownHookManager, ThreadUtils, Utils}
  * `context.awaitTermination()` allows the current thread to wait for the termination
  * of the context by `stop()` or by an exception.
  */
-@deprecated
+@deprecated("This is deprecated as of Spark 3.4.0." +
+  " There are no longer updates to DStream and it's a legacy project." +
+  " There is a newer and easier to use streaming engine in Spark called Structured Streaming." +
+  " You should use Spark Structured Streaming for your streaming applications.", "Spark 3.4.0")
 class StreamingContext private[streaming] (
     _sc: SparkContext,
     _cp: Checkpoint,
@@ -742,7 +745,10 @@ class StreamingContext private[streaming] (
  * StreamingContext object contains a number of utility functions related to the
  * StreamingContext class.
  */
-
+@deprecated("This is deprecated as of Spark 3.4.0." +
+  " There are no longer updates to DStream and it's a legacy project." +
+  " There is a newer and easier to use streaming engine in Spark called Structured Streaming." +
+  " You should use Spark Structured Streaming for your streaming applications.", "Spark 3.4.0")
 object StreamingContext extends Logging {
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -61,7 +61,7 @@ import org.apache.spark.util.{CallSite, ShutdownHookManager, ThreadUtils, Utils}
  * `context.awaitTermination()` allows the current thread to wait for the termination
  * of the context by `stop()` or by an exception.
  * @deprecated This is deprecated as of Spark 3.4.0.
- *             There are no longer updates to DStream and it’s a legacy project.
+ *             There are no longer updates to DStream and it's a legacy project.
  *             There is a newer and easier to use streaming engine
  *             in Spark called Structured Streaming.
  *             You should use Spark Structured Streaming for your streaming applications.
@@ -748,7 +748,7 @@ class StreamingContext private[streaming] (
  * StreamingContext class.
  *
  * @deprecated This is deprecated as of Spark 3.4.0.
- *             There are no longer updates to DStream and it’s a legacy project.
+ *             There are no longer updates to DStream and it's a legacy project.
  *             There is a newer and easier to use streaming engine
  *             in Spark called Structured Streaming.
  *             You should use Spark Structured Streaming for your streaming applications.

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -66,7 +66,7 @@ import org.apache.spark.util.{CallSite, ShutdownHookManager, ThreadUtils, Utils}
  *             in Spark called Structured Streaming.
  *             You should use Spark Structured Streaming for your streaming applications.
  */
-@deprecated("DStream is deprecated. Migrate to Structured Streaming", "Spark 3.4.0")
+@deprecated("DStream is deprecated. Migrate to Structured Streaming.", "Spark 3.4.0")
 class StreamingContext private[streaming] (
     _sc: SparkContext,
     _cp: Checkpoint,
@@ -753,7 +753,7 @@ class StreamingContext private[streaming] (
  *             in Spark called Structured Streaming.
  *             You should use Spark Structured Streaming for your streaming applications.
  */
-@deprecated("DStream is deprecated. Migrate to Structured Streaming", "Spark 3.4.0")
+@deprecated("DStream is deprecated. Migrate to Structured Streaming.", "Spark 3.4.0")
 object StreamingContext extends Logging {
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -61,6 +61,7 @@ import org.apache.spark.util.{CallSite, ShutdownHookManager, ThreadUtils, Utils}
  * `context.awaitTermination()` allows the current thread to wait for the termination
  * of the context by `stop()` or by an exception.
  */
+@deprecated
 class StreamingContext private[streaming] (
     _sc: SparkContext,
     _cp: Checkpoint,

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -60,7 +60,6 @@ import org.apache.spark.util.{CallSite, ShutdownHookManager, ThreadUtils, Utils}
  * using `context.start()` and `context.stop()`, respectively.
  * `context.awaitTermination()` allows the current thread to wait for the termination
  * of the context by `stop()` or by an exception.
- * @since 3.4.0
  * @deprecated This is deprecated as of Spark 3.4.0.
  *             There are no longer updates to DStream and it’s a legacy project.
  *             There is a newer and easier to use streaming engine
@@ -748,7 +747,6 @@ class StreamingContext private[streaming] (
  * StreamingContext object contains a number of utility functions related to the
  * StreamingContext class.
  *
- * @since 3.4.0
  * @deprecated This is deprecated as of Spark 3.4.0.
  *             There are no longer updates to DStream and it’s a legacy project.
  *             There is a newer and easier to use streaming engine

--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -60,11 +60,14 @@ import org.apache.spark.util.{CallSite, ShutdownHookManager, ThreadUtils, Utils}
  * using `context.start()` and `context.stop()`, respectively.
  * `context.awaitTermination()` allows the current thread to wait for the termination
  * of the context by `stop()` or by an exception.
+ * @since 3.4.0
+ * @deprecated This is deprecated as of Spark 3.4.0.
+ *             There are no longer updates to DStream and it’s a legacy project.
+ *             There is a newer and easier to use streaming engine
+ *             in Spark called Structured Streaming.
+ *             You should use Spark Structured Streaming for your streaming applications.
  */
-@deprecated("This is deprecated as of Spark 3.4.0." +
-  " There are no longer updates to DStream and it's a legacy project." +
-  " There is a newer and easier to use streaming engine in Spark called Structured Streaming." +
-  " You should use Spark Structured Streaming for your streaming applications.", "Spark 3.4.0")
+@deprecated("DStream is deprecated. Migrate to Structured Streaming", "Spark 3.4.0")
 class StreamingContext private[streaming] (
     _sc: SparkContext,
     _cp: Checkpoint,
@@ -744,16 +747,21 @@ class StreamingContext private[streaming] (
 /**
  * StreamingContext object contains a number of utility functions related to the
  * StreamingContext class.
+ *
+ * @since 3.4.0
+ * @deprecated This is deprecated as of Spark 3.4.0.
+ *             There are no longer updates to DStream and it’s a legacy project.
+ *             There is a newer and easier to use streaming engine
+ *             in Spark called Structured Streaming.
+ *             You should use Spark Structured Streaming for your streaming applications.
  */
-@deprecated("This is deprecated as of Spark 3.4.0." +
-  " There are no longer updates to DStream and it's a legacy project." +
-  " There is a newer and easier to use streaming engine in Spark called Structured Streaming." +
-  " You should use Spark Structured Streaming for your streaming applications.", "Spark 3.4.0")
+@deprecated("DStream is deprecated. Migrate to Structured Streaming", "Spark 3.4.0")
 object StreamingContext extends Logging {
 
   /**
    * Lock that guards activation of a StreamingContext as well as access to the singleton active
    * StreamingContext in getActiveOrCreate().
+   *
    */
   private val ACTIVATION_LOCK = new Object()
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -56,7 +56,7 @@ import org.apache.spark.streaming.scheduler.StreamingListener
  *             in Spark called Structured Streaming.
  *             You should use Spark Structured Streaming for your streaming applications.
  */
-@deprecated("DStream is deprecated. Migrate to Structured Streaming", "Spark 3.4.0")
+@deprecated("DStream is deprecated. Migrate to Structured Streaming.", "Spark 3.4.0")
 class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -51,6 +51,7 @@ import org.apache.spark.streaming.scheduler.StreamingListener
  * respectively. `context.awaitTermination()` allows the current thread to wait for the
  * termination of a context by `stop()` or by an exception.
  */
+@deprecated
 class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -50,11 +50,14 @@ import org.apache.spark.streaming.scheduler.StreamingListener
  * computation can be started and stopped using `context.start()` and `context.stop()`,
  * respectively. `context.awaitTermination()` allows the current thread to wait for the
  * termination of a context by `stop()` or by an exception.
+ * @since 3.4.0
+ * @deprecated This is deprecated as of Spark 3.4.0.
+ *             There are no longer updates to DStream and it’s a legacy project.
+ *             There is a newer and easier to use streaming engine
+ *             in Spark called Structured Streaming.
+ *             You should use Spark Structured Streaming for your streaming applications.
  */
-@deprecated("This is deprecated as of Spark 3.4.0." +
-  " There are no longer updates to DStream and it's a legacy project." +
-  " There is a newer and easier to use streaming engine in Spark called Structured Streaming." +
-  " You should use Spark Structured Streaming for your streaming applications.", "Spark 3.4.0")
+@deprecated("DStream is deprecated. Migrate to Structured Streaming", "Spark 3.4.0")
 class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -50,7 +50,6 @@ import org.apache.spark.streaming.scheduler.StreamingListener
  * computation can be started and stopped using `context.start()` and `context.stop()`,
  * respectively. `context.awaitTermination()` allows the current thread to wait for the
  * termination of a context by `stop()` or by an exception.
- * @since 3.4.0
  * @deprecated This is deprecated as of Spark 3.4.0.
  *             There are no longer updates to DStream and it’s a legacy project.
  *             There is a newer and easier to use streaming engine

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -51,7 +51,10 @@ import org.apache.spark.streaming.scheduler.StreamingListener
  * respectively. `context.awaitTermination()` allows the current thread to wait for the
  * termination of a context by `stop()` or by an exception.
  */
-@deprecated
+@deprecated("This is deprecated as of Spark 3.4.0." +
+  " There are no longer updates to DStream and it's a legacy project." +
+  " There is a newer and easier to use streaming engine in Spark called Structured Streaming." +
+  " You should use Spark Structured Streaming for your streaming applications.", "Spark 3.4.0")
 class JavaStreamingContext(val ssc: StreamingContext) extends Closeable {
 
   /**

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/java/JavaStreamingContext.scala
@@ -51,7 +51,7 @@ import org.apache.spark.streaming.scheduler.StreamingListener
  * respectively. `context.awaitTermination()` allows the current thread to wait for the
  * termination of a context by `stop()` or by an exception.
  * @deprecated This is deprecated as of Spark 3.4.0.
- *             There are no longer updates to DStream and it’s a legacy project.
+ *             There are no longer updates to DStream and it's a legacy project.
  *             There is a newer and easier to use streaming engine
  *             in Spark called Structured Streaming.
  *             You should use Spark Structured Streaming for your streaming applications.

--- a/streaming/src/test/java/org/apache/spark/streaming/LocalJavaStreamingContext.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/LocalJavaStreamingContext.java
@@ -22,8 +22,6 @@ import org.apache.spark.streaming.api.java.JavaStreamingContext;
 import org.junit.After;
 import org.junit.Before;
 
-@SuppressWarnings( "deprecation" )
-
 public abstract class LocalJavaStreamingContext {
 
     protected transient JavaStreamingContext ssc;

--- a/streaming/src/test/java/org/apache/spark/streaming/LocalJavaStreamingContext.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/LocalJavaStreamingContext.java
@@ -22,6 +22,8 @@ import org.apache.spark.streaming.api.java.JavaStreamingContext;
 import org.junit.After;
 import org.junit.Before;
 
+@SuppressWarnings( "deprecation" )
+
 public abstract class LocalJavaStreamingContext {
 
     protected transient JavaStreamingContext ssc;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Deprecate the DStream interface by deprecating the StreamingContext api.


### Why are the changes needed?
DStream is not longer maintained. Encourage user to migrate to structured streaming.


### Does this PR introduce _any_ user-facing change?
Yes, user that use DStream will see deprecation warning.


### How was this patch tested?
No functional change
