### PR TITLE
[SPARK-42268][CONNECT][PYTHON][TESTS][FOLLOWUP] Add `test_simple_udt` for `UserDefinedType`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2577,6 +2577,22 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             ).collect(),
         )
 
+    def test_simple_udt(self):
+        from pyspark.ml.linalg import MatrixUDT, VectorUDT
+
+        for schema in [
+            StructType().add("key", LongType()).add("val", PythonOnlyUDT()),
+            StructType().add("key", LongType()).add("val", ArrayType(PythonOnlyUDT())),
+            StructType().add("key", LongType()).add("val", MapType(LongType(), PythonOnlyUDT())),
+            StructType().add("key", LongType()).add("val", PythonOnlyUDT()),
+            StructType().add("key", LongType()).add("vec", VectorUDT()),
+            StructType().add("key", LongType()).add("mat", MatrixUDT()),
+        ]:
+            cdf = self.connect.createDataFrame(data=[], schema=schema)
+            sdf = self.spark.createDataFrame(data=[], schema=schema)
+
+            self.assertEqual(cdf.schema, sdf.schema)
+
     def test_simple_udt_from_read(self):
         from pyspark.ml.linalg import Matrices, Vectors
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
add more tests for UDT


### Why are the changes needed?
https://github.com/apache/spark/pull/39835 added tests for UDT for this conversion: 
UDT in Server -> proto -> UDT in Python Client

As per @xinrong-meng 's suggestion, this PR adds more tests to cover this: 
UDT in Python Client -> proto -> UDT in Server -> proto -> UDT in Python Client


### Does this PR introduce _any_ user-facing change?
No, test-only


### How was this patch tested?
added UT