### PR TITLE
[SPARK-41302][SQL] Assign name to _LEGACY_ERROR_TEMP_1185

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -581,6 +581,12 @@
     ],
     "sqlState" : "42805"
   },
+  "IDENTIFIER_TOO_MANY_NAME_PARTS" : {
+    "message" : [
+      "<quoted> is not a valid <identifier> as it has more than 2 name parts."
+    ],
+    "sqlState" : "42601"
+  },
   "INCOMPARABLE_PIVOT_COLUMN" : {
     "message" : [
       "Invalid pivot column <columnName>. Pivot columns must be comparable."
@@ -796,12 +802,6 @@
       "The identifier <ident> is invalid. Please, consider quoting it with back-quotes as `<ident>`."
     ],
     "sqlState" : "42602"
-  },
-  "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS" : {
-    "message" : [
-      "<quoted> is not a valid <identifier> as it has more than 2 name parts."
-    ],
-    "sqlState" : "42601"
   },
   "INVALID_JSON_ROOT_FIELD" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -797,6 +797,11 @@
     ],
     "sqlState" : "42602"
   },
+  "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS" : {
+    "message" : [
+      "<quoted> is not a valid <identifier> as it has more than 2 name parts."
+    ]
+  },
   "INVALID_JSON_ROOT_FIELD" : {
     "message" : [
       "Cannot convert JSON root field to target Spark type."
@@ -2807,11 +2812,6 @@
   "_LEGACY_ERROR_TEMP_1184" : {
     "message" : [
       "Catalog <plugin> does not support <ability>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1185" : {
-    "message" : [
-      "<quoted> is not a valid <identifier> as it has more than 2 name parts."
     ]
   },
   "_LEGACY_ERROR_TEMP_1186" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -800,7 +800,8 @@
   "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS" : {
     "message" : [
       "<quoted> is not a valid <identifier> as it has more than 2 name parts."
-    ]
+    ],
+    "sqlState" : "42601"
   },
   "INVALID_JSON_ROOT_FIELD" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -583,7 +583,7 @@
   },
   "IDENTIFIER_TOO_MANY_NAME_PARTS" : {
     "message" : [
-      "<quoted> is not a valid <identifier> as it has more than 2 name parts."
+      "<identifier> is not a valid identifier as it has more than 2 name parts."
     ],
     "sqlState" : "42601"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
@@ -130,22 +130,20 @@ private[sql] object CatalogV2Implicits {
       }
     }
 
+    def original: String = ident.namespace() :+ ident.name() mkString "."
+
     def asMultipartIdentifier: Seq[String] = ident.namespace :+ ident.name
 
     def asTableIdentifier: TableIdentifier = ident.namespace match {
       case ns if ns.isEmpty => TableIdentifier(ident.name)
       case Array(dbName) => TableIdentifier(ident.name, Some(dbName))
-      case _ =>
-        throw QueryCompilationErrors.identifierHavingMoreThanTwoNamePartsError(
-          quoted, "TableIdentifier")
+      case _ => throw QueryCompilationErrors.identifierTooManyNamePartsError(original)
     }
 
     def asFunctionIdentifier: FunctionIdentifier = ident.namespace() match {
       case ns if ns.isEmpty => FunctionIdentifier(ident.name())
       case Array(dbName) => FunctionIdentifier(ident.name(), Some(dbName))
-      case _ =>
-        throw QueryCompilationErrors.identifierHavingMoreThanTwoNamePartsError(
-          quoted, "FunctionIdentifier")
+      case _ => throw QueryCompilationErrors.identifierTooManyNamePartsError(original)
     }
   }
 
@@ -159,20 +157,18 @@ private[sql] object CatalogV2Implicits {
     def asTableIdentifier: TableIdentifier = parts match {
       case Seq(tblName) => TableIdentifier(tblName)
       case Seq(dbName, tblName) => TableIdentifier(tblName, Some(dbName))
-      case _ =>
-        throw QueryCompilationErrors.identifierHavingMoreThanTwoNamePartsError(
-          quoted, "TableIdentifier")
+      case _ => throw QueryCompilationErrors.identifierTooManyNamePartsError(original)
     }
 
     def asFunctionIdentifier: FunctionIdentifier = parts match {
       case Seq(funcName) => FunctionIdentifier(funcName)
       case Seq(dbName, funcName) => FunctionIdentifier(funcName, Some(dbName))
-      case _ =>
-        throw QueryCompilationErrors.identifierHavingMoreThanTwoNamePartsError(
-          quoted, "FunctionIdentifier")
+      case _ => throw QueryCompilationErrors.identifierTooManyNamePartsError(original)
     }
 
     def quoted: String = parts.map(quoteIfNeeded).mkString(".")
+
+    def original: String = parts.mkString(".")
   }
 
   implicit class TableIdentifierHelper(identifier: TableIdentifier) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1867,7 +1867,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def identifierHavingMoreThanTwoNamePartsError(
       quoted: String, identifier: String): Throwable = {
     new AnalysisException(
-      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
       messageParameters = Map(
         "quoted" -> quoted,
         "identifier" -> identifier))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1864,13 +1864,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
         "ability" -> ability))
   }
 
-  def identifierHavingMoreThanTwoNamePartsError(
-      quoted: String, identifier: String): Throwable = {
+  def identifierTooManyNamePartsError(originalIdentifier: String): Throwable = {
     new AnalysisException(
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      messageParameters = Map(
-        "quoted" -> quoted,
-        "identifier" -> identifier))
+      messageParameters = Map("identifier" -> toSQLId(originalIdentifier)))
   }
 
   def emptyMultipartIdentifierError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1867,7 +1867,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def identifierHavingMoreThanTwoNamePartsError(
       quoted: String, identifier: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1185",
+      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
       messageParameters = Map(
         "quoted" -> quoted,
         "identifier" -> identifier))

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.errors
 
 import org.apache.spark.sql.{AnalysisException, ClassData, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.api.java.{UDF1, UDF2, UDF23Test}
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.expressions.SparkUserDefinedFunction
 import org.apache.spark.sql.functions.{from_json, grouping, grouping_id, lit, struct, sum, udf}
 import org.apache.spark.sql.internal.SQLConf
@@ -678,6 +679,44 @@ class QueryCompilationErrorsSuite
       ),
       context = ExpectedContext("", "", 7, 13, "CAST(1)")
     )
+  }
+
+  test("IDENTIFIER_TOO_MANY_NAME_PARTS: " +
+    "create temp view doesn't support identifiers consisting of more than 2 parts") {
+    checkError(
+      exception = intercept[ParseException] {
+        sql("CREATE TEMPORARY VIEW db_name.schema_name.view_name AS SELECT '1' as test_column")
+      },
+      errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
+      parameters = Map(
+        "quoted" -> "db_name.schema_name.view_name",
+        "identifier" -> "TableIdentifier"
+      )
+    )
+  }
+
+  test("IDENTIFIER_TOO_MANY_NAME_PARTS: " +
+    "alter table doesn't support identifiers consisting of more than 2 parts") {
+    val tableName: String = "t"
+    withTable(tableName) {
+      sql(
+        s"""
+           |CREATE TABLE $tableName (a STRING, b INT, c STRING, d STRING)
+           |USING parquet
+           |PARTITIONED BY (c, d)
+           |""".stripMargin)
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("ALTER TABLE t RENAME TO db_name.schema_name.new_table_name")
+        },
+        errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
+        parameters = Map(
+          "quoted" -> "db_name.schema_name.new_table_name",
+          "identifier" -> "TableIdentifier"
+        )
+      )
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -688,10 +688,8 @@ class QueryCompilationErrorsSuite
         sql("CREATE TEMPORARY VIEW db_name.schema_name.view_name AS SELECT '1' as test_column")
       },
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map(
-        "quoted" -> "db_name.schema_name.view_name",
-        "identifier" -> "TableIdentifier"
-      )
+      sqlState = "42601",
+      parameters = Map("identifier" -> "`db_name`.`schema_name`.`view_name`")
     )
   }
 
@@ -708,13 +706,11 @@ class QueryCompilationErrorsSuite
 
       checkError(
         exception = intercept[AnalysisException] {
-          sql("ALTER TABLE t RENAME TO db_name.schema_name.new_table_name")
+          sql(s"ALTER TABLE $tableName RENAME TO db_name.schema_name.new_table_name")
         },
         errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-        parameters = Map(
-          "quoted" -> "db_name.schema_name.new_table_name",
-          "identifier" -> "TableIdentifier"
-        )
+        sqlState = "42601",
+        parameters = Map("identifier" -> "`db_name`.`schema_name`.`new_table_name`")
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
@@ -1125,16 +1125,12 @@ class V2SessionCatalogNamespaceSuite extends V2SessionCatalogBaseSuite {
     checkError(
       exception = intercept[AnalysisException](testIdent.asTableIdentifier),
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map(
-        "quoted" -> "a.b.c",
-        "identifier" -> "TableIdentifier")
+      parameters = Map("identifier" -> "`a`.`b`.`c`")
     )
     checkError(
       exception = intercept[AnalysisException](testIdent.asFunctionIdentifier),
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map(
-        "quoted" -> "a.b.c",
-        "identifier" -> "FunctionIdentifier")
+      parameters = Map("identifier" -> "`a`.`b`.`c`")
     )
   }
 
@@ -1143,16 +1139,12 @@ class V2SessionCatalogNamespaceSuite extends V2SessionCatalogBaseSuite {
     checkError(
       exception = intercept[AnalysisException](testIdent.asTableIdentifier),
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map(
-        "quoted" -> "a.b.c",
-        "identifier" -> "TableIdentifier")
+      parameters = Map("identifier" -> "`a`.`b`.`c`")
     )
     checkError(
       exception = intercept[AnalysisException](testIdent.asFunctionIdentifier),
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map(
-        "quoted" -> "a.b.c",
-        "identifier" -> "FunctionIdentifier")
+      parameters = Map("identifier" -> "`a`.`b`.`c`")
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
@@ -1127,20 +1127,10 @@ class V2SessionCatalogNamespaceSuite extends V2SessionCatalogBaseSuite {
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
       parameters = Map("identifier" -> "`a`.`b`.`c`")
     )
-    checkError(
-      exception = intercept[AnalysisException](testIdent.asFunctionIdentifier),
-      errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map("identifier" -> "`a`.`b`.`c`")
-    )
   }
 
   test("MultipartIdentifierHelper should throw exception when identifier has more than 2 parts") {
     val testIdent: MultipartIdentifierHelper = Seq("a", "b", "c")
-    checkError(
-      exception = intercept[AnalysisException](testIdent.asTableIdentifier),
-      errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-      parameters = Map("identifier" -> "`a`.`b`.`c`")
-    )
     checkError(
       exception = intercept[AnalysisException](testIdent.asFunctionIdentifier),
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
@@ -1124,14 +1124,14 @@ class V2SessionCatalogNamespaceSuite extends V2SessionCatalogBaseSuite {
     val testIdent: IdentifierHelper = Identifier.of(Array("a", "b"), "c")
     checkError(
       exception = intercept[AnalysisException](testIdent.asTableIdentifier),
-      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
       parameters = Map(
         "quoted" -> "a.b.c",
         "identifier" -> "TableIdentifier")
     )
     checkError(
       exception = intercept[AnalysisException](testIdent.asFunctionIdentifier),
-      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
       parameters = Map(
         "quoted" -> "a.b.c",
         "identifier" -> "FunctionIdentifier")
@@ -1142,14 +1142,14 @@ class V2SessionCatalogNamespaceSuite extends V2SessionCatalogBaseSuite {
     val testIdent: MultipartIdentifierHelper = Seq("a", "b", "c")
     checkError(
       exception = intercept[AnalysisException](testIdent.asTableIdentifier),
-      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
       parameters = Map(
         "quoted" -> "a.b.c",
         "identifier" -> "TableIdentifier")
     )
     checkError(
       exception = intercept[AnalysisException](testIdent.asFunctionIdentifier),
-      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
       parameters = Map(
         "quoted" -> "a.b.c",
         "identifier" -> "FunctionIdentifier")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalogSuite.scala
@@ -1119,4 +1119,40 @@ class V2SessionCatalogNamespaceSuite extends V2SessionCatalogBaseSuite {
     }
     catalog.dropNamespace(testNs, cascade = false)
   }
+
+  test("IdentifierHelper should throw exception when identifier has more than 2 parts") {
+    val testIdent: IdentifierHelper = Identifier.of(Array("a", "b"), "c")
+    checkError(
+      exception = intercept[AnalysisException](testIdent.asTableIdentifier),
+      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      parameters = Map(
+        "quoted" -> "a.b.c",
+        "identifier" -> "TableIdentifier")
+    )
+    checkError(
+      exception = intercept[AnalysisException](testIdent.asFunctionIdentifier),
+      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      parameters = Map(
+        "quoted" -> "a.b.c",
+        "identifier" -> "FunctionIdentifier")
+    )
+  }
+
+  test("MultipartIdentifierHelper should throw exception when identifier has more than 2 parts") {
+    val testIdent: MultipartIdentifierHelper = Seq("a", "b", "c")
+    checkError(
+      exception = intercept[AnalysisException](testIdent.asTableIdentifier),
+      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      parameters = Map(
+        "quoted" -> "a.b.c",
+        "identifier" -> "TableIdentifier")
+    )
+    checkError(
+      exception = intercept[AnalysisException](testIdent.asFunctionIdentifier),
+      errorClass = "INVALID_IDENTIFIER_HAS_MORE_THAN_2_NAME_PARTS",
+      parameters = Map(
+        "quoted" -> "a.b.c",
+        "identifier" -> "FunctionIdentifier")
+    )
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -2684,10 +2684,8 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
           sql("SELECT * FROM h2.test.people where h2.db_name.schema_name.function_name()")
         },
         errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",
-        parameters = Map(
-          "quoted" -> "db_name.schema_name.function_name",
-          "identifier" -> "FunctionIdentifier"
-        )
+        sqlState = "42601",
+        parameters = Map("identifier" -> "`db_name`.`schema_name`.`function_name`")
       )
     } finally {
       JdbcDialects.unregisterDialect(testH2Dialect)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to assign name to `_LEGACY_ERROR_TEMP_1185` -> `IDENTIFIER_TOO_MANY_NAME_PARTS`


### Why are the changes needed?
We should assign proper name to LEGACY_ERROR_TEMP*


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Additional test cases were added
