### PR TITLE
[SPARK-42598][TEST] Refactor TPCH schema to separate file similar to TPCDS for code reuse

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSBase.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.catalyst.TableIdentifier
-
 trait TPCDSBase extends TPCBase with TPCDSSchema {
 
   // The TPCDS queries below are based on v1.4
@@ -65,9 +63,9 @@ trait TPCDSBase extends TPCBase with TPCDSSchema {
     }
   }
 
-  val tableNames: Iterable[String] = tableColumns.keys
+  override protected val tableNames: Iterable[String] = tableColumns.keys
 
-  def createTable(
+  override protected def createTable(
       spark: SparkSession,
       tableName: String,
       format: String = "parquet",
@@ -81,20 +79,4 @@ trait TPCDSBase extends TPCBase with TPCDSSchema {
        """.stripMargin)
   }
 
-  override def createTables(): Unit = {
-    tableNames.foreach { tableName =>
-      createTable(spark, tableName)
-      if (injectStats) {
-        // To simulate plan generation on actual TPC-DS data, injects data stats here
-        spark.sessionState.catalog.alterTableStats(
-          TableIdentifier(tableName), Some(TPCDSTableStats.sf100TableStats(tableName)))
-      }
-    }
-  }
-
-  override def dropTables(): Unit = {
-    tableNames.foreach { tableName =>
-      spark.sessionState.catalog.dropTable(TableIdentifier(tableName), true, true)
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSSchema.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSSchema.scala
@@ -41,9 +41,9 @@ package org.apache.spark.sql
  *    |     Date      |     Date      |
  *    |---------------|---------------|
  */
-trait TPCDSSchema {
+trait TPCDSSchema extends TPCSchema {
 
-  protected val tableColumns: Map[String, String] = Map(
+  override protected val tableColumns: Map[String, String] = Map(
     "store_sales" ->
       """
         |`ss_sold_date_sk` INT,
@@ -543,7 +543,7 @@ trait TPCDSSchema {
   )
 
   // The partition column is consistent with the databricks/spark-sql-perf project.
-  protected val tablePartitionColumns = Map(
+  override protected val tablePartitionColumns = Map(
     "catalog_sales" -> Seq("`cs_sold_date_sk`"),
     "catalog_returns" -> Seq("`cr_returned_date_sk`"),
     "inventory" -> Seq("`inv_date_sk`"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCHSchema.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCHSchema.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+/**
+ * Base trait for TPC-H related tests.
+ *
+ * see more at:
+ * https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.1.pdf
+ *
+ * |---------------|---------------|
+ * |    TPCH       |  Spark  SQL   |
+ * |---------------|---------------|
+ * |  Identifier   |     BIGINT    |
+ * |---------------|---------------|
+ * |    Integer    |      INT      |
+ * |---------------|---------------|
+ * | Decimal(d, f) | Decimal(d, f) |
+ * |---------------|---------------|
+ * |    Char(N)    |     STRING    |
+ * |---------------|---------------|
+ * |  Varchar(N)   |     STRING    |
+ * |---------------|---------------|
+ * |     Date      |     Date      |
+ * |---------------|---------------|
+ */
+
+trait TPCHSchema extends TPCSchema {
+
+  override protected val tableColumns: Map[String, String] = Map(
+    "part" ->
+      """
+        |`p_partkey` BIGINT,
+        |`p_name` STRING,
+        |`p_mfgr` STRING,
+        |`p_brand` STRING,
+        |`p_type` STRING,
+        |`p_size` INT,
+        |`p_container` STRING,
+        |`p_retailprice` DECIMAL(10,0),
+        |`p_comment` STRING
+      """.stripMargin,
+
+    "supplier" ->
+      """
+        |`s_suppkey` BIGINT,
+        |`s_name` STRING,
+        |`s_address` STRING,
+        |`s_nationkey` BIGINT,
+        |`s_phone` STRING,
+        |`s_acctbal` DECIMAL(10,0),
+        |`s_comment` STRING
+      """.stripMargin,
+    "partsupp" ->
+      """
+        |`ps_partkey` BIGINT,
+        |`ps_suppkey` BIGINT,
+        |`ps_availqty` INT,
+        |`ps_supplycost` DECIMAL(10,0),
+        |`ps_comment` STRING
+      """.stripMargin,
+    "customer" ->
+      """
+        |`c_custkey` BIGINT,
+        |`c_name` STRING,
+        |`c_address` STRING,
+        |`c_nationkey` BIGINT,
+        |`c_phone` STRING,
+        |`c_acctbal` DECIMAL(10,0),
+        |`c_mktsegment` STRING,
+        |`c_comment` STRING
+      """.stripMargin,
+    "orders" ->
+      """
+        |`o_orderkey` BIGINT,
+        |`o_custkey` BIGINT,
+        |`o_orderstatus` STRING,
+        |`o_totalprice` DECIMAL(10,0),
+        |`o_orderdate` DATE,
+        |`o_orderpriority` STRING,
+        |`o_clerk` STRING,
+        |`o_shippriority` INT,
+        |`o_comment` STRING
+      """.stripMargin,
+    "lineitem" ->
+      """
+        |`l_orderkey` BIGINT,
+        |`l_partkey` BIGINT,
+        |`l_suppkey` BIGINT,
+        |`l_linenumber` INT,
+        |`l_quantity` DECIMAL(10,0),
+        |`l_extendedprice` DECIMAL(10,0),
+        |`l_discount` DECIMAL(10,0),
+        |`l_tax` DECIMAL(10,0),
+        |`l_returnflag` STRING,
+        |`l_linestatus` STRING,
+        |`l_shipdate` DATE,
+        |`l_commitdate` DATE,
+        | `l_receiptdate` DATE,
+        |`l_shipinstruct` STRING,
+        |`l_shipmode` STRING,
+        |`l_comment` STRING
+      """.stripMargin,
+    "nation" ->
+      """
+        |`n_nationkey` BIGINT,
+        |`n_name` STRING,
+        |`n_regionkey` BIGINT,
+        |`n_comment` STRING
+      """.stripMargin,
+    "region" ->
+      """
+        |`r_regionkey` BIGINT,
+        | `r_name` STRING,
+        | `r_comment` STRING
+      """.stripMargin
+  )
+
+  override protected val tablePartitionColumns: Map[String, Seq[String]] = Map(
+    "part" -> Seq("`p_brand`"),
+    "customer" -> Seq("`c_mktsegment`"),
+    "orders" -> Seq("`o_orderdate`"),
+    "lineitem" -> Seq("`l_shipdate`")
+  )
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCSchema.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCSchema.scala
@@ -17,25 +17,15 @@
 
 package org.apache.spark.sql
 
-trait TPCHBase extends TPCBase with TPCHSchema {
+/**
+ * Base trait for TPC related tests.
+ *
+ * https://www.tpc.org/tpc_documents_current_versions/current_specifications5.asp
+ */
+trait TPCSchema {
 
-  override protected val tableNames: Iterable[String] = tableColumns.keys
+  protected val tableColumns: Map[String, String]
 
-  val tpchQueries = Seq(
-    "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "q10", "q11",
-    "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19", "q20", "q21", "q22")
-
-  override def createTable(
-      spark: SparkSession,
-      tableName: String,
-      format: String = "parquet",
-      options: Seq[String] = Nil): Unit = {
-    spark.sql(
-      s"""
-         |CREATE TABLE `$tableName` (${tableColumns(tableName)})
-         |USING $format
-         |${options.mkString("\n")}
-       """.stripMargin)
-  }
+  protected val tablePartitionColumns: Map[String, Seq[String]]
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changes are only in tests files.
- Refactored the `TPCHBase` class and created `TPCHSchema` similar to TPCDS.
- Created a base class `TPCSchema` which is extended by `TPCDSSchema` and `TPCHSchema`.

### Why are the changes needed?
This PR just refactors the code. Going forward it will help in making code changes at just one place to reflect in both TPCDS and TPCH. 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ran the PlanStabilitySuite to verify the changes. 
