### PR TITLE
[SPARK-42659][ML] Reimplement `FPGrowthModel.transform` with dataframe operations

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/fpm/FPGrowth.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/fpm/FPGrowth.scala
@@ -290,19 +290,15 @@ class FPGrowthModel private[ml] (
     ).withColumn(
       $(predictionCol),
       when(not(isnull(col($(itemsCol)))),
-        array_sort(
-          array_distinct(
-            aggregate(
-              col($(predictionCol)),
-              array().cast(arrayType),
-              (r, s) => when(
-                forall(s.getField("antecedent"),
-                  c => array_contains(col($(itemsCol)), c)),
-                array_union(r,
-                  array_except(s.getField("consequent"), col($(itemsCol))))
-              ).otherwise(r)
-            )
-          )
+        aggregate(
+          col($(predictionCol)),
+          array().cast(arrayType),
+          (r, s) => when(
+            forall(s.getField("antecedent"),
+              c => array_contains(col($(itemsCol)), c)),
+            array_union(r,
+              array_except(s.getField("consequent"), col($(itemsCol))))
+          ).otherwise(r)
         )
       ).otherwise(array().cast(arrayType))
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reimplement `FPGrowthModel.transform` with dataframe operations


### Why are the changes needed?
delay the `collect()` execution of model dataframe `associationRules`

increase the optimization space of SQL optimizer


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing UT