### PR TITLE
[SPARK-42242][BUILD] Upgrade `snappy-java` to 1.1.9.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -248,7 +248,7 @@ scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.4//snappy-java-1.1.8.4.jar
+snappy-java/1.1.9.0//snappy-java-1.1.9.0.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar
 spire-platform_2.12/0.17.0//spire-platform_2.12-0.17.0.jar
 spire-util_2.12/0.17.0//spire-util_2.12-0.17.0.jar

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -248,7 +248,7 @@ scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.9.0//snappy-java-1.1.9.0.jar
+snappy-java/1.1.9.1//snappy-java-1.1.9.1.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar
 spire-platform_2.12/0.17.0//spire-platform_2.12-0.17.0.jar
 spire-util_2.12/0.17.0//spire-util_2.12-0.17.0.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -235,7 +235,7 @@ scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.9.0//snappy-java-1.1.9.0.jar
+snappy-java/1.1.9.1//snappy-java-1.1.9.1.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar
 spire-platform_2.12/0.17.0//spire-platform_2.12-0.17.0.jar
 spire-util_2.12/0.17.0//spire-util_2.12-0.17.0.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -235,7 +235,7 @@ scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.8.4//snappy-java-1.1.8.4.jar
+snappy-java/1.1.9.0//snappy-java-1.1.9.0.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar
 spire-platform_2.12/0.17.0//spire-platform_2.12-0.17.0.jar
 spire-util_2.12/0.17.0//spire-util_2.12-0.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.14.1</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.14.1</fasterxml.jackson.databind.version>
-    <snappy.version>1.1.9.0</snappy.version>
+    <snappy.version>1.1.9.1</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-compress.version>1.22</commons-compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.14.1</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.14.1</fasterxml.jackson.databind.version>
-    <snappy.version>1.1.8.4</snappy.version>
+    <snappy.version>1.1.9.0</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-compress.version>1.22</commons-compress.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `snappy-java` to 1.1.9.1.

### Why are the changes needed?

This version has the following bug fixes.

- Use original compressed and uncompressed buffer's position (https://github.com/xerial/snappy-java/pull/293)
- Fixed running snappy-java as OSGi bundle on Apple Silicon (M1 Pro) (https://github.com/xerial/snappy-java/pull/303)
- Avoid explicit class name in throw_exception (https://github.com/xerial/snappy-java/pull/291)

Here is the full release note.
- https://github.com/xerial/snappy-java/releases/tag/v1.1.9.0
- https://github.com/xerial/snappy-java/releases/tag/v1.1.9.1

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.