### PR TITLE
[SPARK-42575][Connect][Scala] Make all client tests to extend from ConnectFunSuite

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ColumnTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ColumnTestSuite.scala
@@ -20,9 +20,8 @@ import java.io.ByteArrayOutputStream
 
 import scala.collection.JavaConverters._
 
-import org.scalatest.funsuite.{AnyFunSuite => ConnectFunSuite} // scalastyle:ignore funsuite
-
 import org.apache.spark.sql.{functions => fn}
+import org.apache.spark.sql.connect.client.util.ConnectFunSuite
 import org.apache.spark.sql.types.StringType
 
 /**

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -22,19 +22,17 @@ import java.util.concurrent.atomic.AtomicLong
 import io.grpc.Server
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.client.{DummySparkConnectService, SparkConnectClient}
+import org.apache.spark.sql.connect.client.util.ConnectFunSuite
 import org.apache.spark.sql.functions._
 
 // Add sample tests.
 // - sample fraction: simple.sample(0.1)
 // - sample withReplacement_fraction: simple.sample(withReplacement = true, 0.11)
 // Add tests for exceptions thrown
-class DatasetSuite
-    extends AnyFunSuite // scalastyle:ignore funsuite
-    with BeforeAndAfterEach {
+class DatasetSuite extends ConnectFunSuite with BeforeAndAfterEach {
 
   private var server: Server = _
   private var service: DummySparkConnectService = _

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/FunctionTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/FunctionTestSuite.scala
@@ -18,8 +18,7 @@ package org.apache.spark.sql
 
 import java.util.Collections
 
-import org.scalatest.funsuite.{AnyFunSuite => ConnectFunSuite} // scalastyle:ignore funsuite
-
+import org.apache.spark.sql.connect.client.util.ConnectFunSuite
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, StructType}
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
@@ -26,12 +26,12 @@ import scala.util.{Failure, Success, Try}
 import com.google.protobuf.util.JsonFormat
 import io.grpc.inprocess.InProcessChannelBuilder
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-import org.scalatest.funsuite.{AnyFunSuite => ConnectFunSuite} // scalastyle:ignore funsuite
 
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{functions => fn}
 import org.apache.spark.sql.connect.client.SparkConnectClient
+import org.apache.spark.sql.connect.client.util.ConnectFunSuite
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types._

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionSuite.scala
@@ -19,16 +19,14 @@ package org.apache.spark.sql
 import scala.reflect.runtime.universe.typeTag
 
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
 import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.connect.client.util.ConnectFunSuite
 import org.apache.spark.sql.connect.common.UdfPacket
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.util.Utils
 
-class UserDefinedFunctionSuite
-    extends AnyFunSuite // scalastyle:ignore funsuite
-    with BeforeAndAfterEach {
+class UserDefinedFunctionSuite extends ConnectFunSuite with BeforeAndAfterEach {
 
   test("udf and encoder serialization") {
     def func(x: Int): Int = x + 1

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
@@ -22,7 +22,8 @@ import java.util.regex.Pattern
 
 import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.lib.MiMaLib
-import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
+
+import org.apache.spark.sql.connect.client.util.ConnectFunSuite
 import org.apache.spark.sql.connect.client.util.IntegrationTestUtils._
 
 /**
@@ -48,7 +49,7 @@ import org.apache.spark.sql.connect.client.util.IntegrationTestUtils._
  *   1. Run the test again: `sbt "testOnly
  *      org.apache.spark.sql.connect.client.CompatibilitySuite"`
  */
-class CompatibilitySuite extends AnyFunSuite { // scalastyle:ignore funsuite
+class CompatibilitySuite extends ConnectFunSuite {
 
   private lazy val clientJar: File =
     findJar(

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -22,16 +22,14 @@ import io.grpc.{Server, StatusRuntimeException}
 import io.grpc.netty.NettyServerBuilder
 import io.grpc.stub.StreamObserver
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AnalyzePlanRequest, AnalyzePlanResponse, ExecutePlanRequest, ExecutePlanResponse, SparkConnectServiceGrpc}
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connect.client.util.ConnectFunSuite
 import org.apache.spark.sql.connect.common.config.ConnectCommon
 
-class SparkConnectClientSuite
-    extends AnyFunSuite // scalastyle:ignore funsuite
-    with BeforeAndAfterEach {
+class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
 
   private var client: SparkConnectClient = _
   private var service: DummySparkConnectService = _

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/ConnectFunSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/ConnectFunSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.client.util
+
+import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
+
+/**
+ * The basic testsuite the client tests should extend from.
+ */
+trait ConnectFunSuite extends AnyFunSuite {} // scalastyle:ignore funsuite

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -109,9 +109,7 @@ object SparkConnectServerUtils {
   }
 }
 
-trait RemoteSparkSession
-    extends org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
-    with BeforeAndAfterAll {
+trait RemoteSparkSession extends ConnectFunSuite with BeforeAndAfterAll {
   import SparkConnectServerUtils._
   var spark: SparkSession = _
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make all client tests to extend from ConnectFunSuite to avoid `// scalastyle:ignore funsuite` when extending directly from `AnyFunSuite`

### Why are the changes needed?
Simple dev work.

### Does this PR introduce _any_ user-facing change?
No. test only.

### How was this patch tested?
n/a