### PR TITLE
[SPARK-42188][BUILD][3.3] Force SBT protobuf version to match Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
     <log4j.version>2.17.2</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.2</hadoop.version>
+    <!-- SPARK-42188: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.6.2</zookeeper.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -79,6 +79,9 @@ object BuildCommons {
   val testTempDir = s"$sparkHome/target/tmp"
 
   val javaVersion = settingKey[String]("source and target JVM version for javac and scalac")
+
+  // SPARK-42188: needs to be consistent with `protobuf.version` in `pom.xml`.
+  val protoVersion = "2.5.0"
 }
 
 object SparkBuild extends PomBuild {
@@ -703,6 +706,8 @@ object KubernetesIntegrationTests {
  * Overrides to work around sbt's dependency resolution being different from Maven's.
  */
 object DependencyOverrides {
+  import BuildCommons.protoVersion
+
   lazy val guavaVersion = sys.props.get("guava.version").getOrElse("14.0.1")
   lazy val settings = Seq(
     dependencyOverrides += "com.google.guava" % "guava" % guavaVersion,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -711,6 +711,7 @@ object DependencyOverrides {
   lazy val guavaVersion = sys.props.get("guava.version").getOrElse("14.0.1")
   lazy val settings = Seq(
     dependencyOverrides += "com.google.guava" % "guava" % guavaVersion,
+    dependencyOverrides += "com.google.protobuf" % "protobuf-java" % protoVersion,
     dependencyOverrides += "xerces" % "xercesImpl" % "2.12.0",
     dependencyOverrides += "jline" % "jline" % "2.14.6",
     dependencyOverrides += "org.apache.avro" % "avro" % "1.11.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update `SparkBuild.scala` to force SBT use of `protobuf-java` to match the Maven version.  The Maven dependencyManagement section forces `protobuf-java` to use `2.5.0`, but SBT is using `3.14.0`.

### Why are the changes needed?
Define `protoVersion` in `SparkBuild.scala` and use it in `DependencyOverrides` to force the SBT version of `protobuf-java` to match the setting defined in the Maven top-level `pom.xml`.  Add comments to both `pom.xml` and `SparkBuild.scala` to ensure that the values are kept in sync. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Before the update, SBT reported using `3.14.0`:
```
% build/sbt dependencyTree | grep proto | sed 's/^.*-com/com/' | sort | uniq -c
   8 com.google.protobuf:protobuf-java:2.5.0 (evicted by: 3.14.0)
  70 com.google.protobuf:protobuf-java:3.14.0
```

After the patch is applied, SBT reports using `2.5.0`:
```
% build/sbt dependencyTree | grep proto | sed 's/^.*-com/com/' | sort | uniq -c
  70 com.google.protobuf:protobuf-java:2.5.0
```