### PR TITLE
[SPARK-42648][BUILD] Upgrade `versions-maven-plugin` to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
       See: SPARK-36547, SPARK-38394.
        -->
     <scala-maven-plugin.version>4.8.0</scala-maven-plugin.version>
-    <versions-maven-plugin.version>2.14.2</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `versions-maven-plugin` to 2.15.0


### Why are the changes needed?
New version bring some improvements like:
- https://github.com/mojohaus/versions/pull/898
- https://github.com/mojohaus/versions/pull/883
- https://github.com/mojohaus/versions/pull/878
- https://github.com/mojohaus/versions/pull/893

and some bug fix:
- https://github.com/mojohaus/versions/pull/901
- https://github.com/mojohaus/versions/pull/897
- https://github.com/mojohaus/versions/pull/891


The full release notes as follows:
- https://github.com/mojohaus/versions/releases/tag/2.15.0


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- GA `Dependencies test` should work normally
- Manually check `./dev/test-dependencies.sh --replace-manifest`, run successful

