### PR TITLE
[SPARK-42667][CONNECT] Spark Connect: newSession API

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -344,7 +344,9 @@ class SparkSession private[sql] (
   // scalastyle:on
 
   def newSession(): SparkSession = {
-    throw new UnsupportedOperationException("newSession is not supported")
+    val newClient: SparkConnectClient =
+      new SparkConnectClient(this.client.userContext, this.client.channel, this.client.userAgent)
+    SparkSession.builder().client(newClient).build()
   }
 
   private def range(

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -344,9 +344,7 @@ class SparkSession private[sql] (
   // scalastyle:on
 
   def newSession(): SparkSession = {
-    val newClient: SparkConnectClient =
-      new SparkConnectClient(this.client.userContext, this.client.channel, this.client.userAgent)
-    SparkSession.builder().client(newClient).build()
+    SparkSession.builder().client(client.copy()).build()
   }
 
   private def range(

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -30,9 +30,9 @@ import org.apache.spark.sql.connect.common.config.ConnectCommon
  * Conceptually the remote spark session that communicates with the server.
  */
 private[sql] class SparkConnectClient(
-    private[sql] val userContext: proto.UserContext,
-    private[sql] val channel: ManagedChannel,
-    private[sql] val userAgent: String) {
+    private val userContext: proto.UserContext,
+    private val channel: ManagedChannel,
+    private[client] val userAgent: String) {
 
   private[this] val stub = proto.SparkConnectServiceGrpc.newBlockingStub(channel)
 
@@ -147,6 +147,10 @@ private[sql] class SparkConnectClient(
       .setClientType(userAgent)
       .build()
     analyze(request)
+  }
+
+  def copy(): SparkConnectClient = {
+    new SparkConnectClient(userContext, channel, userAgent)
   }
 
   /**

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -30,9 +30,9 @@ import org.apache.spark.sql.connect.common.config.ConnectCommon
  * Conceptually the remote spark session that communicates with the server.
  */
 private[sql] class SparkConnectClient(
-    private val userContext: proto.UserContext,
-    private val channel: ManagedChannel,
-    private[client] val userAgent: String) {
+    private[sql] val userContext: proto.UserContext,
+    private[sql] val channel: ManagedChannel,
+    private[sql] val userAgent: String) {
 
   private[this] val stub = proto.SparkConnectServiceGrpc.newBlockingStub(channel)
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -586,6 +586,12 @@ class ClientE2ETestSuite extends RemoteSparkSession {
       list.asScala.map(kv => Row(kv.key, kv.value)),
       session.createDataFrame(list.asScala.toSeq))
   }
+
+  test("SparkSession newSession") {
+    val oldId = spark.sql("SELECT 1").analyze.getClientId
+    val newId = spark.newSession().sql("SELECT 1").analyze.getClientId
+    assert(oldId == newId)
+  }
 }
 
 private[sql] case class MyType(id: Long, a: Double, b: Double)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -590,7 +590,7 @@ class ClientE2ETestSuite extends RemoteSparkSession {
   test("SparkSession newSession") {
     val oldId = spark.sql("SELECT 1").analyze.getClientId
     val newId = spark.newSession().sql("SELECT 1").analyze.getClientId
-    assert(oldId == newId)
+    assert(oldId != newId)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes an implementation of newSession API. The idea is we reuse user context(e.g. user_id), gRPC channel, etc. But differentiate different Spark Remote Session by client id, which is generated randomly. 

So this idea has the benefits of:
1. reusing gRPC channel to not over too manny connections to the server.
2. Each user can has multiple remote sessions, differentiated by client ids (or named session ids in server side).  

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
API coverage

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

NO
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT