### PR TITLE
[MINOR][BUILD] Delete a invalid TODO from `dev/test-dependencies.sh`

### DIFF
--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -64,7 +64,6 @@ SCALA_BINARY_VERSION=$($MVN -q \
     --non-recursive \
     org.codehaus.mojo:exec-maven-plugin:1.6.0:exec | grep -E '[0-9]+\.[0-9]+')
 if [[ "$SCALA_BINARY_VERSION" != "2.12" ]]; then
-  # TODO(SPARK-36168) Support Scala 2.13 in dev/test-dependencies.sh
   echo "Skip dependency testing on $SCALA_BINARY_VERSION"
   exit 0
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just delete a invalid `TODO(SPARK-36168)` from `dev/test-dependencies.sh` due to SPARK-36168 has been identified as `Not A Problem`.




### Why are the changes needed?
Delete a invalid TODO.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions