### PR TITLE
[SPARK-42603][SQL] Set spark.sql.legacy.createHiveTableByDefault  to false.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4000,7 +4000,7 @@ object SQLConf {
         s"instead of the value of ${DEFAULT_DATA_SOURCE_NAME.key} as the table provider.")
       .version("3.1.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val LEGACY_CHAR_VARCHAR_AS_STRING =
     buildConf("spark.sql.legacy.charVarcharAsString")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2192,6 +2192,13 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
         "operation" -> "generated columns")
     )
   }
+
+  test("SPARK-42603: Set spark.sql.legacy.createHiveTableByDefault to false") {
+    withTable("t1") {
+      sql("CREATE TABLE t1(c1 bigint)")
+      sql("desc formatted t1").collect().toSeq.contains(Row("Provider", "parquet", ""))
+    }
+  }
 }
 
 object FakeLocalFsFileSystem {


### PR DESCRIPTION

### What changes were proposed in this pull request?
Set `spark.sql.legacy.createHiveTableByDefault ` to false.


### Why are the changes needed?
In the spark [documentation](https://github.com/apache/spark/blob/master/docs/sql-ref-syntax-ddl-create-table-datasource.md?plain=1#L121), it is stated that the default creation table is parquet, but you need to set "spark.sql.legacy.createHiveTableByDefault" to false, otherwise the default is textfile.
### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
tests were added
