### PR TITLE
[SPARK-42466][K8S]: Cleanup k8s upload directory when job terminates

### DIFF
--- a/core/src/main/scala/org/apache/spark/UploadDirManager.scala
+++ b/core/src/main/scala/org/apache/spark/UploadDirManager.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.{ShutdownHookManager, Utils}
+
+/**
+ * Kubernetes upload directory manager. It's responsible for cleanup of the upload directory
+ * when spark job finishes.
+ */
+private[spark] class UploadDirManager(conf: SparkConf, appId: String) extends Logging {
+  require(conf.contains("spark.kubernetes.file.upload.path"))
+
+  private val uploadPath = new Path(conf.get("spark.kubernetes.file.upload.path"))
+  private val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
+  private val fileSystem = FileSystem.get(uploadPath.toUri, hadoopConf)
+  private val uploadDirName = s"${uploadPath}/spark-upload-${appId}"
+  private val uploadDirPath = new Path(uploadDirName)
+
+  private val shutdownHook = addShutdownHook()
+
+  private def addShutdownHook(): AnyRef = {
+    logDebug("Adding shutdown hook")
+    ShutdownHookManager.addShutdownHook(ShutdownHookManager.TEMP_DIR_SHUTDOWN_PRIORITY - 1) { () =>
+      logInfo("Shutdown hook called")
+      Utils.tryLogNonFatalError {
+        UploadDirManager.this.cleanUp()
+      }
+    }
+  }
+
+  def cleanUp(): Unit = {
+    if (shutdownHook != null) {
+      ShutdownHookManager.removeShutdownHook(shutdownHook)
+    }
+    if (fileSystem.exists(uploadDirPath)) {
+      if (fileSystem.delete(uploadDirPath, true)) {
+        logInfo(s"Upload dir deleted successfully.: $uploadDirPath")
+      } else {
+        logWarning(s"Failed to delete upload dir: $uploadDirPath")
+      }
+    } else {
+      logInfo("upload dir doesn't exist")
+    }
+  }
+}
+
+private[spark] object UploadDirManager extends Logging {
+
+  def init(conf: SparkConf, appId: String): Option[UploadDirManager] = {
+    if (conf.contains("spark.kubernetes.file.upload.path")) {
+      logInfo("creating instance of UploadDirManager")
+      Some(new UploadDirManager(conf, appId))
+    } else {
+      logInfo("UploadDirManager instance not created")
+      None
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -398,6 +398,10 @@ private[spark] class SparkSubmit extends Logging {
       }.orNull
 
       if (isKubernetesClusterModeDriver) {
+        // register shutdownhook for cleaning up the upload dir
+        if (sparkConf.contains("spark.app.id")) {
+          UploadDirManager.init(sparkConf, sparkConf.get("spark.app.id"))
+        }
         // SPARK-33748: this mimics the behaviour of Yarn cluster mode. If the driver is running
         // in cluster mode, the archives should be available in the driver's current working
         // directory too.

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -166,6 +166,8 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
       "spark.app.id" -> conf.appId,
       KUBERNETES_DRIVER_SUBMIT_CHECK.key -> "true",
       MEMORY_OVERHEAD_FACTOR.key -> defaultOverheadFactor.toString)
+    // set app id in sparkConf as it is required for creating the upload directory
+    conf.sparkConf.set("spark.app.id", conf.appId)
     // try upload local, resolvable files to a hadoop compatible file system
     Seq(JARS, FILES, ARCHIVES, SUBMIT_PYTHON_FILES).foreach { key =>
       val (localUris, remoteUris) =

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverCommandFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverCommandFeatureStep.scala
@@ -96,7 +96,8 @@ private[spark] class DriverCommandFeatureStep(conf: KubernetesDriverConf)
             .orElse(environmentVariables.get(ENV_PYSPARK_PYTHON))
             .orNull))
     }
-
+    // set app id in sparkConf as it is required for creating the upload directory
+    conf.sparkConf.set("spark.app.id", conf.appId)
     // re-write primary resource to be the remote one and upload the related file
     val newResName = KubernetesUtils
       .renameMainAppResource(res, Option(conf.sparkConf), true)


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Instead of creating multiple sub directories in k8s upload directory (spark.kubernetes.file.upload.path) for each file to be uploaded, create a single subdirectory to be used for all file uploads of a specific application. This directory will be named using the spark application id.
2. Delete the sub directory and it's content when job terminates

### Why are the changes needed?
The change is required to cleanup the files and directories which are created under the k8s upload path to prevent space getting full. without this change, user needs to manually clean up these files.

### Does this PR introduce _any_ user-facing change?
Yes, Users submitting spark on k8s job, won't need to manually cleanup the files under upload directory.

### How was this patch tested?
Through git action and manually by running jobs in local k8s cluster.
Also, added unit test for testing the change in behaviour of sub directory creation under upload path.

Some logs for verification:

23/02/22 18:41:16 INFO SparkContext: Successfully stopped SparkContext
23/02/22 18:41:16 INFO ShutdownHookManager: Shutdown hook called
23/02/22 18:41:16 INFO ShutdownHookManager: Deleting directory /spark-local2/spark-f58ecb91-0bb6-4b10-a372-405f69780c15
23/02/22 18:41:16 INFO ShutdownHookManager: Deleting directory /tmp/spark-c10b27ca-fe68-4382-913f-4a535833f64e
23/02/22 18:41:16 INFO ShutdownHookManager: Deleting directory /spark-local1/spark-8c4ef9d8-7688-4f51-b587-16dee1d264c7
23/02/22 18:41:16 INFO UploadDirManager: Shutdown hook called
23/02/22 18:41:17 INFO UploadDirManager: Upload dir deleted successfully.: hdfs://****:8020/user/*****/k8s/spark-upload-spark-b6609808729a49e9b6f53f20ed50d05b

