### PR TITLE
[SPARK-42484] [SQL] UnsafeRowUtils better error message

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtils.scala
@@ -46,15 +46,21 @@ object UnsafeRowUtils {
    *     check if the unused bits in the field are all zeros. The UnsafeRowWriter's write() methods
    *     make this guarantee.
    * - Check the total length of the row.
+   * @param row The input UnsafeRow to be validated
+   * @param expectedSchema The expected schema that should match with the UnsafeRow
+   * @return None if all the checks pass. An error message if the row is not matched with the schema
    */
-  def validateStructuralIntegrity(row: UnsafeRow, expectedSchema: StructType): Boolean = {
+  private def validateStructuralIntegrityWithReasonImpl(
+      row: UnsafeRow, expectedSchema: StructType): Option[String] = {
     if (expectedSchema.fields.length != row.numFields) {
-      return false
+      return Some(s"Field length mismatch: " +
+        s"expected: ${expectedSchema.fields.length}, actual: ${row.numFields}")
     }
     val bitSetWidthInBytes = UnsafeRow.calculateBitSetWidthInBytes(row.numFields)
     val rowSizeInBytes = row.getSizeInBytes
     if (expectedSchema.fields.length > 0 && bitSetWidthInBytes >= rowSizeInBytes) {
-      return false
+      return Some(s"rowSizeInBytes should not exceed bitSetWidthInBytes, " +
+        s"bitSetWidthInBytes: $bitSetWidthInBytes, rowSizeInBytes: $rowSizeInBytes")
     }
     var varLenFieldsSizeInBytes = 0
     expectedSchema.fields.zipWithIndex.foreach {
@@ -62,21 +68,31 @@ object UnsafeRowUtils {
         val (offset, size) = getOffsetAndSize(row, index)
         if (size < 0 ||
             offset < bitSetWidthInBytes + 8 * row.numFields || offset + size > rowSizeInBytes) {
-          return false
+          return Some(s"Variable-length field validation error: field: $field, index: $index")
         }
         varLenFieldsSizeInBytes += size
       case (field, index) if UnsafeRow.isFixedLength(field.dataType) && !row.isNullAt(index) =>
         field.dataType match {
           case BooleanType =>
-            if ((row.getLong(index) >> 1) != 0L) return false
+            if ((row.getLong(index) >> 1) != 0L) {
+              return Some(s"Fixed-length field validation error: field: $field, index: $index")
+            }
           case ByteType =>
-            if ((row.getLong(index) >> 8) != 0L) return false
+            if ((row.getLong(index) >> 8) != 0L) {
+              return Some(s"Fixed-length field validation error: field: $field, index: $index")
+            }
           case ShortType =>
-            if ((row.getLong(index) >> 16) != 0L) return false
+            if ((row.getLong(index) >> 16) != 0L) {
+              return Some(s"Fixed-length field validation error: field: $field, index: $index")
+            }
           case IntegerType =>
-            if ((row.getLong(index) >> 32) != 0L) return false
+            if ((row.getLong(index) >> 32) != 0L) {
+              return Some(s"Fixed-length field validation error: field: $field, index: $index")
+            }
           case FloatType =>
-            if ((row.getLong(index) >> 32) != 0L) return false
+            if ((row.getLong(index) >> 32) != 0L) {
+              return Some(s"Fixed-length field validation error: field: $field, index: $index")
+            }
           case _ =>
         }
       case (field, index) if row.isNullAt(index) =>
@@ -94,17 +110,37 @@ object UnsafeRowUtils {
             val (offset, size) = getOffsetAndSize(row, index)
             if (size != 0 || offset != 0 &&
                 (offset < bitSetWidthInBytes + 8 * row.numFields || offset > rowSizeInBytes)) {
-              return false
+              return Some(s"Variable-length decimal field special case validation error: " +
+                s"field: $field, index: $index")
             }
           case _ =>
-            if (row.getLong(index) != 0L) return false
+            if (row.getLong(index) != 0L) {
+              return Some(s"Variable-length offset-size validation error: " +
+                s"field: $field, index: $index")
+            }
         }
       case _ =>
     }
     if (bitSetWidthInBytes + 8 * row.numFields + varLenFieldsSizeInBytes > rowSizeInBytes) {
-      return false
+      return Some(s"Row total length invalid: " +
+        s"calculated: ${bitSetWidthInBytes + 8 * row.numFields + varLenFieldsSizeInBytes} " +
+        s"rowSizeInBytes: $rowSizeInBytes")
     }
-    true
+    None
+  }
+
+  /**
+   * Wrapper of validateStructuralIntegrityWithReasonImpl, add more information for debugging
+   * @param row The input UnsafeRow to be validated
+   * @param expectedSchema The expected schema that should match with the UnsafeRow
+   * @return None if all the checks pass. An error message if the row is not matched with the schema
+   */
+  def validateStructuralIntegrityWithReason(
+    row: UnsafeRow, expectedSchema: StructType): Option[String] = {
+    validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
+      errorMessage => s"Error message is: $errorMessage, " +
+          s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
+    }
   }
 
   def getOffsetAndSize(row: UnsafeRow, index: Int): (Int, Int) = {
@@ -138,5 +174,26 @@ object UnsafeRowUtils {
     case t: DecimalType if t.precision > Decimal.MAX_LONG_DIGITS => true
     case CalendarIntervalType => true
     case _ => false
+  }
+
+  def getStructuralIntegrityStatus(row: UnsafeRow, expectedSchema: StructType): String = {
+    val fieldStatusArr = expectedSchema.fields.zipWithIndex.map {
+      case (field, index) =>
+        val offsetAndSizeStr = if (!UnsafeRow.isFixedLength(field.dataType)) {
+          val (offset, size) = getOffsetAndSize(row, index)
+          s"offset: $offset, size: $size"
+        } else {
+          "" // offset and size doesn't make sense for fixed length field
+        }
+        s"[UnsafeRowFieldStatus] index: $index, " +
+          s"expectedFieldType: ${field.dataType}, isNull: ${row.isNullAt(index)}, " +
+          s"isFixedLength: ${UnsafeRow.isFixedLength(field.dataType)}. $offsetAndSizeStr"
+    }
+
+    s"[UnsafeRowStatus] expectedSchema: $expectedSchema, " +
+      s"expectedSchemaNumFields: ${expectedSchema.fields.length}, numFields: ${row.numFields}, " +
+      s"bitSetWidthInBytes: ${UnsafeRow.calculateBitSetWidthInBytes(row.numFields)}, " +
+      s"rowSizeInBytes: ${row.getSizeInBytes}\nfieldStatus:\n" +
+      fieldStatusArr.mkString("\n")
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -226,10 +226,10 @@ case class StateStoreCustomTimingMetric(name: String, desc: String) extends Stat
  * An exception thrown when an invalid UnsafeRow is detected in state store.
  */
 class InvalidUnsafeRowException(error: String)
-  extends RuntimeException(s"The streaming query failed by state format invalidation. " +
-    s"The following reasons may cause this: 1. An old Spark version wrote the checkpoint that is " +
-    s"incompatible with the current one; 2. Broken checkpoint files; 3. The query is changed " +
-    s"among restart. For the first case, you can try to restart the application without " +
+  extends RuntimeException("The streaming query failed by state format invalidation. " +
+    "The following reasons may cause this: 1. An old Spark version wrote the checkpoint that is " +
+    "incompatible with the current one; 2. Broken checkpoint files; 3. The query is changed " +
+    "among restart. For the first case, you can try to restart the application without " +
     s"checkpoint or use the legacy Spark version to process the streaming state.\n$error", null)
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -225,12 +225,12 @@ case class StateStoreCustomTimingMetric(name: String, desc: String) extends Stat
 /**
  * An exception thrown when an invalid UnsafeRow is detected in state store.
  */
-class InvalidUnsafeRowException
-  extends RuntimeException("The streaming query failed by state format invalidation. " +
-    "The following reasons may cause this: 1. An old Spark version wrote the checkpoint that is " +
-    "incompatible with the current one; 2. Broken checkpoint files; 3. The query is changed " +
-    "among restart. For the first case, you can try to restart the application without " +
-    "checkpoint or use the legacy Spark version to process the streaming state.", null)
+class InvalidUnsafeRowException(error: String)
+  extends RuntimeException(s"The streaming query failed by state format invalidation. " +
+    s"The following reasons may cause this: 1. An old Spark version wrote the checkpoint that is " +
+    s"incompatible with the current one; 2. Broken checkpoint files; 3. The query is changed " +
+    s"among restart. For the first case, you can try to restart the application without " +
+    s"checkpoint or use the legacy Spark version to process the streaming state.\n$error", null)
 
 /**
  * Trait representing a provider that provide [[StateStore]] instances representing
@@ -341,13 +341,13 @@ object StateStoreProvider {
       valueSchema: StructType,
       conf: StateStoreConf): Unit = {
     if (conf.formatValidationEnabled) {
-      if (!UnsafeRowUtils.validateStructuralIntegrity(keyRow, keySchema)) {
-        throw new InvalidUnsafeRowException
-      }
-      if (conf.formatValidationCheckValue &&
-          !UnsafeRowUtils.validateStructuralIntegrity(valueRow, valueSchema)) {
-        throw new InvalidUnsafeRowException
-      }
+      val validationError = UnsafeRowUtils.validateStructuralIntegrityWithReason(keyRow, keySchema)
+      validationError.foreach { error => throw new InvalidUnsafeRowException(error) }
+    }
+    if (conf.formatValidationCheckValue) {
+      val validationError =
+        UnsafeRowUtils.validateStructuralIntegrityWithReason(valueRow, valueSchema)
+      validationError.foreach { error => throw new InvalidUnsafeRowException(error) }
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1408,7 +1408,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
         errorClass = "UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY",
         parameters = Map("dataSourceType" -> "hive"),
         context = ExpectedContext(s"hive.`${f.getCanonicalPath}`",
-          15, 23 + f.getCanonicalPath.length)
+          15, 21 + f.getCanonicalPath.length)
       )
 
       // data source type is case insensitive
@@ -1419,7 +1419,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
         errorClass = "UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY",
         parameters = Map("dataSourceType" -> "HIVE"),
         context = ExpectedContext(s"HIVE.`${f.getCanonicalPath}`",
-          15, 23 + f.getCanonicalPath.length)
+          15, 21 + f.getCanonicalPath.length)
       )
     })
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1408,7 +1408,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
         errorClass = "UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY",
         parameters = Map("dataSourceType" -> "hive"),
         context = ExpectedContext(s"hive.`${f.getCanonicalPath}`",
-          15, 22 + f.getCanonicalPath.length)
+          15, 23 + f.getCanonicalPath.length)
       )
 
       // data source type is case insensitive
@@ -1419,7 +1419,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
         errorClass = "UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY",
         parameters = Map("dataSourceType" -> "HIVE"),
         context = ExpectedContext(s"HIVE.`${f.getCanonicalPath}`",
-          15, 22 + f.getCanonicalPath.length)
+          15, 23 + f.getCanonicalPath.length)
       )
     })
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1407,7 +1407,8 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
         },
         errorClass = "UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY",
         parameters = Map("dataSourceType" -> "hive"),
-        context = ExpectedContext(s"hive.`${f.getCanonicalPath}`", 15, 104)
+        context = ExpectedContext(s"hive.`${f.getCanonicalPath}`",
+          15, 22 + f.getCanonicalPath.length)
       )
 
       // data source type is case insensitive
@@ -1417,7 +1418,8 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
         },
         errorClass = "UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY",
         parameters = Map("dataSourceType" -> "HIVE"),
-        context = ExpectedContext(s"HIVE.`${f.getCanonicalPath}`", 15, 104)
+        context = ExpectedContext(s"HIVE.`${f.getCanonicalPath}`",
+          15, 22 + f.getCanonicalPath.length)
       )
     })
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Showing the essential information when throwing `InvalidUnsafeRowException`. Including where the check failed, and status of the `unsafeRow` and `expctedSchema`

Example output:
```
[UnsafeRowStatus] expectedSchema: StructType(StructField(key1,IntegerType,false),StructField(key2,IntegerType,false),StructField(sum(key1),IntegerType,false),StructField(sum(key2),IntegerType,false)), expectedSchemaNumFields: 4, numFields: 4, bitSetWidthInBytes: 8, rowSizeInBytes: 40 
fieldStatus: 
[UnsafeRowFieldStatus] index: 0, expectedFieldType: IntegerType, isNull: false, isFixedLength: true, offset: -1, size: -1
[UnsafeRowFieldStatus] index: 1, expectedFieldType: IntegerType, isNull: false, isFixedLength: true, offset: -1, size: -1
[UnsafeRowFieldStatus] index: 2, expectedFieldType: IntegerType, isNull: false, isFixedLength: true, offset: -1, size: -1
[UnsafeRowFieldStatus] index: 3, expectedFieldType: IntegerType, isNull: false, isFixedLength: true, offset: -1, size: -1
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Right now if such error happens, it's hard to track where it errored, and what the misbehaved row & schema looks like. With this change these information are more clear.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests