### PR TITLE
[SPARK-42333][SQL] Change log level to debug when fetching result set from SparkExecuteStatementOperation

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -96,7 +96,7 @@ private[hive] class SparkExecuteStatementOperation(
   private def getNextRowSetInternal(
       order: FetchOrientation,
       maxRowsL: Long): TRowSet = withLocalProperties {
-    log.info(s"Received getNextRowSet request order=${order} and maxRowsL=${maxRowsL} " +
+    log.debug(s"Received getNextRowSet request order=${order} and maxRowsL=${maxRowsL} " +
       s"with ${statementId}")
     validateDefaultFetchOrientation(order)
     assertState(OperationState.FINISHED)
@@ -112,7 +112,7 @@ private[hive] class SparkExecuteStatementOperation(
     val maxRows = maxRowsL.toInt
     val offset = iter.getPosition
     val rows = iter.take(maxRows).toList
-    log.info(s"Returning result set with ${rows.length} rows from offsets " +
+    log.debug(s"Returning result set with ${rows.length} rows from offsets " +
       s"[${iter.getFetchStart}, ${offset}) with $statementId")
     RowSetUtils.toTRowSet(offset, rows, dataTypes, getProtocolVersion, getTimeFormatters)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change log level from info to debug when fetching result set from `SparkExecuteStatementOperation`.


### Why are the changes needed?

Avoid generating too many logs:
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/5399861/216561187-6ad00458-d196-4f3a-a314-b2f309aec482.png">


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.