### PR TITLE
[SPARK-42409][BUILD] Upgrade ZSTD-JNI to 1.5.4-1

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -268,4 +268,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.2-5//zstd-jni-1.5.2-5.jar
+zstd-jni/1.5.4-1//zstd-jni-1.5.4-1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -253,4 +253,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.2-5//zstd-jni-1.5.2-5.jar
+zstd-jni/1.5.4-1//zstd-jni-1.5.4-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -806,7 +806,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.2-5</version>
+        <version>1.5.4-1</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade zstd-jni from 1.5.2-5 to  1.5.4-1


### Why are the changes needed?
This version add support for no finalizer zstd BufferDecompressingStream

- https://github.com/luben/zstd-jni/pull/244

All changes as follows:

- https://github.com/luben/zstd-jni/compare/c1.5.2-5...v1.5.4-1

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions