### PR TITLE
[SPARK-42115][SQL][PYTHON] Push down limit through Python UDFs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1006,7 +1006,7 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
         agg.copy(aggregateExpressions = buildCleanedProjectList(
           p.projectList, agg.aggregateExpressions))
       case Project(l1, g @ GlobalLimit(_, limit @ LocalLimit(_, p2 @ Project(l2, _))))
-        if isRenaming(l1, l2) =>
+        if isRenaming(l1, l2) && l1.forall(!_.exists(_.isInstanceOf[PythonUDF])) =>
         val newProjectList = buildCleanedProjectList(l1, l2)
         g.copy(child = limit.copy(child = p2.copy(projectList = newProjectList)))
       case Project(l1, limit @ LocalLimit(_, p2 @ Project(l2, _))) if isRenaming(l1, l2) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1006,7 +1006,7 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
         agg.copy(aggregateExpressions = buildCleanedProjectList(
           p.projectList, agg.aggregateExpressions))
       case Project(l1, g @ GlobalLimit(_, limit @ LocalLimit(_, p2 @ Project(l2, _))))
-        if isRenaming(l1, l2) && l1.forall(!_.exists(_.isInstanceOf[PythonUDF])) =>
+        if isRenaming(l1, l2) =>
         val newProjectList = buildCleanedProjectList(l1, l2)
         g.copy(child = limit.copy(child = p2.copy(projectList = newProjectList)))
       case Project(l1, limit @ LocalLimit(_, p2 @ Project(l2, _))) if isRenaming(l1, l2) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/37941 that proposes to enable pushing down the limit through Python UDFs by disabling `PushProjectionThroughLimit` if it has Python UDF.

```python
from pyspark.sql.functions import udf

spark.range(10).write.mode("overwrite").parquet("/tmp/abc")

@udf(returnType='string')
def my_udf(arg):
    return arg


df = spark.read.parquet("/tmp/abc")
df = df.limit(10).withColumn("prediction", my_udf(df["id"])).explain()
```

**Before**:

```
== Physical Plan ==
CollectLimit 10
+- *(2) Project [id#3L, pythonUDF0#10 AS prediction#6]
   +- BatchEvalPython [my_udf(id#3L)#5], [pythonUDF0#10]
      +- *(1) ColumnarToRow
         +- FileScan parquet [id#3L] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/tmp/abc], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<id:bigint>
```

**After**:

```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Project [id#3L, pythonUDF0#10 AS prediction#6]
   +- BatchEvalPython [my_udf(id#3L)#5], [pythonUDF0#10]
      +- GlobalLimit 10, 0
         +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=35]
            +- LocalLimit 10
               +- FileScan parquet [id#3L] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/tmp/abc], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<id:bigint>
```

### Why are the changes needed?

To restore the performance issue. This is a regression in the master branch.

Python UDF is very slow, and it is executed asynchronously and process data in batch. So, regardless of the parent limit, Python UDF at least processes one batch (e.g., one Arrow batch) which can potentially cause performance regression especially in a workload like machine learning. 

### Does this PR introduce _any_ user-facing change?

Restore the performance.

### How was this patch tested?
