### PR TITLE
[SPARK-42458][CONNECT][PYTHON] Fixes createDataFrame to support DDL string as schema

### DIFF
--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -692,9 +692,6 @@ def _test() -> None:
 
     globs = pyspark.sql.connect.readwriter.__dict__.copy()
 
-    # TODO(SPARK-42458): createDataFrame should support DDL string as schema
-    del pyspark.sql.connect.readwriter.DataFrameWriter.option.__doc__
-
     globs["spark"] = (
         PySparkSession.builder.appName("sql.connect.readwriter tests")
         .remote("local[4]")

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -313,6 +313,8 @@ class SparkSession:
                 # For cases like createDataFrame([("Alice", None, 80.1)], schema)
                 # we can not infer the schema from the data itself.
                 warnings.warn("failed to infer the schema from data")
+                if _schema is None and _schema_str is not None:
+                    _schema = self.createDataFrame([], schema=_schema_str).schema
                 if _schema is None or not isinstance(_schema, StructType):
                     raise ValueError(
                         "Some of types cannot be determined after inferring, "


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `createDataFrame` to support DDL string as schema.

### Why are the changes needed?

Currently DDL string as schema is ignored when the data is Python objects and the inference fails:

```py
>>> spark.createDataFrame([(100, None)], "age INT, name STRING").show()
Traceback (most recent call last):
...
ValueError: Some of types cannot be determined after inferring, a StructType Schema is required in this case
```

### Does this PR introduce _any_ user-facing change?

The DDL string as schema will not be ignored when the schema can't be inferred from the given data.

```py
>>> spark.createDataFrame([(100, None)], "age INT, name STRING").show()
+---+----+
|age|name|
+---+----+
|100|null|
+---+----+
```

### How was this patch tested?

Enabled related tests.