### PR TITLE
[MINOR][DOCS] Add link to Hadoop docs

### DIFF
--- a/docs/rdd-programming-guide.md
+++ b/docs/rdd-programming-guide.md
@@ -442,7 +442,7 @@ Apart from text files, Spark's Python API also supports several other data forma
 
 **Writable Support**
 
-PySpark SequenceFile support loads an RDD of key-value pairs within Java, converts Writables to base Java types, and pickles the
+PySpark SequenceFile support loads an RDD of key-value pairs within Java, converts [Writables](https://hadoop.apache.org/docs/current/api/org/apache/hadoop/io/Writable.html) to base Java types, and pickles the
 resulting Java objects using [pickle](https://github.com/irmen/pickle/). When saving an RDD of key-value pairs to SequenceFile,
 PySpark does the reverse. It unpickles Python objects into Java objects and then converts them to Writables. The following
 Writables are automatically converted:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add link to Writable in Hadoop docs.

### Why are the changes needed?
The python card of of the blue talks about Writables with no explanation what it is and the meaning of the whole paragraph is lost. While the Scala card links to Hadoop docs, the python card did not.

### Does this PR introduce _any_ user-facing change?
Help docs readability.

### How was this patch tested?
Link is tested accessible.