### PR TITLE
[MINOR][TESTS][DOCS] Fix instructions for running `AvroWriteBenchmark` from sbt

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/execution/benchmark/AvroWriteBenchmark.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/execution/benchmark/AvroWriteBenchmark.scala
@@ -30,7 +30,7 @@ import org.apache.spark.storage.StorageLevel
  *        --jars <spark core test jar>,<spark catalyst test jar>,
   *              <spark sql test jar>,<spark avro jar>
  *        <spark avro test jar>
- *   2. build/sbt "sql/Test/runMain <this class>"
+ *   2. build/sbt "avro/Test/runMain <this class>"
  *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "avro/Test/runMain <this class>"
  *      Results will be written to "benchmarks/AvroWriteBenchmark-results.txt".
  *  }}}


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the instructions for running `AvroWriteBenchmark` from sbt, change the project name to avro.

### Why are the changes needed?

The previous instructions were incorrect.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually ran benchmark according to new instructions.
