### PR TITLE
[SPARK-42116][SQL][TESTS] Mark `ColumnarBatchSuite` as `ExtendedSQLTest`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -43,9 +43,11 @@ import org.apache.spark.sql.execution.datasources.parquet.VectorizedPlainValuesR
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnarBatchRow, ColumnVector}
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
+@ExtendedSQLTest
 class ColumnarBatchSuite extends SparkFunSuite {
 
   private def allocate(capacity: Int, dt: DataType, memMode: MemoryMode): WritableColumnVector = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark `ColumnarBatchSuite` as `ExtendedSQLTest`

### Why are the changes needed?

It took over about 7 minutes in GitHub Action environment and worse in the other CI environment.
- https://github.com/apache/spark/actions/runs/3954751091/jobs/6772414846
```
ColumnarBatchSuite:
...
- Random flat schema (1 minute, 53 seconds)
- Random nested schema (5 minutes, 5 seconds)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.