### PR TITLE
[SPARK-42587][CONNECT][TESTS][FOLLOWUP] Fix `scalafmt` failure

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CompatibilitySuite.scala
@@ -39,8 +39,8 @@ import org.apache.spark.sql.connect.client.util.IntegrationTestUtils._
  *     spark-sql
  *     spark-connect-client-jvm
  * }}}
- * To build the above artifact, use e.g. `build/sbt package` or
- * `build/mvn clean install -DskipTests`.
+ * To build the above artifact, use e.g. `build/sbt package` or `build/mvn clean install
+ * -DskipTests`.
  *
  * When debugging this test, if any changes to the client API, the client jar need to be built
  * before running the test. An example workflow with SBT for this test:

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -32,10 +32,9 @@ import org.apache.spark.util.Utils
 
 /**
  * An util class to start a local spark connect server in a different process for local E2E tests.
- * Pre-running the tests, the spark connect artifact needs to be built using e.g.
- * `build/sbt package`.
- * It is designed to start the server once but shared by all tests. It is equivalent to use the
- * following command to start the connect server via command line:
+ * Pre-running the tests, the spark connect artifact needs to be built using e.g. `build/sbt
+ * package`. It is designed to start the server once but shared by all tests. It is equivalent to
+ * use the following command to start the connect server via command line:
  *
  * {{{
  * bin/spark-shell \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of https://github.com/apache/spark/pull/40180.

### Why are the changes needed?

At previous PR, `Scalastyle` is checked but `scalafmt` was missed at the last commit.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass all CI linter jobs.