### PR TITLE
[SPARK-42171][PYSPARK][TESTS] Fix `pyspark-errors` module and enable it in GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -337,7 +337,7 @@ jobs:
           - >-
             pyspark-pandas-slow
           - >-
-            pyspark-connect
+            pyspark-connect, pyspark-errors
     env:
       MODULES_TO_TEST: ${{ matrix.modules }}
       HADOOP_PROFILE: ${{ inputs.hadoop }}

--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -25,7 +25,7 @@ class ErrorsTest(unittest.TestCase):
     def test_error_classes(self):
         # Test error classes is sorted alphabetically
         error_reader = ErrorClassesReader()
-        error_class_names = error_reader.error_info_map
+        error_class_names = list(error_reader.error_info_map.keys())
         for i in range(len(error_class_names) - 1):
             self.assertTrue(
                 error_class_names[i] < error_class_names[i + 1],


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `pyspark-errors` module test coverall in GitHub Action and fix it.

### Why are the changes needed?

#39387 added `pyspark_errors` module, but didn't enable it in GitHub Action. 

The bug was not exposed in #39387 initially because `ERROR_CLASSES_JSON` has only one item in this PR.
 
https://github.com/apache/spark/blob/8b8d92334faee889d4106a665ce769403e098240/python/pyspark/errors/tests/test_errors.py#L31

The bug is exposed in the subsequent PRs. So, currently, it's broken.

```
$ python/run-tests.py --modules pyspark-errors
...
test_error_classes (pyspark.errors.tests.test_errors.ErrorsTest.test_error_classes) ... ERROR

======================================================================
ERROR: test_error_classes (pyspark.errors.tests.test_errors.ErrorsTest.test_error_classes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/errors/tests/test_errors.py", line 31, in test_error_classes
    error_class_names[i] < error_class_names[i + 1],
    ~~~~~~~~~~~~~~~~~^^^
KeyError: 0
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This PR shows the failure at the first commit by adding `pyspark-errors` test coverage.
- https://github.com/dongjoon-hyun/spark/actions/runs/3999180114/jobs/6862791939

The second commit passed `pyspark-errors` in the CIs.
- https://github.com/dongjoon-hyun/spark/actions/runs/3999260298/jobs/6862968301