### PR TITLE
[SPARK-42386][SQL] Rewrite HiveGenericUDF with Invoke

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -519,7 +519,7 @@ trait StringBinaryPredicateExpressionBuilderBase extends ExpressionBuilder {
 
 object BinaryPredicate {
   def unapply(expr: Expression): Option[StaticInvoke] = expr match {
-    case s @ StaticInvoke(clz, _, "contains" | "startsWith" | "endsWith", Seq(_, _), _, _, _, _)
+    case s @ StaticInvoke(clz, _, "contains" | "startsWith" | "endsWith", Seq(_, _), _, _, _, _, _)
       if clz == classOf[ByteArrayMethods] => Some(s)
     case _ => None
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -145,7 +145,7 @@ private[hive] case class HiveGenericUDF(
       dataType = dataType,
       arguments = children,
       isDeterministic = deterministic,
-      isVarargs = true,
+      isVarargs = true
     )
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/hiveUDFs.scala
@@ -144,7 +144,8 @@ private[hive] case class HiveGenericUDF(
       functionName = "evaluate",
       dataType = dataType,
       arguments = children,
-      isVarargs = true
+      isDeterministic = deterministic,
+      isVarargs = true,
     )
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -724,6 +724,17 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
         checkAnswer(df, Seq(Row("14ab8df5135825bc9f5ff7c30609f02f")))
       }
     }
+    withUserDefinedFunction("MultiArgsGenericUDF" -> false) {
+      sql(s"CREATE FUNCTION MultiArgsGenericUDF AS '${classOf[GenericUDFConcat].getName}'")
+      withTable("MultiArgsGenericUDFTable") {
+        sql("create table MultiArgsGenericUDFTable as " +
+          "select 'Deep-going studying' as x, 'Spark SQL' as y")
+        val df = sql("SELECT MultiArgsGenericUDF(x, ' ', y) from MultiArgsGenericUDFTable")
+        val plan = df.queryExecution.executedPlan
+        assert(plan.isInstanceOf[WholeStageCodegenExec])
+        checkAnswer(df, Seq(Row("Deep-going studying Spark SQL")))
+      }
+    }
   }
 
   test("SPARK-42051: HiveGenericUDF Codegen Support w/ execution failure") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aim to rewrite HiveGenericUDF with Invoke.
Follow by https://github.com/apache/spark/pull/39555

### Why are the changes needed?
With the help of `RuntimeReplaceable`, we don't have to manually implement the codegen logic.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Add new UT.
Pass GA.