### PR TITLE
[SPARK-42574][CONNECT][PYTHON] Fix toPandas to handle duplicated column names

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -545,7 +545,10 @@ class SparkConnectClient(object):
         req = self._execute_plan_request_with_metadata()
         req.plan.CopyFrom(plan)
         table, metrics = self._execute_and_fetch(req)
+        column_names = table.column_names
+        table = table.rename_columns([f"col_{i}" for i in range(len(column_names))])
         pdf = table.to_pandas()
+        pdf.columns = column_names
         if len(metrics) > 0:
             pdf.attrs["metrics"] = metrics
         return pdf

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -112,15 +112,11 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_to_pandas_from_null_dataframe(self):
         super().test_to_pandas_from_null_dataframe()
 
-    # TODO(SPARK-41834): Implement SparkSession.conf
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_pandas_on_cross_join(self):
-        super().test_to_pandas_on_cross_join()
+        self.check_to_pandas_on_cross_join()
 
-    # TODO(SPARK-41834): Implement SparkSession.conf
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_pandas_with_duplicated_column_names(self):
-        super().test_to_pandas_with_duplicated_column_names()
+        self.check_to_pandas_with_duplicated_column_names()
 
     # TODO(SPARK-42367): DataFrame.drop should handle duplicated columns properly
     @unittest.skip("Fails in Spark Connect, should enable.")

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1131,7 +1131,7 @@ class DataFrameTestsMixin:
     def test_to_pandas_with_duplicated_column_names(self):
         for arrow_enabled in [False, True]:
             with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
-                self.check_to_pandas_with_duplicated_column_names(arrow_enabled)
+                self.check_to_pandas_with_duplicated_column_names()
 
     def check_to_pandas_with_duplicated_column_names(self):
         import numpy as np

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1129,19 +1129,27 @@ class DataFrameTestsMixin:
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)  # type: ignore
     def test_to_pandas_with_duplicated_column_names(self):
+        for arrow_enabled in [False, True]:
+            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
+                self.check_to_pandas_with_duplicated_column_names(arrow_enabled)
+
+    def check_to_pandas_with_duplicated_column_names(self):
         import numpy as np
 
         sql = "select 1 v, 1 v"
-        for arrowEnabled in [False, True]:
-            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrowEnabled}):
-                df = self.spark.sql(sql)
-                pdf = df.toPandas()
-                types = pdf.dtypes
-                self.assertEqual(types.iloc[0], np.int32)
-                self.assertEqual(types.iloc[1], np.int32)
+        df = self.spark.sql(sql)
+        pdf = df.toPandas()
+        types = pdf.dtypes
+        self.assertEqual(types.iloc[0], np.int32)
+        self.assertEqual(types.iloc[1], np.int32)
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)  # type: ignore
     def test_to_pandas_on_cross_join(self):
+        for arrow_enabled in [False, True]:
+            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
+                self.check_to_pandas_on_cross_join()
+
+    def check_to_pandas_on_cross_join(self):
         import numpy as np
 
         sql = """
@@ -1151,18 +1159,12 @@ class DataFrameTestsMixin:
           select explode(sequence(1, 3)) v
         ) t2
         """
-        for arrowEnabled in [False, True]:
-            with self.sql_conf(
-                {
-                    "spark.sql.crossJoin.enabled": True,
-                    "spark.sql.execution.arrow.pyspark.enabled": arrowEnabled,
-                }
-            ):
-                df = self.spark.sql(sql)
-                pdf = df.toPandas()
-                types = pdf.dtypes
-                self.assertEqual(types.iloc[0], np.int32)
-                self.assertEqual(types.iloc[1], np.int32)
+        with self.sql_conf({"spark.sql.crossJoin.enabled": True}):
+            df = self.spark.sql(sql)
+            pdf = df.toPandas()
+            types = pdf.dtypes
+            self.assertEqual(types.iloc[0], np.int32)
+            self.assertEqual(types.iloc[1], np.int32)
 
     @unittest.skipIf(have_pandas, "Required Pandas was found.")
     def test_to_pandas_required_pandas_not_found(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `DataFrame.toPandas` to handle duplicated column names.

### Why are the changes needed?

Currently

```py
spark.sql("select 1 v, 1 v").toPandas()
```

fails with the error:

```py
Traceback (most recent call last):
...
  File ".../python/pyspark/sql/connect/dataframe.py", line 1335, in toPandas
    return self._session.client.to_pandas(query)
  File ".../python/pyspark/sql/connect/client.py", line 548, in to_pandas
    pdf = table.to_pandas()
  File "pyarrow/array.pxi", line 830, in pyarrow.lib._PandasConvertible.to_pandas
  File "pyarrow/table.pxi", line 3908, in pyarrow.lib.Table._to_pandas
  File "/.../lib/python3.9/site-packages/pyarrow/pandas_compat.py", line 819, in table_to_blockmanager
    columns = _deserialize_column_index(table, all_columns, column_indexes)
  File "/.../lib/python3.9/site-packages/pyarrow/pandas_compat.py", line 938, in _deserialize_column_index
    columns = _flatten_single_level_multiindex(columns)
  File "/.../lib/python3.9/site-packages/pyarrow/pandas_compat.py", line 1186, in _flatten_single_level_multiindex
    raise ValueError('Found non-unique column index')
ValueError: Found non-unique column index
```

Simliar to #28210.

### Does this PR introduce _any_ user-facing change?

Duplicated column names will be available when calling `toPandas()`.

### How was this patch tested?

Enabled related tests.