### PR TITLE
[SPARK-42545][K8S][DOCS] Remove `experimental` from `Volcano` docs

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1845,8 +1845,6 @@ Spark allows users to specify a custom Kubernetes schedulers.
 
 #### Using Volcano as Customized Scheduler for Spark on Kubernetes
 
-**This feature is currently experimental. In future versions, there may be behavioral changes around configuration, feature step improvement.**
-
 ##### Prerequisites
 * Spark on Kubernetes with [Volcano](https://volcano.sh/en) as a custom scheduler is supported since Spark v3.3.0 and Volcano v1.7.0. Below is an example to install Volcano 1.7.0:
 

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -331,8 +331,6 @@ You can also specify your specific dockerfile to build JVM/Python/R based image 
 
 # Running the Volcano Integration Tests
 
-Volcano integration is experimental in Aapche Spark 3.3.0 and the test coverage is limited.
-
 ## Requirements
 - A minimum of 6 CPUs and 9G of memory is required to complete all Volcano test cases.
 - Volcano v1.7.0.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `experimental` notes from `Volcano` docs.

### Why are the changes needed?

Apache Spark 3.3.0 added `Volcano` as an experimental module. Now, we can remove it from Apache Spark 3.4.0 because we don't expect breaking future behavior changes.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation only change.

### How was this patch tested?

Manual review.