### PR TITLE
[SPARK-42572][SQL][SS] Fix behavior for StateStoreProvider.validateStateRowFormat

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtils.scala
@@ -177,7 +177,8 @@ object UnsafeRowUtils {
   }
 
   def getStructuralIntegrityStatus(row: UnsafeRow, expectedSchema: StructType): String = {
-    val fieldStatusArr = expectedSchema.fields.zipWithIndex.map {
+    val minLength = Math.min(row.numFields(), expectedSchema.fields.length)
+    val fieldStatusArr = expectedSchema.fields.take(minLength).zipWithIndex.map {
       case (field, index) =>
         val offsetAndSizeStr = if (!UnsafeRow.isFixedLength(field.dataType)) {
           val (offset, size) = getOffsetAndSize(row, index)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtils.scala
@@ -136,7 +136,7 @@ object UnsafeRowUtils {
    * @return None if all the checks pass. An error message if the row is not matched with the schema
    */
   def validateStructuralIntegrityWithReason(
-    row: UnsafeRow, expectedSchema: StructType): Option[String] = {
+      row: UnsafeRow, expectedSchema: StructType): Option[String] = {
     validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
       errorMessage => s"Error message is: $errorMessage, " +
           s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -343,11 +343,12 @@ object StateStoreProvider {
     if (conf.formatValidationEnabled) {
       val validationError = UnsafeRowUtils.validateStructuralIntegrityWithReason(keyRow, keySchema)
       validationError.foreach { error => throw new InvalidUnsafeRowException(error) }
-    }
-    if (conf.formatValidationCheckValue) {
-      val validationError =
-        UnsafeRowUtils.validateStructuralIntegrityWithReason(valueRow, valueSchema)
-      validationError.foreach { error => throw new InvalidUnsafeRowException(error) }
+
+      if (conf.formatValidationCheckValue) {
+        val validationError =
+          UnsafeRowUtils.validateStructuralIntegrityWithReason(valueRow, valueSchema)
+        validationError.foreach { error => throw new InvalidUnsafeRowException(error) }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1253,6 +1253,30 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     }
   }
 
+  test("SPARK-42572: StateStore validateStateRowFormat shouldn't check" +
+    " value row format when SQLConf.STATE_STORE_FORMAT_VALIDATION_ENABLED is false") {
+    // By default, when there is an invalid pair of value row and value schema, it should throw
+    val keyRow = dataToKeyRow("key", 1)
+    val valueRow = dataToValueRow(2)
+    val e = intercept[InvalidUnsafeRowException] {
+      // Here valueRow doesn't match with prefixKeySchema
+      StateStoreProvider.validateStateRowFormat(
+        keyRow, keySchema, valueRow, prefixKeySchema, getDefaultStoreConf())
+    }
+    assert(e.getMessage.contains("The streaming query failed by state format invalidation"))
+
+    // When sqlConf.stateStoreFormatValidationEnabled is set to false and
+    // StateStoreConf.FORMAT_VALIDATION_CHECK_VALUE_CONFIG is set to true,
+    // don't check value row
+    val sqlConf = getDefaultSQLConf(SQLConf.STATE_STORE_MIN_DELTAS_FOR_SNAPSHOT.defaultValue.get,
+      SQLConf.MAX_BATCHES_TO_RETAIN_IN_MEMORY.defaultValue.get)
+    sqlConf.setConf(SQLConf.STATE_STORE_FORMAT_VALIDATION_ENABLED, false)
+    val storeConf = StateStoreConf(sqlConf)
+    // Shouldn't throw
+    StateStoreProvider.validateStateRowFormat(
+      keyRow, keySchema, valueRow, prefixKeySchema, storeConf)
+  }
+
   /** Return a new provider with a random id */
   def newStoreProvider(): ProviderClass
 
@@ -1344,6 +1368,7 @@ object StateStoreTestsHelper {
   val keySchema = StructType(
     Seq(StructField("key1", StringType, true), StructField("key2", IntegerType, true)))
   val valueSchema = StructType(Seq(StructField("value", IntegerType, true)))
+  val prefixKeySchema = StructType(Seq(StructField("key1", StringType, true)))
 
   val keyProj = UnsafeProjection.create(Array[DataType](StringType, IntegerType))
   val prefixKeyProj = UnsafeProjection.create(Array[DataType](StringType))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1253,7 +1253,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     }
   }
 
-  test("SPARK-42572: StateStore validateStateRowFormat shouldn't check" +
+  test("SPARK-42572: StateStoreProvider.validateStateRowFormat shouldn't check" +
     " value row format when SQLConf.STATE_STORE_FORMAT_VALIDATION_ENABLED is false") {
     // By default, when there is an invalid pair of value row and value schema, it should throw
     val keyRow = dataToKeyRow("key", 1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
https://github.com/apache/spark/pull/40073 accidentally changed the relationship of the two `if` statement in `StateStoreProvider.validateStateRowFormat`. Before they were inclusive, i.e. 
```
if (a) {
  // <code>
  if (b) {
    // <code>
  }
}
```

It was changed to parallel, i.e.
```
if (a) {
  // <code>
}
if (b) {
    // <code>
}
```

This PR change it back to the original behavior and add a unit test to prevent it in the future.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As above.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test