### PR TITLE
[SPARK-42492][SQL] Add new function filter_value

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6402,6 +6402,23 @@ object functions {
   }
 
   /**
+   * Returns the column if the predicate holds true, null otherwise.
+   * {{{
+   *   df.select(filter_value(col("s"), x => x % 2 === 0))
+   * }}}
+   *
+   * @param column
+   *   the input column
+   * @param f
+   *   col => predicate, the Boolean predicate to filter the input column
+   *
+   * @group normal_funcs
+   * @since 3.5.0
+   */
+  def filter_value(column: Column, f: Column => Column): Column =
+    Column.fn("filter_value", column, createLambda(f))
+
+  /**
    * Returns an array of elements after applying a transformation to each element in the input
    * array.
    * {{{

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6413,7 +6413,7 @@ object functions {
    *   col => predicate, the Boolean predicate to filter the input column
    *
    * @group normal_funcs
-   * @since 3.5.0
+   * @since 4.0.0
    */
   def filter_value(column: Column, f: Column => Column): Column =
     Column.fn("filter_value", column, createLambda(f))

--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -45,6 +45,7 @@ Conditional Functions
     :toctree: api/
 
     coalesce
+    filter_value
     ifnull
     nanvl
     nullif

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -2285,6 +2285,16 @@ def to_xml(col: "ColumnOrName", options: Optional[Dict[str, str]] = None) -> Col
 to_xml.__doc__ = pysparkfuncs.to_xml.__doc__
 
 
+def filter_value(
+    col: "ColumnOrName",
+    f: Union[Callable[[Column], Column], Callable[[Column, Column], Column]],
+) -> Column:
+    return _invoke_higher_order_function("filter_value", [col], [f])
+
+
+filter_value.__doc__ = pysparkfuncs.filter_value.__doc__
+
+
 def transform(
     col: "ColumnOrName",
     f: Union[Callable[[Column], Column], Callable[[Column, Column], Column]],

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -18075,6 +18075,46 @@ def _invoke_higher_order_function(
     return Column(cast(JVMView, sc._jvm).Column(expr(*jcols + jfuns)))
 
 
+@try_remote_functions
+def filter_value(col: "ColumnOrName", f: Callable[[Column], Column]) -> Column:
+    """
+    Returns the column if the predicate holds true, otherwise null.
+
+    .. versionadded:: 3.5.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        name of column or expression
+    f : function
+        a function that takes the input column and returns a boolean indicating whether to
+        return the value or null.
+
+        Can use methods of :class:`~pyspark.sql.Column`, functions defined in
+        :py:mod:`pyspark.sql.functions` and Scala ``UserDefinedFunctions``.
+        Python ``UserDefinedFunctions`` are not supported
+        (`SPARK-27052 <https://issues.apache.org/jira/browse/SPARK-27052>`__).
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column passed in if the predicate returns true, otherwise null.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([[1], [2], [3]], ["value"])
+    >>> df.select(filter_value("value", lambda x: x % 2 == 0).alias("even")).show()
+    +----+
+    |even|
+    +----+
+    |null|
+    |   2|
+    |null|
+    +----+
+    """
+    return _invoke_higher_order_function("FilterValue", [col], [f])
+
+
 @overload
 def transform(col: "ColumnOrName", f: Callable[[Column], Column]) -> Column:
     ...

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -18080,7 +18080,7 @@ def filter_value(col: "ColumnOrName", f: Callable[[Column], Column]) -> Column:
     """
     Returns the column if the predicate holds true, otherwise null.
 
-    .. versionadded:: 3.5.0
+    .. versionadded:: 4.0.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -18075,7 +18075,7 @@ def _invoke_higher_order_function(
     return Column(cast(JVMView, sc._jvm).Column(expr(*jcols + jfuns)))
 
 
-@try_remote_functions
+@_try_remote_functions
 def filter_value(col: "ColumnOrName", f: Callable[[Column], Column]) -> Column:
     """
     Returns the column if the predicate holds true, otherwise null.

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -18107,9 +18107,9 @@ def filter_value(col: "ColumnOrName", f: Callable[[Column], Column]) -> Column:
     +----+
     |even|
     +----+
-    |null|
+    |NULL|
     |   2|
-    |null|
+    |NULL|
     +----+
     """
     return _invoke_higher_order_function("FilterValue", [col], [f])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -385,6 +385,7 @@ object FunctionRegistry {
     expression[Randn]("randn"),
     expression[Stack]("stack"),
     expression[CaseWhen]("when"),
+    expression[FilterValue]("filter_value"),
 
     // math functions
     expression[Acos]("acos"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -306,7 +306,7 @@ trait MapBasedSimpleHigherOrderFunction extends SimpleHigherOrderFunction {
       > SELECT _FUNC_(1, x -> x > 1);
        NULL
   """,
-  since = "3.5.0",
+  since = "4.0.0",
   group = "lambda_funcs")
 case class FilterValue(
     argument: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -301,10 +301,10 @@ trait MapBasedSimpleHigherOrderFunction extends SimpleHigherOrderFunction {
   usage = "_FUNC_(expr, func) - Return the value if func returns true, otherwise return null.",
   examples = """
     Examples:
-      > SELECT _FUNC_(array(1, 2, 3), x -> x + 1);
-       [2,3,4]
-      > SELECT _FUNC_(array(1, 2, 3), (x, i) -> x + i);
-       [1,3,5]
+      > SELECT _FUNC_(1, x -> x > 0);
+       1
+      > SELECT _FUNC_(1, x -> x > 1);
+       NULL
   """,
   since = "3.5.0",
   group = "lambda_funcs")

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6092,7 +6092,7 @@ object functions {
    * @param f col => predicate, the Boolean predicate to filter the input column
    *
    * @group normal_funcs
-   * @since 3.5.0
+   * @since 4.0.0
    */
   def filter_value(column: Column, f: Column => Column): Column = withExpr {
     FilterValue(column.expr, createLambda(f))

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6083,6 +6083,22 @@ object functions {
   }
 
   /**
+   * Returns the column if the predicate holds true, null otherwise.
+   * {{{
+   *   df.select(filter_value(col("s"), x => x % 2 === 0))
+   * }}}
+   *
+   * @param column the input column
+   * @param f col => predicate, the Boolean predicate to filter the input column
+   *
+   * @group normal_funcs
+   * @since 3.5.0
+   */
+  def filter_value(column: Column, f: Column => Column): Column = withExpr {
+    FilterValue(column.expr, createLambda(f))
+  }
+
+  /**
    * Returns an array of elements after applying a transformation to each element
    * in the input array.
    * {{{

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6094,9 +6094,8 @@ object functions {
    * @group normal_funcs
    * @since 4.0.0
    */
-  def filter_value(column: Column, f: Column => Column): Column = withExpr {
-    FilterValue(column.expr, createLambda(f))
-  }
+  def filter_value(column: Column, f: Column => Column): Column =
+    Column.fn("filter_value", column, createLambda(f))
 
   /**
    * Returns an array of elements after applying a transformation to each element

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -141,6 +141,7 @@
 | org.apache.spark.sql.catalyst.expressions.Expm1 | expm1 | SELECT expm1(0) | struct<EXPM1(0):double> |
 | org.apache.spark.sql.catalyst.expressions.Extract | extract | SELECT extract(YEAR FROM TIMESTAMP '2019-08-12 01:00:00.123456') | struct<extract(YEAR FROM TIMESTAMP '2019-08-12 01:00:00.123456'):int> |
 | org.apache.spark.sql.catalyst.expressions.Factorial | factorial | SELECT factorial(5) | struct<factorial(5):bigint> |
+| org.apache.spark.sql.catalyst.expressions.FilterValue | filter_value | SELECT filter_value(1, x -> x > 0) | struct<filter_value(1, lambdafunction((namedlambdavariable() > 0), namedlambdavariable())):int> |
 | org.apache.spark.sql.catalyst.expressions.FindInSet | find_in_set | SELECT find_in_set('ab','abc,b,ab,c,def') | struct<find_in_set(ab, abc,b,ab,c,def):int> |
 | org.apache.spark.sql.catalyst.expressions.Flatten | flatten | SELECT flatten(array(array(1, 2), array(3, 4))) | struct<flatten(array(array(1, 2), array(3, 4))):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.FloorExpressionBuilder | floor | SELECT floor(-0.1) | struct<FLOOR(-0.1):decimal(1,0)> |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a new higher order function `filter_value` which takes a column to validate and a function that takes the result of that column and returns a boolean indicating whether to keep the value or return null. This is semantically the same as a `when` expression passing the column into a validation function, except it guarantees to only evaluate the initial column once. The idea was taken from the Scala `Option.filter`, open to other names if anyone has a better idea.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Conditionally evaluated expressions are currently not candidates for subexpression elimination. This can lead to a lot of duplicate evaluations of expressions when doing common data cleaning tasks, such as only keeping a value if it matches some validation checks. It gets worse when multiple different checks are chained together, and you can end up with a single expensive expression being evaluated numerous times.

https://github.com/apache/spark/pull/32987 attempts to solve this by allowing conditionally evaluated expressions to be candidates for subexpression elimination, however I have not been able to get that merged in the past 1.5 years. I still think that is valuable and useful, especially as an opt-in behavior, but this is an alternative option to help improve performance of these kinds of data validation tasks.

A custom implementation of `NullIf` could help as well, however it would only support exact equals checks, where this can support any logic you need to do validation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Adds a new function.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UTs.