### PR TITLE
[SPARK-42271][CONNECT][PYTHON] Reuse UDF test cases under `pyspark.sql.tests`

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -529,6 +529,8 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.test_parity_types",
         "pyspark.sql.tests.connect.test_parity_column",
         "pyspark.sql.tests.connect.test_parity_readwriter",
+        "pyspark.sql.tests.connect.test_parity_udf",
+        "pyspark.sql.tests.connect.test_parity_pandas_udf",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from pyspark.sql.tests.pandas.test_pandas_udf import PandasUDFTestsMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+
+
+class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
+    @unittest.skip("Relies on self.sc.")
+    def test_udf_wrong_arg(self):
+        super().test_udf_wrong_arg()
+
+    @unittest.skip("Relies on PythonException.")
+    def test_stopiteration_in_udf(self):
+        super().test_stopiteration_in_udf()
+
+    @unittest.skip("Relies on spark.conf")
+    def test_pandas_udf_timestamp_ntz(self):
+        super().test_pandas_udf_timestamp_ntz()
+
+    @unittest.skip("Relies on spark.conf")
+    def test_pandas_udf_detect_unsafe_type_conversion(self):
+        super().test_pandas_udf_detect_unsafe_type_conversion()
+
+    @unittest.skip("Relies on spark.conf")
+    def test_pandas_udf_arrow_overflow(self):
+        super().test_pandas_udf_arrow_overflow()
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.sql.tests.connect.test_parity_pandas_udf import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/connect/test_parity_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf.py
@@ -33,132 +33,152 @@ from pyspark.sql.types import BooleanType
 
 
 class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
-    @unittest.skip("Relies on mapPartitions().")
+    @unittest.skip("Spark Connect does not support mapPartitions() but the test depends on it.")
     def test_worker_original_stdin_closed(self):
         super().test_worker_original_stdin_closed()
 
-    @unittest.skip("Relies on registerFunction().")
-    def test_worker_original_stdin_closed(self):
-        super().test_worker_original_stdin_closed()
-
-    @unittest.skip("Relies on read fomr Hadoop RDD.")
+    @unittest.skip(
+        "Spark Connect does not support reading from Hadoop RDD but the test depends on it."
+    )
     def test_udf_with_input_file_name_for_hadooprdd(self):
         super().test_udf_with_input_file_name_for_hadooprdd()
 
-    @unittest.skip("Relies on accumulator")
+    @unittest.skip("Spark Connect does not support accumulator but the test depends on it.")
     def test_same_accumulator_in_udfs(self):
         super().test_same_accumulator_in_udfs()
 
-    @unittest.skip("Relies on spark.conf")
+    @unittest.skip("Spark Connect does not support spark.conf but the test depends on it.")
     def test_udf_with_column_vector(self):
         super().test_udf_with_column_vector()
 
-    @unittest.skip("Relies on spark.conf")
+    @unittest.skip("Spark Connect does not support spark.conf but the test depends on it.")
     def test_udf_timestamp_ntz(self):
         super().test_udf_timestamp_ntz()
 
-    @unittest.skip("Relies on broadcast")
+    @unittest.skip("Spark Connect does not support broadcast but the test depends on it.")
     def test_broadcast_in_udf(self):
         super().test_broadcast_in_udf()
 
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_chained_udf(self):
-        super().test_chained_udf()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_udf_without_arguments(self):
-        super().test_udf_without_arguments()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_multiple_udfs(self):
-        super().test_multiple_udfs()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_nondeterministic_udf2(self):
-        super().test_nondeterministic_udf2()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_single_udf_with_repeated_argument(self):
-        super().test_single_udf_with_repeated_argument()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_udf(self):
-        super().test_df()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_udf2(self):
-        super().test_df2()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_udf3(self):
-        super().test_df3()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_udf_registration_return_type_none(self):
-        super().test_udf_registration_return_type_none()
-
-    @unittest.skip("Relies on spark.catalog.registerFunction")
-    def test_udf_with_array_type(self):
-        super().test_udf_with_array_type()
-
-    @unittest.skip("Relies on sql_conf")
+    @unittest.skip("Spark Connect does not support sql_conf but the test depends on it.")
     def test_file_dsv2_with_udf_filter(self):
         super().test_file_dsv2_with_udf_filter()
 
-    @unittest.skip("Relies on spark.udf")
-    def test_non_existed_udaf(self):
-        super().test_non_existed_udaf()
-
-    @unittest.skip("Relies on spark.udf")
-    def test_non_existed_udf(self):
-        super().test_non_existed_udf()
-
-    @unittest.skip("Relies on spark.udf")
-    def test_udf_registration_returns_udf(self):
-        super().test_udf_registration_returns_udf()
-
-    @unittest.skip("Relies on cache()")
-    def test_udf_cache(self):
-        super().test_udf_cache()
-
-    @unittest.skip("Relies on UserDefinedFunction._judf_placeholder")
-    def test_udf_defers_judf_initialization(self):
-        super().test_udf_defers_judf_initialization()
-
-    @unittest.skip("Relies on left_outer join type.")
-    def test_udf_in_left_outer_join_condition(self):
-        super().test_udf_in_left_outer_join_condition()
-
-    @unittest.skip("Relies on left_outer join type.")
-    def test_udf_in_filter_on_top_of_outer_join(self):
-        super().test_udf_in_filter_on_top_of_outer_join()
-
-    @unittest.skip("Relies on sql_conf.")
+    @unittest.skip("Spark Connect does not support sql_conf but the test depends on it.")
     def test_udf_in_join_condition(self):
         super().test_udf_in_join_condition()
 
-    @unittest.skip("Relies on df._jdf")
+    @unittest.skip("Spark Connect does not support cache() but the test depends on it.")
+    def test_udf_cache(self):
+        super().test_udf_cache()
+
+    @unittest.skip("Requires JVM access.")
+    def test_udf_defers_judf_initialization(self):
+        super().test_udf_defers_judf_initialization()
+
+    @unittest.skip("Requires JVM access.")
     def test_nondeterministic_udf3(self):
         super().test_nondeterministic_udf3()
 
-    @unittest.skip("Relies on sc._jvm.org.apache.log4j")
+    @unittest.skip("Requires JVM access.")
     def test_nondeterministic_udf_in_aggregate(self):
         super().test_nondeterministic_udf_in_aggregate()
 
-    @unittest.skip("Relies on sc._jvm.org.apache.log4j")
+    @unittest.skip("Requires JVM access.")
     def test_udf_registration_return_type_not_none(self):
         super().test_udf_registration_return_type_not_none()
 
-    @unittest.skip("Parse array<double>")
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_worker_original_stdin_closed(self):
+        super().test_worker_original_stdin_closed()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_chained_udf(self):
+        super().test_chained_udf()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf_without_arguments(self):
+        super().test_udf_without_arguments()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_multiple_udfs(self):
+        super().test_multiple_udfs()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_nondeterministic_udf2(self):
+        super().test_nondeterministic_udf2()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_single_udf_with_repeated_argument(self):
+        super().test_single_udf_with_repeated_argument()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf(self):
+        super().test_df()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf2(self):
+        super().test_df2()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf3(self):
+        super().test_df3()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf_registration_return_type_none(self):
+        super().test_udf_registration_return_type_none()
+
+    # TODO(SPARK-42263): implement `spark.catalog.registerFunction`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf_with_array_type(self):
+        super().test_udf_with_array_type()
+
+    # TODO(SPARK-42210): implement `spark.udf`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_non_existed_udaf(self):
+        super().test_non_existed_udaf()
+
+    # TODO(SPARK-42210): implement `spark.udf`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_non_existed_udf(self):
+        super().test_non_existed_udf()
+
+    # TODO(SPARK-42210): implement `spark.udf`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf_registration_returns_udf(self):
+        super().test_udf_registration_returns_udf()
+
+    # TODO(SPARK-42267): support left_outer join type
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf_in_left_outer_join_condition(self):
+        super().test_udf_in_left_outer_join_condition()
+
+    # TODO(SPARK-42267): support left_outer join type
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_udf_in_filter_on_top_of_outer_join(self):
+        super().test_udf_in_filter_on_top_of_outer_join()
+
+    # TODO(SPARK-42269): support return type as a collection DataType in DDL strings
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_udf_with_string_return_type(self):
         super().test_udf_with_string_return_type()
 
-    # spark.range(1).filter(udf(lambda x: x)("id") >= 0).createTempView("v")
-    @unittest.skip("SparkConnectGrpcException: requirement failed")
+    # TODO(SPARK-41279): fix DataFrame.createTempView
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_udf_in_subquery(self):
         super().test_udf_in_subquery()
 
     def test_udf_not_supported_in_join_condition(self):
+        # The vanilla PySpark throws AnalysisException instead.
         # test python udf is not supported in join type except inner join.
         left = self.spark.createDataFrame([(1, 1, 1), (2, 2, 2)], ["a", "a1", "a2"])
         right = self.spark.createDataFrame([(1, 1, 1), (1, 3, 1)], ["b", "b1", "b2"])

--- a/python/pyspark/sql/tests/connect/test_parity_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf.py
@@ -1,0 +1,191 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from pyspark.testing.connectutils import should_test_connect
+
+if should_test_connect:  # test_udf_with_partial_function
+    from pyspark import sql
+    from pyspark.sql.connect.udf import UserDefinedFunction
+
+    sql.udf.UserDefinedFunction = UserDefinedFunction
+
+from pyspark.sql.tests.test_udf import BaseUDFTestsMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.errors.exceptions import SparkConnectAnalysisException
+from pyspark.sql.connect.functions import udf
+from pyspark.sql.types import BooleanType
+
+
+class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
+    @unittest.skip("Relies on mapPartitions().")
+    def test_worker_original_stdin_closed(self):
+        super().test_worker_original_stdin_closed()
+
+    @unittest.skip("Relies on registerFunction().")
+    def test_worker_original_stdin_closed(self):
+        super().test_worker_original_stdin_closed()
+
+    @unittest.skip("Relies on read fomr Hadoop RDD.")
+    def test_udf_with_input_file_name_for_hadooprdd(self):
+        super().test_udf_with_input_file_name_for_hadooprdd()
+
+    @unittest.skip("Relies on accumulator")
+    def test_same_accumulator_in_udfs(self):
+        super().test_same_accumulator_in_udfs()
+
+    @unittest.skip("Relies on spark.conf")
+    def test_udf_with_column_vector(self):
+        super().test_udf_with_column_vector()
+
+    @unittest.skip("Relies on spark.conf")
+    def test_udf_timestamp_ntz(self):
+        super().test_udf_timestamp_ntz()
+
+    @unittest.skip("Relies on broadcast")
+    def test_broadcast_in_udf(self):
+        super().test_broadcast_in_udf()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_chained_udf(self):
+        super().test_chained_udf()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_udf_without_arguments(self):
+        super().test_udf_without_arguments()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_multiple_udfs(self):
+        super().test_multiple_udfs()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_nondeterministic_udf2(self):
+        super().test_nondeterministic_udf2()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_single_udf_with_repeated_argument(self):
+        super().test_single_udf_with_repeated_argument()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_udf(self):
+        super().test_df()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_udf2(self):
+        super().test_df2()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_udf3(self):
+        super().test_df3()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_udf_registration_return_type_none(self):
+        super().test_udf_registration_return_type_none()
+
+    @unittest.skip("Relies on spark.catalog.registerFunction")
+    def test_udf_with_array_type(self):
+        super().test_udf_with_array_type()
+
+    @unittest.skip("Relies on sql_conf")
+    def test_file_dsv2_with_udf_filter(self):
+        super().test_file_dsv2_with_udf_filter()
+
+    @unittest.skip("Relies on spark.udf")
+    def test_non_existed_udaf(self):
+        super().test_non_existed_udaf()
+
+    @unittest.skip("Relies on spark.udf")
+    def test_non_existed_udf(self):
+        super().test_non_existed_udf()
+
+    @unittest.skip("Relies on spark.udf")
+    def test_udf_registration_returns_udf(self):
+        super().test_udf_registration_returns_udf()
+
+    @unittest.skip("Relies on cache()")
+    def test_udf_cache(self):
+        super().test_udf_cache()
+
+    @unittest.skip("Relies on UserDefinedFunction._judf_placeholder")
+    def test_udf_defers_judf_initialization(self):
+        super().test_udf_defers_judf_initialization()
+
+    @unittest.skip("Relies on left_outer join type.")
+    def test_udf_in_left_outer_join_condition(self):
+        super().test_udf_in_left_outer_join_condition()
+
+    @unittest.skip("Relies on left_outer join type.")
+    def test_udf_in_filter_on_top_of_outer_join(self):
+        super().test_udf_in_filter_on_top_of_outer_join()
+
+    @unittest.skip("Relies on sql_conf.")
+    def test_udf_in_join_condition(self):
+        super().test_udf_in_join_condition()
+
+    @unittest.skip("Relies on df._jdf")
+    def test_nondeterministic_udf3(self):
+        super().test_nondeterministic_udf3()
+
+    @unittest.skip("Relies on sc._jvm.org.apache.log4j")
+    def test_nondeterministic_udf_in_aggregate(self):
+        super().test_nondeterministic_udf_in_aggregate()
+
+    @unittest.skip("Relies on sc._jvm.org.apache.log4j")
+    def test_udf_registration_return_type_not_none(self):
+        super().test_udf_registration_return_type_not_none()
+
+    @unittest.skip("Parse array<double>")
+    def test_udf_with_string_return_type(self):
+        super().test_udf_with_string_return_type()
+
+    # spark.range(1).filter(udf(lambda x: x)("id") >= 0).createTempView("v")
+    @unittest.skip("SparkConnectGrpcException: requirement failed")
+    def test_udf_in_subquery(self):
+        super().test_udf_in_subquery()
+
+    def test_udf_not_supported_in_join_condition(self):
+        # test python udf is not supported in join type except inner join.
+        left = self.spark.createDataFrame([(1, 1, 1), (2, 2, 2)], ["a", "a1", "a2"])
+        right = self.spark.createDataFrame([(1, 1, 1), (1, 3, 1)], ["b", "b1", "b2"])
+        f = udf(lambda a, b: a == b, BooleanType())
+
+        def runWithJoinType(join_type, type_string):
+            with self.assertRaisesRegex(
+                SparkConnectAnalysisException,
+                """Python UDF in the ON clause of a %s JOIN.""" % type_string,
+            ):
+                left.join(right, [f("a", "b"), left.a1 == right.b1], join_type).collect()
+
+        runWithJoinType("full", "FULL OUTER")
+        runWithJoinType("left", "LEFT OUTER")
+        runWithJoinType("right", "RIGHT OUTER")
+        runWithJoinType("leftanti", "LEFT ANTI")
+        runWithJoinType("leftsemi", "LEFT SEMI")
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.sql.tests.connect.test_parity_udf import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/connect/test_parity_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf.py
@@ -157,6 +157,16 @@ class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
     def test_udf_registration_returns_udf(self):
         super().test_udf_registration_returns_udf()
 
+    # TODO(SPARK-42210): implement `spark.udf`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_register_java_function(self):
+        super().test_register_java_function()
+
+    # TODO(SPARK-42210): implement `spark.udf`
+    @unittest.skip("Fails in Spark Connect, should enable.")
+    def test_register_java_udaf(self):
+        super().test_register_java_udaf()
+
     # TODO(SPARK-42267): support left_outer join type
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_udf_in_left_outer_join_condition(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -58,15 +58,15 @@ class PandasUDFTestsMixin:
         self.assertEqual(udf.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         udf = pandas_udf(lambda x: x, "v double", PandasUDFType.GROUPED_MAP)
-        # self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
         self.assertEqual(udf.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         udf = pandas_udf(lambda x: x, "v double", functionType=PandasUDFType.GROUPED_MAP)
-        # self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
         self.assertEqual(udf.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         udf = pandas_udf(lambda x: x, returnType="v double", functionType=PandasUDFType.GROUPED_MAP)
-        # self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
         self.assertEqual(udf.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
     def test_pandas_udf_decorator(self):
@@ -90,14 +90,14 @@ class PandasUDFTestsMixin:
         def foo(x):
             return x
 
-        # self.assertEqual(foo.returnType, schema)
+        self.assertEqual(foo.returnType, schema)
         self.assertEqual(foo.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         @pandas_udf("v double", PandasUDFType.GROUPED_MAP)
         def foo(x):
             return x
 
-        # self.assertEqual(foo.returnType, schema)
+        self.assertEqual(foo.returnType, schema)
         self.assertEqual(foo.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         @pandas_udf(schema, functionType=PandasUDFType.GROUPED_MAP)

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -37,7 +37,7 @@ from pyspark.testing.utils import QuietTest
     not have_pandas or not have_pyarrow,
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
 )
-class PandasUDFTests(ReusedSQLTestCase):
+class PandasUDFTestsMixin:
     def test_pandas_udf_basic(self):
         udf = pandas_udf(lambda x: x, DoubleType())
         self.assertEqual(udf.returnType, DoubleType())
@@ -58,15 +58,15 @@ class PandasUDFTests(ReusedSQLTestCase):
         self.assertEqual(udf.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         udf = pandas_udf(lambda x: x, "v double", PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        # self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
         self.assertEqual(udf.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         udf = pandas_udf(lambda x: x, "v double", functionType=PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        # self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
         self.assertEqual(udf.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         udf = pandas_udf(lambda x: x, returnType="v double", functionType=PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
+        # self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType())]))
         self.assertEqual(udf.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
     def test_pandas_udf_decorator(self):
@@ -90,14 +90,14 @@ class PandasUDFTests(ReusedSQLTestCase):
         def foo(x):
             return x
 
-        self.assertEqual(foo.returnType, schema)
+        # self.assertEqual(foo.returnType, schema)
         self.assertEqual(foo.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         @pandas_udf("v double", PandasUDFType.GROUPED_MAP)
         def foo(x):
             return x
 
-        self.assertEqual(foo.returnType, schema)
+        # self.assertEqual(foo.returnType, schema)
         self.assertEqual(foo.evalType, PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF)
 
         @pandas_udf(schema, functionType=PandasUDFType.GROUPED_MAP)
@@ -290,6 +290,10 @@ class PandasUDFTests(ReusedSQLTestCase):
         ).collect()
         self.assertEqual(df.schema[0].dataType.simpleString(), "interval day to second")
         self.assertEqual(df.first()[0], datetime.timedelta(microseconds=123))
+
+
+class PandasUDFTests(PandasUDFTestsMixin, ReusedSQLTestCase):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -18,7 +18,7 @@
 import unittest
 
 from pyspark.sql.functions import udf
-from pyspark.sql.tests.test_udf import BaseUDFTests
+from pyspark.sql.tests.test_udf import BaseUDFTestsMixin
 from pyspark.testing.sqlutils import (
     have_pandas,
     have_pyarrow,
@@ -31,7 +31,7 @@ from pyspark.testing.sqlutils import (
 @unittest.skipIf(
     not have_pandas or not have_pyarrow, pandas_requirement_message or pyarrow_requirement_message
 )
-class PythonUDFArrowTests(BaseUDFTests, ReusedSQLTestCase):
+class PythonUDFArrowTests(BaseUDFTestsMixin, ReusedSQLTestCase):
     @classmethod
     def setUpClass(cls):
         super(PythonUDFArrowTests, cls).setUpClass()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reuse UDF test cases under `pyspark.sql.tests`.


### Why are the changes needed?
Reach parity to the vanilla PySpark.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests.

SPARK-41661