### PR TITLE
[SPARK-41500] [SQL] Year/Month Interval operations bug fix

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -395,7 +395,7 @@ class Analyzer(override val catalogManager: CatalogManager)
           case (_: YearMonthIntervalType, TimestampType | TimestampNTZType) =>
             TimestampAddYMInterval(r, l)
           case (CalendarIntervalType, CalendarIntervalType) |
-               (_: DayTimeIntervalType, _: DayTimeIntervalType) => a
+               (_: AnsiIntervalType, _: AnsiIntervalType) => a
           case (_: NullType, _: AnsiIntervalType) =>
             a.copy(left = Cast(a.left, a.right.dataType))
           case (_: AnsiIntervalType, _: NullType) =>
@@ -403,6 +403,7 @@ class Analyzer(override val catalogManager: CatalogManager)
           case (DateType, CalendarIntervalType) =>
             DateAddInterval(l, r, ansiEnabled = mode == EvalMode.ANSI)
           case (_, CalendarIntervalType | _: DayTimeIntervalType) => Cast(TimeAdd(l, r), l.dataType)
+          case (_, _: YearMonthIntervalType) => Cast(TimestampAddYMInterval(l, r), l.dataType)
           case (CalendarIntervalType, DateType) =>
             DateAddInterval(r, l, ansiEnabled = mode == EvalMode.ANSI)
           case (CalendarIntervalType | _: DayTimeIntervalType, _) => Cast(TimeAdd(r, l), r.dataType)
@@ -420,7 +421,7 @@ class Analyzer(override val catalogManager: CatalogManager)
           case (TimestampType | TimestampNTZType, _: YearMonthIntervalType) =>
             DatetimeSub(l, r, TimestampAddYMInterval(l, UnaryMinus(r, mode == EvalMode.ANSI)))
           case (CalendarIntervalType, CalendarIntervalType) |
-               (_: DayTimeIntervalType, _: DayTimeIntervalType) => s
+               (_: AnsiIntervalType, _: AnsiIntervalType) => s
           case (_: NullType, _: AnsiIntervalType) =>
             s.copy(left = Cast(s.left, s.right.dataType))
           case (_: AnsiIntervalType, _: NullType) =>
@@ -430,6 +431,9 @@ class Analyzer(override val catalogManager: CatalogManager)
               UnaryMinus(r, mode == EvalMode.ANSI), ansiEnabled = mode == EvalMode.ANSI))
           case (_, CalendarIntervalType | _: DayTimeIntervalType) =>
             Cast(DatetimeSub(l, r, TimeAdd(l, UnaryMinus(r, mode == EvalMode.ANSI))), l.dataType)
+          case (_, _: YearMonthIntervalType) => Cast(
+            DatetimeSub(l, r, TimestampAddYMInterval(l, UnaryMinus(r, mode == EvalMode.ANSI))),
+            l.dataType)
           case _ if AnyTimestampType.unapply(l) || AnyTimestampType.unapply(r) =>
             SubtractTimestamps(l, r)
           case (_, DateType) => SubtractDates(l, r)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -1189,6 +1189,8 @@ object TypeCoercion extends TypeCoercionBase {
         s.copy(left = newLeft, right = newRight)
 
       case t @ TimeAdd(StringType(), _, _) => t.copy(start = Cast(t.start, TimestampType))
+      case t @ TimestampAddYMInterval(StringType(), _, _) =>
+        t.copy(timestamp = Cast(t.timestamp, TimestampType))
     }
   }
 

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -2121,14 +2121,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"INTERVAL '2-2' YEAR TO MONTH\"",
-    "inputType" : "\"INTERVAL YEAR TO MONTH\"",
-    "paramIndex" : "1",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
-    "sqlExpr" : "\"INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3' DAY\""
+    "left" : "\"INTERVAL YEAR TO MONTH\"",
+    "right" : "\"INTERVAL DAY\"",
+    "sqlExpr" : "\"(INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3' DAY)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2147,14 +2145,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"INTERVAL '2-2' YEAR TO MONTH\"",
-    "inputType" : "\"INTERVAL YEAR TO MONTH\"",
-    "paramIndex" : "1",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
-    "sqlExpr" : "\"INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3' DAY\""
+    "left" : "\"INTERVAL DAY\"",
+    "right" : "\"INTERVAL YEAR TO MONTH\"",
+    "sqlExpr" : "\"(INTERVAL '3' DAY + INTERVAL '2-2' YEAR TO MONTH)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2173,14 +2169,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"INTERVAL '2-2' YEAR TO MONTH\"",
-    "inputType" : "\"INTERVAL YEAR TO MONTH\"",
-    "paramIndex" : "1",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
-    "sqlExpr" : "\"INTERVAL '2-2' YEAR TO MONTH + (- INTERVAL '3' DAY)\""
+    "left" : "\"INTERVAL YEAR TO MONTH\"",
+    "right" : "\"INTERVAL DAY\"",
+    "sqlExpr" : "\"(INTERVAL '2-2' YEAR TO MONTH - INTERVAL '3' DAY)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2249,12 +2243,14 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "left" : "\"INT\"",
-    "right" : "\"INTERVAL MONTH\"",
-    "sqlExpr" : "\"(1 + INTERVAL '2' MONTH)\""
+    "inputSql" : "\"1\"",
+    "inputType" : "\"INT\"",
+    "paramIndex" : "1",
+    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "sqlExpr" : "\"1 + INTERVAL '2' MONTH\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/ansi/try_arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/try_arithmetic.sql.out
@@ -212,14 +212,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"INTERVAL '2' YEAR\"",
-    "inputType" : "\"INTERVAL YEAR\"",
-    "paramIndex" : "1",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
-    "sqlExpr" : "\"INTERVAL '2' YEAR + INTERVAL '02' SECOND\""
+    "left" : "\"INTERVAL YEAR\"",
+    "right" : "\"INTERVAL SECOND\"",
+    "sqlExpr" : "\"(INTERVAL '2' YEAR + INTERVAL '02' SECOND)\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1934,14 +1934,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"INTERVAL '2-2' YEAR TO MONTH\"",
-    "inputType" : "\"INTERVAL YEAR TO MONTH\"",
-    "paramIndex" : "1",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
-    "sqlExpr" : "\"INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3' DAY\""
+    "left" : "\"INTERVAL YEAR TO MONTH\"",
+    "right" : "\"INTERVAL DAY\"",
+    "sqlExpr" : "\"(INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3' DAY)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1960,14 +1958,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"INTERVAL '2-2' YEAR TO MONTH\"",
-    "inputType" : "\"INTERVAL YEAR TO MONTH\"",
-    "paramIndex" : "1",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
-    "sqlExpr" : "\"INTERVAL '2-2' YEAR TO MONTH + INTERVAL '3' DAY\""
+    "left" : "\"INTERVAL DAY\"",
+    "right" : "\"INTERVAL YEAR TO MONTH\"",
+    "sqlExpr" : "\"(INTERVAL '3' DAY + INTERVAL '2-2' YEAR TO MONTH)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1986,14 +1982,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"INTERVAL '2-2' YEAR TO MONTH\"",
-    "inputType" : "\"INTERVAL YEAR TO MONTH\"",
-    "paramIndex" : "1",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
-    "sqlExpr" : "\"INTERVAL '2-2' YEAR TO MONTH + (- INTERVAL '3' DAY)\""
+    "left" : "\"INTERVAL YEAR TO MONTH\"",
+    "right" : "\"INTERVAL DAY\"",
+    "sqlExpr" : "\"(INTERVAL '2-2' YEAR TO MONTH - INTERVAL '3' DAY)\""
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2062,12 +2056,14 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
+  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "left" : "\"INT\"",
-    "right" : "\"INTERVAL MONTH\"",
-    "sqlExpr" : "\"(1 + INTERVAL '2' MONTH)\""
+    "inputSql" : "\"1\"",
+    "inputType" : "\"INT\"",
+    "paramIndex" : "1",
+    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "sqlExpr" : "\"1 + INTERVAL '2' MONTH\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out
@@ -166,14 +166,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+  "errorClass" : "DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "inputSql" : "\"INTERVAL '2' YEAR\"",
-    "inputType" : "\"INTERVAL YEAR\"",
-    "paramIndex" : "1",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
-    "sqlExpr" : "\"INTERVAL '2' YEAR + INTERVAL '02' SECOND\""
+    "left" : "\"INTERVAL YEAR\"",
+    "right" : "\"INTERVAL SECOND\"",
+    "sqlExpr" : "\"(INTERVAL '2' YEAR + INTERVAL '02' SECOND)\""
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -994,4 +994,19 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
     checkTrunc("SECOND", "1961-04-12 00:01:02")
     checkTrunc("MINUTE", "1961-04-12 00:01:00")
   }
+
+  test("SPARK-41500: support operations with YearMonthIntervalType") {
+    checkAnswer(
+      spark.sql("select '2022-02-01' - interval 1 year"),
+      Seq(Row("2021-02-01 00:00:00")))
+    checkAnswer(
+      spark.sql("select '2022-02-01' + interval 11 year"),
+      Seq(Row("2033-02-01 00:00:00")))
+    checkAnswer(
+      spark.sql("select '2022-02-01' - interval 5 month"),
+      Seq(Row("2021-09-01 00:00:00")))
+    checkAnswer(
+      spark.sql("select '2022-02-01' + interval 10 month"),
+      Seq(Row("2022-12-01 00:00:00")))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`YearMonthIntervalType` case was missed in `org.apache.spark.sql.catalyst.analysis.Analyzer.ResolveBinaryArithmetic` class. 
Because of that, such kind of queries:
`spark.sql("select '2022-02-01' - interval 1 year")` 
`spark.sql("select '2022-02-01' + interval 1 year")` 
were failing.

Them are failing since **Spark 3.2.0 version**. 
In the earlier versions the queries was working...


### Why are the changes needed?
To fix the interval related operations (add/subtract years/months) bug.

Current error message:
`org.apache.spark.sql.AnalysisException: cannot resolve '(CAST('2022-02-01' AS DOUBLE) - INTERVAL '1' YEAR)' due to data type mismatch: differing types in '(CAST('2022-02-01' AS DOUBLE) - INTERVAL '1' YEAR)' (double and interval year).; line 1 pos 7;
'Project [unresolvedalias((cast(2022-02-01 as double) - INTERVAL '1' YEAR), None)]`


### Does this PR introduce _any_ user-facing change?
Yes, it allows users to use interval related operations (add/subtract years/months) again.
Also, because of this change, some error messages were changed:
- `UNEXPECTED_INPUT_TYPE` -> `BINARY_OP_DIFF_TYPES` (when trying to add/subtract different interval types, like `INTERVAL '2' YEAR + INTERVAL '02' SECOND`)
- `BINARY_OP_DIFF_TYPES` ->  `UNEXPECTED_INPUT_TYPE` (when trying to add/subtract an interval from some value, like `1 + INTERVAL '2' MONTH`)

### How was this patch tested?
An additional test case was added to `org.apache.spark.sql.DateFunctionsSuite` class
