### PR TITLE
[SPARK-42403][CORE] JsonProtocol should handle null JSON strings

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1611,7 +1611,7 @@ private[spark] object JsonProtocol {
     }
 
     def extractString: String = {
-      require(json.isTextual, s"Expected string, got ${json.getNodeType}")
+      require(json.isTextual || json.isNull, s"Expected string or NULL, got ${json.getNodeType}")
       json.textValue
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a regression introduced by #36885 which broke JsonProtocol's ability to parse `null` string values: the old Json4S-based parser would correctly parse null literals, whereas the new code rejects them via an overly-strict type check.

This PR solves this problem by relaxing the type checking in `extractString` so that `null` literals in JSON can be parsed as `null` strings.

### Why are the changes needed?

Fix a regression which prevents the history server from parsing certain types of event logs which contain null strings, including stacktraces containing generated code frames and ExceptionFailure messages where the exception message is `null`.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Added new unit test in JsonProtocolSuite.