### PR TITLE
[SPARK-42674][BUILD] Upgrade scalafmt from 3.7.1 to 3.7.2

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -32,4 +32,4 @@ fileOverride {
     runner.dialect = scala213
   }
 }
-version = 3.7.1
+version = 3.7.2


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade scalafmt from 3.7.1 to 3.7.2

### Why are the changes needed?
A. Release note:
> https://github.com/scalameta/scalafmt/releases

B. V3.7.1 VS V3.7.2
> https://github.com/scalameta/scalafmt/compare/v3.7.1...v3.7.2

C. Bring bug fix & some improvement:
<img width="560" alt="image" src="https://user-images.githubusercontent.com/15246973/222950202-76fea081-3b0b-458b-b963-248e472107f4.png">
<img width="583" alt="image" src="https://user-images.githubusercontent.com/15246973/222950245-47dab2a4-df28-4b31-9a05-0e1ccc8b5acc.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.
