### PR TITLE
[SPARK-42653][CONNECT][FOLLOW-UP] Fix Scala 2.13 build failure by explicit Seq conversion

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
@@ -85,6 +85,7 @@ class ArtifactSuite extends ConnectFunSuite with BeforeAndAfterEach {
       .readAllLines(artifactCrcPath.resolve(crcFileName))
       .asScala
       .map(_.toLong)
+      .toSeq
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `toSeq` to work around Scala 2.13 build at `getCrcValues`.



### Why are the changes needed?

The build in the master branch fails in Scala 2.13 build:

```
[error] /home/runner/work/spark/spark/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala:87:11: type mismatch;
[error]  found   : scala.collection.mutable.Buffer[Long]
[error]  required: Seq[Long]
[error]       .map(_.toLong)
[error]           ^
```

https://github.com/apache/spark/actions/runs/4323142317/jobs/7546408812

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should test it out.