### PR TITLE
[SPARK-42223][SQL] Remove duplicate branches in CASE_WHEN and COALESCE function

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
@@ -293,4 +293,21 @@ class SimplifyConditionalSuite extends PlanTest with ExpressionEvalHelper {
         Some(Literal.create(null, IntegerType))),
       CaseWhen((GreaterThan($"a", 1), Literal.create(1, IntegerType)) :: Nil))
   }
+
+  test("SPARK-42223: Remove duplicate branch in CASE_WHEN and COALESCE function") {
+    assertEquivalent(
+      CaseWhen(
+        (GreaterThan($"a", 1), FalseLiteral) ::
+          (GreaterThan($"a", 2), TrueLiteral) ::
+          (GreaterThan($"a", 1), TrueLiteral) :: Nil,
+        Some(FalseLiteral)),
+      CaseWhen(
+        (GreaterThan($"a", 1), FalseLiteral) ::
+          (GreaterThan($"a", 2), TrueLiteral) :: Nil,
+        Some(FalseLiteral)))
+
+    assertEquivalent(
+      Coalesce(Seq($"a" + 1, $"a" + 2, Literal(1) + $"a", Literal(2) + $"a")),
+      Coalesce(Seq($"a" + 1, $"a" + 2)))
+  }
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Optimize CASE_WHEN and COALESCE SQL function, remove duplicate branches.
For example, we can remove the `id = 200` branch in CASE_WHEN function and remove `id + 1` expression in COALESCE function:
```sql
SELECT
  CASE WHEN id = 200 THEN 1
       WHEN id = 200 THEN 2 -- same condition, can remove
       WHEN id = 200 THEN 3 -- same condition, can remove
       ELSE 0 END as c1,
  coalesce(
    id + 1,
    id + 1, -- same expression, can remove
    id) as c2
FROM t1
```


### Why are the changes needed?

Optimize CASE_WHEN and COALESCE SQL function


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Add UT
