### PR TITLE
[SPARK-42360][SQL] Transform LeftOuter join with IsNull filter on right side to Anti join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -202,42 +202,28 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
     })
   }
 
-  /**
-   * Transform LeftOuter Join to Anti Join if:
-   * 1. Only select from the left side
-   * 2. Exists isNull filter on the right side
-   */
-  object LeftOuterJoinsWithNullFilter extends PredicateHelper {
-    def unapply(plan: LogicalPlan): Option[LogicalPlan] = plan match {
-      case Project(projectList, f @ Filter(cond, j @ Join(left, right, LeftOuter, _, _)))
-        if projectList.forall(canEvaluate(_, left)) =>
-        val filterConditions = splitConjunctivePredicates(cond)
-        val isNullConstraints = f.constraints.collect {
-          case IsNull(e: Attribute) if right.outputSet.contains(e) => e.exprId
-        }
-        val isNotNullConstraints = right.constraints.collect {
-          case IsNotNull(e: Attribute) if right.outputSet.contains(e) => e.exprId
-        }
-        if (isNullConstraints.intersect(isNotNullConstraints).nonEmpty) {
-          val newJoin = j.copy(joinType = LeftAnti)
-          val leftConds = filterConditions.filter(_.references.intersect(right.outputSet).isEmpty)
-          if (leftConds.isEmpty) {
-            Some(Project(projectList, newJoin))
-          } else {
-            Some(Project(projectList, Filter(buildBalancedPredicate(leftConds, And), newJoin)))
-          }
-        } else {
-          None
-        }
-
-      case _ => None
-    }
-  }
-
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
     _.containsPattern(OUTER_JOIN), ruleId) {
-    case LeftOuterJoinsWithNullFilter(newProject) =>
-      newProject
+    case p @ Project(projectList, Filter(cond, j @ Join(left, right, LeftOuter, _, _)))
+        if projectList.forall(canEvaluate(_, left)) =>
+      val notNullAttrs =
+        AttributeSet(right.constraints.collect { case IsNotNull(a: Attribute) => a })
+      if (notNullAttrs.nonEmpty) {
+        val (isNullConditions, rest) = splitConjunctivePredicates(cond).partition {
+          case IsNull(a: Attribute) => notNullAttrs.contains(a)
+          case _ => false
+        }
+        if (isNullConditions.nonEmpty &&
+          rest.forall(_.references.intersect(right.outputSet).isEmpty)) {
+          val newJoin = j.copy(joinType = LeftAnti)
+          p.copy(child = rest.reduceLeftOption(And).map(Filter(_, newJoin)).getOrElse(newJoin))
+        } else {
+          p
+        }
+      } else {
+        p
+      }
+
     case f @ Filter(condition, j @ Join(_, _, RightOuter | LeftOuter | FullOuter, _, _)) =>
       val newJoinType = buildNewJoinType(f, j)
       if (j.joinType == newJoinType) f else Filter(condition, j.copy(joinType = newJoinType))

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78.sf100/explain.txt
@@ -1,74 +1,71 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * Project (69)
-   +- * SortMergeJoin Inner (68)
-      :- * Project (45)
-      :  +- * SortMergeJoin Inner (44)
-      :     :- * Sort (21)
-      :     :  +- * HashAggregate (20)
-      :     :     +- Exchange (19)
-      :     :        +- * HashAggregate (18)
-      :     :           +- * Project (17)
-      :     :              +- * BroadcastHashJoin Inner BuildRight (16)
-      :     :                 :- * Project (14)
-      :     :                 :  +- * Filter (13)
-      :     :                 :     +- * SortMergeJoin LeftOuter (12)
-      :     :                 :        :- * Sort (5)
-      :     :                 :        :  +- Exchange (4)
-      :     :                 :        :     +- * Filter (3)
-      :     :                 :        :        +- * ColumnarToRow (2)
-      :     :                 :        :           +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :                 :        +- * Sort (11)
-      :     :                 :           +- Exchange (10)
-      :     :                 :              +- * Project (9)
-      :     :                 :                 +- * Filter (8)
-      :     :                 :                    +- * ColumnarToRow (7)
-      :     :                 :                       +- Scan parquet spark_catalog.default.store_returns (6)
-      :     :                 +- ReusedExchange (15)
-      :     +- * Sort (43)
-      :        +- * Filter (42)
-      :           +- * HashAggregate (41)
-      :              +- Exchange (40)
-      :                 +- * HashAggregate (39)
-      :                    +- * Project (38)
-      :                       +- * BroadcastHashJoin Inner BuildRight (37)
-      :                          :- * Project (35)
-      :                          :  +- * Filter (34)
-      :                          :     +- * SortMergeJoin LeftOuter (33)
-      :                          :        :- * Sort (26)
-      :                          :        :  +- Exchange (25)
-      :                          :        :     +- * Filter (24)
-      :                          :        :        +- * ColumnarToRow (23)
-      :                          :        :           +- Scan parquet spark_catalog.default.web_sales (22)
-      :                          :        +- * Sort (32)
-      :                          :           +- Exchange (31)
-      :                          :              +- * Project (30)
-      :                          :                 +- * Filter (29)
-      :                          :                    +- * ColumnarToRow (28)
-      :                          :                       +- Scan parquet spark_catalog.default.web_returns (27)
-      :                          +- ReusedExchange (36)
-      +- * Sort (67)
-         +- * Filter (66)
-            +- * HashAggregate (65)
-               +- Exchange (64)
-                  +- * HashAggregate (63)
-                     +- * Project (62)
-                        +- * BroadcastHashJoin Inner BuildRight (61)
-                           :- * Project (59)
-                           :  +- * Filter (58)
-                           :     +- * SortMergeJoin LeftOuter (57)
-                           :        :- * Sort (50)
-                           :        :  +- Exchange (49)
-                           :        :     +- * Filter (48)
-                           :        :        +- * ColumnarToRow (47)
-                           :        :           +- Scan parquet spark_catalog.default.catalog_sales (46)
-                           :        +- * Sort (56)
-                           :           +- Exchange (55)
-                           :              +- * Project (54)
-                           :                 +- * Filter (53)
-                           :                    +- * ColumnarToRow (52)
-                           :                       +- Scan parquet spark_catalog.default.catalog_returns (51)
-                           +- ReusedExchange (60)
+TakeOrderedAndProject (67)
++- * Project (66)
+   +- * SortMergeJoin Inner (65)
+      :- * Project (43)
+      :  +- * SortMergeJoin Inner (42)
+      :     :- * Sort (20)
+      :     :  +- * HashAggregate (19)
+      :     :     +- Exchange (18)
+      :     :        +- * HashAggregate (17)
+      :     :           +- * Project (16)
+      :     :              +- * BroadcastHashJoin Inner BuildRight (15)
+      :     :                 :- * Project (13)
+      :     :                 :  +- * SortMergeJoin LeftAnti (12)
+      :     :                 :     :- * Sort (5)
+      :     :                 :     :  +- Exchange (4)
+      :     :                 :     :     +- * Filter (3)
+      :     :                 :     :        +- * ColumnarToRow (2)
+      :     :                 :     :           +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :                 :     +- * Sort (11)
+      :     :                 :        +- Exchange (10)
+      :     :                 :           +- * Project (9)
+      :     :                 :              +- * Filter (8)
+      :     :                 :                 +- * ColumnarToRow (7)
+      :     :                 :                    +- Scan parquet spark_catalog.default.store_returns (6)
+      :     :                 +- ReusedExchange (14)
+      :     +- * Sort (41)
+      :        +- * Filter (40)
+      :           +- * HashAggregate (39)
+      :              +- Exchange (38)
+      :                 +- * HashAggregate (37)
+      :                    +- * Project (36)
+      :                       +- * BroadcastHashJoin Inner BuildRight (35)
+      :                          :- * Project (33)
+      :                          :  +- * SortMergeJoin LeftAnti (32)
+      :                          :     :- * Sort (25)
+      :                          :     :  +- Exchange (24)
+      :                          :     :     +- * Filter (23)
+      :                          :     :        +- * ColumnarToRow (22)
+      :                          :     :           +- Scan parquet spark_catalog.default.web_sales (21)
+      :                          :     +- * Sort (31)
+      :                          :        +- Exchange (30)
+      :                          :           +- * Project (29)
+      :                          :              +- * Filter (28)
+      :                          :                 +- * ColumnarToRow (27)
+      :                          :                    +- Scan parquet spark_catalog.default.web_returns (26)
+      :                          +- ReusedExchange (34)
+      +- * Sort (64)
+         +- * Filter (63)
+            +- * HashAggregate (62)
+               +- Exchange (61)
+                  +- * HashAggregate (60)
+                     +- * Project (59)
+                        +- * BroadcastHashJoin Inner BuildRight (58)
+                           :- * Project (56)
+                           :  +- * SortMergeJoin LeftAnti (55)
+                           :     :- * Sort (48)
+                           :     :  +- Exchange (47)
+                           :     :     +- * Filter (46)
+                           :     :        +- * ColumnarToRow (45)
+                           :     :           +- Scan parquet spark_catalog.default.catalog_sales (44)
+                           :     +- * Sort (54)
+                           :        +- Exchange (53)
+                           :           +- * Project (52)
+                           :              +- * Filter (51)
+                           :                 +- * ColumnarToRow (50)
+                           :                    +- Scan parquet spark_catalog.default.catalog_returns (49)
+                           +- ReusedExchange (57)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -123,53 +120,49 @@ Arguments: [sr_ticket_number#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST], 
 (12) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ss_ticket_number#3, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#10, sr_item_sk#9]
-Join type: LeftOuter
+Join type: LeftAnti
 Join condition: None
 
-(13) Filter [codegen id : 6]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#3, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7, sr_item_sk#9, sr_ticket_number#10]
-Condition : isnull(sr_ticket_number#10)
-
-(14) Project [codegen id : 6]
+(13) Project [codegen id : 6]
 Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#3, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7, sr_item_sk#9, sr_ticket_number#10]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#3, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7]
 
-(15) ReusedExchange [Reuses operator id: 74]
+(14) ReusedExchange [Reuses operator id: 71]
 Output [2]: [d_date_sk#12, d_year#13]
 
-(16) BroadcastHashJoin [codegen id : 6]
+(15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 6]
+(16) Project [codegen id : 6]
 Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, d_year#13]
 Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7, d_date_sk#12, d_year#13]
 
-(18) HashAggregate [codegen id : 6]
+(17) HashAggregate [codegen id : 6]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, d_year#13]
 Keys [3]: [d_year#13, ss_item_sk#1, ss_customer_sk#2]
 Functions [3]: [partial_sum(ss_quantity#4), partial_sum(UnscaledValue(ss_wholesale_cost#5)), partial_sum(UnscaledValue(ss_sales_price#6))]
 Aggregate Attributes [3]: [sum#14, sum#15, sum#16]
 Results [6]: [d_year#13, ss_item_sk#1, ss_customer_sk#2, sum#17, sum#18, sum#19]
 
-(19) Exchange
+(18) Exchange
 Input [6]: [d_year#13, ss_item_sk#1, ss_customer_sk#2, sum#17, sum#18, sum#19]
 Arguments: hashpartitioning(d_year#13, ss_item_sk#1, ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) HashAggregate [codegen id : 7]
+(19) HashAggregate [codegen id : 7]
 Input [6]: [d_year#13, ss_item_sk#1, ss_customer_sk#2, sum#17, sum#18, sum#19]
 Keys [3]: [d_year#13, ss_item_sk#1, ss_customer_sk#2]
 Functions [3]: [sum(ss_quantity#4), sum(UnscaledValue(ss_wholesale_cost#5)), sum(UnscaledValue(ss_sales_price#6))]
 Aggregate Attributes [3]: [sum(ss_quantity#4)#20, sum(UnscaledValue(ss_wholesale_cost#5))#21, sum(UnscaledValue(ss_sales_price#6))#22]
 Results [6]: [d_year#13 AS ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, sum(ss_quantity#4)#20 AS ss_qty#24, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#5))#21,17,2) AS ss_wc#25, MakeDecimal(sum(UnscaledValue(ss_sales_price#6))#22,17,2) AS ss_sp#26]
 
-(21) Sort [codegen id : 7]
+(20) Sort [codegen id : 7]
 Input [6]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26]
 Arguments: [ss_sold_year#23 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
-(22) Scan parquet spark_catalog.default.web_sales
+(21) Scan parquet spark_catalog.default.web_sales
 Output [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 Batched: true
 Location: InMemoryFileIndex []
@@ -177,111 +170,107 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#33), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int,ws_order_number:int,ws_quantity:int,ws_wholesale_cost:decimal(7,2),ws_sales_price:decimal(7,2)>
 
-(23) ColumnarToRow [codegen id : 8]
+(22) ColumnarToRow [codegen id : 8]
 Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 
-(24) Filter [codegen id : 8]
+(23) Filter [codegen id : 8]
 Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 Condition : (isnotnull(ws_item_sk#27) AND isnotnull(ws_bill_customer_sk#28))
 
-(25) Exchange
+(24) Exchange
 Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 Arguments: hashpartitioning(ws_order_number#29, ws_item_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(26) Sort [codegen id : 9]
+(25) Sort [codegen id : 9]
 Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 Arguments: [ws_order_number#29 ASC NULLS FIRST, ws_item_sk#27 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet spark_catalog.default.web_returns
+(26) Scan parquet spark_catalog.default.web_returns
 Output [3]: [wr_item_sk#34, wr_order_number#35, wr_returned_date_sk#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int>
 
-(28) ColumnarToRow [codegen id : 10]
+(27) ColumnarToRow [codegen id : 10]
 Input [3]: [wr_item_sk#34, wr_order_number#35, wr_returned_date_sk#36]
 
-(29) Filter [codegen id : 10]
+(28) Filter [codegen id : 10]
 Input [3]: [wr_item_sk#34, wr_order_number#35, wr_returned_date_sk#36]
 Condition : (isnotnull(wr_order_number#35) AND isnotnull(wr_item_sk#34))
 
-(30) Project [codegen id : 10]
+(29) Project [codegen id : 10]
 Output [2]: [wr_item_sk#34, wr_order_number#35]
 Input [3]: [wr_item_sk#34, wr_order_number#35, wr_returned_date_sk#36]
 
-(31) Exchange
+(30) Exchange
 Input [2]: [wr_item_sk#34, wr_order_number#35]
 Arguments: hashpartitioning(wr_order_number#35, wr_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(32) Sort [codegen id : 11]
+(31) Sort [codegen id : 11]
 Input [2]: [wr_item_sk#34, wr_order_number#35]
 Arguments: [wr_order_number#35 ASC NULLS FIRST, wr_item_sk#34 ASC NULLS FIRST], false, 0
 
-(33) SortMergeJoin [codegen id : 13]
+(32) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ws_order_number#29, ws_item_sk#27]
 Right keys [2]: [wr_order_number#35, wr_item_sk#34]
-Join type: LeftOuter
+Join type: LeftAnti
 Join condition: None
 
-(34) Filter [codegen id : 13]
-Input [9]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33, wr_item_sk#34, wr_order_number#35]
-Condition : isnull(wr_order_number#35)
-
-(35) Project [codegen id : 13]
+(33) Project [codegen id : 13]
 Output [6]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
-Input [9]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33, wr_item_sk#34, wr_order_number#35]
+Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 
-(36) ReusedExchange [Reuses operator id: 74]
+(34) ReusedExchange [Reuses operator id: 71]
 Output [2]: [d_date_sk#37, d_year#38]
 
-(37) BroadcastHashJoin [codegen id : 13]
+(35) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_sold_date_sk#33]
 Right keys [1]: [d_date_sk#37]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 13]
+(36) Project [codegen id : 13]
 Output [6]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, d_year#38]
 Input [8]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33, d_date_sk#37, d_year#38]
 
-(39) HashAggregate [codegen id : 13]
+(37) HashAggregate [codegen id : 13]
 Input [6]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, d_year#38]
 Keys [3]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28]
 Functions [3]: [partial_sum(ws_quantity#30), partial_sum(UnscaledValue(ws_wholesale_cost#31)), partial_sum(UnscaledValue(ws_sales_price#32))]
 Aggregate Attributes [3]: [sum#39, sum#40, sum#41]
 Results [6]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28, sum#42, sum#43, sum#44]
 
-(40) Exchange
+(38) Exchange
 Input [6]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28, sum#42, sum#43, sum#44]
 Arguments: hashpartitioning(d_year#38, ws_item_sk#27, ws_bill_customer_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(41) HashAggregate [codegen id : 14]
+(39) HashAggregate [codegen id : 14]
 Input [6]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28, sum#42, sum#43, sum#44]
 Keys [3]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28]
 Functions [3]: [sum(ws_quantity#30), sum(UnscaledValue(ws_wholesale_cost#31)), sum(UnscaledValue(ws_sales_price#32))]
 Aggregate Attributes [3]: [sum(ws_quantity#30)#45, sum(UnscaledValue(ws_wholesale_cost#31))#46, sum(UnscaledValue(ws_sales_price#32))#47]
 Results [6]: [d_year#38 AS ws_sold_year#48, ws_item_sk#27, ws_bill_customer_sk#28 AS ws_customer_sk#49, sum(ws_quantity#30)#45 AS ws_qty#50, MakeDecimal(sum(UnscaledValue(ws_wholesale_cost#31))#46,17,2) AS ws_wc#51, MakeDecimal(sum(UnscaledValue(ws_sales_price#32))#47,17,2) AS ws_sp#52]
 
-(42) Filter [codegen id : 14]
+(40) Filter [codegen id : 14]
 Input [6]: [ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49, ws_qty#50, ws_wc#51, ws_sp#52]
 Condition : (coalesce(ws_qty#50, 0) > 0)
 
-(43) Sort [codegen id : 14]
+(41) Sort [codegen id : 14]
 Input [6]: [ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49, ws_qty#50, ws_wc#51, ws_sp#52]
 Arguments: [ws_sold_year#48 ASC NULLS FIRST, ws_item_sk#27 ASC NULLS FIRST, ws_customer_sk#49 ASC NULLS FIRST], false, 0
 
-(44) SortMergeJoin [codegen id : 15]
+(42) SortMergeJoin [codegen id : 15]
 Left keys [3]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49]
 Join type: Inner
 Join condition: None
 
-(45) Project [codegen id : 15]
+(43) Project [codegen id : 15]
 Output [9]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26, ws_qty#50, ws_wc#51, ws_sp#52]
 Input [12]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26, ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49, ws_qty#50, ws_wc#51, ws_sp#52]
 
-(46) Scan parquet spark_catalog.default.catalog_sales
+(44) Scan parquet spark_catalog.default.catalog_sales
 Output [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 Batched: true
 Location: InMemoryFileIndex []
@@ -289,143 +278,139 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#59), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_wholesale_cost:decimal(7,2),cs_sales_price:decimal(7,2)>
 
-(47) ColumnarToRow [codegen id : 16]
+(45) ColumnarToRow [codegen id : 16]
 Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 
-(48) Filter [codegen id : 16]
+(46) Filter [codegen id : 16]
 Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 Condition : (isnotnull(cs_item_sk#54) AND isnotnull(cs_bill_customer_sk#53))
 
-(49) Exchange
+(47) Exchange
 Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 Arguments: hashpartitioning(cs_order_number#55, cs_item_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(50) Sort [codegen id : 17]
+(48) Sort [codegen id : 17]
 Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 Arguments: [cs_order_number#55 ASC NULLS FIRST, cs_item_sk#54 ASC NULLS FIRST], false, 0
 
-(51) Scan parquet spark_catalog.default.catalog_returns
+(49) Scan parquet spark_catalog.default.catalog_returns
 Output [3]: [cr_item_sk#60, cr_order_number#61, cr_returned_date_sk#62]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
 
-(52) ColumnarToRow [codegen id : 18]
+(50) ColumnarToRow [codegen id : 18]
 Input [3]: [cr_item_sk#60, cr_order_number#61, cr_returned_date_sk#62]
 
-(53) Filter [codegen id : 18]
+(51) Filter [codegen id : 18]
 Input [3]: [cr_item_sk#60, cr_order_number#61, cr_returned_date_sk#62]
 Condition : (isnotnull(cr_order_number#61) AND isnotnull(cr_item_sk#60))
 
-(54) Project [codegen id : 18]
+(52) Project [codegen id : 18]
 Output [2]: [cr_item_sk#60, cr_order_number#61]
 Input [3]: [cr_item_sk#60, cr_order_number#61, cr_returned_date_sk#62]
 
-(55) Exchange
+(53) Exchange
 Input [2]: [cr_item_sk#60, cr_order_number#61]
 Arguments: hashpartitioning(cr_order_number#61, cr_item_sk#60, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(56) Sort [codegen id : 19]
+(54) Sort [codegen id : 19]
 Input [2]: [cr_item_sk#60, cr_order_number#61]
 Arguments: [cr_order_number#61 ASC NULLS FIRST, cr_item_sk#60 ASC NULLS FIRST], false, 0
 
-(57) SortMergeJoin [codegen id : 21]
+(55) SortMergeJoin [codegen id : 21]
 Left keys [2]: [cs_order_number#55, cs_item_sk#54]
 Right keys [2]: [cr_order_number#61, cr_item_sk#60]
-Join type: LeftOuter
+Join type: LeftAnti
 Join condition: None
 
-(58) Filter [codegen id : 21]
-Input [9]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59, cr_item_sk#60, cr_order_number#61]
-Condition : isnull(cr_order_number#61)
-
-(59) Project [codegen id : 21]
+(56) Project [codegen id : 21]
 Output [6]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
-Input [9]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59, cr_item_sk#60, cr_order_number#61]
+Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 
-(60) ReusedExchange [Reuses operator id: 74]
+(57) ReusedExchange [Reuses operator id: 71]
 Output [2]: [d_date_sk#63, d_year#64]
 
-(61) BroadcastHashJoin [codegen id : 21]
+(58) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [cs_sold_date_sk#59]
 Right keys [1]: [d_date_sk#63]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 21]
+(59) Project [codegen id : 21]
 Output [6]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, d_year#64]
 Input [8]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59, d_date_sk#63, d_year#64]
 
-(63) HashAggregate [codegen id : 21]
+(60) HashAggregate [codegen id : 21]
 Input [6]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, d_year#64]
 Keys [3]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53]
 Functions [3]: [partial_sum(cs_quantity#56), partial_sum(UnscaledValue(cs_wholesale_cost#57)), partial_sum(UnscaledValue(cs_sales_price#58))]
 Aggregate Attributes [3]: [sum#65, sum#66, sum#67]
 Results [6]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, sum#68, sum#69, sum#70]
 
-(64) Exchange
+(61) Exchange
 Input [6]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, sum#68, sum#69, sum#70]
 Arguments: hashpartitioning(d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(65) HashAggregate [codegen id : 22]
+(62) HashAggregate [codegen id : 22]
 Input [6]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, sum#68, sum#69, sum#70]
 Keys [3]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53]
 Functions [3]: [sum(cs_quantity#56), sum(UnscaledValue(cs_wholesale_cost#57)), sum(UnscaledValue(cs_sales_price#58))]
 Aggregate Attributes [3]: [sum(cs_quantity#56)#71, sum(UnscaledValue(cs_wholesale_cost#57))#72, sum(UnscaledValue(cs_sales_price#58))#73]
 Results [6]: [d_year#64 AS cs_sold_year#74, cs_item_sk#54, cs_bill_customer_sk#53 AS cs_customer_sk#75, sum(cs_quantity#56)#71 AS cs_qty#76, MakeDecimal(sum(UnscaledValue(cs_wholesale_cost#57))#72,17,2) AS cs_wc#77, MakeDecimal(sum(UnscaledValue(cs_sales_price#58))#73,17,2) AS cs_sp#78]
 
-(66) Filter [codegen id : 22]
+(63) Filter [codegen id : 22]
 Input [6]: [cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75, cs_qty#76, cs_wc#77, cs_sp#78]
 Condition : (coalesce(cs_qty#76, 0) > 0)
 
-(67) Sort [codegen id : 22]
+(64) Sort [codegen id : 22]
 Input [6]: [cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75, cs_qty#76, cs_wc#77, cs_sp#78]
 Arguments: [cs_sold_year#74 ASC NULLS FIRST, cs_item_sk#54 ASC NULLS FIRST, cs_customer_sk#75 ASC NULLS FIRST], false, 0
 
-(68) SortMergeJoin [codegen id : 23]
+(65) SortMergeJoin [codegen id : 23]
 Left keys [3]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75]
 Join type: Inner
 Join condition: None
 
-(69) Project [codegen id : 23]
+(66) Project [codegen id : 23]
 Output [13]: [round((cast(ss_qty#24 as double) / cast(coalesce((ws_qty#50 + cs_qty#76), 1) as double)), 2) AS ratio#79, ss_qty#24 AS store_qty#80, ss_wc#25 AS store_wholesale_cost#81, ss_sp#26 AS store_sales_price#82, (coalesce(ws_qty#50, 0) + coalesce(cs_qty#76, 0)) AS other_chan_qty#83, (coalesce(ws_wc#51, 0.00) + coalesce(cs_wc#77, 0.00)) AS other_chan_wholesale_cost#84, (coalesce(ws_sp#52, 0.00) + coalesce(cs_sp#78, 0.00)) AS other_chan_sales_price#85, ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26]
 Input [15]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26, ws_qty#50, ws_wc#51, ws_sp#52, cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75, cs_qty#76, cs_wc#77, cs_sp#78]
 
-(70) TakeOrderedAndProject
+(67) TakeOrderedAndProject
 Input [13]: [ratio#79, store_qty#80, store_wholesale_cost#81, store_sales_price#82, other_chan_qty#83, other_chan_wholesale_cost#84, other_chan_sales_price#85, ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26]
 Arguments: 100, [ss_sold_year#23 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_customer_sk#2 ASC NULLS FIRST, ss_qty#24 DESC NULLS LAST, ss_wc#25 DESC NULLS LAST, ss_sp#26 DESC NULLS LAST, other_chan_qty#83 ASC NULLS FIRST, other_chan_wholesale_cost#84 ASC NULLS FIRST, other_chan_sales_price#85 ASC NULLS FIRST, ratio#79 ASC NULLS FIRST], [ratio#79, store_qty#80, store_wholesale_cost#81, store_sales_price#82, other_chan_qty#83, other_chan_wholesale_cost#84, other_chan_sales_price#85]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (74)
-+- * Filter (73)
-   +- * ColumnarToRow (72)
-      +- Scan parquet spark_catalog.default.date_dim (71)
+BroadcastExchange (71)
++- * Filter (70)
+   +- * ColumnarToRow (69)
+      +- Scan parquet spark_catalog.default.date_dim (68)
 
 
-(71) Scan parquet spark_catalog.default.date_dim
+(68) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#12, d_year#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
+(69) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#12, d_year#13]
 
-(73) Filter [codegen id : 1]
+(70) Filter [codegen id : 1]
 Input [2]: [d_date_sk#12, d_year#13]
 Condition : ((isnotnull(d_year#13) AND (d_year#13 = 2000)) AND isnotnull(d_date_sk#12))
 
-(74) BroadcastExchange
+(71) BroadcastExchange
 Input [2]: [d_date_sk#12, d_year#13]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
 
-Subquery:2 Hosting operator id = 22 Hosting Expression = ws_sold_date_sk#33 IN dynamicpruning#8
+Subquery:2 Hosting operator id = 21 Hosting Expression = ws_sold_date_sk#33 IN dynamicpruning#8
 
-Subquery:3 Hosting operator id = 46 Hosting Expression = cs_sold_date_sk#59 IN dynamicpruning#8
+Subquery:3 Hosting operator id = 44 Hosting Expression = cs_sold_date_sk#59 IN dynamicpruning#8
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78.sf100/simplified.txt
@@ -17,36 +17,35 @@ TakeOrderedAndProject [ss_sold_year,ss_item_sk,ss_customer_sk,ss_qty,ss_wc,ss_sp
                                 Project [ss_item_sk,ss_customer_sk,ss_quantity,ss_wholesale_cost,ss_sales_price,d_year]
                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                     Project [ss_item_sk,ss_customer_sk,ss_quantity,ss_wholesale_cost,ss_sales_price,ss_sold_date_sk]
-                                      Filter [sr_ticket_number]
-                                        SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                          InputAdapter
-                                            WholeStageCodegen (2)
-                                              Sort [ss_ticket_number,ss_item_sk]
-                                                InputAdapter
-                                                  Exchange [ss_ticket_number,ss_item_sk] #2
-                                                    WholeStageCodegen (1)
-                                                      Filter [ss_item_sk,ss_customer_sk]
+                                      SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                        InputAdapter
+                                          WholeStageCodegen (2)
+                                            Sort [ss_ticket_number,ss_item_sk]
+                                              InputAdapter
+                                                Exchange [ss_ticket_number,ss_item_sk] #2
+                                                  WholeStageCodegen (1)
+                                                    Filter [ss_item_sk,ss_customer_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,ss_wholesale_cost,ss_sales_price,ss_sold_date_sk]
+                                                            SubqueryBroadcast [d_date_sk] #1
+                                                              BroadcastExchange #3
+                                                                WholeStageCodegen (1)
+                                                                  Filter [d_year,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
+                                        InputAdapter
+                                          WholeStageCodegen (4)
+                                            Sort [sr_ticket_number,sr_item_sk]
+                                              InputAdapter
+                                                Exchange [sr_ticket_number,sr_item_sk] #4
+                                                  WholeStageCodegen (3)
+                                                    Project [sr_item_sk,sr_ticket_number]
+                                                      Filter [sr_ticket_number,sr_item_sk]
                                                         ColumnarToRow
                                                           InputAdapter
-                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,ss_wholesale_cost,ss_sales_price,ss_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                BroadcastExchange #3
-                                                                  WholeStageCodegen (1)
-                                                                    Filter [d_year,d_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
-                                          InputAdapter
-                                            WholeStageCodegen (4)
-                                              Sort [sr_ticket_number,sr_item_sk]
-                                                InputAdapter
-                                                  Exchange [sr_ticket_number,sr_item_sk] #4
-                                                    WholeStageCodegen (3)
-                                                      Project [sr_item_sk,sr_ticket_number]
-                                                        Filter [sr_ticket_number,sr_item_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                                                            Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                                     InputAdapter
                                       ReusedExchange [d_date_sk,d_year] #3
                 InputAdapter
@@ -61,30 +60,29 @@ TakeOrderedAndProject [ss_sold_year,ss_item_sk,ss_customer_sk,ss_qty,ss_wc,ss_sp
                                   Project [ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_wholesale_cost,ws_sales_price,d_year]
                                     BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                       Project [ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_wholesale_cost,ws_sales_price,ws_sold_date_sk]
-                                        Filter [wr_order_number]
-                                          SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
-                                            InputAdapter
-                                              WholeStageCodegen (9)
-                                                Sort [ws_order_number,ws_item_sk]
-                                                  InputAdapter
-                                                    Exchange [ws_order_number,ws_item_sk] #6
-                                                      WholeStageCodegen (8)
-                                                        Filter [ws_item_sk,ws_bill_customer_sk]
+                                        SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
+                                          InputAdapter
+                                            WholeStageCodegen (9)
+                                              Sort [ws_order_number,ws_item_sk]
+                                                InputAdapter
+                                                  Exchange [ws_order_number,ws_item_sk] #6
+                                                    WholeStageCodegen (8)
+                                                      Filter [ws_item_sk,ws_bill_customer_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_order_number,ws_quantity,ws_wholesale_cost,ws_sales_price,ws_sold_date_sk]
+                                                              ReusedSubquery [d_date_sk] #1
+                                          InputAdapter
+                                            WholeStageCodegen (11)
+                                              Sort [wr_order_number,wr_item_sk]
+                                                InputAdapter
+                                                  Exchange [wr_order_number,wr_item_sk] #7
+                                                    WholeStageCodegen (10)
+                                                      Project [wr_item_sk,wr_order_number]
+                                                        Filter [wr_order_number,wr_item_sk]
                                                           ColumnarToRow
                                                             InputAdapter
-                                                              Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_order_number,ws_quantity,ws_wholesale_cost,ws_sales_price,ws_sold_date_sk]
-                                                                ReusedSubquery [d_date_sk] #1
-                                            InputAdapter
-                                              WholeStageCodegen (11)
-                                                Sort [wr_order_number,wr_item_sk]
-                                                  InputAdapter
-                                                    Exchange [wr_order_number,wr_item_sk] #7
-                                                      WholeStageCodegen (10)
-                                                        Project [wr_item_sk,wr_order_number]
-                                                          Filter [wr_order_number,wr_item_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_returned_date_sk]
+                                                              Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_returned_date_sk]
                                       InputAdapter
                                         ReusedExchange [d_date_sk,d_year] #3
         InputAdapter
@@ -99,29 +97,28 @@ TakeOrderedAndProject [ss_sold_year,ss_item_sk,ss_customer_sk,ss_qty,ss_wc,ss_sp
                           Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_wholesale_cost,cs_sales_price,d_year]
                             BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                               Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_wholesale_cost,cs_sales_price,cs_sold_date_sk]
-                                Filter [cr_order_number]
-                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (17)
-                                        Sort [cs_order_number,cs_item_sk]
-                                          InputAdapter
-                                            Exchange [cs_order_number,cs_item_sk] #9
-                                              WholeStageCodegen (16)
-                                                Filter [cs_item_sk,cs_bill_customer_sk]
+                                SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                  InputAdapter
+                                    WholeStageCodegen (17)
+                                      Sort [cs_order_number,cs_item_sk]
+                                        InputAdapter
+                                          Exchange [cs_order_number,cs_item_sk] #9
+                                            WholeStageCodegen (16)
+                                              Filter [cs_item_sk,cs_bill_customer_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_order_number,cs_quantity,cs_wholesale_cost,cs_sales_price,cs_sold_date_sk]
+                                                      ReusedSubquery [d_date_sk] #1
+                                  InputAdapter
+                                    WholeStageCodegen (19)
+                                      Sort [cr_order_number,cr_item_sk]
+                                        InputAdapter
+                                          Exchange [cr_order_number,cr_item_sk] #10
+                                            WholeStageCodegen (18)
+                                              Project [cr_item_sk,cr_order_number]
+                                                Filter [cr_order_number,cr_item_sk]
                                                   ColumnarToRow
                                                     InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_order_number,cs_quantity,cs_wholesale_cost,cs_sales_price,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
-                                    InputAdapter
-                                      WholeStageCodegen (19)
-                                        Sort [cr_order_number,cr_item_sk]
-                                          InputAdapter
-                                            Exchange [cr_order_number,cr_item_sk] #10
-                                              WholeStageCodegen (18)
-                                                Project [cr_item_sk,cr_order_number]
-                                                  Filter [cr_order_number,cr_item_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_returned_date_sk]
+                                                      Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_returned_date_sk]
                               InputAdapter
                                 ReusedExchange [d_date_sk,d_year] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/explain.txt
@@ -1,74 +1,70 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * Project (69)
-   +- * SortMergeJoin Inner (68)
-      :- * Project (45)
-      :  +- * SortMergeJoin Inner (44)
-      :     :- * Sort (21)
-      :     :  +- * HashAggregate (20)
-      :     :     +- Exchange (19)
-      :     :        +- * HashAggregate (18)
-      :     :           +- * Project (17)
-      :     :              +- * BroadcastHashJoin Inner BuildRight (16)
-      :     :                 :- * Project (14)
-      :     :                 :  +- * Filter (13)
-      :     :                 :     +- * SortMergeJoin LeftOuter (12)
-      :     :                 :        :- * Sort (5)
-      :     :                 :        :  +- Exchange (4)
-      :     :                 :        :     +- * Filter (3)
-      :     :                 :        :        +- * ColumnarToRow (2)
-      :     :                 :        :           +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :                 :        +- * Sort (11)
-      :     :                 :           +- Exchange (10)
-      :     :                 :              +- * Project (9)
-      :     :                 :                 +- * Filter (8)
-      :     :                 :                    +- * ColumnarToRow (7)
-      :     :                 :                       +- Scan parquet spark_catalog.default.store_returns (6)
-      :     :                 +- ReusedExchange (15)
-      :     +- * Sort (43)
-      :        +- * Filter (42)
-      :           +- * HashAggregate (41)
-      :              +- Exchange (40)
-      :                 +- * HashAggregate (39)
-      :                    +- * Project (38)
-      :                       +- * BroadcastHashJoin Inner BuildRight (37)
-      :                          :- * Project (35)
-      :                          :  +- * Filter (34)
-      :                          :     +- * SortMergeJoin LeftOuter (33)
-      :                          :        :- * Sort (26)
-      :                          :        :  +- Exchange (25)
-      :                          :        :     +- * Filter (24)
-      :                          :        :        +- * ColumnarToRow (23)
-      :                          :        :           +- Scan parquet spark_catalog.default.web_sales (22)
-      :                          :        +- * Sort (32)
-      :                          :           +- Exchange (31)
-      :                          :              +- * Project (30)
-      :                          :                 +- * Filter (29)
-      :                          :                    +- * ColumnarToRow (28)
-      :                          :                       +- Scan parquet spark_catalog.default.web_returns (27)
-      :                          +- ReusedExchange (36)
-      +- * Sort (67)
-         +- * Filter (66)
-            +- * HashAggregate (65)
-               +- Exchange (64)
-                  +- * HashAggregate (63)
-                     +- * Project (62)
-                        +- * BroadcastHashJoin Inner BuildRight (61)
-                           :- * Project (59)
-                           :  +- * Filter (58)
-                           :     +- * SortMergeJoin LeftOuter (57)
-                           :        :- * Sort (50)
-                           :        :  +- Exchange (49)
-                           :        :     +- * Filter (48)
-                           :        :        +- * ColumnarToRow (47)
-                           :        :           +- Scan parquet spark_catalog.default.catalog_sales (46)
-                           :        +- * Sort (56)
-                           :           +- Exchange (55)
-                           :              +- * Project (54)
-                           :                 +- * Filter (53)
-                           :                    +- * ColumnarToRow (52)
-                           :                       +- Scan parquet spark_catalog.default.catalog_returns (51)
-                           +- ReusedExchange (60)
+TakeOrderedAndProject (66)
++- * Project (65)
+   +- * BroadcastHashJoin Inner BuildRight (64)
+      :- * Project (42)
+      :  +- * BroadcastHashJoin Inner BuildRight (41)
+      :     :- * HashAggregate (19)
+      :     :  +- Exchange (18)
+      :     :     +- * HashAggregate (17)
+      :     :        +- * Project (16)
+      :     :           +- * BroadcastHashJoin Inner BuildRight (15)
+      :     :              :- * Project (13)
+      :     :              :  +- * SortMergeJoin LeftAnti (12)
+      :     :              :     :- * Sort (5)
+      :     :              :     :  +- Exchange (4)
+      :     :              :     :     +- * Filter (3)
+      :     :              :     :        +- * ColumnarToRow (2)
+      :     :              :     :           +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :              :     +- * Sort (11)
+      :     :              :        +- Exchange (10)
+      :     :              :           +- * Project (9)
+      :     :              :              +- * Filter (8)
+      :     :              :                 +- * ColumnarToRow (7)
+      :     :              :                    +- Scan parquet spark_catalog.default.store_returns (6)
+      :     :              +- ReusedExchange (14)
+      :     +- BroadcastExchange (40)
+      :        +- * Filter (39)
+      :           +- * HashAggregate (38)
+      :              +- Exchange (37)
+      :                 +- * HashAggregate (36)
+      :                    +- * Project (35)
+      :                       +- * BroadcastHashJoin Inner BuildRight (34)
+      :                          :- * Project (32)
+      :                          :  +- * SortMergeJoin LeftAnti (31)
+      :                          :     :- * Sort (24)
+      :                          :     :  +- Exchange (23)
+      :                          :     :     +- * Filter (22)
+      :                          :     :        +- * ColumnarToRow (21)
+      :                          :     :           +- Scan parquet spark_catalog.default.web_sales (20)
+      :                          :     +- * Sort (30)
+      :                          :        +- Exchange (29)
+      :                          :           +- * Project (28)
+      :                          :              +- * Filter (27)
+      :                          :                 +- * ColumnarToRow (26)
+      :                          :                    +- Scan parquet spark_catalog.default.web_returns (25)
+      :                          +- ReusedExchange (33)
+      +- BroadcastExchange (63)
+         +- * Filter (62)
+            +- * HashAggregate (61)
+               +- Exchange (60)
+                  +- * HashAggregate (59)
+                     +- * Project (58)
+                        +- * BroadcastHashJoin Inner BuildRight (57)
+                           :- * Project (55)
+                           :  +- * SortMergeJoin LeftAnti (54)
+                           :     :- * Sort (47)
+                           :     :  +- Exchange (46)
+                           :     :     +- * Filter (45)
+                           :     :        +- * ColumnarToRow (44)
+                           :     :           +- Scan parquet spark_catalog.default.catalog_sales (43)
+                           :     +- * Sort (53)
+                           :        +- Exchange (52)
+                           :           +- * Project (51)
+                           :              +- * Filter (50)
+                           :                 +- * ColumnarToRow (49)
+                           :                    +- Scan parquet spark_catalog.default.catalog_returns (48)
+                           +- ReusedExchange (56)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -123,53 +119,45 @@ Arguments: [sr_ticket_number#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST], 
 (12) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ss_ticket_number#3, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#10, sr_item_sk#9]
-Join type: LeftOuter
+Join type: LeftAnti
 Join condition: None
 
-(13) Filter [codegen id : 6]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#3, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7, sr_item_sk#9, sr_ticket_number#10]
-Condition : isnull(sr_ticket_number#10)
-
-(14) Project [codegen id : 6]
+(13) Project [codegen id : 6]
 Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#3, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7, sr_item_sk#9, sr_ticket_number#10]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#3, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7]
 
-(15) ReusedExchange [Reuses operator id: 74]
+(14) ReusedExchange [Reuses operator id: 70]
 Output [2]: [d_date_sk#12, d_year#13]
 
-(16) BroadcastHashJoin [codegen id : 6]
+(15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#12]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 6]
+(16) Project [codegen id : 6]
 Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, d_year#13]
 Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, ss_sold_date_sk#7, d_date_sk#12, d_year#13]
 
-(18) HashAggregate [codegen id : 6]
+(17) HashAggregate [codegen id : 6]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_quantity#4, ss_wholesale_cost#5, ss_sales_price#6, d_year#13]
 Keys [3]: [d_year#13, ss_item_sk#1, ss_customer_sk#2]
 Functions [3]: [partial_sum(ss_quantity#4), partial_sum(UnscaledValue(ss_wholesale_cost#5)), partial_sum(UnscaledValue(ss_sales_price#6))]
 Aggregate Attributes [3]: [sum#14, sum#15, sum#16]
 Results [6]: [d_year#13, ss_item_sk#1, ss_customer_sk#2, sum#17, sum#18, sum#19]
 
-(19) Exchange
+(18) Exchange
 Input [6]: [d_year#13, ss_item_sk#1, ss_customer_sk#2, sum#17, sum#18, sum#19]
 Arguments: hashpartitioning(d_year#13, ss_item_sk#1, ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(20) HashAggregate [codegen id : 7]
+(19) HashAggregate [codegen id : 21]
 Input [6]: [d_year#13, ss_item_sk#1, ss_customer_sk#2, sum#17, sum#18, sum#19]
 Keys [3]: [d_year#13, ss_item_sk#1, ss_customer_sk#2]
 Functions [3]: [sum(ss_quantity#4), sum(UnscaledValue(ss_wholesale_cost#5)), sum(UnscaledValue(ss_sales_price#6))]
 Aggregate Attributes [3]: [sum(ss_quantity#4)#20, sum(UnscaledValue(ss_wholesale_cost#5))#21, sum(UnscaledValue(ss_sales_price#6))#22]
 Results [6]: [d_year#13 AS ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, sum(ss_quantity#4)#20 AS ss_qty#24, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#5))#21,17,2) AS ss_wc#25, MakeDecimal(sum(UnscaledValue(ss_sales_price#6))#22,17,2) AS ss_sp#26]
 
-(21) Sort [codegen id : 7]
-Input [6]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26]
-Arguments: [ss_sold_year#23 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_customer_sk#2 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.web_sales
+(20) Scan parquet spark_catalog.default.web_sales
 Output [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 Batched: true
 Location: InMemoryFileIndex []
@@ -177,111 +165,107 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#33), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int,ws_order_number:int,ws_quantity:int,ws_wholesale_cost:decimal(7,2),ws_sales_price:decimal(7,2)>
 
-(23) ColumnarToRow [codegen id : 8]
+(21) ColumnarToRow [codegen id : 7]
 Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 
-(24) Filter [codegen id : 8]
+(22) Filter [codegen id : 7]
 Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 Condition : (isnotnull(ws_item_sk#27) AND isnotnull(ws_bill_customer_sk#28))
 
-(25) Exchange
+(23) Exchange
 Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 Arguments: hashpartitioning(ws_order_number#29, ws_item_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(26) Sort [codegen id : 9]
+(24) Sort [codegen id : 8]
 Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 Arguments: [ws_order_number#29 ASC NULLS FIRST, ws_item_sk#27 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet spark_catalog.default.web_returns
+(25) Scan parquet spark_catalog.default.web_returns
 Output [3]: [wr_item_sk#34, wr_order_number#35, wr_returned_date_sk#36]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int>
 
-(28) ColumnarToRow [codegen id : 10]
+(26) ColumnarToRow [codegen id : 9]
 Input [3]: [wr_item_sk#34, wr_order_number#35, wr_returned_date_sk#36]
 
-(29) Filter [codegen id : 10]
+(27) Filter [codegen id : 9]
 Input [3]: [wr_item_sk#34, wr_order_number#35, wr_returned_date_sk#36]
 Condition : (isnotnull(wr_order_number#35) AND isnotnull(wr_item_sk#34))
 
-(30) Project [codegen id : 10]
+(28) Project [codegen id : 9]
 Output [2]: [wr_item_sk#34, wr_order_number#35]
 Input [3]: [wr_item_sk#34, wr_order_number#35, wr_returned_date_sk#36]
 
-(31) Exchange
+(29) Exchange
 Input [2]: [wr_item_sk#34, wr_order_number#35]
 Arguments: hashpartitioning(wr_order_number#35, wr_item_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(32) Sort [codegen id : 11]
+(30) Sort [codegen id : 10]
 Input [2]: [wr_item_sk#34, wr_order_number#35]
 Arguments: [wr_order_number#35 ASC NULLS FIRST, wr_item_sk#34 ASC NULLS FIRST], false, 0
 
-(33) SortMergeJoin [codegen id : 13]
+(31) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ws_order_number#29, ws_item_sk#27]
 Right keys [2]: [wr_order_number#35, wr_item_sk#34]
-Join type: LeftOuter
+Join type: LeftAnti
 Join condition: None
 
-(34) Filter [codegen id : 13]
-Input [9]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33, wr_item_sk#34, wr_order_number#35]
-Condition : isnull(wr_order_number#35)
-
-(35) Project [codegen id : 13]
+(32) Project [codegen id : 12]
 Output [6]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
-Input [9]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33, wr_item_sk#34, wr_order_number#35]
+Input [7]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_order_number#29, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33]
 
-(36) ReusedExchange [Reuses operator id: 74]
+(33) ReusedExchange [Reuses operator id: 70]
 Output [2]: [d_date_sk#37, d_year#38]
 
-(37) BroadcastHashJoin [codegen id : 13]
+(34) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [ws_sold_date_sk#33]
 Right keys [1]: [d_date_sk#37]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 13]
+(35) Project [codegen id : 12]
 Output [6]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, d_year#38]
 Input [8]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, ws_sold_date_sk#33, d_date_sk#37, d_year#38]
 
-(39) HashAggregate [codegen id : 13]
+(36) HashAggregate [codegen id : 12]
 Input [6]: [ws_item_sk#27, ws_bill_customer_sk#28, ws_quantity#30, ws_wholesale_cost#31, ws_sales_price#32, d_year#38]
 Keys [3]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28]
 Functions [3]: [partial_sum(ws_quantity#30), partial_sum(UnscaledValue(ws_wholesale_cost#31)), partial_sum(UnscaledValue(ws_sales_price#32))]
 Aggregate Attributes [3]: [sum#39, sum#40, sum#41]
 Results [6]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28, sum#42, sum#43, sum#44]
 
-(40) Exchange
+(37) Exchange
 Input [6]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28, sum#42, sum#43, sum#44]
 Arguments: hashpartitioning(d_year#38, ws_item_sk#27, ws_bill_customer_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(41) HashAggregate [codegen id : 14]
+(38) HashAggregate [codegen id : 13]
 Input [6]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28, sum#42, sum#43, sum#44]
 Keys [3]: [d_year#38, ws_item_sk#27, ws_bill_customer_sk#28]
 Functions [3]: [sum(ws_quantity#30), sum(UnscaledValue(ws_wholesale_cost#31)), sum(UnscaledValue(ws_sales_price#32))]
 Aggregate Attributes [3]: [sum(ws_quantity#30)#45, sum(UnscaledValue(ws_wholesale_cost#31))#46, sum(UnscaledValue(ws_sales_price#32))#47]
 Results [6]: [d_year#38 AS ws_sold_year#48, ws_item_sk#27, ws_bill_customer_sk#28 AS ws_customer_sk#49, sum(ws_quantity#30)#45 AS ws_qty#50, MakeDecimal(sum(UnscaledValue(ws_wholesale_cost#31))#46,17,2) AS ws_wc#51, MakeDecimal(sum(UnscaledValue(ws_sales_price#32))#47,17,2) AS ws_sp#52]
 
-(42) Filter [codegen id : 14]
+(39) Filter [codegen id : 13]
 Input [6]: [ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49, ws_qty#50, ws_wc#51, ws_sp#52]
 Condition : (coalesce(ws_qty#50, 0) > 0)
 
-(43) Sort [codegen id : 14]
+(40) BroadcastExchange
 Input [6]: [ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49, ws_qty#50, ws_wc#51, ws_sp#52]
-Arguments: [ws_sold_year#48 ASC NULLS FIRST, ws_item_sk#27 ASC NULLS FIRST, ws_customer_sk#49 ASC NULLS FIRST], false, 0
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [plan_id=7]
 
-(44) SortMergeJoin [codegen id : 15]
+(41) BroadcastHashJoin [codegen id : 21]
 Left keys [3]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49]
 Join type: Inner
 Join condition: None
 
-(45) Project [codegen id : 15]
+(42) Project [codegen id : 21]
 Output [9]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26, ws_qty#50, ws_wc#51, ws_sp#52]
 Input [12]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26, ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49, ws_qty#50, ws_wc#51, ws_sp#52]
 
-(46) Scan parquet spark_catalog.default.catalog_sales
+(43) Scan parquet spark_catalog.default.catalog_sales
 Output [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 Batched: true
 Location: InMemoryFileIndex []
@@ -289,143 +273,139 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#59), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_wholesale_cost:decimal(7,2),cs_sales_price:decimal(7,2)>
 
-(47) ColumnarToRow [codegen id : 16]
+(44) ColumnarToRow [codegen id : 14]
 Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 
-(48) Filter [codegen id : 16]
+(45) Filter [codegen id : 14]
 Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 Condition : (isnotnull(cs_item_sk#54) AND isnotnull(cs_bill_customer_sk#53))
 
-(49) Exchange
+(46) Exchange
 Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
-Arguments: hashpartitioning(cs_order_number#55, cs_item_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: hashpartitioning(cs_order_number#55, cs_item_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(50) Sort [codegen id : 17]
+(47) Sort [codegen id : 15]
 Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 Arguments: [cs_order_number#55 ASC NULLS FIRST, cs_item_sk#54 ASC NULLS FIRST], false, 0
 
-(51) Scan parquet spark_catalog.default.catalog_returns
+(48) Scan parquet spark_catalog.default.catalog_returns
 Output [3]: [cr_item_sk#60, cr_order_number#61, cr_returned_date_sk#62]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
 
-(52) ColumnarToRow [codegen id : 18]
+(49) ColumnarToRow [codegen id : 16]
 Input [3]: [cr_item_sk#60, cr_order_number#61, cr_returned_date_sk#62]
 
-(53) Filter [codegen id : 18]
+(50) Filter [codegen id : 16]
 Input [3]: [cr_item_sk#60, cr_order_number#61, cr_returned_date_sk#62]
 Condition : (isnotnull(cr_order_number#61) AND isnotnull(cr_item_sk#60))
 
-(54) Project [codegen id : 18]
+(51) Project [codegen id : 16]
 Output [2]: [cr_item_sk#60, cr_order_number#61]
 Input [3]: [cr_item_sk#60, cr_order_number#61, cr_returned_date_sk#62]
 
-(55) Exchange
+(52) Exchange
 Input [2]: [cr_item_sk#60, cr_order_number#61]
-Arguments: hashpartitioning(cr_order_number#61, cr_item_sk#60, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: hashpartitioning(cr_order_number#61, cr_item_sk#60, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(56) Sort [codegen id : 19]
+(53) Sort [codegen id : 17]
 Input [2]: [cr_item_sk#60, cr_order_number#61]
 Arguments: [cr_order_number#61 ASC NULLS FIRST, cr_item_sk#60 ASC NULLS FIRST], false, 0
 
-(57) SortMergeJoin [codegen id : 21]
+(54) SortMergeJoin [codegen id : 19]
 Left keys [2]: [cs_order_number#55, cs_item_sk#54]
 Right keys [2]: [cr_order_number#61, cr_item_sk#60]
-Join type: LeftOuter
+Join type: LeftAnti
 Join condition: None
 
-(58) Filter [codegen id : 21]
-Input [9]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59, cr_item_sk#60, cr_order_number#61]
-Condition : isnull(cr_order_number#61)
-
-(59) Project [codegen id : 21]
+(55) Project [codegen id : 19]
 Output [6]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
-Input [9]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59, cr_item_sk#60, cr_order_number#61]
+Input [7]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_order_number#55, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59]
 
-(60) ReusedExchange [Reuses operator id: 74]
+(56) ReusedExchange [Reuses operator id: 70]
 Output [2]: [d_date_sk#63, d_year#64]
 
-(61) BroadcastHashJoin [codegen id : 21]
+(57) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_sold_date_sk#59]
 Right keys [1]: [d_date_sk#63]
 Join type: Inner
 Join condition: None
 
-(62) Project [codegen id : 21]
+(58) Project [codegen id : 19]
 Output [6]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, d_year#64]
 Input [8]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, cs_sold_date_sk#59, d_date_sk#63, d_year#64]
 
-(63) HashAggregate [codegen id : 21]
+(59) HashAggregate [codegen id : 19]
 Input [6]: [cs_bill_customer_sk#53, cs_item_sk#54, cs_quantity#56, cs_wholesale_cost#57, cs_sales_price#58, d_year#64]
 Keys [3]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53]
 Functions [3]: [partial_sum(cs_quantity#56), partial_sum(UnscaledValue(cs_wholesale_cost#57)), partial_sum(UnscaledValue(cs_sales_price#58))]
 Aggregate Attributes [3]: [sum#65, sum#66, sum#67]
 Results [6]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, sum#68, sum#69, sum#70]
 
-(64) Exchange
+(60) Exchange
 Input [6]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, sum#68, sum#69, sum#70]
-Arguments: hashpartitioning(d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Arguments: hashpartitioning(d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(65) HashAggregate [codegen id : 22]
+(61) HashAggregate [codegen id : 20]
 Input [6]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53, sum#68, sum#69, sum#70]
 Keys [3]: [d_year#64, cs_item_sk#54, cs_bill_customer_sk#53]
 Functions [3]: [sum(cs_quantity#56), sum(UnscaledValue(cs_wholesale_cost#57)), sum(UnscaledValue(cs_sales_price#58))]
 Aggregate Attributes [3]: [sum(cs_quantity#56)#71, sum(UnscaledValue(cs_wholesale_cost#57))#72, sum(UnscaledValue(cs_sales_price#58))#73]
 Results [6]: [d_year#64 AS cs_sold_year#74, cs_item_sk#54, cs_bill_customer_sk#53 AS cs_customer_sk#75, sum(cs_quantity#56)#71 AS cs_qty#76, MakeDecimal(sum(UnscaledValue(cs_wholesale_cost#57))#72,17,2) AS cs_wc#77, MakeDecimal(sum(UnscaledValue(cs_sales_price#58))#73,17,2) AS cs_sp#78]
 
-(66) Filter [codegen id : 22]
+(62) Filter [codegen id : 20]
 Input [6]: [cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75, cs_qty#76, cs_wc#77, cs_sp#78]
 Condition : (coalesce(cs_qty#76, 0) > 0)
 
-(67) Sort [codegen id : 22]
+(63) BroadcastExchange
 Input [6]: [cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75, cs_qty#76, cs_wc#77, cs_sp#78]
-Arguments: [cs_sold_year#74 ASC NULLS FIRST, cs_item_sk#54 ASC NULLS FIRST, cs_customer_sk#75 ASC NULLS FIRST], false, 0
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [plan_id=11]
 
-(68) SortMergeJoin [codegen id : 23]
+(64) BroadcastHashJoin [codegen id : 21]
 Left keys [3]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75]
 Join type: Inner
 Join condition: None
 
-(69) Project [codegen id : 23]
+(65) Project [codegen id : 21]
 Output [13]: [round((cast(ss_qty#24 as double) / cast(coalesce((ws_qty#50 + cs_qty#76), 1) as double)), 2) AS ratio#79, ss_qty#24 AS store_qty#80, ss_wc#25 AS store_wholesale_cost#81, ss_sp#26 AS store_sales_price#82, (coalesce(ws_qty#50, 0) + coalesce(cs_qty#76, 0)) AS other_chan_qty#83, (coalesce(ws_wc#51, 0.00) + coalesce(cs_wc#77, 0.00)) AS other_chan_wholesale_cost#84, (coalesce(ws_sp#52, 0.00) + coalesce(cs_sp#78, 0.00)) AS other_chan_sales_price#85, ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26]
 Input [15]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26, ws_qty#50, ws_wc#51, ws_sp#52, cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75, cs_qty#76, cs_wc#77, cs_sp#78]
 
-(70) TakeOrderedAndProject
+(66) TakeOrderedAndProject
 Input [13]: [ratio#79, store_qty#80, store_wholesale_cost#81, store_sales_price#82, other_chan_qty#83, other_chan_wholesale_cost#84, other_chan_sales_price#85, ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2, ss_qty#24, ss_wc#25, ss_sp#26]
 Arguments: 100, [ss_sold_year#23 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_customer_sk#2 ASC NULLS FIRST, ss_qty#24 DESC NULLS LAST, ss_wc#25 DESC NULLS LAST, ss_sp#26 DESC NULLS LAST, other_chan_qty#83 ASC NULLS FIRST, other_chan_wholesale_cost#84 ASC NULLS FIRST, other_chan_sales_price#85 ASC NULLS FIRST, ratio#79 ASC NULLS FIRST], [ratio#79, store_qty#80, store_wholesale_cost#81, store_sales_price#82, other_chan_qty#83, other_chan_wholesale_cost#84, other_chan_sales_price#85]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (74)
-+- * Filter (73)
-   +- * ColumnarToRow (72)
-      +- Scan parquet spark_catalog.default.date_dim (71)
+BroadcastExchange (70)
++- * Filter (69)
+   +- * ColumnarToRow (68)
+      +- Scan parquet spark_catalog.default.date_dim (67)
 
 
-(71) Scan parquet spark_catalog.default.date_dim
+(67) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#12, d_year#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
+(68) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#12, d_year#13]
 
-(73) Filter [codegen id : 1]
+(69) Filter [codegen id : 1]
 Input [2]: [d_date_sk#12, d_year#13]
 Condition : ((isnotnull(d_year#13) AND (d_year#13 = 2000)) AND isnotnull(d_date_sk#12))
 
-(74) BroadcastExchange
+(70) BroadcastExchange
 Input [2]: [d_date_sk#12, d_year#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=12]
 
-Subquery:2 Hosting operator id = 22 Hosting Expression = ws_sold_date_sk#33 IN dynamicpruning#8
+Subquery:2 Hosting operator id = 20 Hosting Expression = ws_sold_date_sk#33 IN dynamicpruning#8
 
-Subquery:3 Hosting operator id = 46 Hosting Expression = cs_sold_date_sk#59 IN dynamicpruning#8
+Subquery:3 Hosting operator id = 43 Hosting Expression = cs_sold_date_sk#59 IN dynamicpruning#8
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/simplified.txt
@@ -1,127 +1,119 @@
 TakeOrderedAndProject [ss_sold_year,ss_item_sk,ss_customer_sk,ss_qty,ss_wc,ss_sp,other_chan_qty,other_chan_wholesale_cost,other_chan_sales_price,ratio,store_qty,store_wholesale_cost,store_sales_price]
-  WholeStageCodegen (23)
+  WholeStageCodegen (21)
     Project [ss_qty,ws_qty,cs_qty,ss_wc,ss_sp,ws_wc,cs_wc,ws_sp,cs_sp,ss_sold_year,ss_item_sk,ss_customer_sk]
-      SortMergeJoin [ss_sold_year,ss_item_sk,ss_customer_sk,cs_sold_year,cs_item_sk,cs_customer_sk]
-        InputAdapter
-          WholeStageCodegen (15)
-            Project [ss_sold_year,ss_item_sk,ss_customer_sk,ss_qty,ss_wc,ss_sp,ws_qty,ws_wc,ws_sp]
-              SortMergeJoin [ss_sold_year,ss_item_sk,ss_customer_sk,ws_sold_year,ws_item_sk,ws_customer_sk]
-                InputAdapter
-                  WholeStageCodegen (7)
-                    Sort [ss_sold_year,ss_item_sk,ss_customer_sk]
-                      HashAggregate [d_year,ss_item_sk,ss_customer_sk,sum,sum,sum] [sum(ss_quantity),sum(UnscaledValue(ss_wholesale_cost)),sum(UnscaledValue(ss_sales_price)),ss_sold_year,ss_qty,ss_wc,ss_sp,sum,sum,sum]
-                        InputAdapter
-                          Exchange [d_year,ss_item_sk,ss_customer_sk] #1
-                            WholeStageCodegen (6)
-                              HashAggregate [d_year,ss_item_sk,ss_customer_sk,ss_quantity,ss_wholesale_cost,ss_sales_price] [sum,sum,sum,sum,sum,sum]
-                                Project [ss_item_sk,ss_customer_sk,ss_quantity,ss_wholesale_cost,ss_sales_price,d_year]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    Project [ss_item_sk,ss_customer_sk,ss_quantity,ss_wholesale_cost,ss_sales_price,ss_sold_date_sk]
-                                      Filter [sr_ticket_number]
-                                        SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                          InputAdapter
-                                            WholeStageCodegen (2)
-                                              Sort [ss_ticket_number,ss_item_sk]
-                                                InputAdapter
-                                                  Exchange [ss_ticket_number,ss_item_sk] #2
-                                                    WholeStageCodegen (1)
-                                                      Filter [ss_item_sk,ss_customer_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,ss_wholesale_cost,ss_sales_price,ss_sold_date_sk]
-                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                BroadcastExchange #3
-                                                                  WholeStageCodegen (1)
-                                                                    Filter [d_year,d_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
-                                          InputAdapter
-                                            WholeStageCodegen (4)
-                                              Sort [sr_ticket_number,sr_item_sk]
-                                                InputAdapter
-                                                  Exchange [sr_ticket_number,sr_item_sk] #4
-                                                    WholeStageCodegen (3)
-                                                      Project [sr_item_sk,sr_ticket_number]
-                                                        Filter [sr_ticket_number,sr_item_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+      BroadcastHashJoin [ss_sold_year,ss_item_sk,ss_customer_sk,cs_sold_year,cs_item_sk,cs_customer_sk]
+        Project [ss_sold_year,ss_item_sk,ss_customer_sk,ss_qty,ss_wc,ss_sp,ws_qty,ws_wc,ws_sp]
+          BroadcastHashJoin [ss_sold_year,ss_item_sk,ss_customer_sk,ws_sold_year,ws_item_sk,ws_customer_sk]
+            HashAggregate [d_year,ss_item_sk,ss_customer_sk,sum,sum,sum] [sum(ss_quantity),sum(UnscaledValue(ss_wholesale_cost)),sum(UnscaledValue(ss_sales_price)),ss_sold_year,ss_qty,ss_wc,ss_sp,sum,sum,sum]
+              InputAdapter
+                Exchange [d_year,ss_item_sk,ss_customer_sk] #1
+                  WholeStageCodegen (6)
+                    HashAggregate [d_year,ss_item_sk,ss_customer_sk,ss_quantity,ss_wholesale_cost,ss_sales_price] [sum,sum,sum,sum,sum,sum]
+                      Project [ss_item_sk,ss_customer_sk,ss_quantity,ss_wholesale_cost,ss_sales_price,d_year]
+                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                          Project [ss_item_sk,ss_customer_sk,ss_quantity,ss_wholesale_cost,ss_sales_price,ss_sold_date_sk]
+                            SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                              InputAdapter
+                                WholeStageCodegen (2)
+                                  Sort [ss_ticket_number,ss_item_sk]
                                     InputAdapter
-                                      ReusedExchange [d_date_sk,d_year] #3
-                InputAdapter
-                  WholeStageCodegen (14)
-                    Sort [ws_sold_year,ws_item_sk,ws_customer_sk]
-                      Filter [ws_qty]
-                        HashAggregate [d_year,ws_item_sk,ws_bill_customer_sk,sum,sum,sum] [sum(ws_quantity),sum(UnscaledValue(ws_wholesale_cost)),sum(UnscaledValue(ws_sales_price)),ws_sold_year,ws_customer_sk,ws_qty,ws_wc,ws_sp,sum,sum,sum]
-                          InputAdapter
-                            Exchange [d_year,ws_item_sk,ws_bill_customer_sk] #5
-                              WholeStageCodegen (13)
-                                HashAggregate [d_year,ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_wholesale_cost,ws_sales_price] [sum,sum,sum,sum,sum,sum]
-                                  Project [ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_wholesale_cost,ws_sales_price,d_year]
-                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                      Project [ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_wholesale_cost,ws_sales_price,ws_sold_date_sk]
-                                        Filter [wr_order_number]
-                                          SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
-                                            InputAdapter
-                                              WholeStageCodegen (9)
-                                                Sort [ws_order_number,ws_item_sk]
-                                                  InputAdapter
-                                                    Exchange [ws_order_number,ws_item_sk] #6
-                                                      WholeStageCodegen (8)
-                                                        Filter [ws_item_sk,ws_bill_customer_sk]
+                                      Exchange [ss_ticket_number,ss_item_sk] #2
+                                        WholeStageCodegen (1)
+                                          Filter [ss_item_sk,ss_customer_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,ss_wholesale_cost,ss_sales_price,ss_sold_date_sk]
+                                                  SubqueryBroadcast [d_date_sk] #1
+                                                    BroadcastExchange #3
+                                                      WholeStageCodegen (1)
+                                                        Filter [d_year,d_date_sk]
                                                           ColumnarToRow
                                                             InputAdapter
-                                                              Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_order_number,ws_quantity,ws_wholesale_cost,ws_sales_price,ws_sold_date_sk]
-                                                                ReusedSubquery [d_date_sk] #1
-                                            InputAdapter
-                                              WholeStageCodegen (11)
-                                                Sort [wr_order_number,wr_item_sk]
-                                                  InputAdapter
-                                                    Exchange [wr_order_number,wr_item_sk] #7
-                                                      WholeStageCodegen (10)
-                                                        Project [wr_item_sk,wr_order_number]
-                                                          Filter [wr_order_number,wr_item_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_returned_date_sk]
+                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
+                              InputAdapter
+                                WholeStageCodegen (4)
+                                  Sort [sr_ticket_number,sr_item_sk]
+                                    InputAdapter
+                                      Exchange [sr_ticket_number,sr_item_sk] #4
+                                        WholeStageCodegen (3)
+                                          Project [sr_item_sk,sr_ticket_number]
+                                            Filter [sr_ticket_number,sr_item_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                          InputAdapter
+                            ReusedExchange [d_date_sk,d_year] #3
+            InputAdapter
+              BroadcastExchange #5
+                WholeStageCodegen (13)
+                  Filter [ws_qty]
+                    HashAggregate [d_year,ws_item_sk,ws_bill_customer_sk,sum,sum,sum] [sum(ws_quantity),sum(UnscaledValue(ws_wholesale_cost)),sum(UnscaledValue(ws_sales_price)),ws_sold_year,ws_customer_sk,ws_qty,ws_wc,ws_sp,sum,sum,sum]
+                      InputAdapter
+                        Exchange [d_year,ws_item_sk,ws_bill_customer_sk] #6
+                          WholeStageCodegen (12)
+                            HashAggregate [d_year,ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_wholesale_cost,ws_sales_price] [sum,sum,sum,sum,sum,sum]
+                              Project [ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_wholesale_cost,ws_sales_price,d_year]
+                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                  Project [ws_item_sk,ws_bill_customer_sk,ws_quantity,ws_wholesale_cost,ws_sales_price,ws_sold_date_sk]
+                                    SortMergeJoin [ws_order_number,ws_item_sk,wr_order_number,wr_item_sk]
                                       InputAdapter
-                                        ReusedExchange [d_date_sk,d_year] #3
+                                        WholeStageCodegen (8)
+                                          Sort [ws_order_number,ws_item_sk]
+                                            InputAdapter
+                                              Exchange [ws_order_number,ws_item_sk] #7
+                                                WholeStageCodegen (7)
+                                                  Filter [ws_item_sk,ws_bill_customer_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_order_number,ws_quantity,ws_wholesale_cost,ws_sales_price,ws_sold_date_sk]
+                                                          ReusedSubquery [d_date_sk] #1
+                                      InputAdapter
+                                        WholeStageCodegen (10)
+                                          Sort [wr_order_number,wr_item_sk]
+                                            InputAdapter
+                                              Exchange [wr_order_number,wr_item_sk] #8
+                                                WholeStageCodegen (9)
+                                                  Project [wr_item_sk,wr_order_number]
+                                                    Filter [wr_order_number,wr_item_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_returned_date_sk]
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk,d_year] #3
         InputAdapter
-          WholeStageCodegen (22)
-            Sort [cs_sold_year,cs_item_sk,cs_customer_sk]
+          BroadcastExchange #9
+            WholeStageCodegen (20)
               Filter [cs_qty]
                 HashAggregate [d_year,cs_item_sk,cs_bill_customer_sk,sum,sum,sum] [sum(cs_quantity),sum(UnscaledValue(cs_wholesale_cost)),sum(UnscaledValue(cs_sales_price)),cs_sold_year,cs_customer_sk,cs_qty,cs_wc,cs_sp,sum,sum,sum]
                   InputAdapter
-                    Exchange [d_year,cs_item_sk,cs_bill_customer_sk] #8
-                      WholeStageCodegen (21)
+                    Exchange [d_year,cs_item_sk,cs_bill_customer_sk] #10
+                      WholeStageCodegen (19)
                         HashAggregate [d_year,cs_item_sk,cs_bill_customer_sk,cs_quantity,cs_wholesale_cost,cs_sales_price] [sum,sum,sum,sum,sum,sum]
                           Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_wholesale_cost,cs_sales_price,d_year]
                             BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                               Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_wholesale_cost,cs_sales_price,cs_sold_date_sk]
-                                Filter [cr_order_number]
-                                  SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (17)
-                                        Sort [cs_order_number,cs_item_sk]
-                                          InputAdapter
-                                            Exchange [cs_order_number,cs_item_sk] #9
-                                              WholeStageCodegen (16)
-                                                Filter [cs_item_sk,cs_bill_customer_sk]
+                                SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
+                                  InputAdapter
+                                    WholeStageCodegen (15)
+                                      Sort [cs_order_number,cs_item_sk]
+                                        InputAdapter
+                                          Exchange [cs_order_number,cs_item_sk] #11
+                                            WholeStageCodegen (14)
+                                              Filter [cs_item_sk,cs_bill_customer_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_order_number,cs_quantity,cs_wholesale_cost,cs_sales_price,cs_sold_date_sk]
+                                                      ReusedSubquery [d_date_sk] #1
+                                  InputAdapter
+                                    WholeStageCodegen (17)
+                                      Sort [cr_order_number,cr_item_sk]
+                                        InputAdapter
+                                          Exchange [cr_order_number,cr_item_sk] #12
+                                            WholeStageCodegen (16)
+                                              Project [cr_item_sk,cr_order_number]
+                                                Filter [cr_order_number,cr_item_sk]
                                                   ColumnarToRow
                                                     InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_order_number,cs_quantity,cs_wholesale_cost,cs_sales_price,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #1
-                                    InputAdapter
-                                      WholeStageCodegen (19)
-                                        Sort [cr_order_number,cr_item_sk]
-                                          InputAdapter
-                                            Exchange [cr_order_number,cr_item_sk] #10
-                                              WholeStageCodegen (18)
-                                                Project [cr_item_sk,cr_order_number]
-                                                  Filter [cr_order_number,cr_item_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_returned_date_sk]
+                                                      Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_returned_date_sk]
                               InputAdapter
                                 ReusedExchange [d_date_sk,d_year] #3


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Optimize left outer join to anti join if exists IsNull filter on the right side.
For example, query
```sql
SELECT t1.*
FROM t1 LEFT JOIN t2
ON t1.id = t2.id
WHERE t2.id is null and t1.id = 1 and Rand() < 0.5
```
can be optimized to
```sql
SELECT t1.*
FROM t1 LEFT ANTI JOIN t2
ON t1.id = t2.id
WHERE t1.id = 1 and Rand() < 0.5
```

PostgreSQL also has this optimization
![image](https://github.com/apache/spark/assets/3626747/484eb224-5962-40fa-8544-65637c0d93fe)


### Why are the changes needed?

Optimize left outer join.

Local benchmark code:
```
object LeftOuterToAntiJoinBenchmark extends SqlBasedBenchmark {

  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
    runBenchmark("Compare left outer join to anti join") {
      spark.range(1, 100000, 1, 5)
        .selectExpr("id%5 as id")
        .createOrReplaceTempView("tab")
      val testQuery =
        s"""SELECT t1.*
           |FROM tab t1
           |LEFT OUTER JOIN tab t2
           |ON t1.id = t2.id
           |WHERE t2.id is null
           |""".stripMargin
      val benchmark =
        new Benchmark("Compare left outer join to anti join", 100000, output = output)
      benchmark.addCase(s"Left outer join result") { _ =>
        withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
          "org.apache.spark.sql.catalyst.optimizer.EliminateOuterJoin") {
          val res = spark.sql(testQuery)
          res.noop()
        }
      }
      benchmark.addCase(s"Anti join result") { _ =>
        val res = spark.sql(testQuery)
        res.noop()
      }
      benchmark.run()
    }
  }
}
```
benchmark result
```
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Compare left outer join to anti join:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Left outer join result                             9500           9884         544          0.0       94997.6       1.0X
Anti join result                                    287            356          80          0.3        2869.9      33.1X
```


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added UT
