### PR TITLE
[SPARK-42368][INFRA][TESTS] Exclude SparkRemoteFileTest from GitHub Action K8s IT job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -963,7 +963,7 @@ jobs:
           kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
           kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.7.0/installer/volcano-development.yaml || true
           eval $(minikube docker-env)
-          build/sbt -Psparkr -Pkubernetes -Pvolcano -Pkubernetes-integration-tests -Dspark.kubernetes.test.driverRequestCores=0.5 -Dspark.kubernetes.test.executorRequestCores=0.2 -Dspark.kubernetes.test.volcanoMaxConcurrencyJobNum=1 "kubernetes-integration-tests/test"
+          build/sbt -Psparkr -Pkubernetes -Pvolcano -Pkubernetes-integration-tests -Dspark.kubernetes.test.driverRequestCores=0.5 -Dspark.kubernetes.test.executorRequestCores=0.2 -Dspark.kubernetes.test.volcanoMaxConcurrencyJobNum=1 -Dtest.exclude.tags=local "kubernetes-integration-tests/test"
       - name: Upload Spark on K8S integration tests log files
         if: failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `SparkRemoteFileTest` from K8s IT GitHub Action job.

```
$ git grep localTestTag
resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala:  import KubernetesSuite.{k8sTestTag, localTestTag}
resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala:  test("Run SparkRemoteFileTest using a remote data file", k8sTestTag, localTestTag) {
resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala:  val localTestTag = Tag("local")
```

### Why are the changes needed?

Since #39697 , I've been monitoring this job. The test is too flaky in GitHub Action environment due to the limited resources and slowness.

**MASTER**
- https://github.com/apache/spark/actions/runs/4110706261/jobs/7093797830
- https://github.com/apache/spark/actions/runs/4110355193/jobs/7093093588

**BRANCH-3.4**
- https://github.com/apache/spark/actions/runs/4110731960/jobs/7093844949

### Does this PR introduce _any_ user-facing change?

No. This is a test infra PR.

### How was this patch tested?

Pass the CIs.