### PR TITLE
[SPARK-42410][CONNECT][TESTS][FOLLOWUP] Fix `PlanGenerationTestSuite` together

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
@@ -20,6 +20,7 @@ import java.nio.file.{Files, Path}
 
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
+import scala.util.Properties.versionNumberString
 
 import com.google.protobuf.util.JsonFormat
 import io.grpc.inprocess.InProcessChannelBuilder
@@ -56,6 +57,8 @@ class PlanGenerationTestSuite extends ConnectFunSuite with BeforeAndAfterAll wit
 
   // Borrowed from SparkFunSuite
   private val regenerateGoldenFiles: Boolean = System.getenv("SPARK_GENERATE_GOLDEN_FILES") == "1"
+
+  private val scala = versionNumberString.substring(0, versionNumberString.indexOf(".", 2))
 
   // Borrowed from SparkFunSuite
   private def getWorkspaceFilePath(first: String, more: String*): Path = {
@@ -209,7 +212,7 @@ class PlanGenerationTestSuite extends ConnectFunSuite with BeforeAndAfterAll wit
     select(fn.col("id"))
   }
 
-  test("function udf") {
+  test("function udf " + scala) {
     // This test might be a bit tricky if different JVM
     // versions are used to generate the golden files.
     val functions = Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #39982 to fix `PlanGenerationTestSuite` together.

### Why are the changes needed?

SPARK-42377 added two test suites originally which fails at Scala 2.13, but SPARK-42410 missed `PlanGenerationTestSuite ` while fixing `ProtoToParsedPlanTestSuite`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

```
$ dev/change-scala-version.sh 2.13
$ build/sbt "connect-client-jvm/testOnly org.apache.spark.sql.PlanGenerationTestSuite" -Pscala-2.13
[info] PlanGenerationTestSuite:
...
[info] - function udf 2.13 (514 milliseconds)
...
$ SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "connect-client-jvm/testOnly org.apache.spark.sql.PlanGenerationTestSuite" -Pscala-2.13
...
[info] PlanGenerationTestSuite:
...
[info] - function udf 2.13 (574 milliseconds)
```