### PR TITLE
[SPARK-42142][UI] Handle null string values in CachedQuantile/ExecutorSummary/PoolData

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -282,7 +282,7 @@ message ResourceProfileWrapper {
 message CachedQuantile {
   int64 stage_id = 1;
   int32 stage_attempt_id = 2;
-  string quantile = 3;
+  optional string quantile = 3;
   int64 task_count = 4;
   double duration = 5;
   double executor_deserialize_time = 6;
@@ -365,8 +365,8 @@ message ResourceInformation {
 }
 
 message ExecutorSummary {
-  string id = 1;
-  string host_port = 2;
+  optional string id = 1;
+  optional string host_port = 2;
   bool is_active = 3;
   int32 rdd_blocks = 4;
   int64 memory_used = 5;
@@ -762,6 +762,6 @@ message AppSummary {
 }
 
 message PoolData {
-  string name = 1;
+  optional string name = 1;
   repeated int64 stage_ids = 2;
 }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/CachedQuantileSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/CachedQuantileSerializer.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.status.protobuf
 
 import org.apache.spark.status.CachedQuantile
+import org.apache.spark.status.protobuf.Utils.{getStringField, setStringField}
 
 class CachedQuantileSerializer extends ProtobufSerDe[CachedQuantile] {
 
@@ -25,7 +26,6 @@ class CachedQuantileSerializer extends ProtobufSerDe[CachedQuantile] {
     val builder = StoreTypes.CachedQuantile.newBuilder()
       .setStageId(data.stageId.toLong)
       .setStageAttemptId(data.stageAttemptId)
-      .setQuantile(data.quantile)
       .setTaskCount(data.taskCount)
       .setDuration(data.duration)
       .setExecutorDeserializeTime(data.executorDeserializeTime)
@@ -65,6 +65,7 @@ class CachedQuantileSerializer extends ProtobufSerDe[CachedQuantile] {
       .setShuffleWriteBytes(data.shuffleWriteBytes)
       .setShuffleWriteRecords(data.shuffleWriteRecords)
       .setShuffleWriteTime(data.shuffleWriteTime)
+    setStringField(data.quantile, builder.setQuantile)
     builder.build().toByteArray
   }
 
@@ -73,7 +74,7 @@ class CachedQuantileSerializer extends ProtobufSerDe[CachedQuantile] {
     new CachedQuantile(
       stageId = binary.getStageId.toInt,
       stageAttemptId = binary.getStageAttemptId,
-      quantile = binary.getQuantile,
+      quantile = getStringField(binary.hasQuantile, binary.getQuantile),
       taskCount = binary.getTaskCount,
       duration = binary.getDuration,
       executorDeserializeTime = binary.getExecutorDeserializeTime,

--- a/core/src/main/scala/org/apache/spark/status/protobuf/ExecutorSummaryWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/ExecutorSummaryWrapperSerializer.scala
@@ -24,7 +24,7 @@ import collection.JavaConverters._
 import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.status.ExecutorSummaryWrapper
 import org.apache.spark.status.api.v1.{ExecutorSummary, MemoryMetrics}
-import org.apache.spark.status.protobuf.Utils.getOptional
+import org.apache.spark.status.protobuf.Utils.{getOptional, getStringField, setStringField}
 import org.apache.spark.util.Utils.weakIntern
 
 class ExecutorSummaryWrapperSerializer extends ProtobufSerDe[ExecutorSummaryWrapper] {
@@ -45,8 +45,6 @@ class ExecutorSummaryWrapperSerializer extends ProtobufSerDe[ExecutorSummaryWrap
   private def serializeExecutorSummary(
       input: ExecutorSummary): StoreTypes.ExecutorSummary = {
     val builder = StoreTypes.ExecutorSummary.newBuilder()
-      .setId(input.id)
-      .setHostPort(input.hostPort)
       .setIsActive(input.isActive)
       .setRddBlocks(input.rddBlocks)
       .setMemoryUsed(input.memoryUsed)
@@ -65,7 +63,8 @@ class ExecutorSummaryWrapperSerializer extends ProtobufSerDe[ExecutorSummaryWrap
       .setIsBlacklisted(input.isBlacklisted)
       .setMaxMemory(input.maxMemory)
       .setAddTime(input.addTime.getTime)
-
+    setStringField(input.id, builder.setId)
+    setStringField(input.hostPort, builder.setHostPort)
     input.removeTime.foreach {
       date => builder.setRemoveTime(date.getTime)
     }
@@ -110,8 +109,8 @@ class ExecutorSummaryWrapperSerializer extends ProtobufSerDe[ExecutorSummaryWrap
       getOptional(binary.hasMemoryMetrics,
         () => deserializeMemoryMetrics(binary.getMemoryMetrics))
     new ExecutorSummary(
-      id = weakIntern(binary.getId),
-      hostPort = weakIntern(binary.getHostPort),
+      id = getStringField(binary.hasId, binary.getId),
+      hostPort = getStringField(binary.hasHostPort, () => weakIntern(binary.getHostPort)),
       isActive = binary.getIsActive,
       rddBlocks = binary.getRddBlocks,
       memoryUsed = binary.getMemoryUsed,

--- a/core/src/main/scala/org/apache/spark/status/protobuf/PoolDataSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/PoolDataSerializer.scala
@@ -20,12 +20,13 @@ package org.apache.spark.status.protobuf
 import scala.collection.JavaConverters._
 
 import org.apache.spark.status.PoolData
+import org.apache.spark.status.protobuf.Utils.{getStringField, setStringField}
 
 class PoolDataSerializer extends ProtobufSerDe[PoolData] {
 
   override def serialize(input: PoolData): Array[Byte] = {
     val builder = StoreTypes.PoolData.newBuilder()
-    builder.setName(input.name)
+    setStringField(input.name, builder.setName)
     input.stageIds.foreach(id => builder.addStageIds(id.toLong))
     builder.build().toByteArray
   }
@@ -33,7 +34,7 @@ class PoolDataSerializer extends ProtobufSerDe[PoolData] {
   override def deserialize(bytes: Array[Byte]): PoolData = {
     val poolData = StoreTypes.PoolData.parseFrom(bytes)
     new PoolData(
-      name = poolData.getName,
+      name = getStringField(poolData.hasName, poolData.getName),
       stageIds = poolData.getStageIdsList.asScala.map(_.toInt).toSet
     )
   }

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -535,93 +535,95 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
   }
 
   test("CachedQuantile") {
-    val input = new CachedQuantile(
-      stageId = 1,
-      stageAttemptId = 2,
-      quantile = "a",
-      taskCount = 3L,
-      duration = 4L,
-      executorDeserializeTime = 5.1,
-      executorDeserializeCpuTime = 6.1,
-      executorRunTime = 7.1,
-      executorCpuTime = 8.1,
-      resultSize = 9.1,
-      jvmGcTime = 10.1,
-      resultSerializationTime = 11.1,
-      gettingResultTime = 12.1,
-      schedulerDelay = 13.1,
-      peakExecutionMemory = 14.1,
-      memoryBytesSpilled = 15.1,
-      diskBytesSpilled = 16.1,
-      bytesRead = 17.1,
-      recordsRead = 18.1,
-      bytesWritten = 19.1,
-      recordsWritten = 20.1,
-      shuffleReadBytes = 21.1,
-      shuffleRecordsRead = 22.1,
-      shuffleRemoteBlocksFetched = 23.1,
-      shuffleLocalBlocksFetched = 24.1,
-      shuffleFetchWaitTime = 25.1,
-      shuffleRemoteBytesRead = 26.1,
-      shuffleRemoteBytesReadToDisk = 27.1,
-      shuffleTotalBlocksFetched = 28.1,
-      shuffleCorruptMergedBlockChunks = 29.1,
-      shuffleMergedFetchFallbackCount = 30.1,
-      shuffleMergedRemoteBlocksFetched = 31.1,
-      shuffleMergedLocalBlocksFetched = 32.1,
-      shuffleMergedRemoteChunksFetched = 33.1,
-      shuffleMergedLocalChunksFetched = 34.1,
-      shuffleMergedRemoteBytesRead = 35.1,
-      shuffleMergedLocalBytesRead = 36.1,
-      shuffleRemoteReqsDuration = 37.1,
-      shuffleMergedRemoteReqsDuration = 38.1,
-      shuffleWriteBytes = 39.1,
-      shuffleWriteRecords = 40.1,
-      shuffleWriteTime = 41.1)
-    val bytes = serializer.serialize(input)
-    val result = serializer.deserialize(bytes, classOf[CachedQuantile])
-    assert(result.stageId == input.stageId)
-    assert(result.stageAttemptId == input.stageAttemptId)
-    assert(result.quantile == input.quantile)
-    assert(result.taskCount == input.taskCount)
-    assert(result.duration == input.duration)
-    assert(result.executorDeserializeTime == input.executorDeserializeTime)
-    assert(result.executorDeserializeCpuTime == input.executorDeserializeCpuTime)
-    assert(result.executorRunTime == input.executorRunTime)
-    assert(result.executorCpuTime == input.executorCpuTime)
-    assert(result.resultSize == input.resultSize)
-    assert(result.jvmGcTime == input.jvmGcTime)
-    assert(result.resultSerializationTime == input.resultSerializationTime)
-    assert(result.gettingResultTime == input.gettingResultTime)
-    assert(result.schedulerDelay == input.schedulerDelay)
-    assert(result.peakExecutionMemory == input.peakExecutionMemory)
-    assert(result.memoryBytesSpilled == input.memoryBytesSpilled)
-    assert(result.diskBytesSpilled == input.diskBytesSpilled)
-    assert(result.bytesRead == input.bytesRead)
-    assert(result.recordsRead == input.recordsRead)
-    assert(result.bytesWritten == input.bytesWritten)
-    assert(result.recordsWritten == input.recordsWritten)
-    assert(result.shuffleReadBytes == input.shuffleReadBytes)
-    assert(result.shuffleRecordsRead == input.shuffleRecordsRead)
-    assert(result.shuffleRemoteBlocksFetched == input.shuffleRemoteBlocksFetched)
-    assert(result.shuffleLocalBlocksFetched == input.shuffleLocalBlocksFetched)
-    assert(result.shuffleFetchWaitTime == input.shuffleFetchWaitTime)
-    assert(result.shuffleRemoteBytesRead == input.shuffleRemoteBytesRead)
-    assert(result.shuffleRemoteBytesReadToDisk == input.shuffleRemoteBytesReadToDisk)
-    assert(result.shuffleTotalBlocksFetched == input.shuffleTotalBlocksFetched)
-    assert(result.shuffleCorruptMergedBlockChunks == input.shuffleCorruptMergedBlockChunks)
-    assert(result.shuffleMergedFetchFallbackCount == input.shuffleMergedFetchFallbackCount)
-    assert(result.shuffleMergedRemoteBlocksFetched == input.shuffleMergedRemoteBlocksFetched)
-    assert(result.shuffleMergedLocalBlocksFetched == input.shuffleMergedLocalBlocksFetched)
-    assert(result.shuffleMergedRemoteChunksFetched == input.shuffleMergedRemoteChunksFetched)
-    assert(result.shuffleMergedLocalChunksFetched == input.shuffleMergedLocalChunksFetched)
-    assert(result.shuffleMergedRemoteBytesRead == input.shuffleMergedRemoteBytesRead)
-    assert(result.shuffleMergedLocalBytesRead == input.shuffleMergedLocalBytesRead)
-    assert(result.shuffleRemoteReqsDuration == input.shuffleRemoteReqsDuration)
-    assert(result.shuffleMergedRemoteReqsDuration == input.shuffleMergedRemoteReqsDuration)
-    assert(result.shuffleWriteBytes == input.shuffleWriteBytes)
-    assert(result.shuffleWriteRecords == input.shuffleWriteRecords)
-    assert(result.shuffleWriteTime == input.shuffleWriteTime)
+    Seq("a", null).foreach { quantile =>
+      val input = new CachedQuantile(
+        stageId = 1,
+        stageAttemptId = 2,
+        quantile = quantile,
+        taskCount = 3L,
+        duration = 4L,
+        executorDeserializeTime = 5.1,
+        executorDeserializeCpuTime = 6.1,
+        executorRunTime = 7.1,
+        executorCpuTime = 8.1,
+        resultSize = 9.1,
+        jvmGcTime = 10.1,
+        resultSerializationTime = 11.1,
+        gettingResultTime = 12.1,
+        schedulerDelay = 13.1,
+        peakExecutionMemory = 14.1,
+        memoryBytesSpilled = 15.1,
+        diskBytesSpilled = 16.1,
+        bytesRead = 17.1,
+        recordsRead = 18.1,
+        bytesWritten = 19.1,
+        recordsWritten = 20.1,
+        shuffleReadBytes = 21.1,
+        shuffleRecordsRead = 22.1,
+        shuffleRemoteBlocksFetched = 23.1,
+        shuffleLocalBlocksFetched = 24.1,
+        shuffleFetchWaitTime = 25.1,
+        shuffleRemoteBytesRead = 26.1,
+        shuffleRemoteBytesReadToDisk = 27.1,
+        shuffleTotalBlocksFetched = 28.1,
+        shuffleCorruptMergedBlockChunks = 29.1,
+        shuffleMergedFetchFallbackCount = 30.1,
+        shuffleMergedRemoteBlocksFetched = 31.1,
+        shuffleMergedLocalBlocksFetched = 32.1,
+        shuffleMergedRemoteChunksFetched = 33.1,
+        shuffleMergedLocalChunksFetched = 34.1,
+        shuffleMergedRemoteBytesRead = 35.1,
+        shuffleMergedLocalBytesRead = 36.1,
+        shuffleRemoteReqsDuration = 37.1,
+        shuffleMergedRemoteReqsDuration = 38.1,
+        shuffleWriteBytes = 39.1,
+        shuffleWriteRecords = 40.1,
+        shuffleWriteTime = 41.1)
+      val bytes = serializer.serialize(input)
+      val result = serializer.deserialize(bytes, classOf[CachedQuantile])
+      assert(result.stageId == input.stageId)
+      assert(result.stageAttemptId == input.stageAttemptId)
+      assert(result.quantile == input.quantile)
+      assert(result.taskCount == input.taskCount)
+      assert(result.duration == input.duration)
+      assert(result.executorDeserializeTime == input.executorDeserializeTime)
+      assert(result.executorDeserializeCpuTime == input.executorDeserializeCpuTime)
+      assert(result.executorRunTime == input.executorRunTime)
+      assert(result.executorCpuTime == input.executorCpuTime)
+      assert(result.resultSize == input.resultSize)
+      assert(result.jvmGcTime == input.jvmGcTime)
+      assert(result.resultSerializationTime == input.resultSerializationTime)
+      assert(result.gettingResultTime == input.gettingResultTime)
+      assert(result.schedulerDelay == input.schedulerDelay)
+      assert(result.peakExecutionMemory == input.peakExecutionMemory)
+      assert(result.memoryBytesSpilled == input.memoryBytesSpilled)
+      assert(result.diskBytesSpilled == input.diskBytesSpilled)
+      assert(result.bytesRead == input.bytesRead)
+      assert(result.recordsRead == input.recordsRead)
+      assert(result.bytesWritten == input.bytesWritten)
+      assert(result.recordsWritten == input.recordsWritten)
+      assert(result.shuffleReadBytes == input.shuffleReadBytes)
+      assert(result.shuffleRecordsRead == input.shuffleRecordsRead)
+      assert(result.shuffleRemoteBlocksFetched == input.shuffleRemoteBlocksFetched)
+      assert(result.shuffleLocalBlocksFetched == input.shuffleLocalBlocksFetched)
+      assert(result.shuffleFetchWaitTime == input.shuffleFetchWaitTime)
+      assert(result.shuffleRemoteBytesRead == input.shuffleRemoteBytesRead)
+      assert(result.shuffleRemoteBytesReadToDisk == input.shuffleRemoteBytesReadToDisk)
+      assert(result.shuffleTotalBlocksFetched == input.shuffleTotalBlocksFetched)
+      assert(result.shuffleCorruptMergedBlockChunks == input.shuffleCorruptMergedBlockChunks)
+      assert(result.shuffleMergedFetchFallbackCount == input.shuffleMergedFetchFallbackCount)
+      assert(result.shuffleMergedRemoteBlocksFetched == input.shuffleMergedRemoteBlocksFetched)
+      assert(result.shuffleMergedLocalBlocksFetched == input.shuffleMergedLocalBlocksFetched)
+      assert(result.shuffleMergedRemoteChunksFetched == input.shuffleMergedRemoteChunksFetched)
+      assert(result.shuffleMergedLocalChunksFetched == input.shuffleMergedLocalChunksFetched)
+      assert(result.shuffleMergedRemoteBytesRead == input.shuffleMergedRemoteBytesRead)
+      assert(result.shuffleMergedLocalBytesRead == input.shuffleMergedLocalBytesRead)
+      assert(result.shuffleRemoteReqsDuration == input.shuffleRemoteReqsDuration)
+      assert(result.shuffleMergedRemoteReqsDuration == input.shuffleMergedRemoteReqsDuration)
+      assert(result.shuffleWriteBytes == input.shuffleWriteBytes)
+      assert(result.shuffleWriteRecords == input.shuffleWriteRecords)
+      assert(result.shuffleWriteTime == input.shuffleWriteTime)
+    }
   }
 
   test("Speculation Stage Summary") {
@@ -654,118 +656,120 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
       Some(new ExecutorMetrics(Array(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 1024L)))
     val resources =
       Map("resource1" -> new ResourceInformation("re1", Array("add1", "add2")))
-    val input = new ExecutorSummaryWrapper(
-      info = new ExecutorSummary(
-        id = "id_1",
-        hostPort = "localhost:7777",
-        isActive = true,
-        rddBlocks = 1,
-        memoryUsed = 64,
-        diskUsed = 128,
-        totalCores = 2,
-        maxTasks = 6,
-        activeTasks = 5,
-        failedTasks = 4,
-        completedTasks = 3,
-        totalTasks = 7,
-        totalDuration = 8,
-        totalGCTime = 9,
-        totalInputBytes = 10,
-        totalShuffleRead = 11,
-        totalShuffleWrite = 12,
-        isBlacklisted = false,
-        maxMemory = 256,
-        addTime = new Date(13),
-        removeTime = Some(new Date(14)),
-        removeReason = Some("reason_1"),
-        executorLogs = Map("log1" -> "logs/log1.log", "log2" -> "/log/log2.log"),
-        memoryMetrics = memoryMetrics,
-        blacklistedInStages = Set(19, 20, 21),
-        peakMemoryMetrics = peakMemoryMetric,
-        attributes = Map("attri1" -> "value1", "attri2" -> "val2"),
-        resources = resources,
-        resourceProfileId = 22,
-        isExcluded = true,
-        excludedInStages = Set(23, 24)
+    Seq(("id_1", "localhost:7777"), (null, "")).foreach { case (id, hostPort) =>
+      val input = new ExecutorSummaryWrapper(
+        info = new ExecutorSummary(
+          id = id,
+          hostPort = hostPort,
+          isActive = true,
+          rddBlocks = 1,
+          memoryUsed = 64,
+          diskUsed = 128,
+          totalCores = 2,
+          maxTasks = 6,
+          activeTasks = 5,
+          failedTasks = 4,
+          completedTasks = 3,
+          totalTasks = 7,
+          totalDuration = 8,
+          totalGCTime = 9,
+          totalInputBytes = 10,
+          totalShuffleRead = 11,
+          totalShuffleWrite = 12,
+          isBlacklisted = false,
+          maxMemory = 256,
+          addTime = new Date(13),
+          removeTime = Some(new Date(14)),
+          removeReason = Some("reason_1"),
+          executorLogs = Map("log1" -> "logs/log1.log", "log2" -> "/log/log2.log"),
+          memoryMetrics = memoryMetrics,
+          blacklistedInStages = Set(19, 20, 21),
+          peakMemoryMetrics = peakMemoryMetric,
+          attributes = Map("attri1" -> "value1", "attri2" -> "val2"),
+          resources = resources,
+          resourceProfileId = 22,
+          isExcluded = true,
+          excludedInStages = Set(23, 24)
+        )
       )
-    )
 
-    val bytes = serializer.serialize(input)
-    val result = serializer.deserialize(bytes, classOf[ExecutorSummaryWrapper])
+      val bytes = serializer.serialize(input)
+      val result = serializer.deserialize(bytes, classOf[ExecutorSummaryWrapper])
 
-    assert(result.info.id == input.info.id)
-    assert(result.info.hostPort == input.info.hostPort)
-    assert(result.info.isActive == input.info.isActive)
-    assert(result.info.rddBlocks == input.info.rddBlocks)
-    assert(result.info.memoryUsed == input.info.memoryUsed)
-    assert(result.info.diskUsed == input.info.diskUsed)
-    assert(result.info.totalCores == input.info.totalCores)
-    assert(result.info.maxTasks == input.info.maxTasks)
-    assert(result.info.activeTasks == input.info.activeTasks)
-    assert(result.info.failedTasks == input.info.failedTasks)
-    assert(result.info.completedTasks == input.info.completedTasks)
-    assert(result.info.totalTasks == input.info.totalTasks)
-    assert(result.info.totalDuration == input.info.totalDuration)
-    assert(result.info.totalGCTime == input.info.totalGCTime)
-    assert(result.info.totalInputBytes == input.info.totalInputBytes)
-    assert(result.info.totalShuffleRead == input.info.totalShuffleRead)
-    assert(result.info.totalShuffleWrite == input.info.totalShuffleWrite)
-    assert(result.info.isBlacklisted == input.info.isBlacklisted)
-    assert(result.info.maxMemory == input.info.maxMemory)
-    assert(result.info.addTime == input.info.addTime)
-    assert(result.info.removeTime == input.info.removeTime)
-    assert(result.info.removeReason == input.info.removeReason)
+      assert(result.info.id == input.info.id)
+      assert(result.info.hostPort == input.info.hostPort)
+      assert(result.info.isActive == input.info.isActive)
+      assert(result.info.rddBlocks == input.info.rddBlocks)
+      assert(result.info.memoryUsed == input.info.memoryUsed)
+      assert(result.info.diskUsed == input.info.diskUsed)
+      assert(result.info.totalCores == input.info.totalCores)
+      assert(result.info.maxTasks == input.info.maxTasks)
+      assert(result.info.activeTasks == input.info.activeTasks)
+      assert(result.info.failedTasks == input.info.failedTasks)
+      assert(result.info.completedTasks == input.info.completedTasks)
+      assert(result.info.totalTasks == input.info.totalTasks)
+      assert(result.info.totalDuration == input.info.totalDuration)
+      assert(result.info.totalGCTime == input.info.totalGCTime)
+      assert(result.info.totalInputBytes == input.info.totalInputBytes)
+      assert(result.info.totalShuffleRead == input.info.totalShuffleRead)
+      assert(result.info.totalShuffleWrite == input.info.totalShuffleWrite)
+      assert(result.info.isBlacklisted == input.info.isBlacklisted)
+      assert(result.info.maxMemory == input.info.maxMemory)
+      assert(result.info.addTime == input.info.addTime)
+      assert(result.info.removeTime == input.info.removeTime)
+      assert(result.info.removeReason == input.info.removeReason)
 
-    assert(result.info.executorLogs.size == input.info.executorLogs.size)
-    result.info.executorLogs.keys.foreach { k =>
-      assert(input.info.executorLogs.contains(k))
-      assert(result.info.executorLogs(k) == input.info.executorLogs(k))
-    }
-
-    assert(result.info.memoryMetrics.isDefined == input.info.memoryMetrics.isDefined)
-    if (result.info.memoryMetrics.isDefined && input.info.memoryMetrics.isDefined) {
-      assert(result.info.memoryMetrics.get.usedOnHeapStorageMemory ==
-        input.info.memoryMetrics.get.usedOnHeapStorageMemory)
-      assert(result.info.memoryMetrics.get.usedOffHeapStorageMemory ==
-        input.info.memoryMetrics.get.usedOffHeapStorageMemory)
-      assert(result.info.memoryMetrics.get.totalOnHeapStorageMemory ==
-        input.info.memoryMetrics.get.totalOnHeapStorageMemory)
-      assert(result.info.memoryMetrics.get.totalOffHeapStorageMemory ==
-        input.info.memoryMetrics.get.totalOffHeapStorageMemory)
-    }
-
-    assert(result.info.blacklistedInStages.size == input.info.blacklistedInStages.size)
-    result.info.blacklistedInStages.foreach { stage =>
-      assert(input.info.blacklistedInStages.contains(stage))
-    }
-
-    assert(result.info.peakMemoryMetrics.isDefined == input.info.peakMemoryMetrics.isDefined)
-    if (result.info.peakMemoryMetrics.isDefined && input.info.peakMemoryMetrics.isDefined) {
-      checkAnswer(result.info.peakMemoryMetrics.get, input.info.peakMemoryMetrics.get)
-    }
-
-    assert(result.info.attributes.size == input.info.attributes.size)
-    result.info.attributes.keys.foreach { k =>
-      assert(input.info.attributes.contains(k))
-      assert(result.info.attributes(k) == input.info.attributes(k))
-    }
-
-    assert(result.info.resources.size == input.info.resources.size)
-    result.info.resources.keys.foreach { k =>
-      assert(input.info.resources.contains(k))
-      assert(result.info.resources(k).name == input.info.resources(k).name)
-      result.info.resources(k).addresses.zip(input.info.resources(k).addresses).foreach {
-        case (a1, a2) =>
-          assert(a1 == a2)
+      assert(result.info.executorLogs.size == input.info.executorLogs.size)
+      result.info.executorLogs.keys.foreach { k =>
+        assert(input.info.executorLogs.contains(k))
+        assert(result.info.executorLogs(k) == input.info.executorLogs(k))
       }
-    }
 
-    assert(result.info.resourceProfileId == input.info.resourceProfileId)
-    assert(result.info.isExcluded == input.info.isExcluded)
+      assert(result.info.memoryMetrics.isDefined == input.info.memoryMetrics.isDefined)
+      if (result.info.memoryMetrics.isDefined && input.info.memoryMetrics.isDefined) {
+        assert(result.info.memoryMetrics.get.usedOnHeapStorageMemory ==
+          input.info.memoryMetrics.get.usedOnHeapStorageMemory)
+        assert(result.info.memoryMetrics.get.usedOffHeapStorageMemory ==
+          input.info.memoryMetrics.get.usedOffHeapStorageMemory)
+        assert(result.info.memoryMetrics.get.totalOnHeapStorageMemory ==
+          input.info.memoryMetrics.get.totalOnHeapStorageMemory)
+        assert(result.info.memoryMetrics.get.totalOffHeapStorageMemory ==
+          input.info.memoryMetrics.get.totalOffHeapStorageMemory)
+      }
 
-    assert(result.info.excludedInStages.size == input.info.excludedInStages.size)
-    result.info.excludedInStages.foreach { stage =>
-      assert(input.info.excludedInStages.contains(stage))
+      assert(result.info.blacklistedInStages.size == input.info.blacklistedInStages.size)
+      result.info.blacklistedInStages.foreach { stage =>
+        assert(input.info.blacklistedInStages.contains(stage))
+      }
+
+      assert(result.info.peakMemoryMetrics.isDefined == input.info.peakMemoryMetrics.isDefined)
+      if (result.info.peakMemoryMetrics.isDefined && input.info.peakMemoryMetrics.isDefined) {
+        checkAnswer(result.info.peakMemoryMetrics.get, input.info.peakMemoryMetrics.get)
+      }
+
+      assert(result.info.attributes.size == input.info.attributes.size)
+      result.info.attributes.keys.foreach { k =>
+        assert(input.info.attributes.contains(k))
+        assert(result.info.attributes(k) == input.info.attributes(k))
+      }
+
+      assert(result.info.resources.size == input.info.resources.size)
+      result.info.resources.keys.foreach { k =>
+        assert(input.info.resources.contains(k))
+        assert(result.info.resources(k).name == input.info.resources(k).name)
+        result.info.resources(k).addresses.zip(input.info.resources(k).addresses).foreach {
+          case (a1, a2) =>
+            assert(a1 == a2)
+        }
+      }
+
+      assert(result.info.resourceProfileId == input.info.resourceProfileId)
+      assert(result.info.isExcluded == input.info.isExcluded)
+
+      assert(result.info.excludedInStages.size == input.info.excludedInStages.size)
+      result.info.excludedInStages.foreach { stage =>
+        assert(input.info.excludedInStages.contains(stage))
+      }
     }
   }
 
@@ -1307,14 +1311,16 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
   }
 
   test("PoolData") {
-    val input = new PoolData(
-      name = "big-pool",
-      stageIds = Set(11, 13, 15, 17)
-    )
-    val bytes = serializer.serialize(input)
-    val result = serializer.deserialize(bytes, classOf[PoolData])
-    assert(result.name == input.name)
-    assert(result.stageIds == input.stageIds)
+    Seq("big-pool", null).foreach { name =>
+      val input = new PoolData(
+        name = name,
+        stageIds = Set(11, 13, 15, 17)
+      )
+      val bytes = serializer.serialize(input)
+      val result = serializer.deserialize(bytes, classOf[PoolData])
+      assert(result.name == input.name)
+      assert(result.stageIds == input.stageIds)
+    }
   }
 
   private def checkAnswer(result: TaskMetrics, expected: TaskMetrics): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Similar to https://github.com/apache/spark/pull/39666, this PR handles null string values in CachedQuantile/ExecutorSummary/PoolData
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Properly handles null string values in the protobuf serializer.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UTs