### PR TITLE
[SPARK-42358][CORE] Send ExecutorUpdated with the message argument in Master.removeWorker

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -962,7 +962,7 @@ private[deploy] class Master(
     for (exec <- worker.executors.values) {
       logInfo("Telling app of lost executor: " + exec.id)
       exec.application.driver.send(ExecutorUpdated(
-        exec.id, ExecutorState.LOST, Some("worker lost"), None, Some(worker.host)))
+        exec.id, ExecutorState.LOST, Some(msg), None, Some(worker.host)))
       exec.state = ExecutorState.LOST
       exec.application.removeExecutor(exec)
     }

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -962,7 +962,7 @@ private[deploy] class Master(
     for (exec <- worker.executors.values) {
       logInfo("Telling app of lost executor: " + exec.id)
       exec.application.driver.send(ExecutorUpdated(
-        exec.id, ExecutorState.LOST, Some(msg), None, Some(worker.host)))
+        exec.id, ExecutorState.LOST, Some(s"worker lost: $msg"), None, Some(worker.host)))
       exec.state = ExecutorState.LOST
       exec.application.removeExecutor(exec)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently field `message` in `ExecutorUpdated` sent in Master.removeWorker is always `Some("worker lost")`. This PR change to use the method argument `message` instead.

### Why are the changes needed?
This is to provide more information in the message to better differentiate the causes of worker removals.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.
