### PR TITLE
[SPARK-42625][BUILD] Upgrade `zstd-jni` to 1.5.4-2

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1033-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            605            812         220          0.0       60521.0       1.0X
-Compression 10000 times at level 2 without buffer pool            665            678          20          0.0       66512.5       0.9X
-Compression 10000 times at level 3 without buffer pool            890            903          20          0.0       88961.3       0.7X
-Compression 10000 times at level 1 with buffer pool               829            839          11          0.0       82940.2       0.7X
-Compression 10000 times at level 2 with buffer pool               904            905           1          0.0       90392.3       0.7X
-Compression 10000 times at level 3 with buffer pool              1118           1118           0          0.0      111788.5       0.5X
+Compression 10000 times at level 1 without buffer pool            521            528          10          0.0       52128.1       1.0X
+Compression 10000 times at level 2 without buffer pool            762            766           6          0.0       76186.6       0.7X
+Compression 10000 times at level 3 without buffer pool            956            961           5          0.0       95621.0       0.5X
+Compression 10000 times at level 1 with buffer pool               470            473           4          0.0       46977.0       1.1X
+Compression 10000 times at level 2 with buffer pool               531            534           2          0.0       53141.9       1.0X
+Compression 10000 times at level 3 with buffer pool               728            728           0          0.0       72777.9       0.7X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1033-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           1191           1193           1          0.0      119147.4       1.0X
-Decompression 10000 times from level 2 without buffer pool           1181           1207          37          0.0      118103.4       1.0X
-Decompression 10000 times from level 3 without buffer pool           1188           1194           9          0.0      118810.6       1.0X
-Decompression 10000 times from level 1 with buffer pool              1000           1007          10          0.0       99963.8       1.2X
-Decompression 10000 times from level 2 with buffer pool              1000           1000           1          0.0       99984.2       1.2X
-Decompression 10000 times from level 3 with buffer pool               997            999           1          0.0       99732.9       1.2X
+Decompression 10000 times from level 1 without buffer pool            650            651           1          0.0       64985.4       1.0X
+Decompression 10000 times from level 2 without buffer pool            646            647           1          0.0       64607.7       1.0X
+Decompression 10000 times from level 3 without buffer pool            647            648           1          0.0       64694.4       1.0X
+Decompression 10000 times from level 1 with buffer pool               456            458           2          0.0       45640.6       1.4X
+Decompression 10000 times from level 2 with buffer pool               455            456           0          0.0       45544.2       1.4X
+Decompression 10000 times from level 3 with buffer pool               456            456           0          0.0       45555.6       1.4X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1033-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           2732           2756          34          0.0      273230.8       1.0X
-Compression 10000 times at level 2 without buffer pool           2715           2771          79          0.0      271510.2       1.0X
-Compression 10000 times at level 3 without buffer pool           2919           2976          80          0.0      291941.6       0.9X
-Compression 10000 times at level 1 with buffer pool              2364           2365           1          0.0      236406.8       1.2X
-Compression 10000 times at level 2 with buffer pool              2469           2478          12          0.0      246903.1       1.1X
-Compression 10000 times at level 3 with buffer pool              2660           2666           9          0.0      265959.4       1.0X
+Compression 10000 times at level 1 without buffer pool           2788           2790           2          0.0      278818.1       1.0X
+Compression 10000 times at level 2 without buffer pool           2843           2845           2          0.0      284333.7       1.0X
+Compression 10000 times at level 3 without buffer pool           3010           3035          35          0.0      300966.0       0.9X
+Compression 10000 times at level 1 with buffer pool              2655           2655           0          0.0      265474.7       1.1X
+Compression 10000 times at level 2 with buffer pool              2691           2692           0          0.0      269145.5       1.0X
+Compression 10000 times at level 3 with buffer pool              2825           2828           4          0.0      282471.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1033-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           2518           2520           3          0.0      251829.1       1.0X
-Decompression 10000 times from level 2 without buffer pool           2513           2536          32          0.0      251273.1       1.0X
-Decompression 10000 times from level 3 without buffer pool           2508           2508           1          0.0      250786.2       1.0X
-Decompression 10000 times from level 1 with buffer pool              2339           2353          19          0.0      233916.5       1.1X
-Decompression 10000 times from level 2 with buffer pool              2344           2348           5          0.0      234435.7       1.1X
-Decompression 10000 times from level 3 with buffer pool              2359           2370          16          0.0      235882.7       1.1X
+Decompression 10000 times from level 1 without buffer pool           2740           2749          14          0.0      273978.5       1.0X
+Decompression 10000 times from level 2 without buffer pool           2743           2745           2          0.0      274344.7       1.0X
+Decompression 10000 times from level 3 without buffer pool           2744           2746           2          0.0      274396.1       1.0X
+Decompression 10000 times from level 1 with buffer pool              2617           2617           1          0.0      261670.1       1.0X
+Decompression 10000 times from level 2 with buffer pool              2615           2617           3          0.0      261500.1       1.0X
+Decompression 10000 times from level 3 with buffer pool              2616           2616           1          0.0      261565.9       1.0X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1033-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            369            424          73          0.0       36865.0       1.0X
-Compression 10000 times at level 2 without buffer pool            409            411           1          0.0       40897.8       0.9X
-Compression 10000 times at level 3 without buffer pool            539            543           3          0.0       53932.2       0.7X
-Compression 10000 times at level 1 with buffer pool               163            164           1          0.1       16273.9       2.3X
-Compression 10000 times at level 2 with buffer pool               204            208           6          0.0       20421.0       1.8X
-Compression 10000 times at level 3 with buffer pool               331            332           1          0.0       33078.9       1.1X
+Compression 10000 times at level 1 without buffer pool            396            527         150          0.0       39554.9       1.0X
+Compression 10000 times at level 2 without buffer pool            451            453           2          0.0       45109.2       0.9X
+Compression 10000 times at level 3 without buffer pool            639            640           1          0.0       63949.2       0.6X
+Compression 10000 times at level 1 with buffer pool               192            197           3          0.1       19199.2       2.1X
+Compression 10000 times at level 2 with buffer pool               243            250           4          0.0       24310.4       1.6X
+Compression 10000 times at level 3 with buffer pool               417            431           9          0.0       41711.5       0.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1033-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            544            547           2          0.0       54409.4       1.0X
-Decompression 10000 times from level 2 without buffer pool            544            548           3          0.0       54424.3       1.0X
-Decompression 10000 times from level 3 without buffer pool            545            548           3          0.0       54471.4       1.0X
-Decompression 10000 times from level 1 with buffer pool               434            435           1          0.0       43372.8       1.3X
-Decompression 10000 times from level 2 with buffer pool               434            435           1          0.0       43405.0       1.3X
-Decompression 10000 times from level 3 with buffer pool               434            435           1          0.0       43405.1       1.3X
+Decompression 10000 times from level 1 without buffer pool            687            689           2          0.0       68670.4       1.0X
+Decompression 10000 times from level 2 without buffer pool            685            688           3          0.0       68507.1       1.0X
+Decompression 10000 times from level 3 without buffer pool            686            687           2          0.0       68591.8       1.0X
+Decompression 10000 times from level 1 with buffer pool               497            499           2          0.0       49662.2       1.4X
+Decompression 10000 times from level 2 with buffer pool               496            498           2          0.0       49645.5       1.4X
+Decompression 10000 times from level 3 with buffer pool               496            498           2          0.0       49649.5       1.4X
 
 

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -268,4 +268,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.4-1//zstd-jni-1.5.4-1.jar
+zstd-jni/1.5.4-2//zstd-jni-1.5.4-2.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -253,4 +253,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.4-1//zstd-jni-1.5.4-1.jar
+zstd-jni/1.5.4-2//zstd-jni-1.5.4-2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -806,7 +806,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.4-1</version>
+        <version>1.5.4-2</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to 1.5.4-2. I'll update this PR with the benchmark results soon.

### Why are the changes needed?

To bring the following bug fixes of `v1.5.4-2`,
- https://github.com/luben/zstd-jni/releases/tag/v1.5.4-2
  - https://github.com/luben/zstd-jni/commit/1317e44493c676b1164c8b0398616d43fa349b5b
> This avoids having to lookup the field and fixes a bug where the
wrong fieldId was passed causing a segfault if
ZstdDecompressCtx#reset() was called before ZstdCompressCtx() was used.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass the CI.