### PR TITLE
[SPARK-42383][CORE] Protobuf serializer for `RocksDB.TypeAliases`

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
@@ -431,6 +431,9 @@ public class RocksDB implements KVStore {
       this(null);
     }
 
+    public static TypeAliases of(Map<String, byte[]> aliases) {
+      return new TypeAliases(aliases);
+    }
   }
 
   private static class PrefixCache {

--- a/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
+++ b/core/src/main/protobuf/org/apache/spark/status/protobuf/store_types.proto
@@ -816,3 +816,7 @@ message StreamingQueryProgress {
 message StreamingQueryProgressWrapper {
   StreamingQueryProgress progress = 1;
 }
+
+message RockDBTypeAliases {
+  map<string, bytes> aliases = 1;
+}

--- a/core/src/main/resources/META-INF/services/org.apache.spark.status.protobuf.ProtobufSerDe
+++ b/core/src/main/resources/META-INF/services/org.apache.spark.status.protobuf.ProtobufSerDe
@@ -31,3 +31,4 @@ org.apache.spark.status.protobuf.RDDOperationGraphWrapperSerializer
 org.apache.spark.status.protobuf.StageDataWrapperSerializer
 org.apache.spark.status.protobuf.AppSummarySerializer
 org.apache.spark.status.protobuf.PoolDataSerializer
+org.apache.spark.status.protobuf.RockDBTypeAliasesSerializer

--- a/core/src/main/scala/org/apache/spark/status/protobuf/RockDBTypeAliasesSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/status/protobuf/RockDBTypeAliasesSerializer.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.status.protobuf
+
+import java.util.{HashMap => JHashMap, Map => JMap}
+
+import com.google.protobuf.ByteString
+
+import org.apache.spark.status.protobuf.Utils.setJMapField
+import org.apache.spark.util.kvstore.RocksDB
+
+class RockDBTypeAliasesSerializer extends ProtobufSerDe[RocksDB.TypeAliases] {
+
+  override def serialize(input: RocksDB.TypeAliases): Array[Byte] = {
+    val builder = StoreTypes.RockDBTypeAliases.newBuilder()
+    setJMapField(input.aliases, putAllAliases(builder, _))
+    builder.build().toByteArray
+  }
+
+  override def deserialize(bytes: Array[Byte]): RocksDB.TypeAliases = {
+    val typeAliases = StoreTypes.RockDBTypeAliases.parseFrom(bytes)
+    RocksDB.TypeAliases.of(convertToAliases(typeAliases.getAliasesMap))
+  }
+
+  private def putAllAliases(builder: StoreTypes.RockDBTypeAliases.Builder,
+      aliases: JMap[String, Array[Byte]]): Unit = {
+    aliases.forEach {
+      case (k, v) => builder.putAliases(k, ByteString.copyFrom(v))
+    }
+  }
+
+  private def convertToAliases(input: JMap[String, ByteString]): JHashMap[String, Array[Byte]] = {
+    val aliases = new JHashMap[String, Array[Byte]](input.size())
+    input.forEach {
+      case (k, v) =>
+        aliases.put(k, v.toByteArray)
+    }
+    aliases
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add Protobuf serializer for `RocksDB.TypeAliases`

### Why are the changes needed?
Support fast and compact serialization/deserialization for `RocksDB.TypeAliases` over RocksDB.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?

- New UT
- Local test:
```
export LIVE_UI_LOCAL_STORE_DIR=/tmp/spark-ui   
build/mvn clean install -pl core -Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest
```

```
Run completed in 19 minutes, 42 seconds.
Total number of tests run: 3127
Suites: completed 294, aborted 0
Tests: succeeded 3127, failed 0, canceled 7, ignored 9, pending 0
All tests passed.
```