### PR TITLE
[SPARK-42676][SS] Write temp checkpoints for streaming queries to local filesystem even if default FS is set differently

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ResolveWriteToStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ResolveWriteToStream.scala
@@ -81,7 +81,9 @@ object ResolveWriteToStream extends Rule[LogicalPlan] with SQLConfHelper {
           s" the query didn't fail: $tempDir. If it's required to delete it under any" +
           s" circumstances, please set ${SQLConf.FORCE_DELETE_TEMP_CHECKPOINT_LOCATION.key} to" +
           s" true. Important to know deleting temp checkpoint folder is best effort.")
-        tempDir
+        // SPARK-42676 - Write temp checkpoints for streaming queries to local filesystem
+        // even if default FS is set differently
+        "file://" + tempDir
       } else {
         throw QueryCompilationErrors.checkpointLocationNotSpecifiedError()
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Write temp checkpoints for streaming queries to local filesystem even if default FS is set differently

### Why are the changes needed?
We have seen cases where the default FS could be a remote file system and since the path for streaming checkpoints is not specified explcitily, this could cause pileup under 2 cases:

- query exits with exception and the flag to force checkpoint removal is not set
- driver/cluster terminates without query being terminated gracefully

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Verified that the checkpoint is resolved and written to the local FS

```
23/03/04 01:42:49 INFO ResolveWriteToStream: Checkpoint root file:/local_disk0/tmp/temporary-c97ab8bd-6b03-4c28-93ea-751d30a2d3f9 resolved to file:/local_disk0/tmp/temporary-c97ab8bd-6b03-4c28-93ea-751d30a2d3f9.
...
23/03/04 01:46:37 INFO MicroBatchExecution: [queryId = 66c4c] Deleting checkpoint file:/local_disk0/tmp/temporary-c97ab8bd-6b03-4c28-93ea-751d30a2d3f9.
```