### PR TITLE
[SPARK-42199][SQL] Fix issues around Dataset.groupByKey

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AliasResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AliasResolution.scala
@@ -55,7 +55,11 @@ object AliasResolution {
       case e if !e.resolved => u
       case g: Generator => MultiAlias(g, Nil)
       case c @ Cast(ne: NamedExpression, _, _, _) => Alias(c, ne.name)()
-      case se @ ScopedExpression(ne: NamedExpression, _) => Alias(se, ne.name)()
+      case se @ ScopedExpression(e: Expression, _) =>
+        resolve(UnresolvedAlias(e, optGenAliasFunc)) match {
+          case ne: NamedExpression => Alias(se, ne.name)()
+          case _ => se
+        }
       case e: ExtractValue if extractOnly(e) => Alias(e, toPrettySQL(e))()
       case e if optGenAliasFunc.isDefined =>
         Alias(child, optGenAliasFunc.get.apply(e))()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AliasResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AliasResolution.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.catalyst.expressions.{
   Generator,
   GeneratorOuter,
   Literal,
-  NamedExpression
+  NamedExpression,
+  ScopedExpression
 }
 import org.apache.spark.sql.catalyst.trees.TreePattern.UNRESOLVED_ALIAS
 import org.apache.spark.sql.catalyst.util.{toPrettySQL, AUTO_GENERATED_ALIAS}
@@ -54,6 +55,7 @@ object AliasResolution {
       case e if !e.resolved => u
       case g: Generator => MultiAlias(g, Nil)
       case c @ Cast(ne: NamedExpression, _, _, _) => Alias(c, ne.name)()
+      case se @ ScopedExpression(ne: NamedExpression, _) => Alias(se, ne.name)()
       case e: ExtractValue if extractOnly(e) => Alias(e, toPrettySQL(e))()
       case e if optGenAliasFunc.isDefined =>
         Alias(child, optGenAliasFunc.get.apply(e))()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -197,6 +197,9 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
             u.copy(child = newChild)
           }
 
+        // Do not map (resolve) all children, but only the scope
+        case s : ScopedExpression => s.mapScope(innerResolve(_, isTopLevel = false))
+
         case _ => e.mapChildren(innerResolve(_, isTopLevel = false))
       }
       resolved.copyTagsFrom(e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/scopes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/scopes.scala
@@ -35,6 +35,15 @@ case class ScopedExpression(expr: Expression, scope: Seq[Attribute])
   override def sql: String = s"$prettyName(${expr.sql}, $scope)"
   override lazy val resolved: Boolean = expr.resolved
 
+  def mapScope(f: Expression => Expression): Expression = {
+    // similar to mapChildren, but only for the scope children
+    if (scope.nonEmpty) {
+      this.copy(scope = scope.map(f).map(_.asInstanceOf[Attribute]))
+    } else {
+      this
+    }
+  }
+
   override protected def withNewChildrenInternal(children: IndexedSeq[Expression]): Expression = {
     val scope = children.tail
     assert(scope.forall(_.isInstanceOf[Attribute]), "Scope children have to be attributes")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/scopes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/scopes.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
+import org.apache.spark.sql.catalyst.plans.logical.{CoGroup, LogicalPlan, MapGroups}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.types.DataType
+
+
+/**
+ * An expression that has to be resolved against a scope of resolved attributes.
+ */
+case class ScopedExpression(expr: Expression, scope: Seq[Attribute])
+  extends Expression with Unevaluable {
+  override def children: Seq[Expression] = expr +: scope
+  override def dataType: DataType = expr.dataType
+  override def nullable: Boolean = expr.nullable
+  override def prettyName: String = "scoped"
+  override def sql: String = s"$prettyName(${expr.sql}, $scope)"
+  override lazy val resolved: Boolean = expr.resolved
+
+  override protected def withNewChildrenInternal(children: IndexedSeq[Expression]): Expression = {
+    val scope = children.tail
+    assert(scope.forall(_.isInstanceOf[Attribute]), "Scope children have to be attributes")
+    copy(expr = children.head, scope = scope.map(_.asInstanceOf[Attribute]))
+  }
+}
+
+/**
+ * Restricts the scope of resolving some expressions.
+ */
+object ScopeExpressions extends Rule[LogicalPlan] {
+  private def scopeOrder(scope: Seq[Attribute])(sortOrder: SortOrder): SortOrder = {
+    sortOrder match {
+      case so if so.child.isInstanceOf[ScopedExpression] => so
+      case so => so.copy(
+        child = ScopedExpression(so.child, scope),
+        sameOrderExpressions = so.sameOrderExpressions.map(soe => ScopedExpression(soe, scope))
+      )
+    }
+  }
+
+  private def isNotScoped(sortOrder: SortOrder): Boolean =
+    !sortOrder.child.isInstanceOf[ScopedExpression]
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+    // SPARK-42199: sort order of MapGroups must be scoped to their dataAttributes
+    case mg: MapGroups if mg.dataOrder.exists(isNotScoped) =>
+      mg.copy(dataOrder = mg.dataOrder.map(scopeOrder(mg.dataAttributes)))
+
+    // SPARK-42199: sort order of CoGroups must be scoped to their respective dataAttributes
+    case cg: CoGroup if Seq(cg.leftOrder, cg.rightOrder).exists(_.exists(isNotScoped)) =>
+      val scopedLeftOrder = cg.leftOrder.map(scopeOrder(cg.leftAttr))
+      val scopedRightOrder = cg.rightOrder.map(scopeOrder(cg.rightAttr))
+      cg.copy(leftOrder = scopedLeftOrder, rightOrder = scopedRightOrder)
+  }
+}
+
+/**
+ * Resolves expressions against their scope of attributes.
+ */
+class ResolveScopedExpression(val resolver: Resolver) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveExpressions {
+    case se: ScopedExpression if se.resolved => se.expr
+    case se @ ScopedExpression(expr, attributes) =>
+      val resolved = expr.transformDown {
+        case u@UnresolvedAttribute(nameParts) =>
+          attributes.resolve(nameParts, resolver).getOrElse(u)
+      }
+      if (resolved.fastEquals(expr)) {
+        se
+      } else {
+        resolved
+      }
+  }
+}
+

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2255,6 +2255,9 @@ class SparkConnectPlanner(
     val keyColumn = TypedAggUtils.aggKeyColumn(ds.kEncoder, ds.groupingAttributes)
     val namedColumns = rel.getAggregateExpressionsList.asScala.toSeq
       .map(expr => transformExpressionWithTypedReduceExpression(expr, ds.analyzedData))
+      // SPARK-42199: resolve these aggregate expressions only against dataAttributes
+      // this is to hide key column from expression resolution
+      .map(ScopedExpression(_, ds.dataAttributes))
       .map(toNamedExpression)
     logical.Aggregate(ds.groupingAttributes, keyColumn +: namedColumns, ds.analyzed)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduces `ScopedExpression`, which allows to resolve an expression against a set of attributes. This is used by `Dataset.groupByKey.agg`, `Dataset.groupByKey.flatMapSortedGroups`, and `Dataset.groupByKey.cogroupSorted` to fix surprising error messages and to make `Dataset.groupByKey.mapValues.agg` work at all.

### Why are the changes needed?
Calling `ds.groupByKey(func: V => K)` creates columns to store the key value. These columns may conflict with columns that already exist in `ds`. Function `Dataset.groupByKey.agg` accounts for this with a very specific rule, which has some surprising weaknesses:

```Scala
spark.range(1)
  // groupByKey adds column 'value'
  .groupByKey(id => id)
  // which cannot be referenced, though it is suggested
  .agg(count("value"))
```
```
org.apache.spark.sql.AnalysisException: Column 'value' does not exist.
Did you mean one of the following? [value, id];
```

An existing 'value' column can be referenced:

```Scala
// dataset with column 'value'
spark.range(1).select($"id".as("value")).as[Long]
  // groupByKey adds another column 'value'
  .groupByKey(id => id)
  // agg accounts for the extra column and excludes it when resolving 'value'
  .agg(count("value"))
  .show()
```
```
+---+------------+
|key|count(value)|
+---+------------+
|  0|           1|
+---+------------+
```

While column suggestion shows both 'value' columns:

```Scala
spark.range(1).select($"id".as("value")).as[Long]
  .groupByKey(id => id)
  .agg(count("unknown"))
```
```
org.apache.spark.sql.AnalysisException: Column 'unknown' does not exist.
Did you mean one of the following? [value, value]
```

However, `mapValues` introduces another 'value' column, which should be referencable, but it breaks the exclusion introduced by `agg`:

```Scala
spark.range(1)
  // groupByKey adds column 'value'
  .groupByKey(id => id)
  // adds another 'value' column
  .mapValues(value => value)
  // which cannot be referenced in agg
  .agg(count("value"))
```
```
org.apache.spark.sql.AnalysisException: Reference 'value' is ambiguous, could be: value, value.
```

### Does this PR introduce _any_ user-facing change?
Fixes suggestions in above error messages from
```
... Did you mean one of the following? [value, value]
... Did you mean one of the following? [value, id];
```
to
```
... Did you mean one of the following? [value]
... Did you mean one of the following? [id];
```

Allows for `Dataset.groupByKey.mapValues.agg`.

### How was this patch tested?
Tests in `DatasetSuite`.