### PR TITLE
[SPARK-42525][SQL] Collapse two adjacent windows with semantically-same partition/order

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1251,9 +1251,14 @@ object OptimizeWindowFunctions extends Rule[LogicalPlan] {
  *   independent and are of the same window function type, collapse into the parent.
  */
 object CollapseWindow extends Rule[LogicalPlan] {
+  private def specCompatible(s1: Seq[Expression], s2: Seq[Expression]): Boolean = {
+    s1.length == s2.length &&
+      s1.zip(s2).forall(e => e._1.semanticEquals(e._2))
+  }
+
   private def windowsCompatible(w1: Window, w2: Window): Boolean = {
-    w1.partitionSpec == w2.partitionSpec &&
-      w1.orderSpec == w2.orderSpec &&
+    specCompatible(w1.partitionSpec, w2.partitionSpec) &&
+      specCompatible(w1.orderSpec, w2.orderSpec) &&
       w1.references.intersect(w2.windowOutputSet).isEmpty &&
       w1.windowExpressions.nonEmpty && w2.windowExpressions.nonEmpty &&
       // This assumes Window contains the same type of window expressions. This is ensured

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -3592,6 +3592,34 @@ class DataFrameSuite extends QueryTest
     val df = Seq("0.5944910").toDF("a")
     checkAnswer(df.selectExpr("cast(a as decimal(7,7)) div 100"), Row(0))
   }
+
+  test("SPARK-42525: collapse two adjacent windows with the same partition/order in subquery") {
+    val df1 = spark.range(10).map(_ => (Random.nextInt(10), Random.nextInt(10)))
+      .selectExpr("_1 as a", "_2 as b")
+    df1.cache()
+    df1.createOrReplaceTempView("t1")
+    val df2 = sql(
+      """
+        |select a, b, c, row_number() over (partition by a order by b) as d from
+        |( select a, b, rank() over (partition by a order by b) as c from t1) t2
+        |""".stripMargin
+    )
+    val df3 = sql(
+      """
+        |select a, b,
+        |rank() over (partition by a order by b) as c,
+        |row_number() over (partition by a order by b) as d
+        |from t1
+        |""".stripMargin
+    )
+    val captured = new ByteArrayOutputStream()
+    Console.withOut(captured) {
+      df2.explain()
+    }
+    checkAnswer(df2, df3)
+    val output = captured.toString
+    assert(output.split("\\+- Window").size == 2)
+  }
 }
 
 case class GroupByKey(a: Int, b: Int)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql
 
 import org.scalatest.matchers.must.Matchers.the
+
 import org.apache.spark.TestUtils.{assertNotSpilled, assertSpilled}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, Lag, Literal, NonFoldableLiteral}
 import org.apache.spark.sql.catalyst.optimizer.TransposeWindow
@@ -532,15 +533,10 @@ class DataFrameWindowFunctionsSuite extends QueryTest
   test("window function with aggregator") {
     val agg = udaf(new Aggregator[(Long, Long), Long, Long] {
       def zero: Long = 0L
-
       def reduce(b: Long, a: (Long, Long)): Long = b + (a._1 * a._2)
-
       def merge(b1: Long, b2: Long): Long = b1 + b2
-
       def finish(r: Long): Long = r
-
       def bufferEncoder: Encoder[Long] = Encoders.scalaLong
-
       def outputEncoder: Encoder[Long] = Encoders.scalaLong
     })
 
@@ -1107,7 +1103,7 @@ class DataFrameWindowFunctionsSuite extends QueryTest
   test("NaN and -0.0 in window partition keys") {
     val df = Seq(
       (Float.NaN, Double.NaN),
-      (0.0f / 0.0f, 0.0 / 0.0),
+      (0.0f/0.0f, 0.0/0.0),
       (0.0f, 0.0),
       (-0.0f, -0.0)).toDF("f", "d")
 
@@ -1115,7 +1111,7 @@ class DataFrameWindowFunctionsSuite extends QueryTest
       df.select($"f", count(lit(1)).over(Window.partitionBy("f", "d"))),
       Seq(
         Row(Float.NaN, 2),
-        Row(0.0f / 0.0f, 2),
+        Row(0.0f/0.0f, 2),
         Row(0.0f, 2),
         Row(-0.0f, 2)))
 
@@ -1125,7 +1121,7 @@ class DataFrameWindowFunctionsSuite extends QueryTest
       df.select($"f", count(lit(1)).over(windowSpec1)),
       Seq(
         Row(Float.NaN, 2),
-        Row(0.0f / 0.0f, 2),
+        Row(0.0f/0.0f, 2),
         Row(0.0f, 2),
         Row(-0.0f, 2)))
 
@@ -1134,21 +1130,21 @@ class DataFrameWindowFunctionsSuite extends QueryTest
       df.select($"f", count(lit(1)).over(windowSpec2)),
       Seq(
         Row(Float.NaN, 2),
-        Row(0.0f / 0.0f, 2),
+        Row(0.0f/0.0f, 2),
         Row(0.0f, 2),
         Row(-0.0f, 2)))
 
     // test with df with complicated-type columns.
     val df2 = Seq(
       (Array(-0.0f, 0.0f), Tuple2(-0.0d, Double.NaN), Seq(Tuple2(-0.0d, Double.NaN))),
-      (Array(0.0f, -0.0f), Tuple2(0.0d, Double.NaN), Seq(Tuple2(0.0d, 0.0 / 0.0)))
+      (Array(0.0f, -0.0f), Tuple2(0.0d, Double.NaN), Seq(Tuple2(0.0d, 0.0/0.0)))
     ).toDF("arr", "stru", "arrOfStru")
     val windowSpec3 = Window.partitionBy("arr", "stru", "arrOfStru")
     checkAnswer(
       df2.select($"arr", $"stru", $"arrOfStru", count(lit(1)).over(windowSpec3)),
       Seq(
         Row(Seq(-0.0f, 0.0f), Row(-0.0d, Double.NaN), Seq(Row(-0.0d, Double.NaN)), 2),
-        Row(Seq(0.0f, -0.0f), Row(0.0d, Double.NaN), Seq(Row(0.0d, 0.0 / 0.0)), 2)))
+        Row(Seq(0.0f, -0.0f), Row(0.0d, Double.NaN), Seq(Row(0.0d, 0.0/0.0)), 2)))
   }
 
   test("SPARK-34227: WindowFunctionFrame should clear its states during preparation") {
@@ -1185,8 +1181,8 @@ class DataFrameWindowFunctionsSuite extends QueryTest
     }
 
     def isShuffleExecByRequirement(
-                                    plan: ShuffleExchangeExec,
-                                    desiredClusterColumns: Seq[String]): Boolean = plan match {
+        plan: ShuffleExchangeExec,
+        desiredClusterColumns: Seq[String]): Boolean = plan match {
       case ShuffleExchangeExec(op: HashPartitioning, _, ENSURE_REQUIREMENTS) =>
         partitionExpressionsColumns(op.expressions) === desiredClusterColumns
       case _ => false


### PR DESCRIPTION

### What changes were proposed in this pull request?
Extend the CollapseWindow rule to collapse Window nodes, when one window in subquery.



### Why are the changes needed?

```
select a, b, c, row_number() over (partition by a order by b) as d from
( select a, b, rank() over (partition by a order by b) as c from t1) t2

== Optimized Logical Plan ==
before
Window [row_number() windowspecdefinition(a#11, b#12 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS d#26], [a#11], [b#12 ASC NULLS FIRST]
+- Window [rank(b#12) windowspecdefinition(a#11, b#12 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS c#25], [a#11], [b#12 ASC NULLS FIRST]
   +- InMemoryRelation [a#11, b#12], StorageLevel(disk, memory, deserialized, 1 replicas)
         +- *(1) Project [_1#6 AS a#11, _2#7 AS b#12]
            +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, scala.Tuple2, true]))._1 AS _1#6, knownnotnull(assertnotnull(input[0, scala.Tuple2, true]))._2 AS _2#7]
               +- *(1) MapElements org.apache.spark.sql.DataFrameSuite$$Lambda$1517/1628848368@3a479fda, obj#5: scala.Tuple2
                  +- *(1) DeserializeToObject staticinvoke(class java.lang.Long, ObjectType(class java.lang.Long), valueOf, id#0L, true, false, true), obj#4: java.lang.Long
                     +- *(1) Range (0, 10, step=1, splits=2)

after
Window [rank(b#12) windowspecdefinition(a#11, b#12 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS c#25, row_number() windowspecdefinition(a#11, b#12 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS d#26], [a#11], [b#12 ASC NULLS FIRST]
+- InMemoryRelation [a#11, b#12], StorageLevel(disk, memory, deserialized, 1 replicas)
      +- *(1) Project [_1#6 AS a#11, _2#7 AS b#12]
         +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, scala.Tuple2, true]))._1 AS _1#6, knownnotnull(assertnotnull(input[0, scala.Tuple2, true]))._2 AS _2#7]
            +- *(1) MapElements org.apache.spark.sql.DataFrameSuite$$Lambda$1518/1928028672@4d7a64ca, obj#5: scala.Tuple2
               +- *(1) DeserializeToObject staticinvoke(class java.lang.Long, ObjectType(class java.lang.Long), valueOf, id#0L, true, false, true), obj#4: java.lang.Long
                  +- *(1) Range (0, 10, step=1, splits=2)
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
