### PR TITLE
[SPARK-42130][UI] Handle null string values in AccumulableInfo and ProcessSummary

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -22,8 +22,12 @@ package org.apache.spark.status.protobuf;
  * Developer guides:
  *   - Coding style: https://developers.google.com/protocol-buffers/docs/style
  *   - Use int64 for job/stage IDs, in case of future extension in Spark core.
- *   - Use `weakIntern` on string values in create new objects during deserialization.
- *   - When serializing strings, check if the inputs are null to avoid NPE.
+ *   - For string fields:
+ *     - use `optional string` for protobuf definition
+ *     - on serialization, check if the string is null to avoid NPE
+ *     - on deserialization, set string fields as null if it is not set. Also, use `weakIntern` on
+ *       string values in create new objects during deserialization.
+ *     - add tests with null string inputs
  */
 
 enum JobExecutionStatus {
@@ -66,9 +70,9 @@ message JobDataWrapper {
 
 message AccumulableInfo {
   int64 id = 1;
-  string name = 2;
+  optional string name = 2;
   optional string update = 3;
-  string value = 4;
+  optional string value = 4;
 }
 
 message TaskDataWrapper {
@@ -335,8 +339,8 @@ message SpeculationStageSummaryWrapper {
 }
 
 message ProcessSummary {
-  string id = 1;
-  string host_port = 2;
+  optional string id = 1;
+  optional string host_port = 2;
   bool is_active = 3;
   int32 total_cores = 4;
   int64 add_time = 5;

--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -23,6 +23,7 @@ package org.apache.spark.status.protobuf;
  *   - Coding style: https://developers.google.com/protocol-buffers/docs/style
  *   - Use int64 for job/stage IDs, in case of future extension in Spark core.
  *   - Use `weakIntern` on string values in create new objects during deserialization.
+ *   - When serializing strings, check if the inputs are null to avoid NPE.
  */
 
 enum JobExecutionStatus {

--- a/core/src/main/scala/org/apache/spark/status/protobuf/AccumulableInfoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/AccumulableInfoSerializer.scala
@@ -22,7 +22,7 @@ import java.util.{List => JList}
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.status.api.v1.AccumulableInfo
-import org.apache.spark.status.protobuf.Utils.getOptional
+import org.apache.spark.status.protobuf.Utils.{getOptional, setStringField}
 import org.apache.spark.util.Utils.weakIntern
 
 private[protobuf] object AccumulableInfoSerializer {
@@ -30,8 +30,8 @@ private[protobuf] object AccumulableInfoSerializer {
   def serialize(input: AccumulableInfo): StoreTypes.AccumulableInfo = {
     val builder = StoreTypes.AccumulableInfo.newBuilder()
       .setId(input.id)
-      .setName(input.name)
-      .setValue(input.value)
+    setStringField(input.name, builder.setName)
+    setStringField(input.value, builder.setValue)
     input.update.foreach(builder.setUpdate)
     builder.build()
   }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/AccumulableInfoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/AccumulableInfoSerializer.scala
@@ -22,7 +22,7 @@ import java.util.{List => JList}
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.status.api.v1.AccumulableInfo
-import org.apache.spark.status.protobuf.Utils.{getOptional, setStringField}
+import org.apache.spark.status.protobuf.Utils.{getOptional, getStringField, setStringField}
 import org.apache.spark.util.Utils.weakIntern
 
 private[protobuf] object AccumulableInfoSerializer {
@@ -41,9 +41,9 @@ private[protobuf] object AccumulableInfoSerializer {
     updates.forEach { update =>
       accumulatorUpdates.append(new AccumulableInfo(
         id = update.getId,
-        name = weakIntern(update.getName),
+        name = getStringField(update.hasName, () => weakIntern(update.getName)),
         update = getOptional(update.hasUpdate, update.getUpdate),
-        value = update.getValue))
+        value = getStringField(update.hasValue, update.getValue)))
     }
     accumulatorUpdates
   }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/ProcessSummaryWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/ProcessSummaryWrapperSerializer.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.status.ProcessSummaryWrapper
 import org.apache.spark.status.api.v1.ProcessSummary
-import org.apache.spark.status.protobuf.Utils.{getOptional, setStringField}
+import org.apache.spark.status.protobuf.Utils.{getOptional, getStringField, setStringField}
 
 class ProcessSummaryWrapperSerializer extends ProtobufSerDe[ProcessSummaryWrapper] {
 
@@ -59,8 +59,8 @@ class ProcessSummaryWrapperSerializer extends ProtobufSerDe[ProcessSummaryWrappe
   private def deserializeProcessSummary(info: StoreTypes.ProcessSummary): ProcessSummary = {
     val removeTime = getOptional(info.hasRemoveTime, () => new Date(info.getRemoveTime))
     new ProcessSummary(
-      id = info.getId,
-      hostPort = info.getHostPort,
+      id = getStringField(info.hasId, info.getId),
+      hostPort = getStringField(info.hasHostPort, info.getHostPort),
       isActive = info.getIsActive,
       totalCores = info.getTotalCores,
       addTime = new Date(info.getAddTime),

--- a/core/src/main/scala/org/apache/spark/status/protobuf/ProcessSummaryWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/ProcessSummaryWrapperSerializer.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.status.ProcessSummaryWrapper
 import org.apache.spark.status.api.v1.ProcessSummary
-import org.apache.spark.status.protobuf.Utils.getOptional
+import org.apache.spark.status.protobuf.Utils.{getOptional, setStringField}
 
 class ProcessSummaryWrapperSerializer extends ProtobufSerDe[ProcessSummaryWrapper] {
 
@@ -42,8 +42,8 @@ class ProcessSummaryWrapperSerializer extends ProtobufSerDe[ProcessSummaryWrappe
 
   private def serializeProcessSummary(info: ProcessSummary): StoreTypes.ProcessSummary = {
     val builder = StoreTypes.ProcessSummary.newBuilder()
-    builder.setId(info.id)
-    builder.setHostPort(info.hostPort)
+    setStringField(info.id, builder.setId)
+    setStringField(info.hostPort, builder.setHostPort)
     builder.setIsActive(info.isActive)
     builder.setTotalCores(info.totalCores)
     builder.setAddTime(info.addTime.getTime)

--- a/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
@@ -17,10 +17,18 @@
 
 package org.apache.spark.status.protobuf
 
+import com.google.protobuf.MessageOrBuilder
+
 object Utils {
   def getOptional[T](condition: Boolean, result: () => T): Option[T] = if (condition) {
     Some(result())
   } else {
     None
+  }
+
+  def setStringField(input: String, f: String => MessageOrBuilder): Unit = {
+    if (input != null) {
+      f(input)
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
@@ -31,4 +31,10 @@ object Utils {
       f(input)
     }
   }
+
+  def getStringField(condition: Boolean, result: () => String): String = if (condition) {
+    result()
+  } else {
+    null
+  }
 }

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -758,29 +758,34 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
   }
 
   test("Process Summary") {
-    val input = new ProcessSummaryWrapper(
-      info = new ProcessSummary(
-        id = "id_1",
-        hostPort = "localhost:2020",
-        isActive = true,
-        totalCores = 4,
-        addTime = new Date(1234567L),
-        removeTime = Some(new Date(1234568L)),
-        processLogs = Map("log1" -> "log/log1", "log2" -> "logs/log2.log")
+    Seq(
+      ("id_1", "localhost:2020"),
+      (null, "") // hostPort can't be null. Otherwise there will be NPE.
+    ).foreach { case(id, hostPort) =>
+      val input = new ProcessSummaryWrapper(
+        info = new ProcessSummary(
+          id = id,
+          hostPort = hostPort,
+          isActive = true,
+          totalCores = 4,
+          addTime = new Date(1234567L),
+          removeTime = Some(new Date(1234568L)),
+          processLogs = Map("log1" -> "log/log1", "log2" -> "logs/log2.log")
+        )
       )
-    )
-    val bytes = serializer.serialize(input)
-    val result = serializer.deserialize(bytes, classOf[ProcessSummaryWrapper])
-    assert(result.info.id == input.info.id)
-    assert(result.info.hostPort == input.info.hostPort)
-    assert(result.info.isActive == input.info.isActive)
-    assert(result.info.totalCores == input.info.totalCores)
-    assert(result.info.addTime == input.info.addTime)
-    assert(result.info.removeTime == input.info.removeTime)
-    assert(result.info.processLogs.size == input.info.processLogs.size)
-    result.info.processLogs.keys.foreach { k =>
-      assert(input.info.processLogs.contains(k))
-      assert(result.info.processLogs(k) == input.info.processLogs(k))
+      val bytes = serializer.serialize(input)
+      val result = serializer.deserialize(bytes, classOf[ProcessSummaryWrapper])
+      assert(result.info.id == emptyStringForNull(input.info.id))
+      assert(result.info.hostPort == emptyStringForNull(input.info.hostPort))
+      assert(result.info.isActive == input.info.isActive)
+      assert(result.info.totalCores == input.info.totalCores)
+      assert(result.info.addTime == input.info.addTime)
+      assert(result.info.removeTime == input.info.removeTime)
+      assert(result.info.processLogs.size == input.info.processLogs.size)
+      result.info.processLogs.keys.foreach { k =>
+        assert(input.info.processLogs.contains(k))
+        assert(result.info.processLogs(k) == input.info.processLogs(k))
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -775,8 +775,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       )
       val bytes = serializer.serialize(input)
       val result = serializer.deserialize(bytes, classOf[ProcessSummaryWrapper])
-      assert(result.info.id == emptyStringForNull(input.info.id))
-      assert(result.info.hostPort == emptyStringForNull(input.info.hostPort))
+      assert(result.info.id == input.info.id)
+      assert(result.info.hostPort == input.info.hostPort)
       assert(result.info.isActive == input.info.isActive)
       assert(result.info.totalCores == input.info.totalCores)
       assert(result.info.addTime == input.info.addTime)
@@ -1363,23 +1363,15 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     assert(result.recordsWritten == expected.recordsWritten)
   }
 
-  private def emptyStringForNull(s: String) = {
-    if (s == null) {
-      ""
-    } else {
-      s
-    }
-  }
-
   private def checkAnswer(result: collection.Seq[AccumulableInfo],
       expected: collection.Seq[AccumulableInfo]): Unit = {
     assert(result.length == expected.length)
     result.zip(expected).foreach { case (a1, a2) =>
       assert(a1.id == a2.id)
-      assert(a1.name == emptyStringForNull(a2.name))
+      assert(a1.name == a2.name)
       assert(a1.update.getOrElse("") == a2.update.getOrElse(""))
       assert(a1.update == a2.update)
-      assert(a1.value == emptyStringForNull(a2.value))
+      assert(a1.value == a2.value)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -86,7 +86,8 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
   test("Task Data") {
     val accumulatorUpdates = Seq(
       new AccumulableInfo(1L, "duration", Some("update"), "value1"),
-      new AccumulableInfo(2L, "duration2", None, "value2")
+      new AccumulableInfo(2L, "duration2", None, "value2"),
+      new AccumulableInfo(-1L, null, None, null)
     )
     val input = new TaskDataWrapper(
       taskId = 1,
@@ -1357,14 +1358,23 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
     assert(result.recordsWritten == expected.recordsWritten)
   }
 
+  private def emptyStringForNull(s: String) = {
+    if (s == null) {
+      ""
+    } else {
+      s
+    }
+  }
+
   private def checkAnswer(result: collection.Seq[AccumulableInfo],
       expected: collection.Seq[AccumulableInfo]): Unit = {
     assert(result.length == expected.length)
     result.zip(expected).foreach { case (a1, a2) =>
       assert(a1.id == a2.id)
-      assert(a1.name == a2.name)
+      assert(a1.name == emptyStringForNull(a2.name))
       assert(a1.update.getOrElse("") == a2.update.getOrElse(""))
       assert(a1.update == a2.update)
+      assert(a1.value == emptyStringForNull(a2.value))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
After revisiting https://github.com/apache/spark/pull/39416 and https://github.com/apache/spark/pull/39623, I propose:
* checking nullability of all string fields to avoid NPE
* using `optional string` for the protobuf definition of all string fields. If the deserialized result is None, then set the string field as null. 

Take `AccumulableInfo` as an example, it can be null on created: https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/status/LiveEntity.scala#L744
The null value can make difference in the UI logic: https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala#L791

This PR updates the developer guide and introduces utility methods for serializing/deserializing string fields. It also handles null string values in AccumulableInfo and ProcessSummary for setting an example.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
* update developer guide for better handling of null string values
* add utility methods for future development of string serialization/deserialization
* Properly handles null string values in AccumulableInfo and ProcessSummary for setting an example

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Test null string input values in AccumulableInfo and ProcessSummary protobuf serializer.