### PR TITLE
[SPARK-42353][SS] Cleanup orphan sst and log files in RocksDB checkpoint directory

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -336,8 +336,7 @@ class RocksDBFileManager(
           logDebug(s"Deleted orphan file $dfsFileName")
         } else {
           logDebug(s"Deleted file $dfsFileName that was last used in version $maxUsedVersion")
-        }
-        logDebug(s"Deleted file $dfsFileName that was last used in version $maxUsedVersion")
+        })
       } catch {
         case e: Exception =>
           failedToDelete += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -336,7 +336,7 @@ class RocksDBFileManager(
           logDebug(s"Deleted orphan file $dfsFileName")
         } else {
           logDebug(s"Deleted file $dfsFileName that was last used in version $maxUsedVersion")
-        })
+        }
       } catch {
         case e: Exception =>
           failedToDelete += 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import org.apache.commons.io.{FilenameUtils, IOUtils}
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{Path, PathFilter}
+import org.apache.hadoop.fs.{FileStatus, Path, PathFilter}
 import org.json4s.NoTypeHints
 import org.json4s.jackson.Serialization
 
@@ -219,6 +219,38 @@ class RocksDBFileManager(
   }
 
   /**
+   * Find orphan files which are not tracked by zip files.
+   * Both sst files and log files can be orphan files.
+   * They are uploaded separately before the zip file of that version is uploaded.
+   * When the zip file of a version get overwritten, the referenced sst and log files become orphan.
+   * Be careful here since sst and log files of the ongoing version
+   * also appear to be orphan before their zip file is uploaded.
+   *
+   * @param trackedFiles files tracked by metadata in versioned zip file
+   * @param allFiles all sst or log files in the directory.
+   * @return filenames of orphan files
+   */
+  def findOrphanFiles(trackedFiles: Seq[String], allFiles: Seq[FileStatus]): Seq[String] = {
+    val fileModificationTimes = allFiles.map(file =>
+      file.getPath.getName -> file.getModificationTime).toMap
+    if (trackedFiles.nonEmpty && allFiles.size > trackedFiles.size) {
+      // Some tracked files may not be in the directory when listing.
+      val oldestTrackedFileModificationTime = trackedFiles.flatMap(fileModificationTimes.get(_)).min
+      // If this immutable file is older than any tracked file,
+      // then it can't belong to the ongoing version and it should be safe to clean it up.
+      val orphanFiles = fileModificationTimes
+        .filter(_._2 < oldestTrackedFileModificationTime).keys.toSeq
+      if (orphanFiles.nonEmpty) {
+        logInfo(s"Found ${orphanFiles.size} orphan files: ${orphanFiles.take(20).mkString(", ")}" +
+          "... (display at most 20 filenames) that should be deleted.")
+      }
+      orphanFiles
+    } else {
+      Seq.empty
+    }
+  }
+
+  /**
    * Delete old versions by deleting the associated version and SST files.
    * At a high-level, this method finds which versions to delete, and which SST files that were
    * last used in those versions. It's safe to delete these SST files because a SST file can
@@ -231,9 +263,12 @@ class RocksDBFileManager(
    * - Find the min version that needs to be retained based on the given `numVersionsToRetain`.
    * - Accordingly decide which versions should be deleted.
    * - Resolve all SSTs files of all the existing versions, if not already resolved.
-   * - Find what was the latest version in which each SST file was used.
-   * - Delete the files that were last used in the to-be-deleted versions as we will not
+   * - Find the files that were last used in the to-be-deleted versions as we will not
    *   need those files any more.
+   * - Find the orphan sst and log files whose zip files are not uploaded successfully
+   *   or have been overwritten. To avoid deleting files of ongoing tasks, only delete orphan files
+   *   that are older than all tracked files when there are at least 2 versions.
+   * - Delete files in both to-be-deleted versions and orphan files.
    *
    * Note that it only deletes files that it knows are safe to delete.
    * It may not delete the following files.
@@ -260,7 +295,9 @@ class RocksDBFileManager(
       math.max(minVersionPresent, maxVersionPresent - numVersionsToRetain + 1)
     val versionsToDelete = sortedVersions.takeWhile(_ < minVersionToRetain).toSet[Long]
 
-    // Return if no version to delete
+    // When versionToDelete is non-empty, there are at least 2 versions.
+    // We only delete orphan files when there are at least 2 versions,
+    // which avoid deleting files for running tasks.
     if (versionsToDelete.isEmpty) return
 
     logInfo(
@@ -269,29 +306,46 @@ class RocksDBFileManager(
         s"$numVersionsToRetain versions")
 
     // Resolve RocksDB files for all the versions and find the max version each file is used
-    val fileToMaxUsedVersion = new mutable.HashMap[RocksDBImmutableFile, Long]
+    val fileToMaxUsedVersion = new mutable.HashMap[String, Long]
     sortedVersions.foreach { version =>
       val files = Option(versionToRocksDBFiles.get(version)).getOrElse {
         val newResolvedFiles = getImmutableFilesFromVersionZip(version)
         versionToRocksDBFiles.put(version, newResolvedFiles)
         newResolvedFiles
       }
-      files.foreach(f => fileToMaxUsedVersion(f) = version)
+      files.foreach(f => fileToMaxUsedVersion(f.dfsFileName) =
+        math.max(version, fileToMaxUsedVersion.getOrElse(f.dfsFileName, version)))
     }
 
     // Best effort attempt to delete SST files that were last used in to-be-deleted versions
     val filesToDelete = fileToMaxUsedVersion.filter { case (_, v) => versionsToDelete.contains(v) }
+
+    val sstDir = new Path(dfsRootDir, RocksDBImmutableFile.SST_FILES_DFS_SUBDIR)
+    val logDir = new Path(dfsRootDir, RocksDBImmutableFile.LOG_FILES_DFS_SUBDIR)
+    val allSstFiles = if (fm.exists(sstDir)) fm.list(sstDir).toSeq else Seq.empty
+    val allLogFiles = if (fm.exists(logDir)) fm.list(logDir).toSeq else Seq.empty
+    filesToDelete ++= findOrphanFiles(fileToMaxUsedVersion.keys.toSeq, allSstFiles ++ allLogFiles)
+      .map(_ -> -1L)
     logInfo(s"Deleting ${filesToDelete.size} files not used in versions >= $minVersionToRetain")
     var failedToDelete = 0
-    filesToDelete.foreach { case (file, maxUsedVersion) =>
+    filesToDelete.foreach { case (dfsFileName, maxUsedVersion) =>
       try {
-        val dfsFile = dfsFilePath(file.dfsFileName)
+        val dfsFile = dfsFilePath(dfsFileName)
         fm.delete(dfsFile)
-        logDebug(s"Deleted file $file that was last used in version $maxUsedVersion")
+        if (maxUsedVersion == -1) {
+          logDebug(s"Deleted orphan file $dfsFileName")
+        } else {
+          logDebug(s"Deleted file $dfsFileName that was last used in version $maxUsedVersion")
+        }
+        logDebug(s"Deleted file $dfsFileName that was last used in version $maxUsedVersion")
       } catch {
         case e: Exception =>
           failedToDelete += 1
-          logWarning(s"Error deleting file $file, last used in version $maxUsedVersion", e)
+          if (maxUsedVersion == -1) {
+            logWarning(s"Error deleting orphan file $dfsFileName", e)
+          } else {
+            logWarning(s"Error deleting file $dfsFileName, last used in version $maxUsedVersion", e)
+          }
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When RocksDB version.zip file get overwritten (e.g. concurrent task execution, task/stage/batch reattempts) or the zip file don't get uploaded successfully, the associated sst and log files don't get garbage collected. We can clean up these SST files during periodic state store maintenance. The major concern is that sst files for ongoing version also appear to be "orphan" because they are uploaded before zip file, we have to be careful not to delete them. To be conservative, we only delete orphan files older than all files tracked by current metadata when there are at least 2 versions.


### Why are the changes needed?
When RocksDB version.zip file get overwritten (e.g. concurrent task execution, task/stage/batch reattempts) or the zip file don't get uploaded successfully, the associated sst and log files don't get garbage collected.([https://github.com/databricks/runtime/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala](https://github.com/databricks/runtime/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala#L305-L309)) These files consume storage. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add unit test.
