### PR TITLE
[SPARK-42273][CONNECT][TESTS] Skip Spark Connect tests if dependencies are not installed

### DIFF
--- a/python/pyspark/sql/connect/__init__.py
+++ b/python/pyspark/sql/connect/__init__.py
@@ -26,7 +26,7 @@ from pyspark.sql.pandas.utils import (
 )
 
 
-def check_dependencies(mod_name, file_name):
+def check_dependencies(mod_name: str, file_name: str) -> None:
     if mod_name == "__main__":
         from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 

--- a/python/pyspark/sql/connect/__init__.py
+++ b/python/pyspark/sql/connect/__init__.py
@@ -17,14 +17,26 @@
 
 """Currently Spark Connect is very experimental and the APIs to interact with
 Spark through this API are can be changed at any time without warning."""
+import sys
 
-from pyspark.sql.connect.dataframe import DataFrame  # noqa: F401
 from pyspark.sql.pandas.utils import (
     require_minimum_pandas_version,
     require_minimum_pyarrow_version,
     require_minimum_grpc_version,
 )
 
-require_minimum_pandas_version()
-require_minimum_pyarrow_version()
-require_minimum_grpc_version()
+
+def check_dependencies(mod_name, file_name):
+    if mod_name == "__main__":
+        from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+        if not should_test_connect:
+            print(
+                f"Skipping {file_name} doctests: {connect_requirement_message}",
+                file=sys.stderr,
+            )
+            sys.exit(0)
+    else:
+        require_minimum_pandas_version()
+        require_minimum_pyarrow_version()
+        require_minimum_grpc_version()

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -14,12 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
+
 from typing import Any, List, Optional, TYPE_CHECKING
 
 import pandas as pd
 
 from pyspark.sql.types import StructType
-from pyspark.sql.connect import DataFrame
+from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.catalog import (
     Catalog as PySparkCatalog,
     CatalogMetadata,
@@ -327,43 +331,31 @@ def _test() -> None:
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
-    from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+    import pyspark.sql.connect.catalog
 
-    os.chdir(os.environ["SPARK_HOME"])
+    globs = pyspark.sql.connect.catalog.__dict__.copy()
+    globs["spark"] = (
+        PySparkSession.builder.appName("sql.connect.catalog tests").remote("local[4]").getOrCreate()
+    )
 
-    if should_test_connect:
-        import pyspark.sql.connect.catalog
+    # TODO(SPARK-41612): Support Catalog.isCached
+    # TODO(SPARK-41600): Support Catalog.cacheTable
+    del pyspark.sql.connect.catalog.Catalog.clearCache.__doc__
+    del pyspark.sql.connect.catalog.Catalog.refreshTable.__doc__
+    del pyspark.sql.connect.catalog.Catalog.refreshByPath.__doc__
+    del pyspark.sql.connect.catalog.Catalog.recoverPartitions.__doc__
 
-        globs = pyspark.sql.connect.catalog.__dict__.copy()
-        globs["spark"] = (
-            PySparkSession.builder.appName("sql.connect.catalog tests")
-            .remote("local[4]")
-            .getOrCreate()
-        )
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.connect.catalog,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS
+        | doctest.NORMALIZE_WHITESPACE
+        | doctest.IGNORE_EXCEPTION_DETAIL,
+    )
+    globs["spark"].stop()
 
-        # TODO(SPARK-41612): Support Catalog.isCached
-        # TODO(SPARK-41600): Support Catalog.cacheTable
-        del pyspark.sql.connect.catalog.Catalog.clearCache.__doc__
-        del pyspark.sql.connect.catalog.Catalog.refreshTable.__doc__
-        del pyspark.sql.connect.catalog.Catalog.refreshByPath.__doc__
-        del pyspark.sql.connect.catalog.Catalog.recoverPartitions.__doc__
-
-        (failure_count, test_count) = doctest.testmod(
-            pyspark.sql.connect.catalog,
-            globs=globs,
-            optionflags=doctest.ELLIPSIS
-            | doctest.NORMALIZE_WHITESPACE
-            | doctest.IGNORE_EXCEPTION_DETAIL,
-        )
-        globs["spark"].stop()
-
-        if failure_count:
-            sys.exit(-1)
-    else:
-        print(
-            f"Skipping pyspark.sql.connect.catalog doctests: {connect_requirement_message}",
-            file=sys.stderr,
-        )
+    if failure_count:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -327,7 +327,6 @@ Catalog.__doc__ = PySparkCatalog.__doc__
 
 
 def _test() -> None:
-    import os
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -14,6 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+__all__ = [
+    "ChannelBuilder",
+    "SparkConnectClient",
+]
+
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
+
 import logging
 import os
 import random
@@ -839,9 +848,3 @@ class Retrying:
                 time.sleep(backoff / 1000.0)
 
             yield AttemptManager(self._can_retry, retry_state)
-
-
-__all__ = [
-    "ChannelBuilder",
-    "SparkConnectClient",
-]

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -424,7 +424,6 @@ Column.__doc__ = PySparkColumn.__doc__
 
 
 def _test() -> None:
-    import os
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 import datetime
 import decimal
@@ -425,37 +428,25 @@ def _test() -> None:
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
-    from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+    import pyspark.sql.connect.column
 
-    os.chdir(os.environ["SPARK_HOME"])
+    globs = pyspark.sql.connect.column.__dict__.copy()
+    globs["spark"] = (
+        PySparkSession.builder.appName("sql.connect.column tests").remote("local[4]").getOrCreate()
+    )
 
-    if should_test_connect:
-        import pyspark.sql.connect.column
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.connect.column,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS
+        | doctest.NORMALIZE_WHITESPACE
+        | doctest.IGNORE_EXCEPTION_DETAIL,
+    )
 
-        globs = pyspark.sql.connect.column.__dict__.copy()
-        globs["spark"] = (
-            PySparkSession.builder.appName("sql.connect.column tests")
-            .remote("local[4]")
-            .getOrCreate()
-        )
+    globs["spark"].stop()
 
-        (failure_count, test_count) = doctest.testmod(
-            pyspark.sql.connect.column,
-            globs=globs,
-            optionflags=doctest.ELLIPSIS
-            | doctest.NORMALIZE_WHITESPACE
-            | doctest.IGNORE_EXCEPTION_DETAIL,
-        )
-
-        globs["spark"].stop()
-
-        if failure_count:
-            sys.exit(-1)
-    else:
-        print(
-            f"Skipping pyspark.sql.connect.column doctests: {connect_requirement_message}",
-            file=sys.stderr,
-        )
+    if failure_count:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 import array
 import datetime

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 from typing import (
     TYPE_CHECKING,

--- a/python/pyspark/sql/connect/function_builder.py
+++ b/python/pyspark/sql/connect/function_builder.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 import functools
 from typing import TYPE_CHECKING, Optional, Any, Iterable, Union

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2458,7 +2458,6 @@ def pandas_udf(*args: Any, **kwargs: Any) -> None:
 
 
 def _test() -> None:
-    import os
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 import inspect
 import warnings
@@ -2459,52 +2462,42 @@ def _test() -> None:
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
-    from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+    import pyspark.sql.connect.functions
 
-    os.chdir(os.environ["SPARK_HOME"])
+    globs = pyspark.sql.connect.functions.__dict__.copy()
 
-    if should_test_connect:
-        import pyspark.sql.connect.functions
+    # Spark Connect does not support Spark Context but the test depends on that.
+    del pyspark.sql.connect.functions.monotonically_increasing_id.__doc__
 
-        globs = pyspark.sql.connect.functions.__dict__.copy()
+    # TODO(SPARK-41834): implement Dataframe.conf
+    del pyspark.sql.connect.functions.from_unixtime.__doc__
+    del pyspark.sql.connect.functions.timestamp_seconds.__doc__
+    del pyspark.sql.connect.functions.unix_timestamp.__doc__
 
-        # Spark Connect does not support Spark Context but the test depends on that.
-        del pyspark.sql.connect.functions.monotonically_increasing_id.__doc__
+    # TODO(SPARK-41812): Proper column names after join
+    del pyspark.sql.connect.functions.count_distinct.__doc__
 
-        # TODO(SPARK-41834): implement Dataframe.conf
-        del pyspark.sql.connect.functions.from_unixtime.__doc__
-        del pyspark.sql.connect.functions.timestamp_seconds.__doc__
-        del pyspark.sql.connect.functions.unix_timestamp.__doc__
+    # TODO(SPARK-41843): Implement SparkSession.udf
+    del pyspark.sql.connect.functions.call_udf.__doc__
 
-        # TODO(SPARK-41812): Proper column names after join
-        del pyspark.sql.connect.functions.count_distinct.__doc__
+    globs["spark"] = (
+        PySparkSession.builder.appName("sql.connect.functions tests")
+        .remote("local[4]")
+        .getOrCreate()
+    )
 
-        # TODO(SPARK-41843): Implement SparkSession.udf
-        del pyspark.sql.connect.functions.call_udf.__doc__
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.connect.functions,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS
+        | doctest.NORMALIZE_WHITESPACE
+        | doctest.IGNORE_EXCEPTION_DETAIL,
+    )
 
-        globs["spark"] = (
-            PySparkSession.builder.appName("sql.connect.functions tests")
-            .remote("local[4]")
-            .getOrCreate()
-        )
+    globs["spark"].stop()
 
-        (failure_count, test_count) = doctest.testmod(
-            pyspark.sql.connect.functions,
-            globs=globs,
-            optionflags=doctest.ELLIPSIS
-            | doctest.NORMALIZE_WHITESPACE
-            | doctest.IGNORE_EXCEPTION_DETAIL,
-        )
-
-        globs["spark"].stop()
-
-        if failure_count:
-            sys.exit(-1)
-    else:
-        print(
-            f"Skipping pyspark.sql.connect.functions doctests: {connect_requirement_message}",
-            file=sys.stderr,
-        )
+    if failure_count:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 from typing import (
     Any,
@@ -221,36 +224,24 @@ def _test() -> None:
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
-    from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+    import pyspark.sql.connect.group
 
-    os.chdir(os.environ["SPARK_HOME"])
+    globs = pyspark.sql.connect.group.__dict__.copy()
 
-    if should_test_connect:
-        import pyspark.sql.connect.group
+    globs["spark"] = (
+        PySparkSession.builder.appName("sql.connect.group tests").remote("local[4]").getOrCreate()
+    )
 
-        globs = pyspark.sql.connect.group.__dict__.copy()
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.connect.group,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF,
+    )
 
-        globs["spark"] = (
-            PySparkSession.builder.appName("sql.connect.group tests")
-            .remote("local[4]")
-            .getOrCreate()
-        )
+    globs["spark"].stop()
 
-        (failure_count, test_count) = doctest.testmod(
-            pyspark.sql.connect.group,
-            globs=globs,
-            optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF,
-        )
-
-        globs["spark"].stop()
-
-        if failure_count:
-            sys.exit(-1)
-    else:
-        print(
-            f"Skipping pyspark.sql.connect.group doctests: {connect_requirement_message}",
-            file=sys.stderr,
-        )
+    if failure_count:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -220,7 +220,6 @@ GroupedData.__doc__ = PySparkGroupedData.__doc__
 
 
 def _test() -> None:
-    import os
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 from typing import Any, List, Optional, Sequence, Union, cast, TYPE_CHECKING, Mapping, Dict
 import functools

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
 
+check_dependencies(__name__, __file__)
 
 from typing import Dict
 from typing import Optional, Union, List, overload, Tuple, cast, Any
@@ -606,48 +608,38 @@ def _test() -> None:
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
-    from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+    import pyspark.sql.connect.readwriter
 
-    os.chdir(os.environ["SPARK_HOME"])
+    globs = pyspark.sql.connect.readwriter.__dict__.copy()
 
-    if should_test_connect:
-        import pyspark.sql.connect.readwriter
+    # TODO(SPARK-41817): Support reading with schema
+    del pyspark.sql.connect.readwriter.DataFrameReader.option.__doc__
+    del pyspark.sql.connect.readwriter.DataFrameWriter.option.__doc__
+    del pyspark.sql.connect.readwriter.DataFrameWriter.bucketBy.__doc__
+    del pyspark.sql.connect.readwriter.DataFrameWriter.sortBy.__doc__
 
-        globs = pyspark.sql.connect.readwriter.__dict__.copy()
+    # TODO(SPARK-41818): Support saveAsTable
+    del pyspark.sql.connect.readwriter.DataFrameWriter.insertInto.__doc__
+    del pyspark.sql.connect.readwriter.DataFrameWriter.saveAsTable.__doc__
 
-        # TODO(SPARK-41817): Support reading with schema
-        del pyspark.sql.connect.readwriter.DataFrameReader.option.__doc__
-        del pyspark.sql.connect.readwriter.DataFrameWriter.option.__doc__
-        del pyspark.sql.connect.readwriter.DataFrameWriter.bucketBy.__doc__
-        del pyspark.sql.connect.readwriter.DataFrameWriter.sortBy.__doc__
+    globs["spark"] = (
+        PySparkSession.builder.appName("sql.connect.readwriter tests")
+        .remote("local[4]")
+        .getOrCreate()
+    )
 
-        # TODO(SPARK-41818): Support saveAsTable
-        del pyspark.sql.connect.readwriter.DataFrameWriter.insertInto.__doc__
-        del pyspark.sql.connect.readwriter.DataFrameWriter.saveAsTable.__doc__
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.connect.readwriter,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS
+        | doctest.NORMALIZE_WHITESPACE
+        | doctest.IGNORE_EXCEPTION_DETAIL,
+    )
 
-        globs["spark"] = (
-            PySparkSession.builder.appName("sql.connect.readwriter tests")
-            .remote("local[4]")
-            .getOrCreate()
-        )
+    globs["spark"].stop()
 
-        (failure_count, test_count) = doctest.testmod(
-            pyspark.sql.connect.readwriter,
-            globs=globs,
-            optionflags=doctest.ELLIPSIS
-            | doctest.NORMALIZE_WHITESPACE
-            | doctest.IGNORE_EXCEPTION_DETAIL,
-        )
-
-        globs["spark"].stop()
-
-        if failure_count:
-            sys.exit(-1)
-    else:
-        print(
-            f"Skipping pyspark.sql.connect.readwriter doctests: {connect_requirement_message}",
-            file=sys.stderr,
-        )
+    if failure_count:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -604,7 +604,6 @@ class DataFrameWriter(OptionUtils):
 
 
 def _test() -> None:
-    import os
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
+
 import os
 import warnings
 from collections.abc import Sized
@@ -575,48 +579,36 @@ def _test() -> None:
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
-    from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+    import pyspark.sql.connect.session
 
-    os.chdir(os.environ["SPARK_HOME"])
+    globs = pyspark.sql.connect.session.__dict__.copy()
+    globs["spark"] = (
+        PySparkSession.builder.appName("sql.connect.session tests").remote("local[4]").getOrCreate()
+    )
 
-    if should_test_connect:
-        import pyspark.sql.connect.session
+    # Uses PySpark session to test builder.
+    globs["SparkSession"] = PySparkSession
+    # Spark Connect does not support to set master together.
+    pyspark.sql.connect.session.SparkSession.__doc__ = None
+    del pyspark.sql.connect.session.SparkSession.Builder.master.__doc__
+    # RDD API is not supported in Spark Connect.
+    del pyspark.sql.connect.session.SparkSession.createDataFrame.__doc__
 
-        globs = pyspark.sql.connect.session.__dict__.copy()
-        globs["spark"] = (
-            PySparkSession.builder.appName("sql.connect.session tests")
-            .remote("local[4]")
-            .getOrCreate()
-        )
+    # TODO(SPARK-41811): Implement SparkSession.sql's string formatter
+    del pyspark.sql.connect.session.SparkSession.sql.__doc__
 
-        # Uses PySpark session to test builder.
-        globs["SparkSession"] = PySparkSession
-        # Spark Connect does not support to set master together.
-        pyspark.sql.connect.session.SparkSession.__doc__ = None
-        del pyspark.sql.connect.session.SparkSession.Builder.master.__doc__
-        # RDD API is not supported in Spark Connect.
-        del pyspark.sql.connect.session.SparkSession.createDataFrame.__doc__
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.connect.session,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS
+        | doctest.NORMALIZE_WHITESPACE
+        | doctest.IGNORE_EXCEPTION_DETAIL,
+    )
 
-        # TODO(SPARK-41811): Implement SparkSession.sql's string formatter
-        del pyspark.sql.connect.session.SparkSession.sql.__doc__
+    globs["spark"].stop()
 
-        (failure_count, test_count) = doctest.testmod(
-            pyspark.sql.connect.session,
-            globs=globs,
-            optionflags=doctest.ELLIPSIS
-            | doctest.NORMALIZE_WHITESPACE
-            | doctest.IGNORE_EXCEPTION_DETAIL,
-        )
-
-        globs["spark"].stop()
-
-        if failure_count:
-            sys.exit(-1)
-    else:
-        print(
-            f"Skipping pyspark.sql.connect.session doctests: {connect_requirement_message}",
-            file=sys.stderr,
-        )
+    if failure_count:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -575,7 +575,6 @@ SparkSession.__doc__ = PySparkSession.__doc__
 
 
 def _test() -> None:
-    import os
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 import json
 

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -17,6 +17,10 @@
 """
 User-defined function related classes and functions
 """
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
+
 import functools
 from typing import Callable, Any, TYPE_CHECKING, Optional
 

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pyspark.sql.connect import check_dependencies
+
+check_dependencies(__name__, __file__)
 
 import sys
 from typing import TYPE_CHECKING, Union, Sequence, List, Optional
@@ -231,37 +234,25 @@ def _test() -> None:
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
-    from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+    import pyspark.sql.connect.window
 
-    os.chdir(os.environ["SPARK_HOME"])
+    globs = pyspark.sql.connect.window.__dict__.copy()
+    globs["spark"] = (
+        PySparkSession.builder.appName("sql.connect.window tests").remote("local[4]").getOrCreate()
+    )
 
-    if should_test_connect:
-        import pyspark.sql.connect.window
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.connect.window,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS
+        | doctest.NORMALIZE_WHITESPACE
+        | doctest.IGNORE_EXCEPTION_DETAIL,
+    )
 
-        globs = pyspark.sql.connect.window.__dict__.copy()
-        globs["spark"] = (
-            PySparkSession.builder.appName("sql.connect.window tests")
-            .remote("local[4]")
-            .getOrCreate()
-        )
+    globs["spark"].stop()
 
-        (failure_count, test_count) = doctest.testmod(
-            pyspark.sql.connect.window,
-            globs=globs,
-            optionflags=doctest.ELLIPSIS
-            | doctest.NORMALIZE_WHITESPACE
-            | doctest.IGNORE_EXCEPTION_DETAIL,
-        )
-
-        globs["spark"].stop()
-
-        if failure_count:
-            sys.exit(-1)
-    else:
-        print(
-            f"Skipping pyspark.sql.connect.window doctests: {connect_requirement_message}",
-            file=sys.stderr,
-        )
+    if failure_count:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -230,7 +230,6 @@ Window.__doc__ = PySparkWindow.__doc__
 
 
 def _test() -> None:
-    import os
     import sys
     import doctest
     from pyspark.sql import SparkSession as PySparkSession

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -39,6 +39,7 @@ from pyspark.sql.types import (
 from pyspark.testing.connectutils import (
     should_test_connect,
     ReusedConnectTestCase,
+    connect_requirement_message,
 )
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.errors import (
@@ -2627,7 +2628,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
                 getattr(df.write, f)()
 
 
-class ClientTests(ReusedConnectTestCase):
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class ClientTests(unittest.TestCase):
     def test_retry_error_handling(self):
         # Helper class for wrapping the test.
         class TestError(grpc.RpcError, Exception):
@@ -2738,7 +2740,8 @@ class ClientTests(ReusedConnectTestCase):
         self.assertEqual(call_wrap["raised"], 1)
 
 
-class ChannelBuilderTests(ReusedConnectTestCase):
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
+class ChannelBuilderTests(unittest.TestCase):
     def test_invalid_connection_strings(self):
         invalid = [
             "scc://host:12",

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -26,7 +26,6 @@ from collections import defaultdict
 from pyspark.errors import PySparkTypeError
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.sql import SparkSession as PySparkSession, Row
-from pyspark.sql.connect.client import Retrying
 from pyspark.sql.types import (
     StructType,
     StructField,
@@ -61,6 +60,7 @@ if should_test_connect:
     from pyspark.sql.connect.function_builder import udf
     from pyspark.sql import functions as SF
     from pyspark.sql.connect import functions as CF
+    from pyspark.sql.connect.client import Retrying
 
 
 class SparkConnectSQLTestCase(ReusedConnectTestCase, SQLTestUtils, PandasOnSparkTestUtils):
@@ -2627,7 +2627,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
                 getattr(df.write, f)()
 
 
-class ClientTests(unittest.TestCase):
+class ClientTests(ReusedConnectTestCase):
     def test_retry_error_handling(self):
         # Helper class for wrapping the test.
         class TestError(grpc.RpcError, Exception):
@@ -2738,7 +2738,7 @@ class ClientTests(unittest.TestCase):
         self.assertEqual(call_wrap["raised"], 1)
 
 
-class ChannelBuilderTests(unittest.TestCase):
+class ChannelBuilderTests(ReusedConnectTestCase):
     def test_invalid_connection_strings(self):
         invalid = [
             "scc://host:12",

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -18,20 +18,7 @@
 import decimal
 import datetime
 
-from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
-from pyspark.sql.connect.column import Column
-from pyspark.sql.connect.expressions import LiteralExpression
-from pyspark.sql.connect.types import (
-    JVM_BYTE_MIN,
-    JVM_BYTE_MAX,
-    JVM_SHORT_MIN,
-    JVM_SHORT_MAX,
-    JVM_INT_MIN,
-    JVM_INT_MAX,
-    JVM_LONG_MIN,
-    JVM_LONG_MAX,
-)
-
+from pyspark.sql import functions as SF
 from pyspark.sql.types import (
     Row,
     StructField,
@@ -54,13 +41,26 @@ from pyspark.sql.types import (
     DecimalType,
     BooleanType,
 )
-from pyspark.testing.connectutils import should_test_connect
 from pyspark.errors import SparkConnectException
+from pyspark.testing.connectutils import should_test_connect
+from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
+
 
 if should_test_connect:
     import pandas as pd
-    from pyspark.sql import functions as SF
     from pyspark.sql.connect import functions as CF
+    from pyspark.sql.connect.column import Column
+    from pyspark.sql.connect.expressions import LiteralExpression
+    from pyspark.sql.connect.types import (
+        JVM_BYTE_MIN,
+        JVM_BYTE_MAX,
+        JVM_SHORT_MIN,
+        JVM_SHORT_MAX,
+        JVM_INT_MIN,
+        JVM_INT_MAX,
+        JVM_LONG_MIN,
+        JVM_LONG_MAX,
+    )
 
 
 class SparkConnectColumnTests(SparkConnectSQLTestCase):

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -65,7 +65,7 @@ connect_requirement_message = (
 should_test_connect: str = typing.cast(str, connect_requirement_message is None)
 
 if should_test_connect:
-    from pyspark.sql.connect import DataFrame
+    from pyspark.sql.connect.dataframe import DataFrame
     from pyspark.sql.connect.plan import Read, Range, SQL
     from pyspark.sql.connect.session import SparkSession
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip doctests if the dependencies for Spark Connect are not installed.
The skipping logic has to be added before the modules are loaded because it loads the module first when Python runs doctest. Otherwise, it fails as below:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/.../spark/python/pyspark/sql/tests/connect/test_connect_basic.py", line 29, in <module>
    from pyspark.sql.connect.client import Retrying
  File "/.../spark/python/pyspark/sql/connect/__init__.py", line 21, in <module>
    from pyspark.sql.connect.dataframe import DataFrame  # noqa: F401
  File "/.../spark/python/pyspark/sql/connect/dataframe.py", line 50, in <module>
    import pyspark.sql.connect.plan as plan
  File "/.../spark/python/pyspark/sql/connect/plan.py", line 26, in <module>
    import pyspark.sql.connect.proto as proto
  File "/.../spark/python/pyspark/sql/connect/proto/__init__.py", line 18, in <module>
    from pyspark.sql.connect.proto.base_pb2_grpc import *
  File "/.../spark/python/pyspark/sql/connect/proto/base_pb2_grpc.py", line 19, in <module>
    import grpc
ModuleNotFoundError: No module named 'grpc'
```

### Why are the changes needed?

To make the tests pass without these optional dependencies.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

```
./python/run-tests --module pyspark-connect -p 1
```