### PR TITLE
[SPARK-42389][CORE][TESTS] Ensure Live UI dir be cleaned up after test when `LIVE_UI_LOCAL_STORE_DIR` is configured

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -121,7 +121,7 @@ abstract class SparkFunSuite
           } else if (checkRemaining) {
             val remainingSize = dir.listFiles().length
             if (remainingSize > 0) {
-              logWarning(s"The number of UI dirs not cleaned after the test is $remainingSize")
+              logWarning(s"The number of UI dirs not cleaned is $remainingSize")
               Utils.deleteRecursively(dir)
             }
           } else if (dir.listFiles().nonEmpty) {

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -120,7 +120,7 @@ abstract class SparkFunSuite
             logWarning(s"The number of UI dirs not cleaned after the test is $remainingSize")
             Utils.deleteRecursively(dir)
           }
-        } else if (exists) {
+        } else if (exists && (!dir.isDirectory || dir.listFiles().nonEmpty)) {
           Utils.deleteRecursively(dir)
         }
       case _ => // do nothing

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -520,8 +520,7 @@ object SparkBuild extends PomBuild {
     } ++ Seq[Project](OldDeps.project)
   }
 
-  if (!sys.env.contains("SERIAL_SBT_TESTS") && !sys.env.contains("LIVE_UI_LOCAL_STORE_DIR")) {
-
+  if (!sys.env.contains("SERIAL_SBT_TESTS")) {
     allProjects.foreach(enable(SparkParallelTestGrouping.settings))
   }
 }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -520,7 +520,8 @@ object SparkBuild extends PomBuild {
     } ++ Seq[Project](OldDeps.project)
   }
 
-  if (!sys.env.contains("SERIAL_SBT_TESTS") && !sys.env.contains("LIVE_UI_LOCAL_STORE_DIR") ) {
+  if (!sys.env.contains("SERIAL_SBT_TESTS") && !sys.env.contains("LIVE_UI_LOCAL_STORE_DIR")) {
+
     allProjects.foreach(enable(SparkParallelTestGrouping.settings))
   }
 }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -520,7 +520,7 @@ object SparkBuild extends PomBuild {
     } ++ Seq[Project](OldDeps.project)
   }
 
-  if (!sys.env.contains("SERIAL_SBT_TESTS")) {
+  if (!sys.env.contains("SERIAL_SBT_TESTS") && !sys.env.contains("LIVE_UI_LOCAL_STORE_DIR") ) {
     allProjects.foreach(enable(SparkParallelTestGrouping.settings))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When run Spark UTs with export env `LIVE_UI_LOCAL_STORE_DIR`, there are some  cases not cleaned `LIVE_UI_LOCAL_STORE_DIR` directory after test.

For example, `LauncherBackendSuite`, 

https://github.com/apache/spark/blob/201a91bab0e3d540ee262bd73b597b137f3f987b/core/src/test/scala/org/apache/spark/launcher/LauncherBackendSuite.scala#L70-L72


`handle.kill()` gives `AppStatusStore.close` no chance to execute, and `LIVE_UI_LOCAL_STORE_DIR` will not cleaned up.

So this pr introduces the `cleanupUIDirIfNecessary` function for `SparkFunSuite` to ensure that `LIVE_UI_LOCAL_STORE_DIR` will be cleaned up after test. At the same time, the audit log is added to the `cleanupUIDirIfNecessary` function to facilitate the follow-up investigation of cases that do not clean up `LIVE_UI_LOCAL_STORE_DIR` normally


### Why are the changes needed?
Add a protection mechanism to ensure that `LIVE_UI_LOCAL_STORE_DIR` is cleaned up at the same time, which is more friendly to developers and does not need to manually clean up residual files.


### Does this PR introduce _any_ user-facing change?
No, just for test with export env `LIVE_UI_LOCAL_STORE_DIR`.


### How was this patch tested?
- Pass Github Actions
- Manual test:

run `build/sbt clean "core/testOnly *LauncherBackendSuite"`

**Before**

we can see the residual spark-ui dirs in `LIVE_UI_LOCAL_STORE_DIR` after test:

```
spark-ui-0a416dc8-8732-4b1d-a447-7ce602699411	spark-ui-f6ebf199-41c9-4520-b83e-a82f77df55ce
```

**After**

No files in `LIVE_UI_LOCAL_STORE_DIR` after test, and we can see the following logs in unit-tests.log

```
===== FINISHED o.a.s.launcher.LauncherBackendSuite: 'standalone/client: launcher handle' =====

23/02/10 11:44:41.655 pool-1-thread-1 WARN LauncherBackendSuite: The number of UI dirs not cleaned is 2
```