### PR TITLE
[SPARK-42514][CONNECT] Scala Client add partition transforms functions

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3592,6 +3592,64 @@ object functions {
   def timestamp_seconds(e: Column): Column = Column.fn("timestamp_seconds", e)
 
   //////////////////////////////////////////////////////////////////////////////////////////////
+  // Partition Transforms functions
+  //////////////////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * A transform for timestamps and dates to partition data into years.
+   *
+   * @group partition_transforms
+   * @since 3.4.0
+   */
+  def years(e: Column): Column =
+    Column.fn("years", e)
+
+  /**
+   * A transform for timestamps and dates to partition data into months.
+   *
+   * @group partition_transforms
+   * @since 3.4.0
+   */
+  def months(e: Column): Column =
+    Column.fn("months", e)
+
+  /**
+   * A transform for timestamps and dates to partition data into days.
+   *
+   * @group partition_transforms
+   * @since 3.4.0
+   */
+  def days(e: Column): Column =
+    Column.fn("days", e)
+
+  /**
+   * A transform for timestamps to partition data into hours.
+   *
+   * @group partition_transforms
+   * @since 3.4.0
+   */
+  def hours(e: Column): Column =
+    Column.fn("hours", e)
+
+  /**
+   * A transform for any type that partitions by a hash of the input column.
+   *
+   * @group partition_transforms
+   * @since 3.4.0
+   */
+  def bucket(numBuckets: Column, e: Column): Column =
+    Column.fn("bucket", numBuckets, e)
+
+  /**
+   * A transform for any type that partitions by a hash of the input column.
+   *
+   * @group partition_transforms
+   * @since 3.4.0
+   */
+  def bucket(numBuckets: Int, e: Column): Column =
+    Column.fn("bucket", lit(numBuckets), e)
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
   // Scala UDF functions
   //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/FunctionTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/FunctionTestSuite.scala
@@ -170,6 +170,7 @@ class FunctionTestSuite extends ConnectFunSuite {
     window(a, "10 seconds", "10 seconds"),
     window(a, "10 seconds"))
   testEquals("session_window", session_window(a, "1 second"), session_window(a, lit("1 second")))
+  testEquals("bucket", bucket(lit(3), a), bucket(3, a))
 
   test("assert_true no message") {
     val e = assert_true(a).expr

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
@@ -1386,6 +1386,26 @@ class PlanGenerationTestSuite extends ConnectFunSuite with BeforeAndAfterAll wit
     fn.upper(fn.col("g"))
   }
 
+  functionTest("years") {
+    fn.years(Column("a"))
+  }
+
+  functionTest("months") {
+    fn.months(Column("a"))
+  }
+
+  functionTest("days") {
+    fn.days(Column("a"))
+  }
+
+  functionTest("hours") {
+    fn.hours(Column("a"))
+  }
+
+  functionTest("bucket") {
+    fn.bucket(3, Column("a"))
+  }
+
   private def temporalFunctionTest(name: String)(f: => Column): Unit = {
     test("function " + name) {
       temporals.select(f)

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_bucket.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_bucket.explain
@@ -1,0 +1,2 @@
+Project [bucket(3, a#0) AS bucket(a)#0]
++- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_days.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_days.explain
@@ -1,0 +1,2 @@
+Project [days(a#0) AS days(a)#0]
++- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_hours.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_hours.explain
@@ -1,0 +1,2 @@
+Project [hours(a#0) AS hours(a)#0]
++- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_months.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_months.explain
@@ -1,0 +1,2 @@
+Project [months(a#0) AS months(a)#0]
++- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_years.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_years.explain
@@ -1,0 +1,2 @@
+Project [years(a#0) AS years(a)#0]
++- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_bucket.json
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_bucket.json
@@ -1,0 +1,23 @@
+{
+  "project": {
+    "input": {
+      "localRelation": {
+        "schema": "struct\u003cid:bigint,a:int,b:double,d:struct\u003cid:bigint,a:int,b:double\u003e,e:array\u003cint\u003e,f:map\u003cstring,struct\u003cid:bigint,a:int,b:double\u003e\u003e,g:string\u003e"
+      }
+    },
+    "expressions": [{
+      "unresolvedFunction": {
+        "functionName": "bucket",
+        "arguments": [{
+          "literal": {
+            "integer": 3
+          }
+        }, {
+          "unresolvedAttribute": {
+            "unparsedIdentifier": "a"
+          }
+        }]
+      }
+    }]
+  }
+}

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_bucket.proto.bin
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_bucket.proto.bin
@@ -1,0 +1,5 @@
+ª
+ŽZ‹ˆstruct<id:bigint,a:int,b:double,d:struct<id:bigint,a:int,b:double>,e:array<int>,f:map<string,struct<id:bigint,a:int,b:double>>,g:string>
+bucket
+0
+a

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_days.json
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_days.json
@@ -1,0 +1,19 @@
+{
+  "project": {
+    "input": {
+      "localRelation": {
+        "schema": "struct\u003cid:bigint,a:int,b:double,d:struct\u003cid:bigint,a:int,b:double\u003e,e:array\u003cint\u003e,f:map\u003cstring,struct\u003cid:bigint,a:int,b:double\u003e\u003e,g:string\u003e"
+      }
+    },
+    "expressions": [{
+      "unresolvedFunction": {
+        "functionName": "days",
+        "arguments": [{
+          "unresolvedAttribute": {
+            "unparsedIdentifier": "a"
+          }
+        }]
+      }
+    }]
+  }
+}

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_days.proto.bin
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_days.proto.bin
@@ -1,0 +1,4 @@
+¢
+ŽZ‹ˆstruct<id:bigint,a:int,b:double,d:struct<id:bigint,a:int,b:double>,e:array<int>,f:map<string,struct<id:bigint,a:int,b:double>>,g:string>
+days
+a

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_hours.json
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_hours.json
@@ -1,0 +1,19 @@
+{
+  "project": {
+    "input": {
+      "localRelation": {
+        "schema": "struct\u003cid:bigint,a:int,b:double,d:struct\u003cid:bigint,a:int,b:double\u003e,e:array\u003cint\u003e,f:map\u003cstring,struct\u003cid:bigint,a:int,b:double\u003e\u003e,g:string\u003e"
+      }
+    },
+    "expressions": [{
+      "unresolvedFunction": {
+        "functionName": "hours",
+        "arguments": [{
+          "unresolvedAttribute": {
+            "unparsedIdentifier": "a"
+          }
+        }]
+      }
+    }]
+  }
+}

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_hours.proto.bin
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_hours.proto.bin
@@ -1,0 +1,4 @@
+£
+ŽZ‹ˆstruct<id:bigint,a:int,b:double,d:struct<id:bigint,a:int,b:double>,e:array<int>,f:map<string,struct<id:bigint,a:int,b:double>>,g:string>
+hours
+a

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_months.json
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_months.json
@@ -1,0 +1,19 @@
+{
+  "project": {
+    "input": {
+      "localRelation": {
+        "schema": "struct\u003cid:bigint,a:int,b:double,d:struct\u003cid:bigint,a:int,b:double\u003e,e:array\u003cint\u003e,f:map\u003cstring,struct\u003cid:bigint,a:int,b:double\u003e\u003e,g:string\u003e"
+      }
+    },
+    "expressions": [{
+      "unresolvedFunction": {
+        "functionName": "months",
+        "arguments": [{
+          "unresolvedAttribute": {
+            "unparsedIdentifier": "a"
+          }
+        }]
+      }
+    }]
+  }
+}

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_months.proto.bin
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_months.proto.bin
@@ -1,0 +1,4 @@
+¤
+ŽZ‹ˆstruct<id:bigint,a:int,b:double,d:struct<id:bigint,a:int,b:double>,e:array<int>,f:map<string,struct<id:bigint,a:int,b:double>>,g:string>
+months
+a

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_years.json
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_years.json
@@ -1,0 +1,19 @@
+{
+  "project": {
+    "input": {
+      "localRelation": {
+        "schema": "struct\u003cid:bigint,a:int,b:double,d:struct\u003cid:bigint,a:int,b:double\u003e,e:array\u003cint\u003e,f:map\u003cstring,struct\u003cid:bigint,a:int,b:double\u003e\u003e,g:string\u003e"
+      }
+    },
+    "expressions": [{
+      "unresolvedFunction": {
+        "functionName": "years",
+        "arguments": [{
+          "unresolvedAttribute": {
+            "unparsedIdentifier": "a"
+          }
+        }]
+      }
+    }]
+  }
+}

--- a/connector/connect/common/src/test/resources/query-tests/queries/function_years.proto.bin
+++ b/connector/connect/common/src/test/resources/query-tests/queries/function_years.proto.bin
@@ -1,0 +1,4 @@
+£
+Z‹ˆstruct<id:bigint,a:int,b:double,d:struct<id:bigint,a:int,b:double>,e:array<int>,f:map<string,struct<id:bigint,a:int,b:double>>,g:string>
+years
+a


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims add the partition transforms functions to the Scala spark connect client.


### Why are the changes needed?
Provide same APIs in the Scala spark connect client as in the original Dataset API.


### Does this PR introduce _any_ user-facing change?
Yes, it adds new for functions to the Spark Connect Scala client.




### How was this patch tested?

- Add new test
- Manual checked `connect-client-jvm` and `connect` with Scala-2.13
