### PR TITLE
[SPARK-42381][CONNECT][PYTHON] `CreateDataFrame` should accept objects

### DIFF
--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -105,7 +105,9 @@ class LocalDataToArrowConversion:
                 if value is None:
                     return None
                 else:
-                    assert isinstance(value, (tuple, dict)), f"{type(value)} {value}"
+                    assert isinstance(value, (tuple, dict)) or hasattr(
+                        value, "__dict__"
+                    ), f"{type(value)} {value}"
 
                     _dict = {}
                     if isinstance(value, dict):
@@ -114,6 +116,10 @@ class LocalDataToArrowConversion:
                             _dict[k] = field_convs[k](v)
                     elif isinstance(value, Row) and hasattr(value, "__fields__"):
                         for k, v in value.asDict(recursive=False).items():
+                            assert isinstance(k, str)
+                            _dict[k] = field_convs[k](v)
+                    elif not isinstance(value, Row) and hasattr(value, "__dict__"):
+                        for k, v in value.__dict__.items():
                             assert isinstance(k, str)
                             _dict[k] = field_convs[k](v)
                     else:
@@ -252,6 +258,10 @@ class LocalDataToArrowConversion:
                     _dict[col] = column_convs[col](value)
             elif isinstance(item, Row) and hasattr(item, "__fields__"):
                 for col, value in item.asDict(recursive=False).items():
+                    _dict[col] = column_convs[col](value)
+            elif not isinstance(item, Row) and hasattr(item, "__dict__"):
+                for col, value in item.__dict__.items():
+                    print(col, value)
                     _dict[col] = column_convs[col](value)
             else:
                 i = 0

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -294,7 +294,9 @@ class SparkSession:
                 # For dictionaries, we sort the schema in alphabetical order.
                 _data = [dict(sorted(d.items())) for d in _data]
 
-            elif not isinstance(_data[0], (Row, tuple, list, dict)):
+            elif not isinstance(_data[0], (Row, tuple, list, dict)) and not hasattr(
+                _data[0], "__dict__"
+            ):
                 # input data can be [1, 2, 3]
                 # we need to convert it to [[1], [2], [3]] to be able to infer schema.
                 _data = [[d] for d in _data]

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -37,6 +37,7 @@ from pyspark.sql.types import (
 )
 
 from pyspark.testing.sqlutils import (
+    MyObject,
     SQLTestUtils,
     PythonOnlyUDT,
     ExamplePoint,
@@ -839,6 +840,22 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
             self.assertEqual(cdf.schema, sdf.schema)
             self.assertEqual(cdf.collect(), sdf.collect())
+
+    def test_create_df_from_objects(self):
+        data = [MyObject(1, "1"), MyObject(2, "2")]
+
+        # +---+-----+
+        # |key|value|
+        # +---+-----+
+        # |  1|    1|
+        # |  2|    2|
+        # +---+-----+
+
+        cdf = self.connect.createDataFrame(data)
+        sdf = self.spark.createDataFrame(data)
+
+        self.assertEqual(cdf.schema, sdf.schema)
+        self.assertEqual(cdf.collect(), sdf.collect())
 
     def test_simple_explain_string(self):
         df = self.connect.read.table(self.tbl_name).limit(10)

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -54,11 +54,6 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
     def test_complex_nested_udt_in_df(self):
         super().test_complex_nested_udt_in_df()
 
-    # TODO(SPARK-42020): createDataFrame with UDT
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_create_dataframe_from_objects(self):
-        super().test_create_dataframe_from_objects()
-
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_create_dataframe_schema_mismatch(self):
         super().test_create_dataframe_schema_mismatch()


### PR DESCRIPTION
### What changes were proposed in this pull request?
`CreateDataFrame` should accept objects


### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
enabled UT and added UT