### PR TITLE
[SPARK-41171][SQL] Infer and push down window limit through window if partitionSpec is empty

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -130,6 +130,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
     val operatorOptimizationBatch: Seq[Batch] = {
       Batch("Operator Optimization before Inferring Filters", fixedPoint,
         operatorOptimizationRuleSet: _*) ::
+      Batch("Infer window group limit", Once, InferWindowGroupLimit) ::
       Batch("Infer Filters", Once,
         InferFiltersFromGenerate,
         InferFiltersFromConstraints) ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -120,7 +120,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.EliminateMapObjects" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateOuterJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateSerialization" ::
-      "org.apache.spark.sql.catalyst.optimizer.InsertWindowGroupLimit" ::
+      "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit" ::
       "org.apache.spark.sql.catalyst.optimizer.LikeSimplification" ::
       "org.apache.spark.sql.catalyst.optimizer.LimitPushDown" ::
       "org.apache.spark.sql.catalyst.optimizer.LimitPushDownThroughWindow" ::

--- a/sql/core/benchmarks/TopKBenchmark-results.txt
+++ b/sql/core/benchmarks/TopKBenchmark-results.txt
@@ -6,17 +6,17 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Benchmark Top-K:                                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------
-ROW_NUMBER (PARTITION: , WindowGroupLimit: false)                        10711          11068         363          2.0         510.8       1.0X
-ROW_NUMBER (PARTITION: , WindowGroupLimit: true)                          2611           2929         210          8.0         124.5       4.1X
-ROW_NUMBER (PARTITION: PARTITION BY b, WindowGroupLimit: false)          23829          24085         178          0.9        1136.2       0.4X
-ROW_NUMBER (PARTITION: PARTITION BY b, WindowGroupLimit: true)            6381           6515          97          3.3         304.3       1.7X
-RANK (PARTITION: , WindowGroupLimit: false)                              11459          11798         223          1.8         546.4       0.9X
-RANK (PARTITION: , WindowGroupLimit: true)                                2588           2837         162          8.1         123.4       4.1X
-RANK (PARTITION: PARTITION BY b, WindowGroupLimit: false)                24560          24707         108          0.9        1171.1       0.4X
-RANK (PARTITION: PARTITION BY b, WindowGroupLimit: true)                  6395           6530         109          3.3         304.9       1.7X
-DENSE_RANK (PARTITION: , WindowGroupLimit: false)                        11563          11740         124          1.8         551.3       0.9X
-DENSE_RANK (PARTITION: , WindowGroupLimit: true)                          2563           2819         168          8.2         122.2       4.2X
-DENSE_RANK (PARTITION: PARTITION BY b, WindowGroupLimit: false)          24482          24578          64          0.9        1167.4       0.4X
-DENSE_RANK (PARTITION: PARTITION BY b, WindowGroupLimit: true)            6368           6511         122          3.3         303.7       1.7X
+ROW_NUMBER (PARTITION: , WindowGroupLimit: false)                        11054          11684         406          1.9         527.1       1.0X
+ROW_NUMBER (PARTITION: , WindowGroupLimit: true)                          1737           1772          23         12.1          82.8       6.4X
+ROW_NUMBER (PARTITION: PARTITION BY b, WindowGroupLimit: false)          24570          24698          97          0.9        1171.6       0.4X
+ROW_NUMBER (PARTITION: PARTITION BY b, WindowGroupLimit: true)            6645           6916         219          3.2         316.9       1.7X
+RANK (PARTITION: , WindowGroupLimit: false)                              11590          11917         237          1.8         552.7       1.0X
+RANK (PARTITION: , WindowGroupLimit: true)                                2697           2865         107          7.8         128.6       4.1X
+RANK (PARTITION: PARTITION BY b, WindowGroupLimit: false)                25357          25476          94          0.8        1209.1       0.4X
+RANK (PARTITION: PARTITION BY b, WindowGroupLimit: true)                  6625           6755          92          3.2         315.9       1.7X
+DENSE_RANK (PARTITION: , WindowGroupLimit: false)                        11876          12137         184          1.8         566.3       0.9X
+DENSE_RANK (PARTITION: , WindowGroupLimit: true)                          2678           2961         147          7.8         127.7       4.1X
+DENSE_RANK (PARTITION: PARTITION BY b, WindowGroupLimit: false)          25407          27601         700          0.8        1211.5       0.4X
+DENSE_RANK (PARTITION: PARTITION BY b, WindowGroupLimit: true)            6841           7008         184          3.1         326.2       1.6X
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -84,7 +84,6 @@ class SparkOptimizer(
       PushPredicateThroughNonJoin,
       PushProjectionThroughLimit,
       RemoveNoopOperators) :+
-    Batch("Insert window group limit", Once, InsertWindowGroupLimit) :+
     Batch("User Provided Optimizers", fixedPoint, experimentalMethods.extraOptimizations: _*) :+
     Batch("Replace CTE with Repartition", Once, ReplaceCTERefWithRepartition)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -1284,6 +1284,7 @@ class DataFrameWindowFunctionsSuite extends QueryTest
 
     val window = Window.partitionBy($"key").orderBy($"order".asc_nulls_first)
     val window2 = Window.partitionBy($"key").orderBy($"order".desc_nulls_first)
+    val window3 = Window.orderBy($"order".asc_nulls_first)
 
     Seq(-1, 100).foreach { threshold =>
       withSQLConf(SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD.key -> threshold.toString) {
@@ -1316,6 +1317,24 @@ class DataFrameWindowFunctionsSuite extends QueryTest
               Row("a", 4, "", 2.0, 1),
               Row("a", 4, "", 2.0, 1),
               Row("b", 1, "h", Double.NaN, 1),
+              Row("c", 2, null, 5.0, 1)
+            )
+          )
+
+          checkAnswer(df.withColumn("rn", row_number().over(window3)).where(condition),
+            Seq(
+              Row("c", 2, null, 5.0, 1)
+            )
+          )
+
+          checkAnswer(df.withColumn("rn", rank().over(window3)).where(condition),
+            Seq(
+              Row("c", 2, null, 5.0, 1)
+            )
+          )
+
+          checkAnswer(df.withColumn("rn", dense_rank().over(window3)).where(condition),
+            Seq(
               Row("c", 2, null, 5.0, 1)
             )
           )
@@ -1352,6 +1371,29 @@ class DataFrameWindowFunctionsSuite extends QueryTest
               Row("b", 1, "h", Double.NaN, 1),
               Row("b", 1, "n", Double.PositiveInfinity, 2),
               Row("c", 1, "a", -4.0, 2),
+              Row("c", 2, null, 5.0, 1)
+            )
+          )
+
+          checkAnswer(df.withColumn("rn", row_number().over(window3)).where(condition),
+            Seq(
+              Row("a", 4, "", 2.0, 2),
+              Row("c", 2, null, 5.0, 1)
+            )
+          )
+
+          checkAnswer(df.withColumn("rn", rank().over(window3)).where(condition),
+            Seq(
+              Row("a", 4, "", 2.0, 2),
+              Row("a", 4, "", 2.0, 2),
+              Row("c", 2, null, 5.0, 1)
+            )
+          )
+
+          checkAnswer(df.withColumn("rn", dense_rank().over(window3)).where(condition),
+            Seq(
+              Row("a", 4, "", 2.0, 2),
+              Row("a", 4, "", 2.0, 2),
               Row("c", 2, null, 5.0, 1)
             )
           )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Sometimes, the SQL exists filter which condition compares the window function `ROW_NUMBER()` with number. For example,
```
SELECT *,
         ROW_NUMBER() OVER(ORDER BY a) AS rn
FROM Tab1
WHERE rn <= 5
```
We can create a `Limit` as the parent node of `Window` node. Such as: `Limit(Literal(5), Window)` and the optimizer rule `LimitPushDownThroughWindow` will push down the `Limit` as the child of `Window`. After this optimization, Spark executes top n and reduce the data size before shuffle. We can consider the SQL adjusted as the below.
```
SELECT *,
         ROW_NUMBER() OVER(ORDER BY a) AS rn
FROM 
    (SELECT *
    FROM Tab1
    ORDER BY  a LIMIT 5) t
```
In short, it supports following pattern:
```
SELECT (... row_number()
    OVER (
ORDER BY  ... ) AS rn)
WHERE rn (==|<|<=) k
        AND other conditions
```

### Why are the changes needed?
Improve the performance by infer window limit and push down it through window when partitionSpec is empty.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
The top n (`Limit` + `Sort`) have better performance than `WindowGroupLimit` if the window function is `RowNumber` and `Window`'s partitionSpec is empty.
Before this PR, the micro benchmark of Top-K show below.
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
Intel(R) Core(TM) i7-9750H CPU  2.60GHz
Benchmark Top-K:                                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------------------
ROW_NUMBER (PARTITION: , WindowGroupLimit: false)                        10711          11068         363          2.0         510.8       1.0X
ROW_NUMBER (PARTITION: , WindowGroupLimit: true)                          2611           2929         210          8.0         124.5       4.1X
```
After this PR, the micro benchmark of Top-K show below.
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark Top-K:                                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------------------
ROW_NUMBER (PARTITION: , WindowGroupLimit: false)                        11054          11684         406          1.9         527.1       1.0X
ROW_NUMBER (PARTITION: , WindowGroupLimit: true)                          1737           1772          23         12.1          82.8       6.4X
```
We can see the change of `ROW_NUMBER (PARTITION: , WindowGroupLimit: true) `: 2929 -> 1772.