### PR TITLE
[SPARK-42601][SQL] New physical type Decimal128 for DecimalType

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util;
+
+public class MoreMath {
+  private MoreMath() {
+
+  }
+
+  /**
+   * Compute carry of addition with carry
+   */
+  public static long unsignedCarry(long a, long b, long c) {
+    // HD 2-13
+    return (a & b) | ((a | b) & ~(a + b + c)) >>> 63; // TODO: verify
+  }
+
+  public static long unsignedCarry(long a, long b) {
+    // HD 2-13
+    return ((a >>> 1) + (b >>> 1) + ((a & b) & 1)) >>> 63;
+  }
+
+  public static long unsignedBorrow(long a, long b) {
+    // HD 2-13
+    return ((~a & b) | (~(a ^ b) & (a - b))) >>> 63;
+  }
+
+  public static long ifNegative(long test, long value) {
+    return value & (test >> 63);
+  }
+
+  // TODO: replace with JDK 18's Math.unsignedMultiplyHigh
+  public static long unsignedMultiplyHigh(long x, long y) {
+    // From Hacker's Delight 2nd Ed. 8-3: High-Order Product Signed from/to Unsigned
+    long result = multiplyHigh(x, y);
+    result += (y & (x >> 63)); // equivalent to: if (x < 0) result += y;
+    result += (x & (y >> 63)); // equivalent to: if (y < 0) result += x;
+    return result;
+  }
+
+  /**
+   * Returns as a {@code long} the most significant 64 bits of the 128-bit
+   * product of two 64-bit factors.
+   *
+   * @param x the first value
+   * @param y the second value
+   * @return the result
+   * @since 9
+   */
+  public static long multiplyHigh(long x, long y) {
+    if (x < 0 || y < 0) {
+      // Use technique from section 8-2 of Henry S. Warren, Jr.,
+      // Hacker's Delight (2nd ed.) (Addison Wesley, 2013), 173-174.
+      long x1 = x >> 32;
+      long x2 = x & 0xFFFFFFFFL;
+      long y1 = y >> 32;
+      long y2 = y & 0xFFFFFFFFL;
+      long z2 = x2 * y2;
+      long t = x1 * y2 + (z2 >>> 32);
+      long z1 = t & 0xFFFFFFFFL;
+      long z0 = t >> 32;
+      z1 += x2 * y1;
+      return x1 * y1 + z0 + (z1 >> 32);
+    } else {
+      // Use Karatsuba technique with two base 2^32 digits.
+      long x1 = x >>> 32;
+      long y1 = y >>> 32;
+      long x2 = x & 0xFFFFFFFFL;
+      long y2 = y & 0xFFFFFFFFL;
+      long A = x1 * y1;
+      long B = x2 * y2;
+      long C = (x1 + x2) * (y1 + y2);
+      long K = C - A - B;
+      return (((B >>> 32) + K) >>> 32) + A;
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -117,6 +117,22 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       summary = getSummary(context))
   }
 
+  def cannotChangeDecimal128PrecisionError(
+      value: Decimal128,
+      decimalPrecision: Int,
+      decimalScale: Int,
+      context: SQLQueryContext = null): ArithmeticException = {
+    new SparkArithmeticException(
+      errorClass = "NUMERIC_VALUE_OUT_OF_RANGE",
+      messageParameters = Map(
+        "value" -> value.toPlainString,
+        "precision" -> decimalPrecision.toString,
+        "scale" -> decimalScale.toString,
+        "config" -> toSQLConf(SQLConf.ANSI_ENABLED.key)),
+      context = getQueryContext(context),
+      summary = getSummary(context))
+  }
+
   def invalidInputInCastToDatetimeError(
       value: Any,
       from: DataType,
@@ -1251,7 +1267,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
   }
 
   def unscaledValueTooLargeForPrecisionError(
-      value: Decimal,
+      value: java.math.BigDecimal,
       decimalPrecision: Int,
       decimalScale: Int,
       context: SQLQueryContext = null): ArithmeticException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -82,7 +82,8 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    */
   def set(unscaled: Long, precision: Int, scale: Int): Decimal = {
     if (setOrNull(unscaled, precision, scale) == null) {
-      throw QueryExecutionErrors.unscaledValueTooLargeForPrecisionError(this, precision, scale)
+      throw QueryExecutionErrors.unscaledValueTooLargeForPrecisionError(
+        this.toJavaBigDecimal, precision, scale)
     }
     this
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128.scala
@@ -1,0 +1,896 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import java.lang.{Long => JavaLong}
+import java.math.{BigDecimal => JavaBigDecimal, BigInteger}
+
+import scala.math.BigDecimal.RoundingMode
+import scala.util.Try
+
+import org.apache.spark.annotation.Unstable
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.util.Int128Math
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * A mutable implementation of Decimal that can hold a Long if values are small enough.
+ * Otherwise, hold an Int128.
+ *
+ * The semantics of the fields are as follows:
+ * - _precision and _scale represent the SQL precision and scale we are looking for
+ * - If int128 is set, the decimal value is int128.toBigInteger / (10 ** _scale)
+ * - Otherwise, the decimal value is longVal / (10 ** _scale)
+ *
+ * Note, for values between -1.0 and 1.0, precision digits are only counted after dot.
+ */
+@Unstable
+final class Decimal128 extends Ordered[Decimal128] with Serializable {
+  import org.apache.spark.sql.types.Decimal128._
+
+  private var int128Val: Int128 = null
+  private var longVal: Long = 0L
+  private var _precision: Int = 1
+  private var _scale: Int = 0
+
+  def high: Long = if (int128Val.eq(null)) longVal >> 63 else int128Val.high
+  def low: Long = if (int128Val.eq(null)) longVal else int128Val.low
+  def precision: Int = _precision
+  def scale: Int = _scale
+
+  /**
+   * Set this Decimal128 to the given Long. Will have precision 20 and scale 0.
+   */
+  def set(longVal: Long): Decimal128 = {
+    if (longVal <= -POW_10(MAX_LONG_DIGITS) || longVal >= POW_10(MAX_LONG_DIGITS)) {
+      // We can't represent this compactly as a long without risking overflow
+      this.int128Val = Int128(longVal)
+      this.longVal = 0L
+    } else {
+      this.int128Val = null
+      this.longVal = longVal
+    }
+    this._precision = 20
+    this._scale = 0
+    this
+  }
+
+  /**
+   * Set this Decimal128 to the given Int. Will have precision 10 and scale 0.
+   */
+  def set(intVal: Int): Decimal128 = {
+    this.int128Val = null
+    this.longVal = intVal
+    this._precision = 10
+    this._scale = 0
+    this
+  }
+
+  /**
+   * Set this Decimal128 to the given Int128, with a given precision and scale.
+   */
+  def set(high: Long, low: Long, precision: Int, scale: Int): Decimal128 = {
+    checkOverflow(high, low, s"Construct Int128($high, $low) instance.")
+    set(Int128(high, low), precision, scale)
+  }
+
+  /**
+   * Set this Decimal128 to the given Int128, with a given precision and scale.
+   */
+  def set(int128: Int128, precision: Int, scale: Int): Decimal128 = {
+    DecimalType.checkNegativeScale(scale)
+    this.int128Val = int128
+    this.longVal = 0
+    this._precision = precision
+    this._scale = scale
+    this
+  }
+
+  /**
+   * Set this Decimal128 to the given unscaled Long, with a given precision and scale.
+   */
+  def set(unscaled: Long, precision: Int, scale: Int): Decimal128 = {
+    if (setOrNull(unscaled, precision, scale) == null) {
+      throw QueryExecutionErrors.unscaledValueTooLargeForPrecisionError(
+        this.toJavaBigDecimal, precision, scale)
+    }
+    this
+  }
+
+  /**
+   * Set this Decimal128 to the given unscaled Long, with a given precision and scale,
+   * and return it, or return null if it cannot be set due to overflow.
+   */
+  def setOrNull(unscaled: Long, precision: Int, scale: Int): Decimal128 = {
+    DecimalType.checkNegativeScale(scale)
+    if (unscaled <= -POW_10(MAX_LONG_DIGITS) || unscaled >= POW_10(MAX_LONG_DIGITS)) {
+      // We can't represent this compactly as a long without risking overflow
+      if (precision < 19) {
+        return null  // Requested precision is too low to represent this value
+      }
+      this.int128Val = Int128(unscaled)
+      this.longVal = 0L
+    } else {
+      val p = POW_10(math.min(precision, MAX_LONG_DIGITS))
+      if (unscaled <= -p || unscaled >= p) {
+        return null  // Requested precision is too low to represent this value
+      }
+      this.int128Val = null
+      this.longVal = unscaled
+    }
+    this._precision = precision
+    this._scale = scale
+    this
+  }
+
+  /**
+   * Set this Decimal128 to the given BigDecimal value, with a given scale.
+   */
+  def set(decimal: BigDecimal, precision: Int, scale: Int): Decimal128 = {
+    DecimalType.checkNegativeScale(scale)
+    val scaledDecimal = decimal.setScale(scale, RoundingMode.HALF_UP)
+    if (scaledDecimal.precision > precision) {
+      throw QueryExecutionErrors.decimalPrecisionExceedsMaxPrecisionError(
+        scaledDecimal.precision, precision)
+    }
+    this.int128Val = Int128(scaledDecimal.underlying().unscaledValue())
+    this.longVal = 0L
+    this._precision = precision
+    this._scale = scale
+    this
+  }
+
+  /**
+   * Set this Decimal128 to the given BigDecimal value, inheriting its precision and scale.
+   */
+  def set(decimal: BigDecimal): Decimal128 = {
+    this.longVal = 0L
+    if (decimal.precision < decimal.scale) {
+      // For Decimal128, we expect the precision is equal to or large than the scale, however,
+      // in BigDecimal, the digit count starts from the leftmost nonzero digit of the exact
+      // result. For example, the precision of 0.01 equals to 1 based on the definition, but
+      // the scale is 2. The expected precision should be 2.
+      this.int128Val = Int128(decimal.underlying().unscaledValue())
+      this._precision = decimal.scale
+      this._scale = decimal.scale
+    } else if (decimal.scale < 0 && !SQLConf.get.allowNegativeScaleOfDecimalEnabled) {
+      this._precision = decimal.precision - decimal.scale
+      this._scale = 0
+      // set scale to 0 to correct unscaled value
+      this.int128Val = Int128(decimal.setScale(0).underlying().unscaledValue())
+    } else {
+      this.int128Val = Int128(decimal.underlying().unscaledValue())
+      this._precision = decimal.precision
+      this._scale = decimal.scale
+    }
+    this
+  }
+
+  /**
+   * If the value is not in the range of long, convert it to BigDecimal and
+   * the precision and scale are based on the converted value.
+   *
+   * This code avoids BigDecimal object allocation as possible to improve runtime efficiency
+   */
+  def set(bigInteger: BigInteger): Decimal128 = {
+    try {
+      this.int128Val = null
+      this.longVal = bigInteger.longValueExact()
+      this._precision = DecimalType.MAX_PRECISION
+      this._scale = 0
+      this
+    } catch {
+      case _: ArithmeticException =>
+        set(Int128(bigInteger), DecimalType.MAX_PRECISION, 0)
+    }
+  }
+
+  /**
+   * Set this Decimal128 to the given Decimal128 value.
+   */
+  def set(decimal: Decimal128): Decimal128 = {
+    this.int128Val = decimal.int128Val
+    this.longVal = decimal.longVal
+    this._precision = decimal._precision
+    this._scale = decimal._scale
+    this
+  }
+
+  def toBigDecimal: BigDecimal = {
+    if (int128Val.ne(null)) {
+      BigDecimal(int128Val.toBigInteger, _scale)
+    } else {
+      BigDecimal(longVal, _scale)
+    }
+  }
+
+  def toJavaBigDecimal: java.math.BigDecimal = {
+    if (int128Val.ne(null)) {
+      new java.math.BigDecimal(int128Val.toBigInteger, _scale)
+    } else {
+      java.math.BigDecimal.valueOf(longVal, _scale)
+    }
+  }
+
+  def toScalaBigInt: BigInt = if (int128Val.ne(null)) {
+    toBigDecimal.toBigInt
+  } else {
+    BigInt(actualLongVal)
+  }
+
+  def toJavaBigInteger: java.math.BigInteger = if (int128Val.ne(null)) {
+    toJavaBigDecimal.toBigInteger()
+  } else {
+    java.math.BigInteger.valueOf(actualLongVal)
+  }
+
+  def toUnscaledLong: Long = {
+    if (int128Val.ne(null)) {
+      toJavaBigDecimal.unscaledValue().longValueExact()
+    } else {
+      longVal
+    }
+  }
+
+  def isPositive: Boolean = int128Val.isPositive()
+
+  def isNegative: Boolean = int128Val.isNegative()
+
+  override def toString: String = toBigDecimal.toString()
+
+  def toPlainString: String = toJavaBigDecimal.toPlainString
+
+  def toDebugString: String = {
+    if (int128Val.ne(null)) {
+      s"Decimal128(expanded, $int128Val, $precision, $scale)"
+    } else {
+      s"Decimal128(compact, $longVal, $precision, $scale)"
+    }
+  }
+
+  def toDouble: Double = toBigDecimal.doubleValue
+
+  def toFloat: Float = toBigDecimal.floatValue
+
+  private def actualLongVal: Long = longVal / POW_10(_scale)
+
+  def toLong: Long = if (int128Val.eq(null)) {
+    actualLongVal
+  } else {
+    toBigDecimal.longValue
+  }
+
+  def toInt: Int = toLong.toInt
+
+  /**
+   * @return the Byte value that is equal to the rounded decimal128.
+   * @throws ArithmeticException if the decimal128 is too big to fit in Byte type.
+   */
+  private[sql] def roundToByte(): Byte =
+    roundToNumeric[Byte](ByteType, Byte.MaxValue, Byte.MinValue) (_.toByte) (_.toByte)
+
+  /**
+   * @return the Short value that is equal to the rounded decimal128.
+   * @throws ArithmeticException if the decimal128 is too big to fit in Short type.
+   */
+  private[sql] def roundToShort(): Short =
+    roundToNumeric[Short](ShortType, Short.MaxValue, Short.MinValue) (_.toShort) (_.toShort)
+
+  /**
+   * @return the Int value that is equal to the rounded decimal128.
+   * @throws ArithmeticException if the decimal128 too big to fit in Int type.
+   */
+  private[sql] def roundToInt(): Int =
+    roundToNumeric[Int](IntegerType, Int.MaxValue, Int.MinValue) (_.toInt) (_.toInt)
+
+  private def roundToNumeric[T <: AnyVal](integralType: IntegralType, maxValue: Int, minValue: Int)
+    (f1: Long => T) (f2: Double => T): T = {
+    if (int128Val.eq(null)) {
+      val actualLongVal = longVal / POW_10(_scale)
+      val numericVal = f1(actualLongVal)
+      if (actualLongVal == numericVal) {
+        numericVal
+      } else {
+        throw QueryExecutionErrors.castingCauseOverflowError(
+          this, DecimalType(this.precision, this.scale), integralType)
+      }
+    } else {
+      val doubleVal = this.toDouble
+      if (Math.floor(doubleVal) <= maxValue && Math.ceil(doubleVal) >= minValue) {
+        f2(doubleVal)
+      } else {
+        throw QueryExecutionErrors.castingCauseOverflowError(
+          this, DecimalType(this.precision, this.scale), integralType)
+      }
+    }
+  }
+
+  /**
+   * @return the Long value that is equal to the rounded decimal128.
+   * @throws ArithmeticException if the decimal128 too big to fit in Long type.
+   */
+  private[sql] def roundToLong(): Long = {
+    if (int128Val.eq(null)) {
+      longVal / POW_10(_scale)
+    } else {
+      try {
+        // We cannot store Long.MAX_VALUE as a Double without losing precision.
+        // Here we simply convert the decimal to `BigInteger` and use the method
+        // `longValueExact` to make sure the range check is accurate.
+        toJavaBigDecimal.toBigInteger.longValueExact()
+      } catch {
+        case _: ArithmeticException =>
+          throw QueryExecutionErrors.castingCauseOverflowError(
+            this, DecimalType(this.precision, this.scale), LongType)
+      }
+    }
+  }
+
+  /**
+   * Update precision and scale while keeping our value the same, and return true if successful.
+   *
+   * @return true if successful, false if overflow would occur
+   */
+  def changePrecision(precision: Int, scale: Int): Boolean = {
+    changePrecision(precision, scale, ROUND_HALF_UP)
+  }
+
+  /**
+   * Create new `Decimal128` with given precision and scale.
+   *
+   * @return a non-null `Decimal128` value if successful. Otherwise, if `nullOnOverflow` is true,
+   *         null is returned; if `nullOnOverflow` is false, an `ArithmeticException` is thrown.
+   */
+  private[sql] def toPrecision(
+      precision: Int,
+      scale: Int,
+      roundMode: BigDecimal.RoundingMode.Value = ROUND_HALF_UP,
+      nullOnOverflow: Boolean = true,
+      context: SQLQueryContext = null): Decimal128 = {
+    val copy = clone()
+    if (copy.changePrecision(precision, scale, roundMode)) {
+      copy
+    } else {
+      if (nullOnOverflow) {
+        null
+      } else {
+        throw QueryExecutionErrors.cannotChangeDecimal128PrecisionError(
+          this, precision, scale, context)
+      }
+    }
+  }
+
+  /**
+   * Update precision and scale while keeping our value the same, and return true if successful.
+   *
+   * @return true if successful, false if overflow would occur
+   */
+  private[sql] def changePrecision(
+      precision: Int,
+      scale: Int,
+      roundMode: BigDecimal.RoundingMode.Value): Boolean = {
+    // fast path for UnsafeProjection
+    if (precision == this.precision && scale == this.scale) {
+      return true
+    }
+    DecimalType.checkNegativeScale(scale)
+    var lv = longVal
+    var iv = int128Val
+    // First, update our lv if we can, or transfer over to using a BigDecimal
+    if (iv.eq(null)) {
+      if (scale < _scale) {
+        // Easier case: we just need to divide our scale down
+        val diff = _scale - scale
+        // If diff is greater than max number of digits we store in Long, then
+        // value becomes 0. Otherwise we calculate new value dividing by power of 10.
+        // In both cases we apply rounding after that.
+        if (diff > MAX_LONG_DIGITS) {
+          lv = roundMode match {
+            case ROUND_FLOOR => if (lv < 0) -1L else 0L
+            case ROUND_CEILING => if (lv > 0) 1L else 0L
+            case ROUND_HALF_UP | ROUND_HALF_EVEN => 0L
+            case _ => throw QueryExecutionErrors.unsupportedRoundingMode(roundMode)
+          }
+        } else {
+          val pow10diff = POW_10(diff)
+          // % and / always round to 0
+          val droppedDigits = lv % pow10diff
+          lv /= pow10diff
+          roundMode match {
+            case ROUND_FLOOR =>
+              if (droppedDigits < 0) {
+                lv += -1L
+              }
+            case ROUND_CEILING =>
+              if (droppedDigits > 0) {
+                lv += 1L
+              }
+            case ROUND_HALF_UP =>
+              if (math.abs(droppedDigits) * 2 >= pow10diff) {
+                lv += (if (droppedDigits < 0) -1L else 1L)
+              }
+            case ROUND_HALF_EVEN =>
+              val doubled = math.abs(droppedDigits) * 2
+              if (doubled > pow10diff || doubled == pow10diff && lv % 2 != 0) {
+                lv += (if (droppedDigits < 0) -1L else 1L)
+              }
+            case _ =>
+              throw QueryExecutionErrors.unsupportedRoundingMode(roundMode)
+          }
+        }
+      } else if (scale > _scale) {
+        // We might be able to multiply lv by a power of 10 and not overflow, but if not,
+        // switch to using a BigDecimal
+        val diff = scale - _scale
+        val p = POW_10(math.max(MAX_LONG_DIGITS - diff, 0))
+        if (diff <= MAX_LONG_DIGITS && lv > -p && lv < p) {
+          // Multiplying lv by POW_10(diff) will still keep it below MAX_LONG_DIGITS
+          lv *= POW_10(diff)
+        } else {
+          // Give up on using Longs; switch to BigDecimal, which we'll modify below
+          iv = Int128(lv)
+        }
+      }
+      // In both cases, we will check whether our precision is okay below
+    }
+
+    if (iv.ne(null)) {
+      // We get here if either we started with a BigDecimal, or we switched to one because we would
+      // have overflowed our Long; in either case we must rescale dv to the new scale.
+      if (!rescale(precision, scale, roundMode)) {
+        return false
+      }
+      iv = int128Val
+    } else {
+      // We're still using Longs, but we should check whether we match the new precision
+      val p = POW_10(math.min(precision, MAX_LONG_DIGITS))
+      if (lv <= -p || lv >= p) {
+        // Note that we shouldn't have been able to fix this by switching to BigDecimal
+        return false
+      }
+    }
+    int128Val = iv
+    longVal = lv
+    _precision = precision
+    _scale = scale
+    true
+  }
+
+  def rescale(precision: Int, scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean = {
+    val newDecimalVal = toJavaBigDecimal.setScale(scale, roundMode)
+    if (newDecimalVal.precision > precision) {
+      return false
+    }
+
+    if (roundMode == ROUND_CEILING || roundMode == ROUND_FLOOR) {
+      set(newDecimalVal)
+    } else {
+      try {
+        val rescale = scale - _scale
+        val (newLeftHigh, newLeftLow) = Int128Math.rescale(this.high, this.low, rescale)
+        this.int128Val = Int128(newLeftHigh, newLeftLow)
+      } catch {
+        case _: IllegalArgumentException =>
+          set(newDecimalVal)
+      }
+    }
+
+    true
+  }
+
+  override def compare(other: Decimal128): Int = {
+    if (this.int128Val.eq(null) && other.int128Val.eq(null) && this._scale == other._scale) {
+      if (this.longVal < other.longVal) -1 else if (this.longVal == other.longVal) 0 else 1
+    } else {
+      val (rescale, rescaleLeft) = if (this._scale > other.scale) {
+        (this._scale - other.scale, false)
+      } else if (this._scale < other.scale) {
+        (other.scale - this._scale, true)
+      } else {
+        (0, false)
+      }
+      if (rescale == 0) {
+        Int128.compare(this.high, this.low, other.high, other.low)
+      } else {
+        operatorWithRescale(
+          this.high, this.low, other.high, other.low, rescale, rescaleLeft) (Int128.compare)
+      }
+    }
+  }
+
+  override def clone(): Decimal128 = new Decimal128().set(this)
+
+  override def equals(other: Any): Boolean = other match {
+    case d: Decimal128 =>
+      compare(d) == 0
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int = toBigDecimal.hashCode()
+
+  def isZero: Boolean = if (this.int128Val.ne(null)) this.int128Val.isZero() else this.longVal == 0
+
+  def + (that: Decimal128): Decimal128 = {
+    val resultScale = math.max(this._scale, that._scale)
+    val resultPrecision = math.min(DecimalType.MAX_PRECISION, resultScale +
+      math.max(this._precision - this._scale, that._precision - that._scale) + 1)
+
+    val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that._scale)
+    val rightRescaleFactor = Int128Math.rescaleFactor(that._scale, this._scale)
+
+    if (this.int128Val.eq(null) && that.int128Val.eq(null)) {
+      val newLongVal = this.longVal * Int128Math.longTenToNth(leftRescaleFactor) +
+        that.longVal * Int128Math.longTenToNth(rightRescaleFactor)
+      Decimal128(newLongVal, resultPrecision, resultScale)
+    } else {
+      val (newHigh, newLow) = if (leftRescaleFactor == 0 && rightRescaleFactor == 0) {
+        Int128Math.add(this.high, this.low, that.high, that.low)
+      } else if (leftRescaleFactor == 0) {
+        operatorWithRescale(
+          this.high, this.low, that.high, that.low, rightRescaleFactor, false) (Int128Math.add)
+      } else {
+        operatorWithRescale(
+          this.high, this.low, that.high, that.low, leftRescaleFactor, true)(Int128Math.add)
+      }
+
+      checkOverflow(newHigh, newLow, "Decimal128 addition.")
+
+      Decimal128(Int128(newHigh, newLow), resultPrecision, resultScale)
+    }
+  }
+
+  def - (that: Decimal128): Decimal128 = {
+    val resultScale = math.max(this._scale, that._scale)
+    val resultPrecision = math.min(DecimalType.MAX_PRECISION, resultScale +
+      math.max(this._precision - this._scale, that._precision - that._scale) + 1)
+
+    val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that._scale)
+    val rightRescaleFactor = Int128Math.rescaleFactor(that._scale, this._scale)
+
+    if (this.int128Val.eq(null) && that.int128Val.eq(null)) {
+      val newLongVal = this.longVal * Int128Math.longTenToNth(leftRescaleFactor) -
+        that.longVal * Int128Math.longTenToNth(rightRescaleFactor)
+
+      Decimal128(newLongVal, resultPrecision, resultScale)
+    } else {
+      val (newHigh, newLow) = if (leftRescaleFactor == 0 && rightRescaleFactor == 0) {
+        Int128Math.subtract(this.high, this.low, that.high, that.low)
+      } else if (leftRescaleFactor == 0) {
+        operatorWithRescale(
+          this.high, this.low, that.high, that.low, rightRescaleFactor, false)(Int128Math.subtract)
+      } else {
+        operatorWithRescale(
+          this.high, this.low, that.high, that.low, leftRescaleFactor, true)(Int128Math.subtract)
+      }
+
+      checkOverflow(newHigh, newLow, "Decimal128 subtract.")
+
+      Decimal128(Int128(newHigh, newLow), resultPrecision, resultScale)
+    }
+  }
+
+  def * (that: Decimal128): Decimal128 = {
+    val resultScale = this._scale + that._scale
+    val resultPrecision = math.min(DecimalType.MAX_PRECISION, this._precision + that._precision)
+
+    if (this.int128Val.eq(null) && that.int128Val.eq(null)) {
+      val newLongVal = this.longVal * that.longVal
+      Decimal128(newLongVal, resultPrecision, resultScale)
+    } else {
+      val (newHigh, newLow) = Int128Math.multiply(this.high, this.low, that.high, that.low)
+
+      checkOverflow(newHigh, newLow, "Decimal128 multiply.")
+
+      Decimal128(Int128(newHigh, newLow), resultPrecision, resultScale)
+    }
+  }
+
+  def / (that: Decimal128): Decimal128 = if (that.isZero) {
+    null
+  } else if (this.isZero) {
+    Decimal128.ZERO
+  } else {
+    val resultScale = math.max(this._scale, that._scale)
+    val resultPrecision = math.min(DecimalType.MAX_PRECISION,
+      this._precision + that._scale + math.max(that._scale - this._scale, 0))
+    val rescaleFactor = resultScale - this._scale + that._scale
+
+    if (this.int128Val.eq(null) && that.int128Val.eq(null)) {
+      val resultSignum = this.longVal.signum * that.longVal.signum
+      val unsignedLeft = this.longVal.abs
+      val unsignedRight = that.longVal.abs
+      val rescaledUnsignedLeft = unsignedLeft * Int128Math.longTenToNth(rescaleFactor)
+      var quotient = rescaledUnsignedLeft / unsignedRight
+      val remainder = rescaledUnsignedLeft - (quotient * unsignedRight)
+
+      if (JavaLong.compareUnsigned(remainder * 2, unsignedRight) >= 0) {
+        quotient += 1
+      }
+
+      Decimal128(resultSignum * quotient, resultPrecision, resultScale)
+    } else {
+      val (newHigh, newLow) = try {
+        Int128Math.divideRoundUp(this.high, this.low, that.high, that.low, rescaleFactor, 0)
+      } catch {
+        case _: ArithmeticException =>
+          throw overflowError("Decimal128 division.")
+      }
+
+      checkOverflow(newHigh, newLow, "Decimal128 division.")
+
+      if (newHigh == (newLow >> 63)) {
+        Decimal128(newLow, resultPrecision, resultScale)
+      } else {
+        Decimal128(Int128(newHigh, newLow), resultPrecision, resultScale)
+      }
+    }
+  }
+
+  def % (that: Decimal128): Decimal128 = if (that.isZero) {
+    null
+  } else if (this.isZero) {
+    Decimal128.ZERO
+  } else {
+    val resultScale = math.max(this._scale, that._scale)
+    val resultPrecision =
+      math.min(this._precision - this._scale, that._precision - that._scale) + resultScale
+
+    val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that._scale)
+    val rightRescaleFactor = Int128Math.rescaleFactor(that._scale, this._scale)
+
+    val (newHigh, newLow) = try {
+      Int128Math.remainder(
+        this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor, false)
+    } catch {
+      case _: ArithmeticException =>
+        throw overflowError(s"Get remainder of ${this.int128Val} divide ${that.int128Val}.")
+    }
+
+    if (this.int128Val.eq(null) && that.int128Val.eq(null)) {
+      Decimal128(newLow, resultPrecision, resultScale)
+    } else if (newHigh == (newLow >> 63)) {
+      Decimal128(newLow, resultPrecision, resultScale)
+    } else {
+      Decimal128(Int128(newHigh, newLow), resultPrecision, resultScale)
+    }
+  }
+
+  def quot(that: Decimal128): Decimal128 = {
+    if (that.isZero) {
+      null
+    } else {
+      val resultScale = 0
+      val resultPrecision = this._precision - this._scale + that.scale + resultScale
+
+      val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that.scale)
+      val rightRescaleFactor = Int128Math.rescaleFactor(that.scale, this._scale)
+      val (newHigh, newLow) = try {
+        Int128Math.remainder(
+          this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor, true)
+      } catch {
+        case _: ArithmeticException =>
+          throw overflowError(s"Get quotient of ${this.int128Val} divide ${that.int128Val}.")
+      }
+
+      if (this.int128Val.eq(null) || that.int128Val.eq(null)) {
+        if (newHigh == (newLow >> 63)) {
+          Decimal128(newLow, resultPrecision, resultScale)
+        } else {
+          Decimal128(Int128(newHigh, newLow), resultPrecision, resultScale)
+        }
+      } else {
+        Decimal128(Int128(newHigh, newLow), resultPrecision, resultScale)
+      }
+    }
+  }
+
+  def unary_- : Decimal128 = if (int128Val.ne(null)) {
+    Decimal128(-int128Val, this._precision, this._scale)
+  } else {
+    Decimal128(-longVal, this._precision, this._scale)
+  }
+
+  def abs: Decimal128 = if (this < Decimal128.ZERO) this.unary_- else this
+
+  def floor: Decimal128 = if (scale == 0) this else {
+    val newPrecision = DecimalType.bounded(precision - scale + 1, 0).precision
+    toPrecision(newPrecision, 0, ROUND_FLOOR, nullOnOverflow = false)
+  }
+
+  def ceil: Decimal128 = if (scale == 0) this else {
+    val newPrecision = DecimalType.bounded(precision - scale + 1, 0).precision
+    toPrecision(newPrecision, 0, ROUND_CEILING, nullOnOverflow = false)
+  }
+}
+
+@Unstable
+object Decimal128 {
+  val ROUND_HALF_UP = BigDecimal.RoundingMode.HALF_UP
+  val ROUND_HALF_EVEN = BigDecimal.RoundingMode.HALF_EVEN
+  val ROUND_CEILING = BigDecimal.RoundingMode.CEILING
+  val ROUND_FLOOR = BigDecimal.RoundingMode.FLOOR
+
+  /** Maximum number of decimal digits a Long can represent */
+  val MAX_LONG_DIGITS = 18
+
+  val POW_10 = Array.tabulate[Long](MAX_LONG_DIGITS + 1)(i => math.pow(10, i).toLong)
+
+  private[sql] val ZERO = Decimal128(0)
+  private[sql] val ONE = Decimal128(1)
+
+  def apply(value: Double): Decimal128 = new Decimal128().set(value)
+
+  def apply(value: Long): Decimal128 = new Decimal128().set(value)
+
+  def apply(value: Int): Decimal128 = new Decimal128().set(value)
+
+  def apply(value: BigDecimal): Decimal128 = new Decimal128().set(value)
+
+  def apply(value: java.math.BigDecimal): Decimal128 = new Decimal128().set(value)
+
+  def apply(value: java.math.BigInteger): Decimal128 = new Decimal128().set(value)
+
+  def apply(value: scala.math.BigInt): Decimal128 = new Decimal128().set(value.bigInteger)
+
+  def apply(value: BigDecimal, precision: Int, scale: Int): Decimal128 =
+    new Decimal128().set(value, precision, scale)
+
+  def apply(value: java.math.BigDecimal, precision: Int, scale: Int): Decimal128 =
+    new Decimal128().set(value, precision, scale)
+
+  def apply(high: Long, low: Long, precision: Int, scale: Int): Decimal128 =
+    new Decimal128().set(high, low, precision, scale)
+
+  def apply(int128: Int128, precision: Int, scale: Int): Decimal128 =
+    new Decimal128().set(int128, precision, scale)
+
+  def apply(unscaled: Long, precision: Int, scale: Int): Decimal128 =
+    new Decimal128().set(unscaled, precision, scale)
+
+  def apply(value: String): Decimal128 = new Decimal128().set(BigDecimal(value))
+
+  def operatorWithRescale[T](
+      leftHigh: Long,
+      leftLow: Long,
+      rightHigh: Long,
+      rightLow: Long,
+      rescale: Int,
+      rescaleLeft: Boolean) (f: (Long, Long, Long, Long) => T): T = {
+    if (rescaleLeft) {
+      val (newLeftHigh, newLeftLow) = Int128Math.rescale(leftHigh, leftLow, rescale)
+      f(newLeftHigh, newLeftLow, rightHigh, rightLow)
+    } else {
+      val (newRightHigh, newRightLow) = Int128Math.rescale(rightHigh, rightLow, rescale)
+      f(leftHigh, leftLow, newRightHigh, newRightLow)
+    }
+  }
+
+  def checkOverflow(high: Long, low: Long, msg: String): Unit = {
+    if (Int128.overflows(high, low)) {
+      throw overflowError(msg)
+    }
+  }
+
+  def overflowError(msg: String): ArithmeticException = {
+    new ArithmeticException(s"Decimal overflow: $msg")
+  }
+
+  // This is used for RowEncoder to handle Decimal inside external row.
+  def fromDecimal128(value: Any): Decimal128 = {
+    value match {
+      case j: java.math.BigDecimal => apply(j)
+      case d: BigDecimal => apply(d)
+      case k: scala.math.BigInt => apply(k)
+      case l: java.math.BigInteger => apply(l)
+      case d: Decimal128 => d
+    }
+  }
+
+  private def numDigitsInIntegralPart(bigDecimal: JavaBigDecimal): Int = {
+    bigDecimal.precision - bigDecimal.scale
+  }
+
+  private def stringToJavaBigDecimal(str: UTF8String): JavaBigDecimal = {
+    // According the benchmark test,  `s.toString.trim` is much faster than `s.trim.toString`.
+    // Please refer to https://github.com/apache/spark/pull/26640
+    new JavaBigDecimal(str.toString.trim)
+  }
+
+  def fromString(str: UTF8String): Decimal128 = {
+    try {
+      val bigDecimal = stringToJavaBigDecimal(str)
+      // We fast fail because constructing a very large JavaBigDecimal to Decimal is very slow.
+      // For example: Decimal("6.0790316E+25569151")
+      if (numDigitsInIntegralPart(bigDecimal) > DecimalType.MAX_PRECISION &&
+        !SQLConf.get.allowNegativeScaleOfDecimalEnabled) {
+        null
+      } else {
+        Decimal128(bigDecimal)
+      }
+    } catch {
+      case _: NumberFormatException =>
+        null
+    }
+  }
+
+  def fromStringANSI(
+      str: UTF8String,
+      to: DecimalType = DecimalType.USER_DEFAULT,
+      context: SQLQueryContext = null): Decimal128 = {
+    try {
+      val bigDecimal = stringToJavaBigDecimal(str)
+      // We fast fail because constructing a very large JavaBigDecimal to Decimal is very slow.
+      // For example: Decimal("6.0790316E+25569151")
+      if (numDigitsInIntegralPart(bigDecimal) > DecimalType.MAX_PRECISION &&
+        !SQLConf.get.allowNegativeScaleOfDecimalEnabled) {
+        throw QueryExecutionErrors.outOfDecimalTypeRangeError(str)
+      } else {
+        Decimal128(bigDecimal)
+      }
+    } catch {
+      case _: NumberFormatException =>
+        throw QueryExecutionErrors.invalidInputInCastToNumberError(to, str, context)
+    }
+  }
+
+  /**
+   * Creates a decimal128 from unscaled, precision and scale without checking the bounds.
+   */
+  def createUnsafe(unscaled: Long, precision: Int, scale: Int): Decimal128 = {
+    DecimalType.checkNegativeScale(scale)
+    val dec = new Decimal128()
+    dec.longVal = unscaled
+    dec._precision = precision
+    dec._scale = scale
+    dec
+  }
+
+  /** Common methods for Decimal128 evidence parameters */
+  private[sql] trait Decimal128IsConflicted extends Numeric[Decimal128] {
+    override def plus(x: Decimal128, y: Decimal128): Decimal128 = x + y
+    override def times(x: Decimal128, y: Decimal128): Decimal128 = x * y
+    override def minus(x: Decimal128, y: Decimal128): Decimal128 = x - y
+    override def negate(x: Decimal128): Decimal128 = -x
+    override def toDouble(x: Decimal128): Double = x.toDouble
+    override def toFloat(x: Decimal128): Float = x.toFloat
+    override def toInt(x: Decimal128): Int = x.toInt
+    override def toLong(x: Decimal128): Long = x.toLong
+    override def fromInt(x: Int): Decimal128 = new Decimal128().set(x)
+    override def compare(x: Decimal128, y: Decimal128): Int = x.compare(y)
+    // Added from Scala 2.13; don't override to work in 2.12
+    // TODO revisit once Scala 2.12 support is dropped
+    def parseString(str: String): Option[Decimal128] = Try(Decimal128(str)).toOption
+  }
+
+  /** A [[scala.math.Fractional]] evidence parameter for Decimal128s. */
+  private[sql] object Decimal128IsFractional
+    extends Decimal128IsConflicted with Fractional[Decimal128] {
+    override def div(x: Decimal128, y: Decimal128): Decimal128 = x / y
+  }
+
+  /** A [[scala.math.Integral]] evidence parameter for Decimal128s. */
+  private[sql] object Decimal128AsIfIntegral
+    extends Decimal128IsConflicted with Integral[Decimal128] {
+    override def quot(x: Decimal128, y: Decimal128): Decimal128 = x quot y
+    override def rem(x: Decimal128, y: Decimal128): Decimal128 = x % y
+  }
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import java.lang.{Long => JLong}
+import java.math.BigInteger
+import java.nio.{ByteBuffer, ByteOrder}
+
+import scala.util.Try
+
+import org.apache.spark.annotation.Unstable
+import org.apache.spark.sql.util.Int128Math
+
+/**
+ * A mutable implementation of Int128 that hold two Long values to represent the high and low bits
+ * of 128 bits respectively.
+ *
+ * The semantics of the fields are as follows:
+ * - _high and _low represent the high and low bits of 128 bits respectively
+ */
+@Unstable
+final class Int128 extends Ordered[Int128] with Serializable {
+
+  private var _high: Long = 0L
+  private var _low: Long = 0L
+
+  def high: Long = _high
+  def low: Long = _low
+
+  def set(high: Long, low: Long): Int128 = {
+    _high = high
+    _low = low
+    this
+  }
+
+  def set(value: Long): Int128 = set(value >> 63, value)
+
+  def set(bigInteger: BigInteger): Int128 = {
+    _low = bigInteger.longValue()
+    try {
+      _high = bigInteger.shiftRight(64).longValueExact()
+    } catch {
+      case _: ArithmeticException =>
+        throw new ArithmeticException("BigInteger out of Int128 range")
+    }
+
+    this
+  }
+
+  def isPositive(): Boolean = _high > 0 || (_high == 0 && _low != 0)
+
+  def isNegative(): Boolean = _high < 0
+
+  def isZero(): Boolean = (_high | _low) == 0
+
+  def toBigInteger: BigInteger = new BigInteger(toBigEndianBytes())
+
+  def toBigEndianBytes(): Array[Byte] = {
+    val bytes = new Array[Byte](16)
+    toBigEndianBytes(bytes, 0)
+    bytes
+  }
+
+  def toBigEndianBytes(bytes: Array[Byte], offset: Int): Unit = {
+    val byteBuffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
+    byteBuffer.putLong(offset, high)
+    byteBuffer.putLong(offset + JLong.BYTES, low)
+  }
+
+  def toDouble: Double = toLong.doubleValue
+
+  def toFloat: Float = toLong.floatValue
+
+  def toLong(): Long = low
+
+  def toInt: Int = toLong.toInt
+
+  def scaleUpTen(n: Int): Int128 = {
+    this * Int128(n >> 63, n)
+  }
+
+  def + (that: Int128): Int128 = {
+    val (newHigh, newLow) = Int128Math.add(this, that)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def - (that: Int128): Int128 = {
+    val (newHigh, newLow) = Int128Math.subtract(this, that)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def * (that: Int128): Int128 = {
+    val (newHigh, newLow) = Int128Math.multiply(this, that)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def / (that: Int128): Int128 = if (that.isZero) {
+    null
+  } else {
+    val (newHigh, newLow) =
+      Int128Math.divideRoundUp(this._high, this._low, that.high, that.low, 0, 0)
+
+    Int128(newHigh, newLow)
+  }
+
+  def % (that: Int128): Int128 = if (that.isZero) {
+    null
+  } else {
+    val (newHigh, newLow) =
+      Int128Math.remainder(this._high, this._low, that.high, that.low, 0, 0, false)
+
+    Int128(newHigh, newLow)
+  }
+
+  def quot (that: Int128): Int128 = this / that
+
+  def unary_- : Int128 = {
+    val newHigh = Int128Math.negateHigh(this.high, this.low)
+    val newLow = Int128Math.negateLow(this.low)
+    new Int128().set(newHigh, newLow)
+  }
+
+  override def compare(other: Int128): Int = {
+    Int128.compare(this.high, this.low, other.high, other.low)
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case d: Int128 =>
+      compare(d) == 0
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int = {
+    // FNV-1a style hash
+    var hash = 0x9E3779B185EBCA87L
+    hash = (hash ^ high) * 0xC2B2AE3D27D4EB4FL
+    hash = (hash ^ low) * 0xC2B2AE3D27D4EB4FL
+    JLong.hashCode(hash)
+  }
+
+  override def toString: String = s"Int128($high, $low)"
+}
+
+@Unstable
+object Int128 {
+
+  def apply(high: Long, low: Long): Int128 = new Int128().set(high, low)
+
+  def apply(value: Long): Int128 = new Int128().set(value)
+
+  def apply(bigInteger: BigInteger): Int128 = new Int128().set(bigInteger)
+
+  def apply(value: String): Int128 = new Int128().set(new BigInteger(value))
+
+  val ZERO = Int128(0, 0)
+  val ONE = Int128(0, 1)
+  val MAX_VALUE = Int128(0x7FFFFFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFFFL)
+  val MIN_VALUE = Int128(0x8000000000000000L, 0x0000000000000000L)
+  val MAX_UNSCALED_DECIMAL = Int128("99999999999999999999999999999999999999")
+  val MIN_UNSCALED_DECIMAL = Int128("-99999999999999999999999999999999999999")
+
+  def compare(leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): Int = {
+    var comparison = JLong.compare(leftHigh, rightHigh)
+    if (comparison == 0) {
+      comparison = JLong.compareUnsigned(leftLow, rightLow)
+    }
+
+    comparison
+  }
+
+  def overflows(high: Long, low: Long): Boolean = {
+    compare(high, low, MAX_UNSCALED_DECIMAL.high, MAX_UNSCALED_DECIMAL.low) > 0 ||
+      compare(high, low, MIN_UNSCALED_DECIMAL.high, MIN_UNSCALED_DECIMAL.low) < 0
+  }
+
+  /** Common methods for Int128 evidence parameters */
+  private[sql] trait Int128IsConflicted extends Numeric[Int128] {
+    override def plus(x: Int128, y: Int128): Int128 = x + y
+    override def times(x: Int128, y: Int128): Int128 = x * y
+    override def minus(x: Int128, y: Int128): Int128 = x - y
+    override def negate(x: Int128): Int128 = -x
+    override def toDouble(x: Int128): Double = x.toDouble
+    override def toFloat(x: Int128): Float = x.toFloat
+    override def toInt(x: Int128): Int = x.toInt
+    override def toLong(x: Int128): Long = x.toLong
+    override def fromInt(x: Int): Int128 = new Int128().set(0, x)
+    override def compare(x: Int128, y: Int128): Int = x.compare(y)
+
+    def parseString(str: String): Option[Int128] = Try(Int128(str)).toOption
+  }
+
+  /** A [[scala.math.Integral]] evidence parameter for Int128s. */
+  private[sql] object Int128IsIntegral extends Int128IsConflicted with Integral[Int128] {
+    override def quot(x: Int128, y: Int128): Int128 = x quot y
+    override def rem(x: Int128, y: Int128): Int128 = x % y
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/Int128Math.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/Int128Math.scala
@@ -1,0 +1,1115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util
+
+import java.lang.{Long => JLong}
+import java.lang.Math.{pow, round}
+import java.math.BigInteger
+import java.util.Arrays
+
+import org.apache.spark.sql.types.Int128
+
+object Int128Math {
+
+  val MAX_PRECISION = 38
+
+  // Lowest 32 bits of a long
+  private val LOW_32_BITS = 0xFFFFFFFFL
+
+  // 1..10^38 (largest value < Int128.MAX_VALUE)
+  private val POWERS_OF_TEN = Array.tabulate[Int128](39)(i => Int128(BigInteger.TEN.pow(i)))
+
+  // 5^54 is the largest value < Int128.MAX_VALUE
+  private val POWERS_OF_FIVE =
+    Array.tabulate[Int128](54)(i => Int128(BigInteger.valueOf(5).pow(i)))
+
+  private val LONG_POWERS_OF_TEN_TABLE_LENGTH = 19
+
+  // Although this computes using doubles, incidentally,
+  // this is exact for all powers of 10 that fit in a long.
+  private val LONG_POWERS_OF_TEN =
+    Array.tabulate[Long](LONG_POWERS_OF_TEN_TABLE_LENGTH)(i => round(pow(10, i)))
+
+  /**
+   * 5^13 fits in 2^31.
+   */
+  private val MAX_POWER_OF_FIVE_INT = 13
+
+  /**
+   * 5^x. All unsigned values.
+   */
+  private val POWERS_OF_FIVES_INT = new Array[Int](MAX_POWER_OF_FIVE_INT + 1)
+  POWERS_OF_FIVES_INT(0) = 1
+  for (i <- 1 until POWERS_OF_FIVES_INT.length) {
+    POWERS_OF_FIVES_INT(i) = POWERS_OF_FIVES_INT(i - 1) * 5
+  }
+
+  /**
+   * 5^27 fits in 2^31.
+   */
+  private val MAX_POWER_OF_FIVE_LONG = 27
+
+  /**
+   * 5^x. All unsigned values.
+   */
+  private val POWERS_OF_FIVE_LONG = new Array[Long](MAX_POWER_OF_FIVE_LONG + 1)
+  POWERS_OF_FIVE_LONG(0) = 1
+  for (i <- 1 until POWERS_OF_FIVE_LONG.length) {
+    POWERS_OF_FIVE_LONG(i) = POWERS_OF_FIVE_LONG(i - 1) * 5
+  }
+
+  /**
+   * 10^9 fits in 2^31.
+   */
+  private val MAX_POWER_OF_TEN_INT = 9
+
+  /**
+   * 10^18 fits in 2^63.
+   */
+  private val MAX_POWER_OF_TEN_LONG = 18
+
+  /**
+   * 10^x. All unsigned values.
+   */
+  private val POWERS_OF_TEN_INT = new Array[Int](MAX_POWER_OF_TEN_INT + 1)
+  POWERS_OF_TEN_INT(0) = 1
+  for (i <- 1 until POWERS_OF_TEN_INT.length) {
+    POWERS_OF_TEN_INT(i) = POWERS_OF_TEN_INT(i - 1) * 10
+  }
+
+  private val NUMBER_OF_LONGS = 2
+  private val NUMBER_OF_INTS = 2 * NUMBER_OF_LONGS
+
+  private val INT_BASE = 1L << 32
+
+  def longTenToNth(n: Int): Long = LONG_POWERS_OF_TEN(n)
+
+  def add(left: Int128, right: Int128): (Long, Long) =
+    add(left.high, left.low, right.high, right.low)
+
+  def add(leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): (Long, Long) = {
+    val carry = unsignedCarry(leftLow, rightLow)
+
+    val resultHigh = leftHigh + rightHigh + carry
+    val resultLow = leftLow + rightLow
+
+    if (((resultHigh ^ leftHigh) & (resultHigh ^ rightHigh)) < 0) {
+      throw int128OverflowException(
+        s"Int128($leftHigh, $leftLow) add Int128($rightHigh, $rightLow).")
+    }
+
+    (resultHigh, resultLow)
+  }
+
+  def subtract(left: Int128, right: Int128): (Long, Long) =
+    subtract(left.high, left.low, right.high, right.low)
+
+  def subtract(leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): (Long, Long) = {
+    val borrow = unsignedBorrow(leftLow, rightLow)
+
+    val resultHigh = leftHigh - rightHigh - borrow
+    val resultLow = leftLow - rightLow
+
+    if (((leftHigh ^ rightHigh) & (leftHigh ^ resultHigh)) < 0) {
+      throw int128OverflowException(
+        s"Int128($leftHigh, $leftLow) subtract Int128($rightHigh, $rightLow).")
+    }
+
+    (resultHigh, resultLow)
+  }
+
+  def multiply(left: Int128, right: Int128): (Long, Long) =
+    multiply(left.high, left.low, right.high, right.low)
+
+  def multiply(leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): (Long, Long) = {
+    val leftNegative = leftHigh < 0
+    val rightNegative = rightHigh < 0
+
+    var tmpLeftLow = leftLow
+    var tmpLeftHigh = leftHigh
+    if (leftNegative) {
+      tmpLeftLow = negateLow(tmpLeftLow)
+      tmpLeftHigh = negateHighExact(tmpLeftHigh, tmpLeftLow)
+    }
+
+    var tmpRightLow = rightLow
+    var tmpRightHigh = rightHigh
+    if (rightNegative) {
+      tmpRightLow = negateLow(tmpRightLow)
+      tmpRightHigh = negateHighExact(tmpRightHigh, tmpRightLow)
+    }
+
+    val result = multiplyPositives(tmpLeftHigh, tmpLeftLow, tmpRightHigh, tmpRightLow)
+
+    if (leftNegative == rightNegative) {
+      result
+    } else {
+      (negateHighExact(result._1, result._2), negateLow(result._2))
+    }
+  }
+
+  def divideRoundUp(
+      leftHigh: Long,
+      leftLow: Long,
+      rightHigh: Long,
+      rightLow: Long,
+      leftScale: Int,
+      rightScale: Int): (Long, Long) = {
+    if (leftScale > MAX_PRECISION) {
+      throw int128OverflowException(
+        s"Int128($leftHigh, $leftLow) with scale $leftScale exceeding the max precision.")
+    }
+
+    if (rightScale > MAX_PRECISION) {
+      throw int128OverflowException(
+        s"Int128($rightHigh, $rightLow) with scale $rightScale exceeding the max precision.")
+    }
+
+    val dividendIsNegative = leftHigh < 0
+    val divisorIsNegative = rightHigh < 0
+    val quotientIsNegative = dividendIsNegative != divisorIsNegative
+
+    var tmpLeftLow = leftLow
+    var tmpLeftHigh = leftHigh
+    if (dividendIsNegative) {
+      tmpLeftLow = negateLow(tmpLeftLow)
+      tmpLeftHigh = negateHighExact(tmpLeftHigh, tmpLeftLow)
+    }
+
+    var tmpRightLow = rightLow
+    var tmpRightHigh = rightHigh
+    if (divisorIsNegative) {
+      tmpRightLow = negateLow(tmpRightLow)
+      tmpRightHigh = negateHighExact(tmpRightHigh, tmpRightLow)
+    }
+
+    val (quotient, remainder) =
+      dividePositives(tmpLeftHigh, tmpLeftLow, tmpRightHigh, tmpRightLow, leftScale, rightScale)
+
+    // if (2 * remainder >= divisor) - increment quotient by one
+    val (remainderHigh, remainderLow) = shiftLeft(remainder._1, remainder._2, 1)
+
+    val (quotientHigh, quotientLow) =
+      if (compareUnsigned(remainderHigh, remainderLow, tmpRightHigh, tmpRightLow) >= 0) {
+        incrementUnsafe(quotient._1, quotient._2)
+      } else {
+        (quotient._1, quotient._2)
+      }
+
+    if (quotientIsNegative) {
+      // negateExact not needed since all positive values can be negated without overflow
+      negate(quotientHigh, quotientLow)
+    } else {
+      (quotientHigh, quotientLow)
+    }
+  }
+
+  def remainder(
+      leftHigh: Long,
+      leftLow: Long,
+      rightHigh: Long,
+      rightLow: Long,
+      leftScale: Int,
+      rightScale: Int,
+      returnQuotient: Boolean): (Long, Long) = {
+    val dividendIsNegative = leftHigh < 0
+    val divisorIsNegative = rightHigh < 0
+
+    var tmpLeftLow = leftLow
+    var tmpLeftHigh = leftHigh
+    if (dividendIsNegative) {
+      tmpLeftLow = negateLow(tmpLeftLow)
+      tmpLeftHigh = negateHighExact(tmpLeftHigh, tmpLeftLow)
+    }
+
+    var tmpRightLow = rightLow
+    var tmpRightHigh = rightHigh
+    if (divisorIsNegative) {
+      tmpRightLow = negateLow(tmpRightLow)
+      tmpRightHigh = negateHighExact(tmpRightHigh, tmpRightLow)
+    }
+
+    val (quotient, remainder) = dividePositives(tmpLeftHigh, tmpLeftLow, tmpRightHigh, tmpRightLow,
+      leftScale, rightScale, false, returnQuotient)
+
+    if (returnQuotient) {
+      if (dividendIsNegative != divisorIsNegative) {
+        return negate(quotient._1, quotient._2)
+      }
+      return quotient
+    }
+
+    if (dividendIsNegative) {
+      // negateExact not needed since all positive values can be negated without overflow
+      negate(remainder._1, remainder._2)
+    } else {
+      (remainder._1, remainder._2)
+    }
+  }
+
+  def rescaleFactor(fromScale: Long, toScale: Long): Int =
+    Integer.max(0, toScale.toInt - fromScale.toInt)
+
+  def shiftLeft(high: Long, low: Long, shift: Int): (Long, Long) = {
+    var tmpHigh = high
+    var tmpLow = low
+
+    if (shift < 64) {
+      tmpHigh = (tmpHigh << shift) | (low >>> 1 >>> (63 - shift))
+      tmpLow = tmpLow << shift
+    }
+    else {
+      tmpHigh = tmpLow << (shift - 64)
+      tmpLow = 0
+    }
+
+    (tmpHigh, tmpLow)
+  }
+
+  def rescale(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    if (rescale == 0) {
+      (high, low)
+    } else if (rescale > 0) {
+      shiftLeftBy10(high, low, rescale)
+    } else {
+      scaleDownRoundUp(high, low, -rescale)
+    }
+  }
+
+  def rescaleTruncate(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    if (rescale == 0) {
+      (high, low)
+    } else if (rescale > 0) {
+      shiftLeftBy10(high, low, rescale)
+    } else {
+      scaleDownTruncate(high, low, -rescale)
+    }
+  }
+
+  /**
+   * Multiplies by 10^rescaleFactor. Only positive rescaleFactor values are allowed.
+   */
+  def shiftLeftBy10(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    if (rescale >= POWERS_OF_TEN.length) {
+      throw int128OverflowException(s"Rescale Int128($high, $low) with $rescale.")
+    }
+
+    val negative = high < 0
+
+    var tmpHigh = high
+    var tmpLow = low
+    if (negative) {
+      tmpHigh = negateHighExact(tmpHigh, tmpLow)
+      tmpLow = negateLow(tmpLow)
+    }
+
+    val result =
+      multiplyPositives(tmpHigh, tmpLow, POWERS_OF_TEN(rescale).high, POWERS_OF_TEN(rescale).low)
+
+    if (negative) {
+      (negateHighExact(result._1, result._2), negateLow(result._2))
+    } else {
+      result
+    }
+  }
+
+  private def negate(high: Long, low: Long): (Long, Long) = (negateHigh(high, low), negateLow(low))
+
+  def negateHighExact(high: Long, low: Long): Long = {
+    if (high == Int128.MIN_VALUE.high && low == Int128.MIN_VALUE.low) {
+      throw int128OverflowException(s"Cannot negate high exact for Int128($high, $low).")
+    }
+
+    negateHigh(high, low)
+  }
+
+  def negateHigh(high: Long, low: Long): Long = -high - (if (low == 0) 0 else 1)
+
+  def negateLow(low: Long): Long = -low
+
+  private def multiplyPositives(
+      leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): (Long, Long) = {
+    val z1High = MoreMath.unsignedMultiplyHigh(leftLow, rightLow)
+    val z1Low = leftLow * rightLow
+    val z2Low = leftLow * rightHigh
+    val z3Low = leftHigh * rightLow
+
+    val resultHigh = z1High + z2Low + z3Low
+    val resultLow = z1Low
+
+    if ((leftHigh != 0 && rightHigh != 0) ||
+      resultHigh < 0 || z1High < 0 || z2Low < 0 || z3Low < 0 ||
+      MoreMath.unsignedMultiplyHigh(leftLow, rightHigh) != 0 ||
+      MoreMath.unsignedMultiplyHigh(leftHigh, rightLow) != 0) {
+      throw int128OverflowException(
+        s"Int128($leftHigh, $leftLow) and Int128($rightHigh, $rightLow) in multiple positives.")
+    }
+
+    (resultHigh, resultLow)
+  }
+
+  private def dividePositives(
+      dividendHigh: Long, dividendLow: Long, divisor: Int): (Long, Long, Int) = {
+    var remainder = dividendHigh
+    val high = remainder / divisor
+    remainder %= divisor
+
+    remainder = highValue(dividendLow) + (remainder << 32)
+    val z1 = remainder / divisor
+    remainder %= divisor
+
+    remainder = lowValue(dividendLow) + (remainder << 32)
+    val z0 = remainder / divisor
+
+    val low = (z1 << 32) | (z0 & 0xFFFFFFFFL)
+
+    (high, low, (remainder % divisor).toInt)
+  }
+
+  private def dividePositives(
+      leftHigh: Long,
+      leftLow: Long,
+      rightHigh: Long,
+      rightLow: Long,
+      leftScale: Int,
+      rightScale: Int,
+      returnBoth: Boolean = true,
+      returnQuotient: Boolean = false): ((Long, Long), (Long, Long)) = {
+    if (rightHigh == 0 && rightLow == 0) {
+      throw divisionByZeroException()
+    }
+
+    // to fit 128b * 128b * 32b unsigned multiplication
+    val dividend = new Array[Int](NUMBER_OF_INTS * 2 + 1)
+    dividend(0) = lowInt(leftLow)
+    dividend(1) = highInt(leftLow)
+    dividend(2) = lowInt(leftHigh)
+    dividend(3) = highInt(leftHigh)
+
+    if (leftScale > 0) {
+      shiftLeftBy5Destructive(dividend, leftScale)
+      shiftLeftMultiPrecision(dividend, NUMBER_OF_INTS * 2, leftScale)
+    }
+
+    val divisor = new Array[Int](NUMBER_OF_INTS * 2)
+    divisor(0) = lowInt(rightLow)
+    divisor(1) = highInt(rightLow)
+    divisor(2) = lowInt(rightHigh)
+    divisor(3) = highInt(rightHigh)
+
+    if (rightScale > 0) {
+      shiftLeftBy5Destructive(divisor, rightScale)
+      shiftLeftMultiPrecision(divisor, NUMBER_OF_INTS * 2, rightScale)
+    }
+
+    val multiPrecisionQuotient = new Array[Int](NUMBER_OF_INTS * 2)
+    divideUnsignedMultiPrecision(dividend, divisor, multiPrecisionQuotient)
+
+    lazy val quotient = pack(multiPrecisionQuotient)
+    lazy val remainder = pack(dividend)
+
+    if (returnBoth) {
+      (quotient, remainder)
+    } else if (returnQuotient) {
+      (quotient, null)
+    } else {
+      (null, remainder)
+    }
+  }
+
+  private def scaleDownRoundUp(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    // optimized path for smaller values
+    if (rescale <= MAX_POWER_OF_TEN_LONG && high == 0 && low >= 0) {
+      val divisor = LONG_POWERS_OF_TEN(rescale)
+      var newLow = low / divisor
+      if (low % divisor >= (divisor >> 1)) {
+        newLow += 1
+      }
+      return (0, newLow)
+    }
+
+    scaleDown(high, low, rescale, true)
+  }
+
+  private def scaleDownTruncate(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    // optimized path for smaller values
+    if (rescale <= MAX_POWER_OF_TEN_LONG && high == 0 && low >= 0) {
+      val divisor = LONG_POWERS_OF_TEN(rescale)
+      val newLow = low / divisor
+
+      return (0, newLow)
+    }
+
+    scaleDown(high, low, rescale, false)
+  }
+
+  private def scaleDown(high: Long, low: Long, rescale: Int, roundUp: Boolean): (Long, Long) = {
+    val negative = high < 0
+    var tmpHigh = high
+    var tmpLow = low
+    if (negative) {
+      tmpHigh = negateHighExact(tmpHigh, tmpLow)
+      tmpLow = negateLow(tmpLow)
+    }
+
+    // Scales down for 10**rescaleFactor.
+    // Because divide by int has limited divisor,
+    // we choose code path with the least amount of divisions
+    val result = if ((rescale - 1) / MAX_POWER_OF_FIVE_INT < (rescale - 1) / MAX_POWER_OF_TEN_INT) {
+      // scale down for 10**rescale is equivalent to scaling down with 5**rescaleFactor first,
+      // then with 2**rescaleFactor
+      val result = scaleDownFive(high, low, rescale)
+      shiftRight(result._1, result._2, rescale, roundUp)
+    } else {
+      scaleDownTen(tmpHigh, tmpLow, rescale, roundUp)
+    }
+
+    if (negative) {
+      // negateExact not needed since all positive values can be negated without overflow
+      negate(result._1, result._2)
+    } else {
+      result
+    }
+  }
+
+  /**
+   * Scale down the value for 5**fiveScale (result := decimal / 5**fiveScale).
+   */
+  private def scaleDownFive(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    if (high < 0) {
+      throw negativeInt128Error()
+    }
+
+    var tmpHigh = high
+    var tmpLow = low
+    var fiveScale = rescale
+    while (true) {
+      val powerFive = Math.min(fiveScale, MAX_POWER_OF_FIVE_INT)
+      fiveScale -= powerFive
+
+      val divisor = POWERS_OF_FIVES_INT(powerFive)
+      val result = dividePositives(tmpHigh, tmpLow, divisor)
+
+      if (fiveScale == 0) {
+        return (result._1, result._2)
+      }
+
+      tmpHigh = result._1
+      tmpLow = result._2
+    }
+
+    (tmpHigh, tmpLow)
+  }
+
+  /**
+   * Scale down the value for 10**tenScale (this := this / 5**tenScale). This
+   * method rounds-up, eg 44/10=4, 44/10=5.
+   */
+  private def scaleDownTen(high: Long, low: Long, rescale: Int, roundUp: Boolean): (Long, Long) = {
+    if (high < 0) {
+      throw negativeInt128Error()
+    }
+
+    var needsRounding: Boolean = false
+    var tenScale = rescale
+    var tmpHigh = high
+    var tmpLow = low
+    do {
+      val powerTen = Math.min(tenScale, MAX_POWER_OF_TEN_INT)
+      tenScale -= powerTen
+
+      val divisor = POWERS_OF_TEN_INT(powerTen)
+      val result = divideCheckRound(tmpHigh, tmpLow, divisor)
+
+      tmpHigh = result._1
+      tmpLow = result._2
+      needsRounding = result._3
+    } while (tenScale > 0)
+
+    if (roundUp && needsRounding) {
+      incrementUnsafe(tmpHigh, tmpLow)
+    } else {
+      (tmpHigh, tmpLow)
+    }
+  }
+
+  def shiftRight(high: Long, low: Long, shift: Int, roundUp: Boolean): (Long, Long) = {
+    if (high < 0) {
+      throw negativeInt128Error()
+    }
+
+    if (shift == 0) {
+      return (high, low)
+    }
+
+    var needsRounding: Boolean = false
+    val (newHigh, newLow) = if (shift < 64) {
+      needsRounding = roundUp && (low & (1L << (shift - 1))) != 0
+      (high >> shift, (high << 1 << (63 - shift)) | (low >>> shift))
+    } else {
+      needsRounding = roundUp && (high & (1L << (shift - 64 - 1))) != 0
+      (0L, high >> (shift - 64))
+    }
+
+    if (needsRounding) {
+      (incrementHigh(newHigh, newLow), incrementLow(newLow))
+    } else {
+      (newHigh, newLow)
+    }
+  }
+
+  private def divideCheckRound(
+    dividendHigh: Long, dividendLow: Long, divisor: Int): (Long, Long, Boolean) = {
+    val (high, low, remainder) = dividePositives(dividendHigh, dividendLow, divisor)
+    (high, low, remainder >= (divisor >> 1))
+  }
+
+  /**
+   * Value must have a length of 8
+   */
+  private def shiftLeftBy5Destructive(value: Array[Int], shift: Int): Unit = {
+    if (shift <= MAX_POWER_OF_FIVE_INT) {
+      multiply256Destructive(value, POWERS_OF_FIVES_INT(shift))
+    } else if (shift < MAX_POWER_OF_TEN_LONG) {
+      multiply256Destructive(value, POWERS_OF_FIVE_LONG(shift))
+    } else {
+      multiply256Destructive(value, POWERS_OF_FIVE(shift))
+    }
+  }
+
+  /**
+   * This an unsigned operation. Supplying negative arguments will yield wrong results.
+   * Assumes left array length to be >= 5. However only first 4 int values are multiplied
+   */
+  private def multiply256Destructive(left: Array[Int], r0: Int): Unit = {
+    val l0 = Integer.toUnsignedLong(left(0))
+    val l1 = Integer.toUnsignedLong(left(1))
+    val l2 = Integer.toUnsignedLong(left(2))
+    val l3 = Integer.toUnsignedLong(left(3))
+
+    var accumulator = r0 * l0
+    val z0 = lowValue(accumulator)
+    var z1 = highValue(accumulator)
+
+    accumulator = r0 * l1 + z1
+    z1 = lowValue(accumulator)
+    var z2 = highValue(accumulator)
+
+    accumulator = r0 * l2 + z2
+    z2 = lowValue(accumulator)
+    var z3 = highValue(accumulator)
+
+    accumulator = r0 * l3 + z3
+    z3 = lowValue(accumulator)
+    val z4 = highValue(accumulator)
+
+    left(0) = z0.toInt
+    left(1) = z1.toInt
+    left(2) = z2.toInt
+    left(3) = z3.toInt
+    left(4) = z4.toInt
+  }
+
+  /**
+   * This an unsigned operation. Supplying negative arguments will yield wrong results.
+   * Assumes left array length to be >= 6. However only first 4 int values are multiplied
+   */
+  private def multiply256Destructive(left: Array[Int], right: Long): Unit = {
+    val l0 = Integer.toUnsignedLong(left(0))
+    val l1 = Integer.toUnsignedLong(left(1))
+    val l2 = Integer.toUnsignedLong(left(2))
+    val l3 = Integer.toUnsignedLong(left(3))
+
+    val r0 = lowValue(right)
+    val r1 = highValue(right)
+
+    var z0 = 0L
+    var z1 = 0L
+    var z2 = 0L
+    var z3 = 0L
+    var z4 = 0L
+    var z5 = 0L
+
+    if (l0 != 0) {
+      var accumulator = r0 * l0
+      z0 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l0
+
+      z1 = lowValue(accumulator)
+      z2 = highValue(accumulator)
+    }
+
+    if (l1 != 0) {
+      var accumulator = r0 * l1 + z1
+      z1 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l1 + z2
+
+      z2 = lowValue(accumulator)
+      z3 = highValue(accumulator)
+    }
+
+    if (l2 != 0) {
+      var accumulator = r0 * l2 + z2
+      z2 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l2 + z3
+
+      z3 = lowValue(accumulator)
+      z4 = highValue(accumulator)
+    }
+
+    if (l3 != 0) {
+      var accumulator = r0 * l3 + z3
+      z3 = lowValue(accumulator);
+      accumulator = highValue(accumulator) + r1 * l3 + z4
+
+      z4 = lowValue(accumulator)
+      z5 = highValue(accumulator)
+    }
+
+    left(0) = z0.toInt
+    left(1) = z1.toInt
+    left(2) = z2.toInt
+    left(3) = z3.toInt
+    left(4) = z4.toInt
+    left(5) = z5.toInt
+  }
+
+  /**
+   * This an unsigned operation. Supplying negative arguments will yield wrong results.
+   * Assumes left array length to be >= 8. However only first 4 int values are multiplied
+   */
+  private def multiply256Destructive(left: Array[Int], right: Int128): Unit = {
+    val l0 = Integer.toUnsignedLong(left(0))
+    val l1 = Integer.toUnsignedLong(left(1))
+    val l2 = Integer.toUnsignedLong(left(2))
+    val l3 = Integer.toUnsignedLong(left(3))
+
+    val r0 = lowValue(right.low)
+    val r1 = highValue(right.low)
+    val r2 = lowValue(right.high)
+    val r3 = highValue(right.high)
+
+    var z0 = 0L
+    var z1 = 0L
+    var z2 = 0L
+    var z3 = 0L
+    var z4 = 0L
+    var z5 = 0L
+    var z6 = 0L
+    var z7 = 0L
+
+    if (l0 != 0) {
+      var accumulator = r0 * l0
+      z0 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l0
+
+      z1 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r2 * l0
+
+      z2 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r3 * l0
+
+      z3 = lowValue(accumulator)
+      z4 = highValue(accumulator)
+    }
+
+    if (l1 != 0) {
+      var accumulator = r0 * l1 + z1
+      z1 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l1 + z2
+
+      z2 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r2 * l1 + z3
+
+      z3 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r3 * l1 + z4
+
+      z4 = lowValue(accumulator)
+      z5 = highValue(accumulator)
+    }
+
+    if (l2 != 0) {
+      var accumulator = r0 * l2 + z2
+      z2 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l2 + z3
+
+      z3 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r2 * l2 + z4
+
+      z4 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r3 * l2 + z5
+
+      z5 = lowValue(accumulator)
+      z6 = highValue(accumulator)
+    }
+
+    if (l3 != 0) {
+      var accumulator = r0 * l3 + z3
+      z3 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l3 + z4
+
+      z4 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r2 * l3 + z5
+
+      z5 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r3 * l3 + z6
+
+      z6 = lowValue(accumulator)
+      z7 = highValue(accumulator)
+    }
+
+    left(0) = z0.toInt
+    left(1) = z1.toInt
+    left(2) = z2.toInt
+    left(3) = z3.toInt
+    left(4) = z4.toInt
+    left(5) = z5.toInt
+    left(6) = z6.toInt
+    left(7) = z7.toInt
+  }
+
+  def shiftLeftMultiPrecision(number: Array[Int], length: Int, shifts: Int): Unit = {
+    if (shifts == 0) {
+      return
+    }
+    // wordShifts = shifts / 32
+    val wordShifts = shifts >>> 5
+    // we don't wan't to loose any leading bits
+    for (i <- 0 until wordShifts) {
+      checkState(number(length - i - 1) == 0)
+    }
+
+    if (wordShifts > 0) {
+      System.arraycopy(number, 0, number, wordShifts, length - wordShifts)
+      Arrays.fill(number, 0, wordShifts, 0)
+    }
+    val bitShifts = shifts & 31
+    if (bitShifts > 0) {
+      // we don't wan't to loose any leading bits
+      checkState(number(length - 1) >>> (Integer.SIZE - bitShifts) == 0)
+      for (position <- length - 1 until 0 by -1) {
+        number(position) =
+          (number(position) << bitShifts) | (number(position - 1) >>> (Integer.SIZE - bitShifts))
+      }
+      number(0) = number(0) << bitShifts
+    }
+  }
+
+  /**
+   * Divides mutableDividend / mutable divisor
+   * Places remainder in first argument and quotient in the last argument
+   */
+  private def divideUnsignedMultiPrecision(
+      dividend: Array[Int], divisor: Array[Int], quotient: Array[Int]): Unit = {
+    checkArgument(dividend.length == NUMBER_OF_INTS * 2 + 1)
+    checkArgument(divisor.length == NUMBER_OF_INTS * 2)
+    checkArgument(quotient.length == NUMBER_OF_INTS * 2)
+
+    val divisorLength = digitsInIntegerBase(divisor)
+    val dividendLength = digitsInIntegerBase(dividend)
+
+    if (dividendLength < divisorLength) {
+      return
+    }
+
+    if (divisorLength == 1) {
+      val remainder = divideUnsignedMultiPrecision(dividend, dividendLength, divisor(0))
+      checkState(dividend(dividend.length - 1) == 0)
+      System.arraycopy(dividend, 0, quotient, 0, quotient.length)
+      Arrays.fill(dividend, 0)
+      dividend(0) = remainder
+      return
+    }
+
+    // normalize divisor. Most significant divisor word must be > BASE/2
+    // effectively it can be achieved by shifting divisor left until the leftmost bit is 1
+    val nlz = Integer.numberOfLeadingZeros(divisor(divisorLength - 1))
+    shiftLeftMultiPrecision(divisor, divisorLength, nlz)
+    val normalizedDividendLength = Math.min(dividend.length, dividendLength + 1)
+    shiftLeftMultiPrecision(dividend, normalizedDividendLength, nlz)
+
+    divideKnuthNormalized(dividend, normalizedDividendLength, divisor, divisorLength, quotient)
+
+    // un-normalize remainder which is stored in dividend
+    shiftRightMultiPrecision(dividend, normalizedDividendLength, nlz)
+  }
+
+  private def digitsInIntegerBase(digits: Array[Int]): Int = {
+    var length = digits.length
+    while (length > 0 && digits(length - 1) == 0) {
+      length -= 1
+    }
+    length
+  }
+
+  private def divideUnsignedMultiPrecision(
+      dividend: Array[Int], dividendLength: Int, divisor: Int): Int = {
+    if (divisor == 0) {
+      throw divisionByZeroException()
+    }
+
+    if (dividendLength == 1) {
+      val dividendUnsigned = Integer.toUnsignedLong(dividend(0))
+      val divisorUnsigned = Integer.toUnsignedLong(divisor)
+      val quotient = dividendUnsigned / divisorUnsigned
+      val remainder = dividendUnsigned - (divisorUnsigned * quotient)
+      dividend(0) = quotient.toInt
+      return remainder.toInt
+    }
+
+    val divisorUnsigned = Integer.toUnsignedLong(divisor)
+    var remainder = 0L
+    for (dividendIndex <- dividendLength - 1 to 0 by -1) {
+      remainder = (remainder << 32) + Integer.toUnsignedLong(dividend(dividendIndex))
+      val quotient = divideUnsignedLong(remainder, divisor)
+      dividend(dividendIndex) = quotient.toInt
+      remainder = remainder - (quotient * divisorUnsigned)
+    }
+    remainder.toInt
+  }
+
+  private def divideUnsignedLong(dividend: Long, divisor: Int): Long = {
+    val unsignedDivisor = Integer.toUnsignedLong(divisor)
+
+    if (dividend > 0) {
+      return dividend / unsignedDivisor
+    }
+
+    // HD 9-3, 4) q = divideUnsigned(n, 2) / d * 2
+    var quotient = ((dividend >>> 1) / unsignedDivisor) * 2
+    val remainder = dividend - quotient * unsignedDivisor
+
+    if (JLong.compareUnsigned(remainder, unsignedDivisor) >= 0) {
+      quotient += 1
+    }
+
+    quotient
+  }
+
+  private def divideKnuthNormalized(
+      remainder: Array[Int],
+      dividendLength: Int,
+      divisor: Array[Int],
+      divisorLength: Int,
+      quotient: Array[Int]): Unit = {
+    val v1 = divisor(divisorLength - 1)
+    val v0 = divisor(divisorLength - 2)
+    for (reminderIndex <- dividendLength - 1 to divisorLength by -1) {
+      var qHat = estimateQuotient(remainder(reminderIndex), remainder(reminderIndex - 1),
+        remainder(reminderIndex - 2), v1, v0)
+      if (qHat != 0) {
+        val overflow = multiplyAndSubtractUnsignedMultiPrecision(
+          remainder, reminderIndex, divisor, divisorLength, qHat)
+        // Add back - probability is 2**(-31). R += D. Q[digit] -= 1
+        if (overflow) {
+          qHat -= 1
+          addUnsignedMultiPrecision(remainder, reminderIndex, divisor, divisorLength)
+        }
+      }
+      quotient(reminderIndex - divisorLength) = qHat
+    }
+  }
+
+  /**
+   * Use the Knuth notation
+   * <p>
+   * u{x} - dividend
+   * v{v} - divisor
+   */
+  private def estimateQuotient(u2: Int, u1: Int, u0: Int, v1: Int, v0: Int): Int = {
+    // estimate qhat based on the first 2 digits of divisor divided by the first digit of a dividend
+    val u21 = combineInts(u2, u1)
+    var qhat = 0L
+    if (u2 == v1) {
+      qhat = INT_BASE - 1
+    } else if (u21 >= 0) {
+      qhat = u21 / Integer.toUnsignedLong(v1)
+    } else {
+      qhat = divideUnsignedLong(u21, v1)
+    }
+
+    if (qhat == 0) {
+      return 0
+    }
+
+    // Check if qhat is greater than expected considering only first 3 digits of a dividend
+    // This step help to eliminate all the cases when the estimation is greater than q by 2
+    // and eliminates most of the cases when qhat is greater than q by 1
+    //
+    // u2 * b * b + u1 * b + u0 >= (v1 * b + v0) * qhat
+    // u2 * b * b + u1 * b + u0 >= v1 * b * qhat + v0 * qhat
+    // u2 * b * b + u1 * b - v1 * b * qhat >=  v0 * qhat - u0
+    // (u21 - v1 * qhat) * b >=  v0 * qhat - u0
+    // (u21 - v1 * qhat) * b + u0 >=  v0 * qhat
+    // When ((u21 - v1 * qhat) * b + u0) is less than (v0 * qhat) decrease qhat by one
+
+    var iterations = 0
+    var rhat = u21 - Integer.toUnsignedLong(v1) * qhat
+    while (JLong.compareUnsigned(rhat, INT_BASE) < 0 &&
+      JLong.compareUnsigned(Integer.toUnsignedLong(v0) * qhat, combineInts(lowInt(rhat), u0)) > 0) {
+      iterations += 1
+      qhat -= 1
+      rhat += Integer.toUnsignedLong(v1)
+    }
+
+    if (iterations > 2) {
+      throw new IllegalStateException("qhat is greater than q by more than 2: " + iterations)
+    }
+
+    qhat.toInt
+  }
+
+  /**
+   * Calculate multi-precision [left - right * multiplier] with given left offset and length.
+   * Return true when overflow occurred
+   */
+  private def multiplyAndSubtractUnsignedMultiPrecision(
+      left: Array[Int],
+      leftOffset: Int,
+      right: Array[Int],
+      length: Int,
+      multiplier: Int): Boolean = {
+    val unsignedMultiplier = Integer.toUnsignedLong(multiplier)
+    var leftIndex = leftOffset - length
+    var multiplyAccumulator = 0L
+    var subtractAccumulator = INT_BASE
+
+    for (rightIndex <- 0 until length) {
+      multiplyAccumulator =
+        Integer.toUnsignedLong(right(rightIndex)) * unsignedMultiplier + multiplyAccumulator
+      subtractAccumulator = (subtractAccumulator + Integer.toUnsignedLong(left(leftIndex))) -
+        Integer.toUnsignedLong(lowInt(multiplyAccumulator))
+      multiplyAccumulator = highValue(multiplyAccumulator)
+      left(leftIndex) = lowInt(subtractAccumulator)
+      subtractAccumulator = highValue(subtractAccumulator) + INT_BASE - 1
+      leftIndex += 1
+    }
+    subtractAccumulator += Integer.toUnsignedLong(left(leftIndex)) - multiplyAccumulator
+    left(leftIndex) = lowInt(subtractAccumulator)
+    highInt(subtractAccumulator) == 0
+  }
+
+  private def addUnsignedMultiPrecision(
+      left: Array[Int], leftOffset: Int, right: Array[Int], length: Int): Unit = {
+    var leftIndex = leftOffset - length
+    var carry = 0
+    for (rightIndex <- 0 until length) {
+    val accumulator = Integer.toUnsignedLong(left(leftIndex)) +
+      Integer.toUnsignedLong(right(rightIndex)) + Integer.toUnsignedLong(carry)
+    left(leftIndex) = lowInt(accumulator)
+    carry = highInt(accumulator)
+    leftIndex += 1
+  }
+    left(leftIndex) += carry
+  }
+
+  private def shiftRightMultiPrecision(
+      number: Array[Int], length: Int, shifts: Int): Array[Int] = {
+    if (shifts == 0) {
+      return number
+    }
+    // wordShifts = shifts / 32
+    val wordShifts = shifts >>> 5
+    // we don't wan't to loose any trailing bits
+    for (i <- 0 until wordShifts) {
+      checkState(number(i) == 0)
+    }
+    if (wordShifts > 0) {
+      System.arraycopy(number, wordShifts, number, 0, length - wordShifts)
+      Arrays.fill(number, length - wordShifts, length, 0)
+    }
+    val bitShifts = shifts & 31
+    if (bitShifts > 0) {
+      // we don't wan't to loose any trailing bits
+      checkState(number(0) << (Integer.SIZE - bitShifts) == 0)
+      for (position <- 0 until length - 1) {
+        number(position) =
+          (number(position) >>> bitShifts) | (number(position + 1) << (Integer.SIZE - bitShifts))
+      }
+      number(length - 1) = number(length - 1) >>> bitShifts
+    }
+    number;
+  }
+
+  private def pack(parts: Array[Int]): (Long, Long) = {
+    val high = parts(3).toLong << 32 | (parts(2) & 0xFFFFFFFFL)
+    val low = (parts(1).toLong << 32) | (parts(0) & 0xFFFFFFFFL)
+
+    if (parts(4) != 0 || parts(5) != 0 || parts(6) != 0 || parts(7) != 0) {
+      throw new ArithmeticException("Overflow");
+    }
+
+    (high, low)
+  }
+
+  private def compareUnsigned(
+      leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): Int = {
+    var comparison = JLong.compareUnsigned(leftHigh, rightHigh)
+    if (comparison == 0) {
+      comparison = JLong.compareUnsigned(leftLow, rightLow)
+    }
+
+    comparison
+  }
+
+  private def incrementUnsafe(high: Long, low: Long): (Long, Long) =
+    (incrementHigh(high, low), incrementLow(low))
+
+  def incrementHigh(high: Long, low: Long): Long = high + (if (low == -1) 1 else 0)
+
+  def incrementLow(low: Long): Long = low + 1
+
+  private def combineInts(high: Int, low: Int): Long =
+    (high.toLong << 32) | Integer.toUnsignedLong(low)
+
+  private def highValue(value: Long): Long = value >>> 32
+
+  private def lowValue(value: Long): Long = value & LOW_32_BITS
+
+  private def highInt(value: Long): Int = highValue(value).toInt
+
+  private def lowInt(value: Long): Int = value.toInt
+
+  private def unsignedCarry(left: Long, right: Long): Long =
+    ((left >>> 1) + (right >>> 1) + ((left & right) & 1)) >>> 63 // HD 2-13
+
+  private def unsignedBorrow(left: Long, right: Long): Long =
+    ((~left & right) | (~(left ^ right) & (left - right))) >>> 63 // HD 2-13
+
+  private def checkState(condition: Boolean): Unit = {
+    if (!condition) {
+      throw new IllegalStateException();
+    }
+  }
+
+  private def checkArgument(condition: Boolean): Unit = {
+    if (!condition) {
+      throw new IllegalArgumentException()
+    }
+  }
+
+  def divisionByZeroException(): ArithmeticException =
+    new ArithmeticException("Division by zero")
+
+  private def int128OverflowException(message: String): ArithmeticException =
+    new ArithmeticException(s"Int128 Overflow. $message")
+
+  private def negativeInt128Error(): IllegalArgumentException =
+    new IllegalArgumentException("Value must be positive")
+
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/Decimal128Suite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/Decimal128Suite.scala
@@ -163,7 +163,7 @@ class Decimal128Suite extends SparkFunSuite with PrivateMethodTester with SQLHel
     assert(e2.getMessage.contains("BigInteger out of Int128 range"))
   }
 
-  // Accessor for the BigDecimal value of a Decimal, which will be null if it's using Longs
+  // Accessor for the Int128 value of a Decimal128, which will be null if it's using Longs
   private val int128Val = PrivateMethod[Int128](Symbol("int128Val"))
 
   /** Check whether a decimal is represented compactly (passing whether we expect it to be) */
@@ -248,73 +248,6 @@ class Decimal128Suite extends SparkFunSuite with PrivateMethodTester with SQLHel
     assert(Decimal128(10, 2, 0) - Decimal128(-90, 2, 0) === Decimal128(100, 3, 0))
   }
 
-  test("other arithmetic") {
-    // test +
-    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 1) === Decimal128(0))
-    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 2) === Decimal128(900, 3, 2))
-    assert(Decimal128(100, 3, 2) + Decimal128(-100, 3, 1) === Decimal128(-900, 3, 2))
-    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 2) === Decimal128("9.00"))
-    assert(Decimal128("10.0") + Decimal128("-1.00") === Decimal128(BigDecimal("9.00")))
-    assert(Decimal128("15432.21543600787131") + Decimal128("57832.21543600787313") ===
-      Decimal128(BigDecimal("73264.43087201574444")))
-    val e1 = intercept[ArithmeticException](
-      Decimal128("170141183460469231731687303715884105727") + Decimal128(1))
-    assert(e1.getMessage.contains(
-      "Int128 Overflow. Int128(9223372036854775807, -1) add Int128(0, 1)."))
-
-    // test -
-    assert(Decimal128(100) - Decimal128(-100) === Decimal128(200))
-    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 1) === Decimal128(200, 3, 1))
-    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 2) === Decimal128(1100, 4, 2))
-    assert(Decimal128(100, 3, 2) - Decimal128(-100, 3, 1) === Decimal128(1100, 4, 2))
-    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 2) === Decimal128("11.00"))
-    assert(Decimal128("10.0") - Decimal128("-1.00") === Decimal128(BigDecimal("11.00")))
-    assert(Decimal128("15432.21543600787131") - Decimal128("57832.21543600787313") ===
-      Decimal128(BigDecimal("-42400.00000000000182")))
-    val e2 = intercept[ArithmeticException](
-      Decimal128("-170141183460469231731687303715884105728") - Decimal128(1))
-    assert(e2.getMessage.contains(
-      "Int128 Overflow. Int128(-9223372036854775808, 0) subtract Int128(0, 1)."))
-
-    // test *
-    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 1) === Decimal128(-10000, 5, 2))
-    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 2) === Decimal128(-10000, 5, 3))
-    assert(Decimal128(100, 3, 2) * Decimal128(-100, 3, 1) === Decimal128(-10000, 5, 3))
-    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 2) === Decimal128("-10.00"))
-    assert(Decimal128("10.0") * Decimal128("-1.00") === Decimal128(BigDecimal("-10.00")))
-    assert(Decimal128("15432.21543600787131") * Decimal128("57832.21543600787313") ===
-      Decimal128(BigDecimal("892479207.7500933852299992378118469003")))
-    assert(Decimal128(1e13) * Decimal128(1e13) === Decimal128(1e26))
-    val e3 = intercept[ArithmeticException](
-      Decimal128("12345678901234567890123456789012345678") * Decimal128(9))
-    assert(e3.getMessage.contains("Decimal overflow: Decimal128 multiply."))
-
-    // test /
-    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 1) === Decimal128(-1, 1, 0))
-    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 2) === Decimal128(-10, 2, 0))
-    assert(Decimal128(100, 3, 2) / Decimal128(-100, 3, 1) === Decimal128(-10, 2, 2))
-    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 2) === Decimal128("-10.00"))
-    assert(Decimal128("10.0") / Decimal128("-1.00") === Decimal128(BigDecimal("-10.00")))
-    assert(Decimal128("15432.21543600") / Decimal128("57832.21543") ===
-      Decimal128(BigDecimal("0.26684462")))
-    assert(Decimal128(100) / Decimal128(0) === null)
-    val e4 = intercept[ArithmeticException](
-      Decimal128("12345678901234567890123456789012345678") / Decimal128(1, 1, 1))
-    assert(e4.getMessage.contains("Decimal overflow: Decimal128 division."))
-
-    // test %
-    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 1) === Decimal128(0))
-    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 2) === Decimal128(0))
-    assert(Decimal128(100, 3, 2) % Decimal128(-100, 3, 1) === Decimal128(100, 3, 2))
-    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 2) === Decimal128("0.0"))
-    assert(Decimal128("10.0") % Decimal128("-1.00") === Decimal128(BigDecimal("0.0")))
-    assert(Decimal128("15432.21543600") % Decimal128("57832.21543") ===
-      Decimal128(BigDecimal("15432.21543600")))
-    assert(Decimal128(100) % Decimal128(3) === Decimal128(1))
-    assert(Decimal128(-100) % Decimal128(3) === Decimal128(-1))
-    assert(Decimal128(100) % Decimal128(0) === null)
-  }
-
   test("quot") {
     assert(Decimal128(100).quot(Decimal128(100)) === Decimal128(BigDecimal("1")))
     assert(Decimal128(100).quot(Decimal128(33)) === Decimal128(BigDecimal("3")))
@@ -332,9 +265,7 @@ class Decimal128Suite extends SparkFunSuite with PrivateMethodTester with SQLHel
     assert(-Decimal128(-100) === Decimal128(BigDecimal("100")))
     assert(Decimal128(100).abs === Decimal128(BigDecimal("100")))
     assert(Decimal128(-100).abs === Decimal128(BigDecimal("100")))
-  }
 
-  test("negate") {
     assert(-Decimal128("15432.21543600") === Decimal128(BigDecimal("-15432.21543600")))
     assert(-Decimal128("-57832.21543") === Decimal128(BigDecimal("57832.21543")))
   }
@@ -360,11 +291,9 @@ class Decimal128Suite extends SparkFunSuite with PrivateMethodTester with SQLHel
 
   test("fix loss of precision/scale when doing division operation") {
     val a = Decimal128(2) / Decimal128(3)
-    // Different from Decimal: assert(a.toDouble < 1.0 && a.toDouble > 0.6)
-    assert(a.toDouble == 1.0)
+    assert(a.toDouble < 1.0 && a.toDouble > 0.6)
     val b = Decimal128(1) / Decimal128(8)
-    // Different from Decimal: assert(b.toDouble === 0.125)
-    assert(b.toDouble === 0.0)
+    assert(b.toDouble === 0.125)
   }
 
   test("set/setOrNull") {
@@ -459,6 +388,13 @@ class Decimal128Suite extends SparkFunSuite with PrivateMethodTester with SQLHel
       assert(Decimal128.fromString(UTF8String.fromString(string)) === Decimal128(string))
       assert(Decimal128.fromStringANSI(UTF8String.fromString(string)) === Decimal128(string))
     }
+
+    val e1 = intercept[ArithmeticException](Decimal128.fromString(
+      UTF8String.fromString("28.9259999999999983799625624669715762138")))
+    assert(e1.getMessage.contains("BigInteger out of Int128 range"))
+    val e2 = intercept[ArithmeticException](Decimal128.fromStringANSI(
+      UTF8String.fromString("28.9259999999999983799625624669715762138")))
+    assert(e2.getMessage.contains("BigInteger out of Int128 range"))
   }
 
   test("SPARK-37451: Performance improvement regressed String to Decimal cast") {
@@ -525,6 +461,73 @@ class Decimal128Suite extends SparkFunSuite with PrivateMethodTester with SQLHel
       assert(decimal.toBigDecimal === bd,
         s"unscaled: $unscaled, scaleFrom: $scaleFrom, scaleTo: $scaleTo, mode: $roundMode")
     }
+  }
+
+  test("other arithmetic") {
+    // test +
+    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 1) === Decimal128(0))
+    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 2) === Decimal128(900, 3, 2))
+    assert(Decimal128(100, 3, 2) + Decimal128(-100, 3, 1) === Decimal128(-900, 3, 2))
+    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 2) === Decimal128("9.00"))
+    assert(Decimal128("10.0") + Decimal128("-1.00") === Decimal128(BigDecimal("9.00")))
+    assert(Decimal128("15432.21543600787131") + Decimal128("57832.21543600787313") ===
+      Decimal128(BigDecimal("73264.43087201574444")))
+    val e1 = intercept[ArithmeticException](
+      Decimal128("170141183460469231731687303715884105727") + Decimal128(1))
+    assert(e1.getMessage.contains(
+      "Int128 Overflow. Int128(9223372036854775807, -1) add Int128(0, 1)."))
+
+    // test -
+    assert(Decimal128(100) - Decimal128(-100) === Decimal128(200))
+    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 1) === Decimal128(200, 3, 1))
+    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 2) === Decimal128(1100, 4, 2))
+    assert(Decimal128(100, 3, 2) - Decimal128(-100, 3, 1) === Decimal128(1100, 4, 2))
+    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 2) === Decimal128("11.00"))
+    assert(Decimal128("10.0") - Decimal128("-1.00") === Decimal128(BigDecimal("11.00")))
+    assert(Decimal128("15432.21543600787131") - Decimal128("57832.21543600787313") ===
+      Decimal128(BigDecimal("-42400.00000000000182")))
+    val e2 = intercept[ArithmeticException](
+      Decimal128("-170141183460469231731687303715884105728") - Decimal128(1))
+    assert(e2.getMessage.contains(
+      "Int128 Overflow. Int128(-9223372036854775808, 0) subtract Int128(0, 1)."))
+
+    // test *
+    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 1) === Decimal128(-10000, 5, 2))
+    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 2) === Decimal128(-10000, 5, 3))
+    assert(Decimal128(100, 3, 2) * Decimal128(-100, 3, 1) === Decimal128(-10000, 5, 3))
+    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 2) === Decimal128("-10.00"))
+    assert(Decimal128("10.0") * Decimal128("-1.00") === Decimal128(BigDecimal("-10.00")))
+    assert(Decimal128("15432.21543600787131") * Decimal128("57832.21543600787313") ===
+      Decimal128(BigDecimal("892479207.7500933852299992378118469003")))
+    assert(Decimal128(1e13) * Decimal128(1e13) === Decimal128(1e26))
+    val e3 = intercept[ArithmeticException](
+      Decimal128("12345678901234567890123456789012345678") * Decimal128(9))
+    assert(e3.getMessage.contains("Decimal overflow: Decimal128 multiply."))
+
+    // test /
+    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 1) === Decimal128(-1, 1, 0))
+    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 2) === Decimal128(-10, 2, 0))
+    assert(Decimal128(100, 3, 2) / Decimal128(-100, 3, 1) === Decimal128(-10, 2, 2))
+    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 2) === Decimal128("-10.00"))
+    assert(Decimal128("10.0") / Decimal128("-1.00") === Decimal128(BigDecimal("-10.00")))
+    assert(Decimal128("15432.21543600") / Decimal128("57832.21543") ===
+      Decimal128(BigDecimal("0.26684462")))
+    assert(Decimal128(100) / Decimal128(0) === null)
+    val e4 = intercept[ArithmeticException](
+      Decimal128("12345678901234567890123456789012345678") / Decimal128(1, 1, 1))
+    assert(e4.getMessage.contains("Decimal overflow: Decimal128 division."))
+
+    // test %
+    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 1) === Decimal128(0))
+    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 2) === Decimal128(0))
+    assert(Decimal128(100, 3, 2) % Decimal128(-100, 3, 1) === Decimal128(100, 3, 2))
+    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 2) === Decimal128("0.0"))
+    assert(Decimal128("10.0") % Decimal128("-1.00") === Decimal128(BigDecimal("0.0")))
+    assert(Decimal128("15432.21543600") % Decimal128("57832.21543") ===
+      Decimal128(BigDecimal("15432.21543600")))
+    assert(Decimal128(100) % Decimal128(3) === Decimal128(1))
+    assert(Decimal128(-100) % Decimal128(3) === Decimal128(-1))
+    assert(Decimal128(100) % Decimal128(0) === null)
   }
 
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/Decimal128Suite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/Decimal128Suite.scala
@@ -1,0 +1,530 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import org.scalatest.PrivateMethodTester
+
+import org.apache.spark.{SparkArithmeticException, SparkException, SparkFunSuite, SparkNumberFormatException}
+import org.apache.spark.sql.catalyst.plans.SQLHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.Decimal.{ROUND_CEILING, ROUND_FLOOR, ROUND_HALF_EVEN, ROUND_HALF_UP}
+import org.apache.spark.unsafe.types.UTF8String
+
+class Decimal128Suite extends SparkFunSuite with PrivateMethodTester with SQLHelper{
+
+  val allSupportedRoundModes = Seq(ROUND_HALF_UP, ROUND_HALF_EVEN, ROUND_CEILING, ROUND_FLOOR)
+
+  /** Check that a Decimal128 has the given string representation, precision and scale */
+  private def checkDecimal128(d: Decimal128, string: String, precision: Int, scale: Int): Unit = {
+    assert(d.toString === string)
+    assert(d.precision === precision)
+    assert(d.scale === scale)
+  }
+
+  test("creating decimals") {
+    checkDecimal128(new Decimal128(), "0", 1, 0)
+    checkDecimal128(Decimal128(BigDecimal("0.09")), "0.09", 2, 2)
+    checkDecimal128(Decimal128(BigDecimal("0.9")), "0.9", 1, 1)
+    checkDecimal128(Decimal128(BigDecimal("0.90")), "0.90", 2, 2)
+    checkDecimal128(Decimal128(BigDecimal("0.0")), "0.0", 1, 1)
+    checkDecimal128(Decimal128(BigDecimal("0")), "0", 1, 0)
+    checkDecimal128(Decimal128(BigDecimal("1.0")), "1.0", 2, 1)
+    checkDecimal128(Decimal128(BigDecimal("-0.09")), "-0.09", 2, 2)
+    checkDecimal128(Decimal128(BigDecimal("-0.9")), "-0.9", 1, 1)
+    checkDecimal128(Decimal128(BigDecimal("-0.90")), "-0.90", 2, 2)
+    checkDecimal128(Decimal128(BigDecimal("-1.0")), "-1.0", 2, 1)
+    checkDecimal128(Decimal128(BigDecimal("10.030")), "10.030", 5, 3)
+    checkDecimal128(Decimal128(BigDecimal("10.030"), 4, 1), "10.0", 4, 1)
+    checkDecimal128(Decimal128(BigDecimal("-9.95"), 4, 1), "-10.0", 4, 1)
+    checkDecimal128(Decimal128("10.030"), "10.030", 5, 3)
+    checkDecimal128(Decimal128(10.03), "10.03", 4, 2)
+    checkDecimal128(Decimal128(17L), "17", 20, 0)
+    checkDecimal128(Decimal128(17), "17", 10, 0)
+    checkDecimal128(Decimal128(17L, 2, 1), "1.7", 2, 1)
+    checkDecimal128(Decimal128(170L, 4, 2), "1.70", 4, 2)
+    checkDecimal128(Decimal128(17L, 24, 1), "1.7", 24, 1)
+    checkDecimal128(Decimal128(1e17.toLong, 18, 0), 1e17.toLong.toString, 18, 0)
+    checkDecimal128(Decimal128(1000000000000000000L, 20, 2), "10000000000000000.00", 20, 2)
+    checkDecimal128(Decimal128(Long.MaxValue), Long.MaxValue.toString, 20, 0)
+    checkDecimal128(Decimal128(Long.MinValue), Long.MinValue.toString, 20, 0)
+    checkDecimal128(Decimal128(Int128.MAX_VALUE, 38, 0),
+      "170141183460469231731687303715884105727", 38, 0)
+    checkDecimal128(Decimal128(Int128.MIN_VALUE, 38, 0),
+      "-170141183460469231731687303715884105728", 38, 0)
+
+    checkError(
+      exception = intercept[SparkArithmeticException](Decimal128(170L, 2, 1)),
+      errorClass = "NUMERIC_VALUE_OUT_OF_RANGE",
+      parameters = Map(
+        "value" -> "0",
+        "precision" -> "2",
+        "scale" -> "1",
+        "config" -> "\"spark.sql.ansi.enabled\""))
+    checkError(
+      exception = intercept[SparkArithmeticException](Decimal128(170L, 2, 0)),
+      errorClass = "NUMERIC_VALUE_OUT_OF_RANGE",
+      parameters = Map(
+        "value" -> "0",
+        "precision" -> "2",
+        "scale" -> "0",
+        "config" -> "\"spark.sql.ansi.enabled\""))
+    checkError(
+      exception = intercept[SparkArithmeticException](Decimal128(BigDecimal("10.030"), 2, 1)),
+      errorClass = "DECIMAL_PRECISION_EXCEEDS_MAX_PRECISION",
+      parameters = Map("precision" -> "3", "maxPrecision" -> "2"))
+    checkError(
+      exception = intercept[SparkArithmeticException](Decimal128(BigDecimal("-9.95"), 2, 1)),
+      errorClass = "DECIMAL_PRECISION_EXCEEDS_MAX_PRECISION",
+      parameters = Map("precision" -> "3", "maxPrecision" -> "2"))
+    checkError(
+      exception = intercept[SparkArithmeticException](Decimal128(1e17.toLong, 17, 0)),
+      errorClass = "NUMERIC_VALUE_OUT_OF_RANGE",
+      parameters = Map(
+        "value" -> "0",
+        "precision" -> "17",
+        "scale" -> "0",
+        "config" -> "\"spark.sql.ansi.enabled\""))
+
+    // Int128 overflow.
+    val e =
+      intercept[ArithmeticException](Decimal128(0x8000000000000000L, 0x0000000000000000L, 38, 0))
+    assert(e.getMessage.contains(
+      "Decimal overflow: Construct Int128(-9223372036854775808, 0) instance."))
+  }
+
+  test("creating decimals with negative scale under legacy mode") {
+    withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
+      checkDecimal128(Decimal128(BigDecimal("98765"), 5, -3), "9.9E+4", 5, -3)
+      checkDecimal128(Decimal128(BigDecimal("314.159"), 6, -2), "3E+2", 6, -2)
+      checkDecimal128(Decimal128(BigDecimal(1.579e12), 4, -9), "1.579E+12", 4, -9)
+      checkDecimal128(Decimal128(BigDecimal(1.579e12), 4, -10), "1.58E+12", 4, -10)
+      checkDecimal128(Decimal128(103050709L, 9, -10), "1.03050709E+18", 9, -10)
+      checkDecimal128(Decimal128(1e8.toLong, 10, -10), "1.00000000E+18", 10, -10)
+    }
+  }
+
+  test("SPARK-30252: Negative scale is not allowed by default") {
+    def checkNegativeScaleDecimal(d: => Decimal128): Unit = {
+      checkError(
+        exception = intercept[SparkException] (d),
+        errorClass = "INTERNAL_ERROR",
+        parameters = Map("message" -> ("Negative scale is not allowed: -3. " +
+          "Set the config \"spark.sql.legacy.allowNegativeScaleOfDecimal\" " +
+          "to \"true\" to allow it."))
+      )
+    }
+    checkNegativeScaleDecimal(Decimal128(BigDecimal("98765"), 5, -3))
+    checkNegativeScaleDecimal(Decimal128(BigDecimal("98765").underlying(), 5, -3))
+    checkNegativeScaleDecimal(Decimal128(98765L, 5, -3))
+    checkNegativeScaleDecimal(Decimal128.createUnsafe(98765L, 5, -3))
+  }
+
+  test("double and long values") {
+    /** Check that a Decimal128 converts to the given double and long values */
+    def checkValues(d: Decimal128, doubleValue: Double, longValue: Long): Unit = {
+      assert(d.toDouble === doubleValue)
+      assert(d.toLong === longValue)
+    }
+
+    checkValues(new Decimal128(), 0.0, 0L)
+    checkValues(Decimal128(BigDecimal("10.030")), 10.03, 10L)
+    checkValues(Decimal128(BigDecimal("10.030"), 4, 1), 10.0, 10L)
+    checkValues(Decimal128(BigDecimal("-9.95"), 4, 1), -10.0, -10L)
+    checkValues(Decimal128(10.03), 10.03, 10L)
+    checkValues(Decimal128(17L), 17.0, 17L)
+    checkValues(Decimal128(17), 17.0, 17L)
+    checkValues(Decimal128(17L, 2, 1), 1.7, 1L)
+    checkValues(Decimal128(170L, 4, 2), 1.7, 1L)
+    checkValues(Decimal128(1e16.toLong), 1e16, 1e16.toLong)
+    checkValues(Decimal128(1e17.toLong), 1e17, 1e17.toLong)
+    checkValues(Decimal128(1e18.toLong), 1e18, 1e18.toLong)
+    checkValues(Decimal128(2e18.toLong), 2e18, 2e18.toLong)
+    checkValues(Decimal128(Long.MaxValue), Long.MaxValue.toDouble, Long.MaxValue)
+    checkValues(Decimal128(Long.MinValue), Long.MinValue.toDouble, Long.MinValue)
+
+    val e1 = intercept[ArithmeticException](Decimal128(Double.MaxValue))
+    assert(e1.getMessage.contains("BigInteger out of Int128 range"))
+    val e2 = intercept[ArithmeticException](Decimal128(Double.MinValue))
+    assert(e2.getMessage.contains("BigInteger out of Int128 range"))
+  }
+
+  // Accessor for the BigDecimal value of a Decimal, which will be null if it's using Longs
+  private val int128Val = PrivateMethod[Int128](Symbol("int128Val"))
+
+  /** Check whether a decimal is represented compactly (passing whether we expect it to be) */
+  private def checkCompact(d: Decimal128, expected: Boolean): Unit = {
+    val isCompact = d.invokePrivate(int128Val()).eq(null)
+    assert(isCompact == expected, s"$d ${if (expected) "was not" else "was"} compact")
+  }
+
+  test("small decimals represented as unscaled long") {
+    checkCompact(new Decimal128(), true)
+    checkCompact(Decimal128(BigDecimal("10.03")), false)
+    checkCompact(Decimal128(BigDecimal("100000000000000000000")), false)
+    checkCompact(Decimal128(17L), true)
+    checkCompact(Decimal128(17), true)
+    checkCompact(Decimal128(17L, 2, 1), true)
+    checkCompact(Decimal128(170L, 4, 2), true)
+    checkCompact(Decimal128(17L, 24, 1), true)
+    checkCompact(Decimal128(1e16.toLong), true)
+    checkCompact(Decimal128(1e17.toLong), true)
+    checkCompact(Decimal128(1e18.toLong - 1), true)
+    checkCompact(Decimal128(- 1e18.toLong + 1), true)
+    checkCompact(Decimal128(1e18.toLong - 1, 30, 10), true)
+    checkCompact(Decimal128(- 1e18.toLong + 1, 30, 10), true)
+    checkCompact(Decimal128(1e18.toLong), false)
+    checkCompact(Decimal128(-1e18.toLong), false)
+    checkCompact(Decimal128(1e18.toLong, 30, 10), false)
+    checkCompact(Decimal128(-1e18.toLong, 30, 10), false)
+    checkCompact(Decimal128(Long.MaxValue), false)
+    checkCompact(Decimal128(Long.MinValue), false)
+  }
+
+  test("hash code") {
+    assert(Decimal128(123).hashCode() === (123).##)
+    assert(Decimal128(-123).hashCode() === (-123).##)
+    assert(Decimal128(Int.MaxValue).hashCode() === Int.MaxValue.##)
+    assert(Decimal128(Long.MaxValue).hashCode() === Long.MaxValue.##)
+    assert(Decimal128(BigDecimal(123)).hashCode() === (123).##)
+  }
+
+  test("equals") {
+    // The decimals on the left are stored compactly, while the ones on the right aren't
+    checkCompact(Decimal128(123), true)
+    checkCompact(Decimal128(BigDecimal(123)), false)
+    checkCompact(Decimal128("123"), false)
+    assert(Decimal128(123) === Decimal128(BigDecimal(123)))
+    assert(Decimal128(123) === Decimal128(BigDecimal("123.00")))
+    assert(Decimal128(-123) === Decimal128(BigDecimal(-123)))
+    assert(Decimal128(-123) === Decimal128(BigDecimal("-123.00")))
+
+    assert(Decimal128(123, 3, 1) === Decimal128(BigDecimal("12.3")))
+    assert(Decimal128(-123, 3, 2) === Decimal128(BigDecimal("-1.23")))
+  }
+
+  test("isZero") {
+    assert(Decimal128(0).isZero)
+    assert(Decimal128(0, 0, 2).isZero)
+    assert(Decimal128("0").isZero)
+    assert(Decimal128("0.000").isZero)
+    assert(!Decimal128(1).isZero)
+    assert(!Decimal128(1, 4, 2).isZero)
+    assert(!Decimal128("1").isZero)
+    assert(!Decimal128("0.001").isZero)
+  }
+
+  test("arithmetic") {
+    assert(Decimal128(100) + Decimal128(-100) === Decimal128(0))
+    assert(Decimal128(100) + Decimal128(-100) === Decimal128(0))
+    assert(Decimal128(100) * Decimal128(-100) === Decimal128(-10000))
+    assert(Decimal128(1e13) * Decimal128(1e13) === Decimal128(1e26))
+    assert(Decimal128(100) / Decimal128(-100) === Decimal128(-1))
+    assert(Decimal128(100) / Decimal128(0) === null)
+    assert(Decimal128(100) % Decimal128(-100) === Decimal128(0))
+    assert(Decimal128(100) % Decimal128(3) === Decimal128(1))
+    assert(Decimal128(-100) % Decimal128(3) === Decimal128(-1))
+    assert(Decimal128(100) % Decimal128(0) === null)
+  }
+
+  test("longVal arithmetic") {
+    assert(Decimal128(10, 2, 0) + Decimal128(10, 2, 0) === Decimal128(20, 3, 0))
+    assert(Decimal128(10, 2, 0) + Decimal128(90, 2, 0) === Decimal128(100, 3, 0))
+    assert(Decimal128(10, 2, 0) - Decimal128(-10, 2, 0) === Decimal128(20, 3, 0))
+    assert(Decimal128(10, 2, 0) - Decimal128(-90, 2, 0) === Decimal128(100, 3, 0))
+  }
+
+  test("other arithmetic") {
+    // test +
+    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 1) === Decimal128(0))
+    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 2) === Decimal128(900, 3, 2))
+    assert(Decimal128(100, 3, 2) + Decimal128(-100, 3, 1) === Decimal128(-900, 3, 2))
+    assert(Decimal128(100, 3, 1) + Decimal128(-100, 3, 2) === Decimal128("9.00"))
+    assert(Decimal128("10.0") + Decimal128("-1.00") === Decimal128(BigDecimal("9.00")))
+    assert(Decimal128("15432.21543600787131") + Decimal128("57832.21543600787313") ===
+      Decimal128(BigDecimal("73264.43087201574444")))
+    val e1 = intercept[ArithmeticException](
+      Decimal128("170141183460469231731687303715884105727") + Decimal128(1))
+    assert(e1.getMessage.contains(
+      "Int128 Overflow. Int128(9223372036854775807, -1) add Int128(0, 1)."))
+
+    // test -
+    assert(Decimal128(100) - Decimal128(-100) === Decimal128(200))
+    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 1) === Decimal128(200, 3, 1))
+    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 2) === Decimal128(1100, 4, 2))
+    assert(Decimal128(100, 3, 2) - Decimal128(-100, 3, 1) === Decimal128(1100, 4, 2))
+    assert(Decimal128(100, 3, 1) - Decimal128(-100, 3, 2) === Decimal128("11.00"))
+    assert(Decimal128("10.0") - Decimal128("-1.00") === Decimal128(BigDecimal("11.00")))
+    assert(Decimal128("15432.21543600787131") - Decimal128("57832.21543600787313") ===
+      Decimal128(BigDecimal("-42400.00000000000182")))
+    val e2 = intercept[ArithmeticException](
+      Decimal128("-170141183460469231731687303715884105728") - Decimal128(1))
+    assert(e2.getMessage.contains(
+      "Int128 Overflow. Int128(-9223372036854775808, 0) subtract Int128(0, 1)."))
+
+    // test *
+    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 1) === Decimal128(-10000, 5, 2))
+    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 2) === Decimal128(-10000, 5, 3))
+    assert(Decimal128(100, 3, 2) * Decimal128(-100, 3, 1) === Decimal128(-10000, 5, 3))
+    assert(Decimal128(100, 3, 1) * Decimal128(-100, 3, 2) === Decimal128("-10.00"))
+    assert(Decimal128("10.0") * Decimal128("-1.00") === Decimal128(BigDecimal("-10.00")))
+    assert(Decimal128("15432.21543600787131") * Decimal128("57832.21543600787313") ===
+      Decimal128(BigDecimal("892479207.7500933852299992378118469003")))
+    assert(Decimal128(1e13) * Decimal128(1e13) === Decimal128(1e26))
+    val e3 = intercept[ArithmeticException](
+      Decimal128("12345678901234567890123456789012345678") * Decimal128(9))
+    assert(e3.getMessage.contains("Decimal overflow: Decimal128 multiply."))
+
+    // test /
+    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 1) === Decimal128(-1, 1, 0))
+    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 2) === Decimal128(-10, 2, 0))
+    assert(Decimal128(100, 3, 2) / Decimal128(-100, 3, 1) === Decimal128(-10, 2, 2))
+    assert(Decimal128(100, 3, 1) / Decimal128(-100, 3, 2) === Decimal128("-10.00"))
+    assert(Decimal128("10.0") / Decimal128("-1.00") === Decimal128(BigDecimal("-10.00")))
+    assert(Decimal128("15432.21543600") / Decimal128("57832.21543") ===
+      Decimal128(BigDecimal("0.26684462")))
+    assert(Decimal128(100) / Decimal128(0) === null)
+    val e4 = intercept[ArithmeticException](
+      Decimal128("12345678901234567890123456789012345678") / Decimal128(1, 1, 1))
+    assert(e4.getMessage.contains("Decimal overflow: Decimal128 division."))
+
+    // test %
+    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 1) === Decimal128(0))
+    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 2) === Decimal128(0))
+    assert(Decimal128(100, 3, 2) % Decimal128(-100, 3, 1) === Decimal128(100, 3, 2))
+    assert(Decimal128(100, 3, 1) % Decimal128(-100, 3, 2) === Decimal128("0.0"))
+    assert(Decimal128("10.0") % Decimal128("-1.00") === Decimal128(BigDecimal("0.0")))
+    assert(Decimal128("15432.21543600") % Decimal128("57832.21543") ===
+      Decimal128(BigDecimal("15432.21543600")))
+    assert(Decimal128(100) % Decimal128(3) === Decimal128(1))
+    assert(Decimal128(-100) % Decimal128(3) === Decimal128(-1))
+    assert(Decimal128(100) % Decimal128(0) === null)
+  }
+
+  test("quot") {
+    assert(Decimal128(100).quot(Decimal128(100)) === Decimal128(BigDecimal("1")))
+    assert(Decimal128(100).quot(Decimal128(33)) === Decimal128(BigDecimal("3")))
+    assert(Decimal128(100).quot(Decimal128(-100)) === Decimal128(BigDecimal("-1")))
+    assert(Decimal128(100).quot(Decimal128(-33)) === Decimal128(BigDecimal("-3")))
+
+    assert(Decimal128("15432.21543600").quot(Decimal128("57832.21543")) ===
+      Decimal128(BigDecimal("0")))
+    assert(Decimal128("57832.21543").quot(Decimal128("15432.21543600")) ===
+      Decimal128(BigDecimal("3")))
+  }
+
+  test("negate & abs") {
+    assert(-Decimal128(100) === Decimal128(BigDecimal("-100")))
+    assert(-Decimal128(-100) === Decimal128(BigDecimal("100")))
+    assert(Decimal128(100).abs === Decimal128(BigDecimal("100")))
+    assert(Decimal128(-100).abs === Decimal128(BigDecimal("100")))
+  }
+
+  test("negate") {
+    assert(-Decimal128("15432.21543600") === Decimal128(BigDecimal("-15432.21543600")))
+    assert(-Decimal128("-57832.21543") === Decimal128(BigDecimal("57832.21543")))
+  }
+
+  test("floor & ceil") {
+    assert(Decimal128("10.03").floor === Decimal128(BigDecimal("10")))
+    assert(Decimal128("10.03").ceil === Decimal128(BigDecimal("11")))
+    assert(Decimal128("-10.03").floor === Decimal128(BigDecimal("-11")))
+    assert(Decimal128("-10.03").ceil === Decimal128(BigDecimal("-10")))
+  }
+
+  test("accurate precision after multiplication") {
+    val decimal =
+      (Decimal128(Long.MaxValue, 38, 0) * Decimal128(Long.MaxValue, 38, 0)).toJavaBigDecimal
+    assert(decimal.unscaledValue.toString === "85070591730234615847396907784232501249")
+  }
+
+  test("fix non-terminating decimal expansion problem") {
+    val decimal = Decimal128(1.0, 10, 3) / Decimal128(3.0, 10, 3)
+    // The difference between decimal should not be more than 0.001.
+    assert(decimal.toDouble - 0.333 < 0.001)
+  }
+
+  test("fix loss of precision/scale when doing division operation") {
+    val a = Decimal128(2) / Decimal128(3)
+    // Different from Decimal: assert(a.toDouble < 1.0 && a.toDouble > 0.6)
+    assert(a.toDouble == 1.0)
+    val b = Decimal128(1) / Decimal128(8)
+    // Different from Decimal: assert(b.toDouble === 0.125)
+    assert(b.toDouble === 0.0)
+  }
+
+  test("set/setOrNull") {
+    assert(new Decimal128().set(10L, 10, 0).toUnscaledLong === 10L)
+    assert(new Decimal128().set(100L, 10, 0).toUnscaledLong === 100L)
+    assert(Decimal128(Long.MaxValue, 100, 0).toUnscaledLong === Long.MaxValue)
+  }
+
+  test("changePrecision/toPrecision on compact decimal should respect rounding mode") {
+    allSupportedRoundModes.foreach { mode =>
+      Seq("0.4", "0.5", "0.6", "1.0", "1.1", "1.6", "2.5", "5.5").foreach { n =>
+        Seq("", "-").foreach { sign =>
+          val bd = BigDecimal(sign + n)
+          val unscaled = (bd * 10).toLongExact
+          val d = Decimal128(unscaled, 8, 1)
+          assert(d.changePrecision(10, 0, mode))
+          assert(d.toString === bd.setScale(0, mode).toString(), s"num: $sign$n, mode: $mode")
+
+          val copy = d.toPrecision(10, 0, mode)
+          assert(copy !== null)
+          assert(d.ne(copy))
+          assert(d === copy)
+          assert(copy.toString === bd.setScale(0, mode).toString(), s"num: $sign$n, mode: $mode")
+        }
+      }
+    }
+  }
+
+  test("SPARK-20341: support BigInt's value does not fit in long value range") {
+    val bigInt = scala.math.BigInt("9223372036854775808")
+    val decimal = Decimal128.apply(bigInt)
+    assert(decimal.toJavaBigDecimal.unscaledValue.toString === "9223372036854775808")
+  }
+
+  test("SPARK-26038: toScalaBigInt/toJavaBigInteger") {
+    // not fitting long
+    val decimal = Decimal128("1234568790123456789.1234879012345678901")
+    assert(decimal.toScalaBigInt == scala.math.BigInt("1234568790123456789"))
+    assert(decimal.toJavaBigInteger == new java.math.BigInteger("1234568790123456789"))
+    // fitting long
+    val decimalLong = Decimal128(123456789123456789L, 18, 9)
+    assert(decimalLong.toScalaBigInt == scala.math.BigInt("123456789"))
+    assert(decimalLong.toJavaBigInteger == new java.math.BigInteger("123456789"))
+  }
+
+  test("UTF8String to Decimal128") {
+    def checkFromString(string: String): Unit = {
+      assert(Decimal128.fromString(UTF8String.fromString(string)) === Decimal128(string))
+      assert(Decimal128.fromStringANSI(UTF8String.fromString(string)) === Decimal128(string))
+    }
+
+    def checkOutOfRangeFromString(string: String): Unit = {
+      assert(Decimal128.fromString(UTF8String.fromString(string)) === null)
+      checkError(
+        exception = intercept[SparkArithmeticException](
+          Decimal.fromStringANSI(UTF8String.fromString(string))),
+        errorClass = "NUMERIC_OUT_OF_SUPPORTED_RANGE",
+        parameters = Map("value" -> string))
+    }
+
+    checkFromString("12345678901234567890123456789012345678")
+    checkOutOfRangeFromString("123456789012345678901234567890123456789")
+
+    checkFromString("0.00000000000000000000000000000000000001")
+    checkFromString("0.000000000000000000000000000000000000000000000001")
+
+    checkFromString("6E-640")
+
+    checkFromString("6E+37")
+    checkOutOfRangeFromString("6E+38")
+    checkOutOfRangeFromString("6.0790316E+25569151")
+
+    assert(Decimal128.fromString(UTF8String.fromString("str")) === null)
+    checkError(
+      exception = intercept[SparkNumberFormatException](
+        Decimal128.fromStringANSI(UTF8String.fromString("str"))),
+      errorClass = "CAST_INVALID_INPUT",
+      parameters = Map(
+        "expression" -> "'str'",
+        "sourceType" -> "\"STRING\"",
+        "targetType" -> "\"DECIMAL(10,0)\"",
+        "ansiConfig" -> "\"spark.sql.ansi.enabled\""))
+  }
+
+  test("SPARK-35841: Casting string to decimal type doesn't work " +
+    "if the sum of the digits is greater than 38") {
+    val values = Array(
+      "28.925999999999998379962562466971576213",
+      "2.9259999999999983799625624669715762138"
+    )
+    for (string <- values) {
+      assert(Decimal128.fromString(UTF8String.fromString(string)) === Decimal128(string))
+      assert(Decimal128.fromStringANSI(UTF8String.fromString(string)) === Decimal128(string))
+    }
+  }
+
+  test("SPARK-37451: Performance improvement regressed String to Decimal cast") {
+    val values = Array("7.836725755512218E38")
+    for (string <- values) {
+      assert(Decimal128.fromString(UTF8String.fromString(string)) === null)
+      checkError(
+        exception = intercept[SparkArithmeticException](
+          Decimal128.fromStringANSI(UTF8String.fromString(string))),
+        errorClass = "NUMERIC_OUT_OF_SUPPORTED_RANGE",
+        parameters = Map("value" -> string))
+    }
+
+    withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
+      for (string <- values) {
+        assert(Decimal128.fromString(UTF8String.fromString(string)) === Decimal128(string))
+        assert(Decimal128.fromStringANSI(UTF8String.fromString(string)) === Decimal128(string))
+      }
+    }
+  }
+
+  // 18 is a max number of digits in Decimal's compact long
+  test("SPARK-41554: decrease/increase scale by 18 and more on compact decimal") {
+    val unscaledNums = Seq(
+      0L, 1L, 10L, 51L, 123L, 523L,
+      // 18 digits
+      912345678901234567L,
+      112345678901234567L,
+      512345678901234567L
+    )
+    val precision = 38
+    // generate some (from, to) scale pairs, e.g. (38, 18), (-20, -2), etc
+    val scalePairs = for {
+      scale <- Seq(38, 20, 19, 18)
+      delta <- Seq(38, 20, 19, 18)
+      a = scale
+      b = scale - delta
+    } yield {
+      Seq((a, b), (-a, -b), (b, a), (-b, -a))
+    }
+
+    for {
+      unscaled <- unscaledNums
+      mode <- allSupportedRoundModes
+      (scaleFrom, scaleTo) <- scalePairs.flatten
+      sign <- Seq(1L, -1L)
+    } {
+      val unscaledWithSign = unscaled * sign
+      if (scaleFrom < 0 || scaleTo < 0) {
+        withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
+          checkScaleChange(unscaledWithSign, scaleFrom, scaleTo, mode)
+        }
+      } else {
+        checkScaleChange(unscaledWithSign, scaleFrom, scaleTo, mode)
+      }
+    }
+
+    def checkScaleChange(unscaled: Long, scaleFrom: Int, scaleTo: Int,
+                         roundMode: BigDecimal.RoundingMode.Value): Unit = {
+      val decimal = Decimal128(unscaled, precision, scaleFrom)
+      checkCompact(decimal, true)
+      decimal.changePrecision(precision, scaleTo, roundMode)
+      val bd = BigDecimal(unscaled, scaleFrom).setScale(scaleTo, roundMode)
+      assert(decimal.toBigDecimal === bd,
+        s"unscaled: $unscaled, scaleFrom: $scaleFrom, scaleTo: $scaleTo, mode: $roundMode")
+    }
+  }
+
+}

