### PR TITLE
[SPARK-42245][BUILD]  Upgrade scalafmt from 3.6.1 to 3.7.1

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -32,4 +32,4 @@ fileOverride {
     runner.dialect = scala213
   }
 }
-version = 3.6.1
+version = 3.7.1


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade scalafmt from 3.6.1 to 3.7.1

### Why are the changes needed?
A. Release note:
> https://github.com/scalameta/scalafmt/releases

B. V3.6.1 VS V3.7.1
> https://github.com/scalameta/scalafmt/compare/v3.6.1...v3.7.1

C. Bring bug fix & some improvement:
<img width="571" alt="image" src="https://user-images.githubusercontent.com/15246973/215639186-47ad2abc-5827-4b0b-a401-10737bd05743.png">
<img width="641" alt="image" src="https://user-images.githubusercontent.com/15246973/215639316-0df69d85-cb6b-40f8-acbf-d792193d1ba1.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually run: sh ./dev/scalafmt
Pass GA.