### PR TITLE
[SPARK-42131][SQL] Extract the function that construct the select statement for JDBC dialect.

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -62,6 +62,7 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
     .set("spark.sql.catalog.db2", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.db2.url", db.getJdbcUrl(dockerIp, externalPort))
     .set("spark.sql.catalog.db2.pushDownAggregate", "true")
+    .set("spark.sql.catalog.db2.pushDownLimit", "true")
 
   override def tablePreparation(connection: Connection): Unit = {
     connection.prepareStatement(

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -22,8 +22,7 @@ import java.sql.{Connection, SQLFeatureNotSupportedException}
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, DataFrame}
-import org.apache.spark.sql.catalyst.plans.logical.Sort
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.DatabaseOnDocker
 import org.apache.spark.sql.types._
@@ -97,38 +96,6 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     }.getCause.asInstanceOf[SQLFeatureNotSupportedException].getMessage
 
     assert(msg.contains("UpdateColumnNullability is not supported"))
-  }
-
-  test("simple scan with LIMIT") {
-    val df = sql(s"SELECT * FROM $catalogAndNamespace." +
-      s"${caseConvert("employee")} WHERE dept > 0 LIMIT 1")
-    assert(limitPushed(df, 1))
-    val row = df.collect()
-    assert(row.length === 1)
-    assert(row(0).getInt(0) === 1)
-    assert(row(0).getString(1) === "amy")
-    assert(row(0).getDecimal(2) === new java.math.BigDecimal("10000.00"))
-    assert(row(0).getDouble(3) === 1000d)
-  }
-
-  private def checkSortRemoved(df: DataFrame): Unit = {
-    val sorts = df.queryExecution.optimizedPlan.collect {
-      case s: Sort => s
-    }
-    assert(sorts.isEmpty)
-  }
-
-  test("simple scan with top N") {
-    val df = sql(s"SELECT * FROM $catalogAndNamespace." +
-      s"${caseConvert("employee")} WHERE dept > 0 ORDER BY salary LIMIT 1")
-    assert(limitPushed(df, 1))
-    checkSortRemoved(df)
-    val row = df.collect()
-    assert(row.length === 1)
-    assert(row(0).getInt(0) === 1)
-    assert(row(0).getString(1) === "cathy")
-    assert(row(0).getDecimal(2) === new java.math.BigDecimal("9000.00"))
-    assert(row(0).getDouble(3) === 1200d)
   }
 
   testVarPop()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -55,6 +55,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     .set("spark.sql.catalog.mysql", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.mysql.url", db.getJdbcUrl(dockerIp, externalPort))
     .set("spark.sql.catalog.mysql.pushDownAggregate", "true")
+    .set("spark.sql.catalog.mysql.pushDownLimit", "true")
 
   override val connectionTimeout = timeout(7.minutes)
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -76,6 +76,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
     .set("spark.sql.catalog.oracle", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.oracle.url", db.getJdbcUrl(dockerIp, externalPort))
     .set("spark.sql.catalog.oracle.pushDownAggregate", "true")
+    .set("spark.sql.catalog.oracle.pushDownLimit", "true")
 
   override val connectionTimeout = timeout(7.minutes)
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -82,7 +82,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
 
   override def tablePreparation(connection: Connection): Unit = {
     connection.prepareStatement(
-      "CREATE TABLE employee (dept NUMBER(32), name VARCHAR2(32), salary NUMBER(20, 2)," +
+      "CREATE TABLE employee (dept NUMBER(32, 0), name VARCHAR2(32), salary NUMBER(20, 2)," +
         " bonus BINARY_DOUBLE)").executeUpdate()
   }
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -82,7 +82,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
 
   override def tablePreparation(connection: Connection): Unit = {
     connection.prepareStatement(
-      "CREATE TABLE employee (dept NUMBER(32, 0), name VARCHAR2(32), salary NUMBER(20, 2)," +
+      "CREATE TABLE employee (dept NUMBER(32), name VARCHAR2(32), salary NUMBER(20, 2)," +
         " bonus BINARY_DOUBLE)").executeUpdate()
   }
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -41,7 +41,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
   val namespaceOpt: Option[String] = None
 
-  protected def catalogAndNamespace =
+  private def catalogAndNamespace =
     namespaceOpt.map(namespace => s"$catalogName.$namespace").getOrElse(catalogName)
 
   // dialect specific update column type test

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -21,10 +21,11 @@ import org.apache.logging.log4j.Level
 
 import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.apache.spark.sql.catalyst.analysis.{IndexAlreadyExistsException, NoSuchIndexException, UnresolvedAttribute}
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Sample}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Sample, Sort}
 import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.connector.catalog.{Catalogs, Identifier, TableCatalog}
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
+import org.apache.spark.sql.connector.expressions.NullOrdering
 import org.apache.spark.sql.connector.expressions.aggregate.GeneralAggregateFunc
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, V1ScanWrapper}
 import org.apache.spark.sql.jdbc.DockerIntegrationFunSuite
@@ -313,7 +314,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     }
   }
 
-  protected def limitPushed(df: DataFrame, limit: Int): Boolean = {
+  private def limitPushed(df: DataFrame, limit: Int): Boolean = {
     df.queryExecution.optimizedPlan.collect {
       case relation: DataSourceV2ScanRelation => relation.scan match {
         case v1: V1ScanWrapper =>
@@ -402,7 +403,52 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     }
   }
 
-  protected def checkAggregateRemoved(df: DataFrame): Unit = {
+  private def checkSortRemoved(df: DataFrame): Unit = {
+    val sorts = df.queryExecution.optimizedPlan.collect {
+      case s: Sort => s
+    }
+    assert(sorts.isEmpty)
+  }
+
+  test("simple scan with LIMIT") {
+    val df = sql(s"SELECT * FROM $catalogAndNamespace." +
+      s"${caseConvert("employee")} WHERE dept > 0 LIMIT 1")
+    assert(limitPushed(df, 1))
+    val rows = df.collect()
+    assert(rows.length === 1)
+    assert(rows(0).getInt(0) === 1)
+    assert(rows(0).getString(1) === "amy")
+    assert(rows(0).getDecimal(2) === new java.math.BigDecimal("10000.00"))
+    assert(rows(0).getDouble(3) === 1000d)
+  }
+
+  test("simple scan with top N") {
+    Seq(NullOrdering.values()).flatten.foreach { nullOrdering =>
+      val df1 = sql(s"SELECT * FROM $catalogAndNamespace." +
+        s"${caseConvert("employee")} WHERE dept > 0 ORDER BY salary $nullOrdering LIMIT 1")
+      assert(limitPushed(df1, 1))
+      checkSortRemoved(df1)
+      val rows1 = df1.collect()
+      assert(rows1.length === 1)
+      assert(rows1(0).getInt(0) === 1)
+      assert(rows1(0).getString(1) === "cathy")
+      assert(rows1(0).getDecimal(2) === new java.math.BigDecimal("9000.00"))
+      assert(rows1(0).getDouble(3) === 1200d)
+
+      val df2 = sql(s"SELECT * FROM $catalogAndNamespace." +
+        s"${caseConvert("employee")} WHERE dept > 0 ORDER BY bonus DESC $nullOrdering LIMIT 1")
+      assert(limitPushed(df2, 1))
+      checkSortRemoved(df2)
+      val rows2 = df2.collect()
+      assert(rows2.length === 1)
+      assert(rows2(0).getInt(0) === 2)
+      assert(rows2(0).getString(1) === "david")
+      assert(rows2(0).getDecimal(2) === new java.math.BigDecimal("10000.00"))
+      assert(rows2(0).getDouble(3) === 1300d)
+    }
+  }
+
+  private def checkAggregateRemoved(df: DataFrame): Unit = {
     val aggregates = df.queryExecution.optimizedPlan.collect {
       case agg: Aggregate => agg
     }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -40,7 +40,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
   val namespaceOpt: Option[String] = None
 
-  private def catalogAndNamespace =
+  protected def catalogAndNamespace =
     namespaceOpt.map(namespace => s"$catalogName.$namespace").getOrElse(catalogName)
 
   // dialect specific update column type test
@@ -313,7 +313,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     }
   }
 
-  private def limitPushed(df: DataFrame, limit: Int): Boolean = {
+  protected def limitPushed(df: DataFrame, limit: Int): Boolean = {
     df.queryExecution.optimizedPlan.collect {
       case relation: DataSourceV2ScanRelation => relation.scan match {
         case v1: V1ScanWrapper =>

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -411,40 +411,37 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
   }
 
   test("simple scan with LIMIT") {
-    val df = sql(s"SELECT * FROM $catalogAndNamespace." +
+    val df = sql(s"SELECT name, salary, bonus FROM $catalogAndNamespace." +
       s"${caseConvert("employee")} WHERE dept > 0 LIMIT 1")
     assert(limitPushed(df, 1))
     val rows = df.collect()
     assert(rows.length === 1)
-    assert(rows(0).getInt(0) === 1)
-    assert(rows(0).getString(1) === "amy")
-    assert(rows(0).getDecimal(2) === new java.math.BigDecimal("10000.00"))
-    assert(rows(0).getDouble(3) === 1000d)
+    assert(rows(0).getString(0) === "amy")
+    assert(rows(0).getDecimal(1) === new java.math.BigDecimal("10000.00"))
+    assert(rows(0).getDouble(2) === 1000d)
   }
 
   test("simple scan with top N") {
     Seq(NullOrdering.values()).flatten.foreach { nullOrdering =>
-      val df1 = sql(s"SELECT * FROM $catalogAndNamespace." +
+      val df1 = sql(s"SELECT name, salary, bonus FROM $catalogAndNamespace." +
         s"${caseConvert("employee")} WHERE dept > 0 ORDER BY salary $nullOrdering LIMIT 1")
       assert(limitPushed(df1, 1))
       checkSortRemoved(df1)
       val rows1 = df1.collect()
       assert(rows1.length === 1)
-      assert(rows1(0).getInt(0) === 1)
-      assert(rows1(0).getString(1) === "cathy")
-      assert(rows1(0).getDecimal(2) === new java.math.BigDecimal("9000.00"))
-      assert(rows1(0).getDouble(3) === 1200d)
+      assert(rows1(0).getString(0) === "cathy")
+      assert(rows1(0).getDecimal(1) === new java.math.BigDecimal("9000.00"))
+      assert(rows1(0).getDouble(2) === 1200d)
 
-      val df2 = sql(s"SELECT * FROM $catalogAndNamespace." +
+      val df2 = sql(s"SELECT name, salary, bonus FROM $catalogAndNamespace." +
         s"${caseConvert("employee")} WHERE dept > 0 ORDER BY bonus DESC $nullOrdering LIMIT 1")
       assert(limitPushed(df2, 1))
       checkSortRemoved(df2)
       val rows2 = df2.collect()
       assert(rows2.length === 1)
-      assert(rows2(0).getInt(0) === 2)
-      assert(rows2(0).getString(1) === "david")
-      assert(rows2(0).getDecimal(2) === new java.math.BigDecimal("10000.00"))
-      assert(rows2(0).getDouble(3) === 1300d)
+      assert(rows2(0).getString(0) === "david")
+      assert(rows2(0).getDecimal(1) === new java.math.BigDecimal("10000.00"))
+      assert(rows2(0).getDouble(2) === 1300d)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -259,9 +259,10 @@ private[jdbc] class JDBCRDD(
       .withLimit(limit)
       .withOffset(offset)
 
-    val sqlText = groupByColumns.map(builder.withGroupByColumns).getOrElse(
-      sample.map(builder.withTableSample).getOrElse(builder)).build()
+    groupByColumns.foreach(builder.withGroupByColumns)
+    sample.foreach(builder.withTableSample)
 
+    val sqlText = builder.build()
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
     stmt.setFetchSize(options.fetchSize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -251,7 +251,7 @@ private[jdbc] class JDBCRDD(
     // fully-qualified table name in the SELECT statement.  I don't know how to
     // talk about a table in a completely portable way.
 
-    val builder = dialect.getJdbcSQLBuilder(options)
+    val builder = dialect.getJdbcSQLQueryBuilder(options)
     val sqlText = builder
       .withColumns(columns)
       .withPredicates(predicates, part)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -251,7 +251,7 @@ private[jdbc] class JDBCRDD(
     // fully-qualified table name in the SELECT statement.  I don't know how to
     // talk about a table in a completely portable way.
 
-    val builder = dialect
+    var builder = dialect
       .getJdbcSQLQueryBuilder(options)
       .withColumns(columns)
       .withPredicates(predicates, part)
@@ -259,8 +259,13 @@ private[jdbc] class JDBCRDD(
       .withLimit(limit)
       .withOffset(offset)
 
-    groupByColumns.foreach(builder.withGroupByColumns)
-    sample.foreach(builder.withTableSample)
+    groupByColumns.foreach { groupByKeys =>
+      builder = builder.withGroupByColumns(groupByKeys)
+    }
+
+    sample.foreach { tableSampleInfo =>
+      builder = builder.withTableSample(tableSampleInfo)
+    }
 
     val sqlText = builder.build()
     stmt = conn.prepareStatement(sqlText,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -251,16 +251,16 @@ private[jdbc] class JDBCRDD(
     // fully-qualified table name in the SELECT statement.  I don't know how to
     // talk about a table in a completely portable way.
 
-    val builder = dialect.getJdbcSQLQueryBuilder(options)
-    val sqlText = builder
+    val builder = dialect
+      .getJdbcSQLQueryBuilder(options)
       .withColumns(columns)
       .withPredicates(predicates, part)
       .withGroupByColumns(groupByColumns)
       .withSortOrders(sortOrders)
       .withLimit(limit)
       .withOffset(offset)
-      .withTableSample(sample)
-      .build()
+
+    val sqlText = sample.map(builder.withTableSample).getOrElse(builder).build()
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
     stmt.setFetchSize(options.fetchSize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -255,12 +255,13 @@ private[jdbc] class JDBCRDD(
       .getJdbcSQLQueryBuilder(options)
       .withColumns(columns)
       .withPredicates(predicates, part)
-      .withGroupByColumns(groupByColumns)
       .withSortOrders(sortOrders)
       .withLimit(limit)
       .withOffset(offset)
 
-    val sqlText = sample.map(builder.withTableSample).getOrElse(builder).build()
+    val sqlText = groupByColumns.map(builder.withGroupByColumns).getOrElse(
+      sample.map(builder.withTableSample).getOrElse(builder)).build()
+
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
     stmt.setFetchSize(options.fetchSize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -184,29 +184,6 @@ private[jdbc] class JDBCRDD(
   private val columnList: String = if (columns.isEmpty) "1" else columns.mkString(",")
 
   /**
-   * `filters`, but as a WHERE clause suitable for injection into a SQL query.
-   */
-  private val filterWhereClause: String = {
-    val dialect = JdbcDialects.get(url)
-    predicates.flatMap(dialect.compileExpression(_)).map(p => s"($p)").mkString(" AND ")
-  }
-
-  /**
-   * A WHERE clause representing both `filters`, if any, and the current partition.
-   */
-  private def getWhereClause(part: JDBCPartition): String = {
-    if (part.whereClause != null && filterWhereClause.length > 0) {
-      "WHERE " + s"($filterWhereClause)" + " AND " + s"(${part.whereClause})"
-    } else if (part.whereClause != null) {
-      "WHERE " + part.whereClause
-    } else if (filterWhereClause.length > 0) {
-      "WHERE " + filterWhereClause
-    } else {
-      ""
-    }
-  }
-
-  /**
    * A GROUP BY clause representing pushed-down grouping columns.
    */
   private def getGroupByClause: String = {
@@ -299,20 +276,8 @@ private[jdbc] class JDBCRDD(
     // fully-qualified table name in the SELECT statement.  I don't know how to
     // talk about a table in a completely portable way.
 
-    val myWhereClause = getWhereClause(part)
-
-    val myTableSampleClause: String = if (sample.nonEmpty) {
-      JdbcDialects.get(url).getTableSample(sample.get)
-    } else {
-      ""
-    }
-
-    val myLimitClause: String = dialect.getLimitClause(limit)
-    val myOffsetClause: String = dialect.getOffsetClause(offset)
-
-    val sqlText = options.prepareQuery +
-      s"SELECT $columnList FROM ${options.tableOrQuery} $myTableSampleClause" +
-      s" $myWhereClause $getGroupByClause $getOrderByClause $myLimitClause $myOffsetClause"
+    val sqlText = dialect.getSQLText(options, columnList, sample, predicates, part,
+      getGroupByClause, getOrderByClause, limit, offset)
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
     stmt.setFetchSize(options.fetchSize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -184,6 +184,29 @@ private[jdbc] class JDBCRDD(
   private val columnList: String = if (columns.isEmpty) "1" else columns.mkString(",")
 
   /**
+   * `filters`, but as a WHERE clause suitable for injection into a SQL query.
+   */
+  private val filterWhereClause: String = {
+    val dialect = JdbcDialects.get(url)
+    predicates.flatMap(dialect.compileExpression(_)).map(p => s"($p)").mkString(" AND ")
+  }
+
+  /**
+   * A WHERE clause representing both `filters`, if any, and the current partition.
+   */
+  private def getWhereClause(part: JDBCPartition): String = {
+    if (part.whereClause != null && filterWhereClause.length > 0) {
+      "WHERE " + s"($filterWhereClause)" + " AND " + s"(${part.whereClause})"
+    } else if (part.whereClause != null) {
+      "WHERE " + part.whereClause
+    } else if (filterWhereClause.length > 0) {
+      "WHERE " + filterWhereClause
+    } else {
+      ""
+    }
+  }
+
+  /**
    * A GROUP BY clause representing pushed-down grouping columns.
    */
   private def getGroupByClause: String = {
@@ -276,8 +299,19 @@ private[jdbc] class JDBCRDD(
     // fully-qualified table name in the SELECT statement.  I don't know how to
     // talk about a table in a completely portable way.
 
-    val sqlText = dialect.getSQLText(options, columnList, sample, predicates, part,
-      getGroupByClause, getOrderByClause, limit, offset)
+    val myWhereClause = getWhereClause(part)
+
+    val myTableSampleClause: String = if (sample.nonEmpty) {
+      JdbcDialects.get(url).getTableSample(sample.get)
+    } else {
+      ""
+    }
+
+    val myLimitClause: String = dialect.getLimitClause(limit)
+    val myOffsetClause: String = dialect.getOffsetClause(offset)
+
+    val sqlText = dialect.getSQLText(options, columnList, myTableSampleClause, myWhereClause,
+      getGroupByClause, getOrderByClause, myLimitClause, myOffsetClause)
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
     stmt.setFetchSize(options.fetchSize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -554,7 +554,8 @@ abstract class JdbcDialect extends Serializable with Logging {
   /**
    * returns the SQL builder for the SELECT statement.
    */
-  def getJdbcSQLBuilder(options: JDBCOptions): JdbcSQLBuilder = new JdbcSQLBuilder(this, options)
+  def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
+    new JdbcSQLQueryBuilder(this, options)
 
   def supportsTableSample: Boolean = false
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -538,21 +538,21 @@ abstract class JdbcDialect extends Serializable with Logging {
   }
 
   /**
-   * returns the LIMIT clause for the SELECT statement
+   * Returns the LIMIT clause for the SELECT statement
    */
   def getLimitClause(limit: Integer): String = {
     if (limit > 0 ) s"LIMIT $limit" else ""
   }
 
   /**
-   * returns the OFFSET clause for the SELECT statement
+   * Returns the OFFSET clause for the SELECT statement
    */
   def getOffsetClause(offset: Integer): String = {
     if (offset > 0 ) s"OFFSET $offset" else ""
   }
 
   /**
-   * returns the SQL builder for the SELECT statement.
+   * Returns the SQL builder for the SELECT statement.
    */
   def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
     new JdbcSQLQueryBuilder(this, options)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -552,6 +552,11 @@ abstract class JdbcDialect extends Serializable with Logging {
   }
 
   /**
+   * returns the SQL builder for the SELECT statement.
+   */
+  def getJdbcSQLBuilder(options: JDBCOptions): JdbcSQLBuilder = new JdbcSQLBuilder(this, options)
+
+  /**
    * returns the SQL text for the SELECT statement.
    *
    * @param options - JDBC options that contains url, table and other information.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -37,10 +37,9 @@ import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
 import org.apache.spark.sql.connector.catalog.index.TableIndex
 import org.apache.spark.sql.connector.expressions.{Expression, Literal, NamedReference}
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc
-import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.util.V2ExpressionSQLBuilder
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions, JDBCPartition, JdbcUtils}
+import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions, JdbcUtils}
 import org.apache.spark.sql.execution.datasources.jdbc.connection.ConnectionProvider
 import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -556,34 +556,6 @@ abstract class JdbcDialect extends Serializable with Logging {
    */
   def getJdbcSQLBuilder(options: JDBCOptions): JdbcSQLBuilder = new JdbcSQLBuilder(this, options)
 
-  /**
-   * returns the SQL text for the SELECT statement.
-   *
-   * @param options - JDBC options that contains url, table and other information.
-   * @param columnList - The names of the columns or aggregate columns to SELECT.
-   * @param tableSampleClause - The table sample clause for the SELECT statement.
-   * @param whereClause - The WHERE clause for the SELECT statement.
-   * @param groupByClause - The group by clause for the SELECT statement.
-   * @param orderByClause - The order by clause for the SELECT statement.
-   * @param limitClause - The LIMIT clause for the SELECT statement.
-   * @param offsetClause - The OFFSET clause for the SELECT statement.
-   * @return
-   */
-  def getSQLText(
-      options: JDBCOptions,
-      columnList: String,
-      tableSampleClause: String,
-      whereClause: String,
-      groupByClause: String,
-      orderByClause: String,
-      limitClause: String,
-      offsetClause: String): String = {
-
-    options.prepareQuery +
-      s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
-      s" $whereClause $groupByClause $orderByClause $limitClause $offsetClause"
-  }
-
   def supportsTableSample: Boolean = false
 
   def getTableSample(sample: TableSampleInfo): String =

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLBuilder.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JDBCPartition}
+import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
+
+/**
+ * The builder to generate jdbc sql query.
+ *
+ * @since 3.4.0
+ */
+class JdbcSQLBuilder(dialect: JdbcDialect, options: JDBCOptions) {
+
+  var columnList: String = "1"
+  var whereClause: String = ""
+  var groupByClause: String = ""
+  var orderByClause: String = ""
+  var limitClause: String = ""
+  var offsetClause: String = ""
+  var tableSampleClause: String = ""
+
+  def withColumns(columns: Array[String]): JdbcSQLBuilder = {
+    if (columns.nonEmpty) {
+      columnList = columns.mkString(",")
+    }
+    this
+  }
+
+  def withPredicates(predicates: Array[Predicate], part: JDBCPartition): JdbcSQLBuilder = {
+    // `filters`, but as a WHERE clause suitable for injection into a SQL query.
+    val filterWhereClause: String = {
+      predicates.flatMap(dialect.compileExpression(_)).map(p => s"($p)").mkString(" AND ")
+    }
+
+    // A WHERE clause representing both `filters`, if any, and the current partition.
+    whereClause = if (part.whereClause != null && filterWhereClause.length > 0) {
+      "WHERE " + s"($filterWhereClause)" + " AND " + s"(${part.whereClause})"
+    } else if (part.whereClause != null) {
+      "WHERE " + part.whereClause
+    } else if (filterWhereClause.length > 0) {
+      "WHERE " + filterWhereClause
+    } else {
+      ""
+    }
+
+    this
+  }
+
+  def withGroupByColumns(groupByColumns: Option[Array[String]]): JdbcSQLBuilder = {
+    if (groupByColumns.nonEmpty && groupByColumns.get.nonEmpty) {
+      // The GROUP BY columns should already be quoted by the caller side.
+      groupByClause = s"GROUP BY ${groupByColumns.get.mkString(", ")}"
+    }
+
+    this
+  }
+
+  def withSortOrders(sortOrders: Array[String]): JdbcSQLBuilder = {
+    if (sortOrders.nonEmpty) {
+      orderByClause = s" ORDER BY ${sortOrders.mkString(", ")}"
+    }
+
+    this
+  }
+
+  def withLimit(limit: Int): JdbcSQLBuilder = {
+    limitClause = dialect.getLimitClause(limit)
+
+    this
+  }
+
+  def withOffset(offset: Int): JdbcSQLBuilder = {
+    offsetClause = dialect.getOffsetClause(offset)
+
+    this
+  }
+
+  def withTableSample(sample: Option[TableSampleInfo]): JdbcSQLBuilder = {
+    if (sample.nonEmpty) {
+      tableSampleClause = dialect.getTableSample(sample.get)
+    }
+
+    this
+  }
+
+  def build(): String = {
+    options.prepareQuery +
+      s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
+      s" $whereClause $groupByClause $orderByClause $limitClause $offsetClause"
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLBuilder.scala
@@ -31,37 +31,37 @@ class JdbcSQLBuilder(dialect: JdbcDialect, options: JDBCOptions) {
   /**
    * `columns`, but as a String suitable for injection into a SQL query.
    */
-  var columnList: String = "1"
+  protected var columnList: String = "1"
 
   /**
    * A WHERE clause representing both `filters`, if any, and the current partition.
    */
-  var whereClause: String = ""
+  protected var whereClause: String = ""
 
   /**
    * A GROUP BY clause representing pushed-down grouping columns.
    */
-  var groupByClause: String = ""
+  protected var groupByClause: String = ""
 
   /**
    * A ORDER BY clause representing pushed-down sort of top n.
    */
-  var orderByClause: String = ""
+  protected var orderByClause: String = ""
 
   /**
    * A LIMIT clause representing pushed-down limit.
    */
-  var limitClause: String = ""
+  protected var limitClause: String = ""
 
   /**
    * A OFFSET clause representing pushed-down offset.
    */
-  var offsetClause: String = ""
+  protected var offsetClause: String = ""
 
   /**
    * A table sample clause representing pushed-down table sample.
    */
-  var tableSampleClause: String = ""
+  protected var tableSampleClause: String = ""
 
   def withColumns(columns: Array[String]): JdbcSQLBuilder = {
     if (columns.nonEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLBuilder.scala
@@ -28,12 +28,39 @@ import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
  */
 class JdbcSQLBuilder(dialect: JdbcDialect, options: JDBCOptions) {
 
+  /**
+   * `columns`, but as a String suitable for injection into a SQL query.
+   */
   var columnList: String = "1"
+
+  /**
+   * A WHERE clause representing both `filters`, if any, and the current partition.
+   */
   var whereClause: String = ""
+
+  /**
+   * A GROUP BY clause representing pushed-down grouping columns.
+   */
   var groupByClause: String = ""
+
+  /**
+   * A ORDER BY clause representing pushed-down sort of top n.
+   */
   var orderByClause: String = ""
+
+  /**
+   * A LIMIT clause representing pushed-down limit.
+   */
   var limitClause: String = ""
+
+  /**
+   * A OFFSET clause representing pushed-down offset.
+   */
   var offsetClause: String = ""
+
+  /**
+   * A table sample clause representing pushed-down table sample.
+   */
   var tableSampleClause: String = ""
 
   def withColumns(columns: Array[String]): JdbcSQLBuilder = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
@@ -104,11 +104,9 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
   /**
    * Constructs the GROUP BY clause that following dialect's SQL syntax.
    */
-  def withGroupByColumns(groupByColumns: Option[Array[String]]): JdbcSQLQueryBuilder = {
-    if (groupByColumns.nonEmpty && groupByColumns.get.nonEmpty) {
-      // The GROUP BY columns should already be quoted by the caller side.
-      groupByClause = s"GROUP BY ${groupByColumns.get.mkString(", ")}"
-    }
+  def withGroupByColumns(groupByColumns: Array[String]): JdbcSQLQueryBuilder = {
+    // The GROUP BY columns should already be quoted by the caller side.
+    groupByClause = s"GROUP BY ${groupByColumns.mkString(", ")}"
 
     this
   }
@@ -151,6 +149,9 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
     this
   }
 
+  /**
+   * Build the final SQL query that following dialect's SQL syntax.
+   */
   def build(): String = {
     // Constructs the LIMIT clause that following dialect's SQL syntax.
     val limitClause = dialect.getLimitClause(limit)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
  * matter, as all these clauses follow the natural SQL order: sample the table first, then filter,
  * then group by, then sort, then offset, then limit.
  *
- * @since 3.4.0
+ * @since 3.5.0
  */
 class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
 
@@ -67,6 +67,10 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
    */
   protected var tableSampleClause: String = ""
 
+  /**
+   * The columns names that following dialect's SQL syntax.
+   * e.g. The column name is the raw name or quoted name.
+   */
   def withColumns(columns: Array[String]): JdbcSQLQueryBuilder = {
     if (columns.nonEmpty) {
       columnList = columns.mkString(",")
@@ -74,6 +78,9 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
     this
   }
 
+  /**
+   * Constructs the WHERE clause that following dialect's SQL syntax.
+   */
   def withPredicates(predicates: Array[Predicate], part: JDBCPartition): JdbcSQLQueryBuilder = {
     // `filters`, but as a WHERE clause suitable for injection into a SQL query.
     val filterWhereClause: String = {
@@ -94,6 +101,9 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
     this
   }
 
+  /**
+   * Constructs the GROUP BY clause that following dialect's SQL syntax.
+   */
   def withGroupByColumns(groupByColumns: Option[Array[String]]): JdbcSQLQueryBuilder = {
     if (groupByColumns.nonEmpty && groupByColumns.get.nonEmpty) {
       // The GROUP BY columns should already be quoted by the caller side.
@@ -103,6 +113,9 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
     this
   }
 
+  /**
+   * Constructs the ORDER BY clause that following dialect's SQL syntax.
+   */
   def withSortOrders(sortOrders: Array[String]): JdbcSQLQueryBuilder = {
     if (sortOrders.nonEmpty) {
       orderByClause = s" ORDER BY ${sortOrders.mkString(", ")}"
@@ -111,28 +124,37 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
     this
   }
 
+  /**
+   * Saves the limit value used to construct LIMIT clause.
+   */
   def withLimit(limit: Int): JdbcSQLQueryBuilder = {
     this.limit = limit
 
     this
   }
 
+  /**
+   * Saves the offset value used to construct OFFSET clause.
+   */
   def withOffset(offset: Int): JdbcSQLQueryBuilder = {
     this.offset = offset
 
     this
   }
 
-  def withTableSample(sample: Option[TableSampleInfo]): JdbcSQLQueryBuilder = {
-    if (sample.nonEmpty) {
-      tableSampleClause = dialect.getTableSample(sample.get)
-    }
+  /**
+   * Constructs the table sample clause that following dialect's SQL syntax.
+   */
+  def withTableSample(sample: TableSampleInfo): JdbcSQLQueryBuilder = {
+    tableSampleClause = dialect.getTableSample(sample)
 
     this
   }
 
   def build(): String = {
+    // Constructs the LIMIT clause that following dialect's SQL syntax.
     val limitClause = dialect.getLimitClause(limit)
+    // Constructs the OFFSET clause that following dialect's SQL syntax.
     val offsetClause = dialect.getOffsetClause(offset)
 
     options.prepareQuery +

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
@@ -105,8 +105,10 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
    * Constructs the GROUP BY clause that following dialect's SQL syntax.
    */
   def withGroupByColumns(groupByColumns: Array[String]): JdbcSQLQueryBuilder = {
-    // The GROUP BY columns should already be quoted by the caller side.
-    groupByClause = s"GROUP BY ${groupByColumns.mkString(", ")}"
+    if (groupByColumns.nonEmpty) {
+      // The GROUP BY columns should already be quoted by the caller side.
+      groupByClause = s"GROUP BY ${groupByColumns.mkString(", ")}"
+    }
 
     this
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
  *
  * @since 3.4.0
  */
-class JdbcSQLBuilder(dialect: JdbcDialect, options: JDBCOptions) {
+class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
 
   /**
    * `columns`, but as a String suitable for injection into a SQL query.
@@ -63,14 +63,14 @@ class JdbcSQLBuilder(dialect: JdbcDialect, options: JDBCOptions) {
    */
   protected var tableSampleClause: String = ""
 
-  def withColumns(columns: Array[String]): JdbcSQLBuilder = {
+  def withColumns(columns: Array[String]): JdbcSQLQueryBuilder = {
     if (columns.nonEmpty) {
       columnList = columns.mkString(",")
     }
     this
   }
 
-  def withPredicates(predicates: Array[Predicate], part: JDBCPartition): JdbcSQLBuilder = {
+  def withPredicates(predicates: Array[Predicate], part: JDBCPartition): JdbcSQLQueryBuilder = {
     // `filters`, but as a WHERE clause suitable for injection into a SQL query.
     val filterWhereClause: String = {
       predicates.flatMap(dialect.compileExpression(_)).map(p => s"($p)").mkString(" AND ")
@@ -90,7 +90,7 @@ class JdbcSQLBuilder(dialect: JdbcDialect, options: JDBCOptions) {
     this
   }
 
-  def withGroupByColumns(groupByColumns: Option[Array[String]]): JdbcSQLBuilder = {
+  def withGroupByColumns(groupByColumns: Option[Array[String]]): JdbcSQLQueryBuilder = {
     if (groupByColumns.nonEmpty && groupByColumns.get.nonEmpty) {
       // The GROUP BY columns should already be quoted by the caller side.
       groupByClause = s"GROUP BY ${groupByColumns.get.mkString(", ")}"
@@ -99,7 +99,7 @@ class JdbcSQLBuilder(dialect: JdbcDialect, options: JDBCOptions) {
     this
   }
 
-  def withSortOrders(sortOrders: Array[String]): JdbcSQLBuilder = {
+  def withSortOrders(sortOrders: Array[String]): JdbcSQLQueryBuilder = {
     if (sortOrders.nonEmpty) {
       orderByClause = s" ORDER BY ${sortOrders.mkString(", ")}"
     }
@@ -107,19 +107,19 @@ class JdbcSQLBuilder(dialect: JdbcDialect, options: JDBCOptions) {
     this
   }
 
-  def withLimit(limit: Int): JdbcSQLBuilder = {
+  def withLimit(limit: Int): JdbcSQLQueryBuilder = {
     limitClause = dialect.getLimitClause(limit)
 
     this
   }
 
-  def withOffset(offset: Int): JdbcSQLBuilder = {
+  def withOffset(offset: Int): JdbcSQLQueryBuilder = {
     offsetClause = dialect.getOffsetClause(offset)
 
     this
   }
 
-  def withTableSample(sample: Option[TableSampleInfo]): JdbcSQLBuilder = {
+  def withTableSample(sample: Option[TableSampleInfo]): JdbcSQLQueryBuilder = {
     if (sample.nonEmpty) {
       tableSampleClause = dialect.getTableSample(sample.get)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -183,7 +183,7 @@ private object MsSqlServerDialect extends JdbcDialect {
   }
 
   override def getLimitClause(limit: Integer): String = {
-    if (limit > 0 ) s"TOP $limit" else ""
+    if (limit > 0) s"TOP $limit" else ""
   }
 
   override def classifyException(message: String, e: Throwable): AnalysisException = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -199,7 +199,10 @@ private object MsSqlServerDialect extends JdbcDialect {
 
   class MsSqlServerSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
     extends JdbcSQLQueryBuilder(dialect, options) {
+
     override def build(): String = {
+      val limitClause = dialect.getLimitClause(limit)
+
       options.prepareQuery +
         s"SELECT $limitClause $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
         s" $whereClause $groupByClause $orderByClause"

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -200,6 +200,7 @@ private object MsSqlServerDialect extends JdbcDialect {
   class MsSqlServerSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
     extends JdbcSQLQueryBuilder(dialect, options) {
 
+    // TODO[SPARK-42289]: DS V2 pushdown could let JDBC dialect decide to push down offset
     override def build(): String = {
       val limitClause = dialect.getLimitClause(limit)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -186,11 +186,6 @@ private object MsSqlServerDialect extends JdbcDialect {
     if (limit > 0 ) s"TOP $limit" else ""
   }
 
-  override def getOffsetClause(offset: Integer): String = {
-    // MS SQL Server doesn't support offset clause.
-    ""
-  }
-
   override def classifyException(message: String, e: Throwable): AnalysisException = {
     e match {
       case sqlException: SQLException =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -24,8 +24,9 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException
-import org.apache.spark.sql.connector.expressions.Expression
+import org.apache.spark.sql.connector.expressions.{Expression, NullOrdering, SortDirection}
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -63,6 +64,20 @@ private object MsSqlServerDialect extends JdbcDialect {
     supportedFunctions.contains(funcName)
 
   class MsSqlServerSQLBuilder extends JDBCSQLBuilder {
+    override def visitSortOrder(
+        sortKey: String, sortDirection: SortDirection, nullOrdering: NullOrdering): String = {
+      (sortDirection, nullOrdering) match {
+        case (SortDirection.ASCENDING, NullOrdering.NULLS_FIRST) =>
+          s"$sortKey $sortDirection"
+        case (SortDirection.ASCENDING, NullOrdering.NULLS_LAST) =>
+          s"CASE WHEN $sortKey IS NULL THEN 1 ELSE 0 END, $sortKey $sortDirection"
+        case (SortDirection.DESCENDING, NullOrdering.NULLS_FIRST) =>
+          s"CASE WHEN $sortKey IS NULL THEN 0 ELSE 1 END, $sortKey $sortDirection"
+        case (SortDirection.DESCENDING, NullOrdering.NULLS_LAST) =>
+          s"$sortKey $sortDirection"
+      }
+    }
+
     override def dialectFunctionName(funcName: String): String = funcName match {
       case "VAR_POP" => "VARP"
       case "VAR_SAMP" => "VAR"
@@ -168,6 +183,11 @@ private object MsSqlServerDialect extends JdbcDialect {
   }
 
   override def getLimitClause(limit: Integer): String = {
+    if (limit > 0 ) s"TOP $limit" else ""
+  }
+
+  override def getOffsetClause(offset: Integer): String = {
+    // MS SQL Server doesn't support offset clause.
     ""
   }
 
@@ -181,4 +201,16 @@ private object MsSqlServerDialect extends JdbcDialect {
       case _ => super.classifyException(message, e)
     }
   }
+
+  class MsSqlServerSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
+    extends JdbcSQLQueryBuilder(dialect, options) {
+    override def build(): String = {
+      options.prepareQuery +
+        s"SELECT $limitClause $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
+        s" $whereClause $groupByClause $orderByClause"
+    }
+  }
+
+  override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
+    new MsSqlServerSQLQueryBuilder(this, options)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -24,6 +24,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.expressions.Expression
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -173,4 +174,33 @@ private case object OracleDialect extends JdbcDialect {
     val nullable = if (isNullable) "NULL" else "NOT NULL"
     s"ALTER TABLE $tableName MODIFY ${quoteIdentifier(columnName)} $nullable"
   }
+
+  override def getLimitClause(limit: Integer): String = {
+    if (limit > 0 ) s"rownum <= $limit" else ""
+  }
+
+  class OracleSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
+    extends JdbcSQLQueryBuilder(dialect, options) {
+
+    override def build(): String = {
+      // Oracle doesn't support LIMIT clause.
+      // We can use rownum <= n to limit the number of rows in the result set.
+      if (limit > 0) {
+        val limitClause = dialect.getLimitClause(limit)
+        if (whereClause.isEmpty) {
+          whereClause = s"WHERE $limitClause"
+        } else {
+          whereClause += s"AND $limitClause"
+        }
+      }
+
+      // TODO[SPARK-42289]: DS V2 pushdown could let JDBC dialect decide to push down offset
+      options.prepareQuery +
+        s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
+        s" $whereClause $groupByClause $orderByClause"
+    }
+  }
+
+  override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
+    new OracleSQLQueryBuilder(this, options)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -178,7 +178,7 @@ private case object OracleDialect extends JdbcDialect {
   override def getLimitClause(limit: Integer): String = {
     // Oracle doesn't support LIMIT clause.
     // We can use rownum <= n to limit the number of rows in the result set.
-    if (limit > 0 ) s"WHERE rownum <= $limit" else ""
+    if (limit > 0) s"WHERE rownum <= $limit" else ""
   }
 
   class OracleSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -184,8 +184,8 @@ private case object OracleDialect extends JdbcDialect {
   class OracleSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
     extends JdbcSQLQueryBuilder(dialect, options) {
 
+    // TODO[SPARK-42289]: DS V2 pushdown could let JDBC dialect decide to push down offset
     override def build(): String = {
-      // TODO[SPARK-42289]: DS V2 pushdown could let JDBC dialect decide to push down offset
       val selectStmt = s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
         s" $whereClause $groupByClause $orderByClause"
       if (limit > 0) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, JDBCRDD uses fixed format for SELECT statement.
```
val sqlText = options.prepareQuery +
      s"SELECT $columnList FROM ${options.tableOrQuery} $myTableSampleClause" +
      s" $myWhereClause $getGroupByClause $getOrderByClause $myLimitClause $myOffsetClause"
```

But some databases have different syntax. For example, MS SQL Server uses keyword TOP to describe LIMIT clause or Top N.
The LIMIT clause of MS SQL Server show below.
```
SELECT TOP(1) Model, Color, Price  
      FROM dbo.Cars  
      WHERE Color = 'blue'
```
The Top N of MS SQL Server show below.
```
SELECT TOP(1) Model, Color, Price  
FROM dbo.Cars  
WHERE Color = 'blue'  
ORDER BY Price ASC
```

This PR lets JDBC dialect could define their own syntax.

### Why are the changes needed?
Extract the function that construct the select statement for JDBC dialect.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
N/A
