### PR TITLE
[SPARK-42196][SS] Fix typo in StreamingQuery.runId

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
@@ -52,7 +52,7 @@ trait StreamingQuery {
 
   /**
    * Returns the unique id of this run of the query. That is, every start/restart of a query will
-   * generated a unique runId. Therefore, every time a query is restarted from
+   * generate a unique runId. Therefore, every time a query is restarted from
    * checkpoint, it will have the same [[id]] but different [[runId]]s.
    */
   def runId: UUID


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixed the typo in code in the API documentation

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local test