### PR TITLE
[SPARK-42624][PYTHON][TESTS] Reorganize imports in test_functions

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -18,6 +18,7 @@
 import unittest
 
 from pyspark.errors.exceptions.connect import SparkConnectException
+from pyspark.sql.connect.column import Column
 from pyspark.sql.tests.test_functions import FunctionsTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
@@ -42,8 +43,6 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
         self.check_raise_error(SparkConnectException)
 
     def test_sorting_functions_with_column(self):
-        from pyspark.sql.connect.column import Column
-
         self.check_sorting_functions_with_column(Column)
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reorganizes imports in `python/pyspark/sql/tests/test_functions.py`.

### Why are the changes needed?

Currently imports in the file `python/pyspark/sql/tests/test_functions.py` is not organized well.

There are individual imports in test functions, or imports by function names or module names, etc.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Modified tests.