### PR TITLE
[WIP][SPARK-42630][CONNECT][PYTHON] Make `parse_data_type` use new proto message `DDLParse`

### DIFF
--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -349,13 +349,9 @@ def parse_data_type(data_type: str) -> DataType:
     from pyspark.sql import SparkSession as PySparkSession
 
     assert is_remote()
-    return_type_schema = (
-        PySparkSession.builder.getOrCreate().createDataFrame(data=[], schema=data_type).schema
-    )
-    with_col_name = " " in data_type.strip()
-    if len(return_type_schema.fields) == 1 and not with_col_name:
-        # To match pyspark.sql.types._parse_datatype_string
-        return_type = return_type_schema.fields[0].dataType
-    else:
-        return_type = return_type_schema
-    return return_type
+    session = PySparkSession.builder.getOrCreate()
+    parsed = session.client._analyze(  # type: ignore[attr-defined]
+        method="ddl_parse", ddl_string=data_type
+    ).parsed
+    assert parsed is not None
+    return proto_schema_to_pyspark_data_type(parsed)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `parse_data_type` use new proto message `DDLParse`

### Why are the changes needed?
when the ddl_string represents an atomic type, existing method based on `DataFrame.schema` (which is always a StructType) has an extra conversion: AtomicType -> StructType -> AtomicType

This PR leverages the dedicated proto message


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing UT