### PR TITLE
[SPARK-42268][CONNECT][PYTHON] Add UserDefinedType in protos

### DIFF
--- a/connector/connect/common/src/main/protobuf/spark/connect/types.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/types.proto
@@ -61,6 +61,9 @@ message DataType {
     Array array = 20;
     Struct struct = 21;
     Map map = 22;
+
+    // UserDefinedType
+    UDT udt = 23;
   }
 
   message Boolean {
@@ -171,5 +174,13 @@ message DataType {
     DataType value_type = 2;
     bool value_contains_null = 3;
     uint32 type_variation_reference = 4;
+  }
+
+  message UDT {
+    string type = 1;
+    optional string jvm_class = 2;
+    optional string python_class = 3;
+    optional string serialized_python_class = 4;
+    DataType sql_type = 5;
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
@@ -22,6 +22,7 @@ import scala.collection.convert.ImplicitConversions._
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 /**
  * This object offers methods to convert to/from connect proto to catalyst types.
@@ -61,6 +62,9 @@ object DataTypeProtoConverter {
       case proto.DataType.KindCase.ARRAY => toCatalystArrayType(t.getArray)
       case proto.DataType.KindCase.STRUCT => toCatalystStructType(t.getStruct)
       case proto.DataType.KindCase.MAP => toCatalystMapType(t.getMap)
+
+      case proto.DataType.KindCase.UDT => toCatalystUDT(t.getUdt)
+
       case _ =>
         throw InvalidPlanInput(s"Does not support convert ${t.getKindCase} to catalyst types.")
     }
@@ -112,6 +116,31 @@ object DataTypeProtoConverter {
 
   private def toCatalystMapType(t: proto.DataType.Map): MapType = {
     MapType(toCatalystType(t.getKeyType), toCatalystType(t.getValueType), t.getValueContainsNull)
+  }
+
+  private def toCatalystUDT(t: proto.DataType.UDT): UserDefinedType[_] = {
+    if (t.getType != "udf") {
+      throw InvalidPlanInput(
+        s"""UserDefinedType requires the 'type' field to be 'udf', but got '${t.getType}'.""")
+    }
+
+    if (t.hasJvmClass) {
+      Utils
+        .classForName[UserDefinedType[_]](t.getJvmClass)
+        .getConstructor()
+        .newInstance()
+    } else {
+      if (!t.hasPythonClass || !t.hasSerializedPythonClass || !t.hasSqlType) {
+        throw InvalidPlanInput(
+          "PythonUserDefinedType requires all the three fields: " +
+            "python_class, serialized_python_class and sql_type.")
+      }
+
+      new PythonUserDefinedType(
+        sqlType = toCatalystType(t.getSqlType),
+        pyUDT = t.getPythonClass,
+        serializedPyClass = t.getSerializedPythonClass)
+    }
   }
 
   def toConnectProtoType(t: DataType): proto.DataType = {
@@ -295,6 +324,36 @@ object DataTypeProtoConverter {
               .setValueType(toConnectProtoType(valueType))
               .setValueContainsNull(valueContainsNull)
               .build())
+          .build()
+
+      case pyudt: PythonUserDefinedType =>
+        // Python UDT
+        proto.DataType
+          .newBuilder()
+          .setUdt(
+            proto.DataType.UDT
+              .newBuilder()
+              .setType("udt")
+              .setPythonClass(pyudt.pyUDT)
+              .setSqlType(toConnectProtoType(pyudt.sqlType))
+              .build())
+          .build()
+
+      case udt: UserDefinedType[_] =>
+        // Scala/Java UDT
+        val builder = proto.DataType.UDT.newBuilder()
+        builder
+          .setType("udt")
+          .setJvmClass(udt.getClass.getName)
+          .setSqlType(toConnectProtoType(udt.sqlType))
+
+        if (udt.pyUDT != null) {
+          builder.setPythonClass(udt.pyUDT)
+        }
+
+        proto.DataType
+          .newBuilder()
+          .setUdt(builder.build())
           .build()
 
       case _ =>

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/DataTypeProtoConverter.scala
@@ -119,9 +119,9 @@ object DataTypeProtoConverter {
   }
 
   private def toCatalystUDT(t: proto.DataType.UDT): UserDefinedType[_] = {
-    if (t.getType != "udf") {
+    if (t.getType != "udt") {
       throw InvalidPlanInput(
-        s"""UserDefinedType requires the 'type' field to be 'udf', but got '${t.getType}'.""")
+        s"""UserDefinedType requires the 'type' field to be 'udt', but got '${t.getType}'.""")
     }
 
     if (t.hasJvmClass) {

--- a/python/pyspark/sql/connect/proto/types_pb2.py
+++ b/python/pyspark/sql/connect/proto/types_pb2.py
@@ -30,7 +30,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x19spark/connect/types.proto\x12\rspark.connect"\x8e\x1d\n\x08\x44\x61taType\x12\x32\n\x04null\x18\x01 \x01(\x0b\x32\x1c.spark.connect.DataType.NULLH\x00R\x04null\x12\x38\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x1e.spark.connect.DataType.BinaryH\x00R\x06\x62inary\x12;\n\x07\x62oolean\x18\x03 \x01(\x0b\x32\x1f.spark.connect.DataType.BooleanH\x00R\x07\x62oolean\x12\x32\n\x04\x62yte\x18\x04 \x01(\x0b\x32\x1c.spark.connect.DataType.ByteH\x00R\x04\x62yte\x12\x35\n\x05short\x18\x05 \x01(\x0b\x32\x1d.spark.connect.DataType.ShortH\x00R\x05short\x12;\n\x07integer\x18\x06 \x01(\x0b\x32\x1f.spark.connect.DataType.IntegerH\x00R\x07integer\x12\x32\n\x04long\x18\x07 \x01(\x0b\x32\x1c.spark.connect.DataType.LongH\x00R\x04long\x12\x35\n\x05\x66loat\x18\x08 \x01(\x0b\x32\x1d.spark.connect.DataType.FloatH\x00R\x05\x66loat\x12\x38\n\x06\x64ouble\x18\t \x01(\x0b\x32\x1e.spark.connect.DataType.DoubleH\x00R\x06\x64ouble\x12;\n\x07\x64\x65\x63imal\x18\n \x01(\x0b\x32\x1f.spark.connect.DataType.DecimalH\x00R\x07\x64\x65\x63imal\x12\x38\n\x06string\x18\x0b \x01(\x0b\x32\x1e.spark.connect.DataType.StringH\x00R\x06string\x12\x32\n\x04\x63har\x18\x0c \x01(\x0b\x32\x1c.spark.connect.DataType.CharH\x00R\x04\x63har\x12<\n\x08var_char\x18\r \x01(\x0b\x32\x1f.spark.connect.DataType.VarCharH\x00R\x07varChar\x12\x32\n\x04\x64\x61te\x18\x0e \x01(\x0b\x32\x1c.spark.connect.DataType.DateH\x00R\x04\x64\x61te\x12\x41\n\ttimestamp\x18\x0f \x01(\x0b\x32!.spark.connect.DataType.TimestampH\x00R\ttimestamp\x12K\n\rtimestamp_ntz\x18\x10 \x01(\x0b\x32$.spark.connect.DataType.TimestampNTZH\x00R\x0ctimestampNtz\x12W\n\x11\x63\x61lendar_interval\x18\x11 \x01(\x0b\x32(.spark.connect.DataType.CalendarIntervalH\x00R\x10\x63\x61lendarInterval\x12[\n\x13year_month_interval\x18\x12 \x01(\x0b\x32).spark.connect.DataType.YearMonthIntervalH\x00R\x11yearMonthInterval\x12U\n\x11\x64\x61y_time_interval\x18\x13 \x01(\x0b\x32\'.spark.connect.DataType.DayTimeIntervalH\x00R\x0f\x64\x61yTimeInterval\x12\x35\n\x05\x61rray\x18\x14 \x01(\x0b\x32\x1d.spark.connect.DataType.ArrayH\x00R\x05\x61rray\x12\x38\n\x06struct\x18\x15 \x01(\x0b\x32\x1e.spark.connect.DataType.StructH\x00R\x06struct\x12/\n\x03map\x18\x16 \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x03map\x1a\x43\n\x07\x42oolean\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x42yte\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x41\n\x05Short\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x43\n\x07Integer\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04Long\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x41\n\x05\x46loat\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x44ouble\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06String\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x42inary\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04NULL\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x45\n\tTimestamp\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x44\x61te\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aH\n\x0cTimestampNTZ\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aL\n\x10\x43\x61lendarInterval\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\xb3\x01\n\x11YearMonthInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1a\xb1\x01\n\x0f\x44\x61yTimeInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1aX\n\x04\x43har\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a[\n\x07VarChar\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\x99\x01\n\x07\x44\x65\x63imal\x12\x19\n\x05scale\x18\x01 \x01(\x05H\x00R\x05scale\x88\x01\x01\x12!\n\tprecision\x18\x02 \x01(\x05H\x01R\tprecision\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x08\n\x06_scaleB\x0c\n\n_precision\x1a\xa1\x01\n\x0bStructField\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x34\n\tdata_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x08\x64\x61taType\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\x12\x1f\n\x08metadata\x18\x04 \x01(\tH\x00R\x08metadata\x88\x01\x01\x42\x0b\n\t_metadata\x1a\x7f\n\x06Struct\x12;\n\x06\x66ields\x18\x01 \x03(\x0b\x32#.spark.connect.DataType.StructFieldR\x06\x66ields\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\xa2\x01\n\x05\x41rray\x12:\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x0b\x65lementType\x12#\n\rcontains_null\x18\x02 \x01(\x08R\x0c\x63ontainsNull\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReference\x1a\xdb\x01\n\x03Map\x12\x32\n\x08key_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x07keyType\x12\x36\n\nvalue_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\tvalueType\x12.\n\x13value_contains_null\x18\x03 \x01(\x08R\x11valueContainsNull\x12\x38\n\x18type_variation_reference\x18\x04 \x01(\rR\x16typeVariationReferenceB\x06\n\x04kindB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
+    b'\n\x19spark/connect/types.proto\x12\rspark.connect"\xd1\x1f\n\x08\x44\x61taType\x12\x32\n\x04null\x18\x01 \x01(\x0b\x32\x1c.spark.connect.DataType.NULLH\x00R\x04null\x12\x38\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x1e.spark.connect.DataType.BinaryH\x00R\x06\x62inary\x12;\n\x07\x62oolean\x18\x03 \x01(\x0b\x32\x1f.spark.connect.DataType.BooleanH\x00R\x07\x62oolean\x12\x32\n\x04\x62yte\x18\x04 \x01(\x0b\x32\x1c.spark.connect.DataType.ByteH\x00R\x04\x62yte\x12\x35\n\x05short\x18\x05 \x01(\x0b\x32\x1d.spark.connect.DataType.ShortH\x00R\x05short\x12;\n\x07integer\x18\x06 \x01(\x0b\x32\x1f.spark.connect.DataType.IntegerH\x00R\x07integer\x12\x32\n\x04long\x18\x07 \x01(\x0b\x32\x1c.spark.connect.DataType.LongH\x00R\x04long\x12\x35\n\x05\x66loat\x18\x08 \x01(\x0b\x32\x1d.spark.connect.DataType.FloatH\x00R\x05\x66loat\x12\x38\n\x06\x64ouble\x18\t \x01(\x0b\x32\x1e.spark.connect.DataType.DoubleH\x00R\x06\x64ouble\x12;\n\x07\x64\x65\x63imal\x18\n \x01(\x0b\x32\x1f.spark.connect.DataType.DecimalH\x00R\x07\x64\x65\x63imal\x12\x38\n\x06string\x18\x0b \x01(\x0b\x32\x1e.spark.connect.DataType.StringH\x00R\x06string\x12\x32\n\x04\x63har\x18\x0c \x01(\x0b\x32\x1c.spark.connect.DataType.CharH\x00R\x04\x63har\x12<\n\x08var_char\x18\r \x01(\x0b\x32\x1f.spark.connect.DataType.VarCharH\x00R\x07varChar\x12\x32\n\x04\x64\x61te\x18\x0e \x01(\x0b\x32\x1c.spark.connect.DataType.DateH\x00R\x04\x64\x61te\x12\x41\n\ttimestamp\x18\x0f \x01(\x0b\x32!.spark.connect.DataType.TimestampH\x00R\ttimestamp\x12K\n\rtimestamp_ntz\x18\x10 \x01(\x0b\x32$.spark.connect.DataType.TimestampNTZH\x00R\x0ctimestampNtz\x12W\n\x11\x63\x61lendar_interval\x18\x11 \x01(\x0b\x32(.spark.connect.DataType.CalendarIntervalH\x00R\x10\x63\x61lendarInterval\x12[\n\x13year_month_interval\x18\x12 \x01(\x0b\x32).spark.connect.DataType.YearMonthIntervalH\x00R\x11yearMonthInterval\x12U\n\x11\x64\x61y_time_interval\x18\x13 \x01(\x0b\x32\'.spark.connect.DataType.DayTimeIntervalH\x00R\x0f\x64\x61yTimeInterval\x12\x35\n\x05\x61rray\x18\x14 \x01(\x0b\x32\x1d.spark.connect.DataType.ArrayH\x00R\x05\x61rray\x12\x38\n\x06struct\x18\x15 \x01(\x0b\x32\x1e.spark.connect.DataType.StructH\x00R\x06struct\x12/\n\x03map\x18\x16 \x01(\x0b\x32\x1b.spark.connect.DataType.MapH\x00R\x03map\x12/\n\x03udt\x18\x17 \x01(\x0b\x32\x1b.spark.connect.DataType.UDTH\x00R\x03udt\x1a\x43\n\x07\x42oolean\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x42yte\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x41\n\x05Short\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x43\n\x07Integer\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04Long\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x41\n\x05\x46loat\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x44ouble\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06String\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x42\n\x06\x42inary\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04NULL\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\x45\n\tTimestamp\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a@\n\x04\x44\x61te\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aH\n\x0cTimestampNTZ\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1aL\n\x10\x43\x61lendarInterval\x12\x38\n\x18type_variation_reference\x18\x01 \x01(\rR\x16typeVariationReference\x1a\xb3\x01\n\x11YearMonthInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1a\xb1\x01\n\x0f\x44\x61yTimeInterval\x12$\n\x0bstart_field\x18\x01 \x01(\x05H\x00R\nstartField\x88\x01\x01\x12 \n\tend_field\x18\x02 \x01(\x05H\x01R\x08\x65ndField\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x0e\n\x0c_start_fieldB\x0c\n\n_end_field\x1aX\n\x04\x43har\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a[\n\x07VarChar\x12\x16\n\x06length\x18\x01 \x01(\x05R\x06length\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\x99\x01\n\x07\x44\x65\x63imal\x12\x19\n\x05scale\x18\x01 \x01(\x05H\x00R\x05scale\x88\x01\x01\x12!\n\tprecision\x18\x02 \x01(\x05H\x01R\tprecision\x88\x01\x01\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReferenceB\x08\n\x06_scaleB\x0c\n\n_precision\x1a\xa1\x01\n\x0bStructField\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x34\n\tdata_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x08\x64\x61taType\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\x12\x1f\n\x08metadata\x18\x04 \x01(\tH\x00R\x08metadata\x88\x01\x01\x42\x0b\n\t_metadata\x1a\x7f\n\x06Struct\x12;\n\x06\x66ields\x18\x01 \x03(\x0b\x32#.spark.connect.DataType.StructFieldR\x06\x66ields\x12\x38\n\x18type_variation_reference\x18\x02 \x01(\rR\x16typeVariationReference\x1a\xa2\x01\n\x05\x41rray\x12:\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x0b\x65lementType\x12#\n\rcontains_null\x18\x02 \x01(\x08R\x0c\x63ontainsNull\x12\x38\n\x18type_variation_reference\x18\x03 \x01(\rR\x16typeVariationReference\x1a\xdb\x01\n\x03Map\x12\x32\n\x08key_type\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x07keyType\x12\x36\n\nvalue_type\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\tvalueType\x12.\n\x13value_contains_null\x18\x03 \x01(\x08R\x11valueContainsNull\x12\x38\n\x18type_variation_reference\x18\x04 \x01(\rR\x16typeVariationReference\x1a\x8f\x02\n\x03UDT\x12\x12\n\x04type\x18\x01 \x01(\tR\x04type\x12 \n\tjvm_class\x18\x02 \x01(\tH\x00R\x08jvmClass\x88\x01\x01\x12&\n\x0cpython_class\x18\x03 \x01(\tH\x01R\x0bpythonClass\x88\x01\x01\x12;\n\x17serialized_python_class\x18\x04 \x01(\tH\x02R\x15serializedPythonClass\x88\x01\x01\x12\x32\n\x08sql_type\x18\x05 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x07sqlTypeB\x0c\n\n_jvm_classB\x0f\n\r_python_classB\x1a\n\x18_serialized_python_classB\x06\n\x04kindB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
 )
 
 
@@ -58,6 +58,7 @@ _DATATYPE_STRUCTFIELD = _DATATYPE.nested_types_by_name["StructField"]
 _DATATYPE_STRUCT = _DATATYPE.nested_types_by_name["Struct"]
 _DATATYPE_ARRAY = _DATATYPE.nested_types_by_name["Array"]
 _DATATYPE_MAP = _DATATYPE.nested_types_by_name["Map"]
+_DATATYPE_UDT = _DATATYPE.nested_types_by_name["UDT"]
 DataType = _reflection.GeneratedProtocolMessageType(
     "DataType",
     (_message.Message,),
@@ -269,6 +270,15 @@ DataType = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.DataType.Map)
             },
         ),
+        "UDT": _reflection.GeneratedProtocolMessageType(
+            "UDT",
+            (_message.Message,),
+            {
+                "DESCRIPTOR": _DATATYPE_UDT,
+                "__module__": "spark.connect.types_pb2"
+                # @@protoc_insertion_point(class_scope:spark.connect.DataType.UDT)
+            },
+        ),
         "DESCRIPTOR": _DATATYPE,
         "__module__": "spark.connect.types_pb2"
         # @@protoc_insertion_point(class_scope:spark.connect.DataType)
@@ -298,57 +308,60 @@ _sym_db.RegisterMessage(DataType.StructField)
 _sym_db.RegisterMessage(DataType.Struct)
 _sym_db.RegisterMessage(DataType.Array)
 _sym_db.RegisterMessage(DataType.Map)
+_sym_db.RegisterMessage(DataType.UDT)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b"\n\036org.apache.spark.connect.protoP\001"
     _DATATYPE._serialized_start = 45
-    _DATATYPE._serialized_end = 3771
-    _DATATYPE_BOOLEAN._serialized_start = 1421
-    _DATATYPE_BOOLEAN._serialized_end = 1488
-    _DATATYPE_BYTE._serialized_start = 1490
-    _DATATYPE_BYTE._serialized_end = 1554
-    _DATATYPE_SHORT._serialized_start = 1556
-    _DATATYPE_SHORT._serialized_end = 1621
-    _DATATYPE_INTEGER._serialized_start = 1623
-    _DATATYPE_INTEGER._serialized_end = 1690
-    _DATATYPE_LONG._serialized_start = 1692
-    _DATATYPE_LONG._serialized_end = 1756
-    _DATATYPE_FLOAT._serialized_start = 1758
-    _DATATYPE_FLOAT._serialized_end = 1823
-    _DATATYPE_DOUBLE._serialized_start = 1825
-    _DATATYPE_DOUBLE._serialized_end = 1891
-    _DATATYPE_STRING._serialized_start = 1893
-    _DATATYPE_STRING._serialized_end = 1959
-    _DATATYPE_BINARY._serialized_start = 1961
-    _DATATYPE_BINARY._serialized_end = 2027
-    _DATATYPE_NULL._serialized_start = 2029
-    _DATATYPE_NULL._serialized_end = 2093
-    _DATATYPE_TIMESTAMP._serialized_start = 2095
-    _DATATYPE_TIMESTAMP._serialized_end = 2164
-    _DATATYPE_DATE._serialized_start = 2166
-    _DATATYPE_DATE._serialized_end = 2230
-    _DATATYPE_TIMESTAMPNTZ._serialized_start = 2232
-    _DATATYPE_TIMESTAMPNTZ._serialized_end = 2304
-    _DATATYPE_CALENDARINTERVAL._serialized_start = 2306
-    _DATATYPE_CALENDARINTERVAL._serialized_end = 2382
-    _DATATYPE_YEARMONTHINTERVAL._serialized_start = 2385
-    _DATATYPE_YEARMONTHINTERVAL._serialized_end = 2564
-    _DATATYPE_DAYTIMEINTERVAL._serialized_start = 2567
-    _DATATYPE_DAYTIMEINTERVAL._serialized_end = 2744
-    _DATATYPE_CHAR._serialized_start = 2746
-    _DATATYPE_CHAR._serialized_end = 2834
-    _DATATYPE_VARCHAR._serialized_start = 2836
-    _DATATYPE_VARCHAR._serialized_end = 2927
-    _DATATYPE_DECIMAL._serialized_start = 2930
-    _DATATYPE_DECIMAL._serialized_end = 3083
-    _DATATYPE_STRUCTFIELD._serialized_start = 3086
-    _DATATYPE_STRUCTFIELD._serialized_end = 3247
-    _DATATYPE_STRUCT._serialized_start = 3249
-    _DATATYPE_STRUCT._serialized_end = 3376
-    _DATATYPE_ARRAY._serialized_start = 3379
-    _DATATYPE_ARRAY._serialized_end = 3541
-    _DATATYPE_MAP._serialized_start = 3544
-    _DATATYPE_MAP._serialized_end = 3763
+    _DATATYPE._serialized_end = 4094
+    _DATATYPE_BOOLEAN._serialized_start = 1470
+    _DATATYPE_BOOLEAN._serialized_end = 1537
+    _DATATYPE_BYTE._serialized_start = 1539
+    _DATATYPE_BYTE._serialized_end = 1603
+    _DATATYPE_SHORT._serialized_start = 1605
+    _DATATYPE_SHORT._serialized_end = 1670
+    _DATATYPE_INTEGER._serialized_start = 1672
+    _DATATYPE_INTEGER._serialized_end = 1739
+    _DATATYPE_LONG._serialized_start = 1741
+    _DATATYPE_LONG._serialized_end = 1805
+    _DATATYPE_FLOAT._serialized_start = 1807
+    _DATATYPE_FLOAT._serialized_end = 1872
+    _DATATYPE_DOUBLE._serialized_start = 1874
+    _DATATYPE_DOUBLE._serialized_end = 1940
+    _DATATYPE_STRING._serialized_start = 1942
+    _DATATYPE_STRING._serialized_end = 2008
+    _DATATYPE_BINARY._serialized_start = 2010
+    _DATATYPE_BINARY._serialized_end = 2076
+    _DATATYPE_NULL._serialized_start = 2078
+    _DATATYPE_NULL._serialized_end = 2142
+    _DATATYPE_TIMESTAMP._serialized_start = 2144
+    _DATATYPE_TIMESTAMP._serialized_end = 2213
+    _DATATYPE_DATE._serialized_start = 2215
+    _DATATYPE_DATE._serialized_end = 2279
+    _DATATYPE_TIMESTAMPNTZ._serialized_start = 2281
+    _DATATYPE_TIMESTAMPNTZ._serialized_end = 2353
+    _DATATYPE_CALENDARINTERVAL._serialized_start = 2355
+    _DATATYPE_CALENDARINTERVAL._serialized_end = 2431
+    _DATATYPE_YEARMONTHINTERVAL._serialized_start = 2434
+    _DATATYPE_YEARMONTHINTERVAL._serialized_end = 2613
+    _DATATYPE_DAYTIMEINTERVAL._serialized_start = 2616
+    _DATATYPE_DAYTIMEINTERVAL._serialized_end = 2793
+    _DATATYPE_CHAR._serialized_start = 2795
+    _DATATYPE_CHAR._serialized_end = 2883
+    _DATATYPE_VARCHAR._serialized_start = 2885
+    _DATATYPE_VARCHAR._serialized_end = 2976
+    _DATATYPE_DECIMAL._serialized_start = 2979
+    _DATATYPE_DECIMAL._serialized_end = 3132
+    _DATATYPE_STRUCTFIELD._serialized_start = 3135
+    _DATATYPE_STRUCTFIELD._serialized_end = 3296
+    _DATATYPE_STRUCT._serialized_start = 3298
+    _DATATYPE_STRUCT._serialized_end = 3425
+    _DATATYPE_ARRAY._serialized_start = 3428
+    _DATATYPE_ARRAY._serialized_end = 3590
+    _DATATYPE_MAP._serialized_start = 3593
+    _DATATYPE_MAP._serialized_end = 3812
+    _DATATYPE_UDT._serialized_start = 3815
+    _DATATYPE_UDT._serialized_end = 4086
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/types_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/types_pb2.pyi
@@ -637,6 +637,85 @@ class DataType(google.protobuf.message.Message):
             ],
         ) -> None: ...
 
+    class UDT(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        TYPE_FIELD_NUMBER: builtins.int
+        JVM_CLASS_FIELD_NUMBER: builtins.int
+        PYTHON_CLASS_FIELD_NUMBER: builtins.int
+        SERIALIZED_PYTHON_CLASS_FIELD_NUMBER: builtins.int
+        SQL_TYPE_FIELD_NUMBER: builtins.int
+        type: builtins.str
+        jvm_class: builtins.str
+        python_class: builtins.str
+        serialized_python_class: builtins.str
+        @property
+        def sql_type(self) -> global___DataType: ...
+        def __init__(
+            self,
+            *,
+            type: builtins.str = ...,
+            jvm_class: builtins.str | None = ...,
+            python_class: builtins.str | None = ...,
+            serialized_python_class: builtins.str | None = ...,
+            sql_type: global___DataType | None = ...,
+        ) -> None: ...
+        def HasField(
+            self,
+            field_name: typing_extensions.Literal[
+                "_jvm_class",
+                b"_jvm_class",
+                "_python_class",
+                b"_python_class",
+                "_serialized_python_class",
+                b"_serialized_python_class",
+                "jvm_class",
+                b"jvm_class",
+                "python_class",
+                b"python_class",
+                "serialized_python_class",
+                b"serialized_python_class",
+                "sql_type",
+                b"sql_type",
+            ],
+        ) -> builtins.bool: ...
+        def ClearField(
+            self,
+            field_name: typing_extensions.Literal[
+                "_jvm_class",
+                b"_jvm_class",
+                "_python_class",
+                b"_python_class",
+                "_serialized_python_class",
+                b"_serialized_python_class",
+                "jvm_class",
+                b"jvm_class",
+                "python_class",
+                b"python_class",
+                "serialized_python_class",
+                b"serialized_python_class",
+                "sql_type",
+                b"sql_type",
+                "type",
+                b"type",
+            ],
+        ) -> None: ...
+        @typing.overload
+        def WhichOneof(
+            self, oneof_group: typing_extensions.Literal["_jvm_class", b"_jvm_class"]
+        ) -> typing_extensions.Literal["jvm_class"] | None: ...
+        @typing.overload
+        def WhichOneof(
+            self, oneof_group: typing_extensions.Literal["_python_class", b"_python_class"]
+        ) -> typing_extensions.Literal["python_class"] | None: ...
+        @typing.overload
+        def WhichOneof(
+            self,
+            oneof_group: typing_extensions.Literal[
+                "_serialized_python_class", b"_serialized_python_class"
+            ],
+        ) -> typing_extensions.Literal["serialized_python_class"] | None: ...
+
     NULL_FIELD_NUMBER: builtins.int
     BINARY_FIELD_NUMBER: builtins.int
     BOOLEAN_FIELD_NUMBER: builtins.int
@@ -659,6 +738,7 @@ class DataType(google.protobuf.message.Message):
     ARRAY_FIELD_NUMBER: builtins.int
     STRUCT_FIELD_NUMBER: builtins.int
     MAP_FIELD_NUMBER: builtins.int
+    UDT_FIELD_NUMBER: builtins.int
     @property
     def null(self) -> global___DataType.NULL: ...
     @property
@@ -708,6 +788,9 @@ class DataType(google.protobuf.message.Message):
     def struct(self) -> global___DataType.Struct: ...
     @property
     def map(self) -> global___DataType.Map: ...
+    @property
+    def udt(self) -> global___DataType.UDT:
+        """UserDefinedType"""
     def __init__(
         self,
         *,
@@ -733,6 +816,7 @@ class DataType(google.protobuf.message.Message):
         array: global___DataType.Array | None = ...,
         struct: global___DataType.Struct | None = ...,
         map: global___DataType.Map | None = ...,
+        udt: global___DataType.UDT | None = ...,
     ) -> None: ...
     def HasField(
         self,
@@ -779,6 +863,8 @@ class DataType(google.protobuf.message.Message):
             b"timestamp",
             "timestamp_ntz",
             b"timestamp_ntz",
+            "udt",
+            b"udt",
             "var_char",
             b"var_char",
             "year_month_interval",
@@ -830,6 +916,8 @@ class DataType(google.protobuf.message.Message):
             b"timestamp",
             "timestamp_ntz",
             b"timestamp_ntz",
+            "udt",
+            b"udt",
             "var_char",
             b"var_char",
             "year_month_interval",
@@ -861,6 +949,7 @@ class DataType(google.protobuf.message.Message):
         "array",
         "struct",
         "map",
+        "udt",
     ] | None: ...
 
 global___DataType = DataType

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -201,7 +201,7 @@ def proto_schema_to_pyspark_data_type(schema: pb2.DataType) -> DataType:
         json_value = {}
         if schema.udt.HasField("python_class"):
             json_value["pyClass"] = schema.udt.python_class
-        if schema.udt.HasField("python_class"):
+        if schema.udt.HasField("serialized_python_class"):
             json_value["serializedClass"] = schema.udt.serialized_python_class
         return UserDefinedType.fromJson(json_value)
     else:

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -44,6 +44,7 @@ from pyspark.sql.types import (
     BinaryType,
     BooleanType,
     NullType,
+    UserDefinedType,
 )
 
 import pyspark.sql.connect.proto as pb2
@@ -108,6 +109,17 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
     elif isinstance(data_type, ArrayType):
         ret.array.element_type.CopyFrom(pyspark_types_to_proto_types(data_type.elementType))
         ret.array.contains_null = data_type.containsNull
+    elif isinstance(data_type, UserDefinedType):
+        json_value = data_type.jsonValue()
+        ret.udt.type = "udt"
+        if "class" in json_value:
+            # Scala/Java UDT
+            ret.udt.jvm_class = json_value["class"]
+        else:
+            # Python UDT
+            ret.udt.serialized_python_class = json_value["serializedClass"]
+        ret.udt.python_class = json_value["pyClass"]
+        ret.udt.sql_type.CopyFrom(pyspark_types_to_proto_types(data_type.sqlType()))
     else:
         raise Exception(f"Unsupported data type {data_type}")
     return ret
@@ -184,6 +196,14 @@ def proto_schema_to_pyspark_data_type(schema: pb2.DataType) -> DataType:
             proto_schema_to_pyspark_data_type(schema.map.value_type),
             schema.map.value_contains_null,
         )
+    elif schema.HasField("udt"):
+        assert schema.udt.type == "udt"
+        json_value = {}
+        if schema.udt.HasField("python_class"):
+            json_value["pyClass"] = schema.udt.python_class
+        if schema.udt.HasField("python_class"):
+            json_value["serializedClass"] = schema.udt.serialized_python_class
+        return UserDefinedType.fromJson(json_value)
     else:
         raise Exception(f"Unsupported data type {schema}")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add UserDefinedType in protos, after this PR, `df.schema` will support UDT

note: UDT is still not supported in `df.collect` and `session.createDataFrame`, it needs changes in `ArrowConverters`

### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
added tests
