### PR TITLE
[SPARK-42272][CONNEC][TESTS] Use an available ephemeral port for Spark Connect server in testing

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -226,9 +226,11 @@ object SparkConnectService {
 
   private var server: Server = _
 
-  // For testing purpose.
+  // For testing purpose, it's package level private.
   private[connect] lazy val localPort = {
     assert(server != null)
+    // Return the actual local port being used. This can be different from the csonfigured port
+    // when the server binds to the port 0 as an example.
     server.getPort
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -226,6 +226,12 @@ object SparkConnectService {
 
   private var server: Server = _
 
+  // For testing purpose.
+  private[connect] lazy val localPort = {
+    assert(server != null)
+    server.getPort
+  }
+
   private val userSessionMapping =
     cacheBuilder(CACHE_SIZE, CACHE_TIMEOUT_SECONDS).build[SessionCacheKey, SessionHolder]()
 

--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -68,15 +68,9 @@ Running Tests for Spark Connect
 Running Tests for Python Client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to run the tests for Spark Connect in Pyth, you should pass ``--parallelism 1`` option together, for example, as below:
-
-.. code-block:: bash
-
-    python/run-tests --module pyspark-connect --parallelism 1
-
-Note that if you made some changes in Protobuf definitions, for example, at
+In order to test the changes in Protobuf definitions, for example, at
 `spark/connector/connect/common/src/main/protobuf/spark/connect <https://github.com/apache/spark/tree/master/connector/connect/common/src/main/protobuf/spark/connect>`_,
-you should regenerate Python Protobuf client by running ``dev/connect-gen-protos.sh``.
+you should regenerate Python Protobuf client first by running ``dev/connect-gen-protos.sh``.
 
 
 Running PySpark Shell with Python Client

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -501,7 +501,8 @@ class SparkSession:
             default_conf = {"spark.plugins": "org.apache.spark.sql.connect.SparkConnectPlugin"}
 
             if "SPARK_TESTING" in os.environ:
-                # TODO: explain avaliable port.
+                # For testing, we use 0 to use an ephemeral port to allow parallel testing.
+                # See also SPARK-42272.
                 overwrite_conf["spark.connect.grpc.binding.port"] = "0"
 
             def create_conf(**kwargs: Any) -> SparkConf:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -500,6 +500,10 @@ class SparkSession:
             # Configurations to be set if unset.
             default_conf = {"spark.plugins": "org.apache.spark.sql.connect.SparkConnectPlugin"}
 
+            if "SPARK_TESTING" in os.environ:
+                # TODO: explain avaliable port.
+                overwrite_conf["spark.connect.grpc.binding.port"] = "0"
+
             def create_conf(**kwargs: Any) -> SparkConf:
                 conf = SparkConf(**kwargs)
                 for k, v in overwrite_conf.items():


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use an available ephemeral port for Spark Connect server in testing by using `0` to server, and the actual local port in client side.

### Why are the changes needed?

To allow parallel testing that we have in `./python/run-tests`.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

```bash
./python/run-tests --module pyspark-connect
```