### PR TITLE
[SPARK-42324][SQL] Assign name to _LEGACY_ERROR_TEMP_1001

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1539,9 +1539,9 @@
   },
   "UNRESOLVED_USING_COLUMN_FOR_JOIN" : {
     "message" : [
-      "USING column <colName> cannot be resolved on the <side> side of the join. The <side>-side columns: [<plan>]."
+      "USING column <colName> cannot be resolved on the <side> side of the join. The <side>-side columns: [<suggestion>]."
     ],
-    "sqlState" : "42877"
+    "sqlState" : "42703"
   },
   "UNSUPPORTED_DATATYPE" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1540,7 +1540,8 @@
   "UNRESOLVED_USING_COLUMN_FOR_JOIN" : {
     "message" : [
       "USING column <colName> cannot be resolved on the <side> side of the join. The <side>-side columns: [<plan>]."
-    ]
+    ],
+    "sqlState" : "42877"
   },
   "UNSUPPORTED_DATATYPE" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1537,6 +1537,11 @@
     ],
     "sqlState" : "42883"
   },
+  "UNRESOLVED_USING_COLUMN_FOR_JOIN" : {
+    "message" : [
+      "USING column <colName> cannot be resolved on the <side> side of the join. The <side>-side columns: [<plan>]."
+    ]
+  },
   "UNSUPPORTED_DATATYPE" : {
     "message" : [
       "Unsupported data type <typeName>."
@@ -2154,11 +2159,6 @@
   "_LEGACY_ERROR_TEMP_1000" : {
     "message" : [
       "LEGACY store assignment policy is disallowed in Spark data source V2. Please set the configuration <configKey> to other values."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1001" : {
-    "message" : [
-      "USING column `<colName>` cannot be resolved on the <side> side of the join. The <side>-side columns: [<plan>]."
     ]
   },
   "_LEGACY_ERROR_TEMP_1002" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3447,12 +3447,14 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
 
     val leftKeys = joinNames.map { keyName =>
       left.output.find(attr => resolver(attr.name, keyName)).getOrElse {
-        throw QueryCompilationErrors.unresolvedUsingColForJoinError(keyName, left, "left")
+        throw QueryCompilationErrors.unresolvedUsingColForJoinError(
+          keyName, left.schema.fieldNames.map(toSQLId).mkString(", "), "left")
       }
     }
     val rightKeys = joinNames.map { keyName =>
       right.output.find(attr => resolver(attr.name, keyName)).getOrElse {
-        throw QueryCompilationErrors.unresolvedUsingColForJoinError(keyName, right, "right")
+        throw QueryCompilationErrors.unresolvedUsingColForJoinError(
+          keyName, right.schema.fieldNames.map(toSQLId).mkString(", "), "right")
       }
     }
     val joinPairs = leftKeys.zip(rightKeys)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3448,13 +3448,13 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     val leftKeys = joinNames.map { keyName =>
       left.output.find(attr => resolver(attr.name, keyName)).getOrElse {
         throw QueryCompilationErrors.unresolvedUsingColForJoinError(
-          keyName, left.schema.fieldNames.map(toSQLId).mkString(", "), "left")
+          keyName, left.schema.fieldNames.sorted.map(toSQLId).mkString(", "), "left")
       }
     }
     val rightKeys = joinNames.map { keyName =>
       right.output.find(attr => resolver(attr.name, keyName)).getOrElse {
         throw QueryCompilationErrors.unresolvedUsingColForJoinError(
-          keyName, right.schema.fieldNames.map(toSQLId).mkString(", "), "right")
+          keyName, right.schema.fieldNames.sorted.map(toSQLId).mkString(", "), "right")
       }
     }
     val joinPairs = leftKeys.zip(rightKeys)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -196,9 +196,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def unresolvedUsingColForJoinError(
       colName: String, plan: LogicalPlan, side: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1001",
+      errorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
       messageParameters = Map(
-        "colName" -> colName,
+        "colName" -> toSQLId(colName),
         "side" -> side,
         "plan" -> plan.output.map(_.name).mkString(", ")))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -194,13 +194,13 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def unresolvedUsingColForJoinError(
-      colName: String, plan: LogicalPlan, side: String): Throwable = {
+      colName: String, suggestion: String, side: String): Throwable = {
     new AnalysisException(
       errorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
       messageParameters = Map(
         "colName" -> toSQLId(colName),
         "side" -> side,
-        "plan" -> plan.output.map(_.name).mkString(", ")))
+        "suggestion" -> suggestion))
   }
 
   def unresolvedAttributeError(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
@@ -112,12 +112,12 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
       r1.join(r2, UsingJoin(Inner, Seq("d"))),
       expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
       expectedMessageParameters = Map(
-        "colName" -> "`d`", "side" -> "left", "suggestion" -> "`b`, `a`"))
+        "colName" -> "`d`", "side" -> "left", "suggestion" -> "`a`, `b`"))
     assertAnalysisErrorClass(
       r1.join(r2, UsingJoin(Inner, Seq("b"))),
       expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
       expectedMessageParameters = Map(
-        "colName" -> "`b`", "side" -> "right", "suggestion" -> "`c`, `a`"))
+        "colName" -> "`b`", "side" -> "right", "suggestion" -> "`a`, `c`"))
   }
 
   test("using join with a case sensitive analyzer") {
@@ -130,7 +130,7 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
       r1.join(r2, UsingJoin(Inner, Seq("A"))),
       expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
       expectedMessageParameters = Map(
-        "colName" -> "`A`", "side" -> "left", "suggestion" -> "`b`, `a`"))
+        "colName" -> "`A`", "side" -> "left", "suggestion" -> "`a`, `b`"))
   }
 
   test("using join on nested fields") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
@@ -108,12 +108,14 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
   }
 
   test("using unresolved attribute") {
-    assertAnalysisError(
+    assertAnalysisErrorClass(
       r1.join(r2, UsingJoin(Inner, Seq("d"))),
-      "USING column `d` cannot be resolved on the left side of the join" :: Nil)
-    assertAnalysisError(
+      expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
+      expectedMessageParameters = Map("colName" -> "`d`", "side" -> "left", "plan" -> "b, a"))
+    assertAnalysisErrorClass(
       r1.join(r2, UsingJoin(Inner, Seq("b"))),
-      "USING column `b` cannot be resolved on the right side of the join" :: Nil)
+      expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
+      expectedMessageParameters = Map("colName" -> "`b`", "side" -> "right", "plan" -> "c, a"))
   }
 
   test("using join with a case sensitive analyzer") {
@@ -122,16 +124,17 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
     val usingPlan = r1.join(r2, UsingJoin(Inner, Seq("a")), None)
     checkAnalysis(usingPlan, expected, caseSensitive = true)
 
-    assertAnalysisError(
+    assertAnalysisErrorClass(
       r1.join(r2, UsingJoin(Inner, Seq("A"))),
-      "USING column `A` cannot be resolved on the left side of the join" :: Nil)
+      expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
+      expectedMessageParameters = Map("colName" -> "`A`", "side" -> "left", "plan" -> "b, a"))
   }
 
   test("using join on nested fields") {
-    assertAnalysisError(
+    assertAnalysisErrorClass(
       r5.join(r6, UsingJoin(Inner, Seq("d.f1"))),
-      "USING column `d.f1` cannot be resolved on the left side of the join. " +
-        "The left-side columns: [d]" :: Nil)
+      expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
+      expectedMessageParameters = Map("colName" -> "`d`.`f1`", "side" -> "left", "plan" -> "d"))
   }
 
   test("using join with a case insensitive analyzer") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveNaturalJoinSuite.scala
@@ -111,11 +111,13 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
     assertAnalysisErrorClass(
       r1.join(r2, UsingJoin(Inner, Seq("d"))),
       expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
-      expectedMessageParameters = Map("colName" -> "`d`", "side" -> "left", "plan" -> "b, a"))
+      expectedMessageParameters = Map(
+        "colName" -> "`d`", "side" -> "left", "suggestion" -> "`b`, `a`"))
     assertAnalysisErrorClass(
       r1.join(r2, UsingJoin(Inner, Seq("b"))),
       expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
-      expectedMessageParameters = Map("colName" -> "`b`", "side" -> "right", "plan" -> "c, a"))
+      expectedMessageParameters = Map(
+        "colName" -> "`b`", "side" -> "right", "suggestion" -> "`c`, `a`"))
   }
 
   test("using join with a case sensitive analyzer") {
@@ -127,14 +129,16 @@ class ResolveNaturalJoinSuite extends AnalysisTest {
     assertAnalysisErrorClass(
       r1.join(r2, UsingJoin(Inner, Seq("A"))),
       expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
-      expectedMessageParameters = Map("colName" -> "`A`", "side" -> "left", "plan" -> "b, a"))
+      expectedMessageParameters = Map(
+        "colName" -> "`A`", "side" -> "left", "suggestion" -> "`b`, `a`"))
   }
 
   test("using join on nested fields") {
     assertAnalysisErrorClass(
       r5.join(r6, UsingJoin(Inner, Seq("d.f1"))),
       expectedErrorClass = "UNRESOLVED_USING_COLUMN_FOR_JOIN",
-      expectedMessageParameters = Map("colName" -> "`d`.`f1`", "side" -> "left", "plan" -> "d"))
+      expectedMessageParameters = Map(
+        "colName" -> "`d`.`f1`", "side" -> "left", "suggestion" -> "`d`"))
   }
 
   test("using join with a case insensitive analyzer") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR proposes to assign name to _LEGACY_ERROR_TEMP_1001, "UNRESOLVED_USING_COLUMN_FOR_JOIN".


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We should assign proper name to _LEGACY_ERROR_TEMP_*


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

`./build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite*`