### PR TITLE
[MINOR][SQL] Enhance data type check error message

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -1298,8 +1298,9 @@ trait ComplexTypeMergingExpression extends Expression {
       "The collection of input data types must not be empty.")
     require(
       TypeCoercion.haveSameType(inputTypesForMerging),
-      "All input types must be the same except nullable, containsNull, valueContainsNull flags." +
-        s" The input types found are\n\t${inputTypesForMerging.mkString("\n\t")}")
+      "All input types must be the same except nullable, containsNull, valueContainsNull flags. " +
+        s"The expression is: $this. " +
+        s"The input types found are\n\t${inputTypesForMerging.mkString("\n\t")}.")
   }
 
   private lazy val internalDataType: DataType = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the expression to data type check error message.

Before This PR:
```
requirement failed: All input types must be the same except nullable, containsNull, valueContainsNull flags. The input types found are
	DecimalType(30,2)
	DecimalType(35,2).
```

After this PR:
```
requirement failed: All input types must be the same except nullable, containsNull, valueContainsNull flags. The expression is: CASE WHEN upper(TAX_STATE#472) IN (UK,EU) THEN bround((((QTY#507 * ITEM_PRICE#506) + coalesce(ITEM_SALES_TAX_AMT#510, 0.00)) / QTY#507), 2) ELSE cast(ITEM_PRICE#506 as decimal(35,2)) END. The input types found are
	DecimalType(30,2)
	DecimalType(35,2).
```
### Why are the changes needed?

It is difficult to find out which expression has this issue when there are lots of expressions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual testing.

