### PR TITLE
[SPARK-41391][SQL] The output column name of groupBy.agg(count_distinct) is incorrect

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -95,7 +95,7 @@ class RelationalGroupedDataset protected[sql](
   }
 
   /**
-   * Returns true if `exprs` contains a [[Star]].
+   * Returns true if `exprs` contains a star.
    */
   def containsStar(exprs: Seq[Expression]): Boolean =
     exprs.exists(_.collect { case _: Star => true }.nonEmpty)

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -91,7 +91,8 @@ class RelationalGroupedDataset protected[sql](
       UnresolvedAlias(a, Some(Column.generateAlias))
     case ag: UnresolvedFunction if (containsStar(Seq(ag))) || ag.isDistinct =>
              UnresolvedAlias(expr, None)
-    case expr: Expression =>  if (containsStar(Seq(expr))) {
+    case expr: Expression =>
+       if (containsStar(Seq(expr))) {
             UnresolvedAlias(expr, None)
         } else {
           Alias(expr, toPrettySQL(expr))()

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -91,7 +91,11 @@ class RelationalGroupedDataset protected[sql](
       UnresolvedAlias(a, Some(Column.generateAlias))
     case ag: UnresolvedFunction if (containsStar(Seq(ag))) || ag.isDistinct =>
              UnresolvedAlias(expr, None)
-    case expr: Expression => Alias(expr, toPrettySQL(expr))()
+    case expr: Expression =>  if (containsStar(Seq(expr))) {
+            UnresolvedAlias(expr, None)
+        } else {
+          Alias(expr, toPrettySQL(expr))()
+        }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -89,8 +89,17 @@ class RelationalGroupedDataset protected[sql](
     case expr: NamedExpression => expr
     case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
       UnresolvedAlias(a, Some(Column.generateAlias))
+    case ag: UnresolvedFunction if (containsStar(Seq(ag))) =>
+      UnresolvedAlias(expr, None)
     case expr: Expression => Alias(expr, toPrettySQL(expr))()
   }
+
+  /**
+   * Returns true if `exprs` contains a [[Star]].
+   */
+  def containsStar(exprs: Seq[Expression]): Boolean =
+    exprs.exists(_.collect { case _: Star => true }.nonEmpty)
+
 
   private[this] def aggregateNumericColumns(colNames: String*)(f: Expression => AggregateFunction)
     : DataFrame = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
-import org.apache.spark.sql.catalyst.util.toPrettySQL
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
 import org.apache.spark.sql.streaming.OutputMode
@@ -89,15 +88,12 @@ class RelationalGroupedDataset protected[sql](
     case expr: NamedExpression => expr
     case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
       UnresolvedAlias(a, Some(Column.generateAlias))
-    case ag: UnresolvedFunction if (containsStar(Seq(ag))) || ag.isDistinct =>
-      UnresolvedAlias(expr, None)
-    case expr: Expression => Alias(expr, toPrettySQL(expr))()
+    case expr: Expression => UnresolvedAlias(expr, None)
   }
-
   /**
    * Returns true if `exprs` contains a star.
    */
-  def containsStar(exprs: Seq[Expression]): Boolean =
+  @inline final private def containsStar(exprs: Seq[Expression]): Boolean =
     exprs.exists(_.collect { case _: Star => true }.nonEmpty)
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -93,7 +93,7 @@ class RelationalGroupedDataset protected[sql](
   /**
    * Returns true if `exprs` contains a star.
    */
-  @inline final private def containsStar(exprs: Seq[Expression]): Boolean =
+  private[this] def containsStar(exprs: Seq[Expression]): Boolean =
     exprs.exists(_.collect { case _: Star => true }.nonEmpty)
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -89,21 +89,13 @@ class RelationalGroupedDataset protected[sql](
     case expr: NamedExpression => expr
     case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
       UnresolvedAlias(a, Some(Column.generateAlias))
-    case ag: UnresolvedFunction if (containsStar(Seq(ag))) || ag.isDistinct =>
-             UnresolvedAlias(expr, None)
     case expr: Expression =>
-       if (containsStar(Seq(expr))) {
+         if (expr.isInstanceOf[UnresolvedFunction]) {
             UnresolvedAlias(expr, None)
         } else {
           Alias(expr, toPrettySQL(expr))()
         }
   }
-
-  /**
-   * Returns true if `exprs` contains a star.
-   */
-   private[this] def containsStar(exprs: Seq[Expression]): Boolean =
-    exprs.exists(_.collect { case _: Star => true }.nonEmpty)
 
   private[this] def aggregateNumericColumns(colNames: String*)(f: Expression => AggregateFunction)
     : DataFrame = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -89,7 +89,7 @@ class RelationalGroupedDataset protected[sql](
     case expr: NamedExpression => expr
     case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
       UnresolvedAlias(a, Some(Column.generateAlias))
-    case ag: UnresolvedFunction if (containsStar(Seq(ag))) =>
+    case ag: UnresolvedFunction if (containsStar(Seq(ag))) || ag.isDistinct =>
       UnresolvedAlias(expr, None)
     case expr: Expression => Alias(expr, toPrettySQL(expr))()
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -90,13 +90,6 @@ class RelationalGroupedDataset protected[sql](
       UnresolvedAlias(a, Some(Column.generateAlias))
     case expr: Expression => UnresolvedAlias(expr, None)
   }
-  /**
-   * Returns true if `exprs` contains a star.
-   */
-  private[this] def containsStar(exprs: Seq[Expression]): Boolean =
-    exprs.exists(_.collect { case _: Star => true }.nonEmpty)
-
-
   private[this] def aggregateNumericColumns(colNames: String*)(f: Expression => AggregateFunction)
     : DataFrame = {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -89,12 +89,8 @@ class RelationalGroupedDataset protected[sql](
     case expr: NamedExpression => expr
     case a: AggregateExpression if a.aggregateFunction.isInstanceOf[TypedAggregateExpression] =>
       UnresolvedAlias(a, Some(Column.generateAlias))
-    case expr: Expression =>
-         if (expr.isInstanceOf[UnresolvedFunction]) {
-            UnresolvedAlias(expr, None)
-        } else {
-          Alias(expr, toPrettySQL(expr))()
-        }
+    case u: UnresolvedFunction => UnresolvedAlias(expr, None)
+    case expr: Expression => Alias(expr, toPrettySQL(expr))()
   }
 
   private[this] def aggregateNumericColumns(colNames: String*)(f: Expression => AggregateFunction)

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -48,7 +48,7 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
     }
   }
 
-  // Primitives
+  /** Primitives */
 
   /** @since 1.6.0 */
   implicit def newIntEncoder: Encoder[Int] = Encoders.scalaInt

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -48,7 +48,7 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
     }
   }
 
-  /** Primitives */
+  // Primitives 
 
   /** @since 1.6.0 */
   implicit def newIntEncoder: Encoder[Int] = Encoders.scalaInt

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -40,7 +40,7 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
    */
   implicit class StringToColumn(val sc: StringContext) {
     def $(args: Any*): ColumnName = {
-        new ColumnName(sc.s(args: _*))
+      new ColumnName(sc.s(args: _*))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -40,7 +40,11 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
    */
   implicit class StringToColumn(val sc: StringContext) {
     def $(args: Any*): ColumnName = {
-      new ColumnName(sc.s(args: _*))
+      if (sc.parts.length == 1 && sc.parts.contains("*")) {
+        new ColumnName("*")
+      } else {
+        new ColumnName(sc.s(args: _*))
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -48,8 +48,7 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
     }
   }
 
-  // Primitives 
-
+  // Primitives
   /** @since 1.6.0 */
   implicit def newIntEncoder: Encoder[Int] = Encoders.scalaInt
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -45,7 +45,7 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   }
 
   // Primitives
-  
+
   /** @since 1.6.0 */
   implicit def newIntEncoder: Encoder[Int] = Encoders.scalaInt
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -40,11 +40,7 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
    */
   implicit class StringToColumn(val sc: StringContext) {
     def $(args: Any*): ColumnName = {
-      if (sc.parts.length == 1 && sc.parts.contains("*")) {
-        new ColumnName("*")
-      } else {
         new ColumnName(sc.s(args: _*))
-      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLImplicits.scala
@@ -45,6 +45,7 @@ abstract class SQLImplicits extends LowPrioritySQLImplicits {
   }
 
   // Primitives
+  
   /** @since 1.6.0 */
   implicit def newIntEncoder: Encoder[Int] = Encoders.scalaInt
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1136,7 +1136,7 @@ class DataFrameSuite extends QueryTest
     assert(getSchemaAsSeq(summaryDF) === Seq("summary", "name", "age", "height"))
     checkAnswer(approxSummaryDF, approxSummaryResult)
   }
-  
+
   test("SPARK-41391: Correct the output column name of groupBy.agg(count_distinct)") {
     withTempView("person") {
       person.createOrReplaceTempView("person")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1136,6 +1136,7 @@ class DataFrameSuite extends QueryTest
     assert(getSchemaAsSeq(summaryDF) === Seq("summary", "name", "age", "height"))
     checkAnswer(approxSummaryDF, approxSummaryResult)
   }
+  
   test("SPARK-41391: Correct the output column name of groupBy.agg(count_distinct)") {
     withTempView("person") {
       person.createOrReplaceTempView("person")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -1136,6 +1136,17 @@ class DataFrameSuite extends QueryTest
     assert(getSchemaAsSeq(summaryDF) === Seq("summary", "name", "age", "height"))
     checkAnswer(approxSummaryDF, approxSummaryResult)
   }
+  test("SPARK-41391: Correct the output column name of groupBy.agg(count_distinct)") {
+    withTempView("person") {
+      person.createOrReplaceTempView("person")
+      val df1 = person.groupBy("id").agg(count_distinct(col("name")))
+      val df2 = spark.sql("SELECT id, COUNT(DISTINCT name) FROM person GROUP BY id")
+      assert(df1.columns === df2.columns)
+      val df3 = person.groupBy("id").agg(count_distinct(col("*")))
+      val df4 = spark.sql("SELECT id, COUNT(DISTINCT *) FROM person GROUP BY id")
+      assert(df3.columns === df4.columns)
+    }
+  }
 
   test("summary advanced") {
     val stats = Array("count", "50.01%", "max", "mean", "min", "25%")


### PR DESCRIPTION
### What changes were proposed in this pull request?

correct the output column name of groupBy.agg(count_distinct),  so the "*" is expanded correctly into column names and the output column has the distinct keyword.

### Why are the changes needed?

Output column name for groupBy.agg(count_distinct)  is incorrect . However similar queries in spark sql return correct output column. For groupBy.agg queries on dataframe "*" is not expanded correctly in the output column  and the distinct keyword is missing from output column.

```
// initializing data
scala> val df = spark.range(1, 10).withColumn("value", lit(1))
df: org.apache.spark.sql.DataFrame = [id: bigint, value: int]
scala> df.createOrReplaceTempView("table")

// Dataframe  aggregate queries with incorrect output column
scala> df.groupBy("id").agg(count_distinct($"*"))
res3: org.apache.spark.sql.DataFrame = [id: bigint, count(unresolvedstar()): bigint]
scala> df.groupBy("id").agg(count_distinct($"value"))
res1: org.apache.spark.sql.DataFrame = [id: bigint, count(value): bigint]

// Spark Sql aggregate queries with correct output column
scala> spark.sql(" SELECT id, COUNT(DISTINCT *) FROM table GROUP BY id ")
res4: org.apache.spark.sql.DataFrame = [id: bigint, count(DISTINCT id, value): bigint]
scala> spark.sql(" SELECT id, COUNT(DISTINCT value) FROM table GROUP BY id ")
res2: org.apache.spark.sql.DataFrame = [id: bigint, count(DISTINCT value): bigint]
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added UT