### PR TITLE
[SPARK-42261][SPARK-42260][K8S] Log Allocation Stalls and Trigger Allocation event without blocking on snapshot

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -727,6 +727,18 @@ private[spark] object Config extends Logging {
       .checkValue(value => value > 0, "Maximum number of pending pods should be a positive integer")
       .createWithDefault(Int.MaxValue)
 
+  val KUBERNETES_ALLOCATION_BLOCK_ON_SNAPSHOT =
+    ConfigBuilder("spark.kubernetes.allocation.blockOnSnapshot")
+      .doc("By default Spark on Kube will not trigger a new allocation until Kube delivers a new " +
+        "snapshot this allows an implicit feedback from the cluster manager in that if it is too " +
+        "busy snapshots may be backed up. Settings this to false increases the speed at which " +
+        "Spark an scale up but does increase the risk of an excessive number of pending " +
+        s"resources in some environments. See ${KUBERNETES_MAX_PENDING_PODS.key} " +
+        s" ${KUBERNETES_ALLOCATION_BATCH_SIZE.key} for configuration options.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val KUBERNETES_EXECUTOR_SNAPSHOTS_SUBSCRIBERS_GRACE_PERIOD =
     ConfigBuilder("spark.kubernetes.executorSnapshotsSubscribersShutdownGracePeriod")
       .doc("Time to wait for graceful shutdown kubernetes-executor-snapshots-subscribers " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

Log Allocation Stalls when we are unable to allocate any pods (but wish to) during a K8s snapshot event.
Trigger Allocation event without blocking on snapshot provided that there is enough room in maxPendingPods.

### Why are the changes needed?

Spark on K8s dynamic allocation can be difficult to debug, prone to stalling in heavily loaded clusters, and waiting for snapshot events has an unnecessary delay for pod allocation.

### Does this PR introduce _any_ user-facing change?

New log messages, faster pod scale up.

### How was this patch tested?

Modified existing test to verify that we are both triggering allocation with pending pods and tracking when we are stalled.