### PR TITLE
[SPARK-42649][CORE] Remove the standard Apache License header from the top of third-party source files

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/LimitedInputStream.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/LimitedInputStream.java
@@ -1,21 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
  * Based on LimitedInputStream.java from Google Guava
  *
  * Copyright (C) 2007 The Guava Authors

--- a/core/src/main/java/org/apache/spark/util/collection/TimSort.java
+++ b/core/src/main/java/org/apache/spark/util/collection/TimSort.java
@@ -1,21 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
  * Based on TimSort.java from the Android Open Source Project
  *
  *  Copyright (C) 2008 The Android Open Source Project

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -141,3 +141,5 @@ any.proto
 empty.proto
 .*\.explain
 .*\.proto.bin
+LimitedInputStream.java
+TimSort.java


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the standard Apache License header from the top of third-party source files.

According to LICENSE file, I found two files.
- https://github.com/apache/spark/blob/master/LICENSE

### Why are the changes needed?

This was requested via `dev@spark` mailing list.
- https://lists.apache.org/thread/wfy9sykncw2znhzlvyd18bkyjr7l9x43

Here is the ASF legal policy.
- https://www.apache.org/legal/src-headers.html#3party
> Do not add the standard Apache License header to the top of third-party source files.

### Does this PR introduce _any_ user-facing change?

No. This is a source code distribution.

### How was this patch tested?

Manual review.