### PR TITLE
[SPARK-42366][SHUFFLE] Log shuffle data corruption diagnose cause

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
@@ -154,7 +154,7 @@ public class ShuffleChecksumHelper {
       logger.warn("Unable to diagnose shuffle block corruption", e);
       cause = Cause.UNKNOWN_ISSUE;
     }
-    logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}, " +
+    logger.debug("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}, " +
       "checksumByReader {}, checksumByWriter {}, checksumByReCalculation {}",
       duration, checksumFile.getAbsolutePath(), cause,
       checksumByReader, checksumByWriter, checksumByReCalculation);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
@@ -154,7 +154,7 @@ public class ShuffleChecksumHelper {
       logger.warn("Unable to diagnose shuffle block corruption", e);
       cause = Cause.UNKNOWN_ISSUE;
     }
-    logger.debug("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}, " +
+    logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}, " +
       "checksumByReader {}, checksumByWriter {}, checksumByReCalculation {}",
       duration, checksumFile.getAbsolutePath(), cause,
       checksumByReader, checksumByWriter, checksumByReCalculation);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
@@ -125,6 +125,7 @@ public class ShuffleChecksumHelper {
       ManagedBuffer partitionData,
       long checksumByReader) {
     Cause cause;
+    long duration = -1L;
     try {
       long diagnoseStartNs = System.nanoTime();
       // Try to get the checksum instance before reading the checksum file so that
@@ -133,9 +134,7 @@ public class ShuffleChecksumHelper {
       Checksum checksumAlgo = getChecksumByAlgorithm(algorithm);
       long checksumByWriter = readChecksumByReduceId(checksumFile, reduceId);
       long checksumByReCalculation = calculateChecksumForPartition(partitionData, checksumAlgo);
-      long duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - diagnoseStartNs);
-      logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}",
-        duration, checksumFile.getAbsolutePath());
+      duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - diagnoseStartNs);
       if (checksumByWriter != checksumByReCalculation) {
         cause = Cause.DISK_ISSUE;
       } else if (checksumByWriter != checksumByReader) {
@@ -153,6 +152,8 @@ public class ShuffleChecksumHelper {
       logger.warn("Unable to diagnose shuffle block corruption", e);
       cause = Cause.UNKNOWN_ISSUE;
     }
+    logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}",
+            duration, checksumFile.getAbsolutePath(), cause);
     return cause;
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
@@ -126,16 +126,14 @@ public class ShuffleChecksumHelper {
       long checksumByReader) {
     Cause cause;
     long duration = -1L;
-    long checksumByWriter = -1L;
-    long checksumByReCalculation = -1L;
     try {
       long diagnoseStartNs = System.nanoTime();
       // Try to get the checksum instance before reading the checksum file so that
       // `UnsupportedOperationException` can be thrown first before `FileNotFoundException`
       // when the checksum algorithm isn't supported.
       Checksum checksumAlgo = getChecksumByAlgorithm(algorithm);
-      checksumByWriter = readChecksumByReduceId(checksumFile, reduceId);
-      checksumByReCalculation = calculateChecksumForPartition(partitionData, checksumAlgo);
+      long checksumByWriter = readChecksumByReduceId(checksumFile, reduceId);
+      long checksumByReCalculation = calculateChecksumForPartition(partitionData, checksumAlgo);
       duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - diagnoseStartNs);
       if (checksumByWriter != checksumByReCalculation) {
         cause = Cause.DISK_ISSUE;
@@ -154,10 +152,8 @@ public class ShuffleChecksumHelper {
       logger.warn("Unable to diagnose shuffle block corruption", e);
       cause = Cause.UNKNOWN_ISSUE;
     }
-    logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}, " +
-      "checksumByReader {}, checksumByWriter {}, checksumByReCalculation {}",
-      duration, checksumFile.getAbsolutePath(), cause,
-      checksumByReader, checksumByWriter, checksumByReCalculation);
+    logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}",
+            duration, checksumFile.getAbsolutePath(), cause);
     return cause;
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
@@ -126,14 +126,16 @@ public class ShuffleChecksumHelper {
       long checksumByReader) {
     Cause cause;
     long duration = -1L;
+    long checksumByWriter = -1L;
+    long checksumByReCalculation = -1L;
     try {
       long diagnoseStartNs = System.nanoTime();
       // Try to get the checksum instance before reading the checksum file so that
       // `UnsupportedOperationException` can be thrown first before `FileNotFoundException`
       // when the checksum algorithm isn't supported.
       Checksum checksumAlgo = getChecksumByAlgorithm(algorithm);
-      long checksumByWriter = readChecksumByReduceId(checksumFile, reduceId);
-      long checksumByReCalculation = calculateChecksumForPartition(partitionData, checksumAlgo);
+      checksumByWriter = readChecksumByReduceId(checksumFile, reduceId);
+      checksumByReCalculation = calculateChecksumForPartition(partitionData, checksumAlgo);
       duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - diagnoseStartNs);
       if (checksumByWriter != checksumByReCalculation) {
         cause = Cause.DISK_ISSUE;
@@ -152,8 +154,10 @@ public class ShuffleChecksumHelper {
       logger.warn("Unable to diagnose shuffle block corruption", e);
       cause = Cause.UNKNOWN_ISSUE;
     }
-    logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}",
-            duration, checksumFile.getAbsolutePath(), cause);
+    logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}, " +
+      "checksumByReader {}, checksumByWriter {}, checksumByReCalculation {}",
+      duration, checksumFile.getAbsolutePath(), cause,
+      checksumByReader, checksumByWriter, checksumByReCalculation);
     return cause;
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/checksum/ShuffleChecksumHelper.java
@@ -126,14 +126,16 @@ public class ShuffleChecksumHelper {
       long checksumByReader) {
     Cause cause;
     long duration = -1L;
+    long checksumByWriter = -1L;
+    long checksumByReCalculation = -1L;
     try {
       long diagnoseStartNs = System.nanoTime();
       // Try to get the checksum instance before reading the checksum file so that
       // `UnsupportedOperationException` can be thrown first before `FileNotFoundException`
       // when the checksum algorithm isn't supported.
       Checksum checksumAlgo = getChecksumByAlgorithm(algorithm);
-      long checksumByWriter = readChecksumByReduceId(checksumFile, reduceId);
-      long checksumByReCalculation = calculateChecksumForPartition(partitionData, checksumAlgo);
+      checksumByWriter = readChecksumByReduceId(checksumFile, reduceId);
+      checksumByReCalculation = calculateChecksumForPartition(partitionData, checksumAlgo);
       duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - diagnoseStartNs);
       if (checksumByWriter != checksumByReCalculation) {
         cause = Cause.DISK_ISSUE;
@@ -152,8 +154,15 @@ public class ShuffleChecksumHelper {
       logger.warn("Unable to diagnose shuffle block corruption", e);
       cause = Cause.UNKNOWN_ISSUE;
     }
-    logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}",
-            duration, checksumFile.getAbsolutePath(), cause);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}, " +
+        "checksumByReader {}, checksumByWriter {}, checksumByReCalculation {}",
+        duration, checksumFile.getAbsolutePath(), cause,
+        checksumByReader, checksumByWriter, checksumByReCalculation);
+    } else {
+      logger.info("Shuffle corruption diagnosis took {} ms, checksum file {}, cause {}",
+        duration, checksumFile.getAbsolutePath(), cause);
+    }
     return cause;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Output the cause in the `diagnoseCorruption` method.


### Why are the changes needed?
It is convenient to collect the reason of shuffle corruption from the shuffle service Log deployed by YARN Nodemanager.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
exist UT
