### PR TITLE
[SPARK-42427][SQL][TESTS][FOLLOW-UP] Remove duplicate overflow test for conv

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -222,8 +222,6 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df.selectExpr("conv(num, fromBase, toBase)"), Row("101001101"))
     checkAnswer(df.selectExpr("""conv("100", 2, 10)"""), Row("4"))
     checkAnswer(df.selectExpr("""conv("-10", 16, -10)"""), Row("-16"))
-    checkAnswer(
-      df.selectExpr("""conv("9223372036854775807", 36, -16)"""), Row("-1")) // for overflow
   }
 
   test("SPARK-33428 conv function should trim input string") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove duplicate test (see https://github.com/apache/spark/commit/cb463fb40e8f663b7e3019c8d8560a3490c241d0).

### Why are the changes needed?

This test fails with ANSI mode on https://github.com/apache/spark/actions/runs/4213931226/jobs/7314033662, and it's a duplicate. Should better remove.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested.