### PR TITLE
[MINOR][K8S][DOCS] Add all resource managers in `Scheduling Within an Application` section

### DIFF
--- a/docs/job-scheduling.md
+++ b/docs/job-scheduling.md
@@ -195,6 +195,9 @@ of cluster resources. This means that short jobs submitted while a long job is r
 resources right away and still get good response times, without waiting for the long job to finish. This
 mode is best for multi-user settings.
 
+This feature is disabled by default and available on all coarse-grained cluster managers, i.e.
+[standalone mode](spark-standalone.html), [YARN mode](running-on-yarn.html),
+[K8s mode](running-on-kubernetes.html) and [Mesos coarse-grained mode](running-on-mesos.html#mesos-run-modes).
 To enable the fair scheduler, simply set the `spark.scheduler.mode` property to `FAIR` when configuring
 a SparkContext:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`Job Scheduling` document doesn't mention `K8s resource manager` so far because `Scheduling Across Applications` section only mentions all resource managers except K8s.

This PR aims to add all supported resource managers in `Scheduling Within an Application section` section.

### Why are the changes needed?

K8s also supports `FAIR` schedule within an application.

### Does this PR introduce _any_ user-facing change?

No. This is a doc-only update.

### How was this patch tested?

N/A