### PR TITLE
[SPARK-42294][SQL] Include column default values in DESCRIBE output for V2 tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.util
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
@@ -265,6 +267,21 @@ object ResolveDefaultColumns {
         }
       }
     }
+  }
+
+  /** If any fields in a schema have default values, appends them to the result. */
+  def getDescribeMetadata(schema: StructType): Seq[(String, String, String)] = {
+    val rows = new ArrayBuffer[(String, String, String)]()
+    if (schema.fields.exists(_.metadata.contains(CURRENT_DEFAULT_COLUMN_METADATA_KEY))) {
+      rows.append(("", "", ""))
+      rows.append(("# Column Default Values", "", ""))
+      schema.foreach { column =>
+        column.getCurrentDefaultValue().map { value =>
+          rows.append((column.name, column.dataType.simpleString, value))
+        }
+      }
+    }
+    rows
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -281,7 +281,7 @@ object ResolveDefaultColumns {
         }
       }
     }
-    rows
+    rows.toSeq
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -648,13 +648,8 @@ case class DescribeTableCommand(
       }
 
       // If any columns have default values, append them to the result.
-      if (metadata.schema.fields.exists(_.metadata.contains(CURRENT_DEFAULT_COLUMN_METADATA_KEY))) {
-        append(result, "", "", "")
-        append(result, "# Column Default Values", "", "")
-        metadata.schema.foreach { column =>
-          column.getCurrentDefaultValue().map(
-            append(result, column.name, column.dataType.simpleString, _))
-        }
+      ResolveDefaultColumns.getDescribeMetadata(metadata.schema).foreach { row =>
+        append(result, row._1, row._2, row._3)
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -23,8 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns.CURRENT_DEFAULT_COLUMN_METADATA_KEY
-import org.apache.spark.sql.catalyst.util.quoteIfNeeded
+import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, ResolveDefaultColumns}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SupportsMetadataColumns, Table, TableCatalog}
 import org.apache.spark.sql.connector.expressions.IdentityTransform
 
@@ -71,13 +70,8 @@ case class DescribeTableExec(
     rows += toCatalystRow("Table Properties", properties, "")
 
     // If any columns have default values, append them to the result.
-    if (table.schema.fields.exists(_.metadata.contains(CURRENT_DEFAULT_COLUMN_METADATA_KEY))) {
-      rows += emptyRow()
-      rows += toCatalystRow("# Column Default Values", "", "")
-      table.schema.foreach { column =>
-        column.getCurrentDefaultValue().map(
-          rows += toCatalystRow(column.name, column.dataType.simpleString, _))
-      }
+    ResolveDefaultColumns.getDescribeMetadata(table.schema).foreach { row =>
+      rows += toCatalystRow(row._1, row._2, row._3)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Include column default values in DESCRIBE output for V2 tables.

This was previously implemented for V1 tables, but missed V2 tables.

### Why are the changes needed?

DESCRIBE commands make it easier to work with tables by inspecting their metadata.

### Does this PR introduce _any_ user-facing change?

Yes, it adds more information to DESCRIBE commands for tables with default column values.

### How was this patch tested?

This PR adds unit test coverage.