### PR TITLE
[SPARK-42265][SPARK-41820][CONNECT] Fix createTempView and its variations to work with not analyzed plans

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1476,8 +1476,7 @@ class SparkConnectPlanner(val session: SparkSession) {
       plan = transformRelation(createView.getInput),
       allowExisting = false,
       replace = createView.getReplace,
-      viewType = viewType,
-      isAnalyzed = true)
+      viewType = viewType)
 
     Dataset.ofRows(session, plan).queryExecution.commandExecuted
   }

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1690,10 +1690,6 @@ def _test() -> None:
     del pyspark.sql.connect.dataframe.DataFrame.repartition.__doc__
     del pyspark.sql.connect.dataframe.DataFrame.repartitionByRange.__doc__
 
-    # TODO(SPARK-41820): Fix SparkConnectException: requirement failed
-    del pyspark.sql.connect.dataframe.DataFrame.createOrReplaceGlobalTempView.__doc__
-    del pyspark.sql.connect.dataframe.DataFrame.createOrReplaceTempView.__doc__
-
     # TODO(SPARK-41823): ambiguous column names
     del pyspark.sql.connect.dataframe.DataFrame.drop.__doc__
     del pyspark.sql.connect.dataframe.DataFrame.join.__doc__

--- a/python/pyspark/sql/tests/connect/test_parity_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf.py
@@ -170,11 +170,6 @@ class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
     def test_udf_with_string_return_type(self):
         super().test_udf_with_string_return_type()
 
-    # TODO(SPARK-41279): fix DataFrame.createTempView
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_udf_in_subquery(self):
-        super().test_udf_in_subquery()
-
     def test_udf_registration_returns_udf(self):
         df = self.spark.range(10)
         add_three = self.spark.udf.register("add_three", lambda x: x + 3, IntegerType())


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `createTempView` and its variations to work with not analyzed plans.

- `createTempView`
- `createOrReplaceTempView`
- `createGlobalTempView`
- `createOrReplaceGlobalTempView`

### Why are the changes needed?

Currently `SparkConnectPlanner` creates `CreateViewCommand` with `isAnalyzed = true`, but the child plan can be not-analyzed yet.

### Does this PR introduce _any_ user-facing change?

Users can run `createTempView` and its variations with not analyzed plans.

### How was this patch tested?

Enabled the related tests.