### PR TITLE
[SPARK-42226][BUILD] Upgrade `versions-maven-plugin` to 2.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
       See: SPARK-36547, SPARK-38394.
        -->
     <scala-maven-plugin.version>4.8.0</scala-maven-plugin.version>
-    <versions-maven-plugin.version>2.14.1</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.14.2</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `versions-maven-plugin` to 2.14.2


### Why are the changes needed?
New version bring some improvement like [Add a simple cache for ComparableVersions
](https://github.com/mojohaus/versions/pull/870)
The full release notes as follows:
- https://github.com/mojohaus/versions/releases/tag/2.14.2


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- GA `Dependencies test` should work normally
- Manually check `./dev/test-dependencies.sh --replace-manifest`, run successful

