### PR TITLE
[SPARK-42615][CONNECT][FOLLOWUP] Fix SparkConnectAnalyzeHandler to use withActive

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
@@ -37,10 +37,11 @@ private[connect] class SparkConnectAnalyzeHandler(
       SparkConnectService
         .getOrCreateIsolatedSession(request.getUserContext.getUserId, request.getClientId)
         .session
-
-    val response = process(request, session)
-    responseObserver.onNext(response)
-    responseObserver.onCompleted()
+    session.withActive {
+      val response = process(request, session)
+      responseObserver.onNext(response)
+      responseObserver.onCompleted()
+    }
   }
 
   def process(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `SparkConnectAnalyzeHandler` to use `withActive`.

### Why are the changes needed?

Similar to #40165, `SQLConf.get` is necessary when transforming the proto to plans.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.