### PR TITLE
[SPARK-42504][SQL] NestedColumnAliasing support pruning adjacent projects

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -1161,4 +1161,14 @@ abstract class SchemaPruningSuite
     checkAnswer(mapQuery, Row(0, null) :: Row(1, null) ::
       Row(null, null) :: Row(null, null) :: Nil)
   }
+
+  testSchemaPruning("SPARK-42504: NestedColumnAliasing support pruning adjacent projects") {
+    val query = spark.sql(
+      "SELECT employer.id + 1, employer.id + 1 as x, x + 2 as y FROM departments")
+    checkScan(query, "struct<employer: struct<id:int>>")
+    checkAnswer(query,
+      Row(1, 1, 3) ::
+        Row(2, 2, 4) ::
+        Row(3, 3, 5) :: Nil)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr improves the `NestedColumnAliasing` to support prune the adjacent project nodes.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
CollapseProject won't combine adjacent projects into one, e.g. non-cheap expression has been accessed more than once with the below project. Then there would be possible to appear some adjacent project nodes that `NestedColumnAliasing` does not support pruning.

It's a common case with lateral column alias that it would push down an extra project, e.g.
```sql
CREATE TABLE t (c struct<c1: int, c2 string>) USING PARQUET;
SELECT c.c1, c.c1 + 1 as x, x + 1 FROM t;

-- before
*(1) Project [c#15.c1 AS c1#53, x#47, (x#47 + 1) AS (lateralAliasReference(x) + 1)#55]
+- *(1) Project [c#15, (c#15.c1 + 1) AS x#47]
   +- *(1) ColumnarToRow
      +- FileScan parquet spark_catalog.default.t[c#15] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c:struct<c1:int,c2:string>>

-- after
*(1) Project [_extract_c1#38 AS c1#34, x#27, (x#27 + 1) AS (lateralAliasReference(x) + 1)#37]
+- *(1) Project [c#33.c1 AS _extract_c1#38, (c#33.c1 + 1) AS x#27]
   +- *(1) ColumnarToRow
      +- FileScan parquet spark_catalog.default.t[c#33] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c:struct<c1:int>>
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add new test