### PR TITLE
[SPARK-41818][SPARK-42000][CONNECT][TESTS][FOLLOWUP] Fix failed test in SparkConnectProtoSuite

### DIFF
--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -602,7 +602,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
         localRelation.write(path = Some("/tmp/tmppath"), format = Some("ThisAintNoFormat"))))
 
     // Default data source not found.
-    assertThrows[SparkClassNotFoundException](
+    assertThrows[AnalysisException](
       transform(localRelation.write(path = Some("/tmp/tmppath"))))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
```
[info] - Write to Path with invalid input *** FAILED *** (298 milliseconds)
[info]   Expected exception org.apache.spark.SparkClassNotFoundException to be thrown, but no exception was thrown (SparkConnectProtoSuite.scala:605)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.funsuite.AnyFunSuite.newAssertionFailedException(AnyFunSuite.scala:1564)
[info]   at org.scalatest.Assertions.assertThrows(Assertions.scala:825)
[info]   at org.scalatest.Assertions.assertThrows$(Assertions.scala:804)
[info]   at org.scalatest.funsuite.AnyFunSuite.assertThrows(AnyFunSuite.scala:1564)
```


### Why are the changes needed?
master was broken


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
manually test