### PR TITLE
[SPARK-40303][DOCS] Deprecate old Java 8 versions prior to 8u362

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Spark runs on both Windows and UNIX-like systems (e.g. Linux, Mac OS), and it sh
 
 Spark runs on Java 8/11/17, Scala 2.12/2.13, Python 3.7+ and R 3.5+.
 Python 3.7 support is deprecated as of Spark 3.4.0.
-Java 8 prior to version 8u201 support is deprecated as of Spark 3.2.0. It's recommended to use 8u362 and later versions.
+Java 8 prior to version 8u362 support is deprecated as of Spark 3.4.0.
 When using the Scala API, it is necessary for applications to use the same version of Scala that Spark was compiled for.
 For example, when using Scala 2.13, use Spark compiled for 2.13, and compile code/applications for Scala 2.13 as well.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Spark runs on both Windows and UNIX-like systems (e.g. Linux, Mac OS), and it sh
 
 Spark runs on Java 8/11/17, Scala 2.12/2.13, Python 3.7+ and R 3.5+.
 Python 3.7 support is deprecated as of Spark 3.4.0.
-Java 8 prior to version 8u201 support is deprecated as of Spark 3.2.0.
+Java 8 prior to version 8u201 support is deprecated as of Spark 3.2.0. It's recommended to use 8u362 and later versions.
 When using the Scala API, it is necessary for applications to use the same version of Scala that Spark was compiled for.
 For example, when using Scala 2.13, use Spark compiled for 2.13, and compile code/applications for Scala 2.13 as well.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to deprecate old Java 8 versions prior to 8u362. 

### Why are the changes needed?

8u362 fixed a performance issue: https://github.com/openjdk/jdk8u-dev/pull/161

Benchmark code:
```scala
val dir = "/tmp/spark/benchmark"
val N = 2000000
val columns = Range(0, 100).map(i => s"id % $i AS id$i")

spark.range(N).selectExpr(columns: _*).write.mode("Overwrite").parquet(dir)

val cnt = 60
val selectExps = columns.take(cnt).map(_.split(" ").last).map(c => s"count(distinct $c)")
val start = System.currentTimeMillis()
spark.read.parquet(dir).selectExpr(selectExps: _*).collect()
println(s"Benchmark result. Java version: ${System.getProperty("java.version")}. Time(ms): ${System.currentTimeMillis() - start}")
```

8u352 benchmark result:
```shell
export JAVA_HOME=/Users/yumwang/Downloads/zulu8.66.0.15-ca-jdk8.0.352-macosx_x64
export PATH=${JAVA_HOME}/bin:${PATH}

bin/spark-shell  --master "local[2]" -i benchmark.scala
Benchmark result. Java version: 1.8.0_352. Time(ms): 641155
```

8u362 benchmark result:
```shell
export JAVA_HOME=/Users/yumwang/Downloads/zulu8.68.0.19-ca-jdk8.0.362-macosx_x64
export PATH=${JAVA_HOME}/bin:${PATH}

bin/spark-shell  --master "local[2]" -i benchmark.scala
Benchmark result. Java version: 1.8.0_362. Time(ms): 79360
```


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.