### PR TITLE
SPARK-42258][PYTHON] pyspark.sql.functions should not expose typing.cast

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -24,7 +24,8 @@ import functools
 import warnings
 from typing import (
     Any,
-    cast,
+    # SPARK-42258: pyspark.sql.functions should not expose typing.cast
+    cast as _cast,
     Callable,
     Dict,
     List,
@@ -3894,7 +3895,7 @@ def log(arg1: Union["ColumnOrName", float], arg2: Optional["ColumnOrName"] = Non
     +-----------------+
     """
     if arg2 is None:
-        return _invoke_function_over_columns("log", cast("ColumnOrName", arg1))
+        return _invoke_function_over_columns("log", _cast("ColumnOrName", arg1))
     else:
         return _invoke_function("log", arg1, _to_java_column(arg2))
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1268,6 +1268,12 @@ class FunctionsTestsMixin:
             message_parameters={"arg_name": "numBuckets", "arg_type": "str"},
         )
 
+    def test_no_cast(self):
+        # SPARK-42258: pyspark.sql.functions should not expose typing.cast
+        from pyspark.sql import functions
+
+        self.assertFalse(hasattr(functions, "cast"))
+
 
 class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):
     pass


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

In the `pyspark.sql.functions`, we replaced `from typing import foo, bar, etc` with `import typing` and all
uses of `foo`, `bar` and `etc` in that module were replaced with `typing.foo`, `typing.bar` and `typing.etc`.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

Exposing methods from `typing` inside `spark.sql.functions` could lead to confusing errors on the user side, like in this example:
```
from pyspark.sql import SparkSession
from pyspark.sql import functions as f

spark = SparkSession.builder.getOrCreate()
df = spark.sql("""SELECT 1 as a""")
df.withColumn("a", f.cast("STRING", f.col("a"))).printSchema()  
```
The code above runs without raising any error but yields an incorrect result:
```
root
|-- a: integer (nullable = false)
```

This is because `f.cast` is in fact `typing.cast` and we should have used `f.col("a").cast("STRING")` instead.


<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes, if a user has made the mistake described in the example above, their code that did run (with an incorrect behaviour) will instead break after they upgrade to a version containing this change. 
But one could argue that it would be a good thing, since it will expose a mistake in their code.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
No new test were added.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
