### PR TITLE
[SPARK-42202][Connect][Test] Improve the E2E test server stop logic

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -67,31 +67,32 @@ object SparkConnectServerUtils {
 
   @volatile private var stopped = false
 
+  private var consoleOut: BufferedOutputStream = _
+  private val serverStopCommand = "q"
+
   private lazy val sparkConnect: Process = {
     debug("Starting the Spark Connect Server...")
     val jar = findSparkConnectJar
     val builder = Process(
-      new File(sparkHome, "bin/spark-shell").getCanonicalPath,
       Seq(
-        "--jars",
-        jar,
+        "bin/spark-submit",
         "--driver-class-path",
         jar,
         "--conf",
-        "spark.plugins=org.apache.spark.sql.connect.SparkConnectPlugin",
-        "--conf",
-        s"spark.connect.grpc.binding.port=$port"))
+        s"spark.connect.grpc.binding.port=$port",
+        "--class",
+        "org.apache.spark.sql.connect.SimpleSparkConnectService",
+        jar),
+      new File(sparkHome))
 
     val io = new ProcessIO(
-      // Hold the input channel to the spark console to keep the console open
-      in => new BufferedOutputStream(in),
-      // Only redirect output if debug to avoid channel interruption error on process termination.
-      out => if (isDebug) Source.fromInputStream(out).getLines.foreach(debug),
-      err => if (isDebug) Source.fromInputStream(err).getLines.foreach(debug))
+      in => consoleOut = new BufferedOutputStream(in),
+      out => Source.fromInputStream(out).getLines.foreach(debug),
+      err => Source.fromInputStream(err).getLines.foreach(debug))
     val process = builder.run(io)
 
     // Adding JVM shutdown hook
-    sys.addShutdownHook(kill())
+    sys.addShutdownHook(stop())
     process
   }
 
@@ -100,10 +101,19 @@ object SparkConnectServerUtils {
     sparkConnect
   }
 
-  def kill(): Int = {
+  def stop(): Int = {
     stopped = true
     debug("Stopping the Spark Connect Server...")
-    sparkConnect.destroy()
+    try {
+      consoleOut.write(serverStopCommand.getBytes)
+      consoleOut.flush()
+      consoleOut.close()
+    } catch {
+      case e: Throwable =>
+        debug(e)
+        sparkConnect.destroy()
+    }
+
     val code = sparkConnect.exitValue()
     debug(s"Spark Connect Server is stopped with exit code: $code")
     code

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/SimpleSparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/SimpleSparkConnectService.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect
+
+import java.util.concurrent.TimeUnit
+
+import scala.io.StdIn
+import scala.sys.exit
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connect.service.SparkConnectService
+
+/**
+ * A simple main class method to start the spark connect server as a service for client tests
+ * using spark-submit:
+ * {{{
+ *     bin/spark-submit --class org.apache.spark.sql.connect.SimpleSparkConnectService
+ * }}}
+ * The service can be stopped by receiving a stop command or until the service get killed.
+ */
+object SimpleSparkConnectService {
+  val stopCommand = "q"
+
+  def main(args: Array[String]): Unit = {
+    while (true) {
+      val conf = new SparkConf()
+      val sparkSession = SparkSession.builder().config(conf).getOrCreate()
+      val sparkContext = sparkSession.sparkContext // init spark context
+      SparkConnectService.start()
+      // scalastyle:off println
+      println("Ready for client connections.")
+      // scalastyle:on println
+      val code = StdIn.readLine()
+      if (code == stopCommand) {
+        // scalastyle:off println
+        println("No more client connections.")
+        // scalastyle:on println
+        // Wait for 1 min for the server to stop
+        SparkConnectService.stop(Some(1), Some(TimeUnit.MINUTES))
+        sparkSession.close()
+        exit(0)
+      }
+    }
+  }
+}

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/SimpleSparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/SimpleSparkConnectService.scala
@@ -34,8 +34,8 @@ import org.apache.spark.sql.connect.service.SparkConnectService
  * }}}
  * The service can be stopped by receiving a stop command or until the service get killed.
  */
-object SimpleSparkConnectService {
-  val stopCommand = "q"
+private[sql] object SimpleSparkConnectService {
+  private val stopCommand = "q"
 
   def main(args: Array[String]): Unit = {
     while (true) {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -285,9 +285,11 @@ object SparkConnectService {
 
   def stop(timeout: Option[Long] = None, unit: Option[TimeUnit] = None): Unit = {
     if (server != null) {
-      server.shutdownNow()
       if (timeout.isDefined && unit.isDefined) {
+        server.shutdown()
         server.awaitTermination(timeout.get, unit.get)
+      } else {
+        server.shutdownNow()
       }
     }
   }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -283,9 +283,12 @@ object SparkConnectService {
     startGRPCService()
   }
 
-  def stop(): Unit = {
+  def stop(timeout: Option[Long] = None, unit: Option[TimeUnit] = None): Unit = {
     if (server != null) {
       server.shutdownNow()
+      if (timeout.isDefined && unit.isDefined) {
+        server.awaitTermination(timeout.get, unit.get)
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Stop the E2E test server without leaving bad error messages due to server being killed.

### Why are the changes needed?
Improvement to better testing experience.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests