### PR TITLE
[SPARK-42573][Connect][Scala] Enable binary compatibility tests on all major client APIs

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -252,7 +252,7 @@ final class DataFrameWriter[T] private[sql] (ds: Dataset[T]) {
       builder.putOptions(k, v)
     }
 
-    ds.session.execute(proto.Command.newBuilder().setWriteOperation(builder).build())
+    ds.sparkSession.execute(proto.Command.newBuilder().setWriteOperation(builder).build())
   }
 
   /**

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
@@ -157,7 +157,7 @@ final class DataFrameWriterV2[T] private[sql] (table: String, ds: Dataset[T])
 
     overwriteCondition.foreach(builder.setOverwriteCondition)
 
-    ds.session.execute(proto.Command.newBuilder().setWriteOperationV2(builder).build())
+    ds.sparkSession.execute(proto.Command.newBuilder().setWriteOperationV2(builder).build())
   }
 }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -41,7 +41,7 @@ class RelationalGroupedDataset protected[sql] (
     groupType: proto.Aggregate.GroupType) {
 
   private[this] def toDF(aggExprs: Seq[Column]): DataFrame = {
-    df.session.newDataset { builder =>
+    df.sparkSession.newDataset { builder =>
       builder.getAggregateBuilder
         .setInput(df.plan.getRoot)
         .addAllGroupingExpressions(groupingExprs.asJava)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
@@ -69,30 +69,131 @@ class CompatibilitySuite extends AnyFunSuite { // scalastyle:ignore funsuite
     val mima = new MiMaLib(Seq(clientJar, sqlJar))
     val allProblems = mima.collectProblems(sqlJar, clientJar, List.empty)
     val includedRules = Seq(
-      IncludeByName("org.apache.spark.sql.Column"),
-      IncludeByName("org.apache.spark.sql.Column$"),
-      IncludeByName("org.apache.spark.sql.Dataset"),
-      // TODO(SPARK-42175) Add the Dataset object definition
-      // IncludeByName("org.apache.spark.sql.Dataset$"),
-      IncludeByName("org.apache.spark.sql.DataFrame"),
+      IncludeByName("org.apache.spark.sql.Column.*"),
+      IncludeByName("org.apache.spark.sql.DataFrame.*"),
       IncludeByName("org.apache.spark.sql.DataFrameReader.*"),
       IncludeByName("org.apache.spark.sql.DataFrameWriter.*"),
       IncludeByName("org.apache.spark.sql.DataFrameWriterV2.*"),
-      IncludeByName("org.apache.spark.sql.SparkSession"),
-      IncludeByName("org.apache.spark.sql.SparkSession$")) ++ includeImplementedMethods(clientJar)
+      IncludeByName("org.apache.spark.sql.Dataset.*"),
+      IncludeByName("org.apache.spark.sql.functions.*"),
+      IncludeByName("org.apache.spark.sql.RelationalGroupedDataset.*"),
+      IncludeByName("org.apache.spark.sql.SparkSession.*"))
     val excludeRules = Seq(
       // Filter unsupported rules:
-      // Two sql overloading methods are marked experimental in the API and skipped in the client.
-      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.sql"),
-      // Deprecated json methods and RDD related methods are skipped in the client.
+      // Note when muting errors for a method, checks on all overloading methods are also muted.
+
+      // Skip all shaded dependencies and proto files in the client.
+      ProblemFilters.exclude[Problem]("org.sparkproject.*"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.connect.proto.*"),
+
+      // DataFrame Reader & Writer
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.DataFrameReader.json"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.DataFrameReader.csv"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.DataFrameReader.jdbc"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.DataFrameWriter.jdbc"),
-      // Skip all shaded dependencies in the client.
-      ProblemFilters.exclude[Problem]("org.sparkproject.*"),
-      ProblemFilters.exclude[Problem]("org.apache.spark.connect.proto.*"),
-      // Disable Range until we support typed APIs
+
+      // Dataset
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.ofRows"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.DATASET_ID_TAG"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.COL_POS_KEY"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.DATASET_ID_KEY"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.curId"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.groupBy"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.observe"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.queryExecution"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.encoder"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.sqlContext"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.as"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.checkpoint"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.localCheckpoint"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.withWatermark"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.na"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.stat"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.joinWith"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.select"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.selectUntyped"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.reduce"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.groupByKey"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.explode"), // deprecated
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.filter"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.map"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.mapPartitions"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.flatMap"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.foreach"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.foreachPartition"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.persist"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.cache"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.storageLevel"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.unpersist"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.rdd"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.toJavaRDD"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.javaRDD"),
+      ProblemFilters.exclude[Problem](
+        "org.apache.spark.sql.Dataset.registerTempTable"
+      ), // deprecated
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.createTempView"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.createOrReplaceTempView"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.createGlobalTempView"),
+      ProblemFilters.exclude[Problem](
+        "org.apache.spark.sql.Dataset.createOrReplaceGlobalTempView"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.writeStream"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.toJSON"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.sameSemantics"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.semanticHash"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.this"),
+
+      // functions
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.udf"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.call_udf"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.callUDF"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.unwrap_udt"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.udaf"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.broadcast"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.count"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.typedlit"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.typedLit"),
+
+      // RelationalGroupedDataset
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.RelationalGroupedDataset.as"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.RelationalGroupedDataset.pivot"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.RelationalGroupedDataset.this"),
+
+      // SparkSession
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.active"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.getDefaultSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.getActiveSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.clearDefaultSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.setDefaultSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.implicits"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.sparkContext"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.version"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.sharedState"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.sessionState"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.sqlContext"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.conf"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.listenerManager"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.experimental"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.udf"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.streams"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.newSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.emptyDataFrame"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.emptyDataset"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.createDataFrame"),
+      ProblemFilters.exclude[Problem](
+        "org.apache.spark.sql.SparkSession.baseRelationToDataFrame"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.createDataset"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.catalog"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.executeCommand"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.readStream"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.time"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.stop"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.this"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.setActiveSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.clearActiveSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.setDefaultSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.clearDefaultSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.getActiveSession"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.getDefaultSession"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.range"))
     val problems = allProblems
       .filter { p =>
@@ -125,31 +226,6 @@ class CompatibilitySuite extends AnyFunSuite { // scalastyle:ignore funsuite
       .foreach(method => {
         assert(oldMethods.map(m => m.toString).contains(method))
       })
-  }
-
-  /**
-   * Find all methods that are implemented in the client jar. Once all major methods are
-   * implemented we can switch to include all methods under the class using ".*" e.g.
-   * "org.apache.spark.sql.Dataset.*"
-   */
-  private def includeImplementedMethods(clientJar: File): Seq[IncludeByName] = {
-    val clsNames = Seq(
-      "org.apache.spark.sql.Column",
-      // TODO(SPARK-42175) Add all overloading methods. Temporarily mute compatibility check for \
-      //  the Dataset methods, as too many overload methods are missing.
-      // "org.apache.spark.sql.Dataset",
-      "org.apache.spark.sql.SparkSession")
-
-    val clientClassLoader: URLClassLoader = new URLClassLoader(Seq(clientJar.toURI.toURL).toArray)
-    clsNames
-      .flatMap { clsName =>
-        val cls = clientClassLoader.loadClass(clsName)
-        // all distinct method names
-        cls.getMethods.map(m => s"$clsName.${m.getName}").toSet
-      }
-      .map { fullName =>
-        IncludeByName(fullName)
-      }
   }
 
   private case class IncludeByName(name: String) extends ProblemFilter {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make binary compatibility check for SparkSession/Dataset/Column/functions etc.

### Why are the changes needed?
Help us to have a good understanding of the current API coverage of the Scala client.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.