### PR TITLE
[SPARK-42270][SQL] Improve sort merge join stability with large stream side

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2131,6 +2131,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val SORT_MERGE_JOIN_BATCH_SIZE =
+    buildConf("spark.sql.codegen.join.sortMergeJoinBatchSize")
+      .internal()
+      .doc("The buffered side batch size in SortMergeJoin")
+      .version("3.5.0")
+      .intConf
+      .createWithDefault(65535)
+
   val MAX_NESTED_VIEW_DEPTH =
     buildConf("spark.sql.view.maxNestedViewDepth")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Sort merge join may oom when right match rows are very large.

### Why are the changes needed?

Improve the stability for SortMergeJoin


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Exists UT
