### PR TITLE
[SPARK-42490][BUILD] Upgrade protobuf-java from 3.21.12 to 3.22.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <protobuf.hadoopDependency.version>2.5.0</protobuf.hadoopDependency.version>
     <!-- Actual Protobuf version in Spark modules like Spark Connect, protobuf connector, etc. -->
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
-    <protobuf.version>3.21.12</protobuf.version>
+    <protobuf.version>3.22.0</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.6.3</zookeeper.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -88,7 +88,7 @@ object BuildCommons {
 
   // Google Protobuf version used for generating the protobuf.
   // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
-  val protoVersion = "3.21.12"
+  val protoVersion = "3.22.0"
   // GRPC version used for Spark Connect.
   val gprcVersion = "1.47.0"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `protobuf-java` from 3.21.12 to 3.22.0 


### Why are the changes needed?
The new version bring some improvements like:

- Use bit-field int values in buildPartial to skip work on unset groups of fields. (https://github.com/protocolbuffers/protobuf/commit/2326aef1a454a4eea363cc6ed8b8def8b88365f5)
- Fix serialization warnings in generated code when compiling with Java 18 and above (https://github.com/protocolbuffers/protobuf/pull/10561)
- Enable Text format parser to skip unknown short-formed repeated fields. (https://github.com/protocolbuffers/protobuf/commit/6dbd4131fa6b2ad29b2b1b827f21fc61b160aeeb)
- Add serialVersionUID to ByteString and subclasses (https://github.com/protocolbuffers/protobuf/pull/10718)

and some bug fix like:
- Mark default instance as immutable first to avoid race during static initialization of default instances. (https://github.com/protocolbuffers/protobuf/pull/10770)

- Fix Timestamps fromDate for negative 'exact second' java.sql.Timestamps (https://github.com/protocolbuffers/protobuf/pull/10321)
- Fix Timestamps.fromDate to correctly handle java.sql.Timestamps before unix epoch (https://github.com/protocolbuffers/protobuf/pull/10126)
- Fix bug in nested builder caching logic where cleared sub-field builders would remain dirty after a clear and build in a parent layer. https://github.com/protocolbuffers/protobuf/issues/10624

The release notes as follows:

- https://github.com/protocolbuffers/protobuf/releases/tag/v22.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions