### PR TITLE
[SPARK-41855][CONNECT][PYTHON][FOLLOWUP] Make `createDataFrame` accept `Decimal('NaN')`

### DIFF
--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -16,6 +16,7 @@
 #
 
 import datetime
+import decimal
 
 import pyarrow as pa
 
@@ -30,6 +31,7 @@ from pyspark.sql.types import (
     ArrayType,
     BinaryType,
     NullType,
+    DecimalType,
 )
 
 from pyspark.sql.connect.types import to_arrow_schema
@@ -65,6 +67,9 @@ class LocalDataToArrowConversion:
             return True
         elif isinstance(dataType, (TimestampType, TimestampNTZType)):
             # Always truncate
+            return True
+        elif isinstance(dataType, DecimalType):
+            # Convert Decimal('NaN') to None
             return True
         else:
             return False
@@ -167,6 +172,17 @@ class LocalDataToArrowConversion:
                     return value.astimezone(datetime.timezone.utc)
 
             return convert_timestample
+
+        elif isinstance(dataType, DecimalType):
+
+            def convert_decimal(value: Any) -> Any:
+                if value is None:
+                    return None
+                else:
+                    assert isinstance(value, decimal.Decimal)
+                    return None if value.is_nan() else value
+
+            return convert_decimal
 
         else:
 

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -37,11 +37,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_create_dataframe_from_pandas_with_dst(self):
         super().test_create_dataframe_from_pandas_with_dst()
 
-    # TODO(SPARK-41855): createDataFrame doesn't handle None/NaN properly
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_create_nan_decimal_dataframe(self):
-        super().test_create_nan_decimal_dataframe()
-
     # TODO(SPARK-41870): Handle duplicate columns in `createDataFrame`
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_duplicated_column_names(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `createDataFrame` accept `Decimal('NaN')`


### Why are the changes needed?
bugfix, refer to https://github.com/apache/spark/pull/34285


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
enabled test
