### PR TITLE
[SPARK-42269][CONNECT][PYTHON] Support complex return types in DDL strings

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -443,8 +443,6 @@ class SparkConnectClient(object):
         """Create a temporary UDF in the session catalog on the other side. We generate a
         temporary name for it."""
 
-        from pyspark.sql import SparkSession as PySparkSession
-
         if name is None:
             name = f"fun_{uuid.uuid4().hex}"
 

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -68,12 +68,12 @@ from pyspark.sql.connect.expressions import (
     PythonUDF,
     CommonInlineUserDefinedFunction,
 )
+from pyspark.sql.connect.types import parse_data_type
 from pyspark.sql.types import (
     DataType,
     StructType,
     StructField,
 )
-from pyspark.sql.utils import is_remote
 from pyspark.serializers import CloudPickleSerializer
 from pyspark.rdd import PythonEvalType
 
@@ -450,16 +450,7 @@ class SparkConnectClient(object):
 
         # convert str return_type to DataType
         if isinstance(return_type, str):
-
-            assert is_remote()
-            return_type_schema = (  # a workaround to parse the DataType from DDL strings
-                PySparkSession.builder.getOrCreate()
-                .createDataFrame(data=[], schema=return_type)
-                .schema
-            )
-            assert len(return_type_schema.fields) == 1, "returnType should be singular"
-            return_type = return_type_schema.fields[0].dataType
-
+            return_type = parse_data_type(return_type)
         # construct a PythonUDF
         py_udf = PythonUDF(
             output_type=return_type.json(),

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -51,6 +51,7 @@ from pyspark.sql.types import (
 )
 
 import pyspark.sql.connect.proto as pb2
+from pyspark.sql.utils import is_remote
 
 
 JVM_BYTE_MIN: int = -(1 << 7)
@@ -337,3 +338,21 @@ def from_arrow_schema(arrow_schema: "pa.Schema") -> StructType:
             for field in arrow_schema
         ]
     )
+
+
+def parse_data_type(data_type: str) -> DataType:
+    # Currently we don't have a way to have a current Spark session in Spark Connect, and
+    # pyspark.sql.SparkSession has a centralized logic to control the session creation.
+    # So uses pyspark.sql.SparkSession for now. Should replace this to using the current
+    # Spark session for Spark Connect in the future.
+    from pyspark.sql import SparkSession as PySparkSession
+
+    assert is_remote()
+    return_type_schema = (
+        PySparkSession.builder.getOrCreate().createDataFrame(data=[], schema=data_type).schema
+    )
+    if len(return_type_schema.fields) == 1:
+        return_type = return_type_schema.fields[0].dataType
+    else:
+        return_type = return_type_schema
+    return return_type

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -113,8 +113,10 @@ class UserDefinedFunction:
                 .createDataFrame(data=[], schema=returnType)
                 .schema
             )
-            assert len(return_type_schema.fields) == 1, "returnType should be singular"
-            self._returnType = return_type_schema.fields[0].dataType
+            if len(return_type_schema.fields) == 1:
+                self._returnType = return_type_schema.fields[0].dataType
+            else:
+                self._returnType = return_type_schema
         else:
             self._returnType = returnType
         self._name = name or (

--- a/python/pyspark/sql/tests/connect/test_parity_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf.py
@@ -165,11 +165,6 @@ class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
     def test_udf_in_left_outer_join_condition(self):
         super().test_udf_in_left_outer_join_condition()
 
-    # TODO(SPARK-42269): support return type as a collection DataType in DDL strings
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_udf_with_string_return_type(self):
-        super().test_udf_with_string_return_type()
-
     def test_udf_registration_returns_udf(self):
         df = self.spark.range(10)
         add_three = self.spark.udf.register("add_three", lambda x: x + 3, IntegerType())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support complex return types in DDL strings.


### Why are the changes needed?
Parity with vanilla PySpark.

### Does this PR introduce _any_ user-facing change?
Yes.

```py
# BEFORE
>>> spark.range(2).select(udf(lambda x: (x, x), "struct<x:integer, y:integer>")("id"))
...
AssertionError: returnType should be singular

>>> spark.udf.register('f', lambda x: (x, x), "struct<x:integer, y:integer>")
...
AssertionError: returnType should be singular

# AFTER
>>> spark.range(2).select(udf(lambda x: (x, x), "struct<x:integer, y:integer>")("id"))
DataFrame[<lambda>(id): struct<x:int,y:int>]

>>> spark.udf.register('f', lambda x: (x, x), "struct<x:integer, y:integer>")
<function <lambda> at 0x7faee0eaaca0>

```

### How was this patch tested?
Unit tests.

SPARK-41661