### PR TITLE
[SPARK-42338][CONNECT] Add details to non-fatal errors to raise a proper exception in the Python client

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -109,6 +109,13 @@ class SparkConnectService(debug: Boolean)
       val status = RPCStatus
         .newBuilder()
         .setCode(RPCCode.INTERNAL_VALUE)
+        .addDetails(
+          ProtoAny.pack(
+            ErrorInfo
+              .newBuilder()
+              .setReason(nf.getClass.getName)
+              .setDomain("org.apache.spark")
+              .build()))
         .setMessage(nf.getLocalizedMessage)
         .build()
       observer.onError(StatusProto.toStatusRuntimeException(status))

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -85,8 +85,7 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_same_semantics_error(self):
         super().test_same_semantics_error()
 
-    # TODO(SPARK-42338): Different exception in DataFrame.sample
-    @unittest.skip("Fails in Spark Connect, should enable.")
+    # Spark Connect throws `IllegalArgumentException` when calling `collect` instead of `sample`.
     def test_sample(self):
         super().test_sample()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds details to non-fatal errors to raise a proper exception in the Python client, which makes `df.sample` raise `IllegalArgumentException` as same as PySpark, except for the timing that is delayed to call actions.

### Why are the changes needed?

Currently `SparkConnectService` does not add details for `NonFatal` exceptions to the `PRCStatus`, so the Python client can't detect the exception properly and raises `SparkConnectGrpcException` instead.

It also should have the details for the Python client.

### Does this PR introduce _any_ user-facing change?

Users will see a proper exception when they call `df.sample` with illegal arguments, but in a different timing.

### How was this patch tested?

Enabled `DataFrameParityTests.test_sample`.