### PR TITLE
[SPARK-42382][BUILD] Upgrade `cyclonedx-maven-plugin` to 2.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3436,7 +3436,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.3</version>
+        <version>2.7.5</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `cyclonedx-maven-plugin` from 2.7.3 to 2.7.5


### Why are the changes needed?
The release notes as follows:

- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.4
- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.5

On the other hand, we can upgrade to use maven 3.9.0 to build Spark after upgrading `cyclonedx-maven-plugin` to 2.7.5, otherwise, the build error described in SPARK-42380 will occur.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions.
- Manual check the `cyclonedx.xml` file can be generated normally.

