### PR TITLE
[SPARK-42595][SQL] Support query inserted partitions after insert data into table when hive.exec.dynamic.partition=true

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -172,7 +172,7 @@ trait ExternalCatalog {
       loadPath: String,
       partition: TablePartitionSpec,
       replace: Boolean,
-      numDP: Int): Unit
+      numDP: Int): Seq[Map[String, String]]
 
   // --------------------------------------------------------------------------
   // Partitions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -185,7 +185,7 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       loadPath: String,
       partition: TablePartitionSpec,
       replace: Boolean,
-      numDP: Int): Unit = {
+      numDP: Int): Seq[Map[String, String]] = {
     delegate.loadDynamicPartitions(db, table, loadPath, partition, replace, numDP)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -395,7 +395,7 @@ class InMemoryCatalog(
       loadPath: String,
       partition: TablePartitionSpec,
       replace: Boolean,
-      numDP: Int): Unit = {
+      numDP: Int): Seq[Map[String, String]] = {
     throw QueryExecutionErrors.methodNotImplementedError("loadDynamicPartitions")
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4168,6 +4168,25 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ENABLE_DYNAMIC_PARTITION_SAVE_PARTITIONS =
+    buildConf("spark.hive.exec.dynamic.partition.savePartitions")
+      .internal()
+      .doc("Enable save partitions after insert table when hive.exec.dynamic.partition=true.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DYNAMIC_PARTITION_SAVE_PARTITIONS_TABLE_NAME_PREFIX =
+    buildConf("spark.hive.exec.dynamic.partition.savePartitions.tableNamePrefix")
+      .internal()
+      .doc("The table name prefix of saved partition table, " +
+        "the whole table name will be " +
+        "${spark.hive.exec.dynamic.partition.savePartitions.tableNamePrefix}_" +
+        "${dbName}_${tableName}")
+      .version("3.5.0")
+      .stringConf
+      .createWithDefault("hive_dynamic_inserted_partitions")
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -949,7 +949,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       loadPath: String,
       partition: TablePartitionSpec,
       replace: Boolean,
-      numDP: Int): Unit = withClient {
+      numDP: Int): Seq[Map[String, String]] = withClient {
     requireTableExists(db, table)
 
     val orderedPartitionSpec = new util.LinkedHashMap[String, String]()

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -269,7 +269,7 @@ private[hive] trait HiveClient {
       tableName: String,
       partSpec: java.util.LinkedHashMap[String, String], // Hive relies on LinkedHashMap ordering
       replace: Boolean,
-      numDP: Int): Unit
+      numDP: Int): Seq[Map[String, String]]
 
   /** Create a function in an existing database. */
   def createFunction(db: String, func: CatalogFunction): Unit

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -977,7 +977,7 @@ private[hive] class HiveClientImpl(
       tableName: String,
       partSpec: java.util.LinkedHashMap[String, String],
       replace: Boolean,
-      numDP: Int): Unit = withHiveState {
+      numDP: Int): Seq[Map[String, String]] = withHiveState {
     val hiveTable = shim.getTable(client, dbName, tableName, true /* throw exception */)
     shim.loadDynamicPartitions(
       client,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -497,7 +497,7 @@ private[client] class Shim_v0_12 extends Shim with Logging {
     val result = loadDynamicPartitionsMethod.invoke(hive, loadPath,
       tableName, partSpec, replace: JBoolean,
       numDP: JInteger, holdDDLTime, listBucketingEnabled: JBoolean)
-    result.asInstanceOf[JList[JMap[String, String]]].asScala.map(_.asScala.toMap)
+    result.asInstanceOf[JList[JMap[String, String]]].asScala.map(_.asScala.toMap).toSeq
   }
 
   override def dropIndex(hive: Hive, dbName: String, tableName: String, indexName: String): Unit = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hive.client
 
-import java.io.{ByteArrayOutputStream, File, FileWriter, PrintStream, PrintWriter}
+import java.io.{ByteArrayOutputStream, File, PrintStream, PrintWriter}
 import java.net.URI
 
 import org.apache.commons.lang3.{JavaVersion, SystemUtils}
@@ -477,43 +477,6 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
 
     assert(insertedPartition.isEmpty)
 
-    withTempDir{dir => {
-      val tmpPath = dir.getAbsolutePath
-      new File(s"$tmpPath/key1=1").mkdir()
-      new File(s"$tmpPath/key1=1/key2=22222").mkdir()
-      val dataFile = new File(s"$tmpPath/key1=1/key2=22222/data")
-      val created = dataFile.createNewFile()
-      assert(created)
-      import java.io.BufferedWriter
-      val writer: BufferedWriter = new BufferedWriter(new FileWriter(dataFile))
-      // value, key1, key2
-      writer.write("1,1,22222")
-      writer.close()
-
-      val insertedPartition = client.loadDynamicPartitions(
-        tmpPath,
-        "default",
-        "src_part",
-        partSpec,
-        replace = false,
-        numDP = 1)
-
-      assert(insertedPartition.size == 1)
-      val partition = insertedPartition.head
-      assert(partition.size == 2)
-      assert(partition("key1").equals("1"))
-      assert(partition("key2").equals("22222"))
-
-      // clean
-      client.dropPartitions(
-        "default",
-        "src_part",
-        Seq(Map("key1" -> "1", "key2" -> "22222")),
-        ignoreIfNotExists = true,
-        purge = true,
-        retainData = false
-      )
-    }}
   }
 
   test("renamePartitions") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSaveDynamicInsertPartitionTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSaveDynamicInsertPartitionTest.scala
@@ -60,9 +60,9 @@ class HiveSaveDynamicInsertPartitionTest extends HivePlanTest with SQLTestUtils 
             s"""
                |INSERT OVERWRITE TABLE test_db.test_table PARTITION (p1=1, p2)
                |select * from (
-               |  select 1 as value, 1 as p1, 2 as p2
+               |  select 1 as value, 2 as p2
                |  union all
-               |  select 2 as value, 1 as p1, 3 as p2
+               |  select 2 as value, 3 as p2
                |)""".stripMargin)
 
           val df = sql(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSaveDynamicInsertPartitionTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSaveDynamicInsertPartitionTest.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.execution
+
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.sql.hive.test.TestHive
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SQLTestUtils
+
+class HiveSaveDynamicInsertPartitionTest extends HivePlanTest with SQLTestUtils with BeforeAndAfter{
+
+  private val tableNamePrefix =
+    TestHive.getConf(SQLConf.DYNAMIC_PARTITION_SAVE_PARTITIONS_TABLE_NAME_PREFIX.key)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    TestHive.setConf(SQLConf.ENABLE_DYNAMIC_PARTITION_SAVE_PARTITIONS, true)
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      TestHive.setConf(SQLConf.ENABLE_DYNAMIC_PARTITION_SAVE_PARTITIONS, false)
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  test("test_save_dynamic_partition") {
+    withDatabase("test_db") {
+      withTable("test_table") {
+        withSQLConf(
+          "hive.exec.dynamic.partition" -> "true",
+          "hive.exec.dynamic.partition.mode" -> "nonstrict"
+        ) {
+          sql("CREATE DATABASE test_db")
+
+          sql(
+            s"""
+               |CREATE TABLE test_db.test_table(i int)
+               |PARTITIONED BY (p int)
+               |STORED AS textfile""".stripMargin)
+
+          sql(
+            s"""
+               |INSERT OVERWRITE TABLE test_db.test_table PARTITION (p)
+               |select 1 as i, 2 as p""".stripMargin)
+
+          val df = sql(
+            s"""
+               |SELECT * FROM TABLE ${tableNamePrefix}_test_db_test_table
+               |""".stripMargin
+          )
+
+          val rows = df.collect()
+          assert(rows.length == 1)
+          assert(rows(0).getAs[String]("p") == "2")
+        }
+      }
+    }
+  }
+
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSaveDynamicInsertPartitionTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSaveDynamicInsertPartitionTest.scala
@@ -60,7 +60,7 @@ class HiveSaveDynamicInsertPartitionTest extends HivePlanTest with SQLTestUtils 
             s"""
                |INSERT OVERWRITE TABLE test_db.test_table PARTITION (p1=1, p2)
                |select * from (
-               |  select 1 as value, 1 as p1, 2 as p2,
+               |  select 1 as value, 1 as p1, 2 as p2
                |  union all
                |  select 2 as value, 1 as p1, 3 as p2
                |)""".stripMargin)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce spark.hive.exec.dynamic.partition.savePartitions=true (default false) spark.hive.exec.dynamic.partition.savePartitions.tableNamePrefix=hive_dynamic_inserted_partitions
when spark.hive.exec.dynamic.partition.savePartitions=true we save the partitions to the 
temporary view $spark.hive.exec.dynamic.partition.savePartitions.tableNamePrefix_$dbName_$tableName


### Why are the changes needed?

When hive.exec.dynamic.partition=true and hive.exec.dynamic.partition.mode=nonstrict, we can insert table by sql like 'insert overwrite table aaa partition(dt) select xxxx',  of course we can know the partitions inserted into the table by the sql itself,  but if we want do something for common use, we need some common way to get the inserted partitions,  for example:

    spark.sql("insert overwrite table aaa partition(dt) select xxxx")  //insert table
    val partitions = getInsertedPartitions()   //need some way to get inserted partitions
    monitorInsertedPartitions(partitions)    //do something for common use
This pull request will allow user to get inserted partitions in a common way

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
new unit test
