### PR TITLE
[SPARK-42182][CONNECT][TESTS] Make `ReusedConnectTestCase` to take Spark configurations

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -454,7 +454,7 @@ class SparkSession:
         return self._client.register_udf(function, return_type)
 
     @staticmethod
-    def _start_connect_server(master: str) -> None:
+    def _start_connect_server(master: str, opts: Dict[str, Any]) -> None:
         """
         Starts the Spark Connect server given the master.
 
@@ -493,6 +493,9 @@ class SparkSession:
         session = PySparkSession._instantiatedSession
         if session is None or session._sc._jsc is None:
             conf = SparkConf()
+            for k, v in opts.items():
+                conf.set(k, v)
+
             # Do not need to worry about the existing configurations because
             # Py4J gateway is not created yet, and `conf` instance is empty here.
             # The configurations belows are manually manipulated later to respect

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -436,7 +436,7 @@ class SparkSession(SparkConversionMixin):
 
                             if url.startswith("local"):
                                 os.environ["SPARK_LOCAL_REMOTE"] = "1"
-                                RemoteSparkSession._start_connect_server(url)
+                                RemoteSparkSession._start_connect_server(url, opts)
                                 url = "sc://localhost"
 
                             os.environ["SPARK_REMOTE"] = url

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -21,7 +21,7 @@ import os
 import functools
 import unittest
 
-from pyspark import Row
+from pyspark import Row, SparkConf
 from pyspark.testing.utils import PySparkErrorTestUtils
 from pyspark.testing.sqlutils import (
     have_pandas,
@@ -169,8 +169,20 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     """
 
     @classmethod
+    def conf(cls):
+        """
+        Override this in subclasses to supply a more specific conf
+        """
+        return SparkConf(loadDefaults=False)
+
+    @classmethod
     def setUpClass(cls):
-        cls.spark = PySparkSession.builder.appName(cls.__name__).remote("local[4]").getOrCreate()
+        cls.spark = (
+            PySparkSession.builder.config(conf=cls.conf())
+            .appName(cls.__name__)
+            .remote("local[4]")
+            .getOrCreate()
+        )
         cls.tempdir = tempfile.NamedTemporaryFile(delete=False)
         os.unlink(cls.tempdir.name)
         cls.testData = [Row(key=i, value=str(i)) for i in range(100)]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to `pyspark.testing.connectutils.ReusedConnectTestCase` to have the ability to set configurations propagated to the server like `pyspark.testing.sqlutils.ReusedSQLTestCase`.

### Why are the changes needed?

`pyspark.testing.connectutils.ReusedConnectTestCase` is designed to cover all test cases for `pyspark.testing.sqlutils.ReusedSQLTestCase`. It should be able to set the configurations identically.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested.