### PR TITLE
[SPARK-42224][CONNECT] Migrate `TypeError` into error framework for Spark Connect functions

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -21,7 +21,7 @@ ERROR_CLASSES_JSON = """
 {
   "COLUMN_IN_LIST": {
     "message": [
-      "<func_name> does not allow a column in a list."
+      "<func_name> does not allow a Column in a list."
     ]
   },
   "HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN" : {
@@ -31,27 +31,42 @@ ERROR_CLASSES_JSON = """
   },
   "NOT_A_COLUMN" : {
     "message" : [
-      "Argument `<arg_name>` should be a column, got <arg_type>."
+      "Argument `<arg_name>` should be a Column, got <arg_type>."
+    ]
+  },
+  "NOT_A_DATAFRAME" : {
+    "message" : [
+      "Argument `<arg_name>` must be a DataFrame, got <arg_type>."
     ]
   },
   "NOT_A_STRING" : {
     "message" : [
-      "Argument `<arg_name>` should be a string, got <arg_type>."
+      "Argument `<arg_name>` should be a str, got <arg_type>."
+    ]
+  },
+  "NOT_COLUMN_OR_DATATYPE_OR_STRING" : {
+    "message" : [
+      "Argument `<arg_name>` should be a Column or str or DataType, but got <arg_type>."
     ]
   },
   "NOT_COLUMN_OR_INTEGER" : {
     "message" : [
-      "Argument `<arg_name>` should be a column or integer, got <arg_type>."
+      "Argument `<arg_name>` should be a Column or int, got <arg_type>."
     ]
   },
   "NOT_COLUMN_OR_INTEGER_OR_STRING" : {
     "message" : [
-      "Argument `<arg_name>` should be a column or integer or string, got <arg_type>."
+      "Argument `<arg_name>` should be a Column, int or str, got <arg_type>."
     ]
   },
   "NOT_COLUMN_OR_STRING" : {
     "message" : [
-      "Argument `<arg_name>` should be a column or string, got <arg_type>."
+      "Argument `<arg_name>` should be a Column or str, got <arg_type>."
+    ]
+  },
+  "UNSUPPORTED_NUMPY_ARRAY_SCALAR" : {
+    "message" : [
+      "The type of array scalar '<dtype>' is not supported."
     ]
   },
   "UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION" : {

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1021,15 +1021,14 @@ class FunctionsTestsMixin:
         with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "2000000"):
             df.select(assert_true(df.id < 2, df.id * 1e6)).toDF("val").collect()
 
-        with self.assertRaises((PySparkTypeError, TypeError)) as pe:
+        with self.assertRaises(TypeError) as pe:
             df.select(assert_true(df.id < 2, 5))
 
-        if isinstance(pe, PySparkTypeError):
-            self.check_error(
-                exception=pe.exception,
-                error_class="NOT_COLUMN_OR_STRING",
-                message_parameters={"arg_name": "errMsg", "arg_type": "int"},
-            )
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "errMsg", "arg_type": "int"},
+        )
 
     def test_raise_error(self):
         from pyspark.sql.functions import raise_error
@@ -1042,15 +1041,14 @@ class FunctionsTestsMixin:
         with self.assertRaisesRegex((Py4JJavaError, SparkConnectException), "barfoo"):
             df.select(raise_error("barfoo")).collect()
 
-        with self.assertRaises((PySparkTypeError, TypeError)) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             df.select(raise_error(None))
 
-        if isinstance(pe, PySparkTypeError):
-            self.check_error(
-                exception=pe.exception,
-                error_class="NOT_COLUMN_OR_STRING",
-                message_parameters={"arg_name": "errMsg", "arg_type": "NoneType"},
-            )
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STRING",
+            message_parameters={"arg_name": "errMsg", "arg_type": "NoneType"},
+        )
 
     def test_sum_distinct(self):
         self.spark.range(10).select(


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to migrate `TypeError` into error framework for Spark Connect functions.

### Why are the changes needed?

To improve errors by leveraging the PySpark error framework for Spark Connect functions.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Fixed & added UTs.