### PR TITLE
[SPARK-42562][CONNECT] UnresolvedNamedLambdaVariable in python do not need unique names

### DIFF
--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -686,10 +686,6 @@ class CastExpression(Expression):
 
 
 class UnresolvedNamedLambdaVariable(Expression):
-
-    _lock: Lock = Lock()
-    _nextVarNameId: int = 0
-
     def __init__(
         self,
         name_parts: Sequence[str],
@@ -711,20 +707,6 @@ class UnresolvedNamedLambdaVariable(Expression):
 
     def __repr__(self) -> str:
         return f"(UnresolvedNamedLambdaVariable({', '.join(self._name_parts)})"
-
-    @staticmethod
-    def fresh_var_name(name: str) -> str:
-        assert isinstance(name, str) and str != ""
-
-        _id: Optional[int] = None
-
-        with UnresolvedNamedLambdaVariable._lock:
-            _id = UnresolvedNamedLambdaVariable._nextVarNameId
-            UnresolvedNamedLambdaVariable._nextVarNameId += 1
-
-        assert _id is not None
-
-        return f"{name}_{_id}"
 
 
 class LambdaFunction(Expression):

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -31,7 +31,6 @@ import json
 import decimal
 import datetime
 import warnings
-from threading import Lock
 
 import numpy as np
 

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -160,10 +160,7 @@ def _create_lambda(f: Callable) -> LambdaFunction:
     parameters = _get_lambda_parameters(f)
 
     arg_names = ["x", "y", "z"][: len(parameters)]
-    arg_exprs = [
-        UnresolvedNamedLambdaVariable([UnresolvedNamedLambdaVariable.fresh_var_name(arg_name)])
-        for arg_name in arg_names
-    ]
+    arg_exprs = [UnresolvedNamedLambdaVariable([arg_name]) for arg_name in arg_names]
     arg_cols = [Column(arg_expr) for arg_expr in arg_exprs]
 
     result = f(*arg_cols)


### PR DESCRIPTION
### What changes were proposed in this pull request?
`UnresolvedNamedLambdaVariable` do not need unique names in python. We already did this for the scala client, and it is good to have parity between the two implementations.


### Why are the changes needed?
Try to avoid unique names for `UnresolvedNamedLambdaVariable`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature


### How was this patch tested?
N/A
