### PR TITLE
[WIP][SPARK-42287][CONNECT][BUILD] Optimize the packaging strategy of connect  client module

### DIFF
--- a/connector/connect/client/jvm/pom.xml
+++ b/connector/connect/client/jvm/pom.xml
@@ -106,6 +106,7 @@
             <includes>
               <include>com.google.guava:*</include>
               <include>io.grpc:*</include>
+              <include>io.perfmark:perfmark-api</include>
               <include>com.google.protobuf:*</include>
               <include>org.apache.spark:spark-connect-common_${scala.binary.version}</include>
             </includes>
@@ -116,6 +117,13 @@
               <shadedPattern>${spark.shade.packageName}.connect.client.grpc</shadedPattern>
               <includes>
                 <include>io.grpc.**</include>
+              </includes>
+            </relocation>
+            <relocation>
+              <pattern>io.perfmark</pattern>
+              <shadedPattern>${spark.shade.packageName}.connect.client.io_perfmark</shadedPattern>
+              <includes>
+                <include>io.perfmark.**</include>
               </includes>
             </relocation>
             <relocation>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -866,15 +866,13 @@ object SparkConnectClient {
     // `listenablefuture-*.jar` and `guava-*.jar`.
     (assembly / assemblyExcludedJars) := {
       val cp = (assembly / fullClasspath).value
-      val excluded = cp filterNot { v =>
+      cp filterNot { v =>
         val name = v.data.getName
         name.startsWith("spark-connect-client-jvm") || name.startsWith("spark-connect-common") ||
           name.startsWith("grpc-") || name.startsWith("protobuf-java") ||
           name.startsWith("failureaccess-") || name.startsWith("listenablefuture-") ||
           name.startsWith("guava-") || name.startsWith("perfmark-api-")
       }
-      (cp -- excluded).foreach(j => println(s"include jar: ${j.data.getName}"))
-      excluded
     },
 
     (assembly / assemblyShadeRules) := Seq(

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -861,8 +861,9 @@ object SparkConnectClient {
     // Exclude `scala-library` from assembly.
     (assembly / assemblyPackageScala / assembleArtifact) := false,
 
-    // assembly will include `spark-connect-common-*.jar`, `grpc-*.jar`,`protobuf-java*.jar`,
-    // `failureaccess-*.jar`, `listenablefuture-*.jar` and `guava-*.jar`.
+    // assembly will include `spark-connect-client-jvm-*.jar`, `spark-connect-common-*.jar`,
+    // `grpc-*.jar`, `protobuf-java*.jar`, `failureaccess-*.jar`, `listenablefuture-*.jar`
+    // and `guava-*.jar`.
     (assembly / assemblyExcludedJars) := {
       val cp = (assembly / fullClasspath).value
       cp filter { v =>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -856,7 +856,7 @@ object SparkConnectClient {
 
     (assembly / test) := { },
 
-    (assembly / logLevel) := Level.Debug,
+    (assembly / logLevel) := Level.Info,
 
     // Exclude `scala-library` from assembly.
     (assembly / assemblyPackageScala / assembleArtifact) := false,

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -867,9 +867,10 @@ object SparkConnectClient {
       val cp = (assembly / fullClasspath).value
       cp filter { v =>
         val name = v.data.getName
-        !name.startsWith("spark-connect-common") && !name.startsWith("grpc-") &&
-          !name.startsWith("protobuf-java") && !name.startsWith("failureaccess-") &&
-          !name.startsWith("listenablefuture-") && !name.startsWith("guava-")
+        !name.startsWith("spark-connect-client-jvm") && !name.startsWith("spark-connect-common") &&
+          !name.startsWith("grpc-") && !name.startsWith("protobuf-java") &&
+          !name.startsWith("failureaccess-") && !name.startsWith("listenablefuture-") &&
+          !name.startsWith("guava-")
       }
     },
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -856,19 +856,20 @@ object SparkConnectClient {
 
     (assembly / test) := { },
 
-    (assembly / logLevel) := Level.Info,
+    (assembly / logLevel) := Level.Debug,
 
     // Exclude `scala-library` from assembly.
     (assembly / assemblyPackageScala / assembleArtifact) := false,
 
-    // Exclude `pmml-model-*.jar`, `scala-collection-compat_*.jar`,`jsr305-*.jar` and
-    // `netty-*.jar` and `unused-1.0.0.jar` from assembly.
+    // assembly will include `spark-connect-common-*.jar`, `grpc-*.jar`,`protobuf-java*.jar`,
+    // `failureaccess-*.jar`, `listenablefuture-*.jar` and `guava-*.jar`.
     (assembly / assemblyExcludedJars) := {
       val cp = (assembly / fullClasspath).value
       cp filter { v =>
         val name = v.data.getName
-        name.startsWith("pmml-model-") || name.startsWith("scala-collection-compat_") ||
-          name.startsWith("jsr305-") || name.startsWith("netty-") || name == "unused-1.0.0.jar"
+        !name.startsWith("spark-connect-common") && !name.startsWith("grpc-") &&
+          !name.startsWith("protobuf-java") && !name.startsWith("failureaccess-") &&
+          !name.startsWith("listenablefuture-") && !name.startsWith("guava-")
       }
     },
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to optimizes the packaging strategy of `connect-client-jvm` module. The main work includes:

- Shade `perfmark-api` to `connect-client-jvm` : `perfmark-api` is used by `grpc`（such as `grpc.internal.ClientCallImpl`） and it is not the default dependency of Spark(not in spark-client jars directory), shade it can simplify user use of `connect-client-jvm`.

- Make `sbt-assembly` and `maven-shade` package same jars for `connect-client-jvm`: 

maven shade just include the following jars:

```
[INFO] --- maven-shade-plugin:3.2.4:shade (default) @ spark-connect-client-jvm_2.12 ---
[INFO] Including org.apache.spark:spark-connect-common_2.12:jar:3.5.0-SNAPSHOT in the shaded jar.
[INFO] Including com.google.guava:failureaccess:jar:1.0.1 in the shaded jar.
[INFO] Including io.grpc:grpc-netty:jar:1.47.0 in the shaded jar.
[INFO] Including io.grpc:grpc-core:jar:1.47.0 in the shaded jar.
[INFO] Including io.perfmark:perfmark-api:jar:0.25.0 in the shaded jar.
[INFO] Including io.grpc:grpc-protobuf:jar:1.47.0 in the shaded jar.
[INFO] Including io.grpc:grpc-api:jar:1.47.0 in the shaded jar.
[INFO] Including io.grpc:grpc-context:jar:1.47.0 in the shaded jar.
[INFO] Including io.grpc:grpc-protobuf-lite:jar:1.47.0 in the shaded jar.
[INFO] Including io.grpc:grpc-services:jar:1.47.0 in the shaded jar.
[INFO] Including com.google.protobuf:protobuf-java-util:jar:3.19.2 in the shaded jar.
[INFO] Including io.grpc:grpc-stub:jar:1.47.0 in the shaded jar.
[INFO] Including com.google.protobuf:protobuf-java:jar:3.21.12 in the shaded jar.
[INFO] Including com.google.guava:guava:jar:31.0.1-jre in the shaded jar.
[INFO] Including com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava in the shaded jar.
```

but `sbt-assembly` it too fat(178MB) and  pack more jars, such as `hadoop`, `roaringbitmap`, `rocksdb` and so on and they are not relocation, so this pr change the result of `assembly / assemblyExcludedJars` refer to maven's behavior.


### Why are the changes needed?
1. Shade `perfmark-api` to `connect-client-jvm` to simplify user use of `connect-client-jvm`
2. Make `sbt-assembly` and `maven-shade` package same jars for `connect-client-jvm`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manually check `sbt-assembly` and `maven-shade` result