### PR TITLE
[SPARK-42137][CORE] Enable `spark.kryo.unsafe` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Kryo.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Kryo.scala
@@ -41,7 +41,7 @@ private[spark] object Kryo {
   val KRYO_USE_UNSAFE = ConfigBuilder("spark.kryo.unsafe")
     .version("2.1.0")
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 
   val KRYO_USE_POOL = ConfigBuilder("spark.kryo.pool")
     .version("3.0.0")

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -70,7 +70,8 @@ public class UnsafeShuffleWriterSuite implements ShuffleChecksumTestHelper {
   long[] partitionSizesInMergedFile;
   final LinkedList<File> spillFilesCreated = new LinkedList<>();
   SparkConf conf;
-  final Serializer serializer = new KryoSerializer(new SparkConf());
+  final Serializer serializer =
+    new KryoSerializer(new SparkConf().set("spark.kryo.unsafe", "false"));
   TaskMetrics taskMetrics;
 
   @Mock(answer = RETURNS_SMART_NULLS) BlockManager blockManager;
@@ -97,7 +98,8 @@ public class UnsafeShuffleWriterSuite implements ShuffleChecksumTestHelper {
     spillFilesCreated.clear();
     conf = new SparkConf()
       .set(package$.MODULE$.BUFFER_PAGESIZE().key(), "1m")
-      .set(package$.MODULE$.MEMORY_OFFHEAP_ENABLED(), false);
+      .set(package$.MODULE$.MEMORY_OFFHEAP_ENABLED(), false)
+      .set("spark.kryo.unsafe", "false");
     taskMetrics = new TaskMetrics();
     memoryManager = new TestMemoryManager(conf);
     taskMemoryManager = new TaskMemoryManager(memoryManager, 0);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1776,7 +1776,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.kryo.unsafe</code></td>
-  <td>false</td>
+  <td>true</td>
   <td>
     Whether to use unsafe based Kryo serializer. Can be
     substantially faster by using Unsafe Based IO.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `spark.kryo.unsafe` by default at Apache Spark 3.4. This configuration was introduced at Apache Spark 2.1.0 and has been used.

https://github.com/apache/spark/blob/66f6a63b4ae00607b7a3d44371d379bbe1374569/core/src/main/scala/org/apache/spark/internal/config/Kryo.scala#L41-L44

Note that this is used only inside `KryoSerializer` class which is still disabled by default. New behavior will be used only when the user sets `KryoSerializer` explicitly.

### Why are the changes needed?

To help a user use `KroSerializer` more easily by setting `spark.serializer=org.apache.spark.serializer.KryoSerializer`.

Apache Spark provides the benchmark result already.

https://github.com/apache/spark/blob/66f6a63b4ae00607b7a3d44371d379bbe1374569/core/benchmarks/KryoBenchmark-jdk11-results.txt#L1-L26

### Does this PR introduce _any_ user-facing change?

No. This is still behind `spark.serializer` configuration which is unchanged.

### How was this patch tested?

Pass the CIs.
