### PR TITLE
[SPARK-41818][CONNECT][PYTHON][FOLLOWUP][TEST] Enable a doctest for DataFrame.write

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1704,9 +1704,6 @@ def _test() -> None:
     # TODO(SPARK-41625): Support Structured Streaming
     del pyspark.sql.connect.dataframe.DataFrame.isStreaming.__doc__
 
-    # TODO(SPARK-41818): Support saveAsTable
-    del pyspark.sql.connect.dataframe.DataFrame.write.__doc__
-
     globs["spark"] = (
         PySparkSession.builder.appName("sql.connect.dataframe tests")
         .remote("local[4]")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enables a doctest for `DataFrame.write`.

### Why are the changes needed?

Now that `DataFrame.write.saveAsTable` was fixed, we can enabled the doctest.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Enabled the doctest.