### PR TITLE
[SPARK-42162] Introduce MultiCommutativeOp expression as a memory optimization for canonicalizing large trees of commutative expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -1374,10 +1374,6 @@ case class MultiCommutativeOp(
     }
   }
 
-  /**
-   * Returns the [[DataType]] of the result of evaluating this expression.  It is
-   * invalid to query the dataType of an unresolved expression (i.e., when `resolved` == false).
-   */
   override def dataType: DataType = {
     originalRoot match {
       case _: Add | _: Multiply =>
@@ -1386,21 +1382,10 @@ case class MultiCommutativeOp(
     }
   }
 
-  /**
-   * Returns whether this node is nullable. This node is nullable if any of its children is
-   * nullable.
-   */
   override def nullable: Boolean = operands.exists(_.nullable)
 
-  /**
-   * Returns a Seq of the children of this node.
-   * Children should not change. Immutability required for containsChild optimization
-   */
   override def children: Seq[Expression] = operands
 
-  /**
-   * Replaces the children of this node by the given children.
-   */
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
     this.copy(operands = newChildren)(originalRoot)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -1346,14 +1346,16 @@ trait CommutativeExpression extends Expression {
  * expressions:
  *      Add, Multiply, And, Or, BitwiseAnd, BitwiseOr, BitwiseXor.
  * @param operands A sequence of operands that produces a commutative expression tree.
+ * @param opCls The class of the root operator of the expression tree.
  * @param evalMode The optional expression evaluation mode.
  * @param originalRoot Root operator of the commutative expression tree before canonicalization.
  *                     This object reference is used to deduce the return dataType of Add and
  *                     Multiply operations when the input datatype is decimal.
  */
 case class MultiCommutativeOp(
-  operands: Seq[Expression],
-  evalMode: Option[EvalMode.Value])(originalRoot: Expression) extends Unevaluable {
+    operands: Seq[Expression],
+    opCls: Class[_],
+    evalMode: Option[EvalMode.Value])(originalRoot: Expression) extends Unevaluable {
   // Helper method to deduce the data type of a single operation.
   private def singleOpDataType(lType: DataType, rType: DataType): DataType = {
     originalRoot match {
@@ -1378,7 +1380,7 @@ case class MultiCommutativeOp(
    */
   override def dataType: DataType = {
     originalRoot match {
-      case Add(_, _, _) | Multiply(_, _, _) =>
+      case _: Add | _: Multiply =>
         operands.map(_.dataType).reduce((l, r) => singleOpDataType(l, r))
       case other => other.dataType
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -480,13 +480,11 @@ case class Add(
 
   override lazy val canonicalized: Expression = {
     // TODO: do not reorder consecutive `Add`s with different `evalMode`
-    val operands = orderCommutative({ case Add(l, r, _) => Seq(l, r) })
-    val reorderResult =
-      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
-        operands.reduce(Add(_, _, evalMode))
-      } else {
-        MultiCommutativeOp(operands, this.getClass, Some(evalMode))(this)
-      }
+    val reorderResult = buildCanonicalizedPlan(
+      { case Add(l, r, _) => Seq(l, r) },
+      { case (l: Expression, r: Expression) => Add(l, r, evalMode)},
+      Some(evalMode)
+    )
     if (resolved && reorderResult.resolved && reorderResult.dataType == dataType) {
       reorderResult
     } else {
@@ -638,13 +636,11 @@ case class Multiply(
 
   override lazy val canonicalized: Expression = {
     // TODO: do not reorder consecutive `Multiply`s with different `evalMode`
-    val operands = orderCommutative({ case Multiply(l, r, _) => Seq(l, r) })
-    val reorderResult =
-      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
-        operands.reduce(Multiply(_, _, evalMode))
-      } else {
-        MultiCommutativeOp(operands, this.getClass, Some(evalMode))(this)
-      }
+    val reorderResult = buildCanonicalizedPlan(
+      { case Multiply(l, r, _) => Seq(l, r) }
+      { case (l: Expression, r: Expression) => Multiply(l, r, evalMode)},
+      Some(evalMode)
+    )
     reorderResult
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -30,7 +30,6 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.{BINARY_ARITHMETIC, TreeP
 import org.apache.spark.sql.catalyst.util.{IntervalMathUtils, IntervalUtils, MathUtils, TypeUtils}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.MULTI_COMMUTATIVE_OP_OPT_THRESHOLD
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 
@@ -636,12 +635,11 @@ case class Multiply(
 
   override lazy val canonicalized: Expression = {
     // TODO: do not reorder consecutive `Multiply`s with different `evalMode`
-    val reorderResult = buildCanonicalizedPlan(
-      { case Multiply(l, r, _) => Seq(l, r) }
+    buildCanonicalizedPlan(
+      { case Multiply(l, r, _) => Seq(l, r) },
       { case (l: Expression, r: Expression) => Multiply(l, r, evalMode)},
       Some(evalMode)
     )
-    reorderResult
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -485,7 +485,7 @@ case class Add(
       if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
         operands.reduce(Add(_, _, evalMode))
       } else {
-        MultiCommutativeOp(operands, Some(evalMode))(this)
+        MultiCommutativeOp(operands, this.getClass, Some(evalMode))(this)
       }
     if (resolved && reorderResult.resolved && reorderResult.dataType == dataType) {
       reorderResult
@@ -643,7 +643,7 @@ case class Multiply(
       if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
         operands.reduce(Multiply(_, _, evalMode))
       } else {
-        MultiCommutativeOp(operands, Some(evalMode))(this)
+        MultiCommutativeOp(operands, this.getClass, Some(evalMode))(this)
       }
     reorderResult
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.{BINARY_ARITHMETIC, TreeP
 import org.apache.spark.sql.catalyst.util.{IntervalMathUtils, IntervalUtils, MathUtils, TypeUtils}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.MULTI_ADD_OPT_THRESHOLD
+import org.apache.spark.sql.internal.SQLConf.MULTI_COMMUTATIVE_OP_OPT_THRESHOLD
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 
@@ -408,74 +408,6 @@ object BinaryArithmetic {
   def unapply(e: BinaryArithmetic): Option[(Expression, Expression)] = Some((e.left, e.right))
 }
 
-/**
- * A helper class used by the Add expression during canonicalization. During
- * canonicalization, when we have a long tree of Add operations, we use the MultiAdd expression
- * to represent that tree instead of creating new Add objects. This class is added as a memory
- * optimization for processing large Add operation trees without creating a large number of
- * new intermediate objects.
- * @param operands A sequence of operands that produces an Add tree.
- * @param evalMode The expression evaluation mode.
- */
-case class MultiAdd(operands: Seq[Expression], evalMode: EvalMode.Value) extends Unevaluable {
-  // When `spark.sql.decimalOperations.allowPrecisionLoss` is set to true, if the precision / scale
-  // needed are out of the range of available values, the scale is reduced up to 6, in order to
-  // prevent the truncation of the integer part of the decimals.
-  private def allowPrecisionLoss: Boolean = SQLConf.get.decimalOperationsAllowPrecisionLoss
-
-  // scalastyle:off
-  // The formula follows Hive which is based on the SQL standard and MS SQL:
-  // https://cwiki.apache.org/confluence/download/attachments/27362075/Hive_Decimal_Precision_Scale_Support.pdf
-  // https://msdn.microsoft.com/en-us/library/ms190476.aspx
-  // Result Precision: max(s1, s2) + max(p1-s1, p2-s2) + 1
-  // Result Scale:     max(s1, s2)
-  // scalastyle:on
-  private def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
-    val resultScale = max(s1, s2)
-    val resultPrecision = max(p1 - s1, p2 - s2) + resultScale + 1
-    if (allowPrecisionLoss) {
-      DecimalType.adjustPrecisionScale(resultPrecision, resultScale)
-    } else {
-      DecimalType.bounded(resultPrecision, resultScale)
-    }
-  }
-
-  // Helper method to deduce the data type of a single addition operation.
-  private def singleAddOpDataType(lType: DataType, rType: DataType): DataType = {
-    (lType, rType) match {
-      case (DecimalType.Fixed(p1, s1), DecimalType.Fixed(p2, s2)) =>
-        resultDecimalType(p1, s1, p2, s2)
-      case _ => lType
-    }
-  }
-
-  /**
-   * Returns the [[DataType]] of the result of evaluating this expression.  It is
-   * invalid to query the dataType of an unresolved expression (i.e., when `resolved` == false).
-   */
-  override def dataType: DataType = {
-    operands.map(_.dataType).reduce((l, r) => singleAddOpDataType(l, r))
-  }
-
-  /**
-   * Returns whether this node is nullable. This node is nullable if any of its children is
-   * nullable.
-   */
-  override def nullable: Boolean = operands.exists(_.nullable)
-
-  /**
-   * Returns a Seq of the children of this node.
-   * Children should not change. Immutability required for containsChild optimization
-   */
-  override def children: Seq[Expression] = operands
-
-  /**
-   * Replaces the children of this node by the given children.
-   */
-  override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
-    this.copy(operands = newChildren)
-}
-
 @ExpressionDescription(
   usage = "expr1 _FUNC_ expr2 - Returns `expr1`+`expr2`.",
   examples = """
@@ -549,11 +481,12 @@ case class Add(
   override lazy val canonicalized: Expression = {
     // TODO: do not reorder consecutive `Add`s with different `evalMode`
     val operands = orderCommutative({ case Add(l, r, _) => Seq(l, r) })
-    val reorderResult = if (operands.length < SQLConf.get.getConf(MULTI_ADD_OPT_THRESHOLD)) {
-      operands.reduce(Add(_, _, evalMode))
-    } else {
-      MultiAdd(operands, evalMode)
-    }
+    val reorderResult =
+      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
+        operands.reduce(Add(_, _, evalMode))
+      } else {
+        MultiCommutativeOp(operands, Some(evalMode))(this)
+      }
     if (resolved && reorderResult.resolved && reorderResult.dataType == dataType) {
       reorderResult
     } else {
@@ -705,7 +638,14 @@ case class Multiply(
 
   override lazy val canonicalized: Expression = {
     // TODO: do not reorder consecutive `Multiply`s with different `evalMode`
-    orderCommutative({ case Multiply(l, r, _) => Seq(l, r) }).reduce(Multiply(_, _, evalMode))
+    val operands = orderCommutative({ case Multiply(l, r, _) => Seq(l, r) })
+    val reorderResult =
+      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
+        operands.reduce(Multiply(_, _, evalMode))
+      } else {
+        MultiCommutativeOp(operands, Some(evalMode))(this)
+      }
+    reorderResult
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.expressions.codegen._
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.MULTI_COMMUTATIVE_OP_OPT_THRESHOLD
 import org.apache.spark.sql.types._
 
 
@@ -64,11 +62,10 @@ case class BitwiseAnd(left: Expression, right: Expression) extends BinaryArithme
     newLeft: Expression, newRight: Expression): BitwiseAnd = copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val reorderResult = buildCanonicalizedPlan(
+    buildCanonicalizedPlan(
       { case BitwiseAnd(l, r) => Seq(l, r) },
       { case (l: Expression, r: Expression) => BitwiseAnd(l, r)}
     )
-    reorderResult
   }
 }
 
@@ -112,11 +109,10 @@ case class BitwiseOr(left: Expression, right: Expression) extends BinaryArithmet
     newLeft: Expression, newRight: Expression): BitwiseOr = copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val reorderResult = buildCanonicalizedPlan(
+    buildCanonicalizedPlan(
       { case BitwiseOr(l, r) => Seq(l, r) },
       { case (l: Expression, r: Expression) => BitwiseOr(l, r)}
     )
-    reorderResult
   }
 }
 
@@ -160,11 +156,10 @@ case class BitwiseXor(left: Expression, right: Expression) extends BinaryArithme
     newLeft: Expression, newRight: Expression): BitwiseXor = copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val reorderResult = buildCanonicalizedPlan(
+    buildCanonicalizedPlan(
       { case BitwiseXor(l, r) => Seq(l, r) },
       { case (l: Expression, r: Expression) => BitwiseXor(l, r)}
     )
-    reorderResult
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -69,7 +69,7 @@ case class BitwiseAnd(left: Expression, right: Expression) extends BinaryArithme
       if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
         operands.reduce(BitwiseAnd)
       } else {
-        MultiCommutativeOp(operands, None)(this)
+        MultiCommutativeOp(operands, this.getClass, None)(this)
       }
     reorderResult
   }
@@ -120,7 +120,7 @@ case class BitwiseOr(left: Expression, right: Expression) extends BinaryArithmet
       if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
         operands.reduce(BitwiseOr)
       } else {
-        MultiCommutativeOp(operands, None)(this)
+        MultiCommutativeOp(operands, this.getClass, None)(this)
       }
     reorderResult
   }
@@ -171,7 +171,7 @@ case class BitwiseXor(left: Expression, right: Expression) extends BinaryArithme
       if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
         operands.reduce(BitwiseXor)
       } else {
-        MultiCommutativeOp(operands, None)(this)
+        MultiCommutativeOp(operands, this.getClass, None)(this)
       }
     reorderResult
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -64,13 +64,10 @@ case class BitwiseAnd(left: Expression, right: Expression) extends BinaryArithme
     newLeft: Expression, newRight: Expression): BitwiseAnd = copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val operands = orderCommutative({ case BitwiseAnd(l, r) => Seq(l, r) })
-    val reorderResult =
-      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
-        operands.reduce(BitwiseAnd)
-      } else {
-        MultiCommutativeOp(operands, this.getClass, None)(this)
-      }
+    val reorderResult = buildCanonicalizedPlan(
+      { case BitwiseAnd(l, r) => Seq(l, r) },
+      { case (l: Expression, r: Expression) => BitwiseAnd(l, r)}
+    )
     reorderResult
   }
 }
@@ -115,13 +112,10 @@ case class BitwiseOr(left: Expression, right: Expression) extends BinaryArithmet
     newLeft: Expression, newRight: Expression): BitwiseOr = copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val operands = orderCommutative({ case BitwiseOr(l, r) => Seq(l, r) })
-    val reorderResult =
-      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
-        operands.reduce(BitwiseOr)
-      } else {
-        MultiCommutativeOp(operands, this.getClass, None)(this)
-      }
+    val reorderResult = buildCanonicalizedPlan(
+      { case BitwiseOr(l, r) => Seq(l, r) },
+      { case (l: Expression, r: Expression) => BitwiseOr(l, r)}
+    )
     reorderResult
   }
 }
@@ -166,13 +160,10 @@ case class BitwiseXor(left: Expression, right: Expression) extends BinaryArithme
     newLeft: Expression, newRight: Expression): BitwiseXor = copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val operands = orderCommutative({ case BitwiseXor(l, r) => Seq(l, r) })
-    val reorderResult =
-      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
-        operands.reduce(BitwiseXor)
-      } else {
-        MultiCommutativeOp(operands, this.getClass, None)(this)
-      }
+    val reorderResult = buildCanonicalizedPlan(
+      { case BitwiseXor(l, r) => Seq(l, r) },
+      { case (l: Expression, r: Expression) => BitwiseXor(l, r)}
+    )
     reorderResult
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -811,7 +811,7 @@ case class And(left: Expression, right: Expression) extends BinaryOperator with 
       if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
         operands.reduce(And)
       } else {
-        MultiCommutativeOp(operands, None)(this)
+        MultiCommutativeOp(operands, this.getClass, None)(this)
       }
     reorderResult
   }
@@ -912,7 +912,7 @@ case class Or(left: Expression, right: Expression) extends BinaryOperator with P
       if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
         operands.reduce(Or)
       } else {
-        MultiCommutativeOp(operands, None)(this)
+        MultiCommutativeOp(operands, this.getClass, None)(this)
       }
     reorderResult
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -806,13 +806,10 @@ case class And(left: Expression, right: Expression) extends BinaryOperator with 
     copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val operands = orderCommutative({ case And(l, r) => Seq(l, r) })
-    val reorderResult =
-      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
-        operands.reduce(And)
-      } else {
-        MultiCommutativeOp(operands, this.getClass, None)(this)
-      }
+    val reorderResult = buildCanonicalizedPlan(
+      { case And(l, r) => Seq(l, r) },
+      { case (l: Expression, r: Expression) => And(l, r)}
+    )
     reorderResult
   }
 }
@@ -907,13 +904,10 @@ case class Or(left: Expression, right: Expression) extends BinaryOperator with P
     copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val operands = orderCommutative({ case Or(l, r) => Seq(l, r) })
-    val reorderResult =
-      if (operands.length < SQLConf.get.getConf(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD)) {
-        operands.reduce(Or)
-      } else {
-        MultiCommutativeOp(operands, this.getClass, None)(this)
-      }
+    val reorderResult = buildCanonicalizedPlan(
+      { case Or(l, r) => Seq(l, r) },
+      { case (l: Expression, r: Expression) => Or(l, r)}
+    )
     reorderResult
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LeafNode, Logical
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.MULTI_COMMUTATIVE_OP_OPT_THRESHOLD
 import org.apache.spark.sql.types._
 
 /**
@@ -806,11 +805,10 @@ case class And(left: Expression, right: Expression) extends BinaryOperator with 
     copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val reorderResult = buildCanonicalizedPlan(
+    buildCanonicalizedPlan(
       { case And(l, r) => Seq(l, r) },
       { case (l: Expression, r: Expression) => And(l, r)}
     )
-    reorderResult
   }
 }
 
@@ -904,11 +902,10 @@ case class Or(left: Expression, right: Expression) extends BinaryOperator with P
     copy(left = newLeft, right = newRight)
 
   override lazy val canonicalized: Expression = {
-    val reorderResult = buildCanonicalizedPlan(
+    buildCanonicalizedPlan(
       { case Or(l, r) => Seq(l, r) },
       { case (l: Expression, r: Expression) => Or(l, r)}
     )
-    reorderResult
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -243,11 +243,11 @@ object SQLConf {
   val MULTI_COMMUTATIVE_OP_OPT_THRESHOLD =
     buildConf("spark.sql.analyzer.canonicalization.multiCommutativeOpMemoryOptThreshold")
       .internal()
-      .doc("The minimum number of consecutive non-commutative operands to" +
+      .doc("The minimum number of operands in a commutative expression tree to" +
         " invoke the MultiCommutativeOp memory optimization during canonicalization.")
       .version("3.4.0")
       .intConf
-      .createWithDefault(2)
+      .createWithDefault(3)
 
   val OPTIMIZER_EXCLUDED_RULES = buildConf("spark.sql.optimizer.excludedRules")
     .doc("Configures a list of rules to be disabled in the optimizer, in which the rules are " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -240,6 +240,15 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
+  val MULTI_ADD_OPT_THRESHOLD =
+    buildConf("spark.sql.analyzer.canonicalization.multiAddMemoryOptThreshold")
+      .internal()
+      .doc("The minimum number of consecutive Add expressions to invoke the MultiAdd " +
+        "memory optimization during canonicalization.")
+      .version("3.3.0")
+      .intConf
+      .createWithDefault(10)
+
   val OPTIMIZER_EXCLUDED_RULES = buildConf("spark.sql.optimizer.excludedRules")
     .doc("Configures a list of rules to be disabled in the optimizer, in which the rules are " +
       "specified by their rule names and separated by comma. It is not guaranteed that all the " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -240,11 +240,11 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
-  val MULTI_ADD_OPT_THRESHOLD =
-    buildConf("spark.sql.analyzer.canonicalization.multiAddMemoryOptThreshold")
+  val MULTI_COMMUTATIVE_OP_OPT_THRESHOLD =
+    buildConf("spark.sql.analyzer.canonicalization.multiCommutativeOpMemoryOptThreshold")
       .internal()
-      .doc("The minimum number of consecutive Add expressions to invoke the MultiAdd " +
-        "memory optimization during canonicalization.")
+      .doc("The minimum number of consecutive commutative expressions to" +
+        " invoke the MultiCommutativeOp memory optimization during canonicalization.")
       .version("3.3.0")
       .intConf
       .createWithDefault(10)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -243,11 +243,11 @@ object SQLConf {
   val MULTI_COMMUTATIVE_OP_OPT_THRESHOLD =
     buildConf("spark.sql.analyzer.canonicalization.multiCommutativeOpMemoryOptThreshold")
       .internal()
-      .doc("The minimum number of consecutive commutative expressions to" +
+      .doc("The minimum number of consecutive non-commutative operands to" +
         " invoke the MultiCommutativeOp memory optimization during canonicalization.")
-      .version("3.3.0")
+      .version("3.4.0")
       .intConf
-      .createWithDefault(10)
+      .createWithDefault(2)
 
   val OPTIMIZER_EXCLUDED_RULES = buildConf("spark.sql.optimizer.excludedRules")
     .doc("Configures a list of rules to be disabled in the optimizer, in which the rules are " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
- This PR introduces a new expression called `MultiCommutativeOp` which is used by the commutative expressions (e.g., `Add`, `Multiply`, `And`, `Or`, `BitwiseOr`, `BitwiseAnd`, `BitwiseXor`) during canonicalization.
- During canonicalization, when there is a list of consecutive commutative expressions, we now create a MultiCommutative expression with references to original operands, instead of creating new objects.
- This new expression is added as a memory optimization to reduce generating a large number of intermediate objects during canonicalization.

### Why are the changes needed?
- With the [recent changes](https://github.com/apache/spark/pull/37851) in the expression canonicalization, a complex query with a large number of commutative operations could end up consuming significantly more (sometimes > 10X) memory on the executors.
- In our case, this issue happens for a specific complex query that has a huge expression tree containing Add operators interleaved by non Add operators.
- The issue is related to canonicalization and why it is causing issues in the executors is because the codegen component relies on expression canonicalization to deduplicate expressions. 
- When we have a large number of Adds interleaved by non-Add operators, [this line](https://github.com/apache/spark/pull/37851/files#diff-7278f2db37934522ee7c74b71525153234cff245cefaf996957e4a9ff3dbaacdR1171) ends up materializing a new canonicalized expression tree at every non-Add operator.
- In our case, analyzing the executor heap histogram shows that the additional memory is consumed by a large number of Add objects.
- The high memory usage causes the executors to lose heartbeat signals and results in task failures.
- The proposed `MultiCommutativeOp` expression avoids generating new Add expressions and keeps the extra memory usage to a minimum.


### Does this PR introduce _any_ user-facing change?
- No

### How was this patch tested?
- Existing unit tests and new unit tests.