### PR TITLE
[SPARK-42506][SQL] Fix Sort's maxRowsPerPartition if maxRows does not exist

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -925,7 +925,7 @@ case class Sort(
   override def output: Seq[Attribute] = child.output
   override def maxRows: Option[Long] = child.maxRows
   override def maxRowsPerPartition: Option[Long] = {
-    if (global) maxRows else child.maxRowsPerPartition
+    if (global) maxRows.orElse(child.maxRowsPerPartition) else child.maxRowsPerPartition
   }
   override def outputOrdering: Seq[SortOrder] = order
   final override val nodePatterns: Seq[TreePattern] = Seq(SORT)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/LogicalPlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/LogicalPlanSuite.scala
@@ -126,6 +126,10 @@ class LogicalPlanSuite extends SparkFunSuite {
     assert(sort2.maxRows === Some(100))
     assert(sort2.maxRowsPerPartition === Some(100))
 
+    val sortLimit = Sort(Seq($"a".asc), true, LocalLimit(Literal(5), LocalRelation($"a".int)))
+    assert(sortLimit.maxRows === None)
+    assert(sortLimit.maxRowsPerPartition === Some(5))
+
     val c1 = Literal(1).as('a).toAttribute.newInstance().withNullability(true)
     val c2 = Literal(2).as('b).toAttribute.newInstance().withNullability(true)
     val expand = Expand(


### PR DESCRIPTION
### What changes were proposed in this pull request?

 Fix `Sort`'s maxRowsPerPartition if maxRows does not exist.

### Why are the changes needed?

`LimitPushDown` may be use this value.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.