### PR TITLE
[SPARK-42213][BUILD][CONNECT] Add `repl` test dependency to `connect-client-jvm` module

### DIFF
--- a/connector/connect/client/jvm/pom.xml
+++ b/connector/connect/client/jvm/pom.xml
@@ -65,6 +65,23 @@
       <version>${guava.version}</version>
       <scope>compile</scope>
     </dependency>
+    <!--
+      SPARK-42213: Add `repl` as test dependency to solve the issue that
+      `ClientE2ETestSuite` cannot find `repl.Main` when maven test.
+    -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <!-- Exclude sql module to resolve compilation conflicts -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_${scala.binary.version}</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to add repl as the test dependency of connect-client-jvm to solve repl.Main not found when maven test。


### Why are the changes needed?
Fix maven test failed of `connect-client-jvm` module.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- Manual test:

```
build/mvn clean
build/mvn clean install -pl connector/connect/server -am -DskipTests
build/mvn clean install -pl connector/connect/client/jvm -am -DskipTests
build/mvn test -pl connector/connect/client/jvm
```

**Before** 
```
ClientE2ETestSuite:
Using jar: /${basedir}/spark-source/connector/connect/server/target/spark-connect_2.12-3.5.0-SNAPSHOT.jar
Error: Failed to load class org.apache.spark.repl.Main.
org.apache.spark.sql.ClientE2ETestSuite *** ABORTED ***
  java.lang.RuntimeException: Failed to start the test server on port 15644.
  at org.apache.spark.sql.connect.client.util.RemoteSparkSession.beforeAll(RemoteSparkSession.scala:158)
  at org.apache.spark.sql.connect.client.util.RemoteSparkSession.beforeAll$(RemoteSparkSession.scala:149)
  at org.apache.spark.sql.ClientE2ETestSuite.beforeAll(ClientE2ETestSuite.scala:22)
  at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
  at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
  at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
  at org.apache.spark.sql.ClientE2ETestSuite.run(ClientE2ETestSuite.scala:22)
  at org.scalatest.Suite.callExecuteOnSuite$1(Suite.scala:1178)
  at org.scalatest.Suite.$anonfun$runNestedSuites$1(Suite.scala:1225)
  at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
```

**After**
```
Run completed in 23 seconds, 662 milliseconds.
Total number of tests run: 27
Suites: completed 5, aborted 0
Tests: succeeded 27, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

- Manual check sbt test:
```
build/sbt package
build/sbt "connect-client-jvm/test"
```
Both before and after will test successfully

