### PR TITLE
[SPARK-42408][CORE] Register DoubleType to KryoSerializer

### DIFF
--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -530,6 +530,8 @@ private[serializer] object KryoSerializer {
       "org.apache.spark.sql.types.IntegerType",
       "org.apache.spark.sql.types.IntegerType$",
       "org.apache.spark.sql.types.LongType$",
+      "org.apache.spark.sql.types.DoubleType",
+      "org.apache.spark.sql.types.DoubleType$",
       "org.apache.spark.sql.types.Metadata",
       "org.apache.spark.sql.types.StringType$",
       "org.apache.spark.sql.types.StructField",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to register `DoubleType` to `KryoSerializer`


### Why are the changes needed?
There was an exception when running a TPCDS 3TB test. 


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Test manually.