### PR TITLE
[SPARK-42524][BUILD] Upgrade numpy and pandas in the release Dockerfile

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -42,8 +42,8 @@ ARG APT_INSTALL="apt-get install --no-install-recommends -y"
 #   We should use the latest Sphinx version once this is fixed.
 # TODO(SPARK-35375): Jinja2 3.0.0+ causes error when building with Sphinx.
 #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-ARG PIP_PKGS="sphinx==3.0.4 mkdocs==1.1.2 numpy==1.19.4 pydata_sphinx_theme==0.4.1 ipython==7.19.0 nbsphinx==0.8.0 numpydoc==1.1.0 jinja2==2.11.3 twine==3.4.1 sphinx-plotly-directive==0.1.3 pandas==1.1.5 pyarrow==3.0.0 plotly==5.4.0 markupsafe==2.0.1 docutils<0.17 grpcio==1.48.1 protobuf==4.21.6 grpcio-status==1.48.1 googleapis-common-protos==1.56.4"
-ARG GEM_PKGS="bundler:2.2.9"
+ARG PIP_PKGS="sphinx==3.0.4 mkdocs==1.1.2 numpy==1.20.3 pydata_sphinx_theme==0.4.1 ipython==7.19.0 nbsphinx==0.8.0 numpydoc==1.1.0 jinja2==2.11.3 twine==3.4.1 sphinx-plotly-directive==0.1.3 pandas==1.5.3 pyarrow==3.0.0 plotly==5.4.0 markupsafe==2.0.1 docutils<0.17 grpcio==1.48.1 protobuf==4.21.6 grpcio-status==1.48.1 googleapis-common-protos==1.56.4"
+ARG GEM_PKGS="bundler:2.3.8"
 
 # Install extra needed repos and refresh.
 # - CRAN repo


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade pandas from 1.1.5 to 1.5.3, numpy from 1.19.4 to 1.20.3 in the Dockerfile used for Spark releases.

They are also what we use to cut `v3.4.0-rc1`.

### Why are the changes needed?
Otherwise, errors are raised as shown below when building release docs.
```
ImportError: Warning: Latest version of pandas (1.5.3) is required to generate the documentation; however, your version was 1.1.5

ImportError: this version of pandas is incompatible with numpy < 1.20.3
your numpy version is 1.19.4.
Please upgrade numpy to >= 1.20.3 to use this pandas version
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual tests.