### PR TITLE
[SPARK-42179][BUILD][SQL][3.3] Upgrade ORC to 1.7.8

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -219,9 +219,9 @@ objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.7.7//orc-core-1.7.7.jar
-orc-mapreduce/1.7.7//orc-mapreduce-1.7.7.jar
-orc-shims/1.7.7//orc-shims-1.7.7.jar
+orc-core/1.7.8//orc-core-1.7.8.jar
+orc-mapreduce/1.7.8//orc-mapreduce-1.7.8.jar
+orc-shims/1.7.8//orc-shims-1.7.8.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -208,9 +208,9 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/1.7.7//orc-core-1.7.7.jar
-orc-mapreduce/1.7.7//orc-mapreduce-1.7.7.jar
-orc-shims/1.7.7//orc-shims-1.7.7.jar
+orc-core/1.7.8//orc-core-1.7.8.jar
+orc-mapreduce/1.7.8//orc-mapreduce-1.7.8.jar
+orc-shims/1.7.8//orc-shims-1.7.8.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.2</parquet.version>
-    <orc.version>1.7.7</orc.version>
+    <orc.version>1.7.8</orc.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 1.7.8 for Apache Spark 3.3.2.

### Why are the changes needed?

Apache ORC 1.7.8 is a maintenance release with important bug fixes.
- https://orc.apache.org/news/2023/01/21/ORC-1.7.8/
  - [ORC-1332](https://issues.apache.org/jira/browse/ORC-1332) Avoid NegativeArraySizeException when using searchArgument
  - [ORC-1343](https://issues.apache.org/jira/browse/ORC-1343) Ignore orc.create.index

### Does this PR introduce _any_ user-facing change?

The ORC dependency is going to be changed from 1.7.6 (Apache Spark 3.3.1) to 1.7.8 (Apache Spark 3.3.2)

### How was this patch tested?

Pass the CIs.