### PR TITLE
[SPARK-42588][SQL] Collapse two adjacent windows with the equivalent partition/order expressions in two withColumn()

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFunctionsSuite.scala
@@ -1445,4 +1445,15 @@ class DataFrameWindowFunctionsSuite extends QueryTest
       assert(windows.size === 1)
     }
   }
+
+  test("SPARK-42588: collapse two adjacent windows with the equivalent " +
+    "partition/order expression") {
+
+    val df = Seq((1, 1), (2, 2)).toDF("a", "b")
+      .withColumn("max_b", expr("max(b) OVER (PARTITION BY abs(a))"))
+      .withColumn("min_b", expr("min(b) OVER (PARTITION BY abs(a))"))
+
+    val windows = df.queryExecution.optimizedPlan.collect { case w: LogicalWindow => w }
+    assert(windows.size === 1)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extend the CollapseWindow rule to collapse Window nodes with the equivalent partition/order expressions in two withColumn() 


### Why are the changes needed?
```
Seq((1, 1), (2, 2)).toDF("a", "b")
      .withColumn("max_b", expr("max(b) OVER (PARTITION BY abs(a))"))
      .withColumn("min_b", expr("min(b) OVER (PARTITION BY abs(a))"))

== Optimized Logical Plan ==
before
Project [a#7, b#8, max_b#11, min_b#17]
+- Window [min(b#8) windowspecdefinition(_w0#19, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS min_b#17], [_w0#19]
   +- Project [a#7, b#8, max_b#11, abs(a#7) AS _w0#19]
      +- Window [max(b#8) windowspecdefinition(_w0#13, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS max_b#11], [_w0#13]
         +- Project [_1#2 AS a#7, _2#3 AS b#8, abs(_1#2) AS _w0#13]
            +- LocalRelation [_1#2, _2#3]
after
Project [a#7, b#8, max_b#11, min_b#17]
+- Window [max(b#8) windowspecdefinition(_w0#13, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS max_b#11, min(b#8) windowspecdefinition(_w0#13, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS min_b#17], [_w0#13]
   +- Project [_1#2 AS a#7, _2#3 AS b#8, abs(_1#2) AS _w0#13]
      +- LocalRelation [_1#2, _2#3]
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
