### PR TITLE
[SPARK-42231][SQL] Turn `MISSING_STATIC_PARTITION_COLUMN` into `internalError`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -997,12 +997,6 @@
     ],
     "sqlState" : "42803"
   },
-  "MISSING_STATIC_PARTITION_COLUMN" : {
-    "message" : [
-      "Unknown static partition column: <columnName>."
-    ],
-    "sqlState" : "42000"
-  },
   "MULTI_UDF_INTERFACE_ERROR" : {
     "message" : [
       "Not allowed to implement multiple UDF interfaces, UDF class <className>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -157,9 +157,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def missingStaticPartitionColumn(staticName: String): Throwable = {
-    new AnalysisException(
-      errorClass = "MISSING_STATIC_PARTITION_COLUMN",
-      messageParameters = Map("columnName" -> staticName))
+    SparkException.internalError(s"Unknown static partition column: $columnName.")
   }
 
   def staticPartitionInUserSpecifiedColumnsError(staticName: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -157,7 +157,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def missingStaticPartitionColumn(staticName: String): Throwable = {
-    SparkException.internalError(s"Unknown static partition column: $columnName.")
+    SparkException.internalError(s"Unknown static partition column: $staticName.")
   }
 
   def staticPartitionInUserSpecifiedColumnsError(staticName: String): Throwable = {


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR proposes to turn `MISSING_STATIC_PARTITION_COLUMN` into `internalError`.

### Why are the changes needed?

`MISSING_STATIC_PARTITION_COLUMN` is not reproducible from user space, so it should not be exposed into error classes.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

The existing CI should pass.
