### PR TITLE
[SPARK-42460][CONNECT] Clean-up results in ClientE2ETestSuite

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2220,7 +2220,7 @@ class Dataset[T] private[sql] (val session: SparkSession, private[sql] val plan:
 
   def collectResult(): SparkResult = session.execute(plan)
 
-  private def withResult[E](f: SparkResult => E): E = {
+  private[sql] def withResult[E](f: SparkResult => E): E = {
     val result = collectResult()
     try f(result)
     finally {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -40,36 +40,30 @@ class ClientE2ETestSuite extends RemoteSparkSession {
 
   test("spark result array") {
     val df = spark.sql("select val from (values ('Hello'), ('World')) as t(val)")
-    df.withResult { result =>
-      assert(result.length == 2)
-      val array = result.toArray
-      assert(array.length == 2)
-      assert(array(0).getString(0) == "Hello")
-      assert(array(1).getString(0) == "World")
-    }
+    val result = df.collect()
+    assert(result.length == 2)
+    assert(result.length == 2)
+    assert(result(0).getString(0) == "Hello")
+    assert(result(1).getString(0) == "World")
   }
 
   test("simple dataset") {
     val df = spark.range(10).limit(3)
-    df.withResult { result =>
-      assert(result.length == 3)
-      val array = result.toArray
-      assert(array(0).getLong(0) == 0)
-      assert(array(1).getLong(0) == 1)
-      assert(array(2).getLong(0) == 2)
-    }
+    val result = df.collect()
+    assert(result.length == 3)
+    assert(result(0).getLong(0) == 0)
+    assert(result(1).getLong(0) == 1)
+    assert(result(2).getLong(0) == 2)
   }
 
   test("simple udf") {
-
     def dummyUdf(x: Int): Int = x + 5
     val myUdf = udf(dummyUdf _)
     val df = spark.range(5).select(myUdf(Column("id")))
-    df.withResult { result =>
-      assert(result.length == 5)
-      result.toArray.zipWithIndex.foreach { case (v, idx) =>
-        assert(v.getInt(0) == idx + 5)
-      }
+    val result = df.collect()
+    assert(result.length == 5)
+    result.zipWithIndex.foreach { case (v, idx) =>
+      assert(v.getInt(0) == idx + 5)
     }
   }
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -42,7 +42,6 @@ class ClientE2ETestSuite extends RemoteSparkSession {
     val df = spark.sql("select val from (values ('Hello'), ('World')) as t(val)")
     val result = df.collect()
     assert(result.length == 2)
-    assert(result.length == 2)
     assert(result(0).getString(0) == "Hello")
     assert(result(1).getString(0) == "World")
   }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -130,8 +130,7 @@ trait RemoteSparkSession
         // Run a simple query to verify the server is really up and ready
         val result = spark
           .sql("select val from (values ('Hello'), ('World')) as t(val)")
-          .collectResult()
-          .toArray
+          .collect()
         assert(result.length == 2)
         success = true
         debug("Spark Connect Server is up.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Clean-up results in `ClientE2ETestSuite`.

### Why are the changes needed?
`ClientE2ETestSuite` is very noisy because we do not clean-up results. This makes testing a bit annoying.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
It is a test.