### PR TITLE
[SPARK-42275][CONNECT][PYTHON] Avoid using built-in list, dict in static typing

### DIFF
--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -132,7 +132,7 @@ class CaseWhen(Expression):
 
 
 class ColumnAlias(Expression):
-    def __init__(self, parent: Expression, alias: list[str], metadata: Any):
+    def __init__(self, parent: Expression, alias: Sequence[str], metadata: Any):
 
         self._alias = alias
         self._metadata = metadata

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1336,7 +1336,7 @@ class WriteOperation(LogicalPlan):
         self.mode: Optional[str] = None
         self.sort_cols: List[str] = []
         self.partitioning_cols: List[str] = []
-        self.options: dict[str, Optional[str]] = {}
+        self.options: Dict[str, Optional[str]] = {}
         self.num_buckets: int = -1
         self.bucket_cols: List[str] = []
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid using built-in list, dict in static typing


### Why are the changes needed?
it's not supported in python 3.8, see https://peps.python.org/pep-0585/

python 3.8
```
>>> from typing import List
>>> a : List[str] = ["a", "b"]
>>> a : list[str] = ["a", "b"]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'type' object is not subscriptable
```

python 3.9
```
>>> from typing import List
>>> a : List[str] = ["a", "b"]
>>> a : list[str] = ["a", "b"]

```

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
manually check
