### PR TITLE
[SPARK-39142][SPARK-42235][PYTHON] Add overloads in pandas function stub file

### DIFF
--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -57,7 +57,7 @@ def ser_to_frame_pandas_udf_example(spark: SparkSession) -> None:
 
     from pyspark.sql.functions import pandas_udf
 
-    @pandas_udf("col1 string, col2 long")  # type: ignore[call-overload]
+    @pandas_udf("col1 string, col2 long")
     def func(s1: pd.Series, s2: pd.Series, s3: pd.DataFrame) -> pd.DataFrame:
         s3['col2'] = s1 + s2.str.len()
         return s3
@@ -90,7 +90,7 @@ def ser_to_ser_pandas_udf_example(spark: SparkSession) -> None:
     def multiply_func(a: pd.Series, b: pd.Series) -> pd.Series:
         return a * b
 
-    multiply = pandas_udf(multiply_func, returnType=LongType())  # type: ignore[call-overload]
+    multiply = pandas_udf(multiply_func, returnType=LongType())
 
     # The function for a pandas_udf should be able to execute with local Pandas data
     x = pd.Series([1, 2, 3])
@@ -125,7 +125,7 @@ def iter_ser_to_iter_ser_pandas_udf_example(spark: SparkSession) -> None:
     df = spark.createDataFrame(pdf)
 
     # Declare the function and create the UDF
-    @pandas_udf("long")  # type: ignore[call-overload]
+    @pandas_udf("long")
     def plus_one(iterator: Iterator[pd.Series]) -> Iterator[pd.Series]:
         for x in iterator:
             yield x + 1
@@ -151,7 +151,7 @@ def iter_sers_to_iter_ser_pandas_udf_example(spark: SparkSession) -> None:
     df = spark.createDataFrame(pdf)
 
     # Declare the function and create the UDF
-    @pandas_udf("long")  # type: ignore[call-overload]
+    @pandas_udf("long")
     def multiply_two_cols(
             iterator: Iterator[Tuple[pd.Series, pd.Series]]) -> Iterator[pd.Series]:
         for a, b in iterator:
@@ -178,7 +178,7 @@ def ser_to_scalar_pandas_udf_example(spark: SparkSession) -> None:
         ("id", "v"))
 
     # Declare the function and create the UDF
-    @pandas_udf("double")  # type: ignore[call-overload]
+    @pandas_udf("double")
     def mean_udf(v: pd.Series) -> float:
         return v.mean()
 

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -658,7 +658,7 @@ class PandasOnSparkFrameMethods:
                 )
                 columns = self_applied._internal.spark_columns
 
-                pudf = pandas_udf(  # type: ignore[call-overload]
+                pudf = pandas_udf(
                     output_func, returnType=return_schema
                 )
                 temp_struct_column = verify_temp_column_name(
@@ -726,7 +726,7 @@ class PandasOnSparkFrameMethods:
                 )
                 columns = self_applied._internal.spark_columns
 
-                pudf = pandas_udf(  # type: ignore[call-overload]
+                pudf = pandas_udf(
                     output_func, returnType=return_schema
                 )
                 temp_struct_column = verify_temp_column_name(

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -658,9 +658,7 @@ class PandasOnSparkFrameMethods:
                 )
                 columns = self_applied._internal.spark_columns
 
-                pudf = pandas_udf(
-                    output_func, returnType=return_schema
-                )
+                pudf = pandas_udf(output_func, returnType=return_schema)
                 temp_struct_column = verify_temp_column_name(
                     self_applied._internal.spark_frame, "__temp_struct__"
                 )
@@ -726,9 +724,7 @@ class PandasOnSparkFrameMethods:
                 )
                 columns = self_applied._internal.spark_columns
 
-                pudf = pandas_udf(
-                    output_func, returnType=return_schema
-                )
+                pudf = pandas_udf(output_func, returnType=return_schema)
                 temp_struct_column = verify_temp_column_name(
                     self_applied._internal.spark_frame, "__temp_struct__"
                 )

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -819,9 +819,7 @@ def read_parquet(
     if index_col is None and pandas_metadata:
         # Try to read pandas metadata
 
-        @pandas_udf(  # type: ignore[call-overload]
-            "index_col array<string>, index_names array<string>"
-        )
+        @pandas_udf("index_col array<string>, index_names array<string>")
         def read_index_metadata(pser: pd.Series) -> pd.DataFrame:
             binary = pser.iloc[0]
             metadata = pq.ParquetFile(pa.BufferReader(binary)).metadata.metadata

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -28,11 +28,11 @@ unary_np_spark_mappings = {
     "abs": F.abs,
     "absolute": F.abs,
     "arccos": F.acos,
-    "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType()),  # type: ignore[call-overload]
+    "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType()),
     "arcsin": F.asin,
-    "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType()),  # type: ignore[call-overload]
+    "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType()),
     "arctan": F.atan,
-    "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType()),  # type: ignore[call-overload]
+    "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType()),
     "bitwise_not": F.bitwiseNOT,
     "cbrt": F.cbrt,
     "ceil": F.ceil,
@@ -40,17 +40,17 @@ unary_np_spark_mappings = {
     "conj": lambda _: NotImplemented,
     "conjugate": lambda _: NotImplemented,  # It requires complex type
     "cos": F.cos,
-    "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType()),  # type: ignore[call-overload]
-    "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType()),  # type: ignore[call-overload]
+    "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType()),
+    "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType()),
     "degrees": F.degrees,
     "exp": F.exp,
-    "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType()),  # type: ignore[call-overload]
+    "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType()),
     "expm1": F.expm1,
-    "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType()),  # type: ignore[call-overload]
+    "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType()),
     "floor": F.floor,
     "frexp": lambda _: NotImplemented,  # 'frexp' output lengths become different
     # and it cannot be supported via pandas UDF.
-    "invert": pandas_udf(lambda s: np.invert(s), DoubleType()),  # type: ignore[call-overload]
+    "invert": pandas_udf(lambda s: np.invert(s), DoubleType()),
     "isfinite": lambda c: c != float("inf"),
     "isinf": lambda c: c == float("inf"),
     "isnan": F.isnan,
@@ -58,27 +58,25 @@ unary_np_spark_mappings = {
     "log": F.log,
     "log10": F.log10,
     "log1p": F.log1p,
-    "log2": pandas_udf(lambda s: np.log2(s), DoubleType()),  # type: ignore[call-overload]
+    "log2": pandas_udf(lambda s: np.log2(s), DoubleType()),
     "logical_not": lambda c: ~(c.cast(BooleanType())),
     "matmul": lambda _: NotImplemented,  # Can return a NumPy array in pandas.
     "negative": lambda c: c * -1,
     "positive": lambda c: c,
-    "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType()),  # type: ignore[call-overload]
+    "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType()),
     "radians": F.radians,
-    "reciprocal": pandas_udf(  # type: ignore[call-overload]
-        lambda s: np.reciprocal(s), DoubleType()
-    ),
-    "rint": pandas_udf(lambda s: np.rint(s), DoubleType()),  # type: ignore[call-overload]
+    "reciprocal": pandas_udf(lambda s: np.reciprocal(s), DoubleType()),
+    "rint": pandas_udf(lambda s: np.rint(s), DoubleType()),
     "sign": lambda c: F.when(c == 0, 0).when(c < 0, -1).otherwise(1),
     "signbit": lambda c: F.when(c < 0, True).otherwise(False),
     "sin": F.sin,
-    "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType()),  # type: ignore[call-overload]
-    "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType()),  # type: ignore[call-overload]
+    "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType()),
+    "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType()),
     "sqrt": F.sqrt,
-    "square": pandas_udf(lambda s: np.square(s), DoubleType()),  # type: ignore[call-overload]
+    "square": pandas_udf(lambda s: np.square(s), DoubleType()),
     "tan": F.tan,
-    "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType()),  # type: ignore[call-overload]
-    "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType()),  # type: ignore[call-overload]
+    "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType()),
+    "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType()),
 }
 
 binary_np_spark_mappings = {
@@ -86,36 +84,20 @@ binary_np_spark_mappings = {
     "bitwise_and": lambda c1, c2: c1.bitwiseAND(c2),
     "bitwise_or": lambda c1, c2: c1.bitwiseOR(c2),
     "bitwise_xor": lambda c1, c2: c1.bitwiseXOR(c2),
-    "copysign": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.copysign(s1, s2), DoubleType()
-    ),
-    "float_power": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.float_power(s1, s2), DoubleType()
-    ),
-    "floor_divide": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.floor_divide(s1, s2), DoubleType()
-    ),
-    "fmax": pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType()),  # type: ignore[call-overload]
-    "fmin": pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType()),  # type: ignore[call-overload]
-    "fmod": pandas_udf(lambda s1, s2: np.fmod(s1, s2), DoubleType()),  # type: ignore[call-overload]
-    "gcd": pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType()),  # type: ignore[call-overload]
-    "heaviside": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.heaviside(s1, s2), DoubleType()
-    ),
+    "copysign": pandas_udf(lambda s1, s2: np.copysign(s1, s2), DoubleType()),
+    "float_power": pandas_udf(lambda s1, s2: np.float_power(s1, s2), DoubleType()),
+    "floor_divide": pandas_udf(lambda s1, s2: np.floor_divide(s1, s2), DoubleType()),
+    "fmax": pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType()),
+    "fmin": pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType()),
+    "fmod": pandas_udf(lambda s1, s2: np.fmod(s1, s2), DoubleType()),
+    "gcd": pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType()),
+    "heaviside": pandas_udf(lambda s1, s2: np.heaviside(s1, s2), DoubleType()),
     "hypot": F.hypot,
-    "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType()),  # type: ignore[call-overload]
-    "ldexp": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.ldexp(s1, s2), DoubleType()
-    ),
-    "left_shift": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.left_shift(s1, s2), LongType()
-    ),
-    "logaddexp": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.logaddexp(s1, s2), DoubleType()
-    ),
-    "logaddexp2": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.logaddexp2(s1, s2), DoubleType()
-    ),
+    "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType()),
+    "ldexp": pandas_udf(lambda s1, s2: np.ldexp(s1, s2), DoubleType()),
+    "left_shift": pandas_udf(lambda s1, s2: np.left_shift(s1, s2), LongType()),
+    "logaddexp": pandas_udf(lambda s1, s2: np.logaddexp(s1, s2), DoubleType()),
+    "logaddexp2": pandas_udf(lambda s1, s2: np.logaddexp2(s1, s2), DoubleType()),
     "logical_and": lambda c1, c2: c1.cast(BooleanType()) & c2.cast(BooleanType()),
     "logical_or": lambda c1, c2: c1.cast(BooleanType()) | c2.cast(BooleanType()),
     "logical_xor": lambda c1, c2: (
@@ -125,13 +107,9 @@ binary_np_spark_mappings = {
     ),
     "maximum": F.greatest,
     "minimum": F.least,
-    "modf": pandas_udf(lambda s1, s2: np.modf(s1, s2), DoubleType()),  # type: ignore[call-overload]
-    "nextafter": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.nextafter(s1, s2), DoubleType()
-    ),
-    "right_shift": pandas_udf(  # type: ignore[call-overload]
-        lambda s1, s2: np.right_shift(s1, s2), LongType()
-    ),
+    "modf": pandas_udf(lambda s1, s2: np.modf(s1, s2), DoubleType()),
+    "nextafter": pandas_udf(lambda s1, s2: np.nextafter(s1, s2), DoubleType()),
+    "right_shift": pandas_udf(lambda s1, s2: np.right_shift(s1, s2), LongType()),
 }
 
 

--- a/python/pyspark/sql/pandas/functions.pyi
+++ b/python/pyspark/sql/pandas/functions.pyi
@@ -47,11 +47,15 @@ class PandasUDFType:
     GROUPED_AGG: PandasGroupedAggUDFType
 
 @overload
+def pandas_udf(f: PandasScalarToScalarFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
+@overload
 def pandas_udf(
     f: PandasScalarToScalarFunction,
     returnType: Union[AtomicDataTypeOrString, ArrayType],
     functionType: PandasScalarUDFType,
 ) -> UserDefinedFunctionLike: ...
+@overload
+def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType]) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
 def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType], returnType: PandasScalarUDFType) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
@@ -59,11 +63,15 @@ def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType], *, functionType: Pan
 @overload
 def pandas_udf(*, returnType: Union[AtomicDataTypeOrString, ArrayType], functionType: PandasScalarUDFType) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
+def pandas_udf(f: PandasScalarToStructFunction, returnType: Union[StructType, str]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
+@overload
 def pandas_udf(
     f: PandasScalarToStructFunction,
     returnType: Union[StructType, str],
     functionType: PandasScalarUDFType,
 ) -> UserDefinedFunctionLike: ...
+@overload
+def pandas_udf(f: Union[StructType, str]) -> Callable[[PandasScalarToStructFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
 def pandas_udf(
     f: Union[StructType, str], returnType: PandasScalarUDFType
@@ -77,11 +85,15 @@ def pandas_udf(
     *, returnType: Union[StructType, str], functionType: PandasScalarUDFType
 ) -> Callable[[PandasScalarToStructFunction], UserDefinedFunctionLike]: ...
 @overload
+def pandas_udf(f: PandasScalarIterFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
+@overload
 def pandas_udf(
     f: PandasScalarIterFunction,
     returnType: Union[AtomicDataTypeOrString, ArrayType],
     functionType: PandasScalarIterUDFType,
 ) -> UserDefinedFunctionLike: ...
+@overload
+def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType]) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
 def pandas_udf(
     f: Union[AtomicDataTypeOrString, ArrayType], returnType: PandasScalarIterUDFType
@@ -95,11 +107,15 @@ def pandas_udf(
     f: Union[AtomicDataTypeOrString, ArrayType], *, functionType: PandasScalarIterUDFType
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
+def pandas_udf(f: PandasGroupedMapFunction, returnType: Union[StructType, str]) -> GroupedMapPandasUserDefinedFunction: ...  # type: ignore[misc]
+@overload
 def pandas_udf(
     f: PandasGroupedMapFunction,
     returnType: Union[StructType, str],
     functionType: PandasGroupedMapUDFType,
 ) -> GroupedMapPandasUserDefinedFunction: ...
+@overload
+def pandas_udf(f: Union[StructType, str]) -> Callable[[PandasGroupedMapFunction], GroupedMapPandasUserDefinedFunction]: ...  # type: ignore[misc]
 @overload
 def pandas_udf(
     f: Union[StructType, str], returnType: PandasGroupedMapUDFType
@@ -113,11 +129,15 @@ def pandas_udf(
     f: Union[StructType, str], *, functionType: PandasGroupedMapUDFType
 ) -> Callable[[PandasGroupedMapFunction], GroupedMapPandasUserDefinedFunction]: ...
 @overload
+def pandas_udf(f: PandasGroupedAggFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
+@overload
 def pandas_udf(
     f: PandasGroupedAggFunction,
     returnType: Union[AtomicDataTypeOrString, ArrayType],
     functionType: PandasGroupedAggUDFType,
 ) -> UserDefinedFunctionLike: ...
+@overload
+def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType]) -> Callable[[PandasGroupedAggFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
 def pandas_udf(
     f: Union[AtomicDataTypeOrString, ArrayType], returnType: PandasGroupedAggUDFType

--- a/python/pyspark/sql/pandas/functions.pyi
+++ b/python/pyspark/sql/pandas/functions.pyi
@@ -93,18 +93,25 @@ def pandas_udf(
     functionType: PandasScalarIterUDFType,
 ) -> UserDefinedFunctionLike: ...
 @overload
-def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType]) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
-@overload
 def pandas_udf(
-    f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType], returnType: PandasScalarIterUDFType
+    f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType]
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
-    *, returnType: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType], functionType: PandasScalarIterUDFType
+    f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType],
+    returnType: PandasScalarIterUDFType,
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
-    f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType], *, functionType: PandasScalarIterUDFType
+    *,
+    returnType: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType],
+    functionType: PandasScalarIterUDFType,
+) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
+@overload
+def pandas_udf(
+    f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType],
+    *,
+    functionType: PandasScalarIterUDFType,
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
@@ -148,7 +155,9 @@ def pandas_udf(
 ) -> Callable[[PandasGroupedAggFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
-    *, returnType: Union[AtomicDataTypeOrString, ArrayType, MapType], functionType: PandasGroupedAggUDFType
+    *,
+    returnType: Union[AtomicDataTypeOrString, ArrayType, MapType],
+    functionType: PandasGroupedAggUDFType,
 ) -> Callable[[PandasGroupedAggFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(

--- a/python/pyspark/sql/pandas/functions.pyi
+++ b/python/pyspark/sql/pandas/functions.pyi
@@ -107,7 +107,7 @@ def pandas_udf(
     f: Union[AtomicDataTypeOrString, ArrayType], *, functionType: PandasScalarIterUDFType
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
-def pandas_udf(f: PandasGroupedMapFunction, returnType: Union[StructType, str]) -> GroupedMapPandasUserDefinedFunction: ...  # type: ignore[misc]
+def pandas_udf(f: PandasGroupedMapFunction, returnType: Union[StructType, str]) -> GroupedMapPandasUserDefinedFunction: ...
 @overload
 def pandas_udf(
     f: PandasGroupedMapFunction,
@@ -129,7 +129,7 @@ def pandas_udf(
     f: Union[StructType, str], *, functionType: PandasGroupedMapUDFType
 ) -> Callable[[PandasGroupedMapFunction], GroupedMapPandasUserDefinedFunction]: ...
 @overload
-def pandas_udf(f: PandasGroupedAggFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
+def pandas_udf(f: PandasGroupedAggFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]) -> UserDefinedFunctionLike: ...
 @overload
 def pandas_udf(
     f: PandasGroupedAggFunction,

--- a/python/pyspark/sql/pandas/functions.pyi
+++ b/python/pyspark/sql/pandas/functions.pyi
@@ -107,7 +107,9 @@ def pandas_udf(
     f: Union[AtomicDataTypeOrString, ArrayType], *, functionType: PandasScalarIterUDFType
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
-def pandas_udf(f: PandasGroupedMapFunction, returnType: Union[StructType, str]) -> GroupedMapPandasUserDefinedFunction: ...
+def pandas_udf(
+    f: PandasGroupedMapFunction, returnType: Union[StructType, str]
+) -> GroupedMapPandasUserDefinedFunction: ...
 @overload
 def pandas_udf(
     f: PandasGroupedMapFunction,
@@ -129,7 +131,9 @@ def pandas_udf(
     f: Union[StructType, str], *, functionType: PandasGroupedMapUDFType
 ) -> Callable[[PandasGroupedMapFunction], GroupedMapPandasUserDefinedFunction]: ...
 @overload
-def pandas_udf(f: PandasGroupedAggFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]) -> UserDefinedFunctionLike: ...
+def pandas_udf(
+    f: PandasGroupedAggFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]
+) -> UserDefinedFunctionLike: ...
 @overload
 def pandas_udf(
     f: PandasGroupedAggFunction,

--- a/python/pyspark/sql/pandas/functions.pyi
+++ b/python/pyspark/sql/pandas/functions.pyi
@@ -38,7 +38,7 @@ from pyspark.sql.pandas._typing import (
 
 from pyspark import since as since  # noqa: F401
 from pyspark.rdd import PythonEvalType as PythonEvalType  # noqa: F401
-from pyspark.sql.types import ArrayType, StructType
+from pyspark.sql.types import ArrayType, MapType, StructType
 
 class PandasUDFType:
     SCALAR: PandasScalarUDFType
@@ -47,21 +47,21 @@ class PandasUDFType:
     GROUPED_AGG: PandasGroupedAggUDFType
 
 @overload
-def pandas_udf(f: PandasScalarToScalarFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
+def pandas_udf(f: PandasScalarToScalarFunction, returnType: Union[AtomicDataTypeOrString, ArrayType, MapType]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
 @overload
 def pandas_udf(
     f: PandasScalarToScalarFunction,
-    returnType: Union[AtomicDataTypeOrString, ArrayType],
+    returnType: Union[AtomicDataTypeOrString, ArrayType, MapType],
     functionType: PandasScalarUDFType,
 ) -> UserDefinedFunctionLike: ...
 @overload
-def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType]) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
+def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType, MapType]) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
-def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType], returnType: PandasScalarUDFType) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
+def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType, MapType], returnType: PandasScalarUDFType) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
-def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType], *, functionType: PandasScalarUDFType) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
+def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType, MapType], *, functionType: PandasScalarUDFType) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
-def pandas_udf(*, returnType: Union[AtomicDataTypeOrString, ArrayType], functionType: PandasScalarUDFType) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
+def pandas_udf(*, returnType: Union[AtomicDataTypeOrString, ArrayType, MapType], functionType: PandasScalarUDFType) -> Callable[[PandasScalarToScalarFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
 def pandas_udf(f: PandasScalarToStructFunction, returnType: Union[StructType, str]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
 @overload
@@ -85,26 +85,26 @@ def pandas_udf(
     *, returnType: Union[StructType, str], functionType: PandasScalarUDFType
 ) -> Callable[[PandasScalarToStructFunction], UserDefinedFunctionLike]: ...
 @overload
-def pandas_udf(f: PandasScalarIterFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
+def pandas_udf(f: PandasScalarIterFunction, returnType: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType]) -> UserDefinedFunctionLike: ...  # type: ignore[misc]
 @overload
 def pandas_udf(
     f: PandasScalarIterFunction,
-    returnType: Union[AtomicDataTypeOrString, ArrayType],
+    returnType: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType],
     functionType: PandasScalarIterUDFType,
 ) -> UserDefinedFunctionLike: ...
 @overload
-def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType]) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
+def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType]) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
 def pandas_udf(
-    f: Union[AtomicDataTypeOrString, ArrayType], returnType: PandasScalarIterUDFType
+    f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType], returnType: PandasScalarIterUDFType
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
-    *, returnType: Union[AtomicDataTypeOrString, ArrayType], functionType: PandasScalarIterUDFType
+    *, returnType: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType], functionType: PandasScalarIterUDFType
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
-    f: Union[AtomicDataTypeOrString, ArrayType], *, functionType: PandasScalarIterUDFType
+    f: Union[AtomicDataTypeOrString, ArrayType, MapType, StructType], *, functionType: PandasScalarIterUDFType
 ) -> Callable[[PandasScalarIterFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
@@ -132,25 +132,25 @@ def pandas_udf(
 ) -> Callable[[PandasGroupedMapFunction], GroupedMapPandasUserDefinedFunction]: ...
 @overload
 def pandas_udf(
-    f: PandasGroupedAggFunction, returnType: Union[AtomicDataTypeOrString, ArrayType]
+    f: PandasGroupedAggFunction, returnType: Union[AtomicDataTypeOrString, ArrayType, MapType]
 ) -> UserDefinedFunctionLike: ...
 @overload
 def pandas_udf(
     f: PandasGroupedAggFunction,
-    returnType: Union[AtomicDataTypeOrString, ArrayType],
+    returnType: Union[AtomicDataTypeOrString, ArrayType, MapType],
     functionType: PandasGroupedAggUDFType,
 ) -> UserDefinedFunctionLike: ...
 @overload
-def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType]) -> Callable[[PandasGroupedAggFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
+def pandas_udf(f: Union[AtomicDataTypeOrString, ArrayType, MapType]) -> Callable[[PandasGroupedAggFunction], UserDefinedFunctionLike]: ...  # type: ignore[misc]
 @overload
 def pandas_udf(
-    f: Union[AtomicDataTypeOrString, ArrayType], returnType: PandasGroupedAggUDFType
+    f: Union[AtomicDataTypeOrString, ArrayType, MapType], returnType: PandasGroupedAggUDFType
 ) -> Callable[[PandasGroupedAggFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
-    *, returnType: Union[AtomicDataTypeOrString, ArrayType], functionType: PandasGroupedAggUDFType
+    *, returnType: Union[AtomicDataTypeOrString, ArrayType, MapType], functionType: PandasGroupedAggUDFType
 ) -> Callable[[PandasGroupedAggFunction], UserDefinedFunctionLike]: ...
 @overload
 def pandas_udf(
-    f: Union[AtomicDataTypeOrString, ArrayType], *, functionType: PandasGroupedAggUDFType
+    f: Union[AtomicDataTypeOrString, ArrayType, MapType], *, functionType: PandasGroupedAggUDFType
 ) -> Callable[[PandasGroupedAggFunction], UserDefinedFunctionLike]: ...


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add some new overloads in pandas function stub file.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoiding static type checkers' s warning in some cases without setting `functionType`, and it is preferred to specify type hints for the pandas UDF instead of specifying pandas UDF type via `functionType` which will be deprecated in the future releases.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA.
