### PR TITLE
[SPARK-42153][UI] Handle null string values in PairStrings/RDDOperationNode/RDDOperationClusterWrapper

### DIFF
--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -185,8 +185,8 @@ message RuntimeInfo {
 }
 
 message PairStrings {
-  string value1 = 1;
-  string value2 = 2;
+  optional string value1 = 1;
+  optional string value2 = 2;
 }
 
 message ApplicationEnvironmentInfo {
@@ -472,16 +472,16 @@ enum DeterministicLevel {
 
 message RDDOperationNode {
   int32 id = 1;
-  string name = 2;
+  optional string name = 2;
   bool cached = 3;
   bool barrier = 4;
-  string callsite = 5;
+  optional string callsite = 5;
   DeterministicLevel output_deterministic_level = 6;
 }
 
 message RDDOperationClusterWrapper {
-  string id = 1;
-  string name = 2;
+  optional string id = 1;
+  optional string name = 2;
   repeated RDDOperationNode child_nodes = 3;
   repeated RDDOperationClusterWrapper child_clusters = 4;
 }

--- a/core/src/main/scala/org/apache/spark/status/protobuf/ApplicationEnvironmentInfoWrapperSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/ApplicationEnvironmentInfoWrapperSerializer.scala
@@ -81,7 +81,8 @@ class ApplicationEnvironmentInfoWrapperSerializer
       scalaVersion = getStringField(rt.hasScalaVersion, () => rt.getScalaVersion)
     )
     val pairSSToTuple = (pair: StoreTypes.PairStrings) => {
-      (pair.getValue1, pair.getValue2)
+      (getStringField(pair.hasValue1, pair.getValue1),
+        getStringField(pair.hasValue2, pair.getValue2))
     }
     new ApplicationEnvironmentInfo(
       runtime = runtime,
@@ -97,8 +98,8 @@ class ApplicationEnvironmentInfoWrapperSerializer
 
   private def serializePairStrings(pair: (String, String)): StoreTypes.PairStrings = {
     val builder = StoreTypes.PairStrings.newBuilder()
-    builder.setValue1(pair._1)
-    builder.setValue2(pair._2)
+    setStringField(pair._1, builder.setValue1)
+    setStringField(pair._2, builder.setValue2)
     builder.build()
   }
 

--- a/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/protobuf/KVStoreProtobufSerializerSuite.scala
@@ -259,9 +259,11 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
           javaVersion = javaVersion,
           javaHome = javaHome,
           scalaVersion = scalaVersion),
-        sparkProperties = Seq(("spark.conf.1", "1"), ("spark.conf.2", "2")),
-        hadoopProperties = Seq(("hadoop.conf.conf1", "1"), ("hadoop.conf2", "val2")),
-        systemProperties = Seq(("sys.prop.1", "value1"), ("sys.prop.2", "value2")),
+        sparkProperties = Seq(("spark.conf.1", "1"), ("spark.conf.2", "2"), (null, null)),
+        hadoopProperties =
+          Seq(("hadoop.conf.conf1", "1"), ("hadoop.conf2", "val2"), (null, "val3")),
+        systemProperties =
+          Seq(("sys.prop.1", "value1"), ("sys.prop.2", "value2"), ("sys.prop.3", null)),
         metricsProperties = Seq(("metric.1", "klass1"), ("metric2", "klass2")),
         classpathEntries = Seq(("/jar1", "System"), ("/jar2", "User")),
         resourceProfiles = Seq(new ResourceProfileInfo(
@@ -875,20 +877,41 @@ class KVStoreProtobufSerializerSuite extends SparkFunSuite {
             cached = true,
             barrier = false,
             callsite = "callsite_1",
-            outputDeterministicLevel = DeterministicLevel.INDETERMINATE)),
-        childClusters = Seq(new RDDOperationClusterWrapper(
-          id = "id_1",
-          name = "name1",
-          childNodes = Seq(
-            RDDOperationNode(
-              id = 15,
-              name = "name3",
-              cached = false,
-              barrier = true,
-              callsite = "callsite_2",
-              outputDeterministicLevel = DeterministicLevel.UNORDERED)),
-          childClusters = Seq.empty
-        ))
+            outputDeterministicLevel = DeterministicLevel.INDETERMINATE),
+          RDDOperationNode(
+            id = 20,
+            name = null,
+            cached = true,
+            barrier = false,
+            callsite = null,
+            outputDeterministicLevel = DeterministicLevel.DETERMINATE)),
+        childClusters = Seq(
+          new RDDOperationClusterWrapper(
+            id = "id_1",
+            name = "name1",
+            childNodes = Seq(
+              RDDOperationNode(
+                id = 15,
+                name = "name3",
+                cached = false,
+                barrier = true,
+                callsite = "callsite_2",
+                outputDeterministicLevel = DeterministicLevel.UNORDERED)),
+            childClusters = Seq.empty
+          ),
+          new RDDOperationClusterWrapper(
+            id = null,
+            name = null,
+            childNodes = Seq(
+              RDDOperationNode(
+                id = 21,
+                name = null,
+                cached = false,
+                barrier = true,
+                callsite = null,
+                outputDeterministicLevel = DeterministicLevel.UNORDERED)),
+            childClusters = Seq.empty
+          ))
       )
     )
     val bytes = serializer.serialize(input)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Similar to #39666, this PR handles null string values in PairStrings/RDDOperationNode/RDDOperationClusterWrapper

### Why are the changes needed?
Properly handles null string values in the protobuf serializer.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
New UTs