### PR TITLE
[SPARK-42528] Optimize PercentileHeap further by removing averaging

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/PercentileHeap.scala
@@ -44,16 +44,11 @@ private[spark] class PercentileHeap(percentage: Double = 0.5) {
 
   /**
    * Returns percentile of the inserted elements as if the inserted elements were sorted and we
-   * returned `sorted(p)` where `p = (sorted.length * percentage).toInt` if number of elements
-   * is odd, otherwise `(sorted(p-1) + sorted(p)) / 2` if number of elements is even.
+   * returned `sorted(p)` where `p = (sorted.length * percentage).toInt`.
    */
   def percentile(): Double = {
     if (isEmpty) throw new NoSuchElementException("empty")
-    if (size % 2 == 1 || smallHeap.isEmpty) {
-      largeHeap.peek
-    } else {
-      (largeHeap.peek + -smallHeap.peek) / 2.0
-    }
+    largeHeap.peek
   }
 
   def insert(x: Double): Unit = {

--- a/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/PercentileHeapSuite.scala
@@ -32,12 +32,7 @@ class PercentileHeapSuite extends SparkFunSuite {
 
   private def percentile(nums: Seq[Int], percentage: Double): Double = {
     val p = (nums.length * percentage).toInt
-    val sorted = nums.sorted.toIndexedSeq
-    if (nums.length % 2 == 1 || p == 0) {
-      sorted(p)
-    } else {
-      (sorted(p - 1) + sorted(p)) / 2.0
-    }
+    nums.sorted.toIndexedSeq(p)
   }
 
   private def testPercentileFor(nums: Seq[Int], percentage: Double) = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the averaging in the case the number of elements in the heap is even. Always return the number from the large heap which matches what we would do if we sorted an array and returned the N'th element where `N = (percentage * num_elements).toInt`.

Both approaches are valid in terms of computing quantiles. For the purpose that PercentileHeap is used today both work just as well, except the version proposed in this PR is 30% faster (or put differently the version in master now is 50% slower than the version in this PR):

```
before
58 ns per op on heaps of size 1000

after
40 ns per op on heaps of size 1000
```

Given that scheduler is performance sensitive on scheduling decisions it is best if we pick the fastest implementation.

### Why are the changes needed?

See above.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests and benchmark.
