### PR TITLE
[SPARK-42177][INFRA][3.4] Change master to branch-3.4 in GitHub Actions 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,7 +30,7 @@ on:
         description: Branch to run the build against
         required: false
         type: string
-        default: master
+        default: branch-3.4
       hadoop:
         description: Hadoop version to run with. HADOOP_PROFILE environment variable should accept it.
         required: false
@@ -58,7 +58,7 @@ jobs:
       required: ${{ steps.set-outputs.outputs.required }}
       image_url: >-
         ${{
-          (inputs.branch == 'master' && steps.infra-image-outputs.outputs.image_url)
+          (inputs.branch == 'branch-3.4' && steps.infra-image-outputs.outputs.image_url)
           || 'dongjoon/apache-spark-github-action-image:20220207'
         }}
     steps:
@@ -274,7 +274,7 @@ jobs:
       (fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
       fromJson(needs.precondition.outputs.required).lint == 'true' ||
       fromJson(needs.precondition.outputs.required).sparkr == 'true') &&
-      inputs.branch == 'master'
+      inputs.branch == 'branch-3.4'
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
### What changes were proposed in this pull request?

Now we cut `branch-3.4`. But the `branch-3.4` points `master` reference (see https://github.com/apache/spark/blob/branch-3.4/.github/workflows/build_and_test.yml) that makes the CI fails https://github.com/apache/spark/actions/runs/4002380215/jobs/6869886029

### Why are the changes needed?

To recover the CI

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI should be monitored after this PR gets merged.