### PR TITLE
[SPARK-42507][SQL][TESTS] Simplify ORC schema merging conflict error check

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -455,11 +455,8 @@ abstract class OrcSuite
             throw new UnsupportedOperationException(s"Unknown ORC implementation: $impl")
         }
 
-        checkError(
-          exception = innerException.asInstanceOf[SparkException],
-          errorClass = "CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE",
-          parameters = Map("left" -> "\"BIGINT\"", "right" -> "\"STRING\"")
-        )
+        assert(innerException.asInstanceOf[SparkException].getErrorClass ===
+          "CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE")
       }
 
       // it is ok if no schema merging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to simplify ORC schema merging conflict error check.

### Why are the changes needed?

Currently, `branch-3.4` CI is broken because the order of partitions.
- https://github.com/apache/spark/runs/11463120795
- https://github.com/apache/spark/runs/11463886897
- https://github.com/apache/spark/runs/11467827738
- https://github.com/apache/spark/runs/11471484144
- https://github.com/apache/spark/runs/11471507531
- https://github.com/apache/spark/runs/11474764316

![Screenshot 2023-02-20 at 12 30 19 PM](https://user-images.githubusercontent.com/9700541/220193503-6d6ce2ce-3fd6-4b01-b91c-bc1ec1f41c03.png)

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass the CIs.