### PR TITLE
[SPARK-42488][BUILD] Upgrade commons-crypto to 1.2.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -41,7 +41,7 @@ commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.22//commons-compress-1.22.jar
 commons-configuration/1.6//commons-configuration-1.6.jar
-commons-crypto/1.1.0//commons-crypto-1.1.0.jar
+commons-crypto/1.2.0//commons-crypto-1.2.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-digester/1.8//commons-digester-1.8.jar
 commons-httpclient/3.1//commons-httpclient-3.1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -41,7 +41,7 @@ commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.22//commons-compress-1.22.jar
-commons-crypto/1.1.0//commons-crypto-1.1.0.jar
+commons-crypto/1.2.0//commons-crypto-1.2.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.11.0//commons-io-2.11.0.jar
 commons-lang/2.6//commons-lang-2.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     <htmlunit-driver.version>4.7.2</htmlunit-driver.version>
     <htmlunit.version>2.67.0</htmlunit.version>
     <maven-antrun.version>1.8</maven-antrun.version>
-    <commons-crypto.version>1.1.0</commons-crypto.version>
+    <commons-crypto.version>1.2.0</commons-crypto.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <tink.version>1.7.0</tink.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade commons-crypto from 1.1.0 to 1.2.0.


### Why are the changes needed?
The new features in 1.2.0 as follows:

https://github.com/apache/commons-crypto/blob/1ebfddd0e77585884872416a0dff2dd114a88864/RELEASE-NOTES.txt#L12-L21

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/1475305/220000261-0c59d7a1-3c88-4ea4-a8c5-39da88ead4f7.png">



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
