### PR TITLE
[SPARK-42675][CONNECT][TESTS] Drop temp view after test `test temp view`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -501,14 +501,19 @@ class ClientE2ETestSuite extends RemoteSparkSession {
   }
 
   test("test temp view") {
-    spark.range(100).createTempView("test1")
-    assert(spark.sql("SELECT * FROM test1").count() == 100)
-    spark.range(1000).createOrReplaceTempView("test1")
-    assert(spark.sql("SELECT * FROM test1").count() == 1000)
-    spark.range(100).createGlobalTempView("view1")
-    assert(spark.sql("SELECT * FROM global_temp.view1").count() == 100)
-    spark.range(1000).createOrReplaceGlobalTempView("view1")
-    assert(spark.sql("SELECT * FROM global_temp.view1").count() == 1000)
+    try {
+      spark.range(100).createTempView("test1")
+      assert(spark.sql("SELECT * FROM test1").count() == 100)
+      spark.range(1000).createOrReplaceTempView("test1")
+      assert(spark.sql("SELECT * FROM test1").count() == 1000)
+      spark.range(100).createGlobalTempView("view1")
+      assert(spark.sql("SELECT * FROM global_temp.view1").count() == 100)
+      spark.range(1000).createOrReplaceGlobalTempView("view1")
+      assert(spark.sql("SELECT * FROM global_temp.view1").count() == 1000)
+    } finally {
+      spark.sql("DROP VIEW IF EXISTS test1")
+      spark.sql("DROP VIEW IF EXISTS global_temp.view1")
+    }
   }
 
   test("version") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just drop temp view after test which create by `test temp view` in `ClientE2ETestSuite`.


### Why are the changes needed?
Drop temp view after test to clean up resource.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions