### PR TITLE
[SPARK-41497][CORE][Follow UP]Modify config `spark.rdd.cache.visibilityTracking.enabled` support version to 3.5.0

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2476,7 +2476,7 @@ package object config {
         " a RDD cache block can be used only when it's marked as visible. And a RDD block will be" +
         " marked as visible only when one of the tasks generating the cache block finished" +
         " successfully. This is relevant in context of consistent accumulator status.")
-      .version("3.4.0")
+      .version("3.5.0")
       .booleanConf
       .createWithDefault(false)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In #39459  we introduced a new config entry `spark.rdd.cache.visibilityTracking.enabled` and mark the support version as 3.4.0. Based on the discussion https://github.com/apache/spark/pull/39459#discussion_r1123978338 we won't backport this to 3.4, so modify the support version for the new added config entry to 3.5.0

### Why are the changes needed?
Fixing config entry  support version.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing UT.
