### PR TITLE
[SPARK-42163][SQL] Fix schema pruning for non-foldable array index or map key

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -1132,7 +1132,7 @@ abstract class SchemaPruningSuite
     checkScan(query, "struct<id:int, name:struct<first:string>>")
   }
 
-  testSchemaPruning("SPARK-?????: GetArrayItem and GetMapItem with non-foldable index") {
+  testSchemaPruning("SPARK-42163: GetArrayItem and GetMapItem with non-foldable index") {
     // Technically, there's no reason that we can't support a non-foldable index, it's just tricky
     // with the existing pruning code. If we ever do support it, this test can be modified to check
     // for a narrower scan schema.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -1131,4 +1131,34 @@ abstract class SchemaPruningSuite
       .select($"id", $"name.first")
     checkScan(query, "struct<id:int, name:struct<first:string>>")
   }
+
+  testSchemaPruning("SPARK-?????: GetArrayItem and GetMapItem with non-foldable index") {
+    // Technically, there's no reason that we can't support a non-foldable index, it's just tricky
+    // with the existing pruning code. If we ever do support it, this test can be modified to check
+    // for a narrower scan schema.
+    val arrayQuery =
+      sql("""
+            |SELECT
+            |employer.company, friends[employer.id].first
+            |FROM contacts
+            |""".stripMargin)
+    checkScan(arrayQuery,
+        """struct<friends:array<struct<first:string,middle:string,last:string>>,
+          |employer:struct<id:int,company:struct<name:string,address:string>>>""".stripMargin)
+    checkAnswer(arrayQuery,
+      Row(Row("abc", "123 Business Street"), "Susan") ::
+      Row(null, null) :: Row(null, null) :: Row(null, null) :: Nil)
+
+    val mapQuery =
+      sql("""
+            |SELECT
+            |employer.id, relatives[employer.company.name].first
+            |FROM contacts
+            |""".stripMargin)
+    checkScan(mapQuery,
+        """struct<relatives:map<string,struct<first:string,middle:string,last:string>>,
+          |employer:struct<id:int,company:struct<name:string>>>""".stripMargin)
+    checkAnswer(mapQuery, Row(0, null) :: Row(1, null) ::
+      Row(null, null) :: Row(null, null) :: Nil)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

In parquet schema pruning, we use SelectedField to try to extract the field that is used in a struct. It looks through GetArrayItem/GetMapItem, but when doing so, it ignores the index/key, which may itself be a struct field. If it is a struct field that is not selected in some other expression, and another field of the same attribute is selected, then pruning will drop the field, resulting in an optimizer error.

This change modifies SelectedField to only look through GetArrayItem/GetMapItem if the index/key argument is foldable. The equivalent code for `ElementAt` was already doing the same thing, so this just makes them consistent.

In principle, we could continue to traverse through these expressions, we'd just need to make sure that the index/key expression was also surfaced to column pruning as an expression that needs to be examined. But this seems like a fairly non-trivial change to the design of the SelectedField class.

There is some risk that the current approach could result in a regression e.g. if there is an existing GetArrayItem that is being successfully pruned, where a non-foldable index argument happens to not trigger an error (because it is not a struct field, or it is preserved due to some other expression).

### Why are the changes needed?

Allows queries that previously would fail in the optimizer to pass.

### Does this PR introduce _any_ user-facing change?

Yes, as described above, there could be a performance regression if a query was previously pruning through a GetArrayItem/GetMapItem, and happened to not fail.

### How was this patch tested?

Unit test included in patch, fails without the patch and passes with it.