### PR TITLE
[SPARK-42233][SQL] Improve error message for `PIVOT_AFTER_GROUP_BY`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1562,7 +1562,7 @@
       },
       "PIVOT_AFTER_GROUP_BY" : {
         "message" : [
-          "PIVOT clause following a GROUP BY clause."
+          "PIVOT clause following a GROUP BY clause. Consider pushing the GROUP BY into a subquery."
         ]
       },
       "PIVOT_TYPE" : {


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR proposes to improve error message for `PIVOT_AFTER_GROUP_BY` to give users better error message.


### Why are the changes needed?

The current error message only shows the cause, not a solution. We should provide proper solution as well in the error message.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

The existing CI should pass.
