### PR TITLE
[SPARK-42521][SQL] Add NULLs for INSERTs with user-specified lists of fewer columns than the target table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -319,7 +319,7 @@ case class ResolveDefaultColumns(catalog: SessionCatalog) extends Rule[LogicalPl
   }
 
   /**
-   * This is a helper for the addMissingDefaultValuesForInsertFromInlineTable methods above.
+   * This is a helper for the addMissingDefaultValuesForInsert* methods above.
    */
   private def getDefaultExpressionsForInsert(
       numQueryOutputs: Int,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3132,7 +3132,7 @@ object SQLConf {
         "columns in the target table, and the remaining columns will receive NULL values.")
       .version("3.4.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val SKIP_TYPE_VALIDATION_ON_ALTER_PARTITION =
     buildConf("spark.sql.legacy.skipTypeValidationOnAlterPartition")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -143,14 +143,16 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
   }
 
   test("SELECT clause generating a different number of columns is not allowed.") {
-    val message = intercept[AnalysisException] {
-      sql(
-        s"""
-        |INSERT OVERWRITE TABLE jsonTable SELECT a FROM jt
+    withSQLConf(SQLConf.USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES.key -> "false") {
+      val message = intercept[AnalysisException] {
+        sql(
+          s"""
+             |INSERT OVERWRITE TABLE jsonTable SELECT a FROM jt
       """.stripMargin)
-    }.getMessage
-    assert(message.contains("target table has 2 column(s) but the inserted data has 1 column(s)")
-    )
+      }.getMessage
+      assert(message.contains("target table has 2 column(s) but the inserted data has 1 column(s)")
+      )
+    }
   }
 
   test("INSERT OVERWRITE a JSONRelation multiple times") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -648,16 +648,18 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
           "columns as the target table: target table has 2 column(s)" +
           " but the inserted data has 3 column(s)"))
 
-        msg = intercept[AnalysisException] {
-          sql("insert into t select 1")
-        }.getMessage
-        assert(msg.contains("`t` requires that the data to be inserted have the same number of " +
-          "columns as the target table: target table has 2 column(s)" +
-          " but the inserted data has 1 column(s)"))
+        withSQLConf(SQLConf.USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES.key -> "false") {
+          msg = intercept[AnalysisException] {
+            sql("insert into t select 1")
+          }.getMessage
+          assert(msg.contains("`t` requires that the data to be inserted have the same number of " +
+            "columns as the target table: target table has 2 column(s)" +
+            " but the inserted data has 1 column(s)"))
 
-        // Insert into table successfully.
-        sql("insert into t select 1, 2.0D")
-        checkAnswer(sql("select * from t"), Row(1, 2.0D))
+          // Insert into table successfully.
+          sql("insert into t select 1, 2.0D")
+          checkAnswer(sql("select * from t"), Row(1, 2.0D))
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -2258,10 +2258,12 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
   }
 
   test("SPARK-36980: Insert support query with CTE") {
-    withTable("t") {
-      sql("CREATE TABLE t(i int, part1 int, part2 int) using parquet")
-      sql("INSERT INTO t WITH v1(c1) as (values (1)) select 1, 2, 3 from v1")
-      checkAnswer(spark.table("t"), Row(1, 2, 3))
+    withSQLConf(SQLConf.USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES.key -> "false") {
+      withTable("t") {
+        sql("CREATE TABLE t(i int, part1 int, part2 int) using parquet")
+        sql("INSERT INTO t WITH v1(c1) as (values (1)) select 1, 2, 3 from v1")
+        checkAnswer(spark.table("t"), Row(1, 2, 3))
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1187,7 +1187,9 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     }
     // When the CASE_SENSITIVE configuration is disabled, then using different cases for the
     // required and provided column names is successful.
-    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+    withSQLConf(
+      SQLConf.CASE_SENSITIVE.key -> "false",
+      SQLConf.USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES.key -> "false") {
       withTable("t") {
         sql("create table t(i boolean, s bigint default 42, q int default 43) using parquet")
         sql("insert into t (I, Q) select true from (select 1)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1251,45 +1251,45 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         assert(intercept[AnalysisException] {
           sql("insert into t (i, q) select true from (select 1)")
         }.getMessage.contains(addTwoColButExpectedThree))
-        // When the USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES configuration is disabled, and no
-        // explicit DEFAULT value is available when the INSERT INTO statement provides fewer
-        // values than expected, the INSERT INTO command fails to execute.
-        withTable("t") {
-          sql("create table t(i boolean, s bigint) using parquet")
-          assert(intercept[AnalysisException] {
-            sql("insert into t (i) values (true)")
-          }.getMessage.contains(addOneColButExpectedTwo))
-        }
-        withTable("t") {
-          sql("create table t(i boolean default true, s bigint) using parquet")
-          assert(intercept[AnalysisException] {
-            sql("insert into t (i) values (default)")
-          }.getMessage.contains(addOneColButExpectedTwo))
-        }
-        withTable("t") {
-          sql("create table t(i boolean, s bigint default 42) using parquet")
-          assert(intercept[AnalysisException] {
-            sql("insert into t (s) values (default)")
-          }.getMessage.contains(addOneColButExpectedTwo))
-        }
-        withTable("t") {
-          sql("create table t(i boolean, s bigint, q int) using parquet partitioned by (i)")
-          assert(intercept[AnalysisException] {
-            sql("insert into t partition(i='true') (s) values(5)")
-          }.getMessage.contains(addTwoColButExpectedThree))
-        }
-        withTable("t") {
-          sql("create table t(i boolean, s bigint, q int) using parquet partitioned by (i)")
-          assert(intercept[AnalysisException] {
-            sql("insert into t partition(i='false') (q) select 43")
-          }.getMessage.contains(addTwoColButExpectedThree))
-        }
-        withTable("t") {
-          sql("create table t(i boolean, s bigint, q int) using parquet partitioned by (i)")
-          assert(intercept[AnalysisException] {
-            sql("insert into t partition(i='false') (q) select default")
-          }.getMessage.contains(addTwoColButExpectedThree))
-        }
+      }
+      // When the USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES configuration is disabled, and no
+      // explicit DEFAULT value is available when the INSERT INTO statement provides fewer
+      // values than expected, the INSERT INTO command fails to execute.
+      withTable("t") {
+        sql("create table t(i boolean, s bigint) using parquet")
+        assert(intercept[AnalysisException] {
+          sql("insert into t (i) values (true)")
+        }.getMessage.contains(addOneColButExpectedTwo))
+      }
+      withTable("t") {
+        sql("create table t(i boolean default true, s bigint) using parquet")
+        assert(intercept[AnalysisException] {
+          sql("insert into t (i) values (default)")
+        }.getMessage.contains(addOneColButExpectedTwo))
+      }
+      withTable("t") {
+        sql("create table t(i boolean, s bigint default 42) using parquet")
+        assert(intercept[AnalysisException] {
+          sql("insert into t (s) values (default)")
+        }.getMessage.contains(addOneColButExpectedTwo))
+      }
+      withTable("t") {
+        sql("create table t(i boolean, s bigint, q int) using parquet partitioned by (i)")
+        assert(intercept[AnalysisException] {
+          sql("insert into t partition(i='true') (s) values(5)")
+        }.getMessage.contains(addTwoColButExpectedThree))
+      }
+      withTable("t") {
+        sql("create table t(i boolean, s bigint, q int) using parquet partitioned by (i)")
+        assert(intercept[AnalysisException] {
+          sql("insert into t partition(i='false') (q) select 43")
+        }.getMessage.contains(addTwoColButExpectedThree))
+      }
+      withTable("t") {
+        sql("create table t(i boolean, s bigint, q int) using parquet partitioned by (i)")
+        assert(intercept[AnalysisException] {
+          sql("insert into t partition(i='false') (q) select default")
+        }.getMessage.contains(addTwoColButExpectedThree))
       }
       // When the CASE_SENSITIVE configuration is enabled, then using different cases for the
       // required and provided column names results in an analysis error.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add NULLs for INSERTs with user-specified lists of fewer columns than the target table.

This is done by changing the `USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES` SQLConf default value from false to true.

### Why are the changes needed?

This behavior is consistent with other query engines.

### Does this PR introduce _any_ user-facing change?

Yes, per above.

### How was this patch tested?

Unit test coverage in `InsertSuite`.