### PR TITLE
[WIP][SPARK-42291] Enable dropping of columns for non V2 tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -476,12 +476,6 @@ class SessionCatalog(
 
     val catalogTable = externalCatalog.getTable(db, table)
     val oldDataSchema = catalogTable.dataSchema
-    // not supporting dropping columns yet
-    val nonExistentColumnNames =
-      oldDataSchema.map(_.name).filterNot(columnNameResolved(newDataSchema, _))
-    if (nonExistentColumnNames.nonEmpty) {
-      throw QueryCompilationErrors.dropNonExistentColumnsNotSupportedError(nonExistentColumnNames)
-    }
 
     externalCatalog.alterTableDataSchema(db, table, newDataSchema)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -109,10 +109,8 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         Seq(ident.catalog.get, ident.database.get, ident.table),
         "RENAME COLUMN")
 
-    case DropColumns(ResolvedV1TableIdentifier(ident), _, _) =>
-      throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-        Seq(ident.catalog.get, ident.database.get, ident.table),
-        "DROP COLUMN")
+    case DropColumns(ResolvedV1TableIdentifier(ident), cols, _) =>
+      AlterTableDropColumnsCommand(ident, cols)
 
     case SetTableProperties(ResolvedV1TableIdentifier(ident), props) =>
       AlterTableSetPropertiesCommand(ident, props, isView = false)


### PR DESCRIPTION
Add support to drop columns in non V2 tables.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Built the jars in 3.2.0 and dropped columns using alter table:
```sql
ALTER TABLE lake.foo DROP COLUMNS (`a`, `b`);
ALTER TABLE lake.foo DROP COLUMNS (`a`)
ALTER TABLE lake.foo DROP COLUMN `a`
```

Tested on Spark 3.2.0 with an external hive metastore; the underlying data is in parquet format in cloud storage. Also affects the latest version.