### PR TITLE
[SPARK-41870][CONNECT][PYTHON] Fix createDataFrame to handle duplicated column names

### DIFF
--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -250,6 +250,8 @@ class LocalDataToArrowConversion:
         pylist: List[List] = [[] for _ in range(len(column_names))]
 
         for item in data:
+            if not isinstance(item, Row) and hasattr(item, "__dict__"):
+                item = item.__dict__
             for i, col in enumerate(column_names):
                 if isinstance(item, dict):
                     value = item.get(col)

--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -252,7 +252,7 @@ class LocalDataToArrowConversion:
         for item in data:
             for i, col in enumerate(column_names):
                 if isinstance(item, dict):
-                    value = item[col]
+                    value = item.get(col)
                 else:
                     value = item[i]
 

--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -243,36 +243,22 @@ class LocalDataToArrowConversion:
 
         column_names = schema.fieldNames()
 
-        column_convs = {
-            field.name: LocalDataToArrowConversion._create_converter(field.dataType)
-            for field in schema.fields
-        }
+        column_convs = [
+            LocalDataToArrowConversion._create_converter(field.dataType) for field in schema.fields
+        ]
 
-        pylist = []
+        pylist: List[List] = [[] for _ in range(len(column_names))]
 
         for item in data:
-            _dict = {}
+            for i, col in enumerate(column_names):
+                if isinstance(item, dict):
+                    value = item[col]
+                else:
+                    value = item[i]
 
-            if isinstance(item, dict):
-                for col, value in item.items():
-                    _dict[col] = column_convs[col](value)
-            elif isinstance(item, Row) and hasattr(item, "__fields__"):
-                for col, value in item.asDict(recursive=False).items():
-                    _dict[col] = column_convs[col](value)
-            elif not isinstance(item, Row) and hasattr(item, "__dict__"):
-                for col, value in item.__dict__.items():
-                    print(col, value)
-                    _dict[col] = column_convs[col](value)
-            else:
-                i = 0
-                for value in item:
-                    col = column_names[i]
-                    _dict[col] = column_convs[col](value)
-                    i += 1
+                pylist[i].append(column_convs[i](value))
 
-            pylist.append(_dict)
-
-        return pa.Table.from_pylist(pylist, schema=pa_schema)
+        return pa.Table.from_arrays(pylist, schema=pa_schema)
 
 
 class ArrowTableToRowsConversion:

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -32,11 +32,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_create_dataframe_from_pandas_with_dst(self):
         super().test_create_dataframe_from_pandas_with_dst()
 
-    # TODO(SPARK-41870): Handle duplicate columns in `createDataFrame`
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_duplicated_column_names(self):
-        super().test_duplicated_column_names()
-
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_help_command(self):
         super().test_help_command()


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `createDataFrame` to handle duplicated column names.

### Why are the changes needed?

Currently the following command returns a wrong result:

```py
>>> spark.createDataFrame([(1, 2)], ["c", "c"]).show()
+---+---+
|  c|  c|
+---+---+
|  2|  2|
+---+---+
```

### Does this PR introduce _any_ user-facing change?

Duplicated column names will work:

```py
>>> spark.createDataFrame([(1, 2)], ["c", "c"]).show()
+---+---+
|  c|  c|
+---+---+
|  1|  2|
+---+---+
```

### How was this patch tested?

Enabled the related test.