--- a/sql/core/benchmarks/DecimalBenchmark-results.txt
+++ b/sql/core/benchmarks/DecimalBenchmark-results.txt
@@ -1,0 +1,91 @@
+================================================================================================
+Benchmark for performance of decimal
+================================================================================================
+
+Preparing data for benchmarking ...
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+Compare decimal addition:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Decimal: s1 + s2                                      6              8           5         17.7          56.3       1.0X
+Decimal128: s1 + s2                                   2              2           0         43.7          22.9       2.5X
+Decimal: s1 + s2 + s3 + s4                           15             16           1          6.8         146.5       0.4X
+Decimal128: s1 + s2 + s3 + s4                         7              8           1         15.1          66.4       0.8X
+Decimal: l1 + l2                                     13             14           1          7.4         134.9       0.4X
+Decimal128: l1 + l2                                   5              6           1         19.3          51.7       1.1X
+Decimal: l1 + l2 + l3 + l4                           37             38           1          2.7         368.3       0.2X
+Decimal128: l1 + l2 + l3 + l4                        16             16           0          6.4         156.6       0.4X
+Decimal: s2 + l3 + l1 + s4                           39             40           1          2.5         393.2       0.1X
+Decimal128: s2 + l3 + l1 + s4                        25             26           1          4.0         251.5       0.2X
+Decimal: lz1 + lz2                                   13             14           1          7.6         131.8       0.4X
+Decimal128: lz1 + lz2                                 5              5           0         19.7          50.7       1.1X
+Decimal: lz1 + lz2 + lz3 + lz4                       37             38           1          2.7         369.2       0.2X
+Decimal128: lz1 + lz2 + lz3 + lz4                    15             16           0          6.5         153.8       0.4X
+Decimal: s2 + lz3 + lz1 + s4                         38             39           1          2.6         379.5       0.1X
+Decimal128: s2 + lz3 + lz1 + s4                      26             26           0          3.9         255.8       0.2X
+
+Preparing data for benchmarking ...
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+Compare decimal multiply:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Decimal: s1 * s2                                      5              5           0         20.2          49.6       1.0X
+Decimal128: s1 * s2                                   2              2           0         44.3          22.6       2.2X
+Decimal: s1 * s2 * s5 * s6                           14             15           1          7.0         142.6       0.3X
+Decimal128: s1 * s2 * s5 * s6                         5              5           0         21.2          47.3       1.0X
+Decimal: s3 * s4                                      9              9           1         11.5          87.1       0.6X
+Decimal128: s3 * s4                                   3              3           0         32.5          30.8       1.6X
+Decimal: l2 * s2                                      9              9           0         11.3          88.6       0.6X
+Decimal128: l2 * s2                                   3              3           0         33.0          30.3       1.6X
+Decimal: l2 * s2 * s5 * s6                           23             24           1          4.3         232.9       0.2X
+Decimal128: l2 * s2 * s5 * s6                        11             12           0          9.1         109.7       0.5X
+Decimal: s1 * l2                                      9             10           0         10.7          93.0       0.5X
+Decimal128: s1 * l2                                   3              3           0         31.9          31.3       1.6X
+Decimal: l1 * l2                                     10             10           0         10.4          96.0       0.5X
+Decimal128: l1 * l2                                   3              3           0         31.7          31.6       1.6X
+
+Preparing data for benchmarking ...
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+Compare decimal division:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Decimal: s1 / s2                                     17             18           1          5.8         172.8       1.0X
+Decimal128: s1 / s2                                   4              4           0         24.5          40.8       4.2X
+Decimal: s1 / s2 / s2 / s2                           47             48           1          2.1         470.6       0.4X
+Decimal128: s1 / s2 / s2 / s2                         9             10           0         10.7          93.5       1.8X
+Decimal: s1 / s3                                     27             28           1          3.7         268.2       0.6X
+Decimal128: s1 / s3                                   4              4           0         24.2          41.3       4.2X
+Decimal: s2 / l1                                     24             25           1          4.1         245.0       0.7X
+Decimal128: s2 / l1                                   4              4           0         23.1          43.3       4.0X
+Decimal: l1 / s2                                     19             20           1          5.1         194.7       0.9X
+Decimal128: l1 / s2                                   4              4           0         24.2          41.4       4.2X
+Decimal: s3 / l1                                     28             29           1          3.5         282.5       0.6X
+Decimal128: s3 / l1                                   4              4           0         24.5          40.9       4.2X
+Decimal: l2 / l3                                     34             36           5          2.9         343.3       0.5X
+Decimal128: l2 / l3                                  15             16           1          6.5         153.2       1.1X
+Decimal: l2 / l4 / l4 / l4                           69             71           1          1.5         689.4       0.3X
+Decimal128: l2 / l4 / l4 / l4                        20             22           1          4.9         202.6       0.9X
+Decimal: l2 / s4 / s4 / s4                           57             59           4          1.8         570.9       0.3X
+Decimal128: l2 / s4 / s4 / s4                        39             41           1          2.5         394.1       0.4X
+
+Preparing data for benchmarking ...
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+Compare decimal modulo:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Decimal: s1 % s2                                     36             37           1          2.7         363.8       1.0X
+Decimal128: s1 % s2                                  18             19           1          5.5         181.4       2.0X
+Decimal: s1 % s2 % s2 % s2                           50             52           3          2.0         504.3       0.7X
+Decimal128: s1 % s2 % s2 % s2                        40             42           2          2.5         399.9       0.9X
+Decimal: s2 % l2                                      8              8           1         13.3          75.1       4.8X
+Decimal128: s2 % l2                                  13             14           1          7.6         132.0       2.8X
+Decimal: l3 % s3                                     50             51           1          2.0         495.5       0.7X
+Decimal128: l3 % s3                                  16             16           0          6.3         157.5       2.3X
+Decimal: s4 % l3                                      8              9           1         12.3          81.3       4.5X
+Decimal128: s4 % l3                                  14             15           1          7.2         138.3       2.6X
+Decimal: l2 % l3                                     14             15           1          7.0         142.4       2.6X
+Decimal128: l2 % l3                                  17             18           1          5.9         169.4       2.1X
+Decimal: l2 % l3 % l4 % l1                           85             87           2          1.2         845.7       0.4X
+Decimal128: l2 % l3 % l4 % l1                        52             53           1          1.9         519.7       0.7X
+
+

--- a/sql/core/benchmarks/DecimalBenchmark-results.txt
+++ b/sql/core/benchmarks/DecimalBenchmark-results.txt
@@ -7,85 +7,85 @@ Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Compare decimal addition:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Decimal: s1 + s2                                      6              8           5         17.7          56.3       1.0X
-Decimal128: s1 + s2                                   2              2           0         43.7          22.9       2.5X
-Decimal: s1 + s2 + s3 + s4                           15             16           1          6.8         146.5       0.4X
-Decimal128: s1 + s2 + s3 + s4                         7              8           1         15.1          66.4       0.8X
-Decimal: l1 + l2                                     13             14           1          7.4         134.9       0.4X
-Decimal128: l1 + l2                                   5              6           1         19.3          51.7       1.1X
-Decimal: l1 + l2 + l3 + l4                           37             38           1          2.7         368.3       0.2X
-Decimal128: l1 + l2 + l3 + l4                        16             16           0          6.4         156.6       0.4X
-Decimal: s2 + l3 + l1 + s4                           39             40           1          2.5         393.2       0.1X
-Decimal128: s2 + l3 + l1 + s4                        25             26           1          4.0         251.5       0.2X
-Decimal: lz1 + lz2                                   13             14           1          7.6         131.8       0.4X
-Decimal128: lz1 + lz2                                 5              5           0         19.7          50.7       1.1X
-Decimal: lz1 + lz2 + lz3 + lz4                       37             38           1          2.7         369.2       0.2X
-Decimal128: lz1 + lz2 + lz3 + lz4                    15             16           0          6.5         153.8       0.4X
-Decimal: s2 + lz3 + lz1 + s4                         38             39           1          2.6         379.5       0.1X
-Decimal128: s2 + lz3 + lz1 + s4                      26             26           0          3.9         255.8       0.2X
+Decimal: s1 + s2                                      6              7           2         17.7          56.4       1.0X
+Decimal128: s1 + s2                                   2              2           0         43.1          23.2       2.4X
+Decimal: s1 + s2 + s3 + s4                           14             15           1          7.1         140.6       0.4X
+Decimal128: s1 + s2 + s3 + s4                         6              8           1         15.6          64.2       0.9X
+Decimal: l1 + l2                                     13             14           1          7.6         130.7       0.4X
+Decimal128: l1 + l2                                   4              5           0         23.2          43.2       1.3X
+Decimal: l1 + l2 + l3 + l4                           34             35           1          2.9         342.3       0.2X
+Decimal128: l1 + l2 + l3 + l4                        14             15           0          7.2         138.7       0.4X
+Decimal: s2 + l3 + l1 + s4                           40             41           1          2.5         395.7       0.1X
+Decimal128: s2 + l3 + l1 + s4                        25             26           1          3.9         253.7       0.2X
+Decimal: lz1 + lz2                                   13             14           1          7.7         129.5       0.4X
+Decimal128: lz1 + lz2                                 4              4           0         26.6          37.6       1.5X
+Decimal: lz1 + lz2 + lz3 + lz4                       37             38           1          2.7         368.4       0.2X
+Decimal128: lz1 + lz2 + lz3 + lz4                    11             12           0          8.8         113.5       0.5X
+Decimal: s2 + lz3 + lz1 + s4                         38             39           1          2.6         381.3       0.1X
+Decimal128: s2 + lz3 + lz1 + s4                      19             20           1          5.2         194.2       0.3X
 
 Preparing data for benchmarking ...
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Compare decimal multiply:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Decimal: s1 * s2                                      5              5           0         20.2          49.6       1.0X
-Decimal128: s1 * s2                                   2              2           0         44.3          22.6       2.2X
-Decimal: s1 * s2 * s5 * s6                           14             15           1          7.0         142.6       0.3X
-Decimal128: s1 * s2 * s5 * s6                         5              5           0         21.2          47.3       1.0X
-Decimal: s3 * s4                                      9              9           1         11.5          87.1       0.6X
-Decimal128: s3 * s4                                   3              3           0         32.5          30.8       1.6X
-Decimal: l2 * s2                                      9              9           0         11.3          88.6       0.6X
-Decimal128: l2 * s2                                   3              3           0         33.0          30.3       1.6X
-Decimal: l2 * s2 * s5 * s6                           23             24           1          4.3         232.9       0.2X
-Decimal128: l2 * s2 * s5 * s6                        11             12           0          9.1         109.7       0.5X
-Decimal: s1 * l2                                      9             10           0         10.7          93.0       0.5X
-Decimal128: s1 * l2                                   3              3           0         31.9          31.3       1.6X
-Decimal: l1 * l2                                     10             10           0         10.4          96.0       0.5X
-Decimal128: l1 * l2                                   3              3           0         31.7          31.6       1.6X
+Decimal: s1 * s2                                      5              5           0         19.5          51.3       1.0X
+Decimal128: s1 * s2                                   2              2           0         44.1          22.7       2.3X
+Decimal: s1 * s2 * s5 * s6                           13             15           1          7.5         132.6       0.4X
+Decimal128: s1 * s2 * s5 * s6                         5              5           0         20.5          48.7       1.1X
+Decimal: s3 * s4                                      9              9           1         11.4          87.9       0.6X
+Decimal128: s3 * s4                                   3              3           0         32.5          30.7       1.7X
+Decimal: l2 * s2                                      9             10           1         11.2          89.2       0.6X
+Decimal128: l2 * s2                                   3              3           0         30.2          33.1       1.6X
+Decimal: l2 * s2 * s5 * s6                           23             25           3          4.3         234.9       0.2X
+Decimal128: l2 * s2 * s5 * s6                        12             12           0          8.6         115.8       0.4X
+Decimal: s1 * l2                                      9             10           0         10.6          94.1       0.5X
+Decimal128: s1 * l2                                   3              3           0         31.8          31.5       1.6X
+Decimal: l1 * l2                                     10             10           0         10.2          97.7       0.5X
+Decimal128: l1 * l2                                   3              3           0         31.9          31.4       1.6X
 
 Preparing data for benchmarking ...
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Compare decimal division:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Decimal: s1 / s2                                     17             18           1          5.8         172.8       1.0X
-Decimal128: s1 / s2                                   4              4           0         24.5          40.8       4.2X
-Decimal: s1 / s2 / s2 / s2                           47             48           1          2.1         470.6       0.4X
-Decimal128: s1 / s2 / s2 / s2                         9             10           0         10.7          93.5       1.8X
-Decimal: s1 / s3                                     27             28           1          3.7         268.2       0.6X
-Decimal128: s1 / s3                                   4              4           0         24.2          41.3       4.2X
-Decimal: s2 / l1                                     24             25           1          4.1         245.0       0.7X
-Decimal128: s2 / l1                                   4              4           0         23.1          43.3       4.0X
-Decimal: l1 / s2                                     19             20           1          5.1         194.7       0.9X
-Decimal128: l1 / s2                                   4              4           0         24.2          41.4       4.2X
-Decimal: s3 / l1                                     28             29           1          3.5         282.5       0.6X
-Decimal128: s3 / l1                                   4              4           0         24.5          40.9       4.2X
-Decimal: l2 / l3                                     34             36           5          2.9         343.3       0.5X
-Decimal128: l2 / l3                                  15             16           1          6.5         153.2       1.1X
-Decimal: l2 / l4 / l4 / l4                           69             71           1          1.5         689.4       0.3X
-Decimal128: l2 / l4 / l4 / l4                        20             22           1          4.9         202.6       0.9X
-Decimal: l2 / s4 / s4 / s4                           57             59           4          1.8         570.9       0.3X
-Decimal128: l2 / s4 / s4 / s4                        39             41           1          2.5         394.1       0.4X
+Decimal: s1 / s2                                     18             18           1          5.7         175.7       1.0X
+Decimal128: s1 / s2                                   5              5           0         21.1          47.5       3.7X
+Decimal: s1 / s2 / s2 / s2                           47             49           1          2.1         473.9       0.4X
+Decimal128: s1 / s2 / s2 / s2                         9              9           0         11.1          90.3       1.9X
+Decimal: s1 / s3                                     27             28           1          3.7         270.2       0.7X
+Decimal128: s1 / s3                                   4              4           0         25.0          40.1       4.4X
+Decimal: s2 / l1                                     25             25           1          4.1         245.8       0.7X
+Decimal128: s2 / l1                                   4              4           0         23.7          42.3       4.2X
+Decimal: l1 / s2                                     20             21           1          5.1         197.5       0.9X
+Decimal128: l1 / s2                                   4              4           0         24.0          41.7       4.2X
+Decimal: s3 / l1                                     28             29           1          3.5         282.1       0.6X
+Decimal128: s3 / l1                                   4              4           0         24.1          41.4       4.2X
+Decimal: l2 / l3                                     34             35           1          2.9         340.1       0.5X
+Decimal128: l2 / l3                                  21             22           1          4.7         213.9       0.8X
+Decimal: l2 / l4 / l4 / l4                           68             71           2          1.5         681.1       0.3X
+Decimal128: l2 / l4 / l4 / l4                        23             24           1          4.3         230.7       0.8X
+Decimal: l2 / s4 / s4 / s4                           58             60           1          1.7         576.0       0.3X
+Decimal128: l2 / s4 / s4 / s4                        40             42           1          2.5         399.2       0.4X
 
 Preparing data for benchmarking ...
 Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
 Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Compare decimal modulo:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Decimal: s1 % s2                                     36             37           1          2.7         363.8       1.0X
-Decimal128: s1 % s2                                  18             19           1          5.5         181.4       2.0X
-Decimal: s1 % s2 % s2 % s2                           50             52           3          2.0         504.3       0.7X
-Decimal128: s1 % s2 % s2 % s2                        40             42           2          2.5         399.9       0.9X
-Decimal: s2 % l2                                      8              8           1         13.3          75.1       4.8X
-Decimal128: s2 % l2                                  13             14           1          7.6         132.0       2.8X
-Decimal: l3 % s3                                     50             51           1          2.0         495.5       0.7X
-Decimal128: l3 % s3                                  16             16           0          6.3         157.5       2.3X
-Decimal: s4 % l3                                      8              9           1         12.3          81.3       4.5X
-Decimal128: s4 % l3                                  14             15           1          7.2         138.3       2.6X
-Decimal: l2 % l3                                     14             15           1          7.0         142.4       2.6X
-Decimal128: l2 % l3                                  17             18           1          5.9         169.4       2.1X
-Decimal: l2 % l3 % l4 % l1                           85             87           2          1.2         845.7       0.4X
-Decimal128: l2 % l3 % l4 % l1                        52             53           1          1.9         519.7       0.7X
+Decimal: s1 % s2                                     36             37           1          2.8         356.6       1.0X
+Decimal128: s1 % s2                                  18             19           1          5.6         178.6       2.0X
+Decimal: s1 % s2 % s2 % s2                           50             52           1          2.0         501.1       0.7X
+Decimal128: s1 % s2 % s2 % s2                        50             51           1          2.0         496.4       0.7X
+Decimal: s2 % l2                                      8              9           1         12.9          77.6       4.6X
+Decimal128: s2 % l2                                  17             17           1          6.1         165.2       2.2X
+Decimal: l3 % s3                                     50             52           1          2.0         503.1       0.7X
+Decimal128: l3 % s3                                  16             16           1          6.4         155.4       2.3X
+Decimal: s4 % l3                                      8              9           2         12.8          77.9       4.6X
+Decimal128: s4 % l3                                  13             14           0          7.4         134.8       2.6X
+Decimal: l2 % l3                                     14             15           0          6.9         144.2       2.5X
+Decimal128: l2 % l3                                  16             17           1          6.2         162.5       2.2X
+Decimal: l2 % l3 % l4 % l1                           85             88           2          1.2         854.1       0.4X
+Decimal128: l2 % l3 % l4 % l1                        51             54           2          1.9         513.4       0.7X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DecimalBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DecimalBenchmark.scala
@@ -1,0 +1,610 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import java.math.BigInteger
+import java.util.Random
+
+import scala.collection.mutable
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.types.{Decimal, Decimal128, DecimalType}
+
+/**
+ * Benchmark for measuring perf of different Base64 implementations
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar> <sql core test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/DecimalBenchmark-results.txt".
+ * }}}
+ */
+object DecimalBenchmark extends SqlBasedBenchmark {
+  private val COUNT = 100000
+  private val RND = new Random()
+
+  private val decimalMap = mutable.Map.empty[String, DecimalType]
+  private val decimalDataMap = mutable.Map.empty[String, Array[Decimal]]
+  private val decimal128DataMap = mutable.Map.empty[String, Array[Decimal128]]
+
+  private def randomDecimal(dataType: DecimalType): BigInteger = {
+    val maxBits = (Math.log(Math.pow(10, dataType.precision)) / Math.log(2)).toInt
+    var bigInteger = new BigInteger(maxBits, RND)
+
+    if (bigInteger.equals(BigInteger.ZERO)) {
+      bigInteger = BigInteger.ONE
+    }
+
+    if (RND.nextBoolean()) {
+      bigInteger = bigInteger.negate()
+    }
+
+    bigInteger
+  }
+
+  private def setUp(
+      rowsNum: Int,
+      decimalMap: Map[String, DecimalType],
+      decimalDataMap: mutable.Map[String, Array[Decimal]],
+      decimal128DataMap: mutable.Map[String, Array[Decimal128]]): Unit = {
+    var idx = 0;
+    while (idx < rowsNum) {
+      decimalMap.foreach { case (symbol, decimalType) =>
+        val bigInteger = randomDecimal(decimalType)
+        val decimalArray = decimalDataMap.getOrElseUpdate(symbol, new Array[Decimal](rowsNum))
+        val decimal128Array =
+          decimal128DataMap.getOrElseUpdate(symbol, new Array[Decimal128](rowsNum))
+
+        if (symbol.startsWith("s")) {
+          val longValue = bigInteger.longValue()
+          decimalArray(idx) = Decimal(longValue, decimalType.precision, decimalType.scale)
+          decimal128Array(idx) = Decimal128(longValue, decimalType.precision, decimalType.scale)
+        } else {
+          decimalArray(idx) = Decimal(bigInteger)
+          decimalArray(idx).changePrecision(decimalType.precision, decimalType.scale)
+          decimal128Array(idx) = Decimal128(bigInteger)
+          decimal128Array(idx).changePrecision(decimalType.precision, decimalType.scale)
+        }
+      }
+
+      idx += 1
+    }
+  }
+
+  def decimalAddition(rowsNum: Int, numIters: Int): Unit = {
+    val benchmark = new Benchmark("Compare decimal addition", rowsNum, output = output)
+
+    prepareDataInfo(benchmark)
+
+    decimalMap.clear()
+    decimalDataMap.clear()
+    decimal128DataMap.clear()
+
+    decimalMap.put("s1", DecimalType(10, 5))
+    decimalMap.put("s2", DecimalType(7, 2))
+    decimalMap.put("s3", DecimalType(12, 2))
+    decimalMap.put("s4", DecimalType(2, 1))
+
+    decimalMap.put("l1", DecimalType(35, 10))
+    decimalMap.put("l2", DecimalType(25, 5))
+    decimalMap.put("l3", DecimalType(20, 6))
+    decimalMap.put("l4", DecimalType(25, 8))
+
+    decimalMap.put("lz1", DecimalType(35, 0))
+    decimalMap.put("lz2", DecimalType(25, 0))
+    decimalMap.put("lz3", DecimalType(20, 0))
+    decimalMap.put("lz4", DecimalType(25, 0))
+
+    setUp(rowsNum, decimalMap.toMap, decimalDataMap, decimal128DataMap)
+
+    benchmark.addCase("Decimal: s1 + s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) + decimalDataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 + s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) + decimal128DataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s1 + s2 + s3 + s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) + decimalDataMap("s2")(i) +
+          decimalDataMap("s3")(i) + decimalDataMap("s4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 + s2 + s3 + s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) + decimal128DataMap("s2")(i) +
+          decimal128DataMap("s3")(i) + decimal128DataMap("s4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l1 + l2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l1")(i) + decimalDataMap("l2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l1 + l2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        try {
+          decimal128DataMap("l1")(i) + decimal128DataMap("l2")(i)
+        } catch {
+          case _: ArithmeticException =>
+        }
+      }
+    }
+
+    benchmark.addCase("Decimal: l1 + l2 + l3 + l4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l1")(i) + decimalDataMap("l2")(i) +
+          decimalDataMap("l3")(i) + decimalDataMap("l4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l1 + l2 + l3 + l4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        try {
+          decimal128DataMap("l1")(i) + decimal128DataMap("l2")(i) +
+            decimal128DataMap("l3")(i) + decimal128DataMap("l4")(i)
+        } catch {
+          case _: ArithmeticException =>
+        }
+      }
+    }
+
+    benchmark.addCase("Decimal: s2 + l3 + l1 + s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s2")(i) + decimalDataMap("l3")(i) +
+          decimalDataMap("l1")(i) + decimalDataMap("s4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s2 + l3 + l1 + s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        try {
+          decimal128DataMap("s2")(i) + decimal128DataMap("l3")(i) +
+            decimal128DataMap("l1")(i) + decimal128DataMap("s4")(i)
+        } catch {
+          case _: ArithmeticException =>
+        }
+      }
+    }
+
+    benchmark.addCase("Decimal: lz1 + lz2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("lz1")(i) + decimalDataMap("lz2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: lz1 + lz2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("lz1")(i) + decimal128DataMap("lz2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: lz1 + lz2 + lz3 + lz4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("lz1")(i) + decimalDataMap("lz2")(i) +
+          decimalDataMap("lz3")(i) + decimalDataMap("lz4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: lz1 + lz2 + lz3 + lz4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("lz1")(i) + decimal128DataMap("lz2")(i) +
+          decimal128DataMap("lz3")(i) + decimal128DataMap("lz4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s2 + lz3 + lz1 + s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s2")(i) + decimalDataMap("lz3")(i) +
+          decimalDataMap("lz1")(i) + decimalDataMap("s4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s2 + lz3 + lz1 + s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s2")(i) + decimal128DataMap("lz3")(i) +
+          decimal128DataMap("lz1")(i) + decimal128DataMap("s4")(i)
+      }
+    }
+
+    benchmark.run()
+  }
+
+  def decimalMultiply(rowsNum: Int, numIters: Int): Unit = {
+    val benchmark = new Benchmark("Compare decimal multiply", rowsNum, output = output)
+
+    prepareDataInfo(benchmark)
+
+    decimalMap.clear()
+    decimalDataMap.clear()
+    decimal128DataMap.clear()
+
+    decimalMap.put("s1", DecimalType(5, 2))
+    decimalMap.put("s2", DecimalType(3, 1))
+    decimalMap.put("s3", DecimalType(10, 5))
+    decimalMap.put("s4", DecimalType(10, 2))
+    decimalMap.put("s5", DecimalType(3, 2))
+    decimalMap.put("s6", DecimalType(2, 1))
+
+    decimalMap.put("l1", DecimalType(19, 10))
+    decimalMap.put("l2", DecimalType(19, 5))
+
+    setUp(rowsNum, decimalMap.toMap, decimalDataMap, decimal128DataMap)
+
+    benchmark.addCase("Decimal: s1 * s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) * decimalDataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 * s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) * decimal128DataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s1 * s2 * s5 * s6", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) * decimalDataMap("s2")(i) *
+          decimalDataMap("s5")(i) * decimalDataMap("s6")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 * s2 * s5 * s6", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) * decimal128DataMap("s2")(i) *
+          decimal128DataMap("s5")(i) * decimal128DataMap("s6")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s3 * s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s3")(i) * decimalDataMap("s4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s3 * s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s3")(i) * decimal128DataMap("s4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l2 * s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l2")(i) * decimalDataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l2 * s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l2")(i) * decimal128DataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l2 * s2 * s5 * s6", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l2")(i) * decimalDataMap("s2")(i) *
+          decimalDataMap("s5")(i) * decimalDataMap("s6")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l2 * s2 * s5 * s6", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l2")(i) * decimal128DataMap("s2")(i) *
+          decimal128DataMap("s5")(i) * decimal128DataMap("s6")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s1 * l2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) * decimalDataMap("l2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 * l2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) * decimal128DataMap("l2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l1 * l2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l1")(i) * decimalDataMap("l2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l1 * l2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l1")(i) * decimal128DataMap("l2")(i)
+      }
+    }
+
+    benchmark.run()
+  }
+
+  def decimalDivision(rowsNum: Int, numIters: Int): Unit = {
+    val benchmark = new Benchmark("Compare decimal division", rowsNum, output = output)
+
+    prepareDataInfo(benchmark)
+
+    decimalMap.clear()
+    decimalDataMap.clear()
+    decimal128DataMap.clear()
+
+    decimalMap.put("s1", DecimalType(8, 3))
+    decimalMap.put("s2", DecimalType(6, 2))
+    decimalMap.put("s3", DecimalType(17, 7))
+    decimalMap.put("s4", DecimalType(3, 2))
+
+    decimalMap.put("l1", DecimalType(19, 3))
+    decimalMap.put("l2", DecimalType(20, 3))
+    decimalMap.put("l3", DecimalType(21, 10))
+    decimalMap.put("l4", DecimalType(19, 4))
+
+    setUp(rowsNum, decimalMap.toMap, decimalDataMap, decimal128DataMap)
+
+    benchmark.addCase("Decimal: s1 / s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) / decimalDataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 / s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) / decimal128DataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s1 / s2 / s2 / s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) / decimalDataMap("s2")(i) /
+          decimalDataMap("s2")(i) / decimalDataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 / s2 / s2 / s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) / decimal128DataMap("s2")(i) /
+          decimal128DataMap("s2")(i) / decimal128DataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s1 / s3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) / decimalDataMap("s3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 / s3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) / decimal128DataMap("s3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s2 / l1", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s2")(i) / decimalDataMap("l1")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s2 / l1", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s2")(i) / decimal128DataMap("l1")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l1 / s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l1")(i) / decimalDataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l1 / s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l1")(i) / decimal128DataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s3 / l1", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s3")(i) / decimalDataMap("l1")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s3 / l1", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s3")(i) / decimal128DataMap("l1")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l2 / l3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l2")(i) / decimalDataMap("l3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l2 / l3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l2")(i) / decimal128DataMap("l3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l2 / l4 / l4 / l4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l2")(i) / decimalDataMap("l4")(i) /
+          decimalDataMap("l4")(i) / decimalDataMap("l4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l2 / l4 / l4 / l4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l2")(i) / decimal128DataMap("l4")(i) /
+          decimal128DataMap("l4")(i) / decimal128DataMap("l4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l2 / s4 / s4 / s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l2")(i) / decimalDataMap("s4")(i) /
+          decimalDataMap("s4")(i) / decimalDataMap("s4")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l2 / s4 / s4 / s4", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l2")(i) / decimal128DataMap("s4")(i) /
+          decimal128DataMap("s4")(i) / decimal128DataMap("s4")(i)
+      }
+    }
+
+    benchmark.run()
+  }
+
+  def decimalModulo(rowsNum: Int, numIters: Int): Unit = {
+    val benchmark = new Benchmark("Compare decimal modulo", rowsNum, output = output)
+
+    prepareDataInfo(benchmark)
+
+    decimalMap.clear()
+    decimalDataMap.clear()
+    decimal128DataMap.clear()
+
+    decimalMap.put("s1", DecimalType(8, 3))
+    decimalMap.put("s2", DecimalType(6, 2))
+    decimalMap.put("s3", DecimalType(9, 0))
+    decimalMap.put("s4", DecimalType(12, 2))
+
+    decimalMap.put("l1", DecimalType(19, 3))
+    decimalMap.put("l2", DecimalType(20, 3))
+    decimalMap.put("l3", DecimalType(21, 10))
+    decimalMap.put("l4", DecimalType(19, 4))
+
+    setUp(rowsNum, decimalMap.toMap, decimalDataMap, decimal128DataMap)
+
+    benchmark.addCase("Decimal: s1 % s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) % decimalDataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 % s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) % decimal128DataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s1 % s2 % s2 % s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s1")(i) % decimalDataMap("s2")(i) %
+          decimalDataMap("s2")(i) % decimalDataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s1 % s2 % s2 % s2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s1")(i) % decimal128DataMap("s2")(i) %
+          decimal128DataMap("s2")(i) % decimal128DataMap("s2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s2 % l2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s2")(i) % decimalDataMap("l2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s2 % l2", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s2")(i) % decimal128DataMap("l2")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l3 % s3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l3")(i) % decimalDataMap("s3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l3 % s3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l3")(i) % decimal128DataMap("s3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: s4 % l3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("s4")(i) % decimalDataMap("l3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: s4 % l3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("s4")(i) % decimal128DataMap("l3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l2 % l3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l2")(i) % decimalDataMap("l3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l2 % l3", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l2")(i) % decimal128DataMap("l3")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal: l2 % l3 % l4 % l1", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimalDataMap("l2")(i) % decimalDataMap("l3")(i) %
+          decimalDataMap("l4")(i) % decimalDataMap("l1")(i)
+      }
+    }
+
+    benchmark.addCase("Decimal128: l2 % l3 % l4 % l1", numIters) { _ =>
+      for (i <- 0 until rowsNum) {
+        decimal128DataMap("l2")(i) % decimal128DataMap("l3")(i) %
+          decimal128DataMap("l4")(i) % decimal128DataMap("l1")(i)
+      }
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val numIters = 300
+    runBenchmark("Benchmark for performance of decimal") {
+      decimalAddition(COUNT, numIters)
+      decimalMultiply(COUNT, numIters)
+      decimalDivision(COUNT, numIters)
+      decimalModulo(COUNT, numIters)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DecimalBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DecimalBenchmark.scala
@@ -184,12 +184,8 @@ object DecimalBenchmark extends SqlBasedBenchmark {
 
     benchmark.addCase("Decimal128: s2 + l3 + l1 + s4", numIters) { _ =>
       for (i <- 0 until rowsNum) {
-        try {
-          decimal128DataMap("s2")(i) + decimal128DataMap("l3")(i) +
-            decimal128DataMap("l1")(i) + decimal128DataMap("s4")(i)
-        } catch {
-          case _: ArithmeticException =>
-        }
+        decimal128DataMap("s2")(i) + decimal128DataMap("l3")(i) +
+          decimal128DataMap("l1")(i) + decimal128DataMap("s4")(i)
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce a new physical type `Decimal128` for `DecimalType`.


### Why are the changes needed?
Spark SQL today supports the `Decimal` data type. The implementation of Spark `Decimal` holds a `BigDecimal` or `Long` value. Spark `Decimal` provides some operators like `+`, `-`, `*`, `/`, `%` and so on. These operators rely heavily on the computational power of `BigDecimal` or `Long` itself. For ease of understanding, take the `+` as an example. The implementation shows below.
```
  def + (that: Decimal): Decimal = {
    if (decimalVal.eq(null) && that.decimalVal.eq(null) && scale == that.scale) {
      Decimal(longVal + that.longVal, Math.max(precision, that.precision) + 1, scale)
    } else {
      Decimal(toBigDecimal.bigDecimal.add(that.toBigDecimal.bigDecimal))
    }
  }
```
We can see add the two `Long` value if Spark `Decimal` holds a `Long` value. Otherwise,  add the two `BigDecimal` if Spark `Decimal` holds a `BigDecimal` value. The other operators of Spark `Decimal` adopt the similar way. Furthermore, the code shown above calls `Decimal.apply` to construct a new instance of Spark `Decimal`.  As we know, the add operator of `BigDecimal` constructed a new instance of `BigDecimal`. In short, Spark `Decimal` is an immutable physical type. Through rough analysis, we know the calculation operators of Spark `Decimal` create a lot of new instances of `Decimal` and may create a lot of new instances of `BigDecimal`.If a large table has a field called 'colA whose type is Spark `Decimal`, the execution of SUM('colA) will involve the creation of a large number of Spark `Decimal` instances and `BigDecimal` instances. These Spark `Decimal` instances and `BigDecimal` instances will lead to garbage collection frequently.

`Int128` is a high-performance data type about 1X~6X more efficient than `BigDecimal` for typical operations. It uses a finite (128 bit) precision and can handle up to decimal(38, X). The implementation of `Int128` just uses two `Long` values to represent the high and low bits of 128 bits respectively. `Int128` is lighter than `BigDecimal`, reduces the cost of new() and garbage collection.

Spark could support a new physical type to represent the `DecimalType` with `Int128`, it would improve the performance for calculation operators.
Now, let's call the new physical type `Decimal128`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New test cases.

Manual test benchmark

```
Compare decimal addition:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Decimal: s1 + s2                                      6              7           2         17.7          56.4       1.0X
Decimal128: s1 + s2                                   2              2           0         43.1          23.2       2.4X
Decimal: s1 + s2 + s3 + s4                           14             15           1          7.1         140.6       0.4X
Decimal128: s1 + s2 + s3 + s4                         6              8           1         15.6          64.2       0.9X
Decimal: l1 + l2                                     13             14           1          7.6         130.7       0.4X
Decimal128: l1 + l2                                   4              5           0         23.2          43.2       1.3X
Decimal: l1 + l2 + l3 + l4                           34             35           1          2.9         342.3       0.2X
Decimal128: l1 + l2 + l3 + l4                        14             15           0          7.2         138.7       0.4X
Decimal: s2 + l3 + l1 + s4                           40             41           1          2.5         395.7       0.1X
Decimal128: s2 + l3 + l1 + s4                        25             26           1          3.9         253.7       0.2X
Decimal: lz1 + lz2                                   13             14           1          7.7         129.5       0.4X
Decimal128: lz1 + lz2                                 4              4           0         26.6          37.6       1.5X
Decimal: lz1 + lz2 + lz3 + lz4                       37             38           1          2.7         368.4       0.2X
Decimal128: lz1 + lz2 + lz3 + lz4                    11             12           0          8.8         113.5       0.5X
Decimal: s2 + lz3 + lz1 + s4                         38             39           1          2.6         381.3       0.1X
Decimal128: s2 + lz3 + lz1 + s4                      19             20           1          5.2         194.2       0.3X
```

```
Compare decimal multiply:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Decimal: s1 * s2                                      5              5           0         19.5          51.3       1.0X
Decimal128: s1 * s2                                   2              2           0         44.1          22.7       2.3X
Decimal: s1 * s2 * s5 * s6                           13             15           1          7.5         132.6       0.4X
Decimal128: s1 * s2 * s5 * s6                         5              5           0         20.5          48.7       1.1X
Decimal: s3 * s4                                      9              9           1         11.4          87.9       0.6X
Decimal128: s3 * s4                                   3              3           0         32.5          30.7       1.7X
Decimal: l2 * s2                                      9             10           1         11.2          89.2       0.6X
Decimal128: l2 * s2                                   3              3           0         30.2          33.1       1.6X
Decimal: l2 * s2 * s5 * s6                           23             25           3          4.3         234.9       0.2X
Decimal128: l2 * s2 * s5 * s6                        12             12           0          8.6         115.8       0.4X
Decimal: s1 * l2                                      9             10           0         10.6          94.1       0.5X
Decimal128: s1 * l2                                   3              3           0         31.8          31.5       1.6X
Decimal: l1 * l2                                     10             10           0         10.2          97.7       0.5X
Decimal128: l1 * l2                                   3              3           0         31.9          31.4       1.6X
```

```
Compare decimal division:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Decimal: s1 / s2                                     18             18           1          5.7         175.7       1.0X
Decimal128: s1 / s2                                   5              5           0         21.1          47.5       3.7X
Decimal: s1 / s2 / s2 / s2                           47             49           1          2.1         473.9       0.4X
Decimal128: s1 / s2 / s2 / s2                         9              9           0         11.1          90.3       1.9X
Decimal: s1 / s3                                     27             28           1          3.7         270.2       0.7X
Decimal128: s1 / s3                                   4              4           0         25.0          40.1       4.4X
Decimal: s2 / l1                                     25             25           1          4.1         245.8       0.7X
Decimal128: s2 / l1                                   4              4           0         23.7          42.3       4.2X
Decimal: l1 / s2                                     20             21           1          5.1         197.5       0.9X
Decimal128: l1 / s2                                   4              4           0         24.0          41.7       4.2X
Decimal: s3 / l1                                     28             29           1          3.5         282.1       0.6X
Decimal128: s3 / l1                                   4              4           0         24.1          41.4       4.2X
Decimal: l2 / l3                                     34             35           1          2.9         340.1       0.5X
Decimal128: l2 / l3                                  21             22           1          4.7         213.9       0.8X
Decimal: l2 / l4 / l4 / l4                           68             71           2          1.5         681.1       0.3X
Decimal128: l2 / l4 / l4 / l4                        23             24           1          4.3         230.7       0.8X
Decimal: l2 / s4 / s4 / s4                           58             60           1          1.7         576.0       0.3X
Decimal128: l2 / s4 / s4 / s4                        40             42           1          2.5         399.2       0.4X
```

```
Compare decimal modulo:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Decimal: s1 % s2                                     36             37           1          2.8         356.6       1.0X
Decimal128: s1 % s2                                  18             19           1          5.6         178.6       2.0X
Decimal: s1 % s2 % s2 % s2                           50             52           1          2.0         501.1       0.7X
Decimal128: s1 % s2 % s2 % s2                        50             51           1          2.0         496.4       0.7X
Decimal: s2 % l2                                      8              9           1         12.9          77.6       4.6X
Decimal128: s2 % l2                                  17             17           1          6.1         165.2       2.2X
Decimal: l3 % s3                                     50             52           1          2.0         503.1       0.7X
Decimal128: l3 % s3                                  16             16           1          6.4         155.4       2.3X
Decimal: s4 % l3                                      8              9           2         12.8          77.9       4.6X
Decimal128: s4 % l3                                  13             14           0          7.4         134.8       2.6X
Decimal: l2 % l3                                     14             15           0          6.9         144.2       2.5X
Decimal128: l2 % l3                                  16             17           1          6.2         162.5       2.2X
Decimal: l2 % l3 % l4 % l1                           85             88           2          1.2         854.1       0.4X
Decimal128: l2 % l3 % l4 % l1                        51             54           2          1.9         513.4       0.7X
```

In some cases, division will have performance regression