### PR TITLE
[SPARK-42341][SQL][TESTS] Fix JoinSelectionHelperSuite and PlanStabilitySuite to use explicit broadcast threshold

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -103,15 +103,17 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
   }
 
   test("getBroadcastBuildSide (hintOnly = false) return None when right has no broadcast hint") {
-    val broadcastSide = getBroadcastBuildSide(
-      left,
-      right,
-      Inner,
-      JoinHint(None, hintNotToBroadcast ),
-      hintOnly = false,
-      SQLConf.get
-    )
-    assert(broadcastSide === None)
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      val broadcastSide = getBroadcastBuildSide(
+        left,
+        right,
+        Inner,
+        JoinHint(None, hintNotToBroadcast ),
+        hintOnly = false,
+        SQLConf.get
+      )
+      assert(broadcastSide === None)
+    }
   }
 
   test("getShuffleHashJoinBuildSide (hintOnly = true) return BuildLeft with only a left hint") {
@@ -179,8 +181,10 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
   }
 
   test("canBroadcastBySize should return true if the plan size is less than 10MB") {
-    assert(canBroadcastBySize(left, SQLConf.get) === false)
-    assert(canBroadcastBySize(right, SQLConf.get) === true)
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      assert(canBroadcastBySize(left, SQLConf.get) === false)
+      assert(canBroadcastBySize(right, SQLConf.get) === true)
+    }
   }
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -257,7 +257,8 @@ trait PlanStabilitySuite extends DisableAdaptiveExecutionSuite {
     val queryString = resourceToString(s"$tpcdsGroup/$query.sql",
       classLoader = Thread.currentThread().getContextClassLoader)
     // Disable char/varchar read-side handling for better performance.
-    withSQLConf(SQLConf.READ_SIDE_CHAR_PADDING.key -> "false") {
+    withSQLConf(SQLConf.READ_SIDE_CHAR_PADDING.key -> "false",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       val qe = sql(queryString).queryExecution
       val plan = qe.executedPlan
       val explain = normalizeLocation(normalizeIds(qe.explainString(FormattedMode)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes `JoinSelectionHelperSuite` and `PlanStabilitySuite` to use explicit broadcast threshold according to the test assumption.

### Why are the changes needed?

To be independent and clear in the tests.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only PR.

### How was this patch tested?

Pass the CIs.