### PR TITLE
[SPARK-42401][SQL][FOLLOWUP] Always set `containsNull=true` for `array_insert`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4840,7 +4840,7 @@ case class ArrayInsert(srcArrayExpr: Expression, posExpr: Expression, itemExpr: 
   override def third: Expression = itemExpr
 
   override def prettyName: String = "array_insert"
-  override def dataType: DataType = if (third.nullable) first.dataType.asNullable else first.dataType
+  override def dataType: DataType = first.dataType.asNullable // out of range pos will add nulls
   override def nullable: Boolean = first.nullable | second.nullable
 
   @transient private lazy val elementType: DataType =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -2753,10 +2753,17 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
 
   }
 
-  test("SPARK-42401: Array insert of null value") {
+  test("SPARK-42401: Array insert of null value (explicit)") {
     val a = Literal.create(Seq("b", "a", "c"), ArrayType(StringType, false))
     checkEvaluation(ArrayInsert(
       a, Literal(2), Literal.create(null, StringType)), Seq("b", null, "a", "c")
+    )
+  }
+
+  test("SPARK-42401: Array insert of null value (implicit)") {
+    val a = Literal.create(Seq("b", "a", "c"), ArrayType(StringType, false))
+    checkEvaluation(ArrayInsert(
+      a, Literal(5), Literal.create("q", StringType)), Seq("b", "a", "c", null, "q")
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -5432,10 +5432,17 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     )
   }
 
-  test("SPARK-42401: array_insert - insert null") {
+  test("SPARK-42401: array_insert - explicitly insert null") {
     checkAnswer(
       sql("select array_insert(array('b', 'a', 'c'), 2, cast(null as string))"),
       Seq(Row(Seq("b", null, "a", "c")))
+    )
+  }
+
+  test("SPARK-42401: array_insert - implicitly insert null") {
+    checkAnswer(
+      sql("select array_insert(array('b', 'a', 'c'), 5, 'q')"),
+      Seq(Row(Seq("b", "a", "c", null, 'q')))
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -5442,7 +5442,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
   test("SPARK-42401: array_insert - implicitly insert null") {
     checkAnswer(
       sql("select array_insert(array('b', 'a', 'c'), 5, 'q')"),
-      Seq(Row(Seq("b", "a", "c", null, 'q')))
+      Seq(Row(Seq("b", "a", "c", null, "q")))
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Always set `containsNull=true` in the data type returned by `ArrayInsert#dataType`.

### Why are the changes needed?

PR #39970 fixed an issue where the data type for `array_insert` did not always have `containsNull=true` when the user was explicitly inserting a nullable value into the array. However, that fix does not handle the case where `array_insert` implicitly inserts null values into the array (e.g., when the insertion position is out-of-range):
```
spark-sql> select array_insert(array('1', '2', '3', '4'), -6, '5');
23/02/14 16:10:19 ERROR Executor: Exception in task 0.0 in stage 0.0 (TID 0)
java.lang.NullPointerException
	at org.apache.spark.sql.catalyst.expressions.codegen.UnsafeWriter.write(UnsafeWriter.java:110)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.project_doConsume_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
```
Because we can't know at planning time whether the insertion position will be out of range, we should always set `containsNull=true` on the data type for `array_insert`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit tests.
