### PR TITLE
[SPARK-42589][CONNECT][TESTS] Exclude `RelationalGroupedDataset.apply` from `CompatibilitySuite`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
@@ -39,8 +39,8 @@ import org.apache.spark.sql.connect.client.util.IntegrationTestUtils._
  *     spark-sql
  *     spark-connect-client-jvm
  * }}}
- * To build the above artifact, use e.g. `build/sbt package` or
- * `build/mvn clean install -DskipTests`.
+ * To build the above artifact, use e.g. `build/sbt package` or `build/mvn clean install
+ * -DskipTests`.
  *
  * When debugging this test, if any changes to the client API, the client jar need to be built
  * before running the test. An example workflow with SBT for this test:

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
@@ -159,6 +159,7 @@ class CompatibilitySuite extends ConnectFunSuite {
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.RelationalGroupedDataset.as"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.RelationalGroupedDataset.pivot"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.RelationalGroupedDataset.this"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.RelationalGroupedDataset.apply"),
 
       // SparkSession
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.active"),

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -32,10 +32,9 @@ import org.apache.spark.util.Utils
 
 /**
  * An util class to start a local spark connect server in a different process for local E2E tests.
- * Pre-running the tests, the spark connect artifact needs to be built using e.g.
- * `build/sbt package`.
- * It is designed to start the server once but shared by all tests. It is equivalent to use the
- * following command to start the connect server via command line:
+ * Pre-running the tests, the spark connect artifact needs to be built using e.g. `build/sbt
+ * package`. It is designed to start the server once but shared by all tests. It is equivalent to
+ * use the following command to start the connect server via command line:
  *
  * {{{
  * bin/spark-shell \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `RelationalGroupedDataset.apply` from the compatibility test and also apply `ScalaFmt` changes on the comments.

https://github.com/apache/spark/blob/24f0c45dc11eb7ac1ee43ebd630cdb325da30326/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala#L692-L697

### Why are the changes needed?

`org/apache/spark/sql/RelationalGroupedDataset` doesn't have the corresponding one of `static method apply(...)`.

- https://github.com/apache/spark/actions/runs/4274237512/jobs/7440712998
```
[info] - compatibility MiMa tests *** FAILED *** (1 second, 474 milliseconds)
[info]   Comparing client jar: /home/runner/work/spark/spark/connector/connect/client/jvm/target/scala-2.13/spark-connect-client-jvm-assembly-3.4.1-SNAPSHOT.jar
[info]   and sql jar: /home/runner/work/spark/spark/sql/core/target/scala-2.13/spark-sql_2.13-3.4.1-SNAPSHOT.jar
[info]   static method apply(org.apache.spark.sql.Dataset,scala.collection.immutable.Seq,org.apache.spark.sql.RelationalGroupedDataset#GroupType)org.apache.spark.sql.RelationalGroupedDataset in class org.apache.spark.sql.RelationalGroupedDataset does not have a correspondent in client version
[info]   method apply(org.apache.spark.sql.Dataset,scala.collection.immutable.Seq,org.apache.spark.sql.RelationalGroupedDataset#GroupType)org.apache.spark.sql.RelationalGroupedDataset in object org.apache.spark.sql.RelationalGroupedDataset does not have a correspondent in client version (CompatibilitySuite.scala:208)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.