### PR TITLE
[SPARK-41629][CONNECT][FOLLOW-UP] Enable access to SparkSession from Plugin

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -20,7 +20,7 @@ import org.apache.spark.internal.config.ConfigBuilder
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.connect.common.config.ConnectCommon
 
-private[spark] object Connect {
+object Connect {
 
   val CONNECT_GRPC_BINDING_PORT =
     ConfigBuilder("spark.connect.grpc.binding.port")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -57,7 +57,7 @@ final case class InvalidCommandInput(
     private val cause: Throwable = null)
     extends Exception(message, cause)
 
-class SparkConnectPlanner(session: SparkSession) {
+class SparkConnectPlanner(val session: SparkSession) {
   private lazy val pythonExec =
     sys.env.getOrElse("PYSPARK_PYTHON", sys.env.getOrElse("PYSPARK_DRIVER_PYTHON", "python3"))
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -89,6 +89,7 @@ class ExampleCommandPlugin extends CommandPlugin {
       return None
     }
     val cmd = command.unpack(classOf[proto.ExamplePluginCommand])
+    assert(planner.session != null)
     SparkContext.getActive.get.setLocalProperty("testingProperty", cmd.getCustomField)
     Some()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch allows the planner and command plugins for Spark Connect to access the Spark Session and let other consumers/users access the configuration provided by the module. Without access to the Spark session the plugins cannot provide their full usability.

### Why are the changes needed?
Usability

### Does this PR introduce _any_ user-facing change?
Plugins have access to Spark session.

### How was this patch tested?
Added assertion in UT that Spark session is not null.