### PR TITLE
[SPARK-42564][CONNECT] Implement SparkSession.version and SparkSession.time

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -17,12 +17,14 @@
 package org.apache.spark.sql
 
 import java.io.Closeable
+import java.util.concurrent.TimeUnit._
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.JavaConverters._
 
 import org.apache.arrow.memory.RootAllocator
 
+import org.apache.spark.SPARK_VERSION
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
@@ -58,6 +60,24 @@ class SparkSession(
     with Logging {
 
   private[this] val allocator = new RootAllocator()
+
+  def version: String = SPARK_VERSION
+
+  /**
+   * Executes some code block and prints to stdout the time taken to execute the block. This is
+   * available in Scala only and is used primarily for interactive testing and debugging.
+   *
+   * @since 3.4.0
+   */
+  def time[T](f: => T): T = {
+    val start = System.nanoTime()
+    val ret = f
+    val end = System.nanoTime()
+    // scalastyle:off println
+    println(s"Time taken: ${NANOSECONDS.toMillis(end - start)} ms")
+    // scalastyle:on println
+    ret
+  }
 
   /**
    * Executes a SQL query substituting named parameters by the given arguments, returning the

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.commons.io.output.TeeOutputStream
 import org.scalactic.TolerantNumerics
 
+import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.connect.client.util.{IntegrationTestUtils, RemoteSparkSession}
 import org.apache.spark.sql.functions.{aggregate, array, col, lit, rand, sequence, shuffle, transform, udf}
 import org.apache.spark.sql.types._
@@ -416,5 +417,14 @@ class ClientE2ETestSuite extends RemoteSparkSession {
     assert(spark.sql("SELECT * FROM global_temp.view1").count() == 100)
     spark.range(1000).createOrReplaceGlobalTempView("view1")
     assert(spark.sql("SELECT * FROM global_temp.view1").count() == 1000)
+  }
+
+  test("version") {
+    assert(spark.version == SPARK_VERSION)
+  }
+
+  test("time") {
+    val timeFragments = Seq("Time taken: ", " ms")
+    testCapturedStdOut(spark.time(spark.sql("select 1").collect()), timeFragments: _*)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to implement SparkSession.version and SparkSession.time.

### Why are the changes needed?
API coverage.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add new UT.