### PR TITLE
[SPARK-42185][INFRA] Add `branch-3.4` to `publish_snapshot` GitHub Action job

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         branch:
           - master
+          - branch-3.4
           - branch-3.3
           - branch-3.2
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `branch-3.4` to `publish_snapshot` GitHub Action job.

### Why are the changes needed?

Since GitHub Action Cron job is executed only at `master` branch, we need to register newly added branch at `master` branch.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A. Manual review.