### PR TITLE
[SPARK-42612][CONNECT][PYTHON][TESTS] Enable more parity tests related to functions

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -224,6 +224,10 @@ def lit(col: Any) -> Column:
     if isinstance(col, Column):
         return col
     elif isinstance(col, list):
+        if any(isinstance(c, Column) for c in col):
+            raise PySparkValueError(
+                error_class="COLUMN_IN_LIST", message_parameters={"func_name": "lit"}
+            )
         return array(*[lit(c) for c in col])
     elif isinstance(col, np.ndarray) and col.ndim == 1:
         if _from_numpy_type(col.dtype) is None:

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -834,9 +834,6 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         p = multi_type_lit.to_plan(None)
         self.assertIsNotNone(p)
 
-        lit_list_plan = lit([lit(10), lit("str")]).to_plan(None)
-        self.assertIsNotNone(lit_list_plan)
-
     def test_column_alias(self) -> None:
         # SPARK-40809: Support for Column Aliases
         col0 = col("a").alias("martin")

--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -38,23 +38,13 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     def test_input_file_name_reset_for_rdd(self):
         super().test_input_file_name_reset_for_rdd()
 
-    # TODO(SPARK-41901): Parity in String representation of Column
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_inverse_trig_functions(self):
-        super().test_inverse_trig_functions()
-
-    # TODO(SPARK-41834): Implement SparkSession.conf
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_lit_list(self):
-        super().test_lit_list()
-
     def test_raise_error(self):
         self.check_raise_error(SparkConnectException)
 
-    # Comparing column type of connect and pyspark
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_sorting_functions_with_column(self):
-        super().test_sorting_functions_with_column()
+        from pyspark.sql.connect.column import Column
+
+        self.check_sorting_functions_with_column(Column)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -251,7 +251,7 @@ class SQLTestUtils:
     def assert_close(a, b):
         c = [j[0] for j in b]
         diff = [abs(v - c[k]) < 1e-6 if math.isfinite(v) else v == c[k] for k, v in enumerate(a)]
-        return sum(diff) == len(a)
+        assert sum(diff) == len(a), f"sum: {sum(diff)}, len: {len(a)}"
 
 
 class ReusedSQLTestCase(ReusedPySparkTestCase, SQLTestUtils, PySparkErrorTestUtils):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enables more parity tests related to `functions`.

### Why are the changes needed?

There are still some more tests we should enable.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Modified/enabled related tests.