### PR TITLE
[SPARK-42284][CONNECT] Make sure connect server assembly is built before running client tests - SBT

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -851,6 +851,9 @@ object SparkConnectClient {
       )
     },
 
+    // Make sure the connect server assembly jar is available for testing.
+    test := ((Test / test) dependsOn (LocalProject("connect") / assembly)).value,
+
     (assembly / test) := { },
 
     (assembly / logLevel) := Level.Info,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR makes sure SBT assembles the connect server assembly jar before we run client tests.

### Why are the changes needed?
It makes it easier to develop and test the JVM client for Spark Connect.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested.