### PR TITLE
[SPARK-42342][PYTHON][CONNECT][TEST] Fix FunctionsParityTests.test_raise_error to call the proper test

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -54,7 +54,7 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
         super().test_lit_np_scalar()
 
     def test_raise_error(self):
-        self.check_assert_true(SparkConnectException)
+        self.check_raise_error(SparkConnectException)
 
     # Comparing column type of connect and pyspark
     @unittest.skip("Fails in Spark Connect, should enable.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #39882.

Fixes `FunctionsParityTests.test_raise_error` to call the proper test.

### Why are the changes needed?

`FunctionsParityTests.test_raise_error` should've called `check_raise_error`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The fixed test.