### PR TITLE
[SPARK-42498] [CONNECT][PYTHON] Reduce spark connect service retries

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -632,7 +632,7 @@ class SparkConnectClient(object):
             Proto representation of the plan.
 
         """
-        logger.info("Execute")
+        logger.debug(f"Execute request: » {os.linesep}{req}{os.linesep} «")
         try:
             for attempt in Retrying(
                 can_retry=SparkConnectClient.retry_exception, **self._retry_policy
@@ -650,7 +650,7 @@ class SparkConnectClient(object):
     def _execute_and_fetch(
         self, req: pb2.ExecutePlanRequest
     ) -> Tuple["pa.Table", List[PlanMetrics]]:
-        logger.info("ExecuteAndFetch")
+        logger.debug(f"ExecuteAndFetch request: » {os.linesep}{req}{os.linesep} «")
 
         m: Optional[pb2.ExecutePlanResponse.Metrics] = None
         batches: List[pa.RecordBatch] = []

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -409,7 +409,7 @@ class SparkConnectClient(object):
         self._builder = ChannelBuilder(connectionString, channelOptions)
         self._user_id = None
         self._retry_policy = {
-            "max_retries": 15,
+            "max_retries": 4,
             "backoff_multiplier": 4,
             "initial_backoff": 50,
             "max_backoff": 60000,
@@ -772,6 +772,7 @@ class AttemptManager:
         if isinstance(exc_val, BaseException):
             # Swallow the exception.
             if self._can_retry(exc_val):
+                logger.debug(f"Server responded with retryable error: {exc_val}")
                 self._retry_state.set_exception(exc_val)
                 return True
             # Bubble up the exception.


### PR DESCRIPTION
### What changes were proposed in this pull request?

* Reduce the number of retries when sending a request to spark connect service.
* Slightly improve debug logging


### Why are the changes needed?

Currently, 15 retries with the current backoff strategy result in the client sitting in
the retry loop for ~400 seconds in the worst case. This means, applications and
users using the spark connect client will hang for >6 minutes with no response.

Instead, simply reduce the retry to 4, which reduces the retry loop in the worst case
to a reasonable ~4 seconds.

### Does this PR introduce _any_ user-facing change?

Reduces the number of retries to the service and improves error response time
when the spark connect service is unresponsive or unreachable.

### How was this patch tested?

Manual testing