### PR TITLE
[SPARK-42451][SQL][TESTS] Simplifies the filter conditions of `testingVersions` in `HiveExternalCatalogVersionsSuite`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -262,7 +262,7 @@ object PROCESS_TABLES extends QueryTest with SQLTestUtils {
   // Tests the latest version of every release line.
   val testingVersions: Seq[String] = if (isPythonVersionAvailable) {
     import scala.io.Source
-    val versions: Seq[String] = try Utils.tryWithResource(
+    try Utils.tryWithResource(
       Source.fromURL(s"$releaseMirror/spark")) { source =>
       source.mkString
         .split("\n")
@@ -274,8 +274,6 @@ object PROCESS_TABLES extends QueryTest with SQLTestUtils {
       // Do not throw exception during object initialization.
       case NonFatal(_) => Nil
     }
-    versions.filter(v => !(v.startsWith("3.1") &&
-      SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_17)))
   } else Seq.empty[String]
 
   protected var spark: SparkSession = _


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark 3.1.x already EOL and has been deleted from https://dist.apache.org/repos/dist/release/spark, this pr remove the filter condition `!(v.startsWith("3.1") && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_17))`  from `testingVersions` check, all version already support test with Java 17.


### Why are the changes needed?
Delete unnecessary test conditions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
