### PR TITLE
[WIP][SPARK-42206][CORE] Omit "Task Executor Metrics" field in eventlogs if values are all zero

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetrics.scala
@@ -85,6 +85,18 @@ class ExecutorMetrics private[spark] extends Serializable {
     }
     updated
   }
+
+  private[spark] def allMetricsAreZero(): Boolean = {
+    var foundNonZero = false
+    var i = 0
+    while (i < metrics.length && !foundNonZero) {
+      if (metrics(i) != 0) {
+        foundNonZero = true
+      }
+      i += 1
+    }
+    !foundNonZero
+  }
 }
 
 private[spark] object ExecutorMetrics {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -212,6 +212,19 @@ package object config {
       .toSequence
       .createWithDefault(GarbageCollectionMetrics.OLD_GENERATION_BUILTIN_GARBAGE_COLLECTORS)
 
+  private[spark] val EVENT_LOG_INCLUDE_ALL_ZERO_TASK_EXECUTOR_METRICS =
+    ConfigBuilder("spark.eventLog.includeAllZeroTaskExecutorMetrics")
+      .doc("Controls whether task end events will include the 'Task Executor Metrics' field " +
+        "even if all metric values are zero. In Spark 3.4.x and earlier these metrics would be " +
+        "logged even if all values were zero, but Spark 3.5.0 omits the metrics from the event " +
+        "to save space in logs. this flag does not impact Spark History Server behavior: it " +
+        "exists only as a backwards-compatibility escape hatch for user applications that " +
+        "might be directly parsing event logs and that relied on the old behavior. " +
+        "See SPARK-42206 for more details.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val EVENT_LOG_OVERWRITE =
     ConfigBuilder("spark.eventLog.overwrite")
       .version("1.0.0")

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -790,6 +790,15 @@ class JsonProtocolSuite extends SparkFunSuite {
         |}""".stripMargin
     assert(JsonProtocol.sparkEventFromJson(unknownFieldsJson) === expected)
   }
+
+  test("SPARK-42206: skip logging of all-zero Task Executor Metrics") {
+    val allZeroTaskExecutorMetrics = new ExecutorMetrics(Map.empty[String, Long])
+    val taskEnd = taskEndFromJson(taskEndJsonString)
+      .copy(taskExecutorMetrics = allZeroTaskExecutorMetrics)
+    val json = sparkEventToJsonString(taskEnd)
+    assertEquals(taskEnd, taskEndFromJson(json))
+    assert(!json.has("Task Executor Metrics"))
+  }
 }
 
 

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -793,7 +793,7 @@ class JsonProtocolSuite extends SparkFunSuite {
   }
 
   test("SPARK-42206: skip logging of all-zero Task Executor Metrics") {
-    val allZeroTaskExecutorMetrics = new ExecutorMetrics(Map.empty[String, Long])
+    val allZeroTaskExecutorMetrics = new ExecutorMetrics(Array.emptyLongArray)
     val taskEnd = taskEndFromJson(taskEndJsonString)
       .copy(taskExecutorMetrics = allZeroTaskExecutorMetrics)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change updates `JsonProtocol` to add logic to exclude the "Task Executor Metrics" field from SparkListenerTaskEnd events in cases where all metric values are zero.


### Why are the changes needed?

This is done to save space from event logs when Spark runs under its default out-of-the-box configuration and tasks are shorter than the executor hearbeat interval.

[SPARK-26329](https://issues.apache.org/jira/browse/SPARK-26329) added "Task Executor Metrics" to JsonProtocol SparkListenerTaskEnd JSON. With the default `spark.executor.metrics.pollingInterval = 0` configuration these metric values are only updated when heartbeats occur. If a task launches and finishes between executor heartbeats then all of the "Task Executor Metrics" values will be zero. For jobs with large numbers of short tasks, this contributes to significant event log bloat.

JsonProtocol already knows how to handle the absence of the "Task Executor Metrics" field, so I think it's safe for us to omit this field when all values are zero.

There is a possibility that third-party code which directly consumes Spark event logs might be relying on the presence of this field. As an "escape-hatch" to avoid breaking such workloads, I have introduced a `spark.eventLog.includeAllZeroTaskExecutorMetrics` (default `false`) which can be set to `true` to restore the old behavior.

### Does this PR introduce _any_ user-facing change?
No user-facing changes in history server.

This could be considered a user-facing change from the perspective of third-party code which does its own processing of Spark logs, hence the config. I think it's reasonable to set a sensible default which shrinks event logs for most users instead of keeping a conservative default to support a hypothetical third-party use case of our event logs.

### How was this patch tested?

Added new test cases in JsonProtocolSuite.