### PR TITLE
[SPARK-42516][SQL] Always capture the session time zone config while creating views

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -398,7 +398,9 @@ object ViewHelper extends SQLConfHelper with Logging {
     val modifiedConfs = conf.getAllConfs.filter { case (k, _) =>
       conf.isModifiable(k) && shouldCaptureConfig(k)
     }
-    // Get the default value of always captured config if it is not set
+    // Some configs have dynamic default values, such as SESSION_LOCAL_TIMEZONE whose
+    // default value relies on the JVM system timezone. We need to always capture them to
+    // to make sure we apply the same configs when reading the view.
     val alwaysCaptured = Seq(SQLConf.SESSION_LOCAL_TIMEZONE)
       .filter(c => !modifiedConfs.contains(c.key))
       .map(c => (c.key, conf.getConf(c)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -354,10 +354,6 @@ object ViewHelper extends SQLConfHelper with Logging {
     SQLConf.DISABLE_HINTS.key
   )
 
-  private val alwaysCapturedConfigs = Seq(
-    SQLConf.SESSION_LOCAL_TIMEZONE.key
-  )
-
   /**
    * Capture view config either of:
    * 1. exists in allowList
@@ -403,15 +399,12 @@ object ViewHelper extends SQLConfHelper with Logging {
       conf.isModifiable(k) && shouldCaptureConfig(k)
     }
     // Get the default value of always captured config if it is not set
-    lazy val allDefinedConfigs = conf.getAllDefinedConfs
-    val alwaysCapturedDefaults = alwaysCapturedConfigs
-      .filter(!modifiedConfs.contains(_))
-      .flatMap(key => allDefinedConfigs.find(_._1 == key))
-      .map { case (key, defaultValue, _, _) => (key, defaultValue) }
-      .toMap
+    val alwaysCaptured = Seq(SQLConf.SESSION_LOCAL_TIMEZONE)
+      .filter(c => !modifiedConfs.contains(c.key))
+      .map(c => (c.key, conf.getConf(c)))
 
     val props = new mutable.HashMap[String, String]
-    for ((key, value) <- modifiedConfs ++ alwaysCapturedDefaults) {
+    for ((key, value) <- modifiedConfs ++ alwaysCaptured) {
       props.put(s"$VIEW_SQL_CONFIG_PREFIX$key", value)
     }
     props.toMap

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -419,22 +419,6 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
       assert(df.schema == dfFromView.schema)
     }
   }
-
-  test("capture the session time zone config while creating a view") {
-    val viewName = "v1"
-    withView(viewName) {
-      assert(get.sessionLocalTimeZone === "America/Los_Angeles")
-      createView(viewName,
-        """select hour(ts) as H from (
-          |  select cast('2022-01-01T00:00:00.000 America/Los_Angeles' as timestamp) as ts
-          |)""".stripMargin, Seq("H"))
-      withDefaultTimeZone(java.time.ZoneId.of("UTC-09:00")) {
-        withSQLConf(SESSION_LOCAL_TIMEZONE.key -> "UTC-10:00") {
-          checkAnswer(sql(s"select H from $viewName"), Row(0))
-        }
-      }
-    }
-  }
 }
 
 abstract class TempViewTestSuite extends SQLViewTestSuite {
@@ -719,6 +703,22 @@ class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
           " TBLPROPERTIES ( 'prop1' = 'value1', 'prop2' = 'value2')" +
           " AS SELECT 1 AS c1, '2' AS c2"
         assert(getShowCreateDDL(formattedViewName(viewName), serde) == expected)
+      }
+    }
+  }
+
+  test("capture the session time zone config while creating a view") {
+    val viewName = "v1_capture_test"
+    withView(viewName) {
+      assert(get.sessionLocalTimeZone === "America/Los_Angeles")
+      createView(viewName,
+        """select hour(ts) as H from (
+          |  select cast('2022-01-01T00:00:00.000 America/Los_Angeles' as timestamp) as ts
+          |)""".stripMargin, Seq("H"))
+      withDefaultTimeZone(java.time.ZoneId.of("UTC-09:00")) {
+        withSQLConf(SESSION_LOCAL_TIMEZONE.key -> "UTC-10:00") {
+          checkAnswer(sql(s"select H from $viewName"), Row(0))
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.CatalogFunction
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.Repartition
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.withDefaultTimeZone
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.internal.SQLConf._
@@ -702,6 +703,22 @@ class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
           " TBLPROPERTIES ( 'prop1' = 'value1', 'prop2' = 'value2')" +
           " AS SELECT 1 AS c1, '2' AS c2"
         assert(getShowCreateDDL(formattedViewName(viewName), serde) == expected)
+      }
+    }
+  }
+
+  test("capture the session time zone config while creating a view") {
+    val viewName = "v1"
+    withView(viewName) {
+      assert(get.sessionLocalTimeZone === "America/Los_Angeles")
+      createView(viewName,
+        """select hour(ts) as H from (
+          |  select cast('2022-01-01T00:00:00.000 America/Los_Angeles' as timestamp) as ts
+          |)""".stripMargin, Seq("H"))
+      withDefaultTimeZone(java.time.ZoneId.of("UTC-09:00")) {
+        withSQLConf(SESSION_LOCAL_TIMEZONE.key -> "UTC-10:00") {
+          checkAnswer(sql(s"select H from $viewName"), Row(0))
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to capture the session time zone config (`spark.sql.session.timeZone`) as a view property, and use it while re-parsing/analysing the view. If the SQL config is not set while creating a view, use the default value of the config.

### Why are the changes needed?
To improve user experience with Spark SQL. The current behaviour might confuse users because query results depends on whether or not the session time zone was set explicitly while creating a view.

### Does this PR introduce _any_ user-facing change?
Yes. Before the changes, the current value of the session time zone is used in view analysis but this behaviour can be restored via another SQL config `spark.sql.legacy.useCurrentConfigsForView`. 

### How was this patch tested?
By running the new test via:
```
$ build/sbt "test:testOnly *.PersistedViewTestSuite"
```