### PR TITLE
[SPARK-42174][PYTHON][INFRA] Use `scikit-learn` instead of `sklearn`

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -65,7 +65,7 @@ RUN Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='ht
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
 
 RUN pypy3 -m pip install numpy 'pandas<=1.5.3' scipy coverage matplotlib
-RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.3' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib openpyxl 'memory-profiler==0.60.0' 'scikit-learn==1.1.*'
+RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.3' scipy unittest-xml-reporting plotly>=4.8 scikit-learn 'mlflow>=1.0' coverage matplotlib openpyxl 'memory-profiler==0.60.0' 'scikit-learn==1.1.*'
 
 # Add Python deps for Spark Connect.
 RUN python3.9 -m pip install grpcio protobuf googleapis-common-protos grpcio-status

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -8,7 +8,7 @@ pandas
 scipy
 plotly
 mlflow>=1.0
-sklearn
+scikit-learn
 matplotlib<3.3.0
 memory-profiler==0.60.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `scikit-learn` instead of `sklearn` which is deprecated in PyPi.

### Why are the changes needed?

https://pypi.org/project/sklearn/
> This repo implements the brownout strategy for deprecating the sklearn package on PyPI.

> replace sklearn by scikit-learn in your pip requirements files (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.