### PR TITLE
[SPARK-42431][CONNECT][FOLLOWUP] Use `Distinct` to delay analysis for `Union` 

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1263,8 +1263,7 @@ class SparkConnectPlanner(val session: SparkSession) {
         if (isAll) {
           union
         } else {
-          val analyzed = new QueryExecution(session, union).analyzed
-          Deduplicate(analyzed.output, analyzed)
+          logical.Distinct(union)
         }
 
       case _ =>

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -30,8 +30,7 @@ import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Row, SaveMode
 import org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GenericInternalRow, UnsafeProjection}
 import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, LeftAnti, LeftOuter, LeftSemi, PlanTest, RightOuter}
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{Distinct, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.connect.dsl.MockRemoteSession
 import org.apache.spark.sql.connect.dsl.commands._
 import org.apache.spark.sql.connect.dsl.expressions._
@@ -370,7 +369,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
     comparePlans(connectPlan5, sparkPlan5)
 
     val connectPlan6 = connectTestRelation.union(connectTestRelation, isAll = false)
-    val sparkPlan6 = sparkTestRelation.union(sparkTestRelation).distinct()
+    val sparkPlan6 = Distinct(sparkTestRelation.union(sparkTestRelation).logicalPlan)
     comparePlans(connectPlan6, sparkPlan6)
 
     val connectPlan7 =
@@ -380,7 +379,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
 
     val connectPlan8 =
       connectTestRelation.union(connectTestRelation2, isAll = false, byName = true)
-    val sparkPlan8 = sparkTestRelation.unionByName(sparkTestRelation2).distinct()
+    val sparkPlan8 = Distinct(sparkTestRelation.unionByName(sparkTestRelation2).logicalPlan)
     comparePlans(connectPlan8, sparkPlan8)
   }
 
@@ -963,7 +962,12 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
 
   // Compares proto plan with DataFrame.
   private def comparePlans(connectPlan: proto.Relation, sparkPlan: DataFrame): Unit = {
+    comparePlans(connectPlan, sparkPlan.queryExecution.analyzed)
+  }
+
+  // Compares proto plan with LogicalPlan.
+  private def comparePlans(connectPlan: proto.Relation, sparkPlan: LogicalPlan): Unit = {
     val connectAnalyzed = analyzePlan(transform(connectPlan))
-    comparePlans(connectAnalyzed, sparkPlan.queryExecution.analyzed, false)
+    comparePlans(connectAnalyzed, sparkPlan, false)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
use `Distinct` instead of `Deduplicate`

### Why are the changes needed?
to delay analysis, see https://github.com/apache/spark/pull/40008#discussion_r1106529796



### Does this PR introduce _any_ user-facing change?
plan shown in `explain` may change


### How was this patch tested?
updated UT