### PR TITLE
[SPARK-42415][SQL] The built-in dialects support OFFSET and paging query.

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -63,6 +63,7 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
     .set("spark.sql.catalog.db2.url", db.getJdbcUrl(dockerIp, externalPort))
     .set("spark.sql.catalog.db2.pushDownAggregate", "true")
     .set("spark.sql.catalog.db2.pushDownLimit", "true")
+    .set("spark.sql.catalog.db2.pushDownOffset", "true")
 
   override def tablePreparation(connection: Connection): Unit = {
     connection.prepareStatement(
@@ -96,6 +97,10 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
   }
 
   override def caseConvert(tableName: String): String = tableName.toUpperCase(Locale.ROOT)
+
+  testOffset()
+  testLimitAndOffset()
+  testPaging()
 
   testVarPop()
   testVarPop(true)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -61,9 +61,6 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.db2", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.db2.url", db.getJdbcUrl(dockerIp, externalPort))
-    .set("spark.sql.catalog.db2.pushDownAggregate", "true")
-    .set("spark.sql.catalog.db2.pushDownLimit", "true")
-    .set("spark.sql.catalog.db2.pushDownOffset", "true")
 
   override def tablePreparation(connection: Connection): Unit = {
     connection.prepareStatement(

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -60,6 +60,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     .set("spark.sql.catalog.mssql.url", db.getJdbcUrl(dockerIp, externalPort))
     .set("spark.sql.catalog.mssql.pushDownAggregate", "true")
     .set("spark.sql.catalog.mssql.pushDownLimit", "true")
+    .set("spark.sql.catalog.mssql.pushDownOffset", "true")
 
   override val connectionTimeout = timeout(7.minutes)
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -58,9 +58,6 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.mssql", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.mssql.url", db.getJdbcUrl(dockerIp, externalPort))
-    .set("spark.sql.catalog.mssql.pushDownAggregate", "true")
-    .set("spark.sql.catalog.mssql.pushDownLimit", "true")
-    .set("spark.sql.catalog.mssql.pushDownOffset", "true")
 
   override val connectionTimeout = timeout(7.minutes)
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -56,6 +56,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
     .set("spark.sql.catalog.mysql.url", db.getJdbcUrl(dockerIp, externalPort))
     .set("spark.sql.catalog.mysql.pushDownAggregate", "true")
     .set("spark.sql.catalog.mysql.pushDownLimit", "true")
+    .set("spark.sql.catalog.mysql.pushDownOffset", "true")
 
   override val connectionTimeout = timeout(7.minutes)
 
@@ -123,6 +124,10 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
   override def supportListIndexes: Boolean = true
 
   override def indexOptions: String = "KEY_BLOCK_SIZE=10"
+
+  testOffset()
+  testLimitAndOffset()
+  testPaging()
 
   testVarPop()
   testVarSamp()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -54,9 +54,6 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.mysql", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.mysql.url", db.getJdbcUrl(dockerIp, externalPort))
-    .set("spark.sql.catalog.mysql.pushDownAggregate", "true")
-    .set("spark.sql.catalog.mysql.pushDownLimit", "true")
-    .set("spark.sql.catalog.mysql.pushDownOffset", "true")
 
   override val connectionTimeout = timeout(7.minutes)
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -77,6 +77,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
     .set("spark.sql.catalog.oracle.url", db.getJdbcUrl(dockerIp, externalPort))
     .set("spark.sql.catalog.oracle.pushDownAggregate", "true")
     .set("spark.sql.catalog.oracle.pushDownLimit", "true")
+    .set("spark.sql.catalog.oracle.pushDownOffset", "true")
 
   override val connectionTimeout = timeout(7.minutes)
 
@@ -104,6 +105,10 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
   }
 
   override def caseConvert(tableName: String): String = tableName.toUpperCase(Locale.ROOT)
+
+  testOffset()
+  testLimitAndOffset()
+  testPaging()
 
   testVarPop()
   testVarSamp()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -75,9 +75,6 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.oracle", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.oracle.url", db.getJdbcUrl(dockerIp, externalPort))
-    .set("spark.sql.catalog.oracle.pushDownAggregate", "true")
-    .set("spark.sql.catalog.oracle.pushDownLimit", "true")
-    .set("spark.sql.catalog.oracle.pushDownOffset", "true")
 
   override val connectionTimeout = timeout(7.minutes)
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -52,6 +52,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
     .set("spark.sql.catalog.postgresql.pushDownTableSample", "true")
     .set("spark.sql.catalog.postgresql.pushDownLimit", "true")
     .set("spark.sql.catalog.postgresql.pushDownAggregate", "true")
+    .set("spark.sql.catalog.postgresql.pushDownOffset", "true")
 
   override def tablePreparation(connection: Connection): Unit = {
     connection.prepareStatement(
@@ -89,6 +90,10 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
   override def supportsIndex: Boolean = true
 
   override def indexOptions: String = "FILLFACTOR=70"
+
+  testOffset()
+  testLimitAndOffset()
+  testPaging()
 
   testVarPop()
   testVarPop(true)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -49,10 +49,6 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.postgresql", classOf[JDBCTableCatalog].getName)
     .set("spark.sql.catalog.postgresql.url", db.getJdbcUrl(dockerIp, externalPort))
-    .set("spark.sql.catalog.postgresql.pushDownTableSample", "true")
-    .set("spark.sql.catalog.postgresql.pushDownLimit", "true")
-    .set("spark.sql.catalog.postgresql.pushDownAggregate", "true")
-    .set("spark.sql.catalog.postgresql.pushDownOffset", "true")
 
   override def tablePreparation(connection: Connection): Unit = {
     connection.prepareStatement(

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -410,6 +410,16 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     assert(sorts.isEmpty)
   }
 
+  private def offsetPushed(df: DataFrame, offset: Int): Boolean = {
+    df.queryExecution.optimizedPlan.collect {
+      case relation: DataSourceV2ScanRelation => relation.scan match {
+        case v1: V1ScanWrapper =>
+          return v1.pushedDownOperators.offset == Some(offset)
+      }
+    }
+    false
+  }
+
   test("simple scan with LIMIT") {
     val df = sql(s"SELECT name, salary, bonus FROM $catalogAndNamespace." +
       s"${caseConvert("employee")} WHERE dept > 0 LIMIT 1")
@@ -442,6 +452,63 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
       assert(rows2(0).getString(0) === "david")
       assert(rows2(0).getDecimal(1) === new java.math.BigDecimal("10000.00"))
       assert(rows2(0).getDouble(2) === 1300d)
+    }
+  }
+
+  protected def testOffset(): Unit = {
+    test("simple scan with OFFSET") {
+      val df = sql(s"SELECT name, salary, bonus FROM $catalogAndNamespace." +
+        s"${caseConvert("employee")} WHERE dept > 0 OFFSET 4")
+      assert(offsetPushed(df, 4))
+      val rows = df.collect()
+      assert(rows.length === 1)
+      assert(rows(0).getString(0) === "jen")
+      assert(rows(0).getDecimal(1) === new java.math.BigDecimal("12000.00"))
+      assert(rows(0).getDouble(2) === 1200d)
+    }
+  }
+
+  protected def testLimitAndOffset(): Unit = {
+    test("simple scan with LIMIT and OFFSET") {
+      val df = sql(s"SELECT name, salary, bonus FROM $catalogAndNamespace." +
+        s"${caseConvert("employee")} WHERE dept > 0 LIMIT 1 OFFSET 2")
+      assert(limitPushed(df, 3))
+      assert(offsetPushed(df, 2))
+      val rows = df.collect()
+      assert(rows.length === 1)
+      assert(rows(0).getString(0) === "cathy")
+      assert(rows(0).getDecimal(1) === new java.math.BigDecimal("9000.00"))
+      assert(rows(0).getDouble(2) === 1200d)
+    }
+  }
+
+  protected def testPaging(): Unit = {
+    test("simple scan with paging: top N and OFFSET") {
+      Seq(NullOrdering.values()).flatten.foreach { nullOrdering =>
+        val df1 = sql(s"SELECT name, salary, bonus FROM $catalogAndNamespace." +
+          s"${caseConvert("employee")}" +
+          s" WHERE dept > 0 ORDER BY salary $nullOrdering, bonus LIMIT 1 OFFSET 2")
+        assert(limitPushed(df1, 3))
+        assert(offsetPushed(df1, 2))
+        checkSortRemoved(df1)
+        val rows1 = df1.collect()
+        assert(rows1.length === 1)
+        assert(rows1(0).getString(0) === "david")
+        assert(rows1(0).getDecimal(1) === new java.math.BigDecimal("10000.00"))
+        assert(rows1(0).getDouble(2) === 1300d)
+
+        val df2 = sql(s"SELECT name, salary, bonus FROM $catalogAndNamespace." +
+          s"${caseConvert("employee")}" +
+          s" WHERE dept > 0 ORDER BY salary DESC $nullOrdering, bonus LIMIT 1 OFFSET 2")
+        assert(limitPushed(df2, 3))
+        assert(offsetPushed(df2, 2))
+        checkSortRemoved(df2)
+        val rows2 = df2.collect()
+        assert(rows2.length === 1)
+        assert(rows2(0).getString(0) === "amy")
+        assert(rows2(0).getDecimal(1) === new java.math.BigDecimal("10000.00"))
+        assert(rows2(0).getDouble(2) === 1000d)
+      }
     }
   }
 

--- a/docs/sql-data-sources-jdbc.md
+++ b/docs/sql-data-sources-jdbc.md
@@ -281,36 +281,36 @@ logging into the data sources.
 
   <tr>
     <td><code>pushDownAggregate</code></td>
-    <td><code>false</code></td>
+    <td><code>true</code></td>
     <td>
-     The option to enable or disable aggregate push-down in V2 JDBC data source. The default value is false, in which case Spark will not push down aggregates to the JDBC data source. Otherwise, if sets to true, aggregates will be pushed down to the JDBC data source. Aggregate push-down is usually turned off when the aggregate is performed faster by Spark than by the JDBC data source. Please note that aggregates can be pushed down if and only if all the aggregate functions and the related filters can be pushed down. If <code>numPartitions</code> equals to 1 or the group by key is the same as <code>partitionColumn</code>, Spark will push down aggregate to data source completely and not apply a final aggregate over the data source output. Otherwise, Spark will apply a final aggregate over the data source output.
+     The option to enable or disable aggregate push-down in V2 JDBC data source. The default value is true, in which case Spark will not push down aggregates to the JDBC data source. Otherwise, if sets to true, aggregates will be pushed down to the JDBC data source. Aggregate push-down is usually turned off when the aggregate is performed faster by Spark than by the JDBC data source. Please note that aggregates can be pushed down if and only if all the aggregate functions and the related filters can be pushed down. If <code>numPartitions</code> equals to 1 or the group by key is the same as <code>partitionColumn</code>, Spark will push down aggregate to data source completely and not apply a final aggregate over the data source output. Otherwise, Spark will apply a final aggregate over the data source output.
     </td>
     <td>read</td>
   </tr>
 
   <tr>
     <td><code>pushDownLimit</code></td>
-    <td><code>false</code></td>
+    <td><code>true</code></td>
     <td>
-     The option to enable or disable LIMIT push-down into V2 JDBC data source. The LIMIT push-down also includes LIMIT + SORT , a.k.a. the Top N operator. The default value is false, in which case Spark does not push down LIMIT or LIMIT with SORT to the JDBC data source. Otherwise, if sets to true, LIMIT or LIMIT with SORT is pushed down to the JDBC data source. If <code>numPartitions</code> is greater than 1, Spark still applies LIMIT or LIMIT with SORT on the result from data source even if LIMIT or LIMIT with SORT is pushed down. Otherwise, if LIMIT or LIMIT with SORT is pushed down and <code>numPartitions</code> equals to 1, Spark will not apply LIMIT or LIMIT with SORT on the result from data source.
+     The option to enable or disable LIMIT push-down into V2 JDBC data source. The LIMIT push-down also includes LIMIT + SORT , a.k.a. the Top N operator. The default value is true, in which case Spark does not push down LIMIT or LIMIT with SORT to the JDBC data source. Otherwise, if sets to true, LIMIT or LIMIT with SORT is pushed down to the JDBC data source. If <code>numPartitions</code> is greater than 1, Spark still applies LIMIT or LIMIT with SORT on the result from data source even if LIMIT or LIMIT with SORT is pushed down. Otherwise, if LIMIT or LIMIT with SORT is pushed down and <code>numPartitions</code> equals to 1, Spark will not apply LIMIT or LIMIT with SORT on the result from data source.
     </td>
     <td>read</td>
   </tr>
 
   <tr>
     <td><code>pushDownOffset</code></td>
-    <td><code>false</code></td>
+    <td><code>true</code></td>
     <td>
-     The option to enable or disable OFFSET push-down into V2 JDBC data source. The default value is false, in which case Spark will not push down OFFSET to the JDBC data source. Otherwise, if sets to true, Spark will try to push down OFFSET to the JDBC data source. If <code>pushDownOffset</code> is true and <code>numPartitions</code> is equal to 1, OFFSET will be pushed down to the JDBC data source. Otherwise, OFFSET will not be pushed down and Spark still applies OFFSET on the result from data source.
+     The option to enable or disable OFFSET push-down into V2 JDBC data source. The default value is true, in which case Spark will not push down OFFSET to the JDBC data source. Otherwise, if sets to true, Spark will try to push down OFFSET to the JDBC data source. If <code>pushDownOffset</code> is true and <code>numPartitions</code> is equal to 1, OFFSET will be pushed down to the JDBC data source. Otherwise, OFFSET will not be pushed down and Spark still applies OFFSET on the result from data source.
     </td>
     <td>read</td>
   </tr>
 
   <tr>
     <td><code>pushDownTableSample</code></td>
-    <td><code>false</code></td>
+    <td><code>true</code></td>
     <td>
-     The option to enable or disable TABLESAMPLE push-down into V2 JDBC data source. The default value is false, in which case Spark does not push down TABLESAMPLE to the JDBC data source. Otherwise, if value sets to true, TABLESAMPLE is pushed down to the JDBC data source.
+     The option to enable or disable TABLESAMPLE push-down into V2 JDBC data source. The default value is true, in which case Spark does not push down TABLESAMPLE to the JDBC data source. Otherwise, if value sets to true, TABLESAMPLE is pushed down to the JDBC data source.
     </td>
     <td>read</td>
   </tr>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -192,19 +192,19 @@ class JDBCOptions(
 
   // An option to allow/disallow pushing down aggregate into JDBC data source
   // This only applies to Data Source V2 JDBC
-  val pushDownAggregate = parameters.getOrElse(JDBC_PUSHDOWN_AGGREGATE, "false").toBoolean
+  val pushDownAggregate = parameters.getOrElse(JDBC_PUSHDOWN_AGGREGATE, "true").toBoolean
 
   // An option to allow/disallow pushing down LIMIT into V2 JDBC data source
   // This only applies to Data Source V2 JDBC
-  val pushDownLimit = parameters.getOrElse(JDBC_PUSHDOWN_LIMIT, "false").toBoolean
+  val pushDownLimit = parameters.getOrElse(JDBC_PUSHDOWN_LIMIT, "true").toBoolean
 
   // An option to allow/disallow pushing down OFFSET into V2 JDBC data source
   // This only applies to Data Source V2 JDBC
-  val pushDownOffset = parameters.getOrElse(JDBC_PUSHDOWN_OFFSET, "false").toBoolean
+  val pushDownOffset = parameters.getOrElse(JDBC_PUSHDOWN_OFFSET, "true").toBoolean
 
   // An option to allow/disallow pushing down TABLESAMPLE into JDBC data source
   // This only applies to Data Source V2 JDBC
-  val pushDownTableSample = parameters.getOrElse(JDBC_PUSHDOWN_TABLESAMPLE, "false").toBoolean
+  val pushDownTableSample = parameters.getOrElse(JDBC_PUSHDOWN_TABLESAMPLE, "true").toBoolean
 
   // The local path of user's keytab file, which is assumed to be pre-uploaded to all nodes either
   // by --files option of spark-submit or manually

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -25,7 +25,6 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException
 import org.apache.spark.sql.connector.expressions.Expression
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.types._
 
 private object DB2Dialect extends JdbcDialect {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -170,25 +170,6 @@ private object DB2Dialect extends JdbcDialect {
     if (offset > 0) s"OFFSET $offset ROWS" else ""
   }
 
-  class DB2SQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
-    extends JdbcSQLQueryBuilder(dialect, options) {
-
-    override def build(): String = {
-      val selectStmt = if (limit > 0 && offset > 0) {
-        val offsetClause = dialect.getOffsetClause(offset)
-        s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
-          s" $whereClause $groupByClause $orderByClause $offsetClause FETCH FIRST $limit ROWS ONLY"
-      } else {
-        super.build()
-      }
-
-      options.prepareQuery + selectStmt
-    }
-  }
-
-  override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
-    new DB2SQLQueryBuilder(this, options)
-
   override def supportsLimit: Boolean = true
 
   override def supportsOffset: Boolean = true

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -167,7 +167,7 @@ private object DB2Dialect extends JdbcDialect {
   }
 
   override def getOffsetClause(offset: Integer): String = {
-    if (offset > 0 ) s"OFFSET $offset ROWS" else ""
+    if (offset > 0) s"OFFSET $offset ROWS" else ""
   }
 
   class DB2SQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
@@ -177,7 +177,7 @@ private object DB2Dialect extends JdbcDialect {
       val selectStmt = if (limit > 0 && offset > 0) {
         val offsetClause = dialect.getOffsetClause(offset)
         s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
-          s" $whereClause $groupByClause $orderByClause $offsetClause FETCH FIRST $limit ROWS only"
+          s" $whereClause $groupByClause $orderByClause $offsetClause FETCH FIRST $limit ROWS ONLY"
       } else {
         super.build()
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -25,6 +25,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException
 import org.apache.spark.sql.connector.expressions.Expression
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.types._
 
 private object DB2Dialect extends JdbcDialect {
@@ -168,6 +169,22 @@ private object DB2Dialect extends JdbcDialect {
   override def getOffsetClause(offset: Integer): String = {
     if (offset > 0) s"OFFSET $offset ROWS" else ""
   }
+
+  class DB2SQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
+    extends JdbcSQLQueryBuilder(dialect, options) {
+
+    override def build(): String = {
+      val limitClause = dialect.getLimitClause(limit)
+      val offsetClause = dialect.getOffsetClause(offset)
+
+      options.prepareQuery +
+        s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
+        s" $whereClause $groupByClause $orderByClause $offsetClause $limitClause"
+    }
+  }
+
+  override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
+    new DB2SQLQueryBuilder(this, options)
 
   override def supportsLimit: Boolean = true
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/DB2Dialect.scala
@@ -188,4 +188,8 @@ private object DB2Dialect extends JdbcDialect {
 
   override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
     new DB2SQLQueryBuilder(this, options)
+
+  override def supportsLimit: Boolean = true
+
+  override def supportsOffset: Boolean = true
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -276,4 +276,8 @@ private[sql] object H2Dialect extends JdbcDialect {
       }
     }
   }
+
+  override def supportsLimit: Boolean = true
+
+  override def supportsOffset: Boolean = true
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -568,6 +568,10 @@ abstract class JdbcDialect extends Serializable with Logging {
 
   /**
    * Returns ture if dialect supports OFFSET clause.
+   *
+   * Note: Some build-in dialect supports OFFSET clause with some trick, please see:
+   * {@link OracleDialect.OracleSQLQueryBuilder} and
+   * {@link MsSqlServerDialect.MsSqlServerSQLQueryBuilder}.
    */
   def supportsOffset: Boolean = true
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -564,17 +564,19 @@ abstract class JdbcDialect extends Serializable with Logging {
    * {@link OracleDialect.OracleSQLQueryBuilder} and
    * {@link MsSqlServerDialect.MsSqlServerSQLQueryBuilder}.
    */
-  def supportsLimit: Boolean = true
+  def supportsLimit: Boolean = false
 
   /**
    * Returns ture if dialect supports OFFSET clause.
    *
    * Note: Some build-in dialect supports OFFSET clause with some trick, please see:
-   * {@link OracleDialect.OracleSQLQueryBuilder} and
-   * {@link MsSqlServerDialect.MsSqlServerSQLQueryBuilder}.
+   * {@link OracleDialect.OracleSQLQueryBuilder}.
    */
-  def supportsOffset: Boolean = true
+  def supportsOffset: Boolean = false
 
+  /**
+   * Returns ture if dialect supports table sample.
+   */
   def supportsTableSample: Boolean = false
 
   def getTableSample(sample: TableSampleInfo): String =

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -197,8 +197,6 @@ private object MsSqlServerDialect extends JdbcDialect {
     }
   }
 
-  override def supportsOffset: Boolean = false
-
   class MsSqlServerSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
     extends JdbcSQLQueryBuilder(dialect, options) {
 
@@ -213,4 +211,6 @@ private object MsSqlServerDialect extends JdbcDialect {
 
   override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
     new MsSqlServerSQLQueryBuilder(this, options)
+
+  override def supportsLimit: Boolean = true
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -202,7 +202,6 @@ private object MsSqlServerDialect extends JdbcDialect {
   class MsSqlServerSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
     extends JdbcSQLQueryBuilder(dialect, options) {
 
-    // TODO[SPARK-42289]: DS V2 pushdown could let JDBC dialect decide to push down offset
     override def build(): String = {
       val limitClause = dialect.getLimitClause(limit)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -197,6 +197,8 @@ private object MsSqlServerDialect extends JdbcDialect {
     }
   }
 
+  override def supportsOffset: Boolean = false
+
   class MsSqlServerSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
     extends JdbcSQLQueryBuilder(dialect, options) {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -309,4 +309,8 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
 
   override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
     new MySQLSQLQueryBuilder(this, options)
+
+  override def supportsLimit: Boolean = true
+
+  override def supportsOffset: Boolean = true
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -291,4 +291,22 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
       throw QueryExecutionErrors.unsupportedDropNamespaceRestrictError()
     }
   }
+
+  class MySQLSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
+    extends JdbcSQLQueryBuilder(dialect, options) {
+
+    override def build(): String = {
+      if (limit < 1 && offset > 0) {
+        val offsetClause = dialect.getOffsetClause(offset)
+        options.prepareQuery +
+          s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
+          s" $whereClause $groupByClause $orderByClause LIMIT 18446744073709551610 $offsetClause"
+      } else {
+        super.build()
+      }
+    }
+  }
+
+  override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
+    new MySQLSQLQueryBuilder(this, options)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -184,8 +184,7 @@ private case object OracleDialect extends JdbcDialect {
   override def getOffsetClause(offset: Integer): String = {
     // Oracle doesn't support OFFSET clause.
     // We can use rownum > n to skip some rows in the result set.
-    // Note: rn is a alias of rownum.
-    if (offset > 0) s"WHERE rn > $offset" else ""
+    if (offset > 0) s"WHERE rownum > $offset" else ""
   }
 
   class OracleSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -214,4 +214,8 @@ private case object OracleDialect extends JdbcDialect {
 
   override def getJdbcSQLQueryBuilder(options: JDBCOptions): JdbcSQLQueryBuilder =
     new OracleSQLQueryBuilder(this, options)
+
+  override def supportsLimit: Boolean = true
+
+  override def supportsOffset: Boolean = true
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -184,8 +184,7 @@ private case object OracleDialect extends JdbcDialect {
   override def getOffsetClause(offset: Integer): String = {
     // Oracle doesn't support OFFSET clause.
     // We can use rownum > n to skip some rows in the result set.
-    // Note: rn is an alias for rownum.
-    if (offset > 0 ) s"WHERE rn > $offset" else ""
+    if (offset > 0 ) s"WHERE rownum > $offset" else ""
   }
 
   class OracleSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
@@ -195,17 +194,16 @@ private case object OracleDialect extends JdbcDialect {
       val selectStmt = s"SELECT $columnList FROM ${options.tableOrQuery} $tableSampleClause" +
         s" $whereClause $groupByClause $orderByClause"
       val finalSelectStmt = if (limit > 0) {
-        val limitClause = dialect.getLimitClause(limit)
         if (offset > 0) {
-          val offsetClause = dialect.getOffsetClause(offset)
-          s"SELECT * FROM (SELECT tab.*, rownum rn FROM ($selectStmt) tab $limitClause)" +
-            s" $offsetClause"
+          s"SELECT $columnList FROM (SELECT tab.*, rownum rn FROM ($selectStmt) tab)" +
+            s" WHERE rn > $offset AND rn <= ${limit + offset}"
         } else {
+          val limitClause = dialect.getLimitClause(limit)
           s"SELECT tab.* FROM ($selectStmt) tab $limitClause"
         }
       } else if (offset > 0) {
         val offsetClause = dialect.getOffsetClause(offset)
-        s"SELECT * FROM (SELECT tab.*, rownum rn FROM ($selectStmt) tab) $offsetClause"
+        s"SELECT tab.* FROM ($selectStmt) tab $offsetClause"
       } else {
         selectStmt
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -184,7 +184,7 @@ private case object OracleDialect extends JdbcDialect {
   override def getOffsetClause(offset: Integer): String = {
     // Oracle doesn't support OFFSET clause.
     // We can use rownum > n to skip some rows in the result set.
-    if (offset > 0 ) s"WHERE rn > $offset" else ""
+    if (offset > 0) s"WHERE rn > $offset" else ""
   }
 
   class OracleSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -178,13 +178,13 @@ private case object OracleDialect extends JdbcDialect {
   override def getLimitClause(limit: Integer): String = {
     // Oracle doesn't support LIMIT clause.
     // We can use rownum <= n to limit the number of rows in the result set.
-    if (limit > 0) s"WHERE rownum <= $limit" else ""
+    if (limit > 0) s"WHERE rn <= $limit" else ""
   }
 
   override def getOffsetClause(offset: Integer): String = {
     // Oracle doesn't support OFFSET clause.
     // We can use rownum > n to skip some rows in the result set.
-    if (offset > 0 ) s"WHERE rownum > $offset" else ""
+    if (offset > 0 ) s"WHERE rn > $offset" else ""
   }
 
   class OracleSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
@@ -199,11 +199,11 @@ private case object OracleDialect extends JdbcDialect {
             s" WHERE rn > $offset AND rn <= ${limit + offset}"
         } else {
           val limitClause = dialect.getLimitClause(limit)
-          s"SELECT tab.* FROM ($selectStmt) tab $limitClause"
+          s"SELECT $columnList FROM (SELECT tab.*, rownum rn FROM ($selectStmt) tab) $limitClause"
         }
       } else if (offset > 0) {
         val offsetClause = dialect.getOffsetClause(offset)
-        s"SELECT tab.* FROM ($selectStmt) tab $offsetClause"
+        s"SELECT $columnList FROM (SELECT tab.*, rownum rn FROM ($selectStmt) tab) $offsetClause"
       } else {
         selectStmt
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -178,12 +178,13 @@ private case object OracleDialect extends JdbcDialect {
   override def getLimitClause(limit: Integer): String = {
     // Oracle doesn't support LIMIT clause.
     // We can use rownum <= n to limit the number of rows in the result set.
-    if (limit > 0) s"WHERE rn <= $limit" else ""
+    if (limit > 0) s"WHERE rownum <= $limit" else ""
   }
 
   override def getOffsetClause(offset: Integer): String = {
     // Oracle doesn't support OFFSET clause.
     // We can use rownum > n to skip some rows in the result set.
+    // Note: rn is a alias of rownum.
     if (offset > 0) s"WHERE rn > $offset" else ""
   }
 
@@ -199,11 +200,11 @@ private case object OracleDialect extends JdbcDialect {
             s" WHERE rn > $offset AND rn <= ${limit + offset}"
         } else {
           val limitClause = dialect.getLimitClause(limit)
-          s"SELECT $columnList FROM (SELECT tab.*, rownum rn FROM ($selectStmt) tab) $limitClause"
+          s"SELECT tab.* FROM ($selectStmt) tab $limitClause"
         }
       } else if (offset > 0) {
         val offsetClause = dialect.getOffsetClause(offset)
-        s"SELECT $columnList FROM (SELECT tab.*, rownum rn FROM ($selectStmt) tab) $offsetClause"
+        s"SELECT tab.* FROM ($selectStmt) tab $offsetClause"
       } else {
         selectStmt
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -184,7 +184,8 @@ private case object OracleDialect extends JdbcDialect {
   override def getOffsetClause(offset: Integer): String = {
     // Oracle doesn't support OFFSET clause.
     // We can use rownum > n to skip some rows in the result set.
-    if (offset > 0) s"WHERE rownum > $offset" else ""
+    // Note: rn is an alias of rownum.
+    if (offset > 0) s"WHERE rn > $offset" else ""
   }
 
   class OracleSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions)
@@ -203,7 +204,7 @@ private case object OracleDialect extends JdbcDialect {
         }
       } else if (offset > 0) {
         val offsetClause = dialect.getOffsetClause(offset)
-        s"SELECT tab.* FROM ($selectStmt) tab $offsetClause"
+        s"SELECT $columnList FROM (SELECT tab.*, rownum rn FROM ($selectStmt) tab) $offsetClause"
       } else {
         selectStmt
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -171,15 +171,6 @@ private object PostgresDialect extends JdbcDialect with SQLConfHelper {
     s"ALTER TABLE $tableName ALTER COLUMN ${quoteIdentifier(columnName)} $nullable"
   }
 
-  override def supportsTableSample: Boolean = true
-
-  override def getTableSample(sample: TableSampleInfo): String = {
-    // hard-coded to BERNOULLI for now because Spark doesn't have a way to specify sample
-    // method name
-    "TABLESAMPLE BERNOULLI" +
-      s" (${(sample.upperBound - sample.lowerBound) * 100}) REPEATABLE (${sample.seed})"
-  }
-
   // CREATE INDEX syntax
   // https://www.postgresql.org/docs/14/sql-createindex.html
   override def createIndex(
@@ -242,5 +233,18 @@ private object PostgresDialect extends JdbcDialect with SQLConfHelper {
       case unsupported: UnsupportedOperationException => throw unsupported
       case _ => super.classifyException(message, e)
     }
+  }
+
+  override def supportsLimit: Boolean = true
+
+  override def supportsOffset: Boolean = true
+
+  override def supportsTableSample: Boolean = true
+
+  override def getTableSample(sample: TableSampleInfo): String = {
+    // hard-coded to BERNOULLI for now because Spark doesn't have a way to specify sample
+    // method name
+    "TABLESAMPLE BERNOULLI" +
+      s" (${(sample.upperBound - sample.lowerBound) * 100}) REPEATABLE (${sample.seed})"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1038,7 +1038,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         .withLimit(123)
         .build()
         .trim() ==
-      "SELECT a,b FROM test     FETCH FIRST 123 ROWS ONLY")
+      "SELECT a,b FROM test      FETCH FIRST 123 ROWS ONLY")
   }
 
   test("table exists query by jdbc dialect") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, DS V2 pushdown could let JDBC dialect decide to push down `OFFSET`, `LIMIT` and table sample. Because some databases doesn't support one of them, so we should keep the default value of these pushdown API false. If one database support the syntax, the JDBC dialect should overwrite the value.
We also have a lot of JDBC options about push down, such as `pushDownOffset`. Users could change the option value to allow or disallow push down.

### Why are the changes needed?
This PR have two aims, one is change all JDBC v2 pushdown options to true and change all the dialect's pushdown API to false, another is let the built-in dialects support `OFFSET` and paging query.


### Does this PR introduce _any_ user-facing change?
No.
Just change the inner implementation.


### How was this patch tested?
New tests.
