### PR TITLE
[SPARK-42437][PYTHON][CONNECT] PySpark catalog.cacheTable will allow to specify storage level

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -929,11 +929,13 @@ class Catalog:
         ----------
         tableName : str
             name of the table to get.
-        storageLevel : :class:`StorageLevel`
-            storage level to set for persistence.
 
             .. versionchanged:: 3.4.0
                 Allow ``tableName`` to be qualified with catalog name.
+
+        storageLevel : :class:`StorageLevel`
+            storage level to set for persistence.
+
             .. versionchanged:: 3.5.0
                 Allow to specify storage level.
 

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -19,6 +19,7 @@ import sys
 import warnings
 from typing import Any, Callable, NamedTuple, List, Optional, TYPE_CHECKING
 
+from pyspark.storagelevel import StorageLevel
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.session import SparkSession
 from pyspark.sql.types import StructType
@@ -87,6 +88,7 @@ class Catalog:
         """Create a new Catalog that wraps the underlying JVM object."""
         self._sparkSession = sparkSession
         self._jsparkSession = sparkSession._jsparkSession
+        self._sc = sparkSession._sc
         self._jcatalog = sparkSession._jsparkSession.catalog()
 
     def currentCatalog(self) -> str:
@@ -917,8 +919,9 @@ class Catalog:
         """
         return self._jcatalog.isCached(tableName)
 
-    def cacheTable(self, tableName: str) -> None:
-        """Caches the specified table in-memory.
+    def cacheTable(self, tableName: str, storageLevel: Optional[StorageLevel] = None) -> None:
+        """Caches the specified table in-memory or with given storage level.
+        Default MEMORY_AND_DISK.
 
         .. versionadded:: 2.0.0
 
@@ -926,15 +929,23 @@ class Catalog:
         ----------
         tableName : str
             name of the table to get.
+        storageLevel : :class:`StorageLevel`
+            storage level to set for persistence.
 
             .. versionchanged:: 3.4.0
                 Allow ``tableName`` to be qualified with catalog name.
+            .. versionchanged:: 3.5.0
+                Allow to specify storage level.
 
         Examples
         --------
         >>> _ = spark.sql("DROP TABLE IF EXISTS tbl1")
         >>> _ = spark.sql("CREATE TABLE tbl1 (name STRING, age INT) USING parquet")
         >>> spark.catalog.cacheTable("tbl1")
+
+        or
+
+        >>> spark.catalog.cacheTable("tbl1", StorageLevel.OFF_HEAP)
 
         Throw an analysis exception when the table does not exist.
 
@@ -949,7 +960,11 @@ class Catalog:
         >>> spark.catalog.uncacheTable("tbl1")
         >>> _ = spark.sql("DROP TABLE tbl1")
         """
-        self._jcatalog.cacheTable(tableName)
+        if storageLevel:
+            javaStorageLevel = self._sc._getJavaStorageLevel(storageLevel)
+            self._jcatalog.cacheTable(tableName, javaStorageLevel)
+        else:
+            self._jcatalog.cacheTable(tableName)
 
     def uncacheTable(self, tableName: str) -> None:
         """Removes the specified table from the in-memory cache.

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -23,6 +23,7 @@ from typing import Any, Callable, List, Optional, TYPE_CHECKING
 import warnings
 import pandas as pd
 
+from pyspark.storagelevel import StorageLevel
 from pyspark.sql.types import StructType
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.catalog import (
@@ -278,8 +279,8 @@ class Catalog:
 
     isCached.__doc__ = PySparkCatalog.isCached.__doc__
 
-    def cacheTable(self, tableName: str) -> None:
-        self._execute_and_fetch(plan.CacheTable(table_name=tableName))
+    def cacheTable(self, tableName: str, storageLevel: Optional[StorageLevel] = None) -> None:
+        self._execute_and_fetch(plan.CacheTable(table_name=tableName, storage_level=storageLevel))
 
     cacheTable.__doc__ = PySparkCatalog.cacheTable.__doc__
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -26,6 +26,7 @@ from inspect import signature, isclass
 
 import pyarrow as pa
 
+from pyspark.storagelevel import StorageLevel
 from pyspark.sql.types import DataType
 
 import pyspark.sql.connect.proto as proto
@@ -1864,14 +1865,24 @@ class IsCached(LogicalPlan):
 
 
 class CacheTable(LogicalPlan):
-    def __init__(self, table_name: str) -> None:
+    def __init__(self, table_name: str, storage_level: Optional[StorageLevel] = None) -> None:
         super().__init__(None)
         self._table_name = table_name
+        self._storage_level = storage_level
 
     def plan(self, session: "SparkConnectClient") -> proto.Relation:
-        plan = proto.Relation(
-            catalog=proto.Catalog(cache_table=proto.CacheTable(table_name=self._table_name))
-        )
+        _cache_table = proto.CacheTable(table_name=self._table_name)
+        if self._storage_level:
+            _cache_table.storage_level.CopyFrom(
+                proto.StorageLevel(
+                    use_disk=self._storage_level.useDisk,
+                    use_memory=self._storage_level.useMemory,
+                    use_off_heap=self._storage_level.useOffHeap,
+                    deserialized=self._storage_level.deserialized,
+                    replication=self._storage_level.replication,
+                )
+            )
+        plan = proto.Relation(catalog=proto.Catalog(cache_table=_cache_table))
         return plan
 
 


### PR DESCRIPTION
Currently PySpark version of `catalog.cacheTable` function does not support to specify storage level. This is to add that.

After changes:

## Spark Connect

```
bin/pyspark --remote "local[*]"
Python 3.9.5 (default, Nov 23 2021, 15:27:38) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
23/02/17 20:41:07 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Welcome to

      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.5.0.dev0
      /_/

Using Python version 3.9.5 (default, Nov 23 2021 15:27:38)
Client connected to the Spark Connect server at localhost
SparkSession available as 'spark'.
>>> spark.range(1).write.saveAsTable("tab1", format="csv", mode="overwrite")
>>> spark.catalog.listTables()
[Table(name='tab1', catalog='spark_catalog', namespace=['default'], description=None, tableType='MANAGED', isTemporary=False)]
>>> spark.catalog.cacheTable("tab1")
>>> spark.catalog.isCached("tab1")
True
>>> spark.catalog.clearCache()
>>> spark.catalog.isCached("tab1")
False
>>> from pyspark.storagelevel import StorageLevel
>>> spark.catalog.cacheTable("tab1", StorageLevel.OFF_HEAP)
>>> spark.catalog.isCached("tab1")
True
```

## PySpark
```
/home/spark# bin/pyspark
Python 3.9.5 (default, Nov 23 2021, 15:27:38) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
23/02/17 20:43:46 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 3.5.0-SNAPSHOT
      /_/

Using Python version 3.9.5 (default, Nov 23 2021 15:27:38)
Spark context Web UI available at http://localhost:4040
Spark context available as 'sc' (master = local[*], app id = local-1676666626670).
SparkSession available as 'spark'.

>>> spark.range(1).write.saveAsTable("tab2", format="csv", mode="overwrite")
>>> spark.catalog.listTables()
[Table(name='tab2', catalog='spark_catalog', namespace=['default'], description=None, tableType='MANAGED', isTemporary=False)]
>>> spark.catalog.cacheTable("tab2")
>>> 
>>> spark.catalog.isCached("tab2")
True
>>> spark.catalog.clearCache()
>>> spark.catalog.isCached("tab2")
False
>>> from pyspark.storagelevel import StorageLevel
>>> spark.catalog.cacheTable("tab2", StorageLevel.OFF_HEAP)
>>> spark.catalog.isCached("tab2")
True

```


### What changes were proposed in this pull request?
Add extra parameter to catalog.cacheTable


### Why are the changes needed?
To allow users specify which storage level to use in cache in PySpark/Connect code


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Updated existing test cases 
