### PR TITLE
[SPARK-41772][CONNECT][PYTHON] Fix incorrect column name in `withField`'s doctest

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -691,9 +691,12 @@ class SparkConnectPlanner(val session: SparkSession) {
     } else {
       logical.OneRowRelation()
     }
-    val projection =
-      rel.getExpressionsList.asScala.map(transformExpression).map(UnresolvedAlias(_))
-    logical.Project(projectList = projection.toSeq, child = baseRel)
+
+    val projection = rel.getExpressionsList.asScala.toSeq
+      .map(transformExpression)
+      .map(toNamedExpression)
+
+    logical.Project(projectList = projection, child = baseRel)
   }
 
   private def transformUnresolvedExpression(exp: proto.Expression): UnresolvedAttribute = {
@@ -743,6 +746,11 @@ class SparkConnectPlanner(val session: SparkSession) {
         throw InvalidPlanInput(
           s"Expression with ID: ${exp.getExprTypeCase.getNumber} is not supported")
     }
+  }
+
+  private def toNamedExpression(expr: Expression): NamedExpression = expr match {
+    case named: NamedExpression => named
+    case expr => UnresolvedAlias(expr)
   }
 
   private def transformExpressionPlugin(extension: ProtoAny): Expression = {
@@ -1244,11 +1252,6 @@ class SparkConnectPlanner(val session: SparkSession) {
       throw InvalidPlanInput("Aggregate needs a plan input")
     }
     val input = transformRelation(rel.getInput)
-
-    def toNamedExpression(expr: Expression): NamedExpression = expr match {
-      case named: NamedExpression => named
-      case expr => UnresolvedAlias(expr)
-    }
 
     val groupingExprs = rel.getGroupingExpressionsList.asScala.toSeq.map(transformExpression)
     val aggExprs = rel.getAggregateExpressionsList.asScala.toSeq.map(transformExpression)

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -439,9 +439,6 @@ def _test() -> None:
             .getOrCreate()
         )
 
-        # TODO(SPARK-41772): Enable pyspark.sql.connect.column.Column.withField doctest
-        del pyspark.sql.connect.column.Column.withField.__doc__
-
         (failure_count, test_count) = doctest.testmod(
             pyspark.sql.connect.column,
             globs=globs,

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -33,6 +33,7 @@ from pyspark.sql.connect.types import (
 )
 
 from pyspark.sql.types import (
+    Row,
     StructField,
     StructType,
     ArrayType,
@@ -58,7 +59,8 @@ from pyspark.sql.connect.client import SparkConnectException
 
 if should_test_connect:
     import pandas as pd
-    from pyspark.sql.connect.functions import lit
+    from pyspark.sql import functions as SF
+    from pyspark.sql.connect import functions as CF
 
 
 class SparkConnectColumnTests(SparkConnectSQLTestCase):
@@ -83,7 +85,7 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
     def test_column_operator(self):
         # SPARK-41351: Column needs to support !=
         df = self.connect.range(10)
-        self.assertEqual(9, len(df.filter(df.id != lit(1)).collect()))
+        self.assertEqual(9, len(df.filter(df.id != CF.lit(1)).collect()))
 
     def test_columns(self):
         # SPARK-41036: test `columns` API for python client.
@@ -133,8 +135,6 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
     def test_column_with_null(self):
         # SPARK-41751: test isNull, isNotNull, eqNullSafe
-        from pyspark.sql import functions as SF
-        from pyspark.sql.connect import functions as CF
 
         query = """
             SELECT * FROM VALUES
@@ -313,9 +313,6 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
     def test_none(self):
         # SPARK-41783: test none
 
-        from pyspark.sql import functions as SF
-        from pyspark.sql.connect import functions as CF
-
         query = """
             SELECT * FROM VALUES
             (1, 1, NULL), (2, NULL, 1), (NULL, 3, 4)
@@ -348,8 +345,10 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
     def test_simple_binary_expressions(self):
         """Test complex expression"""
-        df = self.connect.read.table(self.tbl_name)
-        pdf = df.select(df.id).where(df.id % lit(30) == lit(0)).sort(df.id.asc()).toPandas()
+        cdf = self.connect.read.table(self.tbl_name)
+        pdf = (
+            cdf.select(cdf.id).where(cdf.id % CF.lit(30) == CF.lit(0)).sort(cdf.id.asc()).toPandas()
+        )
         self.assertEqual(len(pdf.index), 4)
 
         res = pd.DataFrame(data={"id": [0, 30, 60, 90]})
@@ -963,6 +962,18 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
                 sdf.b.contains("a"), sdf["c"].contains("j"), sdf["b"].contains(sdf.e)
             ).toPandas(),
         )
+
+    def test_with_field_column_name(self):
+        data = [Row(a=Row(b=1, c=2))]
+
+        cdf = self.connect.createDataFrame(data)
+        cdf1 = cdf.withColumn("a", cdf["a"].withField("b", CF.lit(3))).select("a.b")
+
+        sdf = self.spark.createDataFrame(data)
+        sdf1 = sdf.withColumn("a", sdf["a"].withField("b", SF.lit(3))).select("a.b")
+
+        self.assertEqual(cdf1.schema, sdf1.schema)
+        self.assertEqual(cdf1.collect(), sdf1.collect())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix incorrect column name in `withField`'s doctest

```
pyspark.sql.connect.column.Column.withField
Failed example:
    df.withColumn('a', df['a'].withField('b', lit(3))).select('a.b').show()
Expected:
    +---+
    |  b|
    +---+
    |  3|
    +---+
Got:
    +---+
    |a.b|
    +---+
    |  3|
    +---+
    <BLANKLINE>
```

### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added UT and enabled doctest
