### PR TITLE
[SPARK-41775][PYTHON][FOLLOWUP] Use `pyspark.cloudpickle` instead of `cloudpickle`

### DIFF
--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-import cloudpickle  # type: ignore
 from contextlib import contextmanager
 import collections
 import logging
@@ -31,6 +30,7 @@ import textwrap
 import time
 from typing import Union, Callable, List, Dict, Optional, Any, Tuple, Generator
 
+from pyspark import cloudpickle
 from pyspark.sql import SparkSession
 from pyspark.ml.torch.log_communication import (  # type: ignore
     get_driver_host,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #39369 which aims to use `pyspark.cloudpickle` instead of outside `cloudpickle` dependency.

### Why are the changes needed?

Apache PySpark should not use two versions of `cloudpickle`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.