### PR TITLE
[SPARK-41931][SQL] Better error message for incomplete complex type definition

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -613,7 +613,7 @@
         ]
       }
     },
-    "sqlState" : "42000"
+    "sqlState" : "42K01"
   },
   "INCONSISTENT_BEHAVIOR_CROSS_VERSION" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -609,7 +609,7 @@
       },
       "STRUCT" : {
         "message" : [
-          "The definition of `STRUCT` type is incomplete. You must provide at least one field type. For example: `STRUCT<Field1: INT>`."
+          "The definition of \"STRUCT\" type is incomplete. You must provide at least one field type. For example: \"STRUCT<Field1: INT>\"."
         ]
       }
     },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -602,14 +602,14 @@
           "The definition of `ARRAY` type is incomplete. You must provide an element type. For example: `ARRAY\\<INT\\>`."
         ]
       },
-      "STRUCT" : {
-        "message" : [
-          "The definition of `STRUCT` type is incomplete. You must provide a field type. For example: `STRUCT\\<Field1:INT\\>`."
-        ]
-      },
       "MAP" : {
         "message" : [
           "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP\\<TIMESTAMP, INT\\>`."
+        ]
+      },
+      "STRUCT" : {
+        "message" : [
+          "The definition of `STRUCT` type is incomplete. You must provide a field type. For example: `STRUCT\\<Field1:INT\\>`."
         ]
       }
     },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -592,6 +592,29 @@
       "Detected an incompatible DataSourceRegister. Please remove the incompatible library from classpath or upgrade it. Error: <message>"
     ]
   },
+  "INCOMPLETE_TYPE_DEFINITION" : {
+    "message" : [
+      "Incomplete complex type:"
+    ],
+    "subClass" : {
+      "ARRAY" : {
+        "message" : [
+          "The definition of `ARRAY` type is incomplete. You must provide an element type. For example: `ARRAY\\<INT\\>`."
+        ]
+      },
+      "STRUCT" : {
+        "message" : [
+          "The definition of `STRUCT` type is incomplete. You must provide a field type. For example: `STRUCT\\<Field1:INT\\>`."
+        ]
+      },
+      "MAP" : {
+        "message" : [
+          "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP\\<TIMESTAMP, INT\\>`."
+        ]
+      }
+    },
+    "sqlState" : "42000"
+  },
   "INCONSISTENT_BEHAVIOR_CROSS_VERSION" : {
     "message" : [
       "You may get a different result due to the upgrading to"

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -604,7 +604,7 @@
       },
       "MAP" : {
         "message" : [
-          "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP<TIMESTAMP, INT>`."
+          "The definition of \"MAP\" type is incomplete. You must provide a key type and a value type. For example: \"MAP<TIMESTAMP, INT>\"."
         ]
       },
       "STRUCT" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -599,17 +599,17 @@
     "subClass" : {
       "ARRAY" : {
         "message" : [
-          "The definition of `ARRAY` type is incomplete. You must provide an element type. For example: `ARRAY\\<INT\\>`."
+          "The definition of `ARRAY` type is incomplete. You must provide an element type. For example: `ARRAY<elementType>`."
         ]
       },
       "MAP" : {
         "message" : [
-          "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP\\<TIMESTAMP, INT\\>`."
+          "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP<keyValueTypes>`."
         ]
       },
       "STRUCT" : {
         "message" : [
-          "The definition of `STRUCT` type is incomplete. You must provide a field type. For example: `STRUCT\\<Field1:INT\\>`."
+          "The definition of `STRUCT` type is incomplete. You must provide a field type. For example: `STRUCT<fieldNameType>`."
         ]
       }
     },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -604,12 +604,12 @@
       },
       "MAP" : {
         "message" : [
-          "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP<keyValueTypes>`."
+          "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP<keyType, valueType>`."
         ]
       },
       "STRUCT" : {
         "message" : [
-          "The definition of `STRUCT` type is incomplete. You must provide a field type. For example: `STRUCT<fieldNameType>`."
+          "The definition of `STRUCT` type is incomplete. You must provide at least one field type. For example: `STRUCT<fieldName: fieldType>`."
         ]
       }
     },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -604,12 +604,12 @@
       },
       "MAP" : {
         "message" : [
-          "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP<keyType, valueType>`."
+          "The definition of `MAP` type is incomplete. You must provide a key type and a value type. For example: `MAP<TIMESTAMP, INT>`."
         ]
       },
       "STRUCT" : {
         "message" : [
-          "The definition of `STRUCT` type is incomplete. You must provide at least one field type. For example: `STRUCT<fieldName: fieldType>`."
+          "The definition of `STRUCT` type is incomplete. You must provide at least one field type. For example: `STRUCT<Field1: INT>`."
         ]
       }
     },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -599,7 +599,7 @@
     "subClass" : {
       "ARRAY" : {
         "message" : [
-          "The definition of `ARRAY` type is incomplete. You must provide an element type. For example: `ARRAY<elementType>`."
+          "The definition of \"ARRAY\" type is incomplete. You must provide an element type. For example: \"ARRAY<elementType>\"."
         ]
       },
       "MAP" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2889,6 +2889,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
       case ("interval", Nil) => CalendarIntervalType
       case (dt @ ("character" | "char" | "varchar"), Nil) =>
         throw QueryParsingErrors.charTypeMissingLengthError(dt, ctx)
+      case (dt @ ("array" | "struct" | "map"), Nil) =>
+        throw QueryParsingErrors.nestedTypeMissingElementTypeError(dt, ctx)
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt
         throw QueryParsingErrors.dataTypeUnsupportedError(dtStr, ctx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -292,6 +292,27 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
       ctx)
   }
 
+  def nestedTypeMissingElementTypeError(
+      dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {
+    dataType match {
+      case "array" =>
+        new ParseException(
+          errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
+          messageParameters = Map.empty,
+          ctx)
+      case "struct" =>
+        new ParseException(
+          errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
+          messageParameters = Map.empty,
+          ctx)
+      case "map" =>
+        new ParseException(
+          errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
+          messageParameters = Map.empty,
+          ctx)
+    }
+  }
+
   def partitionTransformNotExpectedError(
       name: String, describe: String, ctx: ApplyTransformContext): Throwable = {
     new ParseException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -298,7 +298,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
       case "array" =>
         new ParseException(
           errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
-          messageParameters = Map("elementType" -> "<elementType>"),
+          messageParameters = Map("elementType" -> "<INT>"),
           ctx)
       case "struct" =>
         new ParseException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -298,17 +298,17 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
       case "array" =>
         new ParseException(
           errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
-          messageParameters = Map("elementType" -> "<INT>"),
+          messageParameters = Map("elementType" -> "<elementType>"),
           ctx)
       case "struct" =>
         new ParseException(
           errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
-          messageParameters = Map("fieldNameType" -> "<Field1:INT>"),
+          messageParameters = Map.empty,
           ctx)
       case "map" =>
         new ParseException(
           errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
-          messageParameters = Map("keyValueTypes" -> "<TIMESTAMP, INT>"),
+          messageParameters = Map.empty,
           ctx)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -298,17 +298,17 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
       case "array" =>
         new ParseException(
           errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
-          messageParameters = Map.empty,
+          messageParameters = Map("elementType" -> "<INT>"),
           ctx)
       case "struct" =>
         new ParseException(
           errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
-          messageParameters = Map.empty,
+          messageParameters = Map("fieldNameType" -> "<Field1:INT>"),
           ctx)
       case "map" =>
         new ParseException(
           errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
-          messageParameters = Map.empty,
+          messageParameters = Map("keyValueTypes" -> "<TIMESTAMP, INT>"),
           ctx)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -592,7 +592,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(struct(1,2,3) AS STRUCT<INT>)"),
       errorClass = "PARSE_SYNTAX_ERROR",
       sqlState = "42601",
-      parameters = Map("error" -> "'<'", "hint" -> ": missing ')'"))
+      parameters = Map("error" -> "'>'", "hint" -> ""))
   }
 
   test("INCOMPLETE_TYPE_DEFINITION: map type definition is incomplete") {
@@ -613,6 +613,6 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(map('1',2) AS MAP<STRING>)"),
       errorClass = "PARSE_SYNTAX_ERROR",
       sqlState = "42601",
-      parameters = Map("error" -> "'<'", "hint" -> ": missing ')'"))
+      parameters = Map("error" -> "'>'", "hint" -> ""))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -546,4 +546,73 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
         start = 0,
         stop = 124))
   }
+
+  test("INCOMPLETE_TYPE_DEFINITION: array type definition is incomplete") {
+    // Cast simple array without specifying element type
+    checkError(
+      exception = parseException("SELECT CAST(array(1,2,3) AS ARRAY)"),
+      errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
+      sqlState = "42000",
+      context = ExpectedContext(fragment = "ARRAY", start = 28, stop = 32))
+    // Cast array of array without specifying element type for inner array
+    checkError(
+      exception = parseException("SELECT CAST(array(array(3)) AS ARRAY<ARRAY>)"),
+      errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
+      sqlState = "42000",
+      context = ExpectedContext(fragment = "ARRAY", start = 37, stop = 41))
+    // Create column of array type without specifying element type
+    checkError(
+      exception = parseException("CREATE TABLE tbl_120691 (col1 ARRAY)"),
+      errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
+      sqlState = "42000",
+      context = ExpectedContext(fragment = "ARRAY", start = 30, stop = 34))
+  }
+
+  test("INCOMPLETE_TYPE_DEFINITION: struct type definition is incomplete") {
+    // Cast simple struct without specifying field type
+    checkError(
+      exception = parseException("SELECT CAST(struct(1,2,3) AS STRUCT)"),
+      errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
+      sqlState = "42000",
+      context = ExpectedContext(fragment = "STRUCT", start = 29, stop = 34))
+    // Cast array of struct without specifying field type in struct
+    checkError(
+      exception = parseException("SELECT CAST(array(struct(1,2)) AS ARRAY<STRUCT>)"),
+      errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
+      sqlState = "42000",
+      context = ExpectedContext(fragment = "STRUCT", start = 40, stop = 45))
+    // Create column of struct type without specifying field type
+    checkError(
+      exception = parseException("CREATE TABLE tbl_120691 (col1 STRUCT)"),
+      errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
+      sqlState = "42000",
+      context = ExpectedContext(fragment = "STRUCT", start = 30, stop = 35))
+    // Invalid syntax `STRUCT<INT>` without field name
+    checkError(
+      exception = parseException("SELECT CAST(struct(1,2,3) AS STRUCT<INT>)"),
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      parameters = Map("error" -> "'<'", "hint" -> ": missing ')'"))
+  }
+
+  test("INCOMPLETE_TYPE_DEFINITION: map type definition is incomplete") {
+    // Cast simple map without specifying element type
+    checkError(
+      exception = parseException("SELECT CAST(map(1,'2') AS MAP)"),
+      errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
+      sqlState = "42000",
+      context = ExpectedContext(fragment = "MAP", start = 26, stop = 28))
+    // Create column of map type without specifying key/value types
+    checkError(
+      exception = parseException("CREATE TABLE tbl_120691 (col1 MAP)"),
+      errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
+      sqlState = "42000",
+      context = ExpectedContext(fragment = "MAP", start = 30, stop = 32))
+    // Invalid syntax `MAP<String>` with only key type
+    checkError(
+      exception = parseException("SELECT CAST(map('1',2) AS MAP<STRING>)"),
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      parameters = Map("error" -> "'<'", "hint" -> ": missing ')'"))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -553,21 +553,21 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(array(1,2,3) AS ARRAY)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
-      parameters = Map("elementType" -> "<elementType>"),
+      parameters = Map("elementType" -> "<INT>"),
       context = ExpectedContext(fragment = "ARRAY", start = 28, stop = 32))
     // Cast array of array without specifying element type for inner array
     checkError(
       exception = parseException("SELECT CAST(array(array(3)) AS ARRAY<ARRAY>)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
-      parameters = Map("elementType" -> "<elementType>"),
+      parameters = Map("elementType" -> "<INT>"),
       context = ExpectedContext(fragment = "ARRAY", start = 37, stop = 41))
     // Create column of array type without specifying element type
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 ARRAY)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
-      parameters = Map("elementType" -> "<elementType>"),
+      parameters = Map("elementType" -> "<INT>"),
       context = ExpectedContext(fragment = "ARRAY", start = 30, stop = 34))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -553,21 +553,21 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(array(1,2,3) AS ARRAY)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
-      parameters = Map("elementType" -> "<INT>"),
+      parameters = Map("elementType" -> "<elementType>"),
       context = ExpectedContext(fragment = "ARRAY", start = 28, stop = 32))
     // Cast array of array without specifying element type for inner array
     checkError(
       exception = parseException("SELECT CAST(array(array(3)) AS ARRAY<ARRAY>)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
-      parameters = Map("elementType" -> "<INT>"),
+      parameters = Map("elementType" -> "<elementType>"),
       context = ExpectedContext(fragment = "ARRAY", start = 37, stop = 41))
     // Create column of array type without specifying element type
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 ARRAY)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
-      parameters = Map("elementType" -> "<INT>"),
+      parameters = Map("elementType" -> "<elementType>"),
       context = ExpectedContext(fragment = "ARRAY", start = 30, stop = 34))
   }
 
@@ -577,21 +577,18 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(struct(1,2,3) AS STRUCT)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
       sqlState = "42K01",
-      parameters = Map("fieldNameType" -> "<Field1:INT>"),
       context = ExpectedContext(fragment = "STRUCT", start = 29, stop = 34))
     // Cast array of struct without specifying field type in struct
     checkError(
       exception = parseException("SELECT CAST(array(struct(1,2)) AS ARRAY<STRUCT>)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
       sqlState = "42K01",
-      parameters = Map("fieldNameType" -> "<Field1:INT>"),
       context = ExpectedContext(fragment = "STRUCT", start = 40, stop = 45))
     // Create column of struct type without specifying field type
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 STRUCT)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
       sqlState = "42K01",
-      parameters = Map("fieldNameType" -> "<Field1:INT>"),
       context = ExpectedContext(fragment = "STRUCT", start = 30, stop = 35))
     // Invalid syntax `STRUCT<INT>` without field name
     checkError(
@@ -607,14 +604,12 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(map(1,'2') AS MAP)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
       sqlState = "42K01",
-      parameters = Map("keyValueTypes" -> "<TIMESTAMP, INT>"),
       context = ExpectedContext(fragment = "MAP", start = 26, stop = 28))
     // Create column of map type without specifying key/value types
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 MAP)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
       sqlState = "42K01",
-      parameters = Map("keyValueTypes" -> "<TIMESTAMP, INT>"),
       context = ExpectedContext(fragment = "MAP", start = 30, stop = 32))
     // Invalid syntax `MAP<String>` with only key type
     checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -553,18 +553,21 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(array(1,2,3) AS ARRAY)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
+      parameters = Map("elementType" -> "<INT>"),
       context = ExpectedContext(fragment = "ARRAY", start = 28, stop = 32))
     // Cast array of array without specifying element type for inner array
     checkError(
       exception = parseException("SELECT CAST(array(array(3)) AS ARRAY<ARRAY>)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
+      parameters = Map("elementType" -> "<INT>"),
       context = ExpectedContext(fragment = "ARRAY", start = 37, stop = 41))
     // Create column of array type without specifying element type
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 ARRAY)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
       sqlState = "42K01",
+      parameters = Map("elementType" -> "<INT>"),
       context = ExpectedContext(fragment = "ARRAY", start = 30, stop = 34))
   }
 
@@ -574,18 +577,21 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(struct(1,2,3) AS STRUCT)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
       sqlState = "42K01",
+      parameters = Map("fieldNameType" -> "<Field1:INT>"),
       context = ExpectedContext(fragment = "STRUCT", start = 29, stop = 34))
     // Cast array of struct without specifying field type in struct
     checkError(
       exception = parseException("SELECT CAST(array(struct(1,2)) AS ARRAY<STRUCT>)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
       sqlState = "42K01",
+      parameters = Map("fieldNameType" -> "<Field1:INT>"),
       context = ExpectedContext(fragment = "STRUCT", start = 40, stop = 45))
     // Create column of struct type without specifying field type
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 STRUCT)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
       sqlState = "42K01",
+      parameters = Map("fieldNameType" -> "<Field1:INT>"),
       context = ExpectedContext(fragment = "STRUCT", start = 30, stop = 35))
     // Invalid syntax `STRUCT<INT>` without field name
     checkError(
@@ -601,12 +607,14 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       exception = parseException("SELECT CAST(map(1,'2') AS MAP)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
       sqlState = "42K01",
+      parameters = Map("keyValueTypes" -> "<TIMESTAMP, INT>"),
       context = ExpectedContext(fragment = "MAP", start = 26, stop = 28))
     // Create column of map type without specifying key/value types
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 MAP)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
       sqlState = "42K01",
+      parameters = Map("keyValueTypes" -> "<TIMESTAMP, INT>"),
       context = ExpectedContext(fragment = "MAP", start = 30, stop = 32))
     // Invalid syntax `MAP<String>` with only key type
     checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -552,19 +552,19 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     checkError(
       exception = parseException("SELECT CAST(array(1,2,3) AS ARRAY)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
-      sqlState = "42000",
+      sqlState = "42K01",
       context = ExpectedContext(fragment = "ARRAY", start = 28, stop = 32))
     // Cast array of array without specifying element type for inner array
     checkError(
       exception = parseException("SELECT CAST(array(array(3)) AS ARRAY<ARRAY>)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
-      sqlState = "42000",
+      sqlState = "42K01",
       context = ExpectedContext(fragment = "ARRAY", start = 37, stop = 41))
     // Create column of array type without specifying element type
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 ARRAY)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.ARRAY",
-      sqlState = "42000",
+      sqlState = "42K01",
       context = ExpectedContext(fragment = "ARRAY", start = 30, stop = 34))
   }
 
@@ -573,25 +573,25 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     checkError(
       exception = parseException("SELECT CAST(struct(1,2,3) AS STRUCT)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
-      sqlState = "42000",
+      sqlState = "42K01",
       context = ExpectedContext(fragment = "STRUCT", start = 29, stop = 34))
     // Cast array of struct without specifying field type in struct
     checkError(
       exception = parseException("SELECT CAST(array(struct(1,2)) AS ARRAY<STRUCT>)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
-      sqlState = "42000",
+      sqlState = "42K01",
       context = ExpectedContext(fragment = "STRUCT", start = 40, stop = 45))
     // Create column of struct type without specifying field type
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 STRUCT)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.STRUCT",
-      sqlState = "42000",
+      sqlState = "42K01",
       context = ExpectedContext(fragment = "STRUCT", start = 30, stop = 35))
     // Invalid syntax `STRUCT<INT>` without field name
     checkError(
       exception = parseException("SELECT CAST(struct(1,2,3) AS STRUCT<INT>)"),
       errorClass = "PARSE_SYNTAX_ERROR",
-      sqlState = "42000",
+      sqlState = "42601",
       parameters = Map("error" -> "'<'", "hint" -> ": missing ')'"))
   }
 
@@ -600,19 +600,19 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     checkError(
       exception = parseException("SELECT CAST(map(1,'2') AS MAP)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
-      sqlState = "42000",
+      sqlState = "42K01",
       context = ExpectedContext(fragment = "MAP", start = 26, stop = 28))
     // Create column of map type without specifying key/value types
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 MAP)"),
       errorClass = "INCOMPLETE_TYPE_DEFINITION.MAP",
-      sqlState = "42000",
+      sqlState = "42K01",
       context = ExpectedContext(fragment = "MAP", start = 30, stop = 32))
     // Invalid syntax `MAP<String>` with only key type
     checkError(
       exception = parseException("SELECT CAST(map('1',2) AS MAP<STRING>)"),
       errorClass = "PARSE_SYNTAX_ERROR",
-      sqlState = "42000",
+      sqlState = "42601",
       parameters = Map("error" -> "'<'", "hint" -> ": missing ')'"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR improves error messages for `ARRAY` / `MAP` / `STRUCT` types without element type specification. A new error class `INCOMPLETE_TYPE_DEFINITION` with subclasses (`ARRAY`, `MAP`, and `STRUCT`) is introduced.

**Details**

In the case where we do `CAST AS` or `CREATE` a complex type without specifying its element type,
e.g.
```
CREATE TABLE t (col ARRAY)
```
`[UNSUPPORTED_DATATYPE] Unsupported data type "ARRAY"` error would be thrown, while we do support the `ARRAY` type and just require it to be typed.

This PR proposes a better error message like 
```
The definition of `ARRAY` type is incomplete. You must provide an element type. For example: `ARRAY<elementType>`.
```


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

The previous error message for incomplete complex types is confusing. A `UNSUPPORTED_DATATYPE` error would be thrown, while we do support complex types. We just require complex types to have their element types specified. We need a clear error message with an example in this case.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### Does this PR introduce _any_ user-facing change?

Yes, this PR changes the error message which is user-facing.

Error message before this PR:
```
spark-sql> SELECT CAST(array(1, 2, 3) AS ARRAY);

[UNSUPPORTED_DATATYPE] Unsupported data type "ARRAY"(line 1, pos 30)
```

Error message after this PR:
```
[INCOMPLETE_TYPE_DEFINITION.ARRAY] Incomplete complex type: The definition of `ARRAY` type is incomplete. You must provide an element type. For example: `ARRAY<elementType>`.
```
Similarly for MAP and STRUCT types.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?

Added unit tests covering CAST and CREATE with ARRAY / STRUCT / MAP types and their nested combinations.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
