### PR TITLE
[SPARK-42146][CORE] Refactor `Utils#setStringField` to make maven build pass when sql module use this method

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
@@ -25,8 +25,8 @@ object Utils {
   }
 
 
-  // TODO(SPARK-42147): Revert SPARK-42146 to make maven build pass
-  //  when other module use `Utils#setStringField`
+  // TODO(SPARK-42147): Restore the signature of f to `String => MessageOrBuilder`
+  //  when `setStringField` used by other modules not cause maven build failure
   def setStringField(input: String, f: String => Any): Unit = {
     if (input != null) {
       f(input)

--- a/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
@@ -24,10 +24,6 @@ object Utils {
     None
   }
 
-
-  // TODO(SPARK-42147): Restore the signature of `f` when `f` is declared as
-  //  `f: String => MessageOrBuilder` and `setStringField` used by other modules
-  //  not cause maven build failure
   def setStringField(input: String, f: String => Any): Unit = {
     if (input != null) {
       f(input)

--- a/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.status.protobuf
 
-import com.google.protobuf.MessageOrBuilder
-
 object Utils {
   def getOptional[T](condition: Boolean, result: () => T): Option[T] = if (condition) {
     Some(result())
@@ -26,7 +24,10 @@ object Utils {
     None
   }
 
-  def setStringField(input: String, f: String => MessageOrBuilder): Unit = {
+
+  // TODO(SPARK-42147): Revert SPARK-42146 to make maven build pass
+  //  when other module use `Utils#setStringField`
+  def setStringField(input: String, f: String => Any): Unit = {
     if (input != null) {
       f(input)
     }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/Utils.scala
@@ -25,8 +25,9 @@ object Utils {
   }
 
 
-  // TODO(SPARK-42147): Restore the signature of f to `String => MessageOrBuilder`
-  //  when `setStringField` used by other modules not cause maven build failure
+  // TODO(SPARK-42147): Restore the signature of `f` when `f` is declared as
+  //  `f: String => MessageOrBuilder` and `setStringField` used by other modules
+  //  not cause maven build failure
   def setStringField(input: String, f: String => Any): Unit = {
     if (input != null) {
       f(input)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims refactor  input parameter type of  `Utils#setStringField` function to make maven build pass when sql module use this functions.


### Why are the changes needed?
Make maven build pass when sql module use `Utils#setStringField` function


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Manual test:

Add the following code to sql module:

```scala 
package org.apache.spark.status.protobuf.sql

import org.apache.spark.SparkFunSuite
import org.apache.spark.status.protobuf.StoreTypes
import org.apache.spark.status.protobuf.Utils.setStringField

class UtilsSuite extends SparkFunSuite {
  test("maven build") {
    val builder = StoreTypes.SQLExecutionUIData.newBuilder()
    setStringField("1", builder.setDetails)
  }
}
```

run `mvn  clean install  -DskipTests  -pl sql/core -am`

**Before** 

```
[ERROR] [Error] /${basedir}/sql/core/src/test/scala/org/apache/spark/status/protobuf/sql/UtilsSuite.scala:27: type mismatch;
 found   : org.apache.spark.status.protobuf.StoreTypes.SQLExecutionUIData.Builder
 required: com.google.protobuf.MessageOrBuilder
[ERROR] one error found
```

**After**
BUILD SUCCESS