### PR TITLE
[SPARK-42671][CONNECT] Fix bug for createDataFrame from complex type schema

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -115,7 +115,7 @@ class SparkSession private[sql] (
   private def createDataset[T](encoder: AgnosticEncoder[T], data: Iterator[T]): Dataset[T] = {
     newDataset(encoder) { builder =>
       val localRelationBuilder = builder.getLocalRelationBuilder
-        .setSchema(encoder.schema.catalogString)
+        .setSchema(encoder.schema.json)
       if (data.nonEmpty) {
         val timeZoneId = conf.get("spark.sql.session.timeZone")
         val arrowData = ConvertToArrow(encoder, data, timeZoneId, allocator)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -604,8 +604,8 @@ class ClientE2ETestSuite extends RemoteSparkSession {
         .add("c1-1", StringType)
         .add("c1-2", StringType))
     val data = Seq(Row(Row(null, "a2")), Row(Row("b1", "b2")), Row(null))
-    val df = spark.createDataFrame(data.asJava, schema)
-    df.show()
+    val result = spark.createDataFrame(data.asJava, schema).collect()
+    assert(result === data)
   }
 }
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -600,9 +600,11 @@ class ClientE2ETestSuite extends RemoteSparkSession {
 
   test("createDataFrame from complex type schema") {
     val schema = new StructType()
-      .add("c1", new StructType()
-        .add("c1-1", StringType)
-        .add("c1-2", StringType))
+      .add(
+        "c1",
+        new StructType()
+          .add("c1-1", StringType)
+          .add("c1-2", StringType))
     val data = Seq(Row(Row(null, "a2")), Row(Row("b1", "b2")), Row(null))
     val result = spark.createDataFrame(data.asJava, schema).collect()
     assert(result === data)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -597,6 +597,16 @@ class ClientE2ETestSuite extends RemoteSparkSession {
     val newId = spark.newSession().sql("SELECT 1").analyze.getClientId
     assert(oldId != newId)
   }
+
+  test("createDataFrame from complex type schema") {
+    val schema = new StructType()
+      .add("c1", new StructType()
+        .add("c1-1", StringType)
+        .add("c1-2", StringType))
+    val data = Seq(Row(Row(null, "a2")), Row(Row("b1", "b2")), Row(null))
+    val df = spark.createDataFrame(data.asJava, schema)
+    df.show()
+  }
 }
 
 private[sql] case class MyType(id: Long, a: Double, b: Double)


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix bug for createDataFrame from complex type schema.

### Why are the changes needed?
When I code UT for `DataFrameNaFunctions` as follow:
val schema = new StructType()
      .add("c1", new StructType()
        .add("c1-1", StringType)
        .add("c1-2", StringType))
val data = Seq(Row(Row(null, "a2")), Row(Row("b1", "b2")), Row(null))
val df = spark.createDataFrame(data.asJava, schema)
df.show()

I found that the above code does not work. The error message as follow:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/15246973/222938339-77dec8c6-549b-41de-869b-8a191a0f745e.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add new UT
Pass GA.