### PR TITLE
[SPARK-42110][SQL][TESTS] Reduce the number of repetition in ParquetDeltaEncodingSuite.`random data test`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaEncodingSuite.scala
@@ -215,7 +215,7 @@ abstract class ParquetDeltaEncodingSuite[T] extends ParquetCompatibilityTest
   test("random data test") {
     val maxSize = 1000
     val data = allocDataArray(maxSize)
-    for (round <- 0 until 100000) {
+    for (round <- 0 until 10) {
       val size = random.nextInt(maxSize)
       for (i <- 0 until size) {
         data(i) = getNextRandom


### PR DESCRIPTION
### What changes were proposed in this pull request?

`random data test` is consuming about 4 minutes in GitHub Action and worse in some other environment.

### Why are the changes needed?

- https://github.com/apache/spark/actions/runs/3948081724/jobs/6757667891

```
ParquetDeltaEncodingInt
- random data test (1 minute, 51 seconds)
...
ParquetDeltaEncodingLong
...
- random data test (1 minute, 54 seconds)
```

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass the CIs.