### PR TITLE
[SPARK-42577][CORE] Add max attempts limitation for stages to avoid potential infinite retry

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2479,4 +2479,11 @@ package object config {
       .version("3.5.0")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val STAGE_MAX_ATTEMPTS =
+    ConfigBuilder("spark.stage.maxAttempts")
+      .doc("TODO")
+      .version("3.4.0")
+      .intConf
+      .createWithDefault(8)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2482,9 +2482,10 @@ package object config {
 
   private[spark] val STAGE_MAX_ATTEMPTS =
     ConfigBuilder("spark.stage.maxAttempts")
-      .doc("Specify the max attempts for a stage - the spark job will be aborted if any of its stages is " +
-        "resubmitted multiple times beyond the limitation. The maximum number of stage retries is the maximum of " +
-        "`spark.stage.maxAttempts` and `spark.stage.maxConsecutiveAttempts`")
+      .doc("Specify the max attempts for a stage - the spark job will be aborted if any of its " +
+        "stages is resubmitted multiple times beyond the max retries limitation. The maximum " +
+        "number of stage retries is the maximum of `spark.stage.maxAttempts` and " +
+        "`spark.stage.maxConsecutiveAttempts`.")
       .version("3.5.0")
       .intConf
       .createWithDefault(Int.MaxValue)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2482,10 +2482,9 @@ package object config {
 
   private[spark] val STAGE_MAX_ATTEMPTS =
     ConfigBuilder("spark.stage.maxAttempts")
-      .doc("The max attempts for a stage, the spark job will be aborted if any of its stages is " +
-        "resubmitted multiple times beyond the limitation. The value should be no less " +
-        "than `spark.stage.maxConsecutiveAttempts` which defines the max attempts for " +
-        "fetch failures.")
+      .doc("Specify the max attempts for a stage - the spark job will be aborted if any of its stages is " +
+        "resubmitted multiple times beyond the limitation. The maximum number of stage retries is the maximum of " +
+        "`spark.stage.maxAttempts` and `spark.stage.maxConsecutiveAttempts`")
       .version("3.5.0")
       .intConf
       .createWithDefault(Int.MaxValue)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2482,8 +2482,11 @@ package object config {
 
   private[spark] val STAGE_MAX_ATTEMPTS =
     ConfigBuilder("spark.stage.maxAttempts")
-      .doc("TODO")
-      .version("3.4.0")
+      .doc("The max attempts for a stage, the spark job will be aborted if any of its stages is " +
+        "resubmitted multiple times beyond the limitation. The value should be no less " +
+        "than `spark.stage.maxConsecutiveAttempts` which defines the max attempts for " +
+        "fetch failures.")
+      .version("3.5.0")
       .intConf
-      .createWithDefault(8)
+      .createWithDefault(16)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2488,5 +2488,5 @@ package object config {
         "fetch failures.")
       .version("3.5.0")
       .intConf
-      .createWithDefault(16)
+      .createWithDefault(Int.MaxValue)
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -235,8 +235,9 @@ private[spark] class DAGScheduler(
   /**
    * Max stage attempts allowed before a stage is aborted.
    */
-  private[scheduler] val maxStageAttempts =
+  private[scheduler] val maxStageAttempts: Int = {
     Math.max(maxConsecutiveStageAttempts, sc.getConf.get(config.STAGE_MAX_ATTEMPTS))
+  }
 
   /**
    * Whether ignore stage fetch failure caused by executor decommission when
@@ -1360,25 +1361,24 @@ private[spark] class DAGScheduler(
     if (jobId.isDefined) {
       logDebug(s"submitStage($stage (name=${stage.name};" +
         s"jobs=${stage.jobIds.toSeq.sorted.mkString(",")}))")
-
-      if (stage.getNextAttemptId() >= maxStageAttempts) {
-        val reason = s"$stage (name=${stage.name}) has been resubmitted for the maximum " +
-          s"allowable number of times: $maxStageAttempts which is the max value of config " +
-          s"`spark.stage.maxAttempts` and `spark.stage.maxConsecutiveAttempts`."
-        abortStage(stage, reason, None)
-      }
-
       if (!waitingStages(stage) && !runningStages(stage) && !failedStages(stage)) {
-        val missing = getMissingParentStages(stage).sortBy(_.id)
-        logDebug("missing: " + missing)
-        if (missing.isEmpty) {
-          logInfo("Submitting " + stage + " (" + stage.rdd + "), which has no missing parents")
-          submitMissingTasks(stage, jobId.get)
+        if (stage.getNextAttemptId() >= maxStageAttempts) {
+          val reason = s"$stage (name=${stage.name}) has been resubmitted for the maximum " +
+            s"allowable number of times: ${maxStageAttempts}, which is the max value of " +
+            s"config `spark.stage.maxAttempts` and `spark.stage.maxConsecutiveAttempts`."
+          abortStage(stage, reason, None)
         } else {
-          for (parent <- missing) {
-            submitStage(parent)
+          val missing = getMissingParentStages(stage).sortBy(_.id)
+          logDebug("missing: " + missing)
+          if (missing.isEmpty) {
+            logInfo("Submitting " + stage + " (" + stage.rdd + "), which has no missing parents")
+            submitMissingTasks(stage, jobId.get)
+          } else {
+            for (parent <- missing) {
+              submitStage(parent)
+            }
+            waitingStages += stage
           }
-          waitingStages += stage
         }
       }
     } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1362,7 +1362,7 @@ private[spark] class DAGScheduler(
       logDebug(s"submitStage($stage (name=${stage.name};" +
         s"jobs=${stage.jobIds.toSeq.sorted.mkString(",")}))")
       if (!waitingStages(stage) && !runningStages(stage) && !failedStages(stage)) {
-        if (stage.getNextAttemptId() >= maxStageAttempts) {
+        if (stage.getNextAttemptId >= maxStageAttempts) {
           val reason = s"$stage (name=${stage.name}) has been resubmitted for the maximum " +
             s"allowable number of times: ${maxStageAttempts}, which is the max value of " +
             s"config `spark.stage.maxAttempts` and `spark.stage.maxConsecutiveAttempts`."

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -70,6 +70,7 @@ private[scheduler] abstract class Stage(
 
   /** The ID to use for the next new attempt for this stage. */
   private var nextAttemptId: Int = 0
+  private[scheduler] def getNextAttemptId(): Int = nextAttemptId
 
   val name: String = callSite.shortForm
   val details: String = callSite.longForm

--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
@@ -70,7 +70,7 @@ private[scheduler] abstract class Stage(
 
   /** The ID to use for the next new attempt for this stage. */
   private var nextAttemptId: Int = 0
-  private[scheduler] def getNextAttemptId(): Int = nextAttemptId
+  private[scheduler] def getNextAttemptId: Int = nextAttemptId
 
   val name: String = callSite.shortForm
   val details: String = callSite.longForm

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -405,13 +405,13 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     mapOutputTracker = spy(new MyMapOutputTrackerMaster(sc.getConf, broadcastManager))
     blockManagerMaster = spy(new MyBlockManagerMaster(sc.getConf))
     doNothing().when(blockManagerMaster).updateRDDBlockVisibility(any(), any())
-    scheduler = new MyDAGScheduler(
+    scheduler = spy(new MyDAGScheduler(
       sc,
       taskScheduler,
       sc.listenerBus,
       mapOutputTracker,
       blockManagerMaster,
-      sc.env)
+      sc.env))
 
     dagEventProcessLoopTester = new DAGSchedulerEventProcessLoopTester(scheduler)
   }
@@ -4592,6 +4592,48 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
       assert(sentHosts.asScala.toSeq === Seq("hostB"))
       completeLatch.await()
       assert(hostAInterrupted)
+    }
+  }
+
+  test("SPARK-42577: fail the job if a shuffle map stage attempts beyond the limitation") {
+    setupStageAbortTest(sc)
+    doAnswer(_ => 1).when(scheduler).maxStageAttempts
+
+    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
+    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(1))
+    val shuffleId = shuffleDep.shuffleId
+    val reduceRdd = new MyRDD(sc, 1, List(shuffleDep), tracker = mapOutputTracker)
+    submit(reduceRdd, Array(0))
+
+    // Stage 0 got scheduled with 2 tasks.
+    assert(taskSets.size === 1 && taskSets(0).tasks.length === 2)
+    val stage0 = scheduler.stageIdToStage(0)
+
+    // Task 0 of stage 0 finished successfully on hostA and then executor on hostA got killed and
+    // shuffle data got lost. Then task 1 of stage 1 finished successfully on hostB.  Stage 0 will
+    // be resubmitted due to shuffle data lost.
+    runEvent(makeCompletionEvent(taskSets(0).tasks(0), Success,
+      makeMapStatus("hostA", reduces = 1, mapTaskId = 0),
+      Seq.empty, Array.empty, createFakeTaskInfoWithId(0)))
+    runEvent(ExecutorLost("hostA-exec", ExecutorKilled))
+
+    runEvent(makeCompletionEvent(taskSets(0).tasks(1), Success,
+      makeMapStatus("hostB", reduces = 1, mapTaskId = 1),
+      Seq.empty, Array.empty, createFakeTaskInfoWithId(1)))
+
+    // Stage should have been aborted and removed from running stages
+    assertDataStructuresEmpty()
+    sc.listenerBus.waitUntilEmpty()
+    assert(ended)
+
+    val expectedMsg = s"$stage0 (name=${stage0.name}) has been resubmitted for the maximum " +
+      s"allowable number of times: 1, which is the max value of " +
+      s"config `spark.stage.maxAttempts` and `spark.stage.maxConsecutiveAttempts`."
+
+    jobResult match {
+      case JobFailed(reason) =>
+        assert(reason.getMessage.contains(expectedMsg))
+      case other => fail(s"expected JobFailed, not $other")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently a stage will be resubmitted in a few scenarios:
1. Task failed with `FetchFailed` will trigger stage re-submit;
2. Barrier task failed;
3. Shuffle data loss due to executor/host decommissioned;

For the first 2 scenarios, there is a config `spark.stage.maxConsecutiveAttempts` to limit the retry times. While for the 3rd scenario, there'll be potential risks for inifinite retry if there are always executors hosting the shuffle data from successful tasks got killed/lost, the stage will be re-run again and again.

To avoid the potential risk, the proposal in this PR is to add a new config `spark.stage.maxConsecutiveAttempts` to limit the overall max attempts number for each stage, the stage will be aborted once the retry times beyond the limitation.

### Why are the changes needed?
To avoid the potential risks for stage infinite retry.

### Does this PR introduce _any_ user-facing change?
Added limitation for stage retry times, so jobs may fail if they need to retry for mutiplte times beyond the limitation.

### How was this patch tested?
Added new UT.
