### PR TITLE
[SPARK-42209][CORE][CONNECT] Introduce `ExtendedConnectTest` to make user can disable tests related to `RemoteSparkSession` selectively

### DIFF
--- a/common/tags/src/test/java/org/apache/spark/tags/ExtendedConnectTest.java
+++ b/common/tags/src/test/java/org/apache/spark/tags/ExtendedConnectTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.tags;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExtendedConnectTest { }

--- a/connector/connect/client/jvm/pom.xml
+++ b/connector/connect/client/jvm/pom.xml
@@ -75,6 +75,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -18,7 +18,9 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.connect.client.util.RemoteSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.tags.ExtendedConnectTest
 
+@ExtendedConnectTest
 class ClientE2ETestSuite extends RemoteSparkSession {
 
   // Spark Result


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add `ExtendedConnectTest` to disable tests related to `RemoteSparkSession` selectively.


### Why are the changes needed?
`RemoteSparkSession` related tests need to be prepared shaded `connect-server.jar`, so this causes developers must to run `sbt package` or `maven clean install -DskipTests` to prepare shaded `connect-server.jar` before testing `connect-client-jvm`, it seems a little cumbersome, so this pr add a new test tag `ExtendedConnectTest` to make developers have the ability to disable relevant test cases through `-Dtest.exclude.tags=org.apache.spark.tags.ExtendedConnectTest`.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- Pass GitHub Actions
- Manual test 

**SBT** 
```
build/sbt clean "connect-client-jvm/test" -Dtest.exclude.tags=org.apache.spark.tags.ExtendedConnectTest
```
```
[info] Run completed in 2 seconds, 416 milliseconds.
[info] Total number of tests run: 24
[info] Suites: completed 4, aborted 0
[info] Tests: succeeded 24, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```
All tests passed and `ClientE2ETestSuite` skipped 


**Maven**
```
build/mvn clean install -pl connector/connect/client/jvm -am -DskipTests
build/mvn clean test -pl connector/connect/client/jvm -Dtest.exclude.tags=org.apache.spark.tags.ExtendedConnectTest
```
```
Run completed in 964 milliseconds.
Total number of tests run: 24
Suites: completed 5, aborted 0
Tests: succeeded 24, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

All tests passed and `ClientE2ETestSuite` skipped 

