### PR TITLE
[SPARK-41283][CONNECT][PYTHON] Add `array_append` to Connect

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -1140,6 +1140,13 @@ def array(*cols: Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName
 array.__doc__ = pysparkfuncs.array.__doc__
 
 
+def array_append(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
+    return _invoke_function_over_columns("array_append", col1, col2)
+
+
+array_append.__doc__ = pysparkfuncs.array_append.__doc__
+
+
 def array_contains(col: "ColumnOrName", value: Any) -> Column:
     return _invoke_function("array_contains", _to_col(col), lit(value))
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -7812,6 +7812,9 @@ def array_append(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.4.0
 
+    .. versionchanged:: 3.4.0
+        Support Spark Connect.
+
     Parameters
     ----------
     col1 : :class:`~pyspark.sql.Column` or str

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -1070,6 +1070,16 @@ class SparkConnectFunctionTests(SparkConnectFuncTestCase):
             sdf.select(SF.array_contains(sdf.a, sdf.f)).toPandas(),
         )
 
+        # test array_append
+        self.assert_eq(
+            cdf.select(CF.array_append(cdf.a, CF.lit("ab"))).toPandas(),
+            sdf.select(SF.array_append(sdf.a, SF.lit("ab"))).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.array_append(cdf.a, cdf.f)).toPandas(),
+            sdf.select(SF.array_append(sdf.a, sdf.f)).toPandas(),
+        )
+
         # test array_join
         self.assert_eq(
             cdf.select(


### PR DESCRIPTION
### What changes were proposed in this pull request?
`array_append` was recently added in SQL and PySpark, this PR adds it to Connect.


### Why are the changes needed?
For parity

### Does this PR introduce _any_ user-facing change?
yes, new function


### How was this patch tested?
added test