### PR TITLE
[SPARK-42528][CORE] Optimize PercentileHeap

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
@@ -25,8 +25,8 @@ import scala.collection.mutable.PriorityQueue
  * Insertion is O(log n), Lookup is O(1).
  *
  * The implementation keeps two heaps: a bottom heap (`botHeap`) and a top heap (`topHeap`). The
- * bottom heap stores all the numbers below the percentile and the top heap stores the ones above the
- * percentile. During insertion the relative sizes of the heaps are adjusted to match the
+ * bottom heap stores all the numbers below the percentile and the top heap stores the ones above
+ * the percentile. During insertion the relative sizes of the heaps are adjusted to match the
  * target percentile.
  */
 private[spark] class PercentileHeap(percentage: Double = 0.5) {
@@ -44,7 +44,7 @@ private[spark] class PercentileHeap(percentage: Double = 0.5) {
    * returned `sorted((sorted.length * percentage).toInt)`.
    */
   def percentile(): Double = {
-    if (isEmpty) throw new IndexOutOfBoundsException("empty")
+    if (isEmpty) throw new NoSuchElementException("empty")
     topHeap.head
   }
 

--- a/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
@@ -44,11 +44,16 @@ private[spark] class PercentileHeap(percentage: Double = 0.5) {
 
   /**
    * Returns percentile of the inserted elements as if the inserted elements were sorted and we
-   * returned `sorted((sorted.length * percentage).toInt)`.
+   * returned `sorted(p)` where `p = (sorted.length * percentage).toInt` if number of elements
+   * is odd, otherwise `(sorted(p-1) + sorted(p)) / 2` if number of elements is even.
    */
   def percentile(): Double = {
     if (isEmpty) throw new NoSuchElementException("empty")
-    largeHeap.peek
+    if (size % 2 == 1 || smallHeap.isEmpty) {
+      largeHeap.peek
+    } else {
+      (largeHeap.peek + -smallHeap.peek) / 2d
+    }
   }
 
   def insert(x: Double): Unit = {

--- a/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable.PriorityQueue
  * Insertion is O(log n), Lookup is O(1).
  *
  * The implementation keeps two heaps: a bottom heap (`botHeap`) and a top heap (`topHeap`). The
- * bottom heap stores all the numbers below the percentile and the top heap the ones above the
+ * bottom heap stores all the numbers below the percentile and the top heap stores the ones above the
  * percentile. During insertion the relative sizes of the heaps are adjusted to match the
  * target percentile.
  */

--- a/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
@@ -20,97 +20,55 @@ package org.apache.spark.util.collection
 import scala.collection.mutable.PriorityQueue
 
 /**
- * PercentileHeap is designed to be used to quickly track the percentile of a group of numbers
- * that may contain duplicates. Inserting a new number has O(log n) time complexity and
- * determining the percentile has O(1) time complexity.
- * The basic idea is to maintain two heaps: a smallerHalf and a largerHalf. The smallerHalf
- * stores the smaller half of all numbers while the largerHalf stores the larger half.
- * The sizes of two heaps need to match the percentage each time when a new number is inserted so
- * that the ratio of their sizes is percentage to (1 - percentage). Therefore each time when
- * percentile() is called we check if the sizes of two heaps match the percentage. If they do,
- * we should return the average of the two top values of heaps. Otherwise we return the top of the
- * heap which exceeds its percentage.
+ * PercentileHeap tracks the percentile of a collection of numbers.
+ *
+ * Insertion is O(log n), Lookup is O(1).
+ *
+ * The implementation keeps two heaps: a bottom heap (`botHeap`) and a top heap (`topHeap`). The
+ * bottom heap stores all the numbers below the percentile and the top heap the ones above the
+ * percentile. During insertion the relative sizes of the heaps are adjusted to match the
+ * target percentile.
  */
-private[spark] class PercentileHeap(percentage: Double = 0.5)(implicit val ord: Ordering[Double]) {
-  assert(percentage >= 0 && percentage <= 1)
+private[spark] class PercentileHeap(percentage: Double = 0.5) {
+  assert(percentage > 0 && percentage < 1)
+
+  private[this] val topHeap = PriorityQueue.empty[Double](Ordering[Double].reverse)
+  private[this] val botHeap = PriorityQueue.empty[Double](Ordering[Double])
+
+  def isEmpty(): Boolean = botHeap.isEmpty && topHeap.isEmpty
+
+  def size(): Int = botHeap.size + topHeap.size
 
   /**
-   * Stores all the numbers less than the current percentile in a smallerHalf,
-   * i.e percentile is the maximum, at the root.
+   * Returns percentile of the inserted elements as if the inserted elements were sorted and we
+   * returned `sorted((sorted.length * percentage).toInt)`.
    */
-  private[this] val smallerHalf = PriorityQueue.empty[Double](ord)
-
-  /**
-   * Stores all the numbers greater than the current percentile in a largerHalf,
-   * i.e percentile is the minimum, at the root.
-   */
-  private[this] val largerHalf = PriorityQueue.empty[Double](ord.reverse)
-
-  def isEmpty(): Boolean = {
-    smallerHalf.isEmpty && largerHalf.isEmpty
+  def percentile(): Double = {
+    if (isEmpty) throw new IndexOutOfBoundsException("empty")
+    topHeap.head
   }
-
-  def size(): Int = {
-    smallerHalf.size + largerHalf.size
-  }
-
-  // Exposed for testing.
-  def smallerSize(): Int = smallerHalf.size
 
   def insert(x: Double): Unit = {
-    // If both heaps are empty, we insert it to the heap that has larger percentage.
     if (isEmpty) {
-      if (percentage < 0.5) smallerHalf.enqueue(x) else largerHalf.enqueue(x)
+      topHeap.enqueue(x)
     } else {
-      // If the number is larger than current percentile, it should be inserted into largerHalf,
-      // otherwise smallerHalf.
-      if (x > percentile) {
-        largerHalf.enqueue(x)
+      val p = topHeap.head
+      val growBot = ((size + 1) * percentage).toInt > botHeap.size
+      if (growBot) {
+        if (x < p) {
+          botHeap.enqueue(x)
+        } else {
+          topHeap.enqueue(x)
+          botHeap.enqueue(topHeap.dequeue)
+        }
       } else {
-        smallerHalf.enqueue(x)
+        if (x < p) {
+          botHeap.enqueue(x)
+          topHeap.enqueue(botHeap.dequeue())
+        } else {
+          topHeap.enqueue(x)
+        }
       }
-    }
-    rebalance()
-  }
-
-  // Calculate the deviation between the ratio of smaller heap size to larger heap size and the
-  // expected ratio, which is percentage : (1 - percentage). Negative result means the smaller
-  // heap has too less elements, positive result means the smaller heap has too many elements.
-  private def calculateDeviation(smallerSize: Int, largerSize: Int): Double = {
-    smallerSize * (1 - percentage) - largerSize * percentage
-  }
-
-  private[this] def rebalance(): Unit = {
-    // If moving one value from heap to the other heap can fit the percentage better, then
-    // move it.
-    val currentDev = calculateDeviation(smallerHalf.size, largerHalf.size)
-    if (currentDev > 0) {
-      val newDev = calculateDeviation(smallerHalf.size - 1, largerHalf.size + 1)
-      if (math.abs(newDev) < currentDev) {
-        largerHalf.enqueue(smallerHalf.dequeue)
-      }
-    }
-    if (currentDev < 0) {
-      val newDev = calculateDeviation(smallerHalf.size + 1, largerHalf.size - 1)
-      if (math.abs(newDev) < -currentDev) {
-        smallerHalf.enqueue(largerHalf.dequeue())
-      }
-    }
-  }
-
-  def percentile: Double = {
-    if (isEmpty) {
-      throw new NoSuchElementException("PercentileHeap is empty.")
-    }
-    val dev = calculateDeviation(smallerHalf.size, largerHalf.size)
-    // If the deviation is very small, we take the average of the top elements from the two heaps
-    // as the percentile.
-    if (smallerHalf.nonEmpty && largerHalf.nonEmpty && math.abs(dev / size) < 0.01) {
-      (largerHalf.head + smallerHalf.head) / 2.0
-    } else if (dev < 0) {
-      largerHalf.head
-    } else {
-      smallerHalf.head
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
@@ -52,7 +52,7 @@ private[spark] class PercentileHeap(percentage: Double = 0.5) {
     if (size % 2 == 1 || smallHeap.isEmpty) {
       largeHeap.peek
     } else {
-      (largeHeap.peek + -smallHeap.peek) / 2d
+      (largeHeap.peek + -smallHeap.peek) / 2.0
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
@@ -30,7 +30,7 @@ class PercentileHeapSuite extends SparkFunSuite {
     }
   }
 
-  private def testPercentileFor(nums: Seq[Double], percentage: Double) = {
+  private def testPercentileFor(nums: Seq[Int], percentage: Double) = {
     val h = new PercentileHeap(percentage)
     Random.shuffle(nums).foreach(h.insert(_))
     assert(h.size == nums.length)
@@ -39,11 +39,11 @@ class PercentileHeapSuite extends SparkFunSuite {
   }
 
   private val tests = Seq(
-    0d until 1d by 1d,
-    0d until 2d by 1d,
-    0d until 11d by 1d,
-    0d until 42d by 1d,
-    0d until 100d by 1d
+    0 until 1,
+    0 until 2,
+    0 until 11,
+    0 until 42,
+    0 until 100
   )
 
   for (t <- tests) {

--- a/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
@@ -63,7 +63,7 @@ class PercentileHeapSuite extends SparkFunSuite {
     }
   }
 
-  test("benchmark") {
+  ignore("benchmark") {
     val input: Seq[Int] = 0 until 1000
     val numRuns = 1000
 

--- a/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
@@ -53,4 +53,28 @@ class PercentileHeapSuite extends SparkFunSuite {
       }
     }
   }
+
+  test("benchmark") {
+    val input: Seq[Int] = 0 until 1000
+    val numRuns = 1000
+
+    def kernel(): Long = {
+      val shuffled = Random.shuffle(input).toArray
+      val start = System.nanoTime()
+      val h = new PercentileHeap(0.95)
+      shuffled.foreach { x =>
+        h.insert(x)
+        for (_ <- 0 until h.size) h.percentile
+      }
+      System.nanoTime() - start
+    }
+    for (_ <- 0 until numRuns) kernel()  // warmup
+
+    var elapsed: Long = 0
+    for (_ <- 0 until numRuns) elapsed += kernel()
+    val perOp = elapsed / (numRuns * input.length)
+    // scalastyle:off println
+    println(s"$perOp ns per op on heaps of size ${input.length}")
+    // scalastyle:on println
+  }
 }

--- a/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
@@ -30,12 +30,21 @@ class PercentileHeapSuite extends SparkFunSuite {
     }
   }
 
+  private def percentile(nums: Seq[Int], percentage: Double): Double = {
+    val p = (nums.length * percentage).toInt
+    val sorted = nums.sorted.toIndexedSeq
+    if (nums.length % 2 == 1 || p == 0) {
+      sorted(p)
+    } else {
+      (sorted(p - 1) + sorted(p)) / 2d
+    }
+  }
+
   private def testPercentileFor(nums: Seq[Int], percentage: Double) = {
     val h = new PercentileHeap(percentage)
     Random.shuffle(nums).foreach(h.insert(_))
     assert(h.size == nums.length)
-    val sorted = nums.sorted.toArray
-    assert(h.percentile == sorted((sorted.length * percentage).toInt))
+    assert(h.percentile == percentile(nums, percentage))
   }
 
   private val tests = Seq(

--- a/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
@@ -23,9 +23,9 @@ import org.apache.spark.SparkFunSuite
 
 class PercentileHeapSuite extends SparkFunSuite {
 
-  test("When PercentileHeap is empty, IndexOutOfBoundsException is thrown.") {
+  test("When PercentileHeap is empty, NoSuchElementException is thrown.") {
     val medianHeap = new PercentileHeap(0.5)
-    intercept[IndexOutOfBoundsException] {
+    intercept[NoSuchElementException] {
       medianHeap.percentile
     }
   }

--- a/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
@@ -36,7 +36,7 @@ class PercentileHeapSuite extends SparkFunSuite {
     if (nums.length % 2 == 1 || p == 0) {
       sorted(p)
     } else {
-      (sorted(p - 1) + sorted(p)) / 2d
+      (sorted(p - 1) + sorted(p)) / 2.0
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Reimplement `PercentileHeap` such that:
- the percentile value is always in the `topHeap`, this speeds up `percentile` access
- rebalance the heaps more efficiently by checking which heap should grow due to the new insertion and doing a rebalance based on target heap sizes
- the heaps are java PriorityQueue's *without* comparators. Comparator call overhead slows down `poll`/`offer` by more than 2x. Instead implement a max-heap by `poll`/`offer` on the negated domain of numbers.

### Why are the changes needed?

`PercentileHeap` is heavy weight enough to cause scheduling delays if inserted inside the scheduler loop.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added more extensive unittests.