### PR TITLE
[SPARK-42201][BUILD] `build/sbt` should allow `SBT_OPTS` to override JVM memory setting

### DIFF
--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -183,8 +183,8 @@ run() {
 
   # run sbt
   execRunner "$java_cmd" \
-    ${SBT_OPTS:-$default_sbt_opts} \
     $(get_mem_opts $sbt_mem) \
+    ${SBT_OPTS:-$default_sbt_opts} \
     ${java_opts} \
     ${java_args[@]} \
     -jar "$sbt_jar" \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix a bug which `build/sbt` doesn't allow JVM memory setting via `SBT_OPTS`.

### Why are the changes needed?

`SBT_OPTS` is supposed to be used in this way in the community.
https://github.com/apache/spark/blob/e30bb538e480940b1963eb14c3267662912d8584/appveyor.yml#L54

However, `SBT_OPTS` memory setting like the following is ignored because ` -Xms4096m -Xmx4096m -XX:ReservedCodeCacheSize=512m` is injected by default after `SBT_OPTS`. We should switch the order.
```
$ SBT_OPTS="-Xmx6g" build/sbt package
```
https://github.com/apache/spark/blob/e30bb538e480940b1963eb14c3267662912d8584/build/sbt-launch-lib.bash#L124

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Manually run the following.
```
$ SBT_OPTS="-Xmx6g" build/sbt package
```

While running the above command, check the JVM options.
```
$ ps aux | grep java
dongjoon         36683 434.3  3.1 418465456 1031888 s001  R+    1:11PM   0:19.86 /Users/dongjoon/.jenv/versions/temurin17/bin/java -Xms4096m -Xmx4096m -XX:ReservedCodeCacheSize=512m -Xmx6g -jar build/sbt-launch-1.8.2.jar package
```