### PR TITLE
[SPARK-42646][BUILD] Upgrade cyclonedx from 2.7.3 to 2.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3436,7 +3436,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.3</version>
+        <version>2.7.5</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade cyclonedx from 2.7.3 to 2.7.5.

### Why are the changes needed?
> When I run: mvn -DskipTests clean package,

During compilation, the following error message appears:
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/15246973/222338040-d7c8d595-be0b-40bb-af49-6b260dc0c425.png">
#### When I upgrade the cyclonedx version to 2.7.5, the above error message disappears.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual check & Pass GA.