### PR TITLE
[SPARK-42405][SQL] Improve array insert documentation

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -7680,9 +7680,9 @@ def array_distinct(col: "ColumnOrName") -> Column:
 def array_insert(arr: "ColumnOrName", pos: "ColumnOrName", value: "ColumnOrName") -> Column:
     """
     Collection function: adds an item into a given array at a specified array index.
-    Array indices start at 1 (or from the end if the index is negative).
-    Index specified beyond the size of the current array (plus additional element)
-    is extended with 'null' elements.
+    Array indices start at 1, or start from the end if index is negative.
+    Index above array size extends the array, or prepends the array if index is negative,
+    with 'null' elements.
 
     .. versionadded:: 3.4.0
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -7681,7 +7681,7 @@ def array_insert(arr: "ColumnOrName", pos: "ColumnOrName", value: "ColumnOrName"
     """
     Collection function: adds an item into a given array at a specified array index.
     Array indices start at 1, or start from the end if index is negative.
-    Index above array size extends the array, or prepends the array if index is negative,
+    Index above array size appends the array, or prepends the array if index is negative,
     with 'null' elements.
 
     .. versionadded:: 3.4.0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4601,6 +4601,7 @@ case class ArrayExcept(left: Expression, right: Expression) extends ArrayBinaryL
     newLeft: Expression, newRight: Expression): ArrayExcept = copy(left = newLeft, right = newRight)
 }
 
+// scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = """
     _FUNC_(x, pos, val) - Places val into index pos of array x.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4601,9 +4601,13 @@ case class ArrayExcept(left: Expression, right: Expression) extends ArrayBinaryL
     newLeft: Expression, newRight: Expression): ArrayExcept = copy(left = newLeft, right = newRight)
 }
 
-// scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(x, pos, val) - Places val into index pos of array x (array indices start at 1, or start from the end if start is negative).\",",
+  usage = """
+    _FUNC_(x, pos, val) - Places val into index pos of array x.
+      Array indices start at 1, or start from the end if start is negative.
+      Index specified beyond the size of the current array (plus additional element)
+      is extended with 'null' elements.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(array(1, 2, 3, 4), 5, 5);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4605,8 +4605,8 @@ case class ArrayExcept(left: Expression, right: Expression) extends ArrayBinaryL
   usage = """
     _FUNC_(x, pos, val) - Places val into index pos of array x.
       Array indices start at 1, or start from the end if index is negative.
-      Index specified beyond the size of the current array (plus additional element)
-      is extended with 'null' elements.
+      Index above array size extends the array, or prepends the array if index is negative,
+      with 'null' elements.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4604,7 +4604,7 @@ case class ArrayExcept(left: Expression, right: Expression) extends ArrayBinaryL
 @ExpressionDescription(
   usage = """
     _FUNC_(x, pos, val) - Places val into index pos of array x.
-      Array indices start at 1, or start from the end if start is negative.
+      Array indices start at 1, or start from the end if index is negative.
       Index specified beyond the size of the current array (plus additional element)
       is extended with 'null' elements.
   """,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4605,7 +4605,7 @@ case class ArrayExcept(left: Expression, right: Expression) extends ArrayBinaryL
   usage = """
     _FUNC_(x, pos, val) - Places val into index pos of array x.
       Array indices start at 1, or start from the end if index is negative.
-      Index above array size extends the array, or prepends the array if index is negative,
+      Index above array size appends the array, or prepends the array if index is negative,
       with 'null' elements.
   """,
   examples = """


### PR DESCRIPTION
### What changes were proposed in this pull request?

Part of cleanup from existing PR https://github.com/apache/spark/pull/38867 - documentation on the scala class ArrayInsert should match the python array_insert function. See comment here: https://github.com/apache/spark/pull/38867#discussion_r1097054656.


### Why are the changes needed?

See https://github.com/apache/spark/pull/38867#discussion_r1097054656.

### Does this PR introduce _any_ user-facing change?
Yes- better documentation of the array_insert function


### How was this patch tested?
Not applicable/ standard unit testing.
