### PR TITLE
[SPARK-42533][CONNECT][Scala] Add ssl for Scala client

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -189,7 +189,12 @@ object SparkSession extends Logging {
   class Builder() extends Logging {
     private var _client: SparkConnectClient = _
 
-    def client(client: SparkConnectClient): Builder = {
+    def remote(connectionString: String): Builder = {
+      client(SparkConnectClient.builder().connectionString(connectionString).build())
+      this
+    }
+
+    private[sql] def client(client: SparkConnectClient): Builder = {
       _client = client
       this
     }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
@@ -98,7 +98,7 @@ class PlanGenerationTestSuite extends ConnectFunSuite with BeforeAndAfterAll wit
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    val client = new SparkConnectClient(
+    val client = SparkConnectClient(
       proto.UserContext.newBuilder().build(),
       InProcessChannelBuilder.forName("/dev/null").build())
     val builder = SparkSession.builder().client(client)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -128,6 +128,10 @@ class SparkConnectClientSuite
       "sc://host:123/;user_id=a94",
       isCorrect = true,
       client => assert(client.userId == "a94")),
+    TestPackURI(
+      "sc://host:123/;user_agent=a945",
+      isCorrect = true,
+      client => assert(client.userAgent == "a945")),
     TestPackURI("scc://host:12", isCorrect = false),
     TestPackURI("http://host", isCorrect = false),
     TestPackURI("sc:/host:1234/path", isCorrect = false),
@@ -143,7 +147,8 @@ class SparkConnectClientSuite
     TestPackURI("sc://host:123/;use_ssl=true;token=mySecretToken", isCorrect = true),
     TestPackURI("sc://host:123/;token=mySecretToken;use_ssl=true", isCorrect = true),
     TestPackURI("sc://host:123/;use_ssl=false;token=mySecretToken", isCorrect = false),
-    TestPackURI("sc://host:123/;token=mySecretToken;use_ssl=false", isCorrect = false))
+    TestPackURI("sc://host:123/;token=mySecretToken;use_ssl=false", isCorrect = false),
+    TestPackURI("sc://host:123/;param1=value1;param2=value2", isCorrect = true))
 
   private def checkTestPack(testPack: TestPackURI): Unit = {
     val client = SparkConnectClient.builder().connectionString(testPack.connectionString).build()
@@ -157,12 +162,6 @@ class SparkConnectClientSuite
       } else {
         checkTestPack(testPack)
       }
-    }
-  }
-
-  test("Unknown parameters throw unsupported errors") {
-    assertThrows[UnsupportedOperationException] {
-      SparkConnectClient.builder().connectionString("sc://host/;xyz=abc").build()
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding SSL encryption and access token support for Scala client

### Why are the changes needed?
To support basic client side encryption to protect data sent over the network.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests. Manual tests.