### PR TITLE
[SPARK-42486][BUILD] Upgrade `ZooKeeper` to 3.6.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -21,7 +21,7 @@ arrow-format/11.0.0//arrow-format-11.0.0.jar
 arrow-memory-core/11.0.0//arrow-memory-core-11.0.0.jar
 arrow-memory-netty/11.0.0//arrow-memory-netty-11.0.0.jar
 arrow-vector/11.0.0//arrow-vector-11.0.0.jar
-audience-annotations/0.5.0//audience-annotations-0.5.0.jar
+audience-annotations/0.13.0//audience-annotations-0.13.0.jar
 avro-ipc/1.11.1//avro-ipc-1.11.1.jar
 avro-mapred/1.11.1//avro-mapred-1.11.1.jar
 avro/1.11.1//avro-1.11.1.jar
@@ -266,6 +266,6 @@ xml-apis/1.4.01//xml-apis-1.4.01.jar
 xmlenc/0.52//xmlenc-0.52.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
-zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
-zookeeper/3.6.3//zookeeper-3.6.3.jar
+zookeeper-jute/3.6.4//zookeeper-jute-3.6.4.jar
+zookeeper/3.6.4//zookeeper-3.6.4.jar
 zstd-jni/1.5.4-1//zstd-jni-1.5.4-1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -20,7 +20,7 @@ arrow-format/11.0.0//arrow-format-11.0.0.jar
 arrow-memory-core/11.0.0//arrow-memory-core-11.0.0.jar
 arrow-memory-netty/11.0.0//arrow-memory-netty-11.0.0.jar
 arrow-vector/11.0.0//arrow-vector-11.0.0.jar
-audience-annotations/0.5.0//audience-annotations-0.5.0.jar
+audience-annotations/0.13.0//audience-annotations-0.13.0.jar
 avro-ipc/1.11.1//avro-ipc-1.11.1.jar
 avro-mapred/1.11.1//avro-mapred-1.11.1.jar
 avro/1.11.1//avro-1.11.1.jar
@@ -251,6 +251,6 @@ wildfly-openssl/1.0.7.Final//wildfly-openssl-1.0.7.Final.jar
 xbean-asm9-shaded/4.22//xbean-asm9-shaded-4.22.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
-zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
-zookeeper/3.6.3//zookeeper-3.6.3.jar
+zookeeper-jute/3.6.4//zookeeper-jute-3.6.4.jar
+zookeeper/3.6.4//zookeeper-3.6.4.jar
 zstd-jni/1.5.4-1//zstd-jni-1.5.4-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <protobuf.version>3.21.12</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
-    <zookeeper.version>3.6.3</zookeeper.version>
+    <zookeeper.version>3.6.4</zookeeper.version>
     <curator.version>2.13.0</curator.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade ZooKeeper from 3.6.3 to 3.6.4

[Release notes](https://zookeeper.apache.org/doc/r3.6.4/releasenotes.html)
### Why are the changes needed?
[ZooKeeper 3.6 is EoL since 30th December, 2022](https://zookeeper.apache.org/releases.html)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA