### PR TITLE
[SPARK-42128][SQL] Support TOP (N) for MS SQL Server dialect as an alternative to Limit pushdown

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -307,11 +307,12 @@ private[jdbc] class JDBCRDD(
       ""
     }
 
+    val myTopExpression: String = dialect.getTopExpression(limit) // SQL Server Limit alternative
     val myLimitClause: String = dialect.getLimitClause(limit)
     val myOffsetClause: String = dialect.getOffsetClause(offset)
 
     val sqlText = options.prepareQuery +
-      s"SELECT $columnList FROM ${options.tableOrQuery} $myTableSampleClause" +
+      s"SELECT $myTopExpression $columnList FROM ${options.tableOrQuery} $myTableSampleClause" +
       s" $myWhereClause $getGroupByClause $getOrderByClause $myLimitClause $myOffsetClause"
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -545,6 +545,14 @@ abstract class JdbcDialect extends Serializable with Logging {
   }
 
   /**
+   * MS SQL Server version of `getLimitClause`.
+   * This is only supported by SQL Server as it uses TOP (N) instead.
+   */
+  def getTopExpression(limit: Integer): String = {
+    ""
+  }
+
+  /**
    * returns the OFFSET clause for the SELECT statement
    */
   def getOffsetClause(offset: Integer): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -167,8 +167,13 @@ private object MsSqlServerDialect extends JdbcDialect {
     throw QueryExecutionErrors.commentOnTableUnsupportedError()
   }
 
+  // SQL Server does not support, it uses `getTopExpression` instead.
   override def getLimitClause(limit: Integer): String = {
     ""
+  }
+
+  override def getTopExpression(limit: Integer): String = {
+    if (limit > 0) s"TOP ($limit)" else ""
   }
 
   override def classifyException(message: String, e: Throwable): AnalysisException = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1001,6 +1001,35 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("Dialect Limit and Top implementation") {
+    // Dialects that support LIMIT N.
+    val limitDialects = Seq(
+      JdbcDialects.get("jdbc:mysql"),
+      JdbcDialects.get("jdbc:postgresql"),
+      JdbcDialects.get("jdbc:db2"),
+      JdbcDialects.get("jdbc:h2")
+    )
+
+    for (dialect <- limitDialects) {
+      assert(dialect.getLimitClause(0) == "")
+      assert(dialect.getTopExpression(0) == "")
+      assert(dialect.getLimitClause(100) == "LIMIT 100")
+      assert(dialect.getTopExpression(100) == "")
+    }
+
+    // Dialects that support TOP (N)
+    val topDialects = Seq(
+      JdbcDialects.get("jdbc:sqlserver")
+    )
+
+    for (dialect <- topDialects) {
+      assert(dialect.getLimitClause(0) == "")
+      assert(dialect.getTopExpression(0) == "")
+      assert(dialect.getLimitClause(100) == "")
+      assert(dialect.getTopExpression(100) == "TOP (100)")
+    }
+  }
+
   test("table exists query by jdbc dialect") {
     val MySQL = JdbcDialects.get("jdbc:mysql://127.0.0.1/db")
     val Postgres = JdbcDialects.get("jdbc:postgresql://127.0.0.1/db")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1001,7 +1001,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("Dialect Limit and Top implementation") {
+  test("SPARK-42128: Dialect Limit and Top implementation") {
     // Dialects that support LIMIT N.
     val limitDialects = Seq(
       JdbcDialects.get("jdbc:mysql"),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds Limit pushdown support for MS SQL Server. Although SQL Server does not support LIMIT clause, it supports TOP (N) expression (https://learn.microsoft.com/en-us/sql/t-sql/queries/top-transact-sql?view=sql-server-ver16) which works in a similar way.

It is a simple change that adds another method to the dialect API to handle TOP expression specifically for SQL Server (or other database that might support it in the future). However, TOP and LIMIT are mutually exclusive in this PR.

TOP (N) also requires that a subquery is named, e.g. `select TOP (5) * from (select * from test) XYZ`, otherwise the query fails. Currently Spark injects `SPARK_GEN_SUBQ_` name, so it works fine.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Enables Limit pushdown for MS SQL Server.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I added a unit test and verified manually against a SQL Server instance.