### PR TITLE
[SPARK-42613][CORE][PYTHON][YARN] PythonRunner should set OMP_NUM_THREADS to task cpus instead of executor cores by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -135,12 +135,10 @@ private[spark] abstract class BasePythonRunner[IN, OUT](
     val execCoresProp = Option(context.getLocalProperty(EXECUTOR_CORES_LOCAL_PROPERTY))
     val memoryMb = Option(context.getLocalProperty(PYSPARK_MEMORY_LOCAL_PROPERTY)).map(_.toLong)
     val localdir = env.blockManager.diskBlockManager.localDirs.map(f => f.getPath()).mkString(",")
-    // if OMP_NUM_THREADS is not explicitly set, override it with the number of cores
+    // If OMP_NUM_THREADS is not explicitly set, override it with the number of task cpus.
+    // See SPARK-42613 for details.
     if (conf.getOption("spark.executorEnv.OMP_NUM_THREADS").isEmpty) {
-      // SPARK-28843: limit the OpenMP thread pool to the number of cores assigned to this executor
-      // this avoids high memory consumption with pandas/numpy because of a large OpenMP thread pool
-      // see https://github.com/numpy/numpy/issues/10455
-      execCoresProp.foreach(envVars.put("OMP_NUM_THREADS", _))
+      envVars.put("OMP_NUM_THREADS", conf.get("spark.task.cpus", "1"))
     }
     envVars.put("SPARK_LOCAL_DIRS", localdir) // it's also used in monitor thread
     if (reuseWorker) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set OMP_NUM_THREADS to `spark.task.cpus` instead of `spark.executor.cores` by default.

### Why are the changes needed?

If OMP_NUM_THREADS is set to executor cores, we might still have issues when the number of executer cores is large but the number of task cpus is 1.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Run the following PySpark UDF script with these 2 Spark properties:

- spark.executor.cores=3
- spark.task.cpus=1

```python
import os
from pyspark.sql import SparkSession
from pyspark.sql.functions import udf

spark = SparkSession.builder.getOrCreate()

var_name = 'OMP_NUM_THREADS'

def get_env_var():
  return os.getenv(var_name)

udf_get_env_var = udf(get_env_var)
spark.range(1).toDF("id").withColumn(f"env_{var_name}", udf_get_env_var()).show(truncate=False)
```

Output with release `3.3.0`:

```
+---+-------------------+
|id |env_OMP_NUM_THREADS|
+---+-------------------+
|0  |3                  |
+---+-------------------+
```

After the fix:

```
+---+-------------------+
|id |env_OMP_NUM_THREADS|
+---+-------------------+
|0  |1                  |
+---+-------------------+
```