### PR TITLE
[SPARK-42376][SS] Introduce watermark propagation among operators

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -1845,7 +1845,7 @@ Some of them are as follows.
   for more details.
 
 - Chaining multiple stateful operations on streaming Datasets is not supported with Update and Complete mode.
-  - In addition, (flat)MapGroupsWithState operation followed by other stateful operation is not supported in Append mode.
+  - In addition, mapGroupsWithState/flatMapGroupsWithState operation followed by other stateful operation is not supported in Append mode.
   - A known workaround is to split your streaming query into multiple queries having a single stateful operation per each query,
     and ensure end-to-end exactly once per query. Ensuring end-to-end exactly once for the last query is optional.
 

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -1845,9 +1845,7 @@ Some of them are as follows.
   for more details.
 
 - Chaining multiple stateful operations on streaming Datasets is not supported with Update and Complete mode.
-  - In addition, below operations followed by other stateful operation is not supported in Append mode.
-    - stream-stream time interval join (inner/outer)
-    - flatMapGroupsWithState
+  - In addition, (flat)MapGroupsWithState operation followed by other stateful operation is not supported in Append mode.
   - A known workaround is to split your streaming query into multiple queries having a single stateful operation per each query,
     and ensure end-to-end exactly once per query. Ensuring end-to-end exactly once for the last query is optional.
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -21,7 +21,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BinaryComparison, CurrentDate, CurrentTimestampLike, Expression, GreaterThan, GreaterThanOrEqual, GroupingSets, LessThan, LessThanOrEqual, LocalTimestamp, MonotonicallyIncreasingID, SessionWindow}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
-import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
@@ -84,9 +83,6 @@ object UnsupportedOperationChecker extends Logging {
    */
   private def ifCannotBeFollowedByStatefulOperation(
       p: LogicalPlan, outputMode: OutputMode): Boolean = p match {
-    case ExtractEquiJoinKeys(_, _, _, otherCondition, _, left, right, _) =>
-      left.isStreaming && right.isStreaming &&
-        otherCondition.isDefined && hasRangeExprAgainstEventTimeCol(otherCondition.get)
     // FlatMapGroupsWithState configured with event time
     case f @ FlatMapGroupsWithState(_, _, _, _, _, _, _, _, _, timeout, _, _, _, _, _, _)
       if f.isStreaming && timeout == GroupStateTimeout.EventTimeTimeout => true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/EventTimeWatermark.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/EventTimeWatermark.scala
@@ -45,6 +45,10 @@ case class EventTimeWatermark(
   final override val nodePatterns: Seq[TreePattern] = Seq(EVENT_TIME_WATERMARK)
 
   // Update the metadata on the eventTime column to include the desired delay.
+  // This is not allowed by default - WatermarkPropagator will throw an exception. We keep the
+  // logic here because we also maintain the compatibility flag. (See
+  // SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE for details.)
+  // TODO: Disallow updating the metadata once we remove the compatibility flag.
   override val output: Seq[Attribute] = child.output.map { a =>
     if (a semanticEquals eventTime) {
       val delayMs = EventTimeWatermark.getDelayMs(delay)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableU
 import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
-import org.apache.spark.sql.execution.streaming.{IncrementalExecution, OffsetSeqMetadata}
+import org.apache.spark.sql.execution.streaming.{IncrementalExecution, OffsetSeqMetadata, WatermarkPropagator}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.util.Utils
@@ -244,7 +244,8 @@ class QueryExecution(
       // output mode does not matter since there is no `Sink`.
       new IncrementalExecution(
         sparkSession, logical, OutputMode.Append(), "<unknown>",
-        UUID.randomUUID, UUID.randomUUID, 0, None, OffsetSeqMetadata(0, 0))
+        UUID.randomUUID, UUID.randomUUID, 0, None, OffsetSeqMetadata(0, 0),
+        WatermarkPropagator.noop())
     } else {
       this
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -106,8 +106,7 @@ trait FlatMapGroupsWithStateExecBase
   // There is no guarantee that any of the column in the output is bound to the watermark. The
   // user function is quite flexible. Hence Spark does not support the stateful operator(s) after
   // (flat)MapGroupsWithState.
-  override def produceOutputWatermark(inputWatermarkMs: Long): Long =
-    WatermarkPropagator.DEFAULT_WATERMARK_MS
+  override def produceOutputWatermark(inputWatermarkMs: Long): Option[Long] = None
 
   /**
    * Process data by applying the user defined function on a per partition basis.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -106,7 +106,7 @@ trait FlatMapGroupsWithStateExecBase
   // There is no guarantee that any of the column in the output is bound to the watermark. The
   // user function is quite flexible. Hence Spark does not support the stateful operator(s) after
   // (flat)MapGroupsWithState.
-  override def produceWatermark(inputWatermarkMs: Long): Long =
+  override def produceOutputWatermark(inputWatermarkMs: Long): Long =
     WatermarkPropagator.DEFAULT_WATERMARK_MS
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -330,8 +330,10 @@ class IncrementalExecution(
   }
 
   override def preparations: Seq[Rule[SparkPlan]] = Seq(
-    shufflePartitionsRule, convertLocalLimitRule, stateOpIdRule, watermarkPropagationRule
-  ) ++ super.preparations
+    shufflePartitionsRule,
+    convertLocalLimitRule,
+    stateOpIdRule,
+    watermarkPropagationRule) ++ super.preparations
 
   /** No need assert supported, as this check has already been done */
   override def assertSupported(): Unit = { }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -341,6 +341,10 @@ class IncrementalExecution(
   /**
    * Should the MicroBatchExecution run another batch based on this execution and the current
    * updated metadata.
+   *
+   * This method performs simulation of watermark propagation against new batch (which is not
+   * planned yet), which is required for asking the needs of another batch to each stateful
+   * operator.
    */
   def shouldRunAnotherBatch(newMetadata: OffsetSeqMetadata): Boolean = {
     val tentativeBatchId = currentBatchId + 1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -98,6 +98,9 @@ class IncrementalExecution(
     }
   }
 
+  private val allowMultipleStatefulOperators: Boolean =
+    sparkSession.sessionState.conf.getConf(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE)
+
   /**
    * Records the current id for a given stateful operator in the query plan as the `state`
    * preparation walks the query plan.
@@ -323,7 +326,7 @@ class IncrementalExecution(
             stateWatermarkPredicates =
               StreamingSymmetricHashJoinHelper.getStateWatermarkPredicates(
                 j.left.output, j.right.output, j.leftKeys, j.rightKeys, j.condition.full,
-                iwEviction)
+                iwEviction, !allowMultipleStatefulOperators)
           )
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -561,7 +561,7 @@ case class StreamingSymmetricHashJoinExec(
       : Iterator[InternalRow] = {
 
       val watermarkAttribute = WatermarkSupport.findEventTimeColumn(inputAttributes,
-        useFirstOccurrence = !allowMultipleStatefulOperators)
+        allowMultipleEventTimeColumns = !allowMultipleStatefulOperators)
       val nonLateRows =
         WatermarkSupport.watermarkExpression(
           watermarkAttribute, eventTimeWatermarkForLateEvents) match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -707,12 +707,11 @@ case class StreamingSymmetricHashJoinExec(
   // must be lower bound of both sides of event time column. The lower bound of event time column
   // for each side is determined by state watermark, hence we take a minimum of (left state
   // watermark, right state watermark, input watermark) to decide the output watermark.
-  override def produceWatermark(inputWatermarkMs: Long): Long = {
+  override def produceOutputWatermark(inputWatermarkMs: Long): Long = {
     val (leftStateWatermark, rightStateWatermark) =
       StreamingSymmetricHashJoinHelper.getStateWatermark(
         left.output, right.output, leftKeys, rightKeys, condition.full, Some(inputWatermarkMs))
 
-    (Seq(leftStateWatermark, rightStateWatermark).filter(_.isDefined).map(_.get) ++
-      Seq(inputWatermarkMs)).min
+    (leftStateWatermark ++ rightStateWatermark ++ Some(inputWatermarkMs)).min
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -709,12 +709,12 @@ case class StreamingSymmetricHashJoinExec(
   // must be lower bound of both sides of event time column. The lower bound of event time column
   // for each side is determined by state watermark, hence we take a minimum of (left state
   // watermark, right state watermark, input watermark) to decide the output watermark.
-  override def produceOutputWatermark(inputWatermarkMs: Long): Long = {
+  override def produceOutputWatermark(inputWatermarkMs: Long): Option[Long] = {
     val (leftStateWatermark, rightStateWatermark) =
       StreamingSymmetricHashJoinHelper.getStateWatermark(
         left.output, right.output, leftKeys, rightKeys, condition.full, Some(inputWatermarkMs),
         !allowMultipleStatefulOperators)
 
-    (leftStateWatermark ++ rightStateWatermark ++ Some(inputWatermarkMs)).min
+    Some((leftStateWatermark ++ rightStateWatermark ++ Some(inputWatermarkMs)).min)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -130,6 +130,41 @@ object StreamingSymmetricHashJoinHelper extends Logging {
     }
   }
 
+  def getStateWatermark(
+      leftAttributes: Seq[Attribute],
+      rightAttributes: Seq[Attribute],
+      leftKeys: Seq[Expression],
+      rightKeys: Seq[Expression],
+      condition: Option[Expression],
+      eventTimeWatermarkForEviction: Option[Long]): (Option[Long], Option[Long]) = {
+    val joinKeyOrdinalForWatermark: Option[Int] = findJoinKeyOrdinalForWatermark(
+      leftKeys, rightKeys)
+
+    def getOneSideStateWatermark(
+        oneSideInputAttributes: Seq[Attribute],
+        otherSideInputAttributes: Seq[Attribute]): Option[Long] = {
+      val isWatermarkDefinedOnInput = oneSideInputAttributes.exists(_.metadata.contains(delayKey))
+      val isWatermarkDefinedOnJoinKey = joinKeyOrdinalForWatermark.isDefined
+
+      if (isWatermarkDefinedOnJoinKey) { // case 1 and 3 in the StreamingSymmetricHashJoinExec docs
+        eventTimeWatermarkForEviction
+      } else if (isWatermarkDefinedOnInput) { // case 2 in the StreamingSymmetricHashJoinExec docs
+        StreamingJoinHelper.getStateValueWatermark(
+          attributesToFindStateWatermarkFor = AttributeSet(oneSideInputAttributes),
+          attributesWithEventWatermark = AttributeSet(otherSideInputAttributes),
+          condition,
+          eventTimeWatermarkForEviction)
+      } else {
+        None
+      }
+    }
+
+    val leftStateWatermark = getOneSideStateWatermark(leftAttributes, rightAttributes)
+    val rightStateWatermark = getOneSideStateWatermark(rightAttributes, leftAttributes)
+
+    (leftStateWatermark, rightStateWatermark)
+  }
+
   /** Get the predicates defining the state watermarks for both sides of the join */
   def getStateWatermarkPredicates(
       leftAttributes: Seq[Attribute],
@@ -139,26 +174,8 @@ object StreamingSymmetricHashJoinHelper extends Logging {
       condition: Option[Expression],
       eventTimeWatermarkForEviction: Option[Long]): JoinStateWatermarkPredicates = {
 
-
-    // Join keys of both sides generate rows of the same fields, that is, same sequence of data
-    // types. If one side (say left side) has a column (say timestamp) that has a watermark on it,
-    // then it will never consider joining keys that are < state key watermark (i.e. event time
-    // watermark). On the other side (i.e. right side), even if there is no watermark defined,
-    // there has to be an equivalent column (i.e., timestamp). And any right side data that has the
-    // timestamp < watermark will not match will not match with left side data, as the left side get
-    // filtered with the explicitly defined watermark. So, the watermark in timestamp column in
-    // left side keys effectively causes the timestamp on the right side to have a watermark.
-    // We will use the ordinal of the left timestamp in the left keys to find the corresponding
-    // right timestamp in the right keys.
-    val joinKeyOrdinalForWatermark: Option[Int] = {
-      leftKeys.zipWithIndex.collectFirst {
-        case (ne: NamedExpression, index) if ne.metadata.contains(delayKey) => index
-      } orElse {
-        rightKeys.zipWithIndex.collectFirst {
-          case (ne: NamedExpression, index) if ne.metadata.contains(delayKey) => index
-        }
-      }
-    }
+    val joinKeyOrdinalForWatermark: Option[Int] = findJoinKeyOrdinalForWatermark(
+      leftKeys, rightKeys)
 
     def getOneSideStateWatermarkPredicate(
         oneSideInputAttributes: Seq[Attribute],
@@ -195,6 +212,28 @@ object StreamingSymmetricHashJoinHelper extends Logging {
     val rightStateWatermarkPredicate =
       getOneSideStateWatermarkPredicate(rightAttributes, rightKeys, leftAttributes)
     JoinStateWatermarkPredicates(leftStateWatermarkPredicate, rightStateWatermarkPredicate)
+  }
+
+  private def findJoinKeyOrdinalForWatermark(
+      leftKeys: Seq[Expression],
+      rightKeys: Seq[Expression]): Option[Int] = {
+    // Join keys of both sides generate rows of the same fields, that is, same sequence of data
+    // types. If one side (say left side) has a column (say timestamp) that has a watermark on it,
+    // then it will never consider joining keys that are < state key watermark (i.e. event time
+    // watermark). On the other side (i.e. right side), even if there is no watermark defined,
+    // there has to be an equivalent column (i.e., timestamp). And any right side data that has the
+    // timestamp < watermark will not match will not match with left side data, as the left side get
+    // filtered with the explicitly defined watermark. So, the watermark in timestamp column in
+    // left side keys effectively causes the timestamp on the right side to have a watermark.
+    // We will use the ordinal of the left timestamp in the left keys to find the corresponding
+    // right timestamp in the right keys.
+    leftKeys.zipWithIndex.collectFirst {
+      case (ne: NamedExpression, index) if ne.metadata.contains(delayKey) => index
+    } orElse {
+      rightKeys.zipWithIndex.collectFirst {
+        case (ne: NamedExpression, index) if ne.metadata.contains(delayKey) => index
+      }
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -136,7 +136,18 @@ object StreamingSymmetricHashJoinHelper extends Logging {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       condition: Option[Expression],
-      eventTimeWatermarkForEviction: Option[Long]): (Option[Long], Option[Long]) = {
+      eventTimeWatermarkForEviction: Option[Long],
+      useFirstEventTimeColumn: Boolean): (Option[Long], Option[Long]) = {
+
+    // Perform assertions against multiple event time columns in the same DataFrame. This method
+    // assumes there is only one event time column per each side (left / right) and it is not very
+    // clear to reason about the correctness if there are multiple event time columns. Disallow to
+    // be conservative.
+    WatermarkSupport.findEventTimeColumn(leftAttributes,
+      useFirstOccurrence = useFirstEventTimeColumn)
+    WatermarkSupport.findEventTimeColumn(rightAttributes,
+      useFirstOccurrence = useFirstEventTimeColumn)
+
     val joinKeyOrdinalForWatermark: Option[Int] = findJoinKeyOrdinalForWatermark(
       leftKeys, rightKeys)
 
@@ -172,7 +183,17 @@ object StreamingSymmetricHashJoinHelper extends Logging {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       condition: Option[Expression],
-      eventTimeWatermarkForEviction: Option[Long]): JoinStateWatermarkPredicates = {
+      eventTimeWatermarkForEviction: Option[Long],
+      useFirstEventTimeColumn: Boolean): JoinStateWatermarkPredicates = {
+
+    // Perform assertions against multiple event time columns in the same DataFrame. This method
+    // assumes there is only one event time column per each side (left / right) and it is not very
+    // clear to reason about the correctness if there are multiple event time columns. Disallow to
+    // be conservative.
+    WatermarkSupport.findEventTimeColumn(leftAttributes,
+      useFirstOccurrence = useFirstEventTimeColumn)
+    WatermarkSupport.findEventTimeColumn(rightAttributes,
+      useFirstOccurrence = useFirstEventTimeColumn)
 
     val joinKeyOrdinalForWatermark: Option[Int] = findJoinKeyOrdinalForWatermark(
       leftKeys, rightKeys)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinHelper.scala
@@ -137,16 +137,16 @@ object StreamingSymmetricHashJoinHelper extends Logging {
       rightKeys: Seq[Expression],
       condition: Option[Expression],
       eventTimeWatermarkForEviction: Option[Long],
-      useFirstEventTimeColumn: Boolean): (Option[Long], Option[Long]) = {
+      allowMultipleEventTimeColumns: Boolean): (Option[Long], Option[Long]) = {
 
     // Perform assertions against multiple event time columns in the same DataFrame. This method
     // assumes there is only one event time column per each side (left / right) and it is not very
     // clear to reason about the correctness if there are multiple event time columns. Disallow to
     // be conservative.
     WatermarkSupport.findEventTimeColumn(leftAttributes,
-      useFirstOccurrence = useFirstEventTimeColumn)
+      allowMultipleEventTimeColumns = allowMultipleEventTimeColumns)
     WatermarkSupport.findEventTimeColumn(rightAttributes,
-      useFirstOccurrence = useFirstEventTimeColumn)
+      allowMultipleEventTimeColumns = allowMultipleEventTimeColumns)
 
     val joinKeyOrdinalForWatermark: Option[Int] = findJoinKeyOrdinalForWatermark(
       leftKeys, rightKeys)
@@ -191,9 +191,9 @@ object StreamingSymmetricHashJoinHelper extends Logging {
     // clear to reason about the correctness if there are multiple event time columns. Disallow to
     // be conservative.
     WatermarkSupport.findEventTimeColumn(leftAttributes,
-      useFirstOccurrence = useFirstEventTimeColumn)
+      allowMultipleEventTimeColumns = useFirstEventTimeColumn)
     WatermarkSupport.findEventTimeColumn(rightAttributes,
-      useFirstOccurrence = useFirstEventTimeColumn)
+      allowMultipleEventTimeColumns = useFirstEventTimeColumn)
 
     val joinKeyOrdinalForWatermark: Option[Int] = findJoinKeyOrdinalForWatermark(
       leftKeys, rightKeys)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
@@ -137,7 +137,7 @@ class UseSingleWatermarkPropagator extends WatermarkPropagator {
  *      This could be individual origin watermark value, but we decide to retain global watermark
  *      to keep the watermark model be simple.
  *   -- stateless nodes: same as input watermark
- *   -- stateful nodes: the return value of `op.produceWatermark(input watermark)`.
+ *   -- stateful nodes: the return value of `op.produceOutputWatermark(input watermark)`.
  *
  *      @see [[StateStoreWriter.produceOutputWatermark]]
  *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
@@ -75,6 +75,7 @@ object NoOpWatermarkPropagator extends WatermarkPropagator {
  * operators. (prior to SPARK-40925) This is only used for compatibility mode.
  */
 class UseSingleWatermarkPropagator extends WatermarkPropagator {
+  // We use treemap to sort the key (batchID) and evict old batch IDs efficiently.
   private val batchIdToWatermark: jutil.TreeMap[Long, Long] = new jutil.TreeMap[Long, Long]()
 
   private def isInitialized(batchId: Long): Boolean = batchIdToWatermark.containsKey(batchId)
@@ -149,6 +150,7 @@ class UseSingleWatermarkPropagator extends WatermarkPropagator {
  * stateful operator, which this implementation will give the value from the association.
  */
 class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
+  // We use treemap to sort the key (batchID) and evict old batch IDs efficiently.
   private val batchIdToWatermark: jutil.TreeMap[Long, Long] = new jutil.TreeMap[Long, Long]()
 
   // contains the association for batchId -> (stateful operator ID -> input watermark)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
@@ -258,8 +258,7 @@ class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
       // In current Spark's logic, event time watermark cannot go down to negative. So even there is
       // no input watermark for operator, the final input watermark for operator should be 0L.
       inputWatermarks(batchId).get(stateOpId) match {
-        case Some(Some(wm)) => wm
-        case Some(None) => 0L
+        case Some(wmOpt) => Math.max(wmOpt.getOrElse(0L), 0L)
         case None => throw new IllegalStateException(s"Watermark for batch ID $batchId and " +
           s"stateOpId $stateOpId is not yet set!")
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import java.{util => jutil}
+
+import scala.collection.mutable
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.streaming.WatermarkPropagator.DEFAULT_WATERMARK_MS
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.Utils
+
+/** Interface for propagating watermark. */
+trait WatermarkPropagator {
+  /**
+   * Request to propagate watermark among operators based on origin watermark value. The result
+   * should be input watermark per stateful operator, which Spark will request the value by calling
+   * getInputWatermarkXXX with operator ID.
+   *
+   * It is recommended for implementation to cache the result, as Spark can request the propagation
+   * multiple times with the same batch ID and origin watermark value.
+   */
+  def propagate(batchId: Long, plan: SparkPlan, originWatermark: Long): Unit
+
+  /** Provide the calculated input watermark for late events for given stateful operator. */
+  def getInputWatermarkForLateEvents(batchId: Long, stateOpId: Long): Long
+
+  /** Provide the calculated input watermark for eviction for given stateful operator. */
+  def getInputWatermarkForEviction(batchId: Long, stateOpId: Long): Long
+
+  /**
+   * Request to clean up cached result on propagation. Spark will call this method when the given
+   * batch ID will be likely to be not re-executed.
+   */
+  def purge(batchId: Long): Unit
+}
+
+/**
+ * Do nothing. This is dummy implementation to help creating a dummy IncrementalExecution instance.
+ */
+class NoOpWatermarkPropagator extends WatermarkPropagator {
+  def propagate(batchId: Long, plan: SparkPlan, originWatermark: Long): Unit = {}
+  def getInputWatermarkForLateEvents(batchId: Long, stateOpId: Long): Long = Long.MinValue
+  def getInputWatermarkForEviction(batchId: Long, stateOpId: Long): Long = Long.MinValue
+  def purge(batchId: Long): Unit = {}
+}
+
+/**
+ * This implementation uses a single global watermark for late events and eviction.
+ *
+ * This implementation provides the behavior before Structured Streaming supports multiple stateful
+ * operators. (prior to SPARK-40925) This is only used for compatibility mode.
+ */
+class UseSingleWatermarkPropagator extends WatermarkPropagator {
+  private val batchIdToWatermark: jutil.TreeMap[Long, Long] = new jutil.TreeMap[Long, Long]()
+
+  private def isInitialized(batchId: Long): Boolean = batchIdToWatermark.containsKey(batchId)
+
+  override def propagate(batchId: Long, plan: SparkPlan, originWatermark: Long): Unit = {
+    if (batchId < 0) {
+      // no-op
+    } else if (isInitialized(batchId)) {
+      val cached = batchIdToWatermark.get(batchId)
+      assert(cached == originWatermark,
+        s"Watermark has been changed for the same batch ID! Batch ID: $batchId, " +
+          s"Value in cache: $cached, value given: $originWatermark")
+    } else {
+      batchIdToWatermark.put(batchId, originWatermark)
+    }
+  }
+
+  private def getInputWatermark(batchId: Long, stateOpId: Long): Long = {
+    if (batchId < 0) {
+      0
+    } else {
+      assert(isInitialized(batchId), s"Watermark for batch ID $batchId is not yet set!")
+      batchIdToWatermark.get(batchId)
+    }
+  }
+
+  def getInputWatermarkForLateEvents(batchId: Long, stateOpId: Long): Long =
+    getInputWatermark(batchId, stateOpId)
+
+  def getInputWatermarkForEviction(batchId: Long, stateOpId: Long): Long =
+    getInputWatermark(batchId, stateOpId)
+
+  override def purge(batchId: Long): Unit = {
+    val keyIter = batchIdToWatermark.keySet().iterator()
+    var stopIter = false
+    while (keyIter.hasNext && !stopIter) {
+      val currKey = keyIter.next()
+      if (currKey <= batchId) {
+        keyIter.remove()
+      } else {
+        stopIter = true
+      }
+    }
+  }
+}
+
+/**
+ * This implementation simulates propagation of watermark among operators.
+ *
+ * The simulation algorithm traverses the physical plan tree via post-order (children first) to
+ * calculate (input watermark, output watermark) for all nodes.
+ *
+ * For each node, below logic is applied:
+ *
+ * - Input watermark for specific node is decided by `min(input watermarks from all children)`.
+ *   -- Children providing no input watermark (DEFAULT_WATERMARK_MS) are excluded.
+ *   -- If there is no valid input watermark from children, input watermark = DEFAULT_WATERMARK_MS.
+ * - Output watermark for specific node is decided as following:
+ *   -- watermark nodes: origin watermark value
+ *      This could be individual origin watermark value, but we decide to retain global watermark
+ *      to keep the watermark model be simple.
+ *   -- stateless nodes: same as input watermark
+ *   -- stateful nodes: the return value of `op.produceWatermark(input watermark)`.
+ *      @see [[StateStoreWriter.produceWatermark]]
+ *
+ * Note that this implementation will throw an exception if watermark node sees a valid input
+ * watermark from children, meaning that we do not support re-definition of watermark.
+ *
+ * Once the algorithm traverses the physical plan tree, the association between stateful operator
+ * and input watermark will be constructed. Spark will request the input watermark for specific
+ * stateful operator, which this implementation will give the value from the association.
+ */
+class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
+  private val batchIdToWatermark: jutil.TreeMap[Long, Long] = new jutil.TreeMap[Long, Long]()
+  private val inputWatermarks: mutable.Map[Long, Map[Long, Long]] =
+    mutable.Map[Long, Map[Long, Long]]()
+
+  private def isInitialized(batchId: Long): Boolean = batchIdToWatermark.containsKey(batchId)
+
+  private def getInputWatermarks(
+      node: SparkPlan,
+      nodeToOutputWatermark: mutable.Map[Int, Long]): Seq[Long] = {
+    node.children.map { child =>
+      nodeToOutputWatermark.getOrElse(child.id, {
+        throw new IllegalStateException(
+          s"watermark for the node ${child.id} should be registered")
+      })
+    }.filter { case curr =>
+      // This path is to exclude children from watermark calculation
+      // which don't have watermark information
+      curr != DEFAULT_WATERMARK_MS
+    }
+  }
+
+  private def doSimulate(batchId: Long, plan: SparkPlan, originWatermark: Long): Unit = {
+    val statefulOperatorIdToNodeId = mutable.HashMap[Long, Int]()
+    val nodeToOutputWatermark = mutable.HashMap[Int, Long]()
+    val nextStatefulOperatorToWatermark = mutable.HashMap[Long, Long]()
+
+    // This calculation relies on post-order traversal of the query plan.
+    plan.transformUp {
+      case node: EventTimeWatermarkExec =>
+        val inputWatermarks = getInputWatermarks(node, nodeToOutputWatermark)
+        if (inputWatermarks.nonEmpty) {
+          throw new AnalysisException("Redefining watermark is disallowed. You can set the " +
+            s"config '${SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE.key}' to 'false' to restore " +
+            "the previous behavior. Note that multiple stateful operators will be disallowed.")
+        }
+
+        nodeToOutputWatermark.put(node.id, originWatermark)
+        node
+
+      case node: StateStoreWriter =>
+        val stOpId = node.stateInfo.get.operatorId
+        statefulOperatorIdToNodeId.put(stOpId, node.id)
+
+        val inputWatermarks = getInputWatermarks(node, nodeToOutputWatermark)
+        val finalInputWatermarkMs = if (inputWatermarks.nonEmpty) {
+          inputWatermarks.min
+        } else {
+          // We can't throw exception here, as we allow stateful operator to process without
+          // watermark. E.g. streaming aggregation with update/complete mode.
+          DEFAULT_WATERMARK_MS
+        }
+
+        val outputWatermarkMs = node.produceWatermark(finalInputWatermarkMs)
+        nodeToOutputWatermark.put(node.id, outputWatermarkMs)
+        nextStatefulOperatorToWatermark.put(stOpId, finalInputWatermarkMs)
+        node
+
+      case node =>
+        // pass-through, but also consider multiple children like the case of union
+        val inputWatermarks = getInputWatermarks(node, nodeToOutputWatermark)
+        val finalInputWatermarkMs = if (inputWatermarks.nonEmpty) {
+          val minCurrInputWatermarkMs = inputWatermarks.min
+          minCurrInputWatermarkMs
+        } else {
+          DEFAULT_WATERMARK_MS
+        }
+
+        nodeToOutputWatermark.put(node.id, finalInputWatermarkMs)
+        node
+    }
+
+    inputWatermarks.put(batchId, nextStatefulOperatorToWatermark.toMap)
+    batchIdToWatermark.put(batchId, originWatermark)
+
+    logDebug(s"global watermark for batch ID $batchId is set to $originWatermark")
+    logDebug(s"input watermarks for batch ID $batchId is set to $nextStatefulOperatorToWatermark")
+  }
+
+  override def propagate(batchId: Long, plan: SparkPlan, originWatermark: Long): Unit = {
+    if (batchId < 0) {
+      // no-op
+    } else if (isInitialized(batchId)) {
+      val cached = batchIdToWatermark.get(batchId)
+      assert(cached == originWatermark,
+        s"Watermark has been changed for the same batch ID! Batch ID: $batchId, " +
+          s"Value in cache: $cached, value given: $originWatermark")
+    } else {
+      logDebug(s"watermark for batch ID $batchId is received as $originWatermark, " +
+        s"call site: ${Utils.getCallSite().longForm}")
+      doSimulate(batchId, plan, originWatermark)
+    }
+  }
+
+  private def getInputWatermark(batchId: Long, stateOpId: Long): Long = {
+    if (batchId < 0) {
+      0
+    } else {
+      assert(isInitialized(batchId), s"Watermark for batch ID $batchId is not yet set!")
+      // In current Spark's logic, event time watermark cannot go down to negative. So even there is
+      // no input watermark for operator, the final input watermark for operator should be 0L.
+      val opWatermark = inputWatermarks(batchId).get(stateOpId)
+      assert(opWatermark.isDefined, s"Watermark for batch ID $batchId and stateOpId $stateOpId " +
+        "is not yet set!")
+      Math.max(opWatermark.get, 0L)
+    }
+  }
+
+  override def getInputWatermarkForLateEvents(batchId: Long, stateOpId: Long): Long =
+    getInputWatermark(batchId - 1, stateOpId)
+
+  override def getInputWatermarkForEviction(batchId: Long, stateOpId: Long): Long =
+    getInputWatermark(batchId, stateOpId)
+
+  override def purge(batchId: Long): Unit = {
+    val keyIter = batchIdToWatermark.keySet().iterator()
+    var stopIter = false
+    while (keyIter.hasNext && !stopIter) {
+      val currKey = keyIter.next()
+      if (currKey <= batchId) {
+        keyIter.remove()
+        inputWatermarks.remove(currKey)
+      } else {
+        stopIter = true
+      }
+    }
+  }
+}
+
+object WatermarkPropagator {
+  val DEFAULT_WATERMARK_MS = -1L
+
+  def apply(conf: SQLConf): WatermarkPropagator = {
+    if (conf.getConf(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE)) {
+      new PropagateWatermarkSimulator
+    } else {
+      new UseSingleWatermarkPropagator
+    }
+  }
+
+  def noop(): WatermarkPropagator = new NoOpWatermarkPropagator
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
@@ -265,8 +265,10 @@ class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
     }
   }
 
-  override def getInputWatermarkForLateEvents(batchId: Long, stateOpId: Long): Long =
+  override def getInputWatermarkForLateEvents(batchId: Long, stateOpId: Long): Long = {
+    // We use watermark for previous microbatch to determine late events.
     getInputWatermark(batchId - 1, stateOpId)
+  }
 
   override def getInputWatermarkForEviction(batchId: Long, stateOpId: Long): Long =
     getInputWatermark(batchId, stateOpId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -219,7 +219,8 @@ class ContinuousExecution(
         runId,
         currentBatchId,
         None,
-        offsetSeqMetadata)
+        offsetSeqMetadata,
+        WatermarkPropagator.noop())
       lastExecution.executedPlan // Force the lazy generation of execution plan
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -115,7 +115,7 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
    * for the output so far (including output from eviction). Operators which behave differently
    * (e.g. different criteria on eviction) must override this method.
    */
-  def produceOutputWatermark(inputWatermarkMs: Long): Long = inputWatermarkMs
+  def produceOutputWatermark(inputWatermarkMs: Long): Option[Long] = Some(inputWatermarkMs)
 
   override lazy val metrics = statefulOperatorCustomMetrics ++ Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -262,7 +262,7 @@ trait WatermarkSupport extends SparkPlan {
   private def watermarkExpression(watermark: Option[Long]): Option[Expression] = {
     WatermarkSupport.watermarkExpression(
       WatermarkSupport.findEventTimeColumn(child.output,
-        useFirstOccurrence = !allowMultipleStatefulOperators), watermark)
+        allowMultipleEventTimeColumns = !allowMultipleStatefulOperators), watermark)
   }
 
   /** Predicate based on keys that matches data older than the late event filtering watermark */
@@ -354,15 +354,15 @@ object WatermarkSupport {
    * Find the column which is marked as "event time" column.
    *
    * If there are multiple event time columns in given column list, the behavior depends on the
-   * parameter `useFirstOccurrence`. If it's set to true, the first occurred column will be
-   * returned. If not, this method will throw an AnalysisException as it is not allowed to have
+   * parameter `allowMultipleEventTimeColumns`. If it's set to true, the first occurred column will
+   * be returned. If not, this method will throw an AnalysisException as it is not allowed to have
    * multiple event time columns.
    */
   def findEventTimeColumn(
       attrs: Seq[Attribute],
-      useFirstOccurrence: Boolean): Option[Attribute] = {
+      allowMultipleEventTimeColumns: Boolean): Option[Attribute] = {
     val eventTimeCols = attrs.filter(_.metadata.contains(EventTimeWatermark.delayKey))
-    if (!useFirstOccurrence) {
+    if (!allowMultipleEventTimeColumns) {
       // There is a case projection leads the same column (same exprId) to appear more than one
       // time. Allowing them does not hurt the correctness of state row eviction, hence let's start
       // with allowing them.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/streamingLimits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/streamingLimits.scala
@@ -101,10 +101,6 @@ case class StreamingGlobalLimitExec(
 
   override protected def withNewChildInternal(newChild: SparkPlan): StreamingGlobalLimitExec =
     copy(child = newChild)
-
-  // This operator will evict based on min input watermark and ensure it will be minimum of
-  // the event time value for the output so far (including output from eviction).
-  override def produceWatermark(inputWatermarkMs: Long): Long = inputWatermarkMs
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/streamingLimits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/streamingLimits.scala
@@ -101,6 +101,10 @@ case class StreamingGlobalLimitExec(
 
   override protected def withNewChildInternal(newChild: SparkPlan): StreamingGlobalLimitExec =
     copy(child = newChild)
+
+  // This operator will evict based on min input watermark and ensure it will be minimum of
+  // the event time value for the output so far (including output from eviction).
+  override def produceWatermark(inputWatermarkMs: Long): Long = inputWatermarkMs
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -29,7 +29,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{AnalysisException, Dataset}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset}
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.UTC
@@ -548,17 +548,73 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
     assert(e.getMessage contains "should not be negative.")
   }
 
-  test("the new watermark should override the old one") {
-    val df = MemoryStream[(Long, Long)].toDF()
+  private def buildTestQueryForOverridingWatermark(): (MemoryStream[(Long, Long)], DataFrame) = {
+    val input = MemoryStream[(Long, Long)]
+    val df = input.toDF()
       .withColumn("first", timestamp_seconds($"_1"))
       .withColumn("second", timestamp_seconds($"_2"))
       .withWatermark("first", "1 minute")
+      .select("*")
       .withWatermark("second", "2 minutes")
+      .groupBy(window($"second", "1 minute"))
+      .count()
 
-    val eventTimeColumns = df.logicalPlan.output
-      .filter(_.metadata.contains(EventTimeWatermark.delayKey))
-    assert(eventTimeColumns.size === 1)
-    assert(eventTimeColumns(0).name === "second")
+    (input, df)
+  }
+
+  test("overriding watermark should not be allowed by default") {
+    val (input, df) = buildTestQueryForOverridingWatermark()
+    testStream(df)(
+      AddData(input, (100L, 200L)),
+      ExpectFailure[AnalysisException](assertFailure = exc => {
+        assert(exc.getMessage.contains("Redefining watermark is disallowed."))
+        assert(exc.getMessage.contains(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE.key))
+      })
+    )
+  }
+
+  test("overriding watermark should not fail in compatibility mode") {
+    withSQLConf(SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE.key -> "false") {
+      val (input, df) = buildTestQueryForOverridingWatermark()
+      testStream(df)(
+        AddData(input, (100L, 200L)),
+        CheckAnswer(),
+        Execute { query =>
+          val lastExecution = query.lastExecution
+          val aggSaveOperator = lastExecution.executedPlan.collect {
+            case j: StateStoreSaveExec => j
+          }.head
+
+          // - watermark from first definition = 100 - 60 = 40
+          // - watermark from second definition = 200 - 120 = 80
+          // - global watermark = min(40, 60) = 40
+          //
+          // As we see the result, even though we override the watermark definition, the old
+          // definition of watermark still plays to calculate global watermark.
+          //
+          // This is conceptually the right behavior. For operators after the first watermark
+          // definition, the column named "first" is considered as event time column, and for
+          // operators after the second watermark definition, the column named "second" is
+          // considered as event time column. The correct "single" value of watermark satisfying
+          // all operators should be lower bound of both columns "first" and "second".
+          //
+          // That said, this easily leads to incorrect definition - e.g. re-define watermark
+          // against the output of streaming aggregation for append mode. The global watermark
+          // cannot advance. This is the reason we don't allow re-define watermark in new behavior.
+          val expectedWatermarkMs = 40 * 1000
+
+          assert(aggSaveOperator.eventTimeWatermarkForLateEvents === Some(expectedWatermarkMs))
+          assert(aggSaveOperator.eventTimeWatermarkForEviction === Some(expectedWatermarkMs))
+
+          val eventTimeCols = aggSaveOperator.keyExpressions.filter(
+            _.metadata.contains(EventTimeWatermark.delayKey))
+          assert(eventTimeCols.size === 1)
+          assert(eventTimeCols.head.name === "window")
+          // 2 minutes delay threshold
+          assert(eventTimeCols.head.metadata.getLong(EventTimeWatermark.delayKey) === 120 * 1000)
+        }
+      )
+    }
   }
 
   test("EventTime watermark should be ignored in batch query.") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -28,6 +28,7 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset}
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
@@ -35,7 +36,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.UTC
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.MemorySink
-import org.apache.spark.sql.functions.{count, timestamp_seconds, window}
+import org.apache.spark.sql.functions.{count, expr, timestamp_seconds, window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode._
 import org.apache.spark.util.Utils
@@ -613,6 +614,64 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
           // 2 minutes delay threshold
           assert(eventTimeCols.head.metadata.getLong(EventTimeWatermark.delayKey) === 120 * 1000)
         }
+      )
+    }
+  }
+
+  private def buildTestQueryForMultiEventTimeColumns()
+    : (MemoryStream[(String, Long)], MemoryStream[(String, Long)], DataFrame) = {
+    val input1 = MemoryStream[(String, Long)]
+    val input2 = MemoryStream[(String, Long)]
+    val df1 = input1.toDF()
+      .selectExpr("_1 AS id1", "timestamp_seconds(_2) AS ts1")
+      .withWatermark("ts1", "1 minute")
+
+    val df2 = input2.toDF()
+      .selectExpr("_1 AS id2", "timestamp_seconds(_2) AS ts2")
+      .withWatermark("ts2", "2 minutes")
+
+    val joined = df1.join(df2, expr("id1 = id2 AND ts1 = ts2 + INTERVAL 10 SECONDS"), "inner")
+      .selectExpr("id1", "ts1", "ts2")
+    // the output of join contains both ts1 and ts2
+    val dedup = joined.dropDuplicates()
+      .selectExpr("id1", "CAST(ts1 AS LONG) AS ts1", "CAST(ts2 AS LONG) AS ts2")
+
+    (input1, input2, dedup)
+  }
+
+  test("multiple event time columns in an input DataFrame for stateful operator is " +
+    "not allowed") {
+    // for ease of verification, we change the session timezone to UTC
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val (input1, input2, dedup) = buildTestQueryForMultiEventTimeColumns()
+      testStream(dedup)(
+        MultiAddData(
+          (input1, Seq(("A", 200L), ("B", 300L))),
+          (input2, Seq(("A", 190L), ("C", 350L)))
+        ),
+        ExpectFailure[SparkException](assertFailure = exc => {
+          val cause = exc.getCause
+          assert(cause.getMessage.contains("More than one event time columns are available."))
+          assert(cause.getMessage.contains(
+            "Please ensure there is at most one event time column per stream."))
+        })
+      )
+    }
+  }
+
+  test("stateful operator should pick the first occurrence of event time column if there is " +
+    "multiple event time columns in compatibility mode") {
+    // for ease of verification, we change the session timezone to UTC
+    withSQLConf(
+      SQLConf.STATEFUL_OPERATOR_ALLOW_MULTIPLE.key -> "false",
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val (input1, input2, dedup) = buildTestQueryForMultiEventTimeColumns()
+      testStream(dedup)(
+        MultiAddData(
+          (input1, Seq(("A", 200L), ("B", 300L))),
+          (input2, Seq(("A", 190L), ("C", 350L)))
+        ),
+        CheckAnswer(("A", 200L, 190L))
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
@@ -828,7 +828,7 @@ class MultiStatefulOperatorsSuite
           }.head
 
           val outputWatermark = joinOperator.produceOutputWatermark(0)
-          assert(outputWatermark === expectedOutputWatermark)
+          assert(outputWatermark.get === expectedOutputWatermark)
         }
       )
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
@@ -17,12 +17,15 @@
 
 package org.apache.spark.sql.streaming
 
+import java.sql.Timestamp
+
 import org.scalatest.BeforeAndAfter
 
-import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.execution.streaming.{MemoryStream, StateStoreSaveExec, StreamingSymmetricHashJoinExec}
 import org.apache.spark.sql.execution.streaming.state.StateStore
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 
 // Tests for the multiple stateful operators support.
 class MultiStatefulOperatorsSuite
@@ -403,35 +406,6 @@ class MultiStatefulOperatorsSuite
     )
   }
 
-  test("join on time interval -> window agg, append mode, should fail") {
-    val input1 = MemoryStream[Int]
-    val inputDF1 = input1.toDF()
-      .withColumnRenamed("value", "value1")
-      .withColumn("eventTime1", timestamp_seconds($"value1"))
-      .withWatermark("eventTime1", "0 seconds")
-
-    val input2 = MemoryStream[(Int, Int)]
-    val inputDF2 = input2.toDS().toDF("start", "end")
-      .withColumn("eventTime2Start", timestamp_seconds($"start"))
-      .withColumn("eventTime2End", timestamp_seconds($"end"))
-      .withColumn("start2", timestamp_seconds($"start"))
-      .withWatermark("eventTime2Start", "0 seconds")
-
-    val stream = inputDF1.join(inputDF2,
-      expr("eventTime1 >= eventTime2Start AND eventTime1 < eventTime2End " +
-        "AND eventTime1 = start2"), "inner")
-      .groupBy(window($"eventTime1", "5 seconds") as 'window)
-      .agg(count("*") as 'count)
-      .select($"window".getField("start").cast("long").as[Long], $"count".as[Long])
-
-    val e = intercept[AnalysisException] {
-      testStream(stream)(
-        StartStream()
-      )
-    }
-    assert(e.getMessage.contains("Detected pattern of possible 'correctness' issue"))
-  }
-
   test("join with range join on non-time intervals -> window agg, append mode, shouldn't fail") {
     val input1 = MemoryStream[Int]
     val inputDF1 = input1.toDF()
@@ -461,6 +435,442 @@ class MultiStatefulOperatorsSuite
       assertNumStateRows(Seq(1, 0)),
       assertNumRowsDroppedByWatermark(Seq(0, 0))
     )
+  }
+
+  test("stream-stream time interval left outer join -> aggregation, append mode") {
+    val input1 = MemoryStream[(String, Timestamp)]
+    val input2 = MemoryStream[(String, Timestamp)]
+
+    val s1 = input1.toDF()
+      .selectExpr("_1 AS id1", "_2 AS timestamp1")
+      .withWatermark("timestamp1", "0 seconds")
+      .as("s1")
+
+    val s2 = input2.toDF()
+      .selectExpr("_1 AS id2", "_2 AS timestamp2")
+      .withWatermark("timestamp2", "0 seconds")
+      .as("s2")
+
+    val s3 = s1.join(s2, expr("s1.id1 = s2.id2 AND (s1.timestamp1 BETWEEN " +
+      "s2.timestamp2 - INTERVAL 1 hour AND s2.timestamp2 + INTERVAL 1 hour)"), "leftOuter")
+
+    val agg = s3.groupBy(window($"timestamp1", "10 minutes"))
+      .agg(count("*").as("cnt"))
+      .selectExpr("CAST(window.start AS STRING) AS window_start",
+        "CAST(window.end AS STRING) AS window_end", "cnt")
+
+    // for ease of verification, we change the session timezone to UTC
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      testStream(agg)(
+        MultiAddData(
+          (input1, Seq(
+            ("1", Timestamp.valueOf("2023-01-01 01:00:10")),
+            ("2", Timestamp.valueOf("2023-01-01 01:00:30")))
+          ),
+          (input2, Seq(
+            ("1", Timestamp.valueOf("2023-01-01 01:00:20"))))
+        ),
+
+        // < data batch >
+        // global watermark (0, 0)
+        // op1 (join)
+        // -- IW (0, 0)
+        // -- OW 0
+        // -- left state
+        // ("1", "2023-01-01 01:00:10", matched=true)
+        // ("1", "2023-01-01 01:00:30", matched=false)
+        // -- right state
+        // ("1", "2023-01-01 01:00:20")
+        // -- result
+        // ("1", "2023-01-01 01:00:10", "1", "2023-01-01 01:00:20")
+        // op2 (aggregation)
+        // -- IW (0, 0)
+        // -- OW 0
+        // -- state row
+        // ("2023-01-01 01:00:00", "2023-01-01 01:10:00", 1)
+        // -- result
+        // None
+
+        // -- watermark calculation
+        // watermark in left input: 2023-01-01 01:00:30
+        // watermark in right input: 2023-01-01 01:00:20
+        // origin watermark: 2023-01-01 01:00:20
+
+        // < no-data batch >
+        // global watermark (0, 2023-01-01 01:00:20)
+        // op1 (join)
+        // -- IW (0, 2023-01-01 01:00:20)
+        // -- OW 2023-01-01 00:00:19.999999
+        // -- left state
+        // ("1", "2023-01-01 01:00:10", matched=true)
+        // ("1", "2023-01-01 01:00:30", matched=false)
+        // -- right state
+        // ("1", "2023-01-01 01:00:20")
+        // -- result
+        // None
+        // op2 (aggregation)
+        // -- IW (0, 2023-01-01 00:00:19.999999)
+        // -- OW 2023-01-01 00:00:19.999999
+        // -- state row
+        // ("2023-01-01 01:00:00", "2023-01-01 01:10:00", 1)
+        // -- result
+        // None
+        CheckAnswer(),
+
+        Execute { query =>
+          val lastExecution = query.lastExecution
+          val joinOperator = lastExecution.executedPlan.collect {
+            case j: StreamingSymmetricHashJoinExec => j
+          }.head
+          val aggSaveOperator = lastExecution.executedPlan.collect {
+            case j: StateStoreSaveExec => j
+          }.head
+
+          assert(joinOperator.eventTimeWatermarkForLateEvents === Some(0))
+          assert(joinOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 01:00:20").getTime))
+
+          assert(aggSaveOperator.eventTimeWatermarkForLateEvents === Some(0))
+          assert(aggSaveOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 00:00:20").getTime - 1))
+        },
+
+        MultiAddData(
+          (input1, Seq(("5", Timestamp.valueOf("2023-01-01 01:15:00")))),
+          (input2, Seq(("6", Timestamp.valueOf("2023-01-01 01:15:00"))))
+        ),
+
+        // < data batch >
+        // global watermark (2023-01-01 01:00:20, 2023-01-01 01:00:20)
+        // op1 (join)
+        // -- IW (2023-01-01 01:00:20, 2023-01-01 01:00:20)
+        // -- OW 2023-01-01 00:00:19.999999
+        // -- left state
+        // ("1", "2023-01-01 01:00:10", matched=true)
+        // ("1", "2023-01-01 01:00:30", matched=false)
+        // ("5", "2023-01-01 01:15:00", matched=false)
+        // -- right state
+        // ("1", "2023-01-01 01:00:20")
+        // ("6", "2023-01-01 01:15:00")
+        // -- result
+        // None
+        // op2 (aggregation)
+        // -- IW (2023-01-01 00:00:19.999999, 2023-01-01 00:00:19.999999)
+        // -- OW 2023-01-01 00:00:19.999999
+        // -- state row
+        // ("2023-01-01 01:00:00", "2023-01-01 01:10:00", 1)
+        // -- result
+        // None
+
+        // -- watermark calculation
+        // watermark in left input: 2023-01-01 01:15:00
+        // watermark in right input: 2023-01-01 01:15:00
+        // origin watermark: 2023-01-01 01:15:00
+
+        // < no-data batch >
+        // global watermark (2023-01-01 01:00:20, 2023-01-01 01:15:00)
+        // op1 (join)
+        // -- IW (2023-01-01 01:00:20, 2023-01-01 01:15:00)
+        // -- OW 2023-01-01 00:14:59.999999
+        // -- left state
+        // ("1", "2023-01-01 01:00:10", matched=true)
+        // ("1", "2023-01-01 01:00:30", matched=false)
+        // ("5", "2023-01-01 01:15:00", matched=false)
+        // -- right state
+        // ("1", "2023-01-01 01:00:20")
+        // ("6", "2023-01-01 01:15:00")
+        // -- result
+        // None
+        // op2 (aggregation)
+        // -- IW (2023-01-01 00:00:19.999999, 2023-01-01 00:14:59.999999)
+        // -- OW 2023-01-01 00:14:59.999999
+        // -- state row
+        // ("2023-01-01 01:00:00", "2023-01-01 01:10:00", 1)
+        // -- result
+        // None
+        CheckAnswer(),
+
+        Execute { query =>
+          val lastExecution = query.lastExecution
+          val joinOperator = lastExecution.executedPlan.collect {
+            case j: StreamingSymmetricHashJoinExec => j
+          }.head
+          val aggSaveOperator = lastExecution.executedPlan.collect {
+            case j: StateStoreSaveExec => j
+          }.head
+
+          assert(joinOperator.eventTimeWatermarkForLateEvents ===
+            Some(Timestamp.valueOf("2023-01-01 01:00:20").getTime))
+          assert(joinOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 01:15:00").getTime))
+
+          assert(aggSaveOperator.eventTimeWatermarkForLateEvents ===
+            Some(Timestamp.valueOf("2023-01-01 00:00:20").getTime - 1))
+          assert(aggSaveOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 00:15:00").getTime - 1))
+        },
+
+        MultiAddData(
+          (input1, Seq(
+            ("5", Timestamp.valueOf("2023-01-01 02:16:00")))),
+          (input2, Seq(
+            ("6", Timestamp.valueOf("2023-01-01 02:16:00"))))
+        ),
+
+        // < data batch >
+        // global watermark (2023-01-01 01:15:00, 2023-01-01 01:15:00)
+        // op1 (join)
+        // -- IW (2023-01-01 01:15:00, 2023-01-01 01:15:00)
+        // -- OW 2023-01-01 00:14:59.999999
+        // -- left state
+        // ("1", "2023-01-01 01:00:10", matched=true)
+        // ("1", "2023-01-01 01:00:30", matched=false)
+        // ("5", "2023-01-01 01:15:00", matched=false)
+        // ("5", "2023-01-01 02:16:00", matched=false)
+        // -- right state
+        // ("1", "2023-01-01 01:00:20")
+        // ("6", "2023-01-01 01:15:00")
+        // ("6", "2023-01-01 02:16:00")
+        // -- result
+        // None
+        // op2 (aggregation)
+        // -- IW (2023-01-01 00:14:59.999999, 2023-01-01 00:14:59.999999)
+        // -- OW 2023-01-01 00:14:59.999999
+        // -- state row
+        // ("2023-01-01 01:00:00", "2023-01-01 01:10:00", 1)
+        // -- result
+        // None
+
+        // -- watermark calculation
+        // watermark in left input: 2023-01-01 02:16:00
+        // watermark in right input: 2023-01-01 02:16:00
+        // origin watermark: 2023-01-01 02:16:00
+
+        // < no-data batch >
+        // global watermark (2023-01-01 01:15:00, 2023-01-01 02:16:00)
+        // op1 (join)
+        // -- IW (2023-01-01 01:15:00, 2023-01-01 02:16:00)
+        // -- OW 2023-01-01 01:15:59.999999
+        // -- left state
+        // ("5", "2023-01-01 02:16:00", matched=false)
+        // -- right state
+        // ("6", "2023-01-01 02:16:00")
+        // -- result
+        // ("1", "2023-01-01 01:00:30", null, null)
+        // ("5", "2023-01-01 01:15:00", null, null)
+        // op2 (aggregation)
+        // -- IW (2023-01-01 00:14:59.999999, 2023-01-01 01:15:59.999999)
+        // -- OW 2023-01-01 01:15:59.999999
+        // -- state row
+        // ("2023-01-01 01:10:00", "2023-01-01 01:20:00", 1)
+        // -- result
+        // ("2023-01-01 01:00:00", "2023-01-01 01:10:00", 2)
+        CheckAnswer(
+          ("2023-01-01 01:00:00", "2023-01-01 01:10:00", 2)
+        ),
+
+        Execute { query =>
+          val lastExecution = query.lastExecution
+          val joinOperator = lastExecution.executedPlan.collect {
+            case j: StreamingSymmetricHashJoinExec => j
+          }.head
+          val aggSaveOperator = lastExecution.executedPlan.collect {
+            case j: StateStoreSaveExec => j
+          }.head
+
+          assert(joinOperator.eventTimeWatermarkForLateEvents ===
+            Some(Timestamp.valueOf("2023-01-01 01:15:00").getTime))
+          assert(joinOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 02:16:00").getTime))
+
+          assert(aggSaveOperator.eventTimeWatermarkForLateEvents ===
+            Some(Timestamp.valueOf("2023-01-01 00:15:00").getTime - 1))
+          assert(aggSaveOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 01:16:00").getTime - 1))
+        }
+      )
+    }
+  }
+
+  // This test case simply swaps the left and right from the test case "stream-stream time interval
+  // left outer join -> aggregation, append mode". This test case intends to verify the behavior
+  // that both event time columns from both inputs are available to use after stream-stream join.
+  // For explanation of the behavior, please refer to the test case "stream-stream time interval
+  // left outer join -> aggregation, append mode".
+  test("stream-stream time interval right outer join -> aggregation, append mode") {
+    val input1 = MemoryStream[(String, Timestamp)]
+    val input2 = MemoryStream[(String, Timestamp)]
+
+    val s1 = input1.toDF()
+      .selectExpr("_1 AS id1", "_2 AS timestamp1")
+      .withWatermark("timestamp1", "0 seconds")
+      .as("s1")
+
+    val s2 = input2.toDF()
+      .selectExpr("_1 AS id2", "_2 AS timestamp2")
+      .withWatermark("timestamp2", "0 seconds")
+      .as("s2")
+
+    val s3 = s1.join(s2, expr("s1.id1 = s2.id2 AND (s1.timestamp1 BETWEEN " +
+      "s2.timestamp2 - INTERVAL 1 hour AND s2.timestamp2 + INTERVAL 1 hour)"), "rightOuter")
+
+    val agg = s3.groupBy(window($"timestamp2", "10 minutes"))
+      .agg(count("*").as("cnt"))
+      .selectExpr("CAST(window.start AS STRING) AS window_start",
+        "CAST(window.end AS STRING) AS window_end", "cnt")
+
+    // for ease of verification, we change the session timezone to UTC
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      testStream(agg)(
+        MultiAddData(
+          (input2, Seq(
+            ("1", Timestamp.valueOf("2023-01-01 01:00:10")),
+            ("2", Timestamp.valueOf("2023-01-01 01:00:30")))
+          ),
+          (input1, Seq(
+            ("1", Timestamp.valueOf("2023-01-01 01:00:20"))))
+        ),
+        CheckAnswer(),
+
+        Execute { query =>
+          val lastExecution = query.lastExecution
+          val joinOperator = lastExecution.executedPlan.collect {
+            case j: StreamingSymmetricHashJoinExec => j
+          }.head
+          val aggSaveOperator = lastExecution.executedPlan.collect {
+            case j: StateStoreSaveExec => j
+          }.head
+
+          assert(joinOperator.eventTimeWatermarkForLateEvents === Some(0))
+          assert(joinOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 01:00:20").getTime))
+
+          assert(aggSaveOperator.eventTimeWatermarkForLateEvents === Some(0))
+          assert(aggSaveOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 00:00:20").getTime - 1))
+        },
+
+        MultiAddData(
+          (input2, Seq(("5", Timestamp.valueOf("2023-01-01 01:15:00")))),
+          (input1, Seq(("6", Timestamp.valueOf("2023-01-01 01:15:00"))))
+        ),
+        CheckAnswer(),
+
+        Execute { query =>
+          val lastExecution = query.lastExecution
+          val joinOperator = lastExecution.executedPlan.collect {
+            case j: StreamingSymmetricHashJoinExec => j
+          }.head
+          val aggSaveOperator = lastExecution.executedPlan.collect {
+            case j: StateStoreSaveExec => j
+          }.head
+
+          assert(joinOperator.eventTimeWatermarkForLateEvents ===
+            Some(Timestamp.valueOf("2023-01-01 01:00:20").getTime))
+          assert(joinOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 01:15:00").getTime))
+
+          assert(aggSaveOperator.eventTimeWatermarkForLateEvents ===
+            Some(Timestamp.valueOf("2023-01-01 00:00:20").getTime - 1))
+          assert(aggSaveOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 00:15:00").getTime - 1))
+        },
+
+        MultiAddData(
+          (input2, Seq(
+            ("5", Timestamp.valueOf("2023-01-01 02:16:00")))),
+          (input1, Seq(
+            ("6", Timestamp.valueOf("2023-01-01 02:16:00"))))
+        ),
+        CheckAnswer(
+          ("2023-01-01 01:00:00", "2023-01-01 01:10:00", 2)
+        ),
+
+        Execute { query =>
+          val lastExecution = query.lastExecution
+          val joinOperator = lastExecution.executedPlan.collect {
+            case j: StreamingSymmetricHashJoinExec => j
+          }.head
+          val aggSaveOperator = lastExecution.executedPlan.collect {
+            case j: StateStoreSaveExec => j
+          }.head
+
+          assert(joinOperator.eventTimeWatermarkForLateEvents ===
+            Some(Timestamp.valueOf("2023-01-01 01:15:00").getTime))
+          assert(joinOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 02:16:00").getTime))
+
+          assert(aggSaveOperator.eventTimeWatermarkForLateEvents ===
+            Some(Timestamp.valueOf("2023-01-01 00:15:00").getTime - 1))
+          assert(aggSaveOperator.eventTimeWatermarkForEviction ===
+            Some(Timestamp.valueOf("2023-01-01 01:16:00").getTime - 1))
+        }
+      )
+    }
+  }
+
+  test("stream-stream time interval join - output watermark for various intervals") {
+    def testOutputWatermarkInJoin(
+        df: DataFrame,
+        input: MemoryStream[(String, Timestamp)],
+        expectedOutputWatermark: Long): Unit = {
+      testStream(df)(
+        // dummy row to trigger execution
+        AddData(input, ("1", Timestamp.valueOf("2023-01-01 01:00:10"))),
+        CheckAnswer(),
+        Execute { query =>
+          val lastExecution = query.lastExecution
+          val joinOperator = lastExecution.executedPlan.collect {
+            case j: StreamingSymmetricHashJoinExec => j
+          }.head
+
+          val outputWatermark = joinOperator.produceWatermark(0)
+          assert(outputWatermark === expectedOutputWatermark)
+        }
+      )
+    }
+
+    val input1 = MemoryStream[(String, Timestamp)]
+    val df1 = input1.toDF
+      .selectExpr("_1 as leftId", "_2 as leftEventTime")
+      .withWatermark("leftEventTime", "5 minutes")
+
+    val input2 = MemoryStream[(String, Timestamp)]
+    val df2 = input2.toDF
+      .selectExpr("_1 as rightId", "_2 as rightEventTime")
+      .withWatermark("rightEventTime", "10 minutes")
+
+    val join1 = df1.join(df2,
+      expr(
+        """
+          |leftId = rightId AND leftEventTime BETWEEN
+          |  rightEventTime AND rightEventTime + INTERVAL 40 seconds
+          |""".stripMargin))
+
+    // right row should wait for additional 40 seconds (+ 1 ms) to be matched with left rows
+    testOutputWatermarkInJoin(join1, input1, -40L * 1000 - 1)
+
+    val join2 = df1.join(df2,
+      expr(
+        """
+          |leftId = rightId AND leftEventTime BETWEEN
+          |  rightEventTime - INTERVAL 30 seconds AND rightEventTime
+          |""".stripMargin))
+
+    // left row should wait for additional 30 seconds (+ 1 ms) to be matched with left rows
+    testOutputWatermarkInJoin(join2, input1, -30L * 1000 - 1)
+
+    val join3 = df1.join(df2,
+      expr(
+        """
+          |leftId = rightId AND leftEventTime BETWEEN
+          |  rightEventTime - INTERVAL 30 seconds AND rightEventTime + INTERVAL 40 seconds
+          |""".stripMargin))
+
+    // left row should wait for additional 30 seconds (+ 1 ms) to be matched with left rows
+    // right row should wait for additional 40 seconds (+ 1 ms) to be matched with right rows
+    // taking minimum of both criteria - 40 seconds (+ 1 ms)
+    testOutputWatermarkInJoin(join3, input1, -40L * 1000 - 1)
   }
 
   private def assertNumStateRows(numTotalRows: Seq[Long]): AssertOnQuery = AssertOnQuery { q =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
@@ -438,16 +438,19 @@ class MultiStatefulOperatorsSuite
   }
 
   test("stream-stream time interval left outer join -> aggregation, append mode") {
+    // This test performs stream-stream time interval left outer join against two streams, and
+    // applies tumble time window aggregation based on the event time column from the output of
+    // stream-stream join.
     val input1 = MemoryStream[(String, Timestamp)]
     val input2 = MemoryStream[(String, Timestamp)]
 
     val s1 = input1.toDF()
-      .selectExpr("_1 AS id1", "_2 AS timestamp1")
+      .toDF("id1", "timestamp1")
       .withWatermark("timestamp1", "0 seconds")
       .as("s1")
 
     val s2 = input2.toDF()
-      .selectExpr("_1 AS id2", "_2 AS timestamp2")
+      .toDF("id2", "timestamp2")
       .withWatermark("timestamp2", "0 seconds")
       .as("s2")
 
@@ -702,12 +705,12 @@ class MultiStatefulOperatorsSuite
     val input2 = MemoryStream[(String, Timestamp)]
 
     val s1 = input1.toDF()
-      .selectExpr("_1 AS id1", "_2 AS timestamp1")
+      .toDF("id1", "timestamp1")
       .withWatermark("timestamp1", "0 seconds")
       .as("s1")
 
     val s2 = input2.toDF()
-      .selectExpr("_1 AS id2", "_2 AS timestamp2")
+      .toDF("id2", "timestamp2")
       .withWatermark("timestamp2", "0 seconds")
       .as("s2")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
@@ -824,7 +824,7 @@ class MultiStatefulOperatorsSuite
             case j: StreamingSymmetricHashJoinExec => j
           }.head
 
-          val outputWatermark = joinOperator.produceWatermark(0)
+          val outputWatermark = joinOperator.produceOutputWatermark(0)
           assert(outputWatermark === expectedOutputWatermark)
         }
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
@@ -150,7 +150,6 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest {
       .withColumn("eventTime", timestamp_seconds($"value"))
       .withWatermark("eventTime", "10 seconds")
       .dropDuplicates()
-      .withWatermark("eventTime", "10 seconds")
       .groupBy(window($"eventTime", "5 seconds") as Symbol("window"))
       .agg(count("*") as Symbol("count"))
       .select($"window".getField("start").cast("long").as[Long], $"count".as[Long])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce watermark propagation among operators via simulation, which enables the workload of "stream-stream time interval join followed by stateful operator".

As of now, Spark considers all stateful operators to have same input watermark and output watermark, which is insufficient to handle stream-stream time interval join. It can delay joined output more than global watermark, based on the join criteria. (e.g. `leftTime BETWEEN rightTime - INTERVAL 30 seconds AND rightTime + INTERVAL 40 seconds`). To address this, the join operator should be able to produce "delayed" watermark to the downstream operator. That said, Spark has to "propagate" watermark among operators, flowing through leaf node(s) to root (going downstream).

This PR introduces a new interface `WatermarkPropagator` which performs simulation of watermark propagation based on the watermark. There are three implementations for this interface:

1. NoOpWatermarkPropagator: Do nothing. This is used for initializing dummy IncrementalExecution.
2. UseSingleWatermarkPropagator: Uses a single global watermark for late events and eviction. This is used for compatibility mode (`spark.sql.streaming.statefulOperator.allowMultiple` to `false`).
3. PropagateWatermarkSimulator: simulates propagation of watermark among operators.

The simulation algorithm used in `PropagateWatermarkSimulator` traverses the physical plan tree via post-order (children first) to calculate (input watermark, output watermark) for all nodes. For each node, below logic is applied:

- Input watermark for specific node is decided by `min(input watermarks from all children)`.
   - Children providing no input watermark are excluded.
   - If there is no valid input watermark from children, it's considered as there is no input watermark.
 - Output watermark for specific node is decided as following:
   - watermark nodes: origin watermark value (global watermark).
   - stateless nodes: same as input watermark.
   - stateful nodes: the return value of `op.produceOutputWatermark(input watermark)`. (if there is no input watermark, there is no output watermark)

Once the algorithm traverses the physical plan tree, the association between stateful operator and input watermark will be constructed. The association is cached after calculation and being used across microbatches, till Spark determines the association as no longer to be used.

As mentioned like `op.produceOutputWatermark()` in above, this PR also adds a new method `produceOutputWatermark` in StateStoreWriter, which requires each stateful operator to calculate output watermark based on given input watermark. In most cases, this is same as the criteria of state eviction, as most stateful operators produce the output from two different kinds:

1. without buffering (event time > input watermark)
2. with buffering (state)

The state eviction happens when event time exceeds a "certain threshold of timestamp", which denotes a lower bound of event time values for output (output watermark). Since most stateful operators construct the predicate for state eviction based on watermark in batch planning phase, they can produce an output watermark once Spark provides an input watermark.

Please refer to the walkthrough code comment for the test case of `stream-stream time interval left outer join -> aggregation, append mode`.

There are several additional decisions made by this PR which introduces backward incompatibility.

1. Re-definition of watermark will be disallowed.

Technically, each watermark node can track its own value of watermark and PropagateWatermarkSimulator can propagate these values correctly. (multiple origins) While this may help to accelerate processing faster stream (as all watermarks don't need to follow the slowest one till join/union), this involves more complicated questions on UX perspective, as all UX about watermark is based on global watermark. This seems harder to address, hence this PR proposes to retain the global watermark as it is.

Since we want to produce watermark as the single origin value, redefinition of watermark does not make sense. Consider stream-stream time interval join followed by another watermark node. Which is the right value of output watermark for another watermark node? delayed watermark, or global watermark?

2. stateful operator will not allow multiple event time columns being defined in the input DataFrame.

The output of stream-stream join may have two event time columns, which is ambiguous on late record filtering and eviction. Currently the first appeared event time column has been picked up for late record filtering and eviction, which is ambiguous to reason about the correctness. After this PR, Spark will throw an exception. The downstream operator has to pick up only one of event time column to continue.

Turning off the flag `spark.sql.streaming.statefulOperator.allowMultiple` will restore the old behavior from the above.

(https://issues.apache.org/jira/browse/SPARK-42549 is filed to remove this limitation later.)

### Why are the changes needed?

stream-stream time interval join followed by stateful operator is not supported yet, and this PR unblocks it.

### Does this PR introduce _any_ user-facing change?

Yes, here is a list of user facing changes (some are backward incompatibility changes, though we have compatibility flag):

- stream-stream time-interval join followed by stateful operator will be allowed.
- Re-definition of watermark will be disallowed.
- stateful operator will not allow multiple event time columns being defined in the input DataFrame.

### How was this patch tested?

New & modified test cases.