### PR TITLE
[SPARK-42166][K8S] Make `docker-image-tool.sh` usage message up-to-date

### DIFF
--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -261,18 +261,18 @@ Examples:
     $0 -m -t testing build
 
   - Build PySpark docker image
-    $0 -r docker.io/myrepo -t v2.3.0 -p kubernetes/dockerfiles/spark/bindings/python/Dockerfile build
+    $0 -r docker.io/myrepo -t v3.4.0 -p kubernetes/dockerfiles/spark/bindings/python/Dockerfile build
 
-  - Build and push image with tag "v2.3.0" to docker.io/myrepo
-    $0 -r docker.io/myrepo -t v2.3.0 build
-    $0 -r docker.io/myrepo -t v2.3.0 push
+  - Build and push image with tag "v3.4.0" to docker.io/myrepo
+    $0 -r docker.io/myrepo -t v3.4.0 build
+    $0 -r docker.io/myrepo -t v3.4.0 push
 
-  - Build and push Java11-based image with tag "v3.0.0" to docker.io/myrepo
-    $0 -r docker.io/myrepo -t v3.0.0 -b java_image_tag=11-jre-focal build
-    $0 -r docker.io/myrepo -t v3.0.0 push
+  - Build and push Java11-based image with tag "v3.4.0" to docker.io/myrepo
+    $0 -r docker.io/myrepo -t v3.4.0 -b java_image_tag=11-jre build
+    $0 -r docker.io/myrepo -t v3.4.0 push
 
-  - Build and push Java11-based image for multiple archs to docker.io/myrepo
-    $0 -r docker.io/myrepo -t v3.0.0 -X -b java_image_tag=11-jre-focal build
+  - Build and push image for multiple archs to docker.io/myrepo
+    $0 -r docker.io/myrepo -t v3.4.0 -X build
     # Note: buildx, which does cross building, needs to do the push during build
     # So there is no separate push step with -X
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `docker-image-tool.sh` usage message up-to-date for Apache Spark 3.4.0.

### Why are the changes needed?

- Simplify `multi-arch` publishing example by removing java tag in order to keep one concept. In addition, Java 17 is better than `Java 11` in terms of multi-arch support.
- Use `v3.4.0` instead of all EOL versions (v2.3.0, v3.0.0)
- Use the smallest multi-arch image tag example, `11-jre`, instead of `11-jre-focal`.
```
$ docker images | grep eclipse-temurin | sort -k7
eclipse-temurin    11-jre           87a0df44b0d1   6 weeks ago     239MB
eclipse-temurin    11-jre-focal     0cb88201ea2b   6 weeks ago     245MB
eclipse-temurin    17-jre           096f7591e8eb   6 weeks ago     260MB
eclipse-temurin    11               a20b0d225174   6 weeks ago     435MB
eclipse-temurin    17               2ed42194c6b0   6 weeks ago     450MB
```

### Does this PR introduce _any_ user-facing change?

Yes, but this is a usage message.

### How was this patch tested?

Manually review.