### PR TITLE
[SPARK-41757][CONNECT][PYTHON][FOLLOW-UP] Enable connect.functions.col doctest

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2453,9 +2453,6 @@ def _test() -> None:
         del pyspark.sql.connect.functions.timestamp_seconds.__doc__
         del pyspark.sql.connect.functions.unix_timestamp.__doc__
 
-        # TODO(SPARK-41757): Fix String representation for Column class
-        del pyspark.sql.connect.functions.col.__doc__
-
         # TODO(SPARK-41812): Proper column names after join
         del pyspark.sql.connect.functions.count_distinct.__doc__
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
To reenable the doc tests for `col` Function, this patch makes the string representation of the Column closer to the regular PySpark Column.

This PR is a follow up to https://github.com/apache/spark/pull/39616 with enabling col doctests

### Why are the changes needed?
Improve Coverage

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Reenabled doc tests.