### PR TITLE
[SPARK-42241][CONNECT][TESTS] Fix the find connect jar condition in `SparkConnectServerUtils#findSparkConnectJar` for maven

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -124,7 +124,8 @@ object SparkConnectServerUtils {
         f.getName.startsWith("spark-connect-assembly") && f.getName.endsWith(".jar")) ||
       // Maven Jar
       (f.getParent.endsWith("target") &&
-        f.getName.startsWith("spark-connect") && f.getName.endsWith(".jar"))
+        f.getName.startsWith("spark-connect") &&
+        f.getName.endsWith(s"${org.apache.spark.SPARK_VERSION}.jar"))
     }
     // It is possible we found more than one: one built by maven, and another by SBT
     assert(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix the finding connect jar condition in `SparkConnectServerUtils#findSparkConnectJar` to ensure the correct connect jar is found for maven test



### Why are the changes needed?
After run 

```
build/mvn -DskipTests clean install -pl connector/connect/server
```
or 
```
build/mvn -DskipTests clean package -pl connector/connect/server
```

There will be 5 jars that meet the original conditions for maven:

```
spark-connect_2.12-3.5.0-SNAPSHOT-javadoc.jar
spark-connect_2.12-3.5.0-SNAPSHOT-sources.jar
spark-connect_2.12-3.5.0-SNAPSHOT-test-sources.jar
spark-connect_2.12-3.5.0-SNAPSHOT-tests.jar
spark-connect_2.12-3.5.0-SNAPSHOT.jar
```

and the head may not `spark-connect_2.12-3.5.0-SNAPSHOT.jar`, so need to make the condition more strictly to ensure that `spark-connect_2.12-3.5.0-SNAPSHOT.jar` is found

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions
