### PR TITLE
[SPARK-42251][SQL] Forbid deicmal type if precision less than 1

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -3041,7 +3041,7 @@
   },
   "_LEGACY_ERROR_TEMP_1229" : {
     "message" : [
-      "<decimalType> can only support precision up to <precision>."
+      "<decimalType> can only support precision in range [<minPrecision>, <maxPrecision>]."
     ]
   },
   "_LEGACY_ERROR_TEMP_1231" : {

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -22,6 +22,10 @@ license: |
 * Table of contents
 {:toc}
 
+## Upgrading from Spark SQL 3.4 to 3.5
+
+  - Since Spark 3.5, decimal type precision can not less than 1, for example the follow query will fail `SELECT CAST(0 AS decimal(0, 0))`.
+
 ## Upgrading from Spark SQL 3.3 to 3.4
   
   - Since Spark 3.4, Number or Number(\*) from Teradata will be treated as Decimal(38,18). In Spark 3.3 or earlier, Number or Number(\*) from Teradata will be treated as Decimal(38, 0), in which case the fractional part will be removed.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2254,12 +2254,14 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
         "precision" -> precision.toString))
   }
 
-  def decimalOnlySupportPrecisionUptoError(decimalType: String, precision: Int): Throwable = {
+  def invalidDecimalPrecisionError(
+      decimalType: String, minPrecision: Int, maxPrecision: Int): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1229",
       messageParameters = Map(
         "decimalType" -> decimalType,
-        "precision" -> precision.toString))
+        "minPrecision" -> minPrecision.toString,
+        "maxPrecision" -> maxPrecision.toString))
   }
 
   def negativeScaleNotAllowedError(scale: Int): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -50,9 +50,9 @@ case class DecimalType(precision: Int, scale: Int) extends FractionalType {
     throw QueryCompilationErrors.decimalCannotGreaterThanPrecisionError(scale, precision)
   }
 
-  if (precision > DecimalType.MAX_PRECISION) {
-    throw QueryCompilationErrors.decimalOnlySupportPrecisionUptoError(
-      DecimalType.simpleString, DecimalType.MAX_PRECISION)
+  if (precision < DecimalType.MIN_PRECISION || precision > DecimalType.MAX_PRECISION) {
+    throw QueryCompilationErrors.invalidDecimalPrecisionError(
+      DecimalType.simpleString, DecimalType.MIN_PRECISION, DecimalType.MAX_PRECISION)
   }
 
   // default constructor for Java
@@ -128,6 +128,7 @@ case class DecimalType(precision: Int, scale: Int) extends FractionalType {
 object DecimalType extends AbstractDataType {
   import scala.math.min
 
+  val MIN_PRECISION = 1
   val MAX_PRECISION = 38
   val MAX_SCALE = 38
   val DEFAULT_SCALE = 18

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -807,7 +807,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException("1.20E-38BD"),
       errorClass = "_LEGACY_ERROR_TEMP_0061",
-      parameters = Map("msg" -> "decimal can only support precision up to 38."),
+      parameters = Map("msg" -> "decimal can only support precision in range [1, 38]."),
       context = ExpectedContext(
         fragment = "1.20E-38BD",
         start = 0,

--- a/sql/core/src/test/resources/sql-tests/inputs/typeCoercion/native/decimalPrecision.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/typeCoercion/native/decimalPrecision.sql
@@ -1446,3 +1446,10 @@ SELECT cast(1 as decimal(3, 0))  <> cast('2017-12-11 09:30:00' as date) FROM t;
 SELECT cast(1 as decimal(5, 0))  <> cast('2017-12-11 09:30:00' as date) FROM t;
 SELECT cast(1 as decimal(10, 0)) <> cast('2017-12-11 09:30:00' as date) FROM t;
 SELECT cast(1 as decimal(20, 0)) <> cast('2017-12-11 09:30:00' as date) FROM t;
+
+
+CREATE TABLE test_decimal(c decimal(0, 0)) USING PARQUET;
+SELECT cast(0 as decimal(0, 0));
+SELECT cast(0.0 as decimal(0, 0));
+SELECT cast(0 as decimal(1, 0));
+SELECT cast(0.0 as decimal(1, 0));

--- a/sql/core/src/test/resources/sql-tests/results/ansi/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/literals.sql.out
@@ -177,7 +177,8 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "_LEGACY_ERROR_TEMP_1229",
   "messageParameters" : {
     "decimalType" : "decimal",
-    "precision" : "38"
+    "maxPrecision" : "38",
+    "minPrecision" : "1"
   }
 }
 
@@ -192,7 +193,8 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "_LEGACY_ERROR_TEMP_1229",
   "messageParameters" : {
     "decimalType" : "decimal",
-    "precision" : "38"
+    "maxPrecision" : "38",
+    "minPrecision" : "1"
   }
 }
 
@@ -477,7 +479,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0061",
   "messageParameters" : {
-    "msg" : "decimal can only support precision up to 38."
+    "msg" : "decimal can only support precision in range [1, 38]."
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/literals.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/literals.sql.out
@@ -177,7 +177,8 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "_LEGACY_ERROR_TEMP_1229",
   "messageParameters" : {
     "decimalType" : "decimal",
-    "precision" : "38"
+    "maxPrecision" : "38",
+    "minPrecision" : "1"
   }
 }
 
@@ -192,7 +193,8 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "_LEGACY_ERROR_TEMP_1229",
   "messageParameters" : {
     "decimalType" : "decimal",
-    "precision" : "38"
+    "maxPrecision" : "38",
+    "minPrecision" : "1"
   }
 }
 
@@ -477,7 +479,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0061",
   "messageParameters" : {
-    "msg" : "decimal can only support precision up to 38."
+    "msg" : "decimal can only support precision in range [1, 38]."
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/numeric.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/numeric.sql.out
@@ -3585,7 +3585,8 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "_LEGACY_ERROR_TEMP_1229",
   "messageParameters" : {
     "decimalType" : "decimal",
-    "precision" : "38"
+    "maxPrecision" : "38",
+    "minPrecision" : "1"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/decimalPrecision.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/decimalPrecision.sql.out
@@ -14837,3 +14837,67 @@ org.apache.spark.sql.AnalysisException
     "fragment" : "cast(1 as decimal(20, 0)) <> cast('2017-12-11 09:30:00' as date)"
   } ]
 }
+
+
+-- !query
+CREATE TABLE test_decimal(c decimal(0, 0)) USING PARQUET
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "_LEGACY_ERROR_TEMP_1229",
+  "messageParameters" : {
+    "decimalType" : "decimal",
+    "maxPrecision" : "38",
+    "minPrecision" : "1"
+  }
+}
+
+
+-- !query
+SELECT cast(0 as decimal(0, 0))
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "_LEGACY_ERROR_TEMP_1229",
+  "messageParameters" : {
+    "decimalType" : "decimal",
+    "maxPrecision" : "38",
+    "minPrecision" : "1"
+  }
+}
+
+
+-- !query
+SELECT cast(0.0 as decimal(0, 0))
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.parser.ParseException
+{
+  "errorClass" : "_LEGACY_ERROR_TEMP_1229",
+  "messageParameters" : {
+    "decimalType" : "decimal",
+    "maxPrecision" : "38",
+    "minPrecision" : "1"
+  }
+}
+
+
+-- !query
+SELECT cast(0 as decimal(1, 0))
+-- !query schema
+struct<CAST(0 AS DECIMAL(1,0)):decimal(1,0)>
+-- !query output
+0
+
+
+-- !query
+SELECT cast(0.0 as decimal(1, 0))
+-- !query schema
+struct<CAST(0.0 AS DECIMAL(1,0)):decimal(1,0)>
+-- !query output
+0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
throw exception if the decimal precision less than 1.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Spark does not actually support decimal type with 0 precision. e.g.

```
– work with in-memory catalog
create table t (c decimal(0, 0)) using parquet;

-- fail with parquet
-- java.lang.IllegalArgumentException: Invalid DECIMAL precision: 0
-- at org.apache.parquet.Preconditions.checkArgument(Preconditions.java:57)
insert into table t values(0);

-- fail with hive catalog
-- Caused by: java.lang.IllegalArgumentException: Decimal precision out of allowed range [1,38]
-- at org.apache.hadoop.hive.serde2.typeinfo.HiveDecimalUtils.validateParameter(HiveDecimalUtils.java:44)
create table t (c decimal(0, 0)) using parquet;
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, one main behavior change is: `SELECT cast(0 as decimal(0, 0))`

- before: return 0
- after: throw exception

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test