### PR TITLE
[SPARK-42335][SQL] Pass the comment option through to univocity if users set it explicitly in CSV dataSource

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -224,6 +224,9 @@ class CSVOptions(
 
   val isCommentSet = this.comment != '\u0000'
 
+  val defaultUnicodeNullAsWrittenComment =
+    SQLConf.get.getConf(SQLConf.LEGACY_DEFAULT_UNICODE_NULL_AS_WRITTEN_COMMENT)
+
   val samplingRatio =
     parameters.get(SAMPLING_RATIO).map(_.toDouble).getOrElse(1.0)
 
@@ -283,6 +286,8 @@ class CSVOptions(
     charToEscapeQuoteEscaping.foreach(format.setCharToEscapeQuoteEscaping)
     if (isCommentSet) {
       format.setComment(comment)
+    } else if (defaultUnicodeNullAsWrittenComment) {
+      format.setComment('\u0000')
     }
     lineSeparatorInWrite.foreach(format.setLineSeparator)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -222,10 +222,10 @@ class CSVOptions(
    */
   val maxErrorContentLength = 1000
 
-  val isCommentSet = this.comment != '\u0000'
-
-  val legacyDefaultUnicodeNullAsWrittenComment =
-    SQLConf.get.getConf(SQLConf.LEGACY_DEFAULT_UNICODE_NULL_AS_WRITTEN_COMMENT)
+  val isCommentSet = parameters.get(COMMENT) match {
+    case Some(value) if value.length == 1 => true
+    case _ => false
+  }
 
   val samplingRatio =
     parameters.get(SAMPLING_RATIO).map(_.toDouble).getOrElse(1.0)
@@ -286,8 +286,6 @@ class CSVOptions(
     charToEscapeQuoteEscaping.foreach(format.setCharToEscapeQuoteEscaping)
     if (isCommentSet) {
       format.setComment(comment)
-    } else if (legacyDefaultUnicodeNullAsWrittenComment) {
-      format.setComment('\u0000')
     }
     lineSeparatorInWrite.foreach(format.setLineSeparator)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -224,7 +224,7 @@ class CSVOptions(
 
   val isCommentSet = this.comment != '\u0000'
 
-  val defaultUnicodeNullAsWrittenComment =
+  val legacyDefaultUnicodeNullAsWrittenComment =
     SQLConf.get.getConf(SQLConf.LEGACY_DEFAULT_UNICODE_NULL_AS_WRITTEN_COMMENT)
 
   val samplingRatio =
@@ -286,7 +286,7 @@ class CSVOptions(
     charToEscapeQuoteEscaping.foreach(format.setCharToEscapeQuoteEscaping)
     if (isCommentSet) {
       format.setComment(comment)
-    } else if (defaultUnicodeNullAsWrittenComment) {
+    } else if (legacyDefaultUnicodeNullAsWrittenComment) {
       format.setComment('\u0000')
     }
     lineSeparatorInWrite.foreach(format.setLineSeparator)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4131,6 +4131,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val LEGACY_DEFAULT_UNICODE_NULL_AS_WRITTEN_COMMENT =
+    buildConf("spark.sql.legacy.csv.defaultUnicodeNullAsWrittenComment")
+      .internal()
+      .doc("When set to false, written comment character passed to `CsvFormat` is not set in " +
+        "CSV data source. If set to true, it restores the legacy behavior that written comment " +
+        "passed to `CsvFormat` will be set as '\u0000'.")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4131,16 +4131,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val LEGACY_DEFAULT_UNICODE_NULL_AS_WRITTEN_COMMENT =
-    buildConf("spark.sql.legacy.csv.defaultUnicodeNullAsWrittenComment")
-      .internal()
-      .doc("When set to false, written comment character passed to `CsvFormat` is not set in " +
-        "CSV data source. If set to true, it restores the legacy behavior that written comment " +
-        "passed to `CsvFormat` will be set as '\u0000'.")
-      .version("3.4.0")
-      .booleanConf
-      .createWithDefault(false)
-
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3101,6 +3101,24 @@ abstract class CSVSuite
     }
   }
 
+  test("Add a legacy spark.sql.legacy.csv.defaultUnicodeNullAsWrittenComment") {
+    Seq("true", "false").foreach { confVal =>
+      withSQLConf(SQLConf.LEGACY_DEFAULT_UNICODE_NULL_AS_WRITTEN_COMMENT.key -> confVal) {
+        withTempPath { path =>
+          Seq(("#abc", 1))
+            .toDF("value", "id")
+            .write
+            .csv(path.getCanonicalPath)
+          if (confVal == "false") {
+            checkAnswer(spark.read.text(path.getCanonicalPath), Row("\"#abc\",1"))
+          } else {
+            checkAnswer(spark.read.text(path.getCanonicalPath), Row("#abc,1"))
+          }
+        }
+      }
+    }
+  }
+
   test("SPARK-40667: validate CSV Options") {
     assert(CSVOptions.getAllOptions.size == 38)
     // Please add validation on any new CSV options here

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3101,7 +3101,8 @@ abstract class CSVSuite
     }
   }
 
-  test("Add a legacy spark.sql.legacy.csv.defaultUnicodeNullAsWrittenComment") {
+  test("SPARK-42335: Add a legacy config for restoring written comment option " +
+    "behavior in CSV dataSource") {
     Seq("true", "false").foreach { confVal =>
       withSQLConf(SQLConf.LEGACY_DEFAULT_UNICODE_NULL_AS_WRITTEN_COMMENT.key -> confVal) {
         withTempPath { path =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Pass the comment option through to univocity if users set it explicitly in CSV dataSource.

### Why are the changes needed?
In #29516 , in order to fix some bugs, univocity-parsers was upgrade from 2.8.3 to 2.9.0, it also involved a new feature of univocity-parsers that quoting values of the first column that start with the comment character. It made a breaking for users downstream that handing a whole row as input.
Before this change:
#abc,1
After this change:
"#abc",1
We change the related `isCommentSet` check logic to enable users to keep behavior as before.

### Does this PR introduce _any_ user-facing change?
Yes, a little. If users set comment option as '\u0000' explicitly, now they should remove it to keep comment option unset.

### How was this patch tested?
Add a full new test.
