### PR TITLE
[SPARK-42274][BUILD] Upgrade `compress-lzf` to 1.1.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -53,7 +53,7 @@ commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-net/3.1//commons-net-3.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.10.0//commons-text-1.10.0.jar
-compress-lzf/1.1//compress-lzf-1.1.jar
+compress-lzf/1.1.2//compress-lzf-1.1.2.jar
 curator-client/2.7.1//curator-client-2.7.1.jar
 curator-framework/2.7.1//curator-framework-2.7.1.jar
 curator-recipes/2.7.1//curator-recipes-2.7.1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -50,7 +50,7 @@ commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.10.0//commons-text-1.10.0.jar
-compress-lzf/1.1//compress-lzf-1.1.jar
+compress-lzf/1.1.2//compress-lzf-1.1.2.jar
 curator-client/2.13.0//curator-client-2.13.0.jar
 curator-framework/2.13.0//curator-framework-2.13.0.jar
 curator-recipes/2.13.0//curator-recipes-2.13.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
       <dependency>
         <groupId>com.ning</groupId>
         <artifactId>compress-lzf</artifactId>
-        <version>1.1</version>
+        <version>1.1.2</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `compress-lzf` to 1.1.2.

### Why are the changes needed?

`compress-lzf 1.1.1+` starts to support `Java 9+` officially.
- [v1.1.1](https://github.com/ning/compress/milestone/7?closed=1)
- [v1.1.2](https://github.com/ning/compress/milestone/8?closed=1)

### Does this PR introduce _any_ user-facing change?

Yes, but only a dependency change.

### How was this patch tested?

Pass the CIs.