### PR TITLE
[SPARK-41823][CONNECT][FOLLOW-UP][TESTS] Disable ANSI mode in ProtoToParsedPlanTestSuite

### DIFF
--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -65,6 +65,7 @@ class ProtoToParsedPlanTestSuite extends SparkFunSuite with SharedSparkSession {
       .set(
         Connect.CONNECT_EXTENSIONS_EXPRESSION_CLASSES.key,
         "org.apache.spark.sql.connect.plugin.ExampleExpressionPlugin")
+      .set(org.apache.spark.sql.internal.SQLConf.ANSI_ENABLED.key, false.toString)
   }
 
   protected val baseResourcePath: Path = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to disable ANSI mode in `ProtoToParsedPlanTestSuite`.

### Why are the changes needed?

The plan suite is independent from ANSI mode as it does not check the result itself, and some tests fail when ANSI mode is on (https://github.com/apache/spark/actions/runs/4299081862/jobs/7493923661):

```
[info] - function_to_date_with_format *** FAILED *** (12 milliseconds)
[info]   Expected and actual plans do not match:
[info]   
[info]   === Expected Plan ===
[info]   Project [cast(gettimestamp(s#0, yyyy-MM-dd, TimestampType, Some(America/Los_Angeles), false) as date) AS to_date(s, yyyy-MM-dd)#0]
[info]   +- LocalRelation <empty>, [d#0, t#0, s#0, x#0L, wt#0]
[info]   
[info]   
[info]   === Actual Plan ===
[info]   Project [cast(gettimestamp(s#0, yyyy-MM-dd, TimestampType, Some(America/Los_Angeles), true) as date) AS to_date(s, yyyy-MM-dd)#0]
[info]   +- LocalRelation <empty>, [d#0, t#0, s#0, x#0L, wt#0] (ProtoToParsedPlanTestSuite.scala:129)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.funsuite.AnyFunSuite.newAssertionFailedException(AnyFunSuite.scala:1564)
[info]   at org.scalatest.Assertions.fail(Assertions.scala:933)
[info]   at org.scalatest.Assertions.fail$(Assertions.scala:929)
[info]   at org.scalatest.funsuite.AnyFunSuite.fail(AnyFunSuite.scala:1564)
[info]   at org.apache.spark.sql.connect.ProtoToParsedPlanTestSuite.$anonfun$createTest$2(ProtoToParsedPlanTestSuite.scala:129)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
```


### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested.