### PR TITLE
[SPARK-41817][CONNECT][PYTHON][TEST] Enable the doctest pyspark.sql.connect.readwriter.DataFrameReader.option

### DIFF
--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -692,8 +692,7 @@ def _test() -> None:
 
     globs = pyspark.sql.connect.readwriter.__dict__.copy()
 
-    # TODO(SPARK-41817): Support reading with schema
-    del pyspark.sql.connect.readwriter.DataFrameReader.option.__doc__
+    # TODO(SPARK-42458): createDataFrame should support DDL string as schema
     del pyspark.sql.connect.readwriter.DataFrameWriter.option.__doc__
 
     globs["spark"] = (

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -174,8 +174,6 @@ class DataFrameReader(OptionUtils):
 
         Examples
         --------
-        >>> from pyspark.sql import SparkSession
-        >>> spark = SparkSession.builder.master("local").getOrCreate()
         >>> spark.read.option("key", "value")
         <...readwriter.DataFrameReader object ...>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enables the doctest `pyspark.sql.connect.readwriter.DataFrameReader.option`.

### Why are the changes needed?

The issue described [SPARK-41817](https://issues.apache.org/jira/browse/SPARK-41817) was already fixed at #39545.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The enabled test.