### PR TITLE
[SPARK-42670][BUILD] Upgrade maven-surefire-plugin to 3.0.0-M9 & eliminate build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2934,7 +2934,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M8</version>
+          <version>3.0.0-M9</version>
           <!-- Note config is repeated in scalatest config -->
           <configuration>
             <includes>
@@ -2957,7 +2957,7 @@
               <JAVA_HOME>${test.java.home}</JAVA_HOME>
               <SPARK_BEELINE_OPTS>-DmyKey=yourValue</SPARK_BEELINE_OPTS>
             </environmentVariables>
-            <systemProperties>
+            <systemPropertyVariables>
               <log4j.configurationFile>file:src/test/resources/log4j2.properties</log4j.configurationFile>
               <derby.system.durability>test</derby.system.durability>
               <java.awt.headless>true</java.awt.headless>
@@ -2972,7 +2972,7 @@
               <spark.hadoop.hadoop.security.key.provider.path>test:///</spark.hadoop.hadoop.security.key.provider.path>
               <!-- Needed by sql/hive tests. -->
               <test.src.tables>src</test.src.tables>
-            </systemProperties>
+            </systemPropertyVariables>
             <failIfNoTests>false</failIfNoTests>
             <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
             <excludedGroups>${test.exclude.tags}</excludedGroups>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade maven-surefire-plugin from 3.0.0-M8 to 3.0.0-M9 & eliminate build warnings.


### Why are the changes needed?
https://github.com/apache/maven-surefire/compare/surefire-3.0.0-M8...surefire-3.0.0-M9
[system-properties](https://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html)

<img width="632" alt="image" src="https://user-images.githubusercontent.com/15246973/222911581-56f886ea-31b5-44d1-a155-74af883bf797.png">

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/15246973/222961111-1cd21386-f141-45d1-9969-be315e93e6dd.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual check & Pass GA.