### PR TITLE
[SPARK-41585][YARN][DOC] Improve doc of the excludeNodes configuration by clarifying the dependency with dynamic allocation

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -626,6 +626,7 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>(none)</td>
   <td>
   Comma-separated list of YARN node names which are excluded from resource allocation.
+  This only applies to executors spawned via dynamic allocation.
   </td>
   <td>3.0.0</td>
 </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is an improvement to the documentation of the excludeNodes configuration for Spark on YARN by clarifying the dependency with dynamic allocation.
The Spark exclude node functionality for Spark on YARN, introduced in [SPARK-26688], allows users to specify a list of node names that are excluded from resource allocation. This is done using the configuration parameter: `spark.yarn.exclude.nodes`  
The feature currently works only for executors allocated via dynamic allocation. To use the feature on Spark 3.3.1, for example, one may set the configurations `spark.dynamicAllocation.enabled=true`, `spark.dynamicAllocation.minExecutors=0` and `spark.executor.instances=0`, thus making Spark spawning executors only via dynamic allocation.

### Why are the changes needed?
Current documentation does not address the dependency of excludeNodes with dynamic allocation.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
NA