### PR TITLE
[SPARK-42126][PYTHON][CONNECT] Accept return type in DDL strings for Python Scalar UDFs in Spark Connect

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -48,7 +48,6 @@ from pyspark.sql.types import (
     StructType,
     StructField,
 )
-from pyspark.sql.utils import is_remote
 
 
 def _configure_logging() -> logging.Logger:
@@ -370,21 +369,6 @@ class SparkConnectClient(object):
     ) -> str:
         """Create a temporary UDF in the session catalog on the other side. We generate a
         temporary name for it."""
-        if isinstance(return_type, str):
-            # Currently we don't have a way to have a current Spark session in Spark Connect, and
-            # pyspark.sql.SparkSession has a centralized logic to control the session creation.
-            # So uses pyspark.sql.SparkSession for now. Should replace this to using the current
-            # Spark session for Spark Connect in the future.
-            from pyspark.sql import SparkSession as PySparkSession
-
-            return_type_schema = (  # a workaround to parse the DataType from DDL strings
-                PySparkSession.builder.getOrCreate()
-                .createDataFrame(data=[], schema=return_type)
-                .schema
-            )
-            assert len(return_type_schema.fields) == 1, "returnType should be singular"
-            return_type = return_type_schema.fields[0].dataType
-
         name = f"fun_{uuid.uuid4().hex}"
         fun = pb2.CreateScalarFunction()
         fun.parts.append(name)

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -48,6 +48,7 @@ from pyspark.sql.types import (
     StructType,
     StructField,
 )
+from pyspark.sql.utils import is_remote
 
 
 def _configure_logging() -> logging.Logger:
@@ -369,6 +370,22 @@ class SparkConnectClient(object):
     ) -> str:
         """Create a temporary UDF in the session catalog on the other side. We generate a
         temporary name for it."""
+        if isinstance(return_type, str):
+            from pyspark.sql import SparkSession as PySparkSession
+
+            # Currently we don't have a way to have a current Spark session in Spark Connect, and
+            # pyspark.sql.SparkSession has a centralized logic to control the session creation.
+            # So uses pyspark.sql.SparkSession for now. Should replace this to using the current
+            # Spark session for Spark Connect in the future.
+            assert is_remote()
+
+            return_type = (  # a workaround to parse DataType from DDL strings
+                PySparkSession.builder.getOrCreate()
+                .createDataframe(data=[], schema=return_type)
+                .schema.fields[0]
+                .dataType
+            )
+
         name = f"fun_{uuid.uuid4().hex}"
         fun = pb2.CreateScalarFunction()
         fun.parts.append(name)

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -371,20 +371,19 @@ class SparkConnectClient(object):
         """Create a temporary UDF in the session catalog on the other side. We generate a
         temporary name for it."""
         if isinstance(return_type, str):
-            from pyspark.sql import SparkSession as PySparkSession
-
             # Currently we don't have a way to have a current Spark session in Spark Connect, and
             # pyspark.sql.SparkSession has a centralized logic to control the session creation.
             # So uses pyspark.sql.SparkSession for now. Should replace this to using the current
             # Spark session for Spark Connect in the future.
-            assert is_remote()
+            from pyspark.sql import SparkSession as PySparkSession
 
-            return_type = (  # a workaround to parse DataType from DDL strings
+            return_type_schema = (  # a workaround to parse the DataType from DDL strings
                 PySparkSession.builder.getOrCreate()
-                .createDataframe(data=[], schema=return_type)
-                .schema.fields[0]
-                .dataType
+                .createDataFrame(data=[], schema=return_type)
+                .schema
             )
+            assert len(return_type_schema.fields) == 1, "returnType should be singular"
+            return_type = return_type_schema.fields[0].dataType
 
         name = f"fun_{uuid.uuid4().hex}"
         fun = pb2.CreateScalarFunction()

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -28,7 +28,6 @@ from pyspark.sql.connect.expressions import (
 )
 from pyspark.sql.connect.column import Column
 from pyspark.sql.types import DataType, StringType
-from pyspark.sql.utils import is_remote
 
 
 if TYPE_CHECKING:

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -28,6 +28,7 @@ from pyspark.sql.connect.expressions import (
 )
 from pyspark.sql.connect.column import Column
 from pyspark.sql.types import DataType, StringType
+from pyspark.sql.utils import is_remote
 
 
 if TYPE_CHECKING:
@@ -98,6 +99,7 @@ class UserDefinedFunction:
             # Spark session for Spark Connect in the future.
             from pyspark.sql import SparkSession as PySparkSession
 
+            assert is_remote()
             return_type_schema = (  # a workaround to parse the DataType from DDL strings
                 PySparkSession.builder.getOrCreate()
                 .createDataFrame(data=[], schema=returnType)

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -2299,6 +2299,14 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
             cdf.withColumn("A", CF.udf(lambda x: x + 1)(cdf.a)).toPandas(),
             sdf.withColumn("A", SF.udf(lambda x: x + 1)(sdf.a)).toPandas(),
         )
+        self.assert_eq(  # returnType as DDL strings
+            cdf.withColumn("C", CF.udf(lambda x: len(x), "int")(cdf.c)).toPandas(),
+            sdf.withColumn("C", SF.udf(lambda x: len(x), "int")(sdf.c)).toPandas(),
+        )
+        self.assert_eq(  # returnType as DataType
+            cdf.withColumn("C", CF.udf(lambda x: len(x), IntegerType())(cdf.c)).toPandas(),
+            sdf.withColumn("C", SF.udf(lambda x: len(x), IntegerType())(sdf.c)).toPandas(),
+        )
 
         # as a decorator
         @CF.udf(StringType())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Accept return type in DDL strings for Python Scalar UDFs in Spark Connect.

The approach proposed in this PR is a workaround to parse DataType from DDL strings. We should think of a more elegant alternative to replace that later.

### Why are the changes needed?
To reach parity with vanilla PySpark.

### Does this PR introduce _any_ user-facing change?
Yes. Return type in DDL strings are accepted now.


### How was this patch tested?
Unit tests.

SPARK-41661