### PR TITLE
[SPARK-42475][CONNECT][DOCS] Getting Started: Live Notebook for Spark Connect

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -22,6 +22,7 @@
 
 VERSION=$(python -c "exec(open('python/pyspark/version.py').read()); print(__version__)")
 TAG=$(git describe --tags --exact-match 2>/dev/null)
+SPARK_HOME=$(python/pyspark/find_spark_home.py)
 
 # If a commit is tagged, exactly specified version of pyspark should be installed to avoid
 # a kind of accident that an old version of pyspark is installed in the live notebook environment.
@@ -32,10 +33,17 @@ else
   SPECIFIER="<="
 fi
 
-pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]$SPECIFIER$VERSION"
+if [[ $VERSION > "3.4.0" ]]; then
+  pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark,connect]$SPECIFIER$VERSION"
+else
+  pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]$SPECIFIER$VERSION"
+fi
 
 # Set 'PYARROW_IGNORE_TIMEZONE' to surpress warnings from PyArrow.
 echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile
+
+# Add sbin to PATH to run `start-connect-server.sh`.
+echo "PATH=${PATH}:${SPARK_HOME}/sbin" >> ~/.profile
 
 # Surpress warnings from Spark jobs, and UI progress bar.
 mkdir -p ~/.ipython/profile_default/startup

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -33,7 +33,7 @@ else
   SPECIFIER="<="
 fi
 
-if [[ $VERSION > "3.4.0" ]]; then
+if [[ $VERSION >= "3.4.0" ]]; then
   pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark,connect]$SPECIFIER$VERSION"
 else
   pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]$SPECIFIER$VERSION"
@@ -44,6 +44,9 @@ echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile
 
 # Add sbin to PATH to run `start-connect-server.sh`.
 echo "PATH=${PATH}:${SPARK_HOME}/sbin" >> ~/.profile
+
+# Add Spark version to env for running command dynamically based on Spark version.
+echo "export SPARK_VERSION=${VERSION}" >> ~/.profile
 
 # Surpress warnings from Spark jobs, and UI progress bar.
 mkdir -p ~/.ipython/profile_default/startup

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -22,7 +22,6 @@
 
 VERSION=$(python -c "exec(open('python/pyspark/version.py').read()); print(__version__)")
 TAG=$(git describe --tags --exact-match 2>/dev/null)
-SPARK_HOME=$(python/pyspark/find_spark_home.py)
 
 # If a commit is tagged, exactly specified version of pyspark should be installed to avoid
 # a kind of accident that an old version of pyspark is installed in the live notebook environment.
@@ -33,7 +32,7 @@ else
   SPECIFIER="<="
 fi
 
-if [[ $VERSION >= "3.4.0" ]]; then
+if [[ ! $VERSION < "3.4.0" ]]; then
   pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark,connect]$SPECIFIER$VERSION"
 else
   pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]$SPECIFIER$VERSION"
@@ -42,11 +41,15 @@ fi
 # Set 'PYARROW_IGNORE_TIMEZONE' to surpress warnings from PyArrow.
 echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile
 
+
 # Add sbin to PATH to run `start-connect-server.sh`.
-echo "PATH=${PATH}:${SPARK_HOME}/sbin" >> ~/.profile
+SPARK_HOME=$(python -c "from pyspark.find_spark_home import _find_spark_home; print(_find_spark_home())")
+echo "export PATH=${PATH}:${SPARK_HOME}/sbin" >> ~/.profile
+
 
 # Add Spark version to env for running command dynamically based on Spark version.
-echo "export SPARK_VERSION=${VERSION}" >> ~/.profile
+SPARK_VERSION=$(python -c "import pyspark; print(pyspark.__version__)")
+echo "export SPARK_VERSION=${SPARK_VERSION}" >> ~/.profile
 
 # Surpress warnings from Spark jobs, and UI progress bar.
 mkdir -p ~/.ipython/profile_default/startup

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -45,7 +45,6 @@ echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile
 SPARK_HOME=$(python -c "from pyspark.find_spark_home import _find_spark_home; print(_find_spark_home())")
 echo "export PATH=${PATH}:${SPARK_HOME}/sbin" >> ~/.profile
 
-
 # Add Spark version to env for running command dynamically based on Spark version.
 SPARK_VERSION=$(python -c "import pyspark; print(pyspark.__version__)")
 echo "export SPARK_VERSION=${SPARK_VERSION}" >> ~/.profile

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -41,7 +41,6 @@ fi
 # Set 'PYARROW_IGNORE_TIMEZONE' to surpress warnings from PyArrow.
 echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile
 
-
 # Add sbin to PATH to run `start-connect-server.sh`.
 SPARK_HOME=$(python -c "from pyspark.find_spark_home import _find_spark_home; print(_find_spark_home())")
 echo "export PATH=${PATH}:${SPARK_HOME}/sbin" >> ~/.profile

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -89,7 +89,7 @@ rst_epilog = """
 .. _binder_df: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb
 .. |binder_ps| replace:: Live Notebook: pandas API on Spark
 .. _binder_ps: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb
-.. |binder_connect| replace:: Live Notebook: DataFrame with Spark Connect
+.. |binder_connect| replace:: Live Notebook: Spark Connect
 .. _binder_connect: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb
 .. |examples| replace:: Examples
 .. _examples: https://github.com/apache/spark/tree/{0}/examples/src/main/python

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -89,6 +89,8 @@ rst_epilog = """
 .. _binder_df: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb
 .. |binder_ps| replace:: Live Notebook: pandas API on Spark
 .. _binder_ps: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb
+.. |binder_connect| replace:: Live Notebook: DataFrame with Spark Connect
+.. _binder_connect: https://mybinder.org/v2/gh/apache/spark/{0}?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb
 .. |examples| replace:: Examples
 .. _examples: https://github.com/apache/spark/tree/{0}/examples/src/main/python
 .. |downloading| replace:: Downloading

--- a/python/docs/source/getting_started/index.rst
+++ b/python/docs/source/getting_started/index.rst
@@ -28,6 +28,7 @@ at `the Spark documentation <https://spark.apache.org/docs/latest/index.html#whe
 There are live notebooks where you can try PySpark out without any other step:
 
 * |binder_df|_
+* |binder_connect|_
 * |binder_ps|_
 
 The list below is the contents of this quickstart page:
@@ -37,4 +38,5 @@ The list below is the contents of this quickstart page:
 
    install
    quickstart_df
+   quickstart_connect
    quickstart_ps

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -4,17 +4,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Quickstart: DataFrame with Spark Connect\n",
+    "# Quickstart: Spark Connect\n",
     "\n",
-    "This is a short introduction and quickstart for the DataFrame with Spark Connect. A DataFrame with Spark Connect is virtually, conceptually identical to an existing [PySpark DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame), so most of the examples from 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) can be reused directly.\n",
+    "This is a short introduction and quickstart for Spark Connect.\n",
     "\n",
-    "However, it does not yet support some key features such as [RDD](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.RDD.html?highlight=rdd#pyspark.RDD) and [SparkSession.conf](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.conf.html#pyspark.sql.SparkSession.conf), so you need to consider it when using DataFrame with Spark Connect.\n",
+    "Spark Connect consists of two parts: server and client.\n",
     "\n",
-    "This notebook shows the basic usages of the DataFrame with Spark Connect geared mainly for those new to Spark Connect, along with comments of which features is not supported compare to the existing DataFrame.\n",
+    "This notebook demonstrates a simple step-by-step example of how it works on the sever and on the client for those new to Spark Connect."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Remote Session (Server)\n",
     "\n",
-    "There is also other useful information in Apache Spark documentation site, see the latest version of [Spark SQL and DataFrames](https://spark.apache.org/docs/latest/sql-programming-guide.html).\n",
+    "First of all, run the PySpark applications on the sever side.\n",
     "\n",
-    "PySpark applications start with initializing `SparkSession` which is the entry point of PySpark as below. In case of running it in PySpark shell via <code>pyspark</code> executable, the shell automatically creates the session in the variable <code>spark</code> for users."
+    "PySpark application start with initializing `SparkSession` which is the entry point of PySpark.\n",
+    "\n",
+    "**Note** that the [SparkSession.Builder.remote](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.builder.remote.html#pyspark.sql.SparkSession.builder.remote) must be specified if you want to make the session to be remote `SparkSession`, which is used for Spark Conenct.\n",
+    "\n",
+    "In case of running it in PySpark shell via `pyspark` executable with `--remote` option, the shell automatically creates the remote SparkSession in the variable spark for users."
    ]
   },
   {
@@ -23,154 +34,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Spark Connect uses SparkSession from `pyspark.sql.connect.session` instead of `pyspark.sql.SparkSession`.\n",
-    "from pyspark.sql.connect.session import SparkSession\n",
+    "from pyspark.sql import SparkSession\n",
     "\n",
-    "spark = SparkSession.builder.getOrCreate()"
+    "spark = SparkSession.builder.getOrCreate()\n",
+    "# spark = SparkSession.builder.remote(\"local[*]\").getOrCreate()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## DataFrame Creation\n",
+    "## Create DataFrame (Server)\n",
     "\n",
-    "A PySpark DataFrame with Spark Connect can be created via `pyspark.sql.connect.session.SparkSession.createDataFrame` typically by passing a list of lists, tuples, dictionaries and `pyspark.sql.Row`s, a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) and an RDD consisting of such a list.\n",
-    "`pyspark.sql.connect.session.SparkSession.createDataFrame` takes the `schema` argument to specify the schema of the DataFrame. When it is omitted, PySpark infers the corresponding schema by taking a sample from the data.\n",
-    "\n",
-    "Firstly, you can create a PySpark DataFrame from a list of rows"
+    "Let's create a PySpark DataFrame by using remote session."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DataFrame[a: bigint, b: double, c: string, d: date, e: timestamp]"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from datetime import datetime, date\n",
-    "import pandas as pd\n",
-    "from pyspark.sql import Row\n",
-    "\n",
-    "df = spark.createDataFrame([\n",
-    "    Row(a=1, b=2., c='string1', d=date(2000, 1, 1), e=datetime(2000, 1, 1, 12, 0)),\n",
-    "    Row(a=2, b=3., c='string2', d=date(2000, 2, 1), e=datetime(2000, 1, 2, 12, 0)),\n",
-    "    Row(a=4, b=5., c='string3', d=date(2000, 3, 1), e=datetime(2000, 1, 3, 12, 0))\n",
-    "])\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create a PySpark DataFrame with an explicit schema."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DataFrame[a: bigint, b: double, c: string, d: date, e: timestamp]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df = spark.createDataFrame([\n",
-    "    (1, 2., 'string1', date(2000, 1, 1), datetime(2000, 1, 1, 12, 0)),\n",
-    "    (2, 3., 'string2', date(2000, 2, 1), datetime(2000, 1, 2, 12, 0)),\n",
-    "    (3, 4., 'string3', date(2000, 3, 1), datetime(2000, 1, 3, 12, 0))\n",
-    "], schema='a long, b double, c string, d date, e timestamp')\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create a PySpark DataFrame from a pandas DataFrame"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DataFrame[a: bigint, b: double, c: string, d: date, e: timestamp]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pandas_df = pd.DataFrame({\n",
-    "    'a': [1, 2, 3],\n",
-    "    'b': [2., 3., 4.],\n",
-    "    'c': ['string1', 'string2', 'string3'],\n",
-    "    'd': [date(2000, 1, 1), date(2000, 2, 1), date(2000, 3, 1)],\n",
-    "    'e': [datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 2, 12, 0), datetime(2000, 1, 3, 12, 0)]\n",
-    "})\n",
-    "df = spark.createDataFrame(pandas_df)\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**[NOT SUPPORTED YET]** Create a PySpark DataFrame from an RDD consisting of a list of tuples.\n",
-    "\n",
-    "This is **NOT** supported with Spark Connect yet. If you want to use [SparkContext](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.SparkContext.html?highlight=sparkcontext#pyspark.SparkContext), use plain PySpark DataFrame instead of DataFrame with Spark Connect."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# rdd = spark.sparkContext.parallelize([\n",
-    "#     (1, 2., 'string1', date(2000, 1, 1), datetime(2000, 1, 1, 12, 0)),\n",
-    "#     (2, 3., 'string2', date(2000, 2, 1), datetime(2000, 1, 2, 12, 0)),\n",
-    "#     (3, 4., 'string3', date(2000, 3, 1), datetime(2000, 1, 3, 12, 0))\n",
-    "# ])\n",
-    "# df = spark.createDataFrame(rdd, schema=['a', 'b', 'c', 'd', 'e'])\n",
-    "# df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The DataFrames created above all have the same results and schema."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -182,584 +63,21 @@
       "+---+---+-------+----------+-------------------+\n",
       "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|\n",
       "|  2|3.0|string2|2000-02-01|2000-01-02 12:00:00|\n",
-      "|  3|4.0|string3|2000-03-01|2000-01-03 12:00:00|\n",
-      "+---+---+-------+----------+-------------------+\n",
-      "\n",
-      "root\n",
-      " |-- a: long (nullable = true)\n",
-      " |-- b: double (nullable = true)\n",
-      " |-- c: string (nullable = true)\n",
-      " |-- d: date (nullable = true)\n",
-      " |-- e: timestamp (nullable = true)\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# All DataFrames above result same.\n",
-    "df.show()\n",
-    "df.printSchema()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Viewing Data\n",
-    "\n",
-    "The top rows of a DataFrame can be displayed using `DataFrame.show()`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+---+---+-------+----------+-------------------+\n",
-      "|  a|  b|      c|         d|                  e|\n",
-      "+---+---+-------+----------+-------------------+\n",
-      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|\n",
-      "+---+---+-------+----------+-------------------+\n",
-      "only showing top 1 row\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.show(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**[NOT SUPPORTED YET]** Alternatively, you can enable `spark.sql.repl.eagerEval.enabled` configuration for the eager evaluation of PySpark DataFrame in notebooks such as Jupyter. The number of rows to show can be controlled via `spark.sql.repl.eagerEval.maxNumRows` configuration.\n",
-    "\n",
-    "This is **NOT** supported with Spark Connect yet. If you want to set various [Spark Configuration](https://spark.apache.org/docs/latest/configuration.html), use plain PySpark DataFrame instead of DataFrame with Spark Connect."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# spark.conf.set('spark.sql.repl.eagerEval.enabled', True)\n",
-    "# df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The rows can also be shown vertically. This is useful when rows are too long to show horizontally."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-RECORD 0------------------\n",
-      " a   | 1                   \n",
-      " b   | 2.0                 \n",
-      " c   | string1             \n",
-      " d   | 2000-01-01          \n",
-      " e   | 2000-01-01 12:00:00 \n",
-      "only showing top 1 row\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.show(1, vertical=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can see the DataFrame's schema and column names as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['a', 'b', 'c', 'd', 'e']"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root\n",
-      " |-- a: long (nullable = true)\n",
-      " |-- b: double (nullable = true)\n",
-      " |-- c: string (nullable = true)\n",
-      " |-- d: date (nullable = true)\n",
-      " |-- e: timestamp (nullable = true)\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.printSchema()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Show the summary of the DataFrame"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+-------+---+---+-------+\n",
-      "|summary|  a|  b|      c|\n",
-      "+-------+---+---+-------+\n",
-      "|  count|  3|  3|      3|\n",
-      "|   mean|2.0|3.0|   null|\n",
-      "| stddev|1.0|1.0|   null|\n",
-      "|    min|  1|2.0|string1|\n",
-      "|    max|  3|4.0|string3|\n",
-      "+-------+---+---+-------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.select(\"a\", \"b\", \"c\").describe().show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`DataFrame.collect()` collects the distributed data to the driver side as the local data in Python. Note that this can throw an out-of-memory error when the dataset is too large to fit in the driver side because it collects all the data from executors to the driver side."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Row(a=1, b=2.0, c='string1', d=datetime.date(2000, 1, 1), e=datetime.datetime(2000, 1, 1, 12, 0)),\n",
-       " Row(a=2, b=3.0, c='string2', d=datetime.date(2000, 2, 1), e=datetime.datetime(2000, 1, 2, 12, 0)),\n",
-       " Row(a=3, b=4.0, c='string3', d=datetime.date(2000, 3, 1), e=datetime.datetime(2000, 1, 3, 12, 0))]"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.collect()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In order to avoid throwing an out-of-memory exception, use `DataFrame.take()` or `DataFrame.tail()`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Row(a=1, b=2.0, c='string1', d=datetime.date(2000, 1, 1), e=datetime.datetime(2000, 1, 1, 12, 0))]"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.take(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "PySpark DataFrame also provides the conversion back to a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) to leverage pandas API. Note that `toPandas` also collects all data into the driver side that can easily cause an out-of-memory-error when the data is too large to fit into the driver side."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "      <th>c</th>\n",
-       "      <th>d</th>\n",
-       "      <th>e</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>string1</td>\n",
-       "      <td>2000-01-01</td>\n",
-       "      <td>2000-01-01 12:00:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>string2</td>\n",
-       "      <td>2000-02-01</td>\n",
-       "      <td>2000-01-02 12:00:00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>string3</td>\n",
-       "      <td>2000-03-01</td>\n",
-       "      <td>2000-01-03 12:00:00</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   a    b        c           d                   e\n",
-       "0  1  2.0  string1  2000-01-01 2000-01-01 12:00:00\n",
-       "1  2  3.0  string2  2000-02-01 2000-01-02 12:00:00\n",
-       "2  3  4.0  string3  2000-03-01 2000-01-03 12:00:00"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.toPandas()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Selecting and Accessing Data\n",
-    "\n",
-    "PySpark DataFrame is lazily evaluated and simply selecting a column does not trigger the computation but it returns a `Column` instance."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Column<'a'>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.a"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In fact, most of column-wise operations return `Column`s."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from pyspark.sql import Column\n",
-    "from pyspark.sql.functions import upper\n",
-    "\n",
-    "type(df.c) == type(upper(df.c)) == type(df.c.isNull())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "These `Column`s can be used to select the columns from a DataFrame. For example, `DataFrame.select()` takes the `Column` instances that returns another DataFrame."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+-------+\n",
-      "|      c|\n",
-      "+-------+\n",
-      "|string1|\n",
-      "|string2|\n",
-      "|string3|\n",
-      "+-------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.select(df.c).show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Assign new `Column` instance."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+---+---+-------+----------+-------------------+-------+\n",
-      "|  a|  b|      c|         d|                  e|upper_c|\n",
-      "+---+---+-------+----------+-------------------+-------+\n",
-      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|STRING1|\n",
-      "|  2|3.0|string2|2000-02-01|2000-01-02 12:00:00|STRING2|\n",
-      "|  3|4.0|string3|2000-03-01|2000-01-03 12:00:00|STRING3|\n",
-      "+---+---+-------+----------+-------------------+-------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.withColumn('upper_c', upper(df.c)).show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To select a subset of rows, use `DataFrame.filter()`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+---+---+-------+----------+-------------------+\n",
-      "|  a|  b|      c|         d|                  e|\n",
-      "+---+---+-------+----------+-------------------+\n",
-      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|\n",
+      "|  4|5.0|string3|2000-03-01|2000-01-03 12:00:00|\n",
       "+---+---+-------+----------+-------------------+\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "df.filter(df.a == 1).show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Applying a Function\n",
+    "from datetime import datetime, date\n",
+    "from pyspark.sql import Row\n",
     "\n",
-    "PySpark supports various UDFs and APIs to allow users to execute Python native functions. See also the latest [Pandas UDFs](https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html#pandas-udfs-aka-vectorized-udfs) and [Pandas Function APIs](https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html#pandas-function-apis). For instance, the example below allows users to directly use the APIs in [a pandas Series](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.html) within Python native function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+------------------+\n",
-      "|pandas_plus_one(a)|\n",
-      "+------------------+\n",
-      "|                 2|\n",
-      "|                 3|\n",
-      "|                 4|\n",
-      "+------------------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "import pandas as pd\n",
-    "from pyspark.sql.functions import pandas_udf\n",
-    "\n",
-    "@pandas_udf('long')\n",
-    "def pandas_plus_one(series: pd.Series) -> pd.Series:\n",
-    "    # Simply plus one by using pandas Series.\n",
-    "    return series + 1\n",
-    "\n",
-    "df.select(pandas_plus_one(df.a)).show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**[NOT SUPPORTED YET]** Another example is [mapInPandas](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.mapInPandas.html?highlight=mapinpandas#pyspark.sql.DataFrame.mapInPandas) which allows users directly use the APIs in a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) without any restrictions such as the result length.\n",
-    "\n",
-    "This is **NOT** supported with Spark Connect yet. If you want to use `mapInPandas`, use plain PySpark DataFrame instead of DataFrame with Spark Connect."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# def pandas_filter_func(iterator):\n",
-    "#     for pandas_df in iterator:\n",
-    "#         yield pandas_df[pandas_df.a == 1]\n",
-    "\n",
-    "# df.mapInPandas(pandas_filter_func, schema=df.schema).show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Grouping Data\n",
-    "\n",
-    "PySpark DataFrame also provides a way of handling grouped data by using the common approach, split-apply-combine strategy.\n",
-    "It groups the data by a certain condition applies a function to each group and then combines them back to the DataFrame."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+-----+------+---+---+\n",
-      "|color| fruit| v1| v2|\n",
-      "+-----+------+---+---+\n",
-      "|  red|banana|  1| 10|\n",
-      "| blue|banana|  2| 20|\n",
-      "|  red|carrot|  3| 30|\n",
-      "| blue| grape|  4| 40|\n",
-      "|  red|carrot|  5| 50|\n",
-      "|black|carrot|  6| 60|\n",
-      "|  red|banana|  7| 70|\n",
-      "|  red| grape|  8| 80|\n",
-      "+-----+------+---+---+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
     "df = spark.createDataFrame([\n",
-    "    ['red', 'banana', 1, 10], ['blue', 'banana', 2, 20], ['red', 'carrot', 3, 30],\n",
-    "    ['blue', 'grape', 4, 40], ['red', 'carrot', 5, 50], ['black', 'carrot', 6, 60],\n",
-    "    ['red', 'banana', 7, 70], ['red', 'grape', 8, 80]], schema=['color', 'fruit', 'v1', 'v2'])\n",
+    "    Row(a=1, b=2., c='string1', d=date(2000, 1, 1), e=datetime(2000, 1, 1, 12, 0)),\n",
+    "    Row(a=2, b=3., c='string2', d=date(2000, 2, 1), e=datetime(2000, 1, 2, 12, 0)),\n",
+    "    Row(a=4, b=5., c='string3', d=date(2000, 3, 1), e=datetime(2000, 1, 3, 12, 0))\n",
+    "])\n",
     "df.show()"
    ]
   },
@@ -767,328 +85,115 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Grouping and then applying the `avg()` function to the resulting groups."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+-----+-------+-------+\n",
-      "|color|avg(v1)|avg(v2)|\n",
-      "+-----+-------+-------+\n",
-      "|  red|    4.8|   48.0|\n",
-      "| blue|    3.0|   30.0|\n",
-      "|black|    6.0|   60.0|\n",
-      "+-----+-------+-------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.groupby('color').avg().show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**[NOT SUPPORTED YET]** You can also apply a Python native function against each group by using pandas API.\n",
+    "## Create a table from Spark DataFrame (Server)\n",
     "\n",
-    "This is **NOT** supported with Spark Connect yet. If you want to use [applyInPandas](file:///Users/haejoon.lee/Desktop/git_store/spark/python/docs/build/html/reference/pyspark.sql/api/pyspark.sql.GroupedData.applyInPandas.html?highlight=applyinpandas#pyspark.sql.GroupedData.applyInPandas), use plain PySpark DataFrame instead of DataFrame with Spark Connect."
+    "After creating a DataFrame, then let's create a table 'spark_connect_test_table' from the DataFrame."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# def plus_mean(pandas_df):\n",
-    "#     return pandas_df.assign(v1=pandas_df.v1 - pandas_df.v1.mean())\n",
-    "\n",
-    "# df.groupby('color').applyInPandas(plus_mean, schema=df.schema).show()"
+    "df.write.saveAsTable(\"spark_connect_test_table\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**[NOT SUPPORTED YET]** Co-grouping and applying a function.\n",
+    "## Create Remote Session (Client)\n",
     "\n",
-    "This is **NOT** supported with Spark Connect yet. If you want to use [applyInPandas](file:///Users/haejoon.lee/Desktop/git_store/spark/python/docs/build/html/reference/pyspark.sql/api/pyspark.sql.GroupedData.applyInPandas.html?highlight=applyinpandas#pyspark.sql.GroupedData.applyInPandas), use plain PySpark DataFrame instead of DataFrame with Spark Connect."
+    "Now, we're ready to connect from client to server. **Note** that the Spark application on the server must be running.\n",
+    "\n",
+    "As we did in the server, the client must also create a remote session to communicate with the server as below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# df1 = spark.createDataFrame(\n",
-    "#     [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],\n",
-    "#     ('time', 'id', 'v1'))\n",
+    "from pyspark.sql import SparkSession\n",
     "\n",
-    "# df2 = spark.createDataFrame(\n",
-    "#     [(20000101, 1, 'x'), (20000101, 2, 'y')],\n",
-    "#     ('time', 'id', 'v2'))\n",
-    "\n",
-    "# def merge_ordered(l, r):\n",
-    "#     return pd.merge_ordered(l, r)\n",
-    "\n",
-    "# df1.groupby('id').cogroup(df2.groupby('id')).applyInPandas(\n",
-    "#     merge_ordered, schema='time int, id int, v1 double, v2 string').show()"
+    "spark = SparkSession.builder.getOrCreate()\n",
+    "# spark = SparkSession.builder.remote(\"local[*]\").getOrCreate()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Getting Data In/Out\n",
+    "## Create DataFrame by using table created from server (Client)\n",
     "\n",
-    "CSV is straightforward and easy to use. Parquet and ORC are efficient and compact file formats to read and write faster.\n",
+    "Now, communication between client and server is possible through the created remote session.\n",
     "\n",
-    "There are many other data sources available in PySpark such as JDBC, text, binaryFile, Avro, etc. See also the latest [Spark SQL, DataFrames and Datasets Guide](https://spark.apache.org/docs/latest/sql-programming-guide.html) in Apache Spark documentation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### CSV"
+    "Let's create a DataFrame on the client side by using a remote session to load a table created on the server."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+-----+------+---+---+\n",
-      "|color| fruit| v1| v2|\n",
-      "+-----+------+---+---+\n",
-      "|black|carrot|  6| 60|\n",
-      "| blue|banana|  2| 20|\n",
-      "| blue| grape|  4| 40|\n",
-      "|  red|banana|  7| 70|\n",
-      "|  red|carrot|  3| 30|\n",
-      "|  red|carrot|  5| 50|\n",
-      "|  red|banana|  1| 10|\n",
-      "|  red| grape|  8| 80|\n",
-      "+-----+------+---+---+\n",
+      "+---+---+-------+----------+-------------------+\n",
+      "|  a|  b|      c|         d|                  e|\n",
+      "+---+---+-------+----------+-------------------+\n",
+      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|\n",
+      "|  4|5.0|string3|2000-03-01|2000-01-03 12:00:00|\n",
+      "|  2|3.0|string2|2000-02-01|2000-01-02 12:00:00|\n",
+      "+---+---+-------+----------+-------------------+\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "df.write.csv('foo.csv', header=True)\n",
-    "spark.read.csv('foo.csv', header=True).show()"
+    "df = spark.read.table(\"spark_connect_test_table\")\n",
+    "df.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Parquet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "23/02/20 14:23:05 WARN MemoryManager: Total allocation exceeds 95.00% (1,020,054,720 bytes) of heap memory\n",
-      "Scaling row group sizes to 95.00% for 8 writers\n",
-      "23/02/20 14:23:05 WARN MemoryManager: Total allocation exceeds 95.00% (1,020,054,720 bytes) of heap memory\n",
-      "Scaling row group sizes to 84.44% for 9 writers\n",
-      "23/02/20 14:23:05 WARN MemoryManager: Total allocation exceeds 95.00% (1,020,054,720 bytes) of heap memory\n",
-      "Scaling row group sizes to 95.00% for 8 writers\n",
-      "+-----+------+---+---+\n",
-      "|color| fruit| v1| v2|\n",
-      "+-----+------+---+---+\n",
-      "|black|carrot|  6| 60|\n",
-      "| blue|banana|  2| 20|\n",
-      "| blue| grape|  4| 40|\n",
-      "|  red|banana|  7| 70|\n",
-      "|  red|carrot|  5| 50|\n",
-      "|  red|banana|  1| 10|\n",
-      "|  red|carrot|  3| 30|\n",
-      "|  red| grape|  8| 80|\n",
-      "+-----+------+---+---+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.write.parquet('bar.parquet')\n",
-    "spark.read.parquet('bar.parquet').show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### ORC"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+-----+------+---+---+\n",
-      "|color| fruit| v1| v2|\n",
-      "+-----+------+---+---+\n",
-      "|  red|banana|  7| 70|\n",
-      "|  red| grape|  8| 80|\n",
-      "|black|carrot|  6| 60|\n",
-      "| blue|banana|  2| 20|\n",
-      "|  red|carrot|  5| 50|\n",
-      "|  red|banana|  1| 10|\n",
-      "| blue| grape|  4| 40|\n",
-      "|  red|carrot|  3| 30|\n",
-      "+-----+------+---+---+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df.write.orc('zoo.orc')\n",
-    "spark.read.orc('zoo.orc').show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Working with SQL\n",
+    "By using Python built-in functions `type`, we can verify whether the currently created DataFrame is created through a Spark Connect.\n",
     "\n",
-    "DataFrame and Spark SQL share the same execution engine so they can be interchangeably used seamlessly. For example, you can register the DataFrame as a table and run a SQL easily as below:"
+    "It should be `pyspark.sql.connect.dataframe.DataFrame` as below:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+--------+\n",
-      "|count(1)|\n",
-      "+--------+\n",
-      "|       8|\n",
-      "+--------+\n",
-      "\n"
-     ]
+     "data": {
+      "text/plain": [
+       "pyspark.sql.connect.dataframe.DataFrame"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.createOrReplaceTempView(\"tableA\")\n",
-    "spark.sql(\"SELECT count(*) from tableA\").show()"
+    "type(df)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition, UDFs can be registered and invoked in SQL out of the box:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+-----------+\n",
-      "|add_one(v1)|\n",
-      "+-----------+\n",
-      "|          2|\n",
-      "|          3|\n",
-      "|          4|\n",
-      "|          5|\n",
-      "|          6|\n",
-      "|          7|\n",
-      "|          8|\n",
-      "|          9|\n",
-      "+-----------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "@pandas_udf(\"integer\")\n",
-    "def add_one(s: pd.Series) -> pd.Series:\n",
-    "    return s + 1\n",
+    "**Note** that a DataFrame with Spark Connect is virtually, conceptually identical to an existing [PySpark DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame), so most of the examples from 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) can be reused directly.\n",
     "\n",
-    "spark.udf.register(\"add_one\", add_one)\n",
-    "spark.sql(\"SELECT add_one(v1) FROM tableA\").show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "These SQL expressions can directly be mixed and used as PySpark columns."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+-----------+\n",
-      "|add_one(v1)|\n",
-      "+-----------+\n",
-      "|          2|\n",
-      "|          3|\n",
-      "|          4|\n",
-      "|          5|\n",
-      "|          6|\n",
-      "|          7|\n",
-      "|          8|\n",
-      "|          9|\n",
-      "+-----------+\n",
-      "\n",
-      "+--------------+\n",
-      "|(count(1) > 0)|\n",
-      "+--------------+\n",
-      "|          true|\n",
-      "+--------------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "from pyspark.sql.functions import expr\n",
-    "\n",
-    "df.selectExpr('add_one(v1)').show()\n",
-    "df.select(expr('count(*)') > 0).show()"
+    "However, note that it does not yet support some key features such as [RDD](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.RDD.html?highlight=rdd#pyspark.RDD) and [SparkSession.conf](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.conf.html#pyspark.sql.SparkSession.conf), so you need to consider it when using Spark Connect."
    ]
   }
  ],

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -1,0 +1,1118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quickstart: DataFrame with Spark Connect\n",
+    "\n",
+    "This is a short introduction and quickstart for the DataFrame with Spark Connect. A DataFrame with Spark Connect is virtually, conceptually identical to an existing [PySpark DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame), so most of the examples from 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) can be reused directly.\n",
+    "\n",
+    "However, it does not yet support some key features such as [RDD](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.RDD.html?highlight=rdd#pyspark.RDD) and [SparkSession.conf](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.conf.html#pyspark.sql.SparkSession.conf), so you need to consider it when using DataFrame with Spark Connect.\n",
+    "\n",
+    "This notebook shows the basic usages of the DataFrame with Spark Connect geared mainly for those new to Spark Connect, along with comments of which features is not supported compare to the existing DataFrame.\n",
+    "\n",
+    "There is also other useful information in Apache Spark documentation site, see the latest version of [Spark SQL and DataFrames](https://spark.apache.org/docs/latest/sql-programming-guide.html).\n",
+    "\n",
+    "PySpark applications start with initializing `SparkSession` which is the entry point of PySpark as below. In case of running it in PySpark shell via <code>pyspark</code> executable, the shell automatically creates the session in the variable <code>spark</code> for users."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Spark Connect uses SparkSession from `pyspark.sql.connect.session` instead of `pyspark.sql.SparkSession`.\n",
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "spark = SparkSession.builder.getOrCreate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DataFrame Creation\n",
+    "\n",
+    "A PySpark DataFrame with Spark Connect can be created via `pyspark.sql.connect.session.SparkSession.createDataFrame` typically by passing a list of lists, tuples, dictionaries and `pyspark.sql.Row`s, a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) and an RDD consisting of such a list.\n",
+    "`pyspark.sql.connect.session.SparkSession.createDataFrame` takes the `schema` argument to specify the schema of the DataFrame. When it is omitted, PySpark infers the corresponding schema by taking a sample from the data.\n",
+    "\n",
+    "Firstly, you can create a PySpark DataFrame from a list of rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[a: bigint, b: double, c: string, d: date, e: timestamp]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from datetime import datetime, date\n",
+    "import pandas as pd\n",
+    "from pyspark.sql import Row\n",
+    "\n",
+    "df = spark.createDataFrame([\n",
+    "    Row(a=1, b=2., c='string1', d=date(2000, 1, 1), e=datetime(2000, 1, 1, 12, 0)),\n",
+    "    Row(a=2, b=3., c='string2', d=date(2000, 2, 1), e=datetime(2000, 1, 2, 12, 0)),\n",
+    "    Row(a=4, b=5., c='string3', d=date(2000, 3, 1), e=datetime(2000, 1, 3, 12, 0))\n",
+    "])\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a PySpark DataFrame with an explicit schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[a: bigint, b: double, c: string, d: date, e: timestamp]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = spark.createDataFrame([\n",
+    "    (1, 2., 'string1', date(2000, 1, 1), datetime(2000, 1, 1, 12, 0)),\n",
+    "    (2, 3., 'string2', date(2000, 2, 1), datetime(2000, 1, 2, 12, 0)),\n",
+    "    (3, 4., 'string3', date(2000, 3, 1), datetime(2000, 1, 3, 12, 0))\n",
+    "], schema='a long, b double, c string, d date, e timestamp')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a PySpark DataFrame from a pandas DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[a: bigint, b: double, c: string, d: date, e: timestamp]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pandas_df = pd.DataFrame({\n",
+    "    'a': [1, 2, 3],\n",
+    "    'b': [2., 3., 4.],\n",
+    "    'c': ['string1', 'string2', 'string3'],\n",
+    "    'd': [date(2000, 1, 1), date(2000, 2, 1), date(2000, 3, 1)],\n",
+    "    'e': [datetime(2000, 1, 1, 12, 0), datetime(2000, 1, 2, 12, 0), datetime(2000, 1, 3, 12, 0)]\n",
+    "})\n",
+    "df = spark.createDataFrame(pandas_df)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**[NOT SUPPORTED YET]** Create a PySpark DataFrame from an RDD consisting of a list of tuples.\n",
+    "\n",
+    "This is **NOT** supported with Spark Connect yet. If you want to use [SparkContext](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.SparkContext.html?highlight=sparkcontext#pyspark.SparkContext), use plain PySpark DataFrame instead of DataFrame with Spark Connect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rdd = spark.sparkContext.parallelize([\n",
+    "#     (1, 2., 'string1', date(2000, 1, 1), datetime(2000, 1, 1, 12, 0)),\n",
+    "#     (2, 3., 'string2', date(2000, 2, 1), datetime(2000, 1, 2, 12, 0)),\n",
+    "#     (3, 4., 'string3', date(2000, 3, 1), datetime(2000, 1, 3, 12, 0))\n",
+    "# ])\n",
+    "# df = spark.createDataFrame(rdd, schema=['a', 'b', 'c', 'd', 'e'])\n",
+    "# df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The DataFrames created above all have the same results and schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+---+-------+----------+-------------------+\n",
+      "|  a|  b|      c|         d|                  e|\n",
+      "+---+---+-------+----------+-------------------+\n",
+      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|\n",
+      "|  2|3.0|string2|2000-02-01|2000-01-02 12:00:00|\n",
+      "|  3|4.0|string3|2000-03-01|2000-01-03 12:00:00|\n",
+      "+---+---+-------+----------+-------------------+\n",
+      "\n",
+      "root\n",
+      " |-- a: long (nullable = true)\n",
+      " |-- b: double (nullable = true)\n",
+      " |-- c: string (nullable = true)\n",
+      " |-- d: date (nullable = true)\n",
+      " |-- e: timestamp (nullable = true)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# All DataFrames above result same.\n",
+    "df.show()\n",
+    "df.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Viewing Data\n",
+    "\n",
+    "The top rows of a DataFrame can be displayed using `DataFrame.show()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+---+-------+----------+-------------------+\n",
+      "|  a|  b|      c|         d|                  e|\n",
+      "+---+---+-------+----------+-------------------+\n",
+      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|\n",
+      "+---+---+-------+----------+-------------------+\n",
+      "only showing top 1 row\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.show(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**[NOT SUPPORTED YET]** Alternatively, you can enable `spark.sql.repl.eagerEval.enabled` configuration for the eager evaluation of PySpark DataFrame in notebooks such as Jupyter. The number of rows to show can be controlled via `spark.sql.repl.eagerEval.maxNumRows` configuration.\n",
+    "\n",
+    "This is **NOT** supported with Spark Connect yet. If you want to set various [Spark Configuration](https://spark.apache.org/docs/latest/configuration.html), use plain PySpark DataFrame instead of DataFrame with Spark Connect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# spark.conf.set('spark.sql.repl.eagerEval.enabled', True)\n",
+    "# df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The rows can also be shown vertically. This is useful when rows are too long to show horizontally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-RECORD 0------------------\n",
+      " a   | 1                   \n",
+      " b   | 2.0                 \n",
+      " c   | string1             \n",
+      " d   | 2000-01-01          \n",
+      " e   | 2000-01-01 12:00:00 \n",
+      "only showing top 1 row\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.show(1, vertical=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see the DataFrame's schema and column names as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['a', 'b', 'c', 'd', 'e']"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- a: long (nullable = true)\n",
+      " |-- b: double (nullable = true)\n",
+      " |-- c: string (nullable = true)\n",
+      " |-- d: date (nullable = true)\n",
+      " |-- e: timestamp (nullable = true)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the summary of the DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-------+---+---+-------+\n",
+      "|summary|  a|  b|      c|\n",
+      "+-------+---+---+-------+\n",
+      "|  count|  3|  3|      3|\n",
+      "|   mean|2.0|3.0|   null|\n",
+      "| stddev|1.0|1.0|   null|\n",
+      "|    min|  1|2.0|string1|\n",
+      "|    max|  3|4.0|string3|\n",
+      "+-------+---+---+-------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.select(\"a\", \"b\", \"c\").describe().show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`DataFrame.collect()` collects the distributed data to the driver side as the local data in Python. Note that this can throw an out-of-memory error when the dataset is too large to fit in the driver side because it collects all the data from executors to the driver side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Row(a=1, b=2.0, c='string1', d=datetime.date(2000, 1, 1), e=datetime.datetime(2000, 1, 1, 12, 0)),\n",
+       " Row(a=2, b=3.0, c='string2', d=datetime.date(2000, 2, 1), e=datetime.datetime(2000, 1, 2, 12, 0)),\n",
+       " Row(a=3, b=4.0, c='string3', d=datetime.date(2000, 3, 1), e=datetime.datetime(2000, 1, 3, 12, 0))]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.collect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to avoid throwing an out-of-memory exception, use `DataFrame.take()` or `DataFrame.tail()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Row(a=1, b=2.0, c='string1', d=datetime.date(2000, 1, 1), e=datetime.datetime(2000, 1, 1, 12, 0))]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.take(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PySpark DataFrame also provides the conversion back to a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) to leverage pandas API. Note that `toPandas` also collects all data into the driver side that can easily cause an out-of-memory-error when the data is too large to fit into the driver side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "      <th>c</th>\n",
+       "      <th>d</th>\n",
+       "      <th>e</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>string1</td>\n",
+       "      <td>2000-01-01</td>\n",
+       "      <td>2000-01-01 12:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>string2</td>\n",
+       "      <td>2000-02-01</td>\n",
+       "      <td>2000-01-02 12:00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>string3</td>\n",
+       "      <td>2000-03-01</td>\n",
+       "      <td>2000-01-03 12:00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   a    b        c           d                   e\n",
+       "0  1  2.0  string1  2000-01-01 2000-01-01 12:00:00\n",
+       "1  2  3.0  string2  2000-02-01 2000-01-02 12:00:00\n",
+       "2  3  4.0  string3  2000-03-01 2000-01-03 12:00:00"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.toPandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Selecting and Accessing Data\n",
+    "\n",
+    "PySpark DataFrame is lazily evaluated and simply selecting a column does not trigger the computation but it returns a `Column` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Column<'a'>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.a"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In fact, most of column-wise operations return `Column`s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyspark.sql import Column\n",
+    "from pyspark.sql.functions import upper\n",
+    "\n",
+    "type(df.c) == type(upper(df.c)) == type(df.c.isNull())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These `Column`s can be used to select the columns from a DataFrame. For example, `DataFrame.select()` takes the `Column` instances that returns another DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-------+\n",
+      "|      c|\n",
+      "+-------+\n",
+      "|string1|\n",
+      "|string2|\n",
+      "|string3|\n",
+      "+-------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.select(df.c).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Assign new `Column` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+---+-------+----------+-------------------+-------+\n",
+      "|  a|  b|      c|         d|                  e|upper_c|\n",
+      "+---+---+-------+----------+-------------------+-------+\n",
+      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|STRING1|\n",
+      "|  2|3.0|string2|2000-02-01|2000-01-02 12:00:00|STRING2|\n",
+      "|  3|4.0|string3|2000-03-01|2000-01-03 12:00:00|STRING3|\n",
+      "+---+---+-------+----------+-------------------+-------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.withColumn('upper_c', upper(df.c)).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To select a subset of rows, use `DataFrame.filter()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+---+-------+----------+-------------------+\n",
+      "|  a|  b|      c|         d|                  e|\n",
+      "+---+---+-------+----------+-------------------+\n",
+      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|\n",
+      "+---+---+-------+----------+-------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.filter(df.a == 1).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Applying a Function\n",
+    "\n",
+    "PySpark supports various UDFs and APIs to allow users to execute Python native functions. See also the latest [Pandas UDFs](https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html#pandas-udfs-aka-vectorized-udfs) and [Pandas Function APIs](https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html#pandas-function-apis). For instance, the example below allows users to directly use the APIs in [a pandas Series](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.html) within Python native function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------------------+\n",
+      "|pandas_plus_one(a)|\n",
+      "+------------------+\n",
+      "|                 2|\n",
+      "|                 3|\n",
+      "|                 4|\n",
+      "+------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from pyspark.sql.functions import pandas_udf\n",
+    "\n",
+    "@pandas_udf('long')\n",
+    "def pandas_plus_one(series: pd.Series) -> pd.Series:\n",
+    "    # Simply plus one by using pandas Series.\n",
+    "    return series + 1\n",
+    "\n",
+    "df.select(pandas_plus_one(df.a)).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**[NOT SUPPORTED YET]** Another example is [mapInPandas](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.mapInPandas.html?highlight=mapinpandas#pyspark.sql.DataFrame.mapInPandas) which allows users directly use the APIs in a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) without any restrictions such as the result length.\n",
+    "\n",
+    "This is **NOT** supported with Spark Connect yet. If you want to use `mapInPandas`, use plain PySpark DataFrame instead of DataFrame with Spark Connect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# def pandas_filter_func(iterator):\n",
+    "#     for pandas_df in iterator:\n",
+    "#         yield pandas_df[pandas_df.a == 1]\n",
+    "\n",
+    "# df.mapInPandas(pandas_filter_func, schema=df.schema).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Grouping Data\n",
+    "\n",
+    "PySpark DataFrame also provides a way of handling grouped data by using the common approach, split-apply-combine strategy.\n",
+    "It groups the data by a certain condition applies a function to each group and then combines them back to the DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----+------+---+---+\n",
+      "|color| fruit| v1| v2|\n",
+      "+-----+------+---+---+\n",
+      "|  red|banana|  1| 10|\n",
+      "| blue|banana|  2| 20|\n",
+      "|  red|carrot|  3| 30|\n",
+      "| blue| grape|  4| 40|\n",
+      "|  red|carrot|  5| 50|\n",
+      "|black|carrot|  6| 60|\n",
+      "|  red|banana|  7| 70|\n",
+      "|  red| grape|  8| 80|\n",
+      "+-----+------+---+---+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = spark.createDataFrame([\n",
+    "    ['red', 'banana', 1, 10], ['blue', 'banana', 2, 20], ['red', 'carrot', 3, 30],\n",
+    "    ['blue', 'grape', 4, 40], ['red', 'carrot', 5, 50], ['black', 'carrot', 6, 60],\n",
+    "    ['red', 'banana', 7, 70], ['red', 'grape', 8, 80]], schema=['color', 'fruit', 'v1', 'v2'])\n",
+    "df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Grouping and then applying the `avg()` function to the resulting groups."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----+-------+-------+\n",
+      "|color|avg(v1)|avg(v2)|\n",
+      "+-----+-------+-------+\n",
+      "|  red|    4.8|   48.0|\n",
+      "| blue|    3.0|   30.0|\n",
+      "|black|    6.0|   60.0|\n",
+      "+-----+-------+-------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.groupby('color').avg().show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**[NOT SUPPORTED YET]** You can also apply a Python native function against each group by using pandas API.\n",
+    "\n",
+    "This is **NOT** supported with Spark Connect yet. If you want to use [applyInPandas](file:///Users/haejoon.lee/Desktop/git_store/spark/python/docs/build/html/reference/pyspark.sql/api/pyspark.sql.GroupedData.applyInPandas.html?highlight=applyinpandas#pyspark.sql.GroupedData.applyInPandas), use plain PySpark DataFrame instead of DataFrame with Spark Connect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# def plus_mean(pandas_df):\n",
+    "#     return pandas_df.assign(v1=pandas_df.v1 - pandas_df.v1.mean())\n",
+    "\n",
+    "# df.groupby('color').applyInPandas(plus_mean, schema=df.schema).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**[NOT SUPPORTED YET]** Co-grouping and applying a function.\n",
+    "\n",
+    "This is **NOT** supported with Spark Connect yet. If you want to use [applyInPandas](file:///Users/haejoon.lee/Desktop/git_store/spark/python/docs/build/html/reference/pyspark.sql/api/pyspark.sql.GroupedData.applyInPandas.html?highlight=applyinpandas#pyspark.sql.GroupedData.applyInPandas), use plain PySpark DataFrame instead of DataFrame with Spark Connect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df1 = spark.createDataFrame(\n",
+    "#     [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],\n",
+    "#     ('time', 'id', 'v1'))\n",
+    "\n",
+    "# df2 = spark.createDataFrame(\n",
+    "#     [(20000101, 1, 'x'), (20000101, 2, 'y')],\n",
+    "#     ('time', 'id', 'v2'))\n",
+    "\n",
+    "# def merge_ordered(l, r):\n",
+    "#     return pd.merge_ordered(l, r)\n",
+    "\n",
+    "# df1.groupby('id').cogroup(df2.groupby('id')).applyInPandas(\n",
+    "#     merge_ordered, schema='time int, id int, v1 double, v2 string').show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Data In/Out\n",
+    "\n",
+    "CSV is straightforward and easy to use. Parquet and ORC are efficient and compact file formats to read and write faster.\n",
+    "\n",
+    "There are many other data sources available in PySpark such as JDBC, text, binaryFile, Avro, etc. See also the latest [Spark SQL, DataFrames and Datasets Guide](https://spark.apache.org/docs/latest/sql-programming-guide.html) in Apache Spark documentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CSV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----+------+---+---+\n",
+      "|color| fruit| v1| v2|\n",
+      "+-----+------+---+---+\n",
+      "|black|carrot|  6| 60|\n",
+      "| blue|banana|  2| 20|\n",
+      "| blue| grape|  4| 40|\n",
+      "|  red|banana|  7| 70|\n",
+      "|  red|carrot|  3| 30|\n",
+      "|  red|carrot|  5| 50|\n",
+      "|  red|banana|  1| 10|\n",
+      "|  red| grape|  8| 80|\n",
+      "+-----+------+---+---+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.write.csv('foo.csv', header=True)\n",
+    "spark.read.csv('foo.csv', header=True).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parquet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "23/02/20 14:23:05 WARN MemoryManager: Total allocation exceeds 95.00% (1,020,054,720 bytes) of heap memory\n",
+      "Scaling row group sizes to 95.00% for 8 writers\n",
+      "23/02/20 14:23:05 WARN MemoryManager: Total allocation exceeds 95.00% (1,020,054,720 bytes) of heap memory\n",
+      "Scaling row group sizes to 84.44% for 9 writers\n",
+      "23/02/20 14:23:05 WARN MemoryManager: Total allocation exceeds 95.00% (1,020,054,720 bytes) of heap memory\n",
+      "Scaling row group sizes to 95.00% for 8 writers\n",
+      "+-----+------+---+---+\n",
+      "|color| fruit| v1| v2|\n",
+      "+-----+------+---+---+\n",
+      "|black|carrot|  6| 60|\n",
+      "| blue|banana|  2| 20|\n",
+      "| blue| grape|  4| 40|\n",
+      "|  red|banana|  7| 70|\n",
+      "|  red|carrot|  5| 50|\n",
+      "|  red|banana|  1| 10|\n",
+      "|  red|carrot|  3| 30|\n",
+      "|  red| grape|  8| 80|\n",
+      "+-----+------+---+---+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.write.parquet('bar.parquet')\n",
+    "spark.read.parquet('bar.parquet').show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ORC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----+------+---+---+\n",
+      "|color| fruit| v1| v2|\n",
+      "+-----+------+---+---+\n",
+      "|  red|banana|  7| 70|\n",
+      "|  red| grape|  8| 80|\n",
+      "|black|carrot|  6| 60|\n",
+      "| blue|banana|  2| 20|\n",
+      "|  red|carrot|  5| 50|\n",
+      "|  red|banana|  1| 10|\n",
+      "| blue| grape|  4| 40|\n",
+      "|  red|carrot|  3| 30|\n",
+      "+-----+------+---+---+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.write.orc('zoo.orc')\n",
+    "spark.read.orc('zoo.orc').show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with SQL\n",
+    "\n",
+    "DataFrame and Spark SQL share the same execution engine so they can be interchangeably used seamlessly. For example, you can register the DataFrame as a table and run a SQL easily as below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+--------+\n",
+      "|count(1)|\n",
+      "+--------+\n",
+      "|       8|\n",
+      "+--------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.createOrReplaceTempView(\"tableA\")\n",
+    "spark.sql(\"SELECT count(*) from tableA\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, UDFs can be registered and invoked in SQL out of the box:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+\n",
+      "|add_one(v1)|\n",
+      "+-----------+\n",
+      "|          2|\n",
+      "|          3|\n",
+      "|          4|\n",
+      "|          5|\n",
+      "|          6|\n",
+      "|          7|\n",
+      "|          8|\n",
+      "|          9|\n",
+      "+-----------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "@pandas_udf(\"integer\")\n",
+    "def add_one(s: pd.Series) -> pd.Series:\n",
+    "    return s + 1\n",
+    "\n",
+    "spark.udf.register(\"add_one\", add_one)\n",
+    "spark.sql(\"SELECT add_one(v1) FROM tableA\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These SQL expressions can directly be mixed and used as PySpark columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+\n",
+      "|add_one(v1)|\n",
+      "+-----------+\n",
+      "|          2|\n",
+      "|          3|\n",
+      "|          4|\n",
+      "|          5|\n",
+      "|          6|\n",
+      "|          7|\n",
+      "|          8|\n",
+      "|          9|\n",
+      "+-----------+\n",
+      "\n",
+      "+--------------+\n",
+      "|(count(1) > 0)|\n",
+      "+--------------+\n",
+      "|          true|\n",
+      "+--------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql.functions import expr\n",
+    "\n",
+    "df.selectExpr('add_one(v1)').show()\n",
+    "df.select(expr('count(*)') > 0).show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.11"
+  },
+  "name": "quickstart",
+  "notebookId": 1927513300154480
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Spark Connect introduced a decoupled client-server architecture for Spark that allows remote connectivity to Spark clusters using the [DataFrame API](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame).\n",
     "\n",
-    "This notebook walks through a simple step-by-step example of how to use Spark Connect to build any type of application that needs to leverage the power of data with Spark.\n",
+    "This notebook walks through a simple step-by-step example of how to use Spark Connect to build any type of application that needs to leverage the power of Spark when working with data.\n",
     "\n",
     "Spark Connect includes both client and server components and we will show you how to set up and use both."
    ]

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -36,8 +36,7 @@
    "source": [
     "from pyspark.sql import SparkSession\n",
     "\n",
-    "spark = SparkSession.builder.getOrCreate()\n",
-    "# spark = SparkSession.builder.remote(\"local[*]\").getOrCreate()"
+    "spark = SparkSession.builder.remote(\"local[*]\").getOrCreate()"
    ]
   },
   {
@@ -118,8 +117,7 @@
    "source": [
     "from pyspark.sql import SparkSession\n",
     "\n",
-    "spark = SparkSession.builder.getOrCreate()\n",
-    "# spark = SparkSession.builder.remote(\"local[*]\").getOrCreate()"
+    "spark = SparkSession.builder.remote(\"local[*]\").getOrCreate()"
    ]
   },
   {

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -6,26 +6,16 @@
    "source": [
     "# Quickstart: Spark Connect\n",
     "\n",
-    "This is a short introduction and quickstart for Spark Connect.\n",
-    "\n",
-    "Spark Connect consists of two parts: server and client.\n",
-    "\n",
-    "This notebook demonstrates a simple step-by-step example of how it works on the sever and on the client for those new to Spark Connect."
+    "This is a short introduction and quickstart for Spark Connect. Spark Connect consists of server and client. This notebook demonstrates a simple step-by-step example of how it works on the server and on the client for new commers to Spark Connect."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create Remote Session (Server)\n",
+    "## Launch Spark Connect server\n",
     "\n",
-    "First of all, run the PySpark applications on the sever side.\n",
-    "\n",
-    "PySpark application start with initializing `SparkSession` which is the entry point of PySpark.\n",
-    "\n",
-    "**Note** that the [SparkSession.Builder.remote](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.builder.remote.html#pyspark.sql.SparkSession.builder.remote) must be specified if you want to make the session to be remote `SparkSession`, which is used for Spark Conenct.\n",
-    "\n",
-    "In case of running it in PySpark shell via `pyspark` executable with `--remote` option, the shell automatically creates the remote SparkSession in the variable spark for users."
+    "Launching server can be done by running `start-connect-server.sh` script as below."
    ]
   },
   {
@@ -34,23 +24,59 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyspark.sql import SparkSession\n",
-    "\n",
-    "spark = SparkSession.builder.remote(\"local[*]\").getOrCreate()"
+    "!./sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.4.0"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create DataFrame (Server)\n",
+    "## Connect from client to server\n",
     "\n",
-    "Let's create a PySpark DataFrame by using remote session."
+    "Now the Spark Connect server is running, we can connect from client to server. Spark Connect server can be accessed via remote `SparkSession`. Before creating remote `SparkSession`, make sure to stop the existing regular `SparkSession` as below because the regular `SparkSession` and remote `SparkSession` cannot coexist."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "SparkSession.builder.getOrCreate().stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The command we used to run the server runs the Spark Connect server at `localhost:15002`. Therefore, we can create a remote `SparkSession` with the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "spark = SparkSession.builder.remote(\"sc://localhost:15002\").getOrCreate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create DataFrame\n",
+    "\n",
+    "Once the remote `SparkSession` is created successfully, it can be used the same as a regular `SparkSession`. Therefore, creating `DataFrame` can be done with the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -84,114 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create a table from Spark DataFrame (Server)\n",
-    "\n",
-    "After creating a DataFrame, then let's create a table 'spark_connect_test_table' from the DataFrame."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.write.saveAsTable(\"spark_connect_test_table\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create Remote Session (Client)\n",
-    "\n",
-    "Now, we're ready to connect from client to server. **Note** that the Spark application on the server must be running.\n",
-    "\n",
-    "As we did in the server, the client must also create a remote session to communicate with the server as below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pyspark.sql import SparkSession\n",
-    "\n",
-    "spark = SparkSession.builder.remote(\"local[*]\").getOrCreate()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create DataFrame by using table created from server (Client)\n",
-    "\n",
-    "Now, communication between client and server is possible through the created remote session.\n",
-    "\n",
-    "Let's create a DataFrame on the client side by using a remote session to load a table created on the server."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+---+---+-------+----------+-------------------+\n",
-      "|  a|  b|      c|         d|                  e|\n",
-      "+---+---+-------+----------+-------------------+\n",
-      "|  1|2.0|string1|2000-01-01|2000-01-01 12:00:00|\n",
-      "|  4|5.0|string3|2000-03-01|2000-01-03 12:00:00|\n",
-      "|  2|3.0|string2|2000-02-01|2000-01-02 12:00:00|\n",
-      "+---+---+-------+----------+-------------------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "df = spark.read.table(\"spark_connect_test_table\")\n",
-    "df.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "By using Python built-in functions `type`, we can verify whether the currently created DataFrame is created through a Spark Connect.\n",
-    "\n",
-    "It should be `pyspark.sql.connect.dataframe.DataFrame` as below:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "pyspark.sql.connect.dataframe.DataFrame"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "type(df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Note** that a DataFrame with Spark Connect is virtually, conceptually identical to an existing [PySpark DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame), so most of the examples from 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) can be reused directly.\n",
-    "\n",
-    "However, note that it does not yet support some key features such as [RDD](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.RDD.html?highlight=rdd#pyspark.RDD) and [SparkSession.conf](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.conf.html#pyspark.sql.SparkSession.conf), so you need to consider it when using Spark Connect."
+    "Most of the examples from 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) can be reused directly, because the usage of `DataFrame` on Spark Connect is the same as an existing [PySpark DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame)."
    ]
   }
  ],

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -24,7 +24,7 @@
    "outputs": [],
    "source": [
     "# Spark Connect uses SparkSession from `pyspark.sql.connect.session` instead of `pyspark.sql.SparkSession`.\n",
-    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql.connect.session import SparkSession\n",
     "\n",
     "spark = SparkSession.builder.getOrCreate()"
    ]

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "from pyspark.sql import SparkSession\n",
     "\n",
-    "SparkSession.builder.getOrCreate().stop()"
+    "SparkSession.builder.master(\"local[*]\").getOrCreate().stop()"
    ]
   },
   {

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -6,16 +6,20 @@
    "source": [
     "# Quickstart: Spark Connect\n",
     "\n",
-    "Spark Connect consists of server and client; this notebook demonstrates a simple step-by-step example of how it works on the server and on the client for new comers to Spark Connect."
+    "Spark Connect introduced a decoupled client-server architecture for Spark that allows remote connectivity to Spark clusters using the [DataFrame API](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame).\n",
+    "\n",
+    "This notebook walks through a simple step-by-step example of how to use Spark Connect to build any type of application that needs to leverage the power of data with Spark.\n",
+    "\n",
+    "Spark Connect includes both client and server components and we will show you how to set up and use both."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Launch Spark Connect server\n",
+    "## Launch Spark server with Spark Connect\n",
     "\n",
-    "Launching the server by `start-connect-server.sh` script. Proper Spark version should be specified for package name (e.g. `org.apache.spark:spark-connect_2.12:3.4.0`)."
+    "To launch Spark with support for Spark Connect sessions, run the `start-connect-server.sh` script."
    ]
   },
   {
@@ -33,7 +37,7 @@
    "source": [
     "## Connect to Spark Connect server\n",
     "\n",
-    "Now the Spark Connect server is running, we can connect to the server. Spark Connect server can be accessed via the client, remote `SparkSession` configured for the server. Before creating the remote `SparkSession`, make sure to stop the existing regular `SparkSession` as below because the regular `SparkSession` and remote `SparkSession` cannot coexist."
+    "Now that the Spark server is running, we can connect to it remotely using Spark Connect. We do this by creating a remote Spark session on the client where our application runs. Before we can do that, we need to make sure to stop the existing regular Spark session because it cannot coexist with the remote Spark Connect session we are about to create."
    ]
   },
   {
@@ -51,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The command we used to run the server runs the Spark Connect server at `localhost:15002`. Therefore, we can create a remote `SparkSession` with the following command."
+    "The command we used above to launch the server configured Spark to run as `localhost:15002`. So now we can create a remote Spark session on the client using the following command."
    ]
   },
   {
@@ -69,7 +73,7 @@
    "source": [
     "## Create DataFrame\n",
     "\n",
-    "Once the remote `SparkSession` is created successfully, it can be used the same as a regular `SparkSession`. Therefore, creating `DataFrame` can be done with the following command."
+    "Once the remote Spark session is created successfully, it can be used the same way as a regular Spark session. Therefore, you can create a DataFrame with the following command."
    ]
   },
   {
@@ -108,7 +112,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) for more detail usage of [PySpark DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame)."
+    "See 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) for more detail usage of DataFrame API."
    ]
   }
  ],

--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Quickstart: Spark Connect\n",
     "\n",
-    "This is a short introduction and quickstart for Spark Connect. Spark Connect consists of server and client. This notebook demonstrates a simple step-by-step example of how it works on the server and on the client for new commers to Spark Connect."
+    "Spark Connect consists of server and client; this notebook demonstrates a simple step-by-step example of how it works on the server and on the client for new comers to Spark Connect."
    ]
   },
   {
@@ -15,7 +15,7 @@
    "source": [
     "## Launch Spark Connect server\n",
     "\n",
-    "Launching server can be done by running `start-connect-server.sh` script as below."
+    "Launching the server by `start-connect-server.sh` script. Proper Spark version should be specified for package name (e.g. `org.apache.spark:spark-connect_2.12:3.4.0`)."
    ]
   },
   {
@@ -24,16 +24,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!./sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.4.0"
+    "!./sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:$SPARK_VERSION"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Connect from client to server\n",
+    "## Connect to Spark Connect server\n",
     "\n",
-    "Now the Spark Connect server is running, we can connect from client to server. Spark Connect server can be accessed via remote `SparkSession`. Before creating remote `SparkSession`, make sure to stop the existing regular `SparkSession` as below because the regular `SparkSession` and remote `SparkSession` cannot coexist."
+    "Now the Spark Connect server is running, we can connect to the server. Spark Connect server can be accessed via the client, remote `SparkSession` configured for the server. Before creating the remote `SparkSession`, make sure to stop the existing regular `SparkSession` as below because the regular `SparkSession` and remote `SparkSession` cannot coexist."
    ]
   },
   {
@@ -60,8 +60,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyspark.sql import SparkSession\n",
-    "\n",
     "spark = SparkSession.builder.remote(\"sc://localhost:15002\").getOrCreate()"
    ]
   },
@@ -110,7 +108,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most of the examples from 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) can be reused directly, because the usage of `DataFrame` on Spark Connect is the same as an existing [PySpark DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame)."
+    "See 'Live Notebook: DataFrame' at [the quickstart page](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) for more detail usage of [PySpark DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame)."
    ]
   }
  ],

--- a/python/docs/source/getting_started/quickstart_df.ipynb
+++ b/python/docs/source/getting_started/quickstart_df.ipynb
@@ -137,39 +137,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a PySpark DataFrame from an RDD consisting of a list of tuples."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DataFrame[a: bigint, b: double, c: string, d: date, e: timestamp]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "rdd = spark.sparkContext.parallelize([\n",
-    "    (1, 2., 'string1', date(2000, 1, 1), datetime(2000, 1, 1, 12, 0)),\n",
-    "    (2, 3., 'string2', date(2000, 2, 1), datetime(2000, 1, 2, 12, 0)),\n",
-    "    (3, 4., 'string3', date(2000, 3, 1), datetime(2000, 1, 3, 12, 0))\n",
-    "])\n",
-    "df = spark.createDataFrame(rdd, schema=['a', 'b', 'c', 'd', 'e'])\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The DataFrames created above all have the same results and schema."
    ]
   },


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add "Live Notebook: DataFrame with Spark Connect" at [Getting Started](https://spark.apache.org/docs/latest/api/python/getting_started/index.html) documents as below:

<img width="794" alt="Screen Shot 2023-02-23 at 1 15 41 PM" src="https://user-images.githubusercontent.com/44108233/220820191-ca0e5705-1694-4eaa-8658-67d522af1bf8.png">


Basically, the notebook copied the contents of 'Live Notebook: DataFrame', and updated the contents related to Spark Connect.

The Notebook looks like the below:

<img width="814" alt="Screen Shot 2023-02-23 at 1 15 54 PM" src="https://user-images.githubusercontent.com/44108233/220820218-bbfb6a58-7009-4327-aea4-72ed6496d77c.png">


### Why are the changes needed?

To help quick start using DataFrame with Spark Connect for those who new to Spark Connect.


### Does this PR introduce _any_ user-facing change?

No, it's documentation.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually built the docs, and run the CI.
