### PR TITLE
[SPARK-XXX][SQL][TESTS] Reduce the degree of concurrency during ORC schema merge conflict tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -443,7 +443,8 @@ abstract class OrcSuite
         .write.orc(new Path(basePath, "foo=2").toString)
 
       // with schema merging, there should throw exception
-      withSQLConf(SQLConf.ORC_SCHEMA_MERGING_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.ORC_SCHEMA_MERGING_ENABLED.key -> "true",
+        "spark.default.parallelism" -> "1") {
         val exception = intercept[SparkException] {
           spark.read.orc(basePath).columns.length
         }.getCause


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce the degree of concurrency during ORC schema merging testing.

### Why are the changes needed?

#40049 seems to expose a few flaky tests in `branch-3.4` CI . Note that `master` branch looks fine.
- https://github.com/apache/spark/runs/11463120795
- https://github.com/apache/spark/runs/11463886897
- https://github.com/apache/spark/runs/11467827738
- https://github.com/apache/spark/runs/11471484144
- https://github.com/apache/spark/runs/11471507531
- https://github.com/apache/spark/runs/11474764316

![Screenshot 2023-02-20 at 12 30 19 PM](https://user-images.githubusercontent.com/9700541/220193503-6d6ce2ce-3fd6-4b01-b91c-bc1ec1f41c03.png)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass the CIs.