### PR TITLE
[SPARK-42583][SQL] Remove the outer join if they are all distinct aggregate functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -21,7 +21,7 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, ExtractFiltersAndInnerJoins}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -194,12 +194,12 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
     }
   }
 
-  private def allDuplicateAgnostic(
-      aggregateExpressions: Seq[NamedExpression]): Boolean = {
-    !aggregateExpressions.exists(_.exists {
-      case agg: AggregateFunction => !EliminateDistinct.isDuplicateAgnostic(agg)
-      case _ => false
-    })
+  private def allDuplicateAgnostic(a: Aggregate): Boolean = {
+    a.groupOnly || a.aggregateExpressions.flatMap { e =>
+      e.collect {
+        case ae: AggregateExpression => ae
+      }
+    }.forall(ae => ae.isDistinct || EliminateDistinct.isDuplicateAgnostic(ae.aggregateFunction))
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
@@ -208,19 +208,19 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
       val newJoinType = buildNewJoinType(f, j)
       if (j.joinType == newJoinType) f else Filter(condition, j.copy(joinType = newJoinType))
 
-    case a @ Aggregate(_, aggExprs, Join(left, _, LeftOuter, _, _))
-        if a.references.subsetOf(left.outputSet) && allDuplicateAgnostic(aggExprs) =>
+    case a @ Aggregate(_, _, Join(left, _, LeftOuter, _, _))
+        if a.references.subsetOf(left.outputSet) && allDuplicateAgnostic(a) =>
       a.copy(child = left)
-    case a @ Aggregate(_, aggExprs, Join(_, right, RightOuter, _, _))
-        if a.references.subsetOf(right.outputSet) && allDuplicateAgnostic(aggExprs) =>
+    case a @ Aggregate(_, _, Join(_, right, RightOuter, _, _))
+        if a.references.subsetOf(right.outputSet) && allDuplicateAgnostic(a) =>
       a.copy(child = right)
-    case a @ Aggregate(_, aggExprs, p @ Project(projectList, Join(left, _, LeftOuter, _, _)))
+    case a @ Aggregate(_, _, p @ Project(projectList, Join(left, _, LeftOuter, _, _)))
         if projectList.forall(_.deterministic) && p.references.subsetOf(left.outputSet) &&
-          allDuplicateAgnostic(aggExprs) =>
+          allDuplicateAgnostic(a) =>
       a.copy(child = p.copy(child = left))
-    case a @ Aggregate(_, aggExprs, p @ Project(projectList, Join(_, right, RightOuter, _, _)))
+    case a @ Aggregate(_, _, p @ Project(projectList, Join(_, right, RightOuter, _, _)))
         if projectList.forall(_.deterministic) && p.references.subsetOf(right.outputSet) &&
-          allDuplicateAgnostic(aggExprs) =>
+          allDuplicateAgnostic(a) =>
       a.copy(child = p.copy(child = right))
 
     case p @ Project(_, ExtractEquiJoinKeys(LeftOuter, _, rightKeys, _, _, left, right, _))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
@@ -189,6 +189,18 @@ class AggregateOptimizeSuite extends AnalysisTest {
           .groupBy()(max($"$t.b"), min($"$t.c")).analyze),
         streamed.groupBy()(max($"$t.b"), min($"$t.c")).analyze)
 
+      // distinct aggregate
+      comparePlans(Optimize.execute(
+        x.join(y, joinType, Some($"x.a" === $"y.a"))
+          .groupBy()(countDistinct($"$t.b"), sumDistinct($"$t.c")).analyze),
+        streamed.groupBy()(countDistinct($"$t.b"), sumDistinct($"$t.c")).analyze)
+
+      // mixed
+      comparePlans(Optimize.execute(
+        x.join(y, joinType, Some($"x.a" === $"y.a"))
+          .groupBy()(countDistinct($"$t.b"), min($"$t.c")).analyze),
+        streamed.groupBy()(countDistinct($"$t.b"), min($"$t.c")).analyze)
+
       // negative cases
       // with non-deterministic project
       val p1 = x.join(y, joinType, Some($"x.a" === $"y.a")).select($"$t.a" as "a1", rand(1) as "b1")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enhance `EliminateOuterJoin` by removing the outer join if they are all distinct aggregate functions. For example:
```sql
SELECT t1.c1, sum(DISTINCT t1.c2) FROM t1 LEFT JOIN t2 ON t1.c1 = t2.c1 GROUP BY t1.c1
==>
SELECT t1.c1, sum(DISTINCT t1.c2) FROM t1 GROUP BY t1.c1
```

### Why are the changes needed?

Improve query performance. TiDB also supports this optimization:
<img width="1221" alt="image" src="https://user-images.githubusercontent.com/5399861/221417544-cfd13fe1-6210-44b3-91d4-c3da0bd084f0.png">


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.