### PR TITLE
[SPARK-42448][SQL] Fix spark sql shell prompt for current db

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4038,7 +4038,7 @@ object SQLConf {
       .doc("When set to true, spark-sql CLI prints the the current database in prompt")
       .version("3.4.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA =
     buildConf("spark.sql.legacy.keepCommandOutputSchema")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4035,6 +4035,7 @@ object SQLConf {
 
   val LEGACY_EMPTY_CURRENT_DB_IN_CLI =
     buildConf("spark.sql.legacy.emptyCurrentDBInCli")
+      .internal()
       .doc("When false, spark-sql CLI prints the the current database in prompt")
       .version("3.4.0")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4033,6 +4033,13 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val CLI_PRINT_CURRENT_DB =
+    buildConf("spark.sql.cli.print.currentDb")
+      .doc("When set to true, spark-sql CLI prints the the current database in prompt")
+      .version("3.44.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA =
     buildConf("spark.sql.legacy.keepCommandOutputSchema")
       .internal()
@@ -4955,6 +4962,8 @@ class SQLConf extends Serializable with Logging {
   def readSideCharPadding: Boolean = getConf(SQLConf.READ_SIDE_CHAR_PADDING)
 
   def cliPrintHeader: Boolean = getConf(SQLConf.CLI_PRINT_HEADER)
+
+  def cliPrintCurrentDb: Boolean = getConf(SQLConf.CLI_PRINT_CURRENT_DB)
 
   def legacyIntervalEnabled: Boolean = getConf(LEGACY_INTERVAL_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4038,7 +4038,7 @@ object SQLConf {
       .doc("When set to true, spark-sql CLI prints the the current database in prompt")
       .version("3.4.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA =
     buildConf("spark.sql.legacy.keepCommandOutputSchema")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4033,12 +4033,12 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val CLI_PRINT_CURRENT_DB =
-    buildConf("spark.sql.cli.print.currentDb")
-      .doc("When set to true, spark-sql CLI prints the the current database in prompt")
+  val LEGACY_EMPTY_CURRENT_DB_IN_CLI =
+    buildConf("spark.sql.legacy.emptyCurrentDBInCli")
+      .doc("When false, spark-sql CLI prints the the current database in prompt")
       .version("3.4.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA =
     buildConf("spark.sql.legacy.keepCommandOutputSchema")
@@ -4962,8 +4962,6 @@ class SQLConf extends Serializable with Logging {
   def readSideCharPadding: Boolean = getConf(SQLConf.READ_SIDE_CHAR_PADDING)
 
   def cliPrintHeader: Boolean = getConf(SQLConf.CLI_PRINT_HEADER)
-
-  def cliPrintCurrentDb: Boolean = getConf(SQLConf.CLI_PRINT_CURRENT_DB)
 
   def legacyIntervalEnabled: Boolean = getConf(LEGACY_INTERVAL_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4036,9 +4036,9 @@ object SQLConf {
   val CLI_PRINT_CURRENT_DB =
     buildConf("spark.sql.cli.print.currentDb")
       .doc("When set to true, spark-sql CLI prints the the current database in prompt")
-      .version("3.44.0")
+      .version("3.4.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA =
     buildConf("spark.sql.legacy.keepCommandOutputSchema")

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -279,13 +279,12 @@ private[hive] object SparkSQLCLIDriver extends Logging {
     var ret = 0
     var prefix = ""
 
-    def currentDB: String = {
-      val printCurrentDb = conf.getBoolVar(HiveConf.ConfVars.CLIPRINTCURRENTDB) ||
-        SparkSQLEnv.sqlContext.conf.cliPrintCurrentDb
-      if (printCurrentDb) {
+    def currentDB = {
+      if (SparkSQLEnv.sqlContext.conf.cliPrintCurrentDb) {
         s" (${SparkSQLEnv.sqlContext.sparkSession.catalog.currentDatabase})"
       } else {
-        ""
+        ReflectionUtils.invokeStatic(classOf[CliDriver], "getFormattedDb",
+          classOf[HiveConf] -> conf, classOf[CliSessionState] -> sessionState)
       }
     }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -48,6 +48,7 @@ import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.client.HiveClientImpl
 import org.apache.spark.sql.hive.security.HiveDelegationTokenProvider
 import org.apache.spark.sql.internal.SharedState
+import org.apache.spark.sql.internal.SQLConf.LEGACY_EMPTY_CURRENT_DB_IN_CLI
 import org.apache.spark.util.ShutdownHookManager
 import org.apache.spark.util.SparkExitCode._
 
@@ -280,7 +281,7 @@ private[hive] object SparkSQLCLIDriver extends Logging {
     var prefix = ""
 
     def currentDB = {
-      if (SparkSQLEnv.sqlContext.conf.cliPrintCurrentDb) {
+      if (!SparkSQLEnv.sqlContext.conf.getConf(LEGACY_EMPTY_CURRENT_DB_IN_CLI)) {
         s" (${SparkSQLEnv.sqlContext.sparkSession.catalog.currentDatabase})"
       } else {
         ReflectionUtils.invokeStatic(classOf[CliDriver], "getFormattedDb",

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -278,8 +278,16 @@ private[hive] object SparkSQLCLIDriver extends Logging {
 
     var ret = 0
     var prefix = ""
-    val currentDB = ReflectionUtils.invokeStatic(classOf[CliDriver], "getFormattedDb",
-      classOf[HiveConf] -> conf, classOf[CliSessionState] -> sessionState)
+
+    def currentDB: String = {
+      val printCurrentDb = conf.getBoolVar(HiveConf.ConfVars.CLIPRINTCURRENTDB) ||
+        SparkSQLEnv.sqlContext.conf.cliPrintCurrentDb
+      if (printCurrentDb) {
+        s" (${SparkSQLEnv.sqlContext.sparkSession.catalog.currentDatabase})"
+      } else {
+        ""
+      }
+    }
 
     def promptWithCurrentDB: String = s"$prompt$currentDB"
     def continuedPromptWithDBSpaces: String = continuedPrompt + ReflectionUtils.invokeStatic(

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -128,7 +128,7 @@ class CliSuite extends SparkFunSuite {
          |  --driver-java-options -Dderby.system.durability=test
          |  $extraHive
          |  --conf spark.ui.enabled=false
-         |  --conf spark.sql.cli.print.currentDb=false
+         |  --conf ${SQLConf.LEGACY_EMPTY_CURRENT_DB_IN_CLI.key}=true
          |  --hiveconf ${ConfVars.METASTORECONNECTURLKEY}=$jdbcUrl
          |  --hiveconf ${ConfVars.SCRATCHDIR}=$scratchDirPath
          |  --hiveconf conf1=conftest
@@ -794,14 +794,15 @@ class CliSuite extends SparkFunSuite {
   test("SPARK-42448: Print correct database in prompt") {
     runCliWithin(
       2.minute,
-      Seq("--conf", s"${SQLConf.CLI_PRINT_CURRENT_DB.key}=true"),
+      Seq("--conf", s"${SQLConf.LEGACY_EMPTY_CURRENT_DB_IN_CLI.key}=false"),
       prompt = "spark-sql (default)>")(
       "set abc;" -> "abc\t<undefined>",
       "create database spark_42448;" -> "")
 
     runCliWithin(
       2.minute,
-      Seq("--conf", s"${SQLConf.CLI_PRINT_CURRENT_DB.key}=true", "--database", "spark_42448"),
+      Seq("--conf", s"${SQLConf.LEGACY_EMPTY_CURRENT_DB_IN_CLI.key}=false", "--database",
+        "spark_42448"),
       prompt = "spark-sql (spark_42448)>")(
       "select current_database();" -> "spark_42448")
   }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -91,7 +91,8 @@ class CliSuite extends SparkFunSuite {
       errorResponses: Seq[String] = Seq("Error:"),
       maybeWarehouse: Option[File] = Some(warehousePath),
       useExternalHiveFile: Boolean = false,
-      metastore: File = metastorePath)(
+      metastore: File = metastorePath,
+      prompt: String = "spark-sql>")(
       queriesAndExpectedAnswers: (String, String)*): Unit = {
 
     // Explicitly adds ENTER for each statement to make sure they are actually entered into the CLI.
@@ -105,7 +106,7 @@ class CliSuite extends SparkFunSuite {
         } else {
           // spark-sql echoes the submitted queries
           val xs = query.split("\n").toList
-          val queryEcho = s"spark-sql> ${xs.head}" :: xs.tail.map(l => s"         > $l")
+          val queryEcho = s"$prompt ${xs.head}" :: xs.tail.map(l => s"         > $l")
           // longer lines sometimes get split in the output,
           // match the first 60 characters of each query line
           queryEcho.map(_.take(60)) :+ answer
@@ -127,6 +128,7 @@ class CliSuite extends SparkFunSuite {
          |  --driver-java-options -Dderby.system.durability=test
          |  $extraHive
          |  --conf spark.ui.enabled=false
+         |  --conf spark.sql.cli.print.currentDb=false
          |  --hiveconf ${ConfVars.METASTORECONNECTURLKEY}=$jdbcUrl
          |  --hiveconf ${ConfVars.SCRATCHDIR}=$scratchDirPath
          |  --hiveconf conf1=conftest
@@ -787,5 +789,20 @@ class CliSuite extends SparkFunSuite {
       Seq("--conf", s"${StaticSQLConf.WAREHOUSE_PATH.key}=${sparkWareHouseDir}",
           "--conf", s"${StaticSQLConf.CATALOG_DEFAULT_DATABASE.key}=spark_35242"))(
       "show tables;" -> "spark_test")
+  }
+
+  test("SPARK-42448: Print correct database in prompt") {
+    runCliWithin(
+      2.minute,
+      Seq("--conf", s"${SQLConf.CLI_PRINT_CURRENT_DB.key}=true"),
+      prompt = "spark-sql (default)>")(
+      "set abc;" -> "abc\t<undefined>",
+      "create database spark_42448;" -> "")
+
+    runCliWithin(
+      2.minute,
+      Seq("--conf", s"${SQLConf.CLI_PRINT_CURRENT_DB.key}=true", "--database", "spark_42448"),
+      prompt = "spark-sql (spark_42448)>")(
+      "select current_database();" -> "spark_42448")
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

The CliSessionState does not contain the current database info, we shall use spark's `catalog.currentDatabase` 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

bugfix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, when users use spark-sql and switch database, the prompt now show the correct one instead of `default`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

locally tested

```textmate
spark-sql (default)> create database abc;
Time taken: 0.24 seconds
spark-sql (default)> use abc;
Time taken: 0.027 seconds
spark-sql (ABC)>
````
