### PR TITLE
[SPARK-42277][CORE] Use RocksDB for `spark.history.store.hybridStore.diskBackend` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -248,5 +248,5 @@ private[spark] object History {
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValues(HybridStoreDiskBackend.values.map(_.toString))
-    .createWithDefault(HybridStoreDiskBackend.LEVELDB.toString)
+    .createWithDefault(HybridStoreDiskBackend.ROCKSDB.toString)
 }

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -30,6 +30,8 @@ license: |
 
 - Since Spark 3.4, Spark will try to decommission cached RDD and shuffle blocks if both `spark.decommission.enabled` and `spark.storage.decommission.enabled` are true. To restore the behavior before Spark 3.4, you can set both `spark.storage.decommission.rddBlocks.enabled` and `spark.storage.decommission.shuffleBlocks.enabled` to `false`.
 
+- Since Spark 3.4, Spark will use RocksDB store if `spark.history.store.hybridStore.enabled` is true. To restore the behavior before Spark 3.4, you can set `spark.history.store.hybridStore.diskBackend` to `LEVELDB`.
+
 ## Upgrading from Core 3.2 to 3.3
 
 - Since Spark 3.3, Spark migrates its log4j dependency from 1.x to 2.x because log4j 1.x has reached end of life and is no longer supported by the community. Vulnerabilities reported after August 2015 against log4j 1.x were not checked and will not be fixed. Users should rewrite original log4j properties files using log4j2 syntax (XML, JSON, YAML, or properties format). Spark rewrites the `conf/log4j.properties.template` which is included in Spark distribution, to `conf/log4j2.properties.template` with log4j2 properties format.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `RocksDB` for `spark.history.store.hybridStore.diskBackend` by default instead of `LevelDB`.

The last update of `LevelDB` is about over 10 years.
- `all except aarch64`: https://mvnrepository.com/artifact/org.fusesource.leveldbjni/leveldbjni-all/1.8 (Oct 17, 2013)
- `aarch64-only`: https://mvnrepository.com/artifact/org.openlabtesting.leveldbjni/leveldbjni-all/1.8 (Aug 28, 2019)

### Why are the changes needed?

RocksDB is maintained well and works on all environments where Apache Spark supports while LevelDB is not maintained at all in these days and doesn't work in some environment like the following.
```
$ SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=$HOME/data/history" sbin/start-history-server.sh
starting org.apache.spark.deploy.history.HistoryServer, logging to /Users/dongjoon/APACHE/spark-merge/logs/spark-dongjoon-org.apache.spark.deploy.history.HistoryServer-1-coffee.local.out
failed to launch: nice -n 0 /Users/dongjoon/APACHE/spark-merge/bin/spark-class org.apache.spark.deploy.history.HistoryServer
        at org.fusesource.hawtjni.runtime.Library.load(Library.java:140)
        at org.fusesource.leveldbjni.JniDBFactory.<clinit>(JniDBFactory.java:48)
        at org.apache.spark.util.kvstore.LevelDB.<init>(LevelDB.java:88)
        at org.apache.spark.status.KVUtils$.open(KVUtils.scala:98)
        at org.apache.spark.status.KVUtils$.$anonfun$createKVStore$1(KVUtils.scala:144)
        at scala.Option.map(Option.scala:230)
        at org.apache.spark.status.KVUtils$.createKVStore(KVUtils.scala:127)
        at org.apache.spark.deploy.history.FsHistoryProvider.<init>(FsHistoryProvider.scala:136)
        at org.apache.spark.deploy.history.FsHistoryProvider.<init>(FsHistoryProvider.scala:86)
        ... 7 more
```


### Does this PR introduce _any_ user-facing change?

Since `spark.history.store.hybridStore.enabled` is `false` by default. There is no behavior change.
In case of `spark.history.store.hybridStore.enabled=true`, History Server will rebuild the new hybrid store simply.

### How was this patch tested?

Pass the CIs.