### PR TITLE
[SPARK-42551][SQL] Support more subexpression elimination cases

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1027,131 +1027,24 @@ class CodegenContext extends Logging {
     splitExpressions(subexprFunctions.toSeq, "subexprFunc_split", Seq("InternalRow" -> INPUT_ROW))
   }
 
-  /**
-   * Perform a function which generates a sequence of ExprCodes with a given mapping between
-   * expressions and common expressions, instead of using the mapping in current context.
-   */
-  def withSubExprEliminationExprs(
-      newSubExprEliminationExprs: Map[ExpressionEquals, SubExprEliminationState])(
-      f: => Seq[ExprCode]): Seq[ExprCode] = {
-    val oldsubExprEliminationExprs = subExprEliminationExprs
-    subExprEliminationExprs = newSubExprEliminationExprs
+  def subexpressionElimination(expressions: Expression*): Block = {
+    var initBlock: Block = EmptyBlock
+    if (SQLConf.get.subexpressionEliminationEnabled) {
+      // Create a clear EquivalentExpressions and SubExprEliminationState mapping
+      val equivalentExpressions: EquivalentExpressions = new EquivalentExpressions
+      // Add current expression tree and compute the common subexpressions.
+      expressions.map(equivalentExpressions.addExprTree(_))
 
-    val genCodes = f
-
-    // Restore previous subExprEliminationExprs
-    subExprEliminationExprs = oldsubExprEliminationExprs
-    genCodes
-  }
-
-  /**
-   * Evaluates a sequence of `SubExprEliminationState` which represent subexpressions. After
-   * evaluating a subexpression, this method will clean up the code block to avoid duplicate
-   * evaluation.
-   */
-  def evaluateSubExprEliminationState(subExprStates: Iterable[SubExprEliminationState]): String = {
-    val code = new StringBuilder()
-
-    subExprStates.foreach { state =>
-      val currentCode = evaluateSubExprEliminationState(state.children) + "\n" + state.eval.code
-      code.append(currentCode + "\n")
-      state.eval.code = EmptyBlock
-    }
-
-    code.toString()
-  }
-
-  /**
-   * Checks and sets up the state and codegen for subexpression elimination in whole-stage codegen.
-   *
-   * This finds the common subexpressions, generates the code snippets that evaluate those
-   * expressions and populates the mapping of common subexpressions to the generated code snippets.
-   *
-   * The generated code snippet for subexpression is wrapped in `SubExprEliminationState`, which
-   * contains an `ExprCode` and the children `SubExprEliminationState` if any. The `ExprCode`
-   * includes java source code, result variable name and is-null variable name of the subexpression.
-   *
-   * Besides, this also returns a sequences of `ExprCode` which are expression codes that need to
-   * be evaluated (as their input parameters) before evaluating subexpressions.
-   *
-   * To evaluate the returned subexpressions, please call `evaluateSubExprEliminationState` with
-   * the `SubExprEliminationState`s to be evaluated. During generating the code, it will cleanup
-   * the states to avoid duplicate evaluation.
-   *
-   * The details of subexpression generation:
-   *   1. Gets subexpression set. See `EquivalentExpressions`.
-   *   2. Generate code of subexpressions as a whole block of code (non-split case)
-   *   3. Check if the total length of the above block is larger than the split-threshold. If so,
-   *      try to split it in step 4, otherwise returning the non-split code block.
-   *   4. Check if parameter lengths of all subexpressions satisfy the JVM limitation, if so,
-   *      try to split, otherwise returning the non-split code block.
-   *   5. For each subexpression, generating a function and put the code into it. To evaluate the
-   *      subexpression, just call the function.
-   *
-   * The explanation of subexpression codegen:
-   *   1. Wrapping in `withSubExprEliminationExprs` call with current subexpression map. Each
-   *      subexpression may depends on other subexpressions (children). So when generating code
-   *      for subexpressions, we iterate over each subexpression and put the mapping between
-   *      (subexpression -> `SubExprEliminationState`) into the map. So in next subexpression
-   *      evaluation, we can look for generated subexpressions and do replacement.
-   */
-  def subexpressionEliminationForWholeStageCodegen(expressions: Seq[Expression]): SubExprCodes = {
-    // Create a clear EquivalentExpressions and SubExprEliminationState mapping
-    val equivalentExpressions: EquivalentExpressions = new EquivalentExpressions
-    val localSubExprEliminationExprsForNonSplit =
-      mutable.HashMap.empty[ExpressionEquals, SubExprEliminationState]
-
-    // Add each expression tree and compute the common subexpressions.
-    expressions.foreach(equivalentExpressions.addExprTree(_))
-
-    // Get all the expressions that appear at least twice and set up the state for subexpression
-    // elimination.
-    val commonExprs = equivalentExpressions.getCommonSubexpressions
-
-    val nonSplitCode = {
-      val allStates = mutable.ArrayBuffer.empty[SubExprEliminationState]
-      commonExprs.map { expr =>
-        withSubExprEliminationExprs(localSubExprEliminationExprsForNonSplit.toMap) {
-          val eval = expr.genCode(this)
-          // Collects other subexpressions from the children.
-          val childrenSubExprs = mutable.ArrayBuffer.empty[SubExprEliminationState]
-          expr.foreach { e =>
-            subExprEliminationExprs.get(ExpressionEquals(e)) match {
-              case Some(state) => childrenSubExprs += state
-              case _ =>
-            }
+      commonExpressions.clear()
+      commonExpressions ++= equivalentExpressions.getAllExprStates(1).map { stats =>
+        val expr = stats.expr
+        val initialized = addMutableState(JAVA_BOOLEAN, "subExprInit")
+        initBlock += code"$initialized = false;\n"
+        val wrapperFunc: ExprCode => ExprCode = { eval =>
+          val (inputVars, exprCodes) = {
+            val (inputVars, exprCodes) = getLocalInputVariableValues(this, expr)
+            (inputVars.toSeq, exprCodes.toSeq)
           }
-          val state = SubExprEliminationState(eval, childrenSubExprs.toSeq)
-          localSubExprEliminationExprsForNonSplit.put(ExpressionEquals(expr), state)
-          allStates += state
-          Seq(eval)
-        }
-      }
-      allStates.toSeq
-    }
-
-    // For some operators, they do not require all its child's outputs to be evaluated in advance.
-    // Instead it only early evaluates part of outputs, for example, `ProjectExec` only early
-    // evaluate the outputs used more than twice. So we need to extract these variables used by
-    // subexpressions and evaluate them before subexpressions.
-    val (inputVarsForAllFuncs, exprCodesNeedEvaluate) = commonExprs.map { expr =>
-      val (inputVars, exprCodes) = getLocalInputVariableValues(this, expr)
-      (inputVars.toSeq, exprCodes.toSeq)
-    }.unzip
-
-    val needSplit = nonSplitCode.map(_.eval.code.length).sum > SQLConf.get.methodSplitThreshold
-    val (subExprsMap, exprCodes) = if (needSplit) {
-      if (inputVarsForAllFuncs.map(calculateParamLengthFromExprValues).forall(isValidParamLength)) {
-        val localSubExprEliminationExprs =
-          mutable.HashMap.empty[ExpressionEquals, SubExprEliminationState]
-
-        commonExprs.zipWithIndex.foreach { case (expr, i) =>
-          val eval = withSubExprEliminationExprs(localSubExprEliminationExprs.toMap) {
-            Seq(expr.genCode(this))
-          }.head
-
-          val value = addMutableState(javaType(expr.dataType), "subExprValue")
-
           val isNullLiteral = eval.isNull match {
             case TrueLiteral | FalseLiteral => true
             case _ => false
@@ -1162,105 +1055,41 @@ class CodegenContext extends Logging {
           } else {
             (eval.isNull, "")
           }
-
-          // Generate the code for this expression tree and wrap it in a function.
-          val fnName = freshName("subExpr")
-          val inputVars = inputVarsForAllFuncs(i)
-          val argList =
-            inputVars.map(v => s"${CodeGenerator.typeName(v.javaType)} ${v.variableName}")
-          val fn =
-            s"""
-               |private void $fnName(${argList.mkString(", ")}) {
-               |  ${eval.code}
-               |  $isNullEvalCode
-               |  $value = ${eval.value};
-               |}
+          val value = addMutableState(javaType(expr.dataType), "subExprValue")
+          val code = if (isValidParamLength(calculateParamLengthFromExprValues(inputVars))) {
+            // Generate the code for this expression tree and wrap it in a function.
+            val fnName = freshName("subExpr")
+            val argList =
+              inputVars.map(v => s"${CodeGenerator.typeName(v.javaType)} ${v.variableName}")
+            val fn =
+              s"""
+                 |private void $fnName(${argList.mkString(", ")}) {
+                 |  if (!$initialized) {
+                 |    ${eval.code}
+                 |    $initialized = true;
+                 |    $isNullEvalCode
+                 |    $value = ${eval.value};
+                 |  }
+                 |}
+                 """.stripMargin
+            val inputVariables = inputVars.map(_.variableName).mkString(", ")
+            code"${addNewFunction(fnName, fn)}($inputVariables);"
+          } else {
+            code"""
+                  |if (!$initialized) {
+                  |  ${eval.code}
+                  |  $initialized = true;
+                  |  $isNullEvalCode
+                  |  $value = ${eval.value};
+                  |}
                """.stripMargin
-
-          // Collects other subexpressions from the children.
-          val childrenSubExprs = mutable.ArrayBuffer.empty[SubExprEliminationState]
-          expr.foreach { e =>
-            localSubExprEliminationExprs.get(ExpressionEquals(e)) match {
-              case Some(state) => childrenSubExprs += state
-              case _ =>
-            }
           }
-
-          val inputVariables = inputVars.map(_.variableName).mkString(", ")
-          val code = code"${addNewFunction(fnName, fn)}($inputVariables);"
-          val state = SubExprEliminationState(
-            ExprCode(code, isNull, JavaCode.global(value, expr.dataType)),
-            childrenSubExprs.toSeq)
-          localSubExprEliminationExprs.put(ExpressionEquals(expr), state)
+          ExprCode(code, isNull, JavaCode.global(value, expr.dataType))
         }
-        (localSubExprEliminationExprs, exprCodesNeedEvaluate)
-      } else {
-        val errMsg = "Failed to split subexpression code into small functions because " +
-          "the parameter length of at least one split function went over the JVM limit: " +
-          MAX_JVM_METHOD_PARAMS_LENGTH
-        if (Utils.isTesting) {
-          throw new IllegalStateException(errMsg)
-        } else {
-          logInfo(errMsg)
-          (localSubExprEliminationExprsForNonSplit, Seq.empty)
-        }
-      }
-    } else {
-      (localSubExprEliminationExprsForNonSplit, Seq.empty)
+        ExpressionEquals(expr) -> (stats.useCount, wrapperFunc, None)
+      }.toMap
     }
-    SubExprCodes(subExprsMap.toMap, exprCodes.flatten)
-  }
-
-  /**
-   * Checks and sets up the state and codegen for subexpression elimination. This finds the
-   * common subexpressions, generates the functions that evaluate those expressions and populates
-   * the mapping of common subexpressions to the generated functions.
-   */
-  private def subexpressionElimination(expressions: Seq[Expression]): Unit = {
-    // Add each expression tree and compute the common subexpressions.
-    expressions.foreach(equivalentExpressions.addExprTree(_))
-
-    // Get all the expressions that appear at least twice and set up the state for subexpression
-    // elimination.
-    val commonExprs = equivalentExpressions.getCommonSubexpressions
-    commonExprs.foreach { expr =>
-      val fnName = freshName("subExpr")
-      val isNull = addMutableState(JAVA_BOOLEAN, "subExprIsNull")
-      val value = addMutableState(javaType(expr.dataType), "subExprValue")
-
-      // Generate the code for this expression tree and wrap it in a function.
-      val eval = expr.genCode(this)
-      val fn =
-        s"""
-           |private void $fnName(InternalRow $INPUT_ROW) {
-           |  ${eval.code}
-           |  $isNull = ${eval.isNull};
-           |  $value = ${eval.value};
-           |}
-           """.stripMargin
-
-      // Add a state and a mapping of the common subexpressions that are associate with this
-      // state. Adding this expression to subExprEliminationExprMap means it will call `fn`
-      // when it is code generated. This decision should be a cost based one.
-      //
-      // The cost of doing subexpression elimination is:
-      //   1. Extra function call, although this is probably *good* as the JIT can decide to
-      //      inline or not.
-      // The benefit doing subexpression elimination is:
-      //   1. Running the expression logic. Even for a simple expression, it is likely more than 3
-      //      above.
-      //   2. Less code.
-      // Currently, we will do this for all non-leaf only expression trees (i.e. expr trees with
-      // at least two nodes) as the cost of doing it is expected to be low.
-
-      val subExprCode = s"${addNewFunction(fnName, fn)}($INPUT_ROW);"
-      subexprFunctions += subExprCode
-      val state = SubExprEliminationState(
-        ExprCode(code"$subExprCode",
-          JavaCode.isNullGlobal(isNull),
-          JavaCode.global(value, expr.dataType)))
-      subExprEliminationExprs += ExpressionEquals(expr) -> state
-    }
+    initBlock
   }
 
   /**
@@ -1270,12 +1099,16 @@ class CodegenContext extends Logging {
    */
   def generateExpressions(
       expressions: Seq[Expression],
-      doSubexpressionElimination: Boolean = false): Seq[ExprCode] = {
+      doSubexpressionElimination: Boolean = false): (Seq[ExprCode], Block) = {
     // We need to make sure that we do not reuse stateful expressions. This is needed for codegen
     // as well because some expressions may implement `CodegenFallback`.
     val cleanedExpressions = expressions.map(_.freshCopyIfContainsStatefulExpression())
-    if (doSubexpressionElimination) subexpressionElimination(cleanedExpressions)
-    cleanedExpressions.map(e => e.genCode(this))
+    val initBlock = if (doSubexpressionElimination) {
+      subexpressionElimination(cleanedExpressions: _*)
+    } else {
+      EmptyBlock
+    }
+    (cleanedExpressions.map(e => e.genCode(this)), initBlock)
   }
 
   /**
@@ -1314,6 +1147,9 @@ class CodegenContext extends Logging {
       EmptyBlock
     }
   }
+
+  private[spark] val commonExpressions =
+    new mutable.HashMap[ExpressionEquals, (Int, ExprCode => ExprCode, Option[ExprCode])]
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateMutableProjection.scala
@@ -61,7 +61,7 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], MutableP
       case (NoOp, _) => false
       case _ => true
     }
-    val exprVals = ctx.generateExpressions(validExpr.map(_._1), useSubexprElimination)
+    val (exprVals, initBlock) = ctx.generateExpressions(validExpr.map(_._1), useSubexprElimination)
 
     // 4-tuples: (code for projection, isNull variable name, value variable name, column index)
     val projectionCodes: Seq[(String, String)] = validExpr.zip(exprVals).map {
@@ -130,6 +130,7 @@ object GenerateMutableProjection extends CodeGenerator[Seq[Expression], MutableP
 
         public java.lang.Object apply(java.lang.Object _i) {
           InternalRow ${ctx.INPUT_ROW} = (InternalRow) _i;
+          $initBlock
           $evalSubexpr
           $allProjections
           // copy all the results into MutableRow

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratePredicate.scala
@@ -38,7 +38,8 @@ object GeneratePredicate extends CodeGenerator[Expression, BasePredicate] {
     val ctx = newCodeGenContext()
 
     // Do sub-expression elimination for predicates.
-    val eval = ctx.generateExpressions(Seq(predicate), useSubexprElimination).head
+    val (evals, initBlock) = ctx.generateExpressions(Seq(predicate), useSubexprElimination)
+    val eval = evals.head
     val evalSubexpr = ctx.subexprFunctionsCode
 
     val codeBody = s"""
@@ -60,6 +61,7 @@ object GeneratePredicate extends CodeGenerator[Expression, BasePredicate] {
         }
 
         public boolean eval(InternalRow ${ctx.INPUT_ROW}) {
+          $initBlock
           $evalSubexpr
           ${eval.code}
           return !${eval.isNull} && ${eval.value};

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -287,7 +287,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
       ctx: CodegenContext,
       expressions: Seq[Expression],
       useSubexprElimination: Boolean = false): ExprCode = {
-    val exprEvals = ctx.generateExpressions(expressions, useSubexprElimination)
+    val (exprEvals, initBlock) = ctx.generateExpressions(expressions, useSubexprElimination)
     val exprSchemas = expressions.map(e => Schema(e.dataType, e.nullable))
 
     val numVarLenFields = exprSchemas.count {
@@ -307,6 +307,7 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
 
     val code =
       code"""
+         |$initBlock
          |$rowWriter.reset();
          |$evalSubexpr
          |$writeExpressions

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -22,8 +22,7 @@ import org.apache.spark.{SparkFunSuite, TaskContext, TaskContextImpl}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{BinaryType, DataType, IntegerType, ObjectType}
+import org.apache.spark.sql.types.{DataType, IntegerType, ObjectType}
 
 class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("Semantic equals and hash") {
@@ -147,15 +146,15 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     val equivalence = new EquivalentExpressions
     equivalence.addExprTree(add)
     // the `two` inside `fallback` should not be added
-    assert(equivalence.getAllExprStates(1).size == 0)
-    assert(equivalence.getAllExprStates().count(_.useCount == 1) == 3) // add, two, explode
+    assert(equivalence.getAllExprStates(1).size == 1)
+    assert(equivalence.getAllExprStates().count(_.useCount == 1) == 2) // add, two, explode
   }
 
   test("Children of conditional expressions: If") {
     val add = Add(Literal(1), Literal(2))
     val condition = GreaterThan(add, Literal(3))
 
-    val ifExpr1 = If(condition, add, add)
+    val ifExpr1 = If(condition, add, Literal(1))
     val equivalence1 = new EquivalentExpressions
     equivalence1.addExprTree(ifExpr1)
 
@@ -172,28 +171,27 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     val equivalence2 = new EquivalentExpressions
     equivalence2.addExprTree(ifExpr2)
 
-    assert(equivalence2.getAllExprStates(1).isEmpty)
-    assert(equivalence2.getAllExprStates().count(_.useCount == 1) == 3)
+    assert(equivalence2.getAllExprStates(1).nonEmpty)
+    assert(equivalence2.getAllExprStates().count(_.useCount == 1) == 4)
 
     val ifExpr3 = If(condition, ifExpr1, ifExpr1)
     val equivalence3 = new EquivalentExpressions
     equivalence3.addExprTree(ifExpr3)
 
     // `add`: 2, `condition`: 2
-    assert(equivalence3.getAllExprStates().count(_.useCount == 2) == 2)
+    assert(equivalence3.getAllExprStates().count(_.useCount == 2) == 3)
     assert(equivalence3.getAllExprStates().filter(_.useCount == 2).exists(_.expr eq condition))
     assert(equivalence3.getAllExprStates().filter(_.useCount == 2).exists(_.expr eq add))
 
     // `ifExpr1`, `ifExpr3`
-    assert(equivalence3.getAllExprStates().count(_.useCount == 1) == 2)
-    assert(equivalence3.getAllExprStates().filter(_.useCount == 1).exists(_.expr eq ifExpr1))
+    assert(equivalence3.getAllExprStates().count(_.useCount == 1) == 1)
     assert(equivalence3.getAllExprStates().filter(_.useCount == 1).exists(_.expr eq ifExpr3))
   }
 
   test("Children of conditional expressions: CaseWhen") {
     val add1 = Add(Literal(1), Literal(2))
     val add2 = Add(Literal(2), Literal(3))
-    val conditions1 = (GreaterThan(add2, Literal(3)), add1) ::
+    val conditions1 = (GreaterThan(add1, Literal(3)), add1) ::
       (GreaterThan(add2, Literal(4)), add1) ::
       (GreaterThan(add2, Literal(5)), add1) :: Nil
 
@@ -215,7 +213,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
 
     // `add1` is repeatedly in all branch values, and first predicate.
     assert(equivalence2.getAllExprStates().count(_.useCount == 2) == 1)
-    assert(equivalence2.getAllExprStates().filter(_.useCount == 2).head.expr eq add1)
+    assert(equivalence2.getAllExprStates().filter(_.useCount == 2).head.expr eq add2)
 
     // Negative case. `add1` or `add2` is not commonly used in all predicates/branch values.
     val conditions3 = (GreaterThan(add1, Literal(3)), add2) ::
@@ -240,8 +238,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     equivalence1.addExprTree(coalesceExpr1)
 
     // `add2` is repeatedly in all conditions.
-    assert(equivalence1.getAllExprStates().count(_.useCount == 2) == 1)
-    assert(equivalence1.getAllExprStates().filter(_.useCount == 2).head.expr eq add2)
+    assert(equivalence1.getAllExprStates().count(_.useCount == 2) == 0)
 
     // Negative case. `add1` and `add2` both are not used in all branches.
     val conditions2 = GreaterThan(add1, Literal(3)) ::
@@ -252,62 +249,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     val equivalence2 = new EquivalentExpressions
     equivalence2.addExprTree(coalesceExpr2)
 
-    assert(equivalence2.getAllExprStates().count(_.useCount == 2) == 0)
-  }
-
-  test("SPARK-34723: Correct parameter type for subexpression elimination under whole-stage") {
-    withSQLConf(SQLConf.CODEGEN_METHOD_SPLIT_THRESHOLD.key -> "1") {
-      val str = BoundReference(0, BinaryType, false)
-      val pos = BoundReference(1, IntegerType, false)
-
-      val substr = new Substring(str, pos)
-
-      val add = Add(Length(substr), Literal(1))
-      val add2 = Add(Length(substr), Literal(2))
-
-      val ctx = new CodegenContext()
-      val exprs = Seq(add, add2)
-
-      val oneVar = ctx.freshVariable("str", BinaryType)
-      val twoVar = ctx.freshVariable("pos", IntegerType)
-      ctx.addMutableState("byte[]", oneVar, forceInline = true, useFreshName = false)
-      ctx.addMutableState("int", twoVar, useFreshName = false)
-
-      ctx.INPUT_ROW = null
-      ctx.currentVars = Seq(
-        ExprCode(TrueLiteral, oneVar),
-        ExprCode(TrueLiteral, twoVar))
-
-      val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(exprs)
-      ctx.withSubExprEliminationExprs(subExprs.states) {
-        exprs.map(_.genCode(ctx))
-      }
-      val subExprsCode = ctx.evaluateSubExprEliminationState(subExprs.states.values)
-
-      val codeBody = s"""
-        public java.lang.Object generate(Object[] references) {
-          return new TestCode(references);
-        }
-
-        class TestCode {
-          ${ctx.declareMutableStates()}
-
-          public TestCode(Object[] references) {
-          }
-
-          public void initialize(int partitionIndex) {
-            ${subExprsCode}
-          }
-
-          ${ctx.declareAddedFunctions()}
-        }
-      """
-
-      val code = CodeFormatter.stripOverlappingComments(
-        new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
-
-      CodeGenerator.compile(code)
-    }
+    assert(equivalence2.getAllExprStates().count(_.useCount == 2) == 1)
   }
 
   test("SPARK-35410: SubExpr elimination should not include redundant child exprs " +
@@ -323,7 +265,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
 
     val commonExprs = equivalence.getAllExprStates(1)
     assert(commonExprs.size == 1)
-    assert(commonExprs.head.useCount == 2)
+    assert(commonExprs.head.useCount == 3)
     assert(commonExprs.head.expr eq add3)
   }
 
@@ -337,8 +279,8 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     equivalence.addExprTree(ifExpr3)
 
     val commonExprs = equivalence.getAllExprStates(1)
-    assert(commonExprs.size == 1)
-    assert(commonExprs.head.useCount == 2)
+    assert(commonExprs.size == 2)
+    assert(commonExprs.head.useCount == 4)
     assert(commonExprs.head.expr eq add)
   }
 
@@ -399,28 +341,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     equivalence.addExprTree(caseWhenExpr)
 
     // `add1` is not in the elseValue, so we can't extract it from the branches
-    assert(equivalence.getAllExprStates().count(_.useCount == 2) == 0)
-  }
-
-  test("SPARK-35829: SubExprEliminationState keeps children sub exprs") {
-    val add1 = Add(Literal(1), Literal(2))
-    val add2 = Add(add1, add1)
-
-    val exprs = Seq(add1, add1, add2, add2)
-    val ctx = new CodegenContext()
-    val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(exprs)
-
-    val add2State = subExprs.states(ExpressionEquals(add2))
-    val add1State = subExprs.states(ExpressionEquals(add1))
-    assert(add2State.children.contains(add1State))
-
-    subExprs.states.values.foreach { state =>
-      assert(state.eval.code != EmptyBlock)
-    }
-    ctx.evaluateSubExprEliminationState(subExprs.states.values)
-    subExprs.states.values.foreach { state =>
-      assert(state.eval.code == EmptyBlock)
-    }
+    assert(equivalence.getAllExprStates().count(_.useCount == 2) == 1)
   }
 
   test("SPARK-38333: PlanExpression expression should skip addExprTree function in Executor") {
@@ -443,7 +364,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     val n1 = NaNvl(Literal(1.0d), Add(add, add))
     val e1 = new EquivalentExpressions
     e1.addExprTree(n1)
-    assert(e1.getCommonSubexpressions.isEmpty)
+    assert(e1.getCommonSubexpressions.nonEmpty)
 
     val n2 = NaNvl(add, add)
     val e2 = new EquivalentExpressions
@@ -466,33 +387,6 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     val hasMatching = equivalence.addExpr(expr)
     val cseState = equivalence.getExprState(expr)
     assert(hasMatching == cseState.isDefined)
-  }
-
-  test("SPARK-42815: Subexpression elimination support shortcut conditional expression") {
-    val add = Add(Literal(1), Literal(0))
-    val equal = EqualTo(add, add)
-
-    def checkShortcut(expr: Expression, numCommonExpr: Int): Unit = {
-      val e1 = If(expr, Literal(1), Literal(2))
-      val ee1 = new EquivalentExpressions(true)
-      ee1.addExprTree(e1)
-      assert(ee1.getCommonSubexpressions.size == numCommonExpr)
-
-      val e2 = expr
-      val ee2 = new EquivalentExpressions(true)
-      ee2.addExprTree(e2)
-      assert(ee2.getCommonSubexpressions.size == numCommonExpr)
-    }
-
-    // shortcut right child
-    checkShortcut(And(Literal(false), equal), 0)
-    checkShortcut(Or(Literal(true), equal), 0)
-    checkShortcut(Not(And(Literal(true), equal)), 0)
-
-    // always eliminate subexpression for left child
-    checkShortcut((And(equal, Literal(false))), 1)
-    checkShortcut(Or(equal, Literal(true)), 1)
-    checkShortcut(Not(And(equal, Literal(false))), 1)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExpandExec.scala
@@ -168,6 +168,8 @@ case class ExpandExec(
     }
 
     // Part 2: switch/case statements
+    initBlock += ctx.subexpressionElimination(
+      projections.flatten.map(BindReferences.bindReference(_, attributeSeq)): _*)
     val switchCaseExprs = projections.zipWithIndex.map { case (exprs, row) =>
       val (exprCodesWithIndices, inputVarSets) = exprs.indices.flatMap { col =>
         if (!sameOutput(col)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -198,6 +198,7 @@ trait CodegenSupport extends SparkPlan {
     s"""
        |${ctx.registerComment(s"CONSUME: ${parent.simpleString(conf.maxToStringFields)}")}
        |$evaluated
+       |${parent.initBlock}
        |$consumeFunc
      """.stripMargin
   }
@@ -341,6 +342,8 @@ trait CodegenSupport extends SparkPlan {
   def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
     throw new UnsupportedOperationException
   }
+
+  var initBlock: Block = EmptyBlock
 
   /**
    * Whether or not the result rows of this operator should be copied before putting into a buffer.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregateCodegenSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggregateCodegenSupport.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.aggregate
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, ExpressionEquals, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReferences
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.codegen._
@@ -207,12 +207,9 @@ trait AggregateCodegenSupport
     val boundUpdateExprs = updateExprs.map { updateExprsForOneFunc =>
       bindReferences(updateExprsForOneFunc, inputAttrs)
     }
-    val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(boundUpdateExprs.flatten)
-    val effectiveCodes = ctx.evaluateSubExprEliminationState(subExprs.states.values)
+    val initBlock = ctx.subexpressionElimination(boundUpdateExprs.flatten: _*)
     val bufferEvals = boundUpdateExprs.map { boundUpdateExprsForOneFunc =>
-      ctx.withSubExprEliminationExprs(subExprs.states) {
-        boundUpdateExprsForOneFunc.map(_.genCode(ctx))
-      }
+      boundUpdateExprsForOneFunc.map(_.genCode(ctx))
     }
 
     val aggNames = functions.map(_.prettyName)
@@ -236,11 +233,11 @@ trait AggregateCodegenSupport
     }
 
     val codeToEvalAggFuncs = generateEvalCodeForAggFuncs(
-      ctx, input, inputAttrs, boundUpdateExprs, aggNames, aggCodeBlocks, subExprs)
+      ctx, input, inputAttrs, boundUpdateExprs, aggNames, aggCodeBlocks)
     s"""
        |// do aggregate
        |// common sub-expressions
-       |$effectiveCodes
+       |$initBlock
        |// evaluate aggregate functions and update aggregation buffers
        |$codeToEvalAggFuncs
      """.stripMargin
@@ -255,19 +252,21 @@ trait AggregateCodegenSupport
       inputAttrs: Seq[Attribute],
       boundUpdateExprs: Seq[Seq[Expression]],
       aggNames: Seq[String],
-      aggCodeBlocks: Seq[Block],
-      subExprs: SubExprCodes): String = {
+      aggCodeBlocks: Seq[Block]): String = {
+    val evaluated = boundUpdateExprs.flatten.map { e =>
+      evaluateRequiredVariables(inputAttrs, input, e.references)
+    }.mkString("", "\n", "\n")
     val aggCodes = if (conf.codegenSplitAggregateFunc &&
       aggCodeBlocks.map(_.length).sum > conf.methodSplitThreshold) {
       val maybeSplitCodes = splitAggregateExpressions(
-        ctx, aggNames, boundUpdateExprs, aggCodeBlocks, subExprs.states)
+        ctx, aggNames, boundUpdateExprs, aggCodeBlocks)
 
       maybeSplitCodes.getOrElse(aggCodeBlocks.map(_.code))
     } else {
       aggCodeBlocks.map(_.code)
     }
 
-    aggCodes.zip(aggregateExpressions.map(ae => (ae.mode, ae.filter))).map {
+    evaluated + aggCodes.zip(aggregateExpressions.map(ae => (ae.mode, ae.filter))).map {
       case (aggCode, (Partial | Complete, Some(condition))) =>
         // Note: wrap in "do { } while(false);", so the generated checks can jump out
         // with "continue;"
@@ -295,59 +294,49 @@ trait AggregateCodegenSupport
       ctx: CodegenContext,
       aggNames: Seq[String],
       aggBufferUpdatingExprs: Seq[Seq[Expression]],
-      aggCodeBlocks: Seq[Block],
-      subExprs: Map[ExpressionEquals, SubExprEliminationState]): Option[Seq[String]] = {
-    val exprValsInSubExprs = subExprs.flatMap { case (_, s) =>
-      s.eval.value :: s.eval.isNull :: Nil
-    }
-    if (exprValsInSubExprs.exists(_.isInstanceOf[SimpleExprValue])) {
-      // `SimpleExprValue`s cannot be used as an input variable for split functions, so
-      // we give up splitting functions if it exists in `subExprs`.
-      None
-    } else {
-      val inputVars = aggBufferUpdatingExprs.map { aggExprsForOneFunc =>
-        val inputVarsForOneFunc = aggExprsForOneFunc.map(
-          CodeGenerator.getLocalInputVariableValues(ctx, _, subExprs)._1).reduce(_ ++ _).toSeq
-        val paramLength = CodeGenerator.calculateParamLengthFromExprValues(inputVarsForOneFunc)
+      aggCodeBlocks: Seq[Block]): Option[Seq[String]] = {
+    val inputVars = aggBufferUpdatingExprs.map { aggExprsForOneFunc =>
+      val inputVarsForOneFunc = aggExprsForOneFunc.map(
+        CodeGenerator.getLocalInputVariableValues(ctx, _)._1).reduce(_ ++ _).toSeq
+      val paramLength = CodeGenerator.calculateParamLengthFromExprValues(inputVarsForOneFunc)
 
-        // Checks if a parameter length for the `aggExprsForOneFunc` does not go over the JVM limit
-        if (CodeGenerator.isValidParamLength(paramLength)) {
-          Some(inputVarsForOneFunc)
-        } else {
-          None
-        }
-      }
-
-      // Checks if all the aggregate code can be split into pieces.
-      // If the parameter length of at lease one `aggExprsForOneFunc` goes over the limit,
-      // we totally give up splitting aggregate code.
-      if (inputVars.forall(_.isDefined)) {
-        val splitCodes = inputVars.flatten.zipWithIndex.map { case (args, i) =>
-          val doAggFunc = ctx.freshName(s"doAggregate_${aggNames(i)}")
-          val argList = args.map { v =>
-            s"${CodeGenerator.typeName(v.javaType)} ${v.variableName}"
-          }.mkString(", ")
-          val doAggFuncName = ctx.addNewFunction(doAggFunc,
-            s"""
-               |private void $doAggFunc($argList) throws java.io.IOException {
-               |  ${aggCodeBlocks(i)}
-               |}
-             """.stripMargin)
-
-          val inputVariables = args.map(_.variableName).mkString(", ")
-          s"$doAggFuncName($inputVariables);"
-        }
-        Some(splitCodes)
+      // Checks if a parameter length for the `aggExprsForOneFunc` does not go over the JVM limit
+      if (CodeGenerator.isValidParamLength(paramLength)) {
+        Some(inputVarsForOneFunc)
       } else {
-        val errMsg = "Failed to split aggregate code into small functions because the parameter " +
-          "length of at least one split function went over the JVM limit: " +
-          CodeGenerator.MAX_JVM_METHOD_PARAMS_LENGTH
-        if (Utils.isTesting) {
-          throw new IllegalStateException(errMsg)
-        } else {
-          logInfo(errMsg)
-          None
-        }
+        None
+      }
+    }
+
+    // Checks if all the aggregate code can be split into pieces.
+    // If the parameter length of at lease one `aggExprsForOneFunc` goes over the limit,
+    // we totally give up splitting aggregate code.
+    if (inputVars.forall(_.isDefined)) {
+      val splitCodes = inputVars.flatten.zipWithIndex.map { case (args, i) =>
+        val doAggFunc = ctx.freshName(s"doAggregate_${aggNames(i)}")
+        val argList = args.map { v =>
+          s"${CodeGenerator.typeName(v.javaType)} ${v.variableName}"
+        }.mkString(", ")
+        val doAggFuncName = ctx.addNewFunction(doAggFunc,
+          s"""
+             |private void $doAggFunc($argList) throws java.io.IOException {
+             |  ${aggCodeBlocks(i)}
+             |}
+           """.stripMargin)
+
+        val inputVariables = args.map(_.variableName).mkString(", ")
+        s"$doAggFuncName($inputVariables);"
+      }
+      Some(splitCodes)
+    } else {
+      val errMsg = "Failed to split aggregate code into small functions because the parameter " +
+        "length of at least one split function went over the JVM limit: " +
+        CodeGenerator.MAX_JVM_METHOD_PARAMS_LENGTH
+      if (Utils.isTesting) {
+        throw new IllegalStateException(errMsg)
+      } else {
+        logInfo(errMsg)
+        None
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -67,24 +67,12 @@ case class ProjectExec(projectList: Seq[NamedExpression], child: SparkPlan)
 
   override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
     val exprs = bindReferences[Expression](projectList, child.output)
-    val (subExprsCode, resultVars, localValInputs) = if (conf.subexpressionEliminationEnabled) {
-      // subexpression elimination
-      val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(exprs)
-      val genVars = ctx.withSubExprEliminationExprs(subExprs.states) {
-        exprs.map(_.genCode(ctx))
-      }
-      (ctx.evaluateSubExprEliminationState(subExprs.states.values), genVars,
-        subExprs.exprCodesNeedEvaluate)
-    } else {
-      ("", exprs.map(_.genCode(ctx)), Seq.empty)
-    }
+    initBlock += ctx.subexpressionElimination(exprs: _*)
+    val resultVars = exprs.map(_.genCode(ctx))
 
     // Evaluation of non-deterministic expressions can't be deferred.
     val nonDeterministicAttrs = projectList.filterNot(_.deterministic).map(_.toAttribute)
     s"""
-       |// common sub-expressions
-       |${evaluateVariables(localValInputs)}
-       |$subExprsCode
        |${evaluateRequiredVariables(output, resultVars, AttributeSet(nonDeterministicAttrs))}
        |${consume(ctx, resultVars)}
      """.stripMargin
@@ -174,6 +162,8 @@ trait GeneratePredicateHelper extends PredicateHelper {
     // TODO: revisit this. We can consider reordering predicates as well.
     val generatedIsNotNullChecks = new Array[Boolean](notNullPreds.length)
     val extraIsNotNullAttrs = mutable.Set[Attribute]()
+    initBlock +=
+      ctx.subexpressionElimination(otherPreds.map(BindReferences.bindReference(_, inputAttrs)): _*)
     val generated = otherPreds.map { c =>
       val nullChecks = c.references.map { r =>
         val idx = notNullPreds.indexWhere { n => n.asInstanceOf[IsNotNull].child.semanticEquals(r)}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/JoinCodegenSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/JoinCodegenSupport.scala
@@ -49,11 +49,14 @@ trait JoinCodegenSupport extends CodegenSupport with BaseJoinExec {
 
       // filter the output via condition
       ctx.currentVars = streamVars ++ buildVars
-      val ev =
-        BindReferences.bindReference(expr, streamPlan.output ++ buildPlan.output).genCode(ctx)
+      val bondExpr = BindReferences.bindReference(expr, streamPlan.output ++ buildPlan.output)
+      initBlock += ctx.subexpressionElimination(bondExpr)
+      val ev = bondExpr.genCode(ctx)
+
       val skipRow = s"${ev.isNull} || !${ev.value}"
       s"""
          |$eval
+         |$initBlock
          |${ev.code}
          |if (!($skipRow))
        """.stripMargin

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -770,26 +770,4 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       }
     }
   }
-
-  test("Give up splitting subexpression code if a parameter length goes over the limit") {
-    withSQLConf(
-        SQLConf.CODEGEN_SPLIT_AGGREGATE_FUNC.key -> "false",
-        SQLConf.CODEGEN_METHOD_SPLIT_THRESHOLD.key -> "1",
-        "spark.sql.CodeGenerator.validParamLength" -> "0") {
-      withTable("t") {
-        val expectedErrMsg = "Failed to split subexpression code into small functions"
-        Seq(
-          // Test case without keys
-          "SELECT AVG(a + b), SUM(a + b + c) FROM VALUES((1, 1, 1)) t(a, b, c)",
-          // Tet case with keys
-          "SELECT k, AVG(a + b), SUM(a + b + c) FROM VALUES((1, 1, 1, 1)) t(k, a, b, c) " +
-            "GROUP BY k").foreach { query =>
-          val e = intercept[IllegalStateException] {
-            sql(query).collect
-          }
-          assert(e.getMessage.contains(expectedErrMsg))
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Support more subexpression elimination cases.

How to do subexpression elimination:

* Get all common expressions from input expressions. Recursively visits all subexpressions regardless of whether the current expression is a conditional expression.
* For each common expression:
  * Add a new boolean variable subExprInit_n to indicate whether we have  already evaluated the common expression, and reset it to false at the start of operator.consume()
  * Add a new wrapper subExpr function for common subexpression.

```java
private void subExpr_n(${argList}) {
 if (!subExprInit_n) {
   ${eval.code}
   subExprInit_n = true;
   subExprIsNull_n = ${eval.isNull};
   subExprValue_n = ${eval.value};
 }
}
```
  * Replace all the common subexpression with the wrapper function `subExpr_n(argList)`.

## New support subexpression elimination patterns

* Support subexpression elimination with conditional expressions

```sql
SELECT case when v + 2 > 1 then 1
            when v + 1 > 2 then 2
            when v + 1 > 3 then 3 END vv
FROM values(1) as t2(v)
```
We can reuse the result of expression  v + 1

```sql
SELECT a, max(if(a > 0, b + c, null)) max_bc, min(if(a > 1, b + c, null)) min_bc
FROM values(1, 1, 1) as t(a, b, c)
GROUP BY a
```
We can reuse the result of expression  b + c

* Support subexpression elimination in FilterExec

```sql
SELECT * FROM (
  SELECT v * v + 1 v1 from values(1) as t2(v)
) t
where v1 > 5 and v1 < 10
```
We can reuse the result of expression  v * v + 1

* Support subexpression elimination in JoinExec

```sql
SELECT * 
FROM values(1, 1) as t1(a, b) 
join values(1, 2) as t2(x, y)
ON b * y between 2 and 3
```
 
We can reuse the result of expression  b * y

* Support subexpression elimination in ExpandExec

```sql
SELECT a, count(b),
   	count(distinct case when b > 1 then b + c else null end) as count_bc_1,
   	count(distinct case when b < 0 then b + c else null end) as count_bc_2
FROM values(1, 1, 1) as t(a, b, c)
GROUP BY a
```
We can reuse the result of expression  b + c

### Why are the changes needed?

Support more subexpression elimination cases, improve performance.

For example, TPCDS q23b query,  we can reuse the result of projection `sum(ss_quantity * ss_sales_price)` in the if expressions:
```
if (isnull((cast(input[2, int, true] as decimal(10,0)) * input[3, decimal(7,2), true])))
   input[0, decimal(28,2), true]
else 
   (input[0, decimal(28,2), true] + cast(knownnotnull((cast(input[2, int, true] as decimal(10,0)) * input[3, decimal(7,2), true])) as decimal(28,2)))
```
q4, q62, q67 are similar to the above.

| Query    | Time with PR | Time without PR | Time diff | Percentage |
|----------|--------------|-----------------|-----------|------------|
| q1.sql   | 36.97        | 36.623          | -0.347    | 99.06%     |
| q2.sql   | 42.699       | 41.741          | -0.958    | 97.76%     |
| q3.sql   | 6.038        | 6.111           | 0.073     | 101.21%    |
| q4.sql   | 273.849      | 323.799         | 49.95     | 118.24%    |
| q5.sql   | 76.202       | 76.353          | 0.151     | 100.20%    |
| q6.sql   | 8.451        | 9.011           | 0.56      | 106.63%    |
| q7.sql   | 13.017       | 12.954          | -0.063    | 99.52%     |
| q8.sql   | 10.22        | 11.027          | 0.807     | 107.90%    |
| q9.sql   | 72.843       | 72.019          | -0.824    | 98.87%     |
| q10.sql  | 13.233       | 14.028          | 0.795     | 106.01%    |
| q11.sql  | 112.252      | 112.983         | 0.731     | 100.65%    |
| q12.sql  | 3.036        | 3.488           | 0.452     | 114.89%    |
| q13.sql  | 12.471       | 12.911          | 0.44      | 103.53%    |
| q14a.sql | 210.201      | 220.12          | 9.919     | 104.72%    |
| q14b.sql | 185.374      | 187.57          | 2.196     | 101.18%    |
| q15.sql  | 10.189       | 10.338          | 0.149     | 101.46%    |
| q16.sql  | 80.756       | 82.503          | 1.747     | 102.16%    |
| q17.sql  | 28.523       | 28.567          | 0.044     | 100.15%    |
| q18.sql  | 13.417       | 14.271          | 0.854     | 106.37%    |
| q19.sql  | 6.366        | 6.53            | 0.164     | 102.58%    |
| q20.sql  | 3.427        | 4.939           | 1.512     | 144.12%    |
| q21.sql  | 2.096        | 2.16            | 0.064     | 103.05%    |
| q22.sql  | 14.4         | 14.01           | -0.39     | 97.29%     |
| q23a.sql | 507.253      | 545.185         | 37.932    | 107.48%    |
| q23b.sql | 707.054      | 768.148         | 61.094    | 108.64%    |
| q24a.sql | 193.116      | 193.793         | 0.677     | 100.35%    |
| q24b.sql | 177.109      | 179.54          | 2.431     | 101.37%    |
| q25.sql  | 22.264       | 22.949          | 0.685     | 103.08%    |
| q26.sql  | 8.68         | 8.973           | 0.293     | 103.38%    |
| q27.sql  | 8.535        | 8.558           | 0.023     | 100.27%    |
| q28.sql  | 101.953      | 102.713         | 0.76      | 100.75%    |
| q29.sql  | 75.392       | 76.211          | 0.819     | 101.09%    |
| q30.sql  | 12.265       | 13.508          | 1.243     | 110.13%    |
| q31.sql  | 26.477       | 26.965          | 0.488     | 101.84%    |
| q32.sql  | 3.393        | 3.507           | 0.114     | 103.36%    |
| q33.sql  | 6.909        | 7.277           | 0.368     | 105.33%    |
| q34.sql  | 8.41         | 8.572           | 0.162     | 101.93%    |
| q35.sql  | 34.214       | 36.822          | 2.608     | 107.62%    |
| q36.sql  | 9.027        | 9.79            | 0.763     | 108.45%    |
| q37.sql  | 36.076       | 36.753          | 0.677     | 101.88%    |
| q38.sql  | 71.768       | 74.473          | 2.705     | 103.77%    |
| q39a.sql | 7.753        | 7.617           | -0.136    | 98.25%     |
| q39b.sql | 6.365        | 7.229           | 0.864     | 113.57%    |
| q40.sql  | 16.588       | 17.164          | 0.576     | 103.47%    |
| q41.sql  | 1.162        | 1.188           | 0.026     | 102.24%    |
| q42.sql  | 2.3          | 2.561           | 0.261     | 111.35%    |
| q43.sql  | 7.407        | 7.605           | 0.198     | 102.67%    |
| q44.sql  | 28.939       | 30.473          | 1.534     | 105.30%    |
| q45.sql  | 9.796        | 9.634           | -0.162    | 98.35%     |
| q46.sql  | 9.496        | 9.692           | 0.196     | 102.06%    |
| q47.sql  | 27.087       | 27.151          | 0.064     | 100.24%    |
| q48.sql  | 14.524       | 14.889          | 0.365     | 102.51%    |
| q49.sql  | 21.466       | 21.572          | 0.106     | 100.49%    |
| q50.sql  | 194.755      | 195.052         | 0.297     | 100.15%    |
| q51.sql  | 37.493       | 38.56           | 1.067     | 102.85%    |
| q52.sql  | 2.227        | 2.28            | 0.053     | 102.38%    |
| q53.sql  | 5.375        | 5.437           | 0.062     | 101.15%    |
| q54.sql  | 12.556       | 13.015          | 0.459     | 103.66%    |
| q55.sql  | 2.341        | 2.809           | 0.468     | 119.99%    |
| q56.sql  | 7.424        | 7.207           | -0.217    | 97.08%     |
| q57.sql  | 17.606       | 17.797          | 0.191     | 101.08%    |
| q58.sql  | 6.169        | 6.374           | 0.205     | 103.32%    |
| q59.sql  | 27.602       | 27.744          | 0.142     | 100.51%    |
| q60.sql  | 7.04         | 7.459           | 0.419     | 105.95%    |
| q61.sql  | 7.838        | 7.816           | -0.022    | 99.72%     |
| q62.sql  | 9.726        | 10.762          | 1.036     | 110.65%    |
| q63.sql  | 4.816        | 5.176           | 0.36      | 107.48%    |
| q64.sql  | 253.937      | 261.034         | 7.097     | 102.79%    |
| q65.sql  | 78.942       | 78.373          | -0.569    | 99.28%     |
| q66.sql  | 15.199       | 14.73           | -0.469    | 96.91%     |
| q67.sql  | 926.049      | 1022.971        | 96.922    | 110.47%    |
| q68.sql  | 7.932        | 7.977           | 0.045     | 100.57%    |
| q69.sql  | 12.101       | 14.699          | 2.598     | 121.47%    |
| q70.sql  | 20.7         | 20.872          | 0.172     | 100.83%    |
| q71.sql  | 14.96        | 15.065          | 0.105     | 100.70%    |
| q72.sql  | 73.215       | 73.955          | 0.74      | 101.01%    |
| q73.sql  | 5.973        | 6.126           | 0.153     | 102.56%    |
| q74.sql  | 97.611       | 99.577          | 1.966     | 102.01%    |
| q75.sql  | 125.005      | 129.508         | 4.503     | 103.60%    |
| q76.sql  | 34.812       | 35.34           | 0.528     | 101.52%    |
| q77.sql  | 7.686        | 8.474           | 0.788     | 110.25%    |
| q78.sql  | 287.959      | 292.936         | 4.977     | 101.73%    |
| q79.sql  | 8.401        | 9.616           | 1.215     | 114.46%    |
| q80.sql  | 59.371       | 60.051          | 0.68      | 101.15%    |
| q81.sql  | 18.452       | 19.499          | 1.047     | 105.67%    |
| q82.sql  | 64.093       | 65.032          | 0.939     | 101.47%    |
| q83.sql  | 4.675        | 4.867           | 0.192     | 104.11%    |
| q84.sql  | 10.456       | 10.816          | 0.36      | 103.44%    |
| q85.sql  | 12.347       | 12.77           | 0.423     | 103.43%    |
| q86.sql  | 6.537        | 6.843           | 0.306     | 104.68%    |
| q87.sql  | 77.427       | 77.876          | 0.449     | 100.58%    |
| q88.sql  | 83.082       | 83.385          | 0.303     | 100.36%    |
| q89.sql  | 6.645        | 6.801           | 0.156     | 102.35%    |
| q90.sql  | 7.841        | 7.883           | 0.042     | 100.54%    |
| q91.sql  | 3.88         | 4.129           | 0.249     | 106.42%    |
| q92.sql  | 3.044        | 3.271           | 0.227     | 107.46%    |
| q93.sql  | 361.149      | 365.883         | 4.734     | 101.31%    |
| q94.sql  | 43.929       | 46.667          | 2.738     | 106.23%    |
| q95.sql  | 196.363      | 197.427         | 1.064     | 100.54%    |
| q96.sql  | 12.457       | 12.496          | 0.039     | 100.31%    |
| q97.sql  | 80.131       | 81.821          | 1.69      | 102.11%    |
| q98.sql  | 6.885        | 7.522           | 0.637     | 109.25%    |
| q99.sql  | 17.685       | 18.009          | 0.324     | 101.83%    |
|          | 6788.707     | 7116.357        | 327.65    | 104.82%    |

One of our production query which has 19 case when  expressions, it's query time changed from 1.1 hour to 42 seconds.

![image](https://user-images.githubusercontent.com/3626747/227448668-8a58ff33-3296-4a95-984b-292af47532ca.png)

A simplify benchmark of the above production query.
```
    spark.range(1, 2000000, 1, 1)
      .selectExpr(
        "cast(id + 1 as decimal) as a",
        "cast(id + 2 as decimal) as b",
        "cast(id + 3 as decimal) as c",
        "cast(id + 4 as decimal) as d")
      .createOrReplaceTempView("tab")
    runBenchmark("Subexpression elimination in ProjectExec") {
      val benchmark =
        new Benchmark("Subexpression elimination in ProjectExec", 2000000, output = output)
      benchmark.addCase(s"Test query") { _ =>
        val query =
          s"""
             |SELECT a, b, c, d,
             |       a * b / c as s1,
             |       CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN 1 ELSE 0 END s2,
             |       CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN
             |            CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN 1 ELSE 0 END
             |       ELSE 0 END s3,
             |       CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN
             |            CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN
             |                 CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN 1 ELSE 0 END
             |            ELSE 0 END
             |       ELSE 0 END s4,
             |       CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN
             |            CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN
             |                 CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN
             |                      CASE WHEN d = 0 THEN 0 WHEN a * b / c > 0 THEN 1 ELSE 0 END
             |                 ELSE 0 END
             |            ELSE 0 END
             |       ELSE 0 END s5
             |FROM tab
             |""".stripMargin
        spark.sql(query).noop()
      }
      benchmark.run()
```
Local benchmark result:
Before this PR:
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_281-b09 on Mac OS X 10.16
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Subexpression elimination in ProjectExec:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Test query                                         9713           9900         263          0.2        4856.7       1.0X
```

After this PR:
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_281-b09 on Mac OS X 10.16
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Subexpression elimination in ProjectExec:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Test query                                         1238           1307          98          8.1         123.8       1.0X
```


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Exists UT.