### PR TITLE
[SPARK-42173][CORE] RpcAddress equality can fail

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/RpcAddress.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcAddress.scala
@@ -23,9 +23,7 @@ import org.apache.spark.util.Utils
 /**
  * Address for an RPC environment, with hostname and port.
  */
-private[spark] case class RpcAddress(_host: String, port: Int) {
-
-  lazy val host: String = Utils.addBracketsIfNeeded(_host)
+private[spark] case class RpcAddress(host: String, port: Int) {
 
   def hostPort: String = host + ":" + port
 
@@ -33,20 +31,29 @@ private[spark] case class RpcAddress(_host: String, port: Int) {
   def toSparkURL: String = "spark://" + hostPort
 
   override def toString: String = hostPort
+
+
 }
 
 
 private[spark] object RpcAddress {
 
+  def apply(host: String, port: Int): RpcAddress = {
+    new RpcAddress(
+      Utils.normalizeIpIfNeeded(host),
+      port
+    )
+  }
+
   /** Return the [[RpcAddress]] represented by `uri`. */
   def fromUrlString(uri: String): RpcAddress = {
     val uriObj = new java.net.URI(uri)
-    RpcAddress(uriObj.getHost, uriObj.getPort)
+    apply(uriObj.getHost, uriObj.getPort)
   }
 
   /** Returns the [[RpcAddress]] encoded in the form of "spark://host:port" */
   def fromSparkURL(sparkUrl: String): RpcAddress = {
     val (host, port) = Utils.extractHostPortFromSparkUrl(sparkUrl)
-    RpcAddress(host, port)
+    apply(host, port)
   }
 }

--- a/core/src/main/scala/org/apache/spark/rpc/RpcAddress.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcAddress.scala
@@ -31,8 +31,6 @@ private[spark] case class RpcAddress(host: String, port: Int) {
   def toSparkURL: String = "spark://" + hostPort
 
   override def toString: String = hostPort
-
-
 }
 
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1110,6 +1110,23 @@ private[spark] object Utils extends Logging {
   }
 
   /**
+   * Normalize IPv6 IPs and no-op on all other hosts.
+   */
+  private[spark] def normalizeIpIfNeeded(host: String): String = {
+    // Is this a v6 address
+    if (host.contains(":")) {
+      // Drop the [] if they are present.
+      val addressRe = """^\[{0,1}(.+?)\]{0,1}$""".r
+      host match {
+        case addressRe(unbracketed) =>
+          addBracketsIfNeeded(InetAddresses.toAddrString(InetAddresses.forString(unbracketed)))
+      }
+    } else {
+      host
+    }
+  }
+
+  /**
    * Checks if the host contains only valid hostname/ip without port
    * NOTE: Incase of IPV6 ip it should be enclosed inside []
    */

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1118,7 +1118,7 @@ private[spark] object Utils extends Logging {
     // This means some invalid addresses are treated as v6 addresses, but since they are
     // not valid hostnames it doesn't matter.
     // See https://www.rfc-editor.org/rfc/rfc1123#page-13 for context around valid hostnames.
-    val addressRe = """^\[{0,1}([0-9:]+?:[0-9]+)\]{0,1}$""".r
+    val addressRe = """^\[{0,1}([0-9:]+?:[0-9]*)\]{0,1}$""".r
     host match {
       case addressRe(unbracketed) =>
         addBracketsIfNeeded(InetAddresses.toAddrString(InetAddresses.forString(unbracketed)))

--- a/core/src/test/scala/org/apache/spark/rpc/RpcAddressSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcAddressSuite.scala
@@ -75,4 +75,9 @@ class RpcAddressSuite extends SparkFunSuite {
     val address = RpcAddress("::0:1", 1234)
     assert(address.toSparkURL == "spark://[::1]:1234")
   }
+
+  test("SPARK-42173: Consistent Sparse Mapping trailing 0s") {
+    val address = RpcAddress("2600::", 1234)
+    assert(address.toSparkURL == "spark://[2600::]:1234")
+  }
 }

--- a/core/src/test/scala/org/apache/spark/rpc/RpcAddressSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcAddressSuite.scala
@@ -70,4 +70,9 @@ class RpcAddressSuite extends SparkFunSuite {
     val address = RpcAddress("::1", 1234)
     assert(address.toSparkURL == "spark://[::1]:1234")
   }
+
+  test("SPARK-42173: Consistent Sparse Mapping") {
+    val address = RpcAddress("::0:1", 1234)
+    assert(address.toSparkURL == "spark://[::1]:1234")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When constructing an RpcAddress use InetUtils to get a consistently formatted IPv6 address if the env is for an IPv6 address.

### Why are the changes needed?

We use RpcAddress equality for various tasks involving executors and a mismatch of equality can cause interesting errors.

### Does this PR introduce _any_ user-facing change?

Log messages might change from sometimes having all the 0s in a v6 address present to not.

### How was this patch tested?

Existing tests + new unit test showing that [::0:1] is formatted to [::1]