### PR TITLE
[SPARK-42359][SQL] Support row skipping when reading CSV files

### DIFF
--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -105,7 +105,7 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>skipLines</code></td>
     <td>0</td>
-    <td>Sets a number of non-empty lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
+    <td>Sets a number of non-empty, uncommented lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
     <td>read</td>
   </tr>
   <tr>

--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -105,7 +105,7 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>skipLines</code></td>
     <td>0</td>
-    <td>Sets a number of non-empty, uncommented lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
+    <td>Sets the number of non-empty, uncommented lines to skip before parsing CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
     <td>read</td>
   </tr>
   <tr>

--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -105,7 +105,7 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>skipLines</code></td>
     <td>0</td>
-    <td>Sets a number of lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
+    <td>Sets a number of non-empty lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
     <td>read</td>
   </tr>
   <tr>

--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -105,7 +105,7 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>skipLines</code></td>
     <td>0</td>
-    <td>Sets a number of lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the the number of <code>skipLines</code> will be taken as the header.</td>
+    <td>Sets a number of lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
     <td>read</td>
   </tr>
   <tr>

--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -105,7 +105,7 @@ Data source options of CSV can be set via:
   <tr>
     <td><code>skipLines</code></td>
     <td>0</td>
-    <td>Sets a number of non-empty, uncommented lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
+    <td>Sets a number of non-empty lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the number of <code>skipLines</code> will be taken as the header.</td>
     <td>read</td>
   </tr>
   <tr>

--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -103,6 +103,12 @@ Data source options of CSV can be set via:
     <td>read/write</td>
   </tr>
   <tr>
+    <td><code>skipLines</code></td>
+    <td>0</td>
+    <td>Sets a number of lines to skip before parsing each of the CSV files. If the <code>header</code> option is set to <code>true</code>, the first line after the the number of <code>skipLines</code> will be taken as the header.</td>
+    <td>read</td>
+  </tr>
+  <tr>
     <td><code>inferSchema</code></td>
     <td>false</td>
     <td>Infers the input schema automatically from data. It requires one extra pass over the data. CSV built-in functions ignore this option.</td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -24,19 +24,19 @@ object CSVExprUtils {
    * Filter ignorable rows for CSV dataset (lines empty, configured to skip, and starting with
    * `comment`). This is currently being used in CSV reading path and CSV schema inference.
    */
-  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+  def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
       iter.filter(_.trim.nonEmpty)
       iter.drop(options.skipLines)
       iter.filter(!_.startsWith(commentPrefix))
     } else {
-      iter.drop(options.skipLines)
       iter.filter(_.trim.nonEmpty)
+      iter.drop(options.skipLines)
     }
   }
 
-  def skipComments(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
       iter.dropWhile(_.trim.isEmpty)
@@ -52,7 +52,7 @@ object CSVExprUtils {
    * Extracts header and moves iterator forward so that only data remains in it
    */
   def extractHeader(iter: Iterator[String], options: CSVOptions): Option[String] = {
-    val nonEmptyLines = skipComments(iter, options)
+    val nonEmptyLines = skipUnwantedLines(iter, options)
     if (nonEmptyLines.hasNext) {
       Some(nonEmptyLines.next())
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -24,19 +24,19 @@ object CSVExprUtils {
    * Filter ignorable rows for CSV dataset (lines empty, configured to skip, and starting with
    * `comment`). This is currently being used in CSV reading path and CSV schema inference.
    */
-  def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
       iter.filter(_.trim.nonEmpty)
       iter.drop(options.skipLines)
       iter.filter(!_.startsWith(commentPrefix))
     } else {
-      iter.filter(_.trim.nonEmpty)
       iter.drop(options.skipLines)
+      iter.filter(_.trim.nonEmpty)
     }
   }
 
-  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+  def skipComments(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
       iter.dropWhile(_.trim.isEmpty)
@@ -52,7 +52,7 @@ object CSVExprUtils {
    * Extracts header and moves iterator forward so that only data remains in it
    */
   def extractHeader(iter: Iterator[String], options: CSVOptions): Option[String] = {
-    val nonEmptyLines = skipUnwantedLines(iter, options)
+    val nonEmptyLines = skipComments(iter, options)
     if (nonEmptyLines.hasNext) {
       Some(nonEmptyLines.next())
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils
 object CSVExprUtils {
   /**
    * Filter ignorable rows for CSV dataset (lines empty, configured to skip, and starting with
-   * `comment`). This is currently being used in CSV reading path.
+   * `comment`). This is currently being used in CSV reading path and CSV schema inference.
    */
   def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
@@ -33,21 +33,6 @@ object CSVExprUtils {
     } else {
       iter.filter(_.trim.nonEmpty)
       iter.drop(options.skipLines)
-    }
-  }
-
-  /**
-   * Filter empty lines and lines starting with `comment`.
-   * This is currently being used in CSV schema inference.
-   */
-  def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    if (options.isCommentSet) {
-      val commentPrefix = options.comment.toString
-      iter.filter { line =>
-        line.trim.nonEmpty && !line.startsWith(commentPrefix)
-      }
-    } else {
-      iter.filter(_.trim.nonEmpty)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -21,38 +21,30 @@ import org.apache.commons.lang3.StringUtils
 
 object CSVExprUtils {
   /**
-   * Filter ignorable rows for CSV iterator (lines empty and starting with `comment`).
-   * This is currently being used in CSV reading path and CSV schema inference.
-   */
-  def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    if (options.isCommentSet) {
-      val commentPrefix = options.comment.toString
-      iter.filter { line =>
-        line.trim.nonEmpty && !line.startsWith(commentPrefix)
-      }
-    } else {
-      iter.filter(_.trim.nonEmpty)
-    }
-  }
-
-  /**
-   * Skips the number of lines specified in options from the start of the file. Then blank entries
-   * (and comments if set) are removed. This function is currently only used for non-multiline CSV
-   * parsing.
+   * Filter ignorable rows for CSV dataset (lines empty, configured to skip, and starting with
+   * `comment`). This is currently being used in CSV reading path and CSV schema inference.
    */
   def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val skippedLines = iter.drop(options.skipLines)
-    filterCommentAndEmpty(skippedLines, options)
+    if (options.isCommentSet) {
+      val commentPrefix = options.comment.toString
+      iter.filter(_.trim.nonEmpty)
+      iter.drop(options.skipLines)
+      iter.filter(!_.startsWith(commentPrefix))
+    } else {
+      iter.drop(options.skipLines)
+      iter.filter(_.trim.nonEmpty)
+    }
   }
 
   def skipComments(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
-      iter.dropWhile { line =>
-        line.trim.isEmpty || line.startsWith(commentPrefix)
-      }
+      iter.dropWhile(_.trim.isEmpty)
+      iter.drop(options.skipLines)
+      iter.dropWhile(_.startsWith(commentPrefix))
     } else {
       iter.dropWhile(_.trim.isEmpty)
+      iter.drop(options.skipLines)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -25,19 +25,13 @@ object CSVExprUtils {
    * This is currently being used in CSV reading path and CSV schema inference.
    */
   def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val nonEmptyLines = iter.filter(_.trim.nonEmpty)
-    filterComment(nonEmptyLines, options)
-  }
-
-  /*
-   * Filter commented rows from CSV iterator.
-   */
-  def filterComment(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
-      iter.filter(!_.startsWith(commentPrefix))
+      iter.filter { line =>
+        line.trim.nonEmpty && !line.startsWith(commentPrefix)
+      }
     } else {
-      iter
+      iter.filter(_.trim.nonEmpty)
     }
   }
 
@@ -46,9 +40,8 @@ object CSVExprUtils {
    * currently being used in CSV reading path and CSV schema inference.
    */
   def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-      val nonEmptyLines = iter.filter(_.trim.nonEmpty)
-      val skippedLines = nonEmptyLines.drop(options.skipLines)
-      filterComment(skippedLines, options)
+    val filteredLines = filterCommentAndEmpty(iter, options)
+    filteredLines.drop(options.skipLines)
   }
 
   def skipCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -21,26 +21,20 @@ import org.apache.commons.lang3.StringUtils
 
 object CSVExprUtils {
   /**
-   * Filter ignorable rows for CSV iterator (lines empty and starting with `comment`).
-   * This is currently being used in CSV reading path and CSV schema inference.
-   */
-  def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    if (options.isCommentSet) {
-      val commentPrefix = options.comment.toString
-      iter.filter { line =>
-        line.trim.nonEmpty && !line.startsWith(commentPrefix)
-      }
-    } else {
-      iter.filter(_.trim.nonEmpty)
-    }
-  }
-
-  /**
    * Filter blank lines, skip specified rows, and remove comments from a CSV iterator. This is
    * currently being used in CSV reading path and CSV schema inference.
    */
   def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val filteredLines = filterCommentAndEmpty(iter, options)
+    val filteredLines = {
+      if (options.isCommentSet) {
+        val commentPrefix = options.comment.toString
+        iter.filter { line =>
+          line.trim.nonEmpty && !line.startsWith(commentPrefix)
+        }
+      } else {
+        iter.filter(_.trim.nonEmpty)
+      }
+    }
     filteredLines.drop(options.skipLines)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -36,14 +36,12 @@ object CSVExprUtils {
   }
 
   /**
-   * Skips the number of lines specified in options from the start of the file. Then
-   * blank entries (and comments if set) are removed.
-   * This function currently only used for non-multiline CSV parsing.
+   * Skips the number of lines specified in options from the start of the file. Then blank entries
+   * (and comments if set) are removed. This function is currently only used for non-multiline CSV
+   * parsing.
    */
   def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val skippedLines = iter.drop {
-      options.skipLines
-    }
+    val skippedLines = iter.drop(options.skipLines)
     filterCommentAndEmpty(skippedLines, options)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils
 object CSVExprUtils {
   /**
    * Filter ignorable rows for CSV dataset (lines empty, configured to skip, and starting with
-   * `comment`). This is currently being used in CSV reading path and CSV schema inference.
+   * `comment`). This is currently being used in CSV reading path.
    */
   def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
@@ -33,6 +33,21 @@ object CSVExprUtils {
     } else {
       iter.filter(_.trim.nonEmpty)
       iter.drop(options.skipLines)
+    }
+  }
+
+  /**
+   * Filter empty lines and lines starting with `comment`.
+   * This is currently being used in CSV schema inference.
+   */
+  def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+    if (options.isCommentSet) {
+      val commentPrefix = options.comment.toString
+      iter.filter { line =>
+        line.trim.nonEmpty && !line.startsWith(commentPrefix)
+      }
+    } else {
+      iter.filter(_.trim.nonEmpty)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -25,13 +25,20 @@ object CSVExprUtils {
    * This is currently being used in CSV reading path and CSV schema inference.
    */
   def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+    val nonEmpty = filterEmpty(iter, options)
+    filterComment(nonEmpty, options)
+  }
+
+  def filterEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+    iter.filter(_.trim.nonEmpty)
+  }
+
+  def filterComment(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
-      iter.filter { line =>
-        line.trim.nonEmpty && !line.startsWith(commentPrefix)
-      }
+      iter.filter(!_.startsWith(commentPrefix))
     } else {
-      iter.filter(_.trim.nonEmpty)
+      iter
     }
   }
 
@@ -41,8 +48,9 @@ object CSVExprUtils {
    * parsing.
    */
   def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val filteredLines = filterCommentAndEmpty(iter, options)
-    filteredLines.drop(options.skipLines)
+    val nonEmpty = filterEmpty(iter, options)
+    val skippedLines = nonEmpty.drop(options.skipLines)
+    filterComment(skippedLines, options)
   }
 
   def skipCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -25,24 +25,30 @@ object CSVExprUtils {
    * This is currently being used in CSV reading path and CSV schema inference.
    */
   def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+    val nonEmptyLines = iter.filter(_.trim.nonEmpty)
+    filterComment(nonEmptyLines, options)
+  }
+
+  /*
+   * Filter commented rows from CSV iterator.
+   */
+  def filterComment(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
-      iter.filter { line =>
-        line.trim.nonEmpty && !line.startsWith(commentPrefix)
-      }
+      iter.filter(!_.startsWith(commentPrefix))
     } else {
-      iter.filter(_.trim.nonEmpty)
+      iter
     }
   }
 
   /**
-   * Skips the number of lines specified in options from the start of the file. Then blank entries
-   * (and comments if set) are removed. This function is currently only used for non-multiline CSV
-   * parsing.
+   * Filter blank lines, skip specified rows, and remove comments from a CSV iterator. This is
+   * currently being used in CSV reading path and CSV schema inference.
    */
-  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val filteredLines = filterCommentAndEmpty(iter, options)
-    filteredLines.drop(options.skipLines)
+  def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+      val nonEmptyLines = iter.filter(_.trim.nonEmpty)
+      val skippedLines = nonEmptyLines.drop(options.skipLines)
+      filterComment(skippedLines, options)
   }
 
   def skipCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -41,11 +41,11 @@ object CSVExprUtils {
    * parsing.
    */
   def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val skippedLines = iter.drop(options.skipLines)
-    filterCommentAndEmpty(skippedLines, options)
+    val filteredLines = filterCommentAndEmpty(iter, options)
+    filteredLines.drop(options.skipLines)
   }
 
-  def skipComments(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+  def skipCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
       iter.dropWhile { line =>
@@ -60,7 +60,7 @@ object CSVExprUtils {
    * Extracts header and moves iterator forward so that only data remains in it
    */
   def extractHeader(iter: Iterator[String], options: CSVOptions): Option[String] = {
-    val nonEmptyLines = skipComments(iter, options)
+    val nonEmptyLines = skipCommentAndEmpty(iter, options)
     if (nonEmptyLines.hasNext) {
       Some(nonEmptyLines.next())
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -25,20 +25,13 @@ object CSVExprUtils {
    * This is currently being used in CSV reading path and CSV schema inference.
    */
   def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val nonEmpty = filterEmpty(iter, options)
-    filterComment(nonEmpty, options)
-  }
-
-  def filterEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    iter.filter(_.trim.nonEmpty)
-  }
-
-  def filterComment(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString
-      iter.filter(!_.startsWith(commentPrefix))
+      iter.filter { line =>
+        line.trim.nonEmpty && !line.startsWith(commentPrefix)
+      }
     } else {
-      iter
+      iter.filter(_.trim.nonEmpty)
     }
   }
 
@@ -48,9 +41,8 @@ object CSVExprUtils {
    * parsing.
    */
   def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
-    val nonEmpty = filterEmpty(iter, options)
-    val skippedLines = nonEmpty.drop(options.skipLines)
-    filterComment(skippedLines, options)
+    val filteredLines = filterCommentAndEmpty(iter, options)
+    filteredLines.drop(options.skipLines)
   }
 
   def skipCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVExprUtils.scala
@@ -35,6 +35,18 @@ object CSVExprUtils {
     }
   }
 
+  /**
+   * Skips the number of lines specified in options from the start of the file. Then
+   * blank entries (and comments if set) are removed.
+   * This function currently only used for non-multiline CSV parsing.
+   */
+  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
+    val skippedLines = iter.drop {
+      options.skipLines
+    }
+    filterCommentAndEmpty(skippedLines, options)
+  }
+
   def skipComments(iter: Iterator[String], options: CSVOptions): Iterator[String] = {
     if (options.isCommentSet) {
       val commentPrefix = options.comment.toString

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -119,6 +119,8 @@ class CSVOptions(
   val comment = getChar(COMMENT, '\u0000')
 
   val headerFlag = getBool(HEADER)
+  val skipLines = getInt(SKIPLINES, 0)
+  require(skipLines >= 0, "'skipLines' must be equal to or greater than 0.")
   val inferSchemaFlag = getBool(INFER_SCHEMA)
   val ignoreLeadingWhiteSpaceInRead = getBool(IGNORE_LEADING_WHITESPACE, default = false)
   val ignoreTrailingWhiteSpaceInRead = getBool(IGNORE_TRAILING_WHITESPACE, default = false)
@@ -332,6 +334,7 @@ class CSVOptions(
 
 object CSVOptions extends DataSourceOptions {
   val HEADER = newOption("header")
+  val SKIPLINES = newOption("skipLines")
   val INFER_SCHEMA = newOption("inferSchema")
   val IGNORE_LEADING_WHITESPACE = newOption("ignoreLeadingWhiteSpace")
   val IGNORE_TRAILING_WHITESPACE = newOption("ignoreTrailingWhiteSpace")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -456,7 +456,7 @@ private[sql] object UnivocityParser {
       schema: StructType): Iterator[InternalRow] = {
     val options = parser.options
 
-    val filteredLines: Iterator[String] = CSVExprUtils.filterUnwantedLines(lines, options)
+    val filteredLines: Iterator[String] = CSVExprUtils.skipUnwantedLines(lines, options)
 
     headerChecker.checkHeaderColumnNames(lines, parser.tokenizer)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -428,7 +428,7 @@ private[sql] object UnivocityParser {
       convert: Array[String] => T) = new Iterator[T] {
     tokenizer.beginParsing(inputStream, encoding)
 
-    // We can handle header and skipLines here since here the stream is open.
+    // We can handle header and skipLines here since the stream is open.
     handleSkipLines()
     handleHeader()
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -456,7 +456,7 @@ private[sql] object UnivocityParser {
       schema: StructType): Iterator[InternalRow] = {
     val options = parser.options
 
-    val filteredLines: Iterator[String] = CSVExprUtils.skipUnwantedLines(lines, options)
+    val filteredLines: Iterator[String] = CSVExprUtils.filterUnwantedLines(lines, options)
 
     headerChecker.checkHeaderColumnNames(lines, parser.tokenizer)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -414,9 +414,7 @@ private[sql] object UnivocityParser {
       tokenizer,
       handleHeader,
       handleSkipLines,
-      parser.options.charset) { tokens =>
-      safeParser.parse(tokens)
-    }.flatten
+      parser.options.charset)(safeParser.parse).flatten
   }
 
   private def convertStream[T](

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -469,7 +469,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone)
     val filteredLines: Dataset[String] =
-      CSVUtils.skipUnwantedLines(csvDataset, parsedOptions)
+      CSVUtils.filterUnwantedLines(csvDataset, parsedOptions)
 
     // For performance, short-circuit the collection of the first line when it won't be used:
     //   - TextInputCSVDataSource - Only uses firstLine to infer an unspecified schema

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -469,7 +469,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone)
     val filteredLines: Dataset[String] =
-      CSVUtils.filterCommentAndEmpty(csvDataset, parsedOptions)
+      CSVUtils.skipUnwantedLines(csvDataset, parsedOptions)
 
     // For performance, short-circuit the collection of the first line when it won't be used:
     //   - TextInputCSVDataSource - Only uses firstLine to infer an unspecified schema

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -469,7 +469,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone)
     val filteredLines: Dataset[String] =
-      CSVUtils.filterUnwantedLines(csvDataset, parsedOptions)
+      CSVUtils.skipUnwantedLines(csvDataset, parsedOptions)
 
     // For performance, short-circuit the collection of the first line when it won't be used:
     //   - TextInputCSVDataSource - Only uses firstLine to infer an unspecified schema

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -127,7 +127,7 @@ object TextInputCSVDataSource extends CSVDataSource {
         val header = CSVUtils.makeSafeHeader(firstRow, caseSensitive, parsedOptions)
         val sampled: Dataset[String] = CSVUtils.sample(csv, parsedOptions)
         val tokenRDD = sampled.rdd.mapPartitions { iter =>
-          val filteredLines = CSVUtils.filterUnwantedLines(iter, parsedOptions)
+          val filteredLines = CSVUtils.filterCommentAndEmpty(iter, parsedOptions)
           val linesWithoutHeader =
             CSVUtils.filterHeaderLine(filteredLines, maybeFirstLine.get, parsedOptions)
           val parser = new CsvParser(parsedOptions.asParserSettings)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -127,7 +127,8 @@ object TextInputCSVDataSource extends CSVDataSource {
         val header = CSVUtils.makeSafeHeader(firstRow, caseSensitive, parsedOptions)
         val sampled: Dataset[String] = CSVUtils.sample(csv, parsedOptions)
         val tokenRDD = sampled.rdd.mapPartitions { iter =>
-          val filteredLines = CSVUtils.filterCommentAndEmpty(iter, parsedOptions)
+          // TODO (tedcj): need to be careful that skiplines doesn't cause an issue here
+          val filteredLines = CSVUtils.skipUnwantedLines(iter, parsedOptions)
           val linesWithoutHeader =
             CSVUtils.filterHeaderLine(filteredLines, maybeFirstLine.get, parsedOptions)
           val parser = new CsvParser(parsedOptions.asParserSettings)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -127,7 +127,7 @@ object TextInputCSVDataSource extends CSVDataSource {
         val header = CSVUtils.makeSafeHeader(firstRow, caseSensitive, parsedOptions)
         val sampled: Dataset[String] = CSVUtils.sample(csv, parsedOptions)
         val tokenRDD = sampled.rdd.mapPartitions { iter =>
-          val filteredLines = CSVUtils.filterCommentAndEmpty(iter, parsedOptions)
+          val filteredLines = CSVUtils.filterUnwantedLines(iter, parsedOptions)
           val linesWithoutHeader =
             CSVUtils.filterHeaderLine(filteredLines, maybeFirstLine.get, parsedOptions)
           val parser = new CsvParser(parsedOptions.asParserSettings)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -108,7 +108,7 @@ object TextInputCSVDataSource extends CSVDataSource {
       inputPaths: Seq[FileStatus],
       parsedOptions: CSVOptions): StructType = {
     val csv = createBaseDataset(sparkSession, inputPaths, parsedOptions)
-    val maybeFirstLine = CSVUtils.skipUnwantedLines(csv, parsedOptions).take(1).headOption
+    val maybeFirstLine = CSVUtils.filterUnwantedLines(csv, parsedOptions).take(1).headOption
     inferFromDataset(sparkSession, csv, maybeFirstLine, parsedOptions)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -108,7 +108,7 @@ object TextInputCSVDataSource extends CSVDataSource {
       inputPaths: Seq[FileStatus],
       parsedOptions: CSVOptions): StructType = {
     val csv = createBaseDataset(sparkSession, inputPaths, parsedOptions)
-    val maybeFirstLine = CSVUtils.filterCommentAndEmpty(csv, parsedOptions).take(1).headOption
+    val maybeFirstLine = CSVUtils.skipUnwantedLines(csv, parsedOptions).take(1).headOption
     inferFromDataset(sparkSession, csv, maybeFirstLine, parsedOptions)
   }
 
@@ -194,6 +194,7 @@ object MultiLineCSVDataSource extends CSVDataSource {
       UnivocityParser.tokenizeStream(
         CodecStreams.createInputStreamWithCloseResource(lines.getConfiguration, path),
         shouldDropHeader = false,
+        parsedOptions.skipLines,
         new CsvParser(parsedOptions.asParserSettings),
         encoding = parsedOptions.charset)
     }.take(1).headOption match {
@@ -206,6 +207,7 @@ object MultiLineCSVDataSource extends CSVDataSource {
               lines.getConfiguration,
               new Path(lines.getPath())),
             parsedOptions.headerFlag,
+            parsedOptions.skipLines,
             new CsvParser(parsedOptions.asParserSettings),
             encoding = parsedOptions.charset)
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -127,8 +127,7 @@ object TextInputCSVDataSource extends CSVDataSource {
         val header = CSVUtils.makeSafeHeader(firstRow, caseSensitive, parsedOptions)
         val sampled: Dataset[String] = CSVUtils.sample(csv, parsedOptions)
         val tokenRDD = sampled.rdd.mapPartitions { iter =>
-          // TODO (tedcj): need to be careful that skiplines doesn't cause an issue here
-          val filteredLines = CSVUtils.skipUnwantedLines(iter, parsedOptions)
+          val filteredLines = CSVUtils.filterCommentAndEmpty(iter, parsedOptions)
           val linesWithoutHeader =
             CSVUtils.filterHeaderLine(filteredLines, maybeFirstLine.get, parsedOptions)
           val parser = new CsvParser(parsedOptions.asParserSettings)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVDataSource.scala
@@ -108,7 +108,7 @@ object TextInputCSVDataSource extends CSVDataSource {
       inputPaths: Seq[FileStatus],
       parsedOptions: CSVOptions): StructType = {
     val csv = createBaseDataset(sparkSession, inputPaths, parsedOptions)
-    val maybeFirstLine = CSVUtils.skipUnwantedLines(csv, parsedOptions).take(1).headOption
+    val maybeFirstLine = CSVUtils.filterUnwantedLines(csv, parsedOptions).take(1).headOption
     inferFromDataset(sparkSession, csv, maybeFirstLine, parsedOptions)
   }
 
@@ -127,8 +127,7 @@ object TextInputCSVDataSource extends CSVDataSource {
         val header = CSVUtils.makeSafeHeader(firstRow, caseSensitive, parsedOptions)
         val sampled: Dataset[String] = CSVUtils.sample(csv, parsedOptions)
         val tokenRDD = sampled.rdd.mapPartitions { iter =>
-          // TODO (tedcj): need to be careful that skiplines doesn't cause an issue here
-          val filteredLines = CSVUtils.skipUnwantedLines(iter, parsedOptions)
+          val filteredLines = CSVUtils.filterUnwantedLines(iter, parsedOptions)
           val linesWithoutHeader =
             CSVUtils.filterHeaderLine(filteredLines, maybeFirstLine.get, parsedOptions)
           val parser = new CsvParser(parsedOptions.asParserSettings)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -43,6 +43,20 @@ object CSVUtils {
   }
 
   /**
+   * Skips the number of lines specified in options from the start of the file. Then
+   * blank entries (and comments if set) are removed.
+   * This is only used for parsing a dataset of CSV strings.
+   */
+  def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
+    import lines.sqlContext.implicits._
+    val skippedLines = lines.rdd.zipWithIndex().toDF("value", "order")
+      .filter($"order" >= options.skipLines)
+      .drop("order")
+      .as[String]
+    filterCommentAndEmpty(skippedLines, options)
+  }
+
+  /**
    * Skip the given first line so that only data can remain in a dataset.
    * This is similar with `dropHeaderLine` below and currently being used in CSV schema inference.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -48,11 +48,11 @@ object CSVUtils {
    */
   def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
     import lines.sqlContext.implicits._
-    val skippedLines = lines.rdd.zipWithIndex().toDF("value", "order")
+    val filteredLines = filterCommentAndEmpty(lines, options)
+    filteredLines.rdd.zipWithIndex().toDF("value", "order")
       .filter($"order" >= options.skipLines)
       .drop("order")
       .as[String]
-    filterCommentAndEmpty(skippedLines, options)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -43,9 +43,8 @@ object CSVUtils {
   }
 
   /**
-   * Skips the number of lines specified in options from the start of the file. Then
-   * blank entries (and comments if set) are removed.
-   * This is only used for parsing a dataset of CSV strings.
+   * Skips the number of lines specified in options from the start of the file. Then blank entries
+   * (and comments if set) are removed. This is currently being used in CSV schema inference.
    */
   def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
     import lines.sqlContext.implicits._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -28,7 +28,7 @@ object CSVUtils {
    * Filter ignorable rows for CSV dataset (lines empty, configured to skip, and starting with
    * `comment`). This is currently being used in CSV schema inference.
    */
-  def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
+  def filterUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
     // Note that this was separately made by SPARK-18362. Logically, this should be the same
     // with the one below, `filterCommentAndEmpty` but execution path is different. One of them
     // might have to be removed in the near future if possible.
@@ -131,6 +131,6 @@ object CSVUtils {
     }
   }
 
-  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] =
-    CSVExprUtils.skipUnwantedLines(iter, options)
+  def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] =
+    CSVExprUtils.filterUnwantedLines(iter, options)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -25,34 +25,22 @@ import org.apache.spark.sql.functions._
 
 object CSVUtils {
   /**
-   * Filter ignorable rows for CSV dataset (lines empty and starting with `comment`).
-   * This is currently being used in CSV schema inference.
+   * Filter blank lines, skip specified rows, and remove comments from a CSV iterator. Then blank
+   * entries (and comments if set) are removed. This is currently being used in CSV schema
+   * inference.
    */
-  def filterCommentAndEmpty(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
-    // Note that this was separately made by SPARK-18362. Logically, this should be the same
-    // with the one below, `filterCommentAndEmpty` but execution path is different. One of them
-    // might have to be removed in the near future if possible.
+  def filterUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
     import lines.sqlContext.implicits._
     val aliased = lines.toDF("value")
-    val nonEmptyLines = aliased.filter(length(trim($"value")) > 0)
-    if (options.isCommentSet) {
-      nonEmptyLines.filter(!$"value".startsWith(options.comment.toString)).as[String]
-    } else {
-      nonEmptyLines.as[String]
-    }
-  }
-
-  /**
-   * Skips the number of lines specified in options from the start of the file. Then blank entries
-   * (and comments if set) are removed. This is currently being used in CSV schema inference.
-   */
-  def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
-    import lines.sqlContext.implicits._
-    val filteredLines = filterCommentAndEmpty(lines, options)
-    filteredLines.rdd.zipWithIndex().toDF("value", "order")
+    val nonEmptyLines = aliased.filter(length(trim($"value")) > 0).as[String]
+    val skippedLines = nonEmptyLines.rdd.zipWithIndex().toDF("value", "order")
       .filter($"order" >= options.skipLines)
       .drop("order")
-      .as[String]
+    if (options.isCommentSet) {
+      skippedLines.filter(!$"value".startsWith(options.comment.toString)).as[String]
+    } else {
+      skippedLines.as[String]
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -131,6 +131,6 @@ object CSVUtils {
     }
   }
 
-  def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] =
-    CSVExprUtils.filterCommentAndEmpty(iter, options)
+  def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] =
+    CSVExprUtils.filterUnwantedLines(iter, options)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -48,17 +48,11 @@ object CSVUtils {
    */
   def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
     import lines.sqlContext.implicits._
-    val aliased = lines.toDF("value")
-    val nonEmptyLines = aliased.filter(length(trim($"value")) > 0).as[String]
-    val skippedLines = nonEmptyLines.rdd.zipWithIndex().toDF("value", "order")
+    val filteredLines = filterCommentAndEmpty(lines, options)
+    filteredLines.rdd.zipWithIndex().toDF("value", "order")
       .filter($"order" >= options.skipLines)
       .drop("order")
-      .as[String].toDF("value")
-    if (options.isCommentSet) {
-      skippedLines.filter(!$"value".startsWith(options.comment.toString)).as[String]
-    } else {
-      skippedLines.as[String]
-    }
+      .as[String]
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -43,9 +43,9 @@ object CSVUtils {
         nonEmptyLines.as[String]
       }
     }
-    commentFilteredLines.rdd.zipWithIndex().toDF("value", "order")
-      .filter($"order" >= options.skipLines)
-      .drop("order")
+    commentFilteredLines.rdd
+      .mapPartitions(_.drop(options.skipLines))
+      .toDF("value")
       .as[String]
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -25,34 +25,24 @@ import org.apache.spark.sql.functions._
 
 object CSVUtils {
   /**
-   * Filter ignorable rows for CSV dataset (lines empty and starting with `comment`).
-   * This is currently being used in CSV schema inference.
+   * Filter ignorable rows for CSV dataset (lines empty, configured to skip, and starting with
+   * `comment`). This is currently being used in CSV schema inference.
    */
-  def filterCommentAndEmpty(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
+  def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
     // Note that this was separately made by SPARK-18362. Logically, this should be the same
     // with the one below, `filterCommentAndEmpty` but execution path is different. One of them
     // might have to be removed in the near future if possible.
     import lines.sqlContext.implicits._
     val aliased = lines.toDF("value")
     val nonEmptyLines = aliased.filter(length(trim($"value")) > 0)
-    if (options.isCommentSet) {
-      nonEmptyLines.filter(!$"value".startsWith(options.comment.toString)).as[String]
-    } else {
-      nonEmptyLines.as[String]
-    }
-  }
-
-  /**
-   * Skips the number of lines specified in options from the start of the file. Then blank entries
-   * (and comments if set) are removed. This is currently being used in CSV schema inference.
-   */
-  def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
-    import lines.sqlContext.implicits._
-    val skippedLines = lines.rdd.zipWithIndex().toDF("value", "order")
+    val skippedLines = nonEmptyLines.rdd.zipWithIndex().toDF("value", "order")
       .filter($"order" >= options.skipLines)
       .drop("order")
-      .as[String]
-    filterCommentAndEmpty(skippedLines, options)
+    if (options.isCommentSet) {
+      skippedLines.filter(!$"value".startsWith(options.comment.toString)).as[String]
+    } else {
+      skippedLines.as[String]
+    }
   }
 
   /**
@@ -141,6 +131,6 @@ object CSVUtils {
     }
   }
 
-  def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] =
-    CSVExprUtils.filterCommentAndEmpty(iter, options)
+  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] =
+    CSVExprUtils.skipUnwantedLines(iter, options)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -131,6 +131,6 @@ object CSVUtils {
     }
   }
 
-  def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] =
-    CSVExprUtils.filterUnwantedLines(iter, options)
+  def filterCommentAndEmpty(iter: Iterator[String], options: CSVOptions): Iterator[String] =
+    CSVExprUtils.filterCommentAndEmpty(iter, options)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -43,8 +43,13 @@ object CSVUtils {
         nonEmptyLines.as[String]
       }
     }
+    // Note that unlike actual CSV reading path, it simply filters the given skipped lines.
+    // Therefore, this skips the line same with the skipped lines if exists.
+    val linesToSkip = commentFilteredLines.head(options.skipLines)
     commentFilteredLines.rdd
-      .mapPartitions(_.drop(options.skipLines))
+      .mapPartitions { iter =>
+        iter.filterNot(linesToSkip.contains(_))
+      }
       .toDF("value")
       .as[String]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -46,10 +46,8 @@ object CSVUtils {
     // Note that unlike actual CSV reading path, it simply filters the given skipped lines.
     // Therefore, this skips the line same with the skipped lines if exists.
     val linesToSkip = commentFilteredLines.head(options.skipLines)
-    commentFilteredLines.rdd
-      .mapPartitions { iter =>
-        iter.filterNot(linesToSkip.contains(_))
-      }
+    commentFilteredLines
+      .mapPartitions(_.filterNot(linesToSkip.contains))
       .toDF("value")
       .as[String]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVUtils.scala
@@ -28,7 +28,7 @@ object CSVUtils {
    * Filter ignorable rows for CSV dataset (lines empty, configured to skip, and starting with
    * `comment`). This is currently being used in CSV schema inference.
    */
-  def filterUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
+  def skipUnwantedLines(lines: Dataset[String], options: CSVOptions): Dataset[String] = {
     // Note that this was separately made by SPARK-18362. Logically, this should be the same
     // with the one below, `filterCommentAndEmpty` but execution path is different. One of them
     // might have to be removed in the near future if possible.
@@ -131,6 +131,6 @@ object CSVUtils {
     }
   }
 
-  def filterUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] =
-    CSVExprUtils.filterUnwantedLines(iter, options)
+  def skipUnwantedLines(iter: Iterator[String], options: CSVOptions): Iterator[String] =
+    CSVExprUtils.skipUnwantedLines(iter, options)
 }

--- a/sql/core/src/test/resources/test-data/cars-with-lines-to-skip.csv
+++ b/sql/core/src/test/resources/test-data/cars-with-lines-to-skip.csv
@@ -1,4 +1,5 @@
 
+# comment
 these,lines,a,load,of
 rubbish,that,,isn't,relevant
 year,make,model,comment,blank

--- a/sql/core/src/test/resources/test-data/cars-with-lines-to-skip.csv
+++ b/sql/core/src/test/resources/test-data/cars-with-lines-to-skip.csv
@@ -1,0 +1,8 @@
+
+these,lines,a,load,of
+rubbish,that,,isn't,relevant
+year,make,model,comment,blank
+"2012","Tesla","S","No comment",
+
+1997,Ford,E350,"Go get one now they are going fast",
+2015,Chevy,Volt

--- a/sql/core/src/test/resources/test-data/cars-with-multiline-lines-to-skip.csv
+++ b/sql/core/src/test/resources/test-data/cars-with-multiline-lines-to-skip.csv
@@ -1,0 +1,9 @@
+
+"these
+lines", contain,,stuff,that
+is,not,relevant,so,ignore
+year,make,model,comment,blank
+"2012","Tesla","S","No comment",
+
+1997,Ford,E350,"Go get one now they are going fast",
+2015,Chevy,Volt

--- a/sql/core/src/test/resources/test-data/cars-with-multiline-lines-to-skip.csv
+++ b/sql/core/src/test/resources/test-data/cars-with-multiline-lines-to-skip.csv
@@ -1,4 +1,5 @@
 
+# comment
 "these
 lines", contain,,stuff,that
 is,not,relevant,so,ignore

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2652,10 +2652,10 @@ abstract class CSVSuite
             assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
             checkAnswer(csv, Row("a", "b", skipLines + 1))
           } else {
-            checkAnswer(csv,
-              Seq(
-                Row("a", "b", String.valueOf(skipLines)),
-                Row("a", "b", String.valueOf(skipLines + 1))))
+            val id = csv.select("_c2").collect()
+            id.zipWithIndex.foreach { case (id, index) =>
+                assert(id === Row(skipLines + index))
+            }
           }
         }
       }
@@ -2678,10 +2678,9 @@ abstract class CSVSuite
           assert(csv.schema.fieldNames === Seq("a", "b\nb", String.valueOf(skipLines)))
           checkAnswer(csv, Row("a", "b\nb", skipLines + 1))
         } else {
-          checkAnswer(csv,
-            Seq(
-              Row("a", "b\nb", String.valueOf(skipLines)),
-              Row("a", "b\nb", String.valueOf(skipLines + 1))))
+          val id = csv.select("_c2").collect()
+          id.zipWithIndex.foreach { case (id, index) =>
+            assert(id === Row(skipLines + index))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2626,6 +2626,21 @@ abstract class CSVSuite
   test("SPARK-42359: parses dataset with skipLines") {
     Seq(0, 1, 2, 10, 100).foreach { skipLines =>
       Seq(true, false).foreach { multiline =>
+        val ds = Seq("", "# comment", "a,b,c", "d,e,f").toDS()
+        val csv = spark.read
+          .option("multiLine", multiline)
+          .option("skipLines", skipLines)
+          .option("inferSchema", true)
+          .option("comment", "#")
+          .csv(ds)
+        checkAnswer(csv, Seq(Row("a", "b", "c"), Row("d", "e", "f")))
+      }
+    }
+  }
+
+  test("SPARK-42359: parses dataset with skipLines") {
+    Seq(0, 1, 2, 10, 100).foreach { skipLines =>
+      Seq(true, false).foreach { multiline =>
         Seq(true, false).foreach { header =>
           val ds = spark.range(skipLines + 2)
             .selectExpr("concat('a,b,', id) AS `a.text`").as[String]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2652,7 +2652,10 @@ abstract class CSVSuite
             assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
             checkAnswer(csv, Row("a", "b", skipLines + 1))
           } else {
-            checkAnswer(csv, Seq(Row("a", "b", skipLines), Row("a", "b", skipLines + 1)))
+            checkAnswer(csv,
+              Seq(
+                Row("a", "b", String.valueOf(skipLines)),
+                Row("a", "b", String.valueOf(skipLines + 1))))
           }
         }
       }
@@ -2675,7 +2678,10 @@ abstract class CSVSuite
           assert(csv.schema.fieldNames === Seq("a", "b\nb", String.valueOf(skipLines)))
           checkAnswer(csv, Row("a", "b\nb", skipLines + 1))
         } else {
-          checkAnswer(csv, Seq(Row("a", "b\nb", skipLines), Row("a", "b\nb", skipLines + 1)))
+          checkAnswer(csv,
+            Seq(
+              Row("a", "b\nb", String.valueOf(skipLines)),
+              Row("a", "b\nb", String.valueOf(skipLines + 1))))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2654,7 +2654,7 @@ abstract class CSVSuite
           } else {
             val id = csv.select("_c2").collect()
             id.zipWithIndex.foreach { case (id, index) =>
-                assert(id === Row(skipLines + index))
+                assert(id.toString === Row(skipLines + index).toString)
             }
           }
         }
@@ -2680,7 +2680,7 @@ abstract class CSVSuite
         } else {
           val id = csv.select("_c2").collect()
           id.zipWithIndex.foreach { case (id, index) =>
-            assert(id === Row(skipLines + index))
+            assert(id.get(0) === skipLines + index)
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2628,7 +2628,7 @@ abstract class CSVSuite
         val ds = Seq("", "1,2,3", "# comment", "4,5,6", "a,b,c", "d,e,f").toDS()
         val csv = spark.read
           .option("multiLine", multiline)
-          .option("skipLines", 3)
+          .option("skipLines", 2)
           .option("inferSchema", true)
           .option("comment", "#")
           .csv(ds)
@@ -2669,6 +2669,7 @@ abstract class CSVSuite
           .option("skipLines", skipLines)
           .option("multiLine", true)
           .option("inferSchema", true)
+          .option("header", header)
           .csv(ds)
         if (header) {
           assert(csv.schema.fieldNames === Seq("a", "b\nb", String.valueOf(skipLines)))
@@ -2686,7 +2687,7 @@ abstract class CSVSuite
         val cars = spark
           .read
           .format("csv")
-          .option("skipLines", 3)
+          .option("skipLines", 2)
           .option("multiLine", multiline)
           .option("header", header)
           .option("comment", "#")
@@ -2702,7 +2703,7 @@ abstract class CSVSuite
       val cars = spark
         .read
         .format("csv")
-        .option("skipLines", 3)
+        .option("skipLines", 2)
         .option("multiLine", true)
         .option("header", header)
         .option("comment", "#")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2652,12 +2652,12 @@ abstract class CSVSuite
             assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
             val id = csv.select(String.valueOf(skipLines)).collect()
             id.zipWithIndex.foreach { case (id, index) =>
-              assert(id.get(0) === String.valueOf(skipLines + index + 1))
+              assert(String.valueOf(id.get(0)) === String.valueOf(skipLines + index + 1))
             }
           } else {
             val id = csv.select("_c2").collect()
             id.zipWithIndex.foreach { case (id, index) =>
-              assert(id.get(0) === String.valueOf(skipLines + index))
+              assert(String.valueOf(id.get(0)) === String.valueOf(skipLines + index))
             }
           }
         }
@@ -2681,12 +2681,12 @@ abstract class CSVSuite
           assert(csv.schema.fieldNames === Seq("a", "b\nb", String.valueOf(skipLines)))
           val id = csv.select(String.valueOf(skipLines)).collect()
           id.zipWithIndex.foreach { case (id, index) =>
-            assert(id.get(0) === String.valueOf(skipLines + index + 1))
+            assert(String.valueOf(id.get(0)) === String.valueOf(skipLines + index + 1))
           }
         } else {
           val id = csv.select("_c2").collect()
           id.zipWithIndex.foreach { case (id, index) =>
-            assert(id.get(0) === String.valueOf(skipLines + index))
+            assert(String.valueOf(id.get(0)) === String.valueOf(skipLines + index))
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2629,7 +2629,7 @@ abstract class CSVSuite
         val csv = spark.read
           .option("multiLine", multiline)
           .option("skipLines", 2)
-          .option("inferSchema", true)
+          .option("inferSchema", false)
           .option("comment", "#")
           .csv(ds)
         checkAnswer(csv, Seq(Row("a", "b", "c"), Row("d", "e", "f")))
@@ -2646,7 +2646,7 @@ abstract class CSVSuite
             .option("header", header)
             .option("multiLine", multiline)
             .option("skipLines", skipLines)
-            .option("inferSchema", true)
+            .option("inferSchema", header)
             .csv(ds)
           if (header) {
             assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
@@ -2668,7 +2668,7 @@ abstract class CSVSuite
         val csv = spark.read
           .option("skipLines", skipLines)
           .option("multiLine", true)
-          .option("inferSchema", true)
+          .option("inferSchema", header)
           .option("header", header)
           .csv(ds)
         if (header) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2628,7 +2628,7 @@ abstract class CSVSuite
         val ds = Seq("", "1,2,3", "# comment", "4,5,6", "a,b,c", "d,e,f").toDS()
         val csv = spark.read
           .option("multiLine", multiline)
-          .option("skipLines", 2)
+          .option("skipLines", 3)
           .option("inferSchema", true)
           .option("comment", "#")
           .csv(ds)
@@ -2686,7 +2686,7 @@ abstract class CSVSuite
         val cars = spark
           .read
           .format("csv")
-          .option("skipLines", 2)
+          .option("skipLines", 3)
           .option("multiLine", multiline)
           .option("header", header)
           .option("comment", "#")
@@ -2702,7 +2702,7 @@ abstract class CSVSuite
       val cars = spark
         .read
         .format("csv")
-        .option("skipLines", 2)
+        .option("skipLines", 3)
         .option("multiLine", true)
         .option("header", header)
         .option("comment", "#")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2681,6 +2681,7 @@ abstract class CSVSuite
           val id = csv.select("_c2").collect()
           id.zipWithIndex.foreach { case (id, index) =>
             assert(id === Row(skipLines + index))
+          }
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3187,7 +3187,7 @@ abstract class CSVSuite
   }
 
   test("SPARK-40667: validate CSV Options") {
-    assert(CSVOptions.getAllOptions.size == 38)
+    assert(CSVOptions.getAllOptions.size == 39)
     // Please add validation on any new CSV options here
     assert(CSVOptions.isValidOption("header"))
     assert(CSVOptions.isValidOption("inferSchema"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2673,7 +2673,7 @@ abstract class CSVSuite
         val cars = spark
           .read
           .format("csv")
-          .option("skipLines", 3)
+          .option("skipLines", 2)
           .option("multiLine", multiline)
           .option("header", header)
           .option("comment", "#")
@@ -2689,7 +2689,7 @@ abstract class CSVSuite
       val cars = spark
         .read
         .format("csv")
-        .option("skipLines", 3)
+        .option("skipLines", 2)
         .option("multiLine", true)
         .option("header", header)
         .option("comment", "#")
@@ -3187,7 +3187,7 @@ abstract class CSVSuite
   }
 
   test("SPARK-40667: validate CSV Options") {
-    assert(CSVOptions.getAllOptions.size == 38)
+    assert(CSVOptions.getAllOptions.size == 39)
     // Please add validation on any new CSV options here
     assert(CSVOptions.isValidOption("header"))
     assert(CSVOptions.isValidOption("inferSchema"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2623,7 +2623,7 @@ abstract class CSVSuite
     assert(errMsg1.contains("'skipLines' must be equal to or greater than 0."))
   }
 
-  test("SPARK-42359: parses dataset with skipLines") {
+  test("SPARK-42359: parses dataset with skipLines, comments, and blanks") {
       Seq(true, false).foreach { multiline =>
         val ds = Seq("", "1,2,3", "# comment", "4,5,6", "a,b,c", "d,e,f").toDS()
         val csv = spark.read

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2623,7 +2623,7 @@ abstract class CSVSuite
     assert(errMsg1.contains("'skipLines' must be equal to or greater than 0."))
   }
 
-  test("SPARK-42359: parses dataset with skipLines, comments, and blanks") {
+  test("SPARK-42359: parses dataset with skipLines") {
       Seq(true, false).foreach { multiline =>
         val ds = Seq("", "1,2,3", "# comment", "4,5,6", "a,b,c", "d,e,f").toDS()
         val csv = spark.read

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2676,6 +2676,7 @@ abstract class CSVSuite
           .option("skipLines", 3)
           .option("multiLine", multiline)
           .option("header", header)
+          .option("comment", "#")
           .csv(testFile(carsWithLinesToSkip))
 
         verifyCars(cars, withHeader = header, checkTypes = false)
@@ -2691,6 +2692,7 @@ abstract class CSVSuite
         .option("skipLines", 3)
         .option("multiLine", true)
         .option("header", header)
+        .option("comment", "#")
         .csv(testFile(carsWithMultilineLinesToSkip))
 
       verifyCars(cars, withHeader = header, checkTypes = false)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2624,18 +2624,16 @@ abstract class CSVSuite
   }
 
   test("SPARK-42359: parses dataset with skipLines") {
-    Seq(0, 1, 2, 10, 100).foreach { skipLines =>
       Seq(true, false).foreach { multiline =>
-        val ds = Seq("", "# comment", "a,b,c", "d,e,f").toDS()
+        val ds = Seq("", "1,2,3", "# comment", "4,5,6", "a,b,c", "d,e,f").toDS()
         val csv = spark.read
           .option("multiLine", multiline)
-          .option("skipLines", skipLines)
+          .option("skipLines", 2)
           .option("inferSchema", true)
           .option("comment", "#")
           .csv(ds)
         checkAnswer(csv, Seq(Row("a", "b", "c"), Row("d", "e", "f")))
       }
-    }
   }
 
   test("SPARK-42359: parses dataset with skipLines") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2650,11 +2650,14 @@ abstract class CSVSuite
             .csv(ds)
           if (header) {
             assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
-            checkAnswer(csv, Row("a", "b", skipLines + 1))
+            val id = csv.select(String.valueOf(skipLines)).collect()
+            id.zipWithIndex.foreach { case (id, index) =>
+              assert(id.get(0) === String.valueOf(skipLines + index + 1))
+            }
           } else {
             val id = csv.select("_c2").collect()
             id.zipWithIndex.foreach { case (id, index) =>
-                assert(id.toString === Row(skipLines + index).toString)
+              assert(id.get(0) === String.valueOf(skipLines + index))
             }
           }
         }
@@ -2676,11 +2679,14 @@ abstract class CSVSuite
           .csv(ds)
         if (header) {
           assert(csv.schema.fieldNames === Seq("a", "b\nb", String.valueOf(skipLines)))
-          checkAnswer(csv, Row("a", "b\nb", skipLines + 1))
+          val id = csv.select(String.valueOf(skipLines)).collect()
+          id.zipWithIndex.foreach { case (id, index) =>
+            assert(id.get(0) === String.valueOf(skipLines + index + 1))
+          }
         } else {
           val id = csv.select("_c2").collect()
           id.zipWithIndex.foreach { case (id, index) =>
-            assert(id.get(0) === skipLines + index)
+            assert(id.get(0) === String.valueOf(skipLines + index))
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2635,15 +2635,15 @@ abstract class CSVSuite
             .option("skipLines", skipLines)
             .option("inferSchema", true)
             .csv(ds)
-          assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
           if (header) {
+            assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
             checkAnswer(csv, Row("a", "b", skipLines + 1))
           } else {
             checkAnswer(csv, Seq(Row("a", "b", skipLines), Row("a", "b", skipLines + 1)))
           }
         }
       }
-    }
+    }tils
   }
 
   test("SPARK-42359: parses dataset with multiline skipLines") {
@@ -2657,8 +2657,8 @@ abstract class CSVSuite
           .option("multiLine", true)
           .option("inferSchema", true)
           .csv(ds)
-        assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
         if (header) {
+          assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
           checkAnswer(csv, Row("a", "b\nb", skipLines + 1))
         } else {
           checkAnswer(csv, Seq(Row("a", "b\nb", skipLines), Row("a", "b\nb", skipLines + 1)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2643,7 +2643,7 @@ abstract class CSVSuite
           }
         }
       }
-    }tils
+    }
   }
 
   test("SPARK-42359: parses dataset with multiline skipLines") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2661,7 +2661,7 @@ abstract class CSVSuite
 
   test("SPARK-42359: parses dataset with multiline skipLines") {
     Seq(0, 1, 2, 10, 100).foreach { skipLines =>
-      Seq(true, false).foreach { header =>
+      Seq(false, true).foreach { header =>
         val ds = spark.range(skipLines + 2)
           .selectExpr("concat('a,\"b\nb\",', id) AS `a.text`")
           .as[String]
@@ -2671,7 +2671,7 @@ abstract class CSVSuite
           .option("inferSchema", true)
           .csv(ds)
         if (header) {
-          assert(csv.schema.fieldNames === Seq("a", "b", String.valueOf(skipLines)))
+          assert(csv.schema.fieldNames === Seq("a", "b\nb", String.valueOf(skipLines)))
           checkAnswer(csv, Row("a", "b\nb", skipLines + 1))
         } else {
           checkAnswer(csv, Seq(Row("a", "b\nb", skipLines), Row("a", "b\nb", skipLines + 1)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3187,7 +3187,7 @@ abstract class CSVSuite
   }
 
   test("SPARK-40667: validate CSV Options") {
-    assert(CSVOptions.getAllOptions.size == 39)
+    assert(CSVOptions.getAllOptions.size == 38)
     // Please add validation on any new CSV options here
     assert(CSVOptions.isValidOption("header"))
     assert(CSVOptions.isValidOption("inferSchema"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added support row skipping when reading CSV files with a `skipLines` option.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In [SPARK-42359](https://issues.apache.org/jira/browse/SPARK-42359) we highlight the need for row skipping functionality in CSV reads. In summary, there is no way of users reading CSV files that do not have the header/data in the first row with the DataFrame API. Advanced users can use RDDs and `zipWithIndex` to remove the first n rows, though this is not compatible with RDDs being an unordered concept.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Now the user's have access to a new a option when reading CSVs. This option defaults to 0 so legacy code will be unaffected. The `skipLines` option that has been added will cause the parser to skip a specified number of lines before parsing the data. It will respect multline values. If the `header` option is set to `true`, the first line after the `skipLines` will be taken as the header.

The option is used: `spark.read.option("skipLines", 2).csv("/path/to/file.csv")`.

This change has been reflected in the user docs.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tests added in CSVSuite for:
* Reads from datasets of Strings with `multiLine` enabled and disabled.
* Reads from CSV files with `multiLine` enabled and disabled (these take different code-paths). 
* Reads with `header` set as `true` and as as `false` (ensure schema is correctly inferred).
* Invalid `skipLines` option throws exception.