### PR TITLE
[SPARK-41741][SQL] Encode the string using the UTF_8 charset in ParquetFilters

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import java.lang.{Boolean => JBoolean, Double => JDouble, Float => JFloat, Long => JLong}
 import java.math.{BigDecimal => JBigDecimal}
+import java.nio.charset.StandardCharsets.UTF_8
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, Instant, LocalDate, Period}
 import java.util.HashSet
@@ -776,7 +777,7 @@ class ParquetFilters(
         Option(prefix).map { v =>
           FilterApi.userDefined(binaryColumn(nameToParquetField(name).fieldNames),
             new UserDefinedPredicate[Binary] with Serializable {
-              private val strToBinary = Binary.fromReusedByteArray(v.getBytes)
+              private val strToBinary = Binary.fromReusedByteArray(v.getBytes(UTF_8))
               private val size = strToBinary.length
 
               override def canDrop(statistics: Statistics[Binary]): Boolean = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2134,7 +2134,7 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
       }
     }
   }
-  
+
   test("SPARK-41741: StringStartsWith should encode the string using the UTF_8 charset") {
     // A hacky way to set the default Java character encoding.
     def setDefaultEncoding(charset: Charset): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import java.io.File
 import java.math.{BigDecimal => JBigDecimal}
-import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, LocalDate, LocalDateTime, Period, ZoneId}
@@ -2132,30 +2131,6 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
           checkAnswer(notIn, Seq())
         }
       }
-    }
-  }
-
-  test("SPARK-41741: StringStartsWith should encode the string using the UTF_8 charset") {
-    // A hacky way to set the default Java character encoding.
-    def setDefaultEncoding(charset: Charset): Unit = {
-      System.setProperty("file.encoding", charset.name())
-      val defaultCharsetField = classOf[Charset].getDeclaredField("defaultCharset")
-      defaultCharsetField.setAccessible(true)
-      defaultCharsetField.set(null, null)
-    }
-    import testImplicits._
-    val defaultCharset = Charset.defaultCharset()
-    val testCharset = Charset.forName("US-ASCII")
-    try {
-      setDefaultEncoding(testCharset)
-      assert(Charset.defaultCharset() === testCharset)
-      // scalastyle:off nonascii
-      val df = Seq("中文", "中国").toDF()
-      testStringPredicate(df, "value like '中%'", false)
-      testStringPredicate(df, "value like '流浪%'", true)
-      // scalastyle:on nonascii
-    } finally {
-      setDefaultEncoding(defaultCharset)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes it encode the string using the `UTF_8` charset in `ParquetFilters`.

### Why are the changes needed?

Fix data issue where the default charset is not `UTF_8`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.