### PR TITLE
[SPARK-42152][BUILD][CORE][SQL][PYTHON][PROTOBUF] Use `_` instead of `-`  for relocation package name

### DIFF
--- a/connector/protobuf/pom.xml
+++ b/connector/protobuf/pom.xml
@@ -101,7 +101,7 @@
           <relocations>
             <relocation>
               <pattern>com.google.protobuf</pattern>
-              <shadedPattern>${spark.shade.packageName}.spark-protobuf.protobuf</shadedPattern>
+              <shadedPattern>${spark.shade.packageName}.spark_protobuf.protobuf</shadedPattern>
               <includes>
                 <include>com.google.protobuf.**</include>
               </includes>

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/functions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/functions.scala
@@ -72,7 +72,7 @@ object functions {
    * Converts a binary column of Protobuf format into its corresponding catalyst value.
    * `messageClassName` points to Protobuf Java class. The jar containing Java class should be
    * shaded. Specifically, `com.google.protobuf.*` should be shaded to
-   * `org.sparkproject.spark-protobuf.protobuf.*`.
+   * `org.sparkproject.spark_protobuf.protobuf.*`.
    * https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
    * Protobuf files.
    *
@@ -92,7 +92,7 @@ object functions {
    * Converts a binary column of Protobuf format into its corresponding catalyst value.
    * `messageClassName` points to Protobuf Java class. The jar containing Java class should be
    * shaded. Specifically, `com.google.protobuf.*` should be shaded to
-   * `org.sparkproject.spark-protobuf.protobuf.*`.
+   * `org.sparkproject.spark_protobuf.protobuf.*`.
    * https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
    * Protobuf files.
    *
@@ -157,7 +157,7 @@ object functions {
    * Converts a column into binary of protobuf format.
    * `messageClassName` points to Protobuf Java class. The jar containing Java class should be
    * shaded. Specifically, `com.google.protobuf.*` should be shaded to
-   * `org.sparkproject.spark-protobuf.protobuf.*`.
+   * `org.sparkproject.spark_protobuf.protobuf.*`.
    * https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
    * Protobuf files.
    *
@@ -177,7 +177,7 @@ object functions {
    * Converts a column into binary of protobuf format.
    * `messageClassName` points to Protobuf Java class. The jar containing Java class should be
    * shaded. Specifically, `com.google.protobuf.*` should be shaded to
-   * `org.sparkproject.spark-protobuf.protobuf.*`.
+   * `org.sparkproject.spark_protobuf.protobuf.*`.
    * https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
    * Protobuf files.
    *

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -693,7 +693,7 @@
             </relocation>
             <relocation>
               <pattern>com.google.protobuf</pattern>
-              <shadedPattern>${spark.shade.packageName}.spark-core.protobuf</shadedPattern>
+              <shadedPattern>${spark.shade.packageName}.spark_core.protobuf</shadedPattern>
               <includes>
                 <include>com.google.protobuf.**</include>
               </includes>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -930,7 +930,7 @@ object SparkProtobuf {
     },
 
     (assembly / assemblyShadeRules) := Seq(
-      ShadeRule.rename("com.google.protobuf.**" -> "org.sparkproject.spark-protobuf.protobuf.@1").inAll,
+      ShadeRule.rename("com.google.protobuf.**" -> "org.sparkproject.spark_protobuf.protobuf.@1").inAll,
     ),
 
     (assembly / assemblyMergeStrategy) := {

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -43,7 +43,7 @@ def from_protobuf(
           `protoc --include_imports --descriptor_set_out=abc.desc abc.proto`
        - Jar containing Protobuf Java class: The jar containing Java class should be shaded.
          Specifically, `com.google.protobuf.*` should be shaded to
-         `org.sparkproject.spark-protobuf.protobuf.*`.
+         `org.sparkproject.spark_protobuf.protobuf.*`.
          https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
          Protobuf files. The jar file can be added with spark-submit option --jars.
 
@@ -105,7 +105,7 @@ def from_protobuf(
     >>> data = [([(1668035962, 2020)])]
     >>> ddl_schema = "value struct<seconds: LONG, nanos: INT>"
     >>> df = spark.createDataFrame(data, ddl_schema)
-    >>> message_class_name = "org.sparkproject.spark-protobuf.protobuf.Timestamp"
+    >>> message_class_name = "org.sparkproject.spark_protobuf.protobuf.Timestamp"
     >>> to_proto_df = df.select(to_protobuf(df.value, message_class_name).alias("value"))
     >>> from_proto_df = to_proto_df.select(
     ...     from_protobuf(to_proto_df.value, message_class_name).alias("value"))
@@ -149,7 +149,7 @@ def to_protobuf(
           `protoc --include_imports --descriptor_set_out=abc.desc abc.proto`
        - Jar containing Protobuf Java class: The jar containing Java class should be shaded.
          Specifically, `com.google.protobuf.*` should be shaded to
-         `org.sparkproject.spark-protobuf.protobuf.*`.
+         `org.sparkproject.spark_protobuf.protobuf.*`.
          https://github.com/rangadi/shaded-protobuf-classes is useful to create shaded jar from
          Protobuf files. The jar file can be added with spark-submit option --jars.
 
@@ -202,7 +202,7 @@ def to_protobuf(
     >>> data = [([(1668035962, 2020)])]
     >>> ddl_schema = "value struct<seconds: LONG, nanos: INT>"
     >>> df = spark.createDataFrame(data, ddl_schema)
-    >>> message_class_name = "org.sparkproject.spark-protobuf.protobuf.Timestamp"
+    >>> message_class_name = "org.sparkproject.spark_protobuf.protobuf.Timestamp"
     >>> proto_df = df.select(to_protobuf(df.value, message_class_name).alias("suite"))
     >>> proto_df.show(truncate=False)
     +----------------------------+


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims change to use `_` instead of `-`  for relocation package name,  the package name in the relevant comments also fix in this pr.


### Why are the changes needed?
Refer to https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html, Java package name can use `_`, not `-`:

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/1475305/213958510-87064245-fd27-4fa1-ab42-a850159da0ab.png">

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions