### PR TITLE
[SPARK-42683] Automatically rename conflicting metadata columns

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -150,6 +150,7 @@ object CheckConnectJvmClientCompatibility {
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.encoder"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.sqlContext"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.joinWith"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.metadataColumn"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.selectUntyped"), // protected
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.reduce"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset.groupByKey"),

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsMetadataColumns.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsMetadataColumns.java
@@ -57,8 +57,10 @@ public interface SupportsMetadataColumns extends Table {
   /**
    * Determines how this data source handles name conflicts between metadata and data columns.
    * <p>
-   * If true, spark will automatically rename the metadata column to resolve the conflict; metadata
-   * columns (renamed or not) can be reliably accessed by calling {@link Dataset.metadataColumn}.
+   * If true, spark will automatically rename the metadata column to resolve the conflict. End users
+   * can reliably select metadata columns (renamed or not) with {@link Dataset.metadataColumn}, and
+   * internal code can use {@link MetadataAttributeWithLogicalName} to extract the logical name from
+   * a metadata attribute.
    * <p>
    * If false, the data column will hide the metadata column. It is recommended that Table
    * implementations which do not support renaming should reject data column names that conflict

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsMetadataColumns.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsMetadataColumns.java
@@ -34,9 +34,8 @@ import org.apache.spark.sql.types.StructType;
  * {@link SupportsPushDownRequiredColumns} must accept metadata fields passed to
  * {@link SupportsPushDownRequiredColumns#pruneColumns(StructType)}.
  * <p>
- * If a table column and a metadata column have the same name, the metadata column will never be
- * requested. It is recommended that Table implementations reject data column name that conflict
- * with metadata column names.
+ * If a table column and a metadata column have the same name, the conflict is resolved by either
+ * renaming or suppressing the metadata column. See {@link canRenameConflictingMetadataColumns}.
  *
  * @since 3.1.0
  */
@@ -48,11 +47,22 @@ public interface SupportsMetadataColumns extends Table {
    * The columns returned by this method may be passed as {@link StructField} in requested
    * projections using {@link SupportsPushDownRequiredColumns#pruneColumns(StructType)}.
    * <p>
-   * If a table column and a metadata column have the same name, the metadata column will never be
-   * requested and is ignored. It is recommended that Table implementations reject data column names
-   * that conflict with metadata column names.
+   * If a table column and a metadata column have the same name, the conflict is resolved by either
+   * renaming or suppressing the metadata column. See {@link canRenameConflictingMetadataColumns}.
    *
    * @return an array of {@link MetadataColumn}
    */
   MetadataColumn[] metadataColumns();
+
+  /**
+   * Determines how this data source handles name conflicts between metadata and data columns.
+   * <p>
+   * If true, spark will automatically rename the metadata column to resolve the conflict; metadata
+   * columns (renamed or not) can be reliably accessed by calling {@link Dataset.metadataColumn}.
+   * <p>
+   * If false, the data column will hide the metadata column. It is recommended that Table
+   * implementations which do not support renaming should reject data column names that conflict
+   * with metadata column names.
+   */
+  default boolean canRenameConflictingMetadataColumns() { return false; }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -198,8 +198,7 @@ package object util extends Logging {
      */
     val QUALIFIED_ACCESS_ONLY = "__qualified_access_only"
 
-    def isMetadataCol: Boolean = attr.metadata.contains(METADATA_COL_ATTR_KEY) &&
-      attr.metadata.getBoolean(METADATA_COL_ATTR_KEY)
+    def isMetadataCol: Boolean = attr.metadata.contains(METADATA_COL_ATTR_KEY)
 
     def qualifiedAccessOnly: Boolean = attr.isMetadataCol &&
       attr.metadata.contains(QUALIFIED_ACCESS_ONLY) &&
@@ -208,7 +207,7 @@ package object util extends Logging {
     def markAsQualifiedAccessOnly(): Attribute = attr.withMetadata(
       new MetadataBuilder()
         .withMetadata(attr.metadata)
-        .putBoolean(METADATA_COL_ATTR_KEY, true)
+        .putString(METADATA_COL_ATTR_KEY, attr.name)
         .putBoolean(QUALIFIED_ACCESS_ONLY, true)
         .build()
     )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Implicits.scala
@@ -100,7 +100,7 @@ object DataSourceV2Implicits {
   implicit class MetadataColumnsHelper(metadata: Array[MetadataColumn]) {
     def asStruct: StructType = {
       val fields = metadata.map { metaCol =>
-        val fieldMeta = new MetadataBuilder().putBoolean(METADATA_COL_ATTR_KEY, true).build()
+        val fieldMeta = new MetadataBuilder().putString(METADATA_COL_ATTR_KEY, metaCol.name).build()
         val field = StructField(metaCol.name, metaCol.dataType, metaCol.isNullable, fieldMeta)
         Option(metaCol.comment).map(field.withComment).getOrElse(field)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -54,7 +54,8 @@ case class DataSourceV2Relation(
 
   override lazy val metadataOutput: Seq[AttributeReference] = table match {
     case hasMeta: SupportsMetadataColumns =>
-      metadataOutputWithOutConflicts(hasMeta.metadataColumns.toAttributes)
+      metadataOutputWithOutConflicts(
+        hasMeta.metadataColumns.toAttributes, hasMeta.canRenameConflictingMetadataColumns)
     case _ =>
       Nil
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -76,6 +76,10 @@ abstract class InMemoryBaseTable(
   override val metadataColumns: Array[MetadataColumn] = Array(IndexColumn, PartitionKeyColumn)
   private val metadataColumnNames = metadataColumns.map(_.name).toSet
 
+  // Metadata column renaming is supported -- see [[InMemoryScanBuilder.pruneColumns]] and
+  // [[BatchScanBaseClass.createReaderFactory]] for implementation details.
+  override val canRenameConflictingMetadataColumns: Boolean = true
+
   private val allowUnsupportedTransforms =
     properties.getOrDefault("allow-unsupported-transforms", "false").toBoolean
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -409,7 +409,7 @@ abstract class InMemoryBaseTable(
           false
         case _ => true
       }
-      new BufferedRowsReaderFactory(metadataColumns, nonMetadataColumns, tableSchema)
+      new BufferedRowsReaderFactory(metadataColumns.toSeq, nonMetadataColumns, tableSchema)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -28,7 +28,7 @@ import com.google.common.base.Objects
 import org.scalatest.Assertions._
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, JoinedRow}
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, JoinedRow, MetadataStructFieldWithLogicalName}
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeUtils}
 import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
 import org.apache.spark.sql.connector.expressions._
@@ -74,7 +74,7 @@ abstract class InMemoryBaseTable(
 
   // purposely exposes a metadata column that conflicts with a data column in some tests
   override val metadataColumns: Array[MetadataColumn] = Array(IndexColumn, PartitionKeyColumn)
-  private val metadataColumnNames = metadataColumns.map(_.name).toSet -- schema.map(_.name)
+  private val metadataColumnNames = metadataColumns.map(_.name).toSet
 
   private val allowUnsupportedTransforms =
     properties.getOrDefault("allow-unsupported-transforms", "false").toBoolean
@@ -297,8 +297,14 @@ abstract class InMemoryBaseTable(
       InMemoryBatchScan(data.map(_.asInstanceOf[InputPartition]), schema, tableSchema)
 
     override def pruneColumns(requiredSchema: StructType): Unit = {
-      val schemaNames = metadataColumnNames ++ tableSchema.map(_.name)
-      schema = StructType(requiredSchema.filter(f => schemaNames.contains(f.name)))
+      // The required schema could contain conflict-renamed metadata columns, so we need to match
+      // them by their logical (original) names, not their current names.
+      val schemaNames = tableSchema.map(_.name).toSet
+      val prunedFields = requiredSchema.filter {
+        case MetadataStructFieldWithLogicalName(f, name) => metadataColumnNames.contains(name)
+        case f => schemaNames.contains(f.name)
+      }
+      schema = StructType(prunedFields)
     }
 
     private var _pushedFilters: Array[Filter] = Array.empty
@@ -392,8 +398,13 @@ abstract class InMemoryBaseTable(
     override def planInputPartitions(): Array[InputPartition] = data.toArray
 
     override def createReaderFactory(): PartitionReaderFactory = {
-      val metadataColumns = readSchema.map(_.name).filter(metadataColumnNames.contains)
-      val nonMetadataColumns = readSchema.filterNot(f => metadataColumns.contains(f.name))
+      val metadataColumns = new mutable.ArrayBuffer[String]()
+      val nonMetadataColumns = readSchema.filter {
+        case MetadataStructFieldWithLogicalName(_, name) =>
+          metadataColumns += name
+          false
+        case _ => true
+      }
       new BufferedRowsReaderFactory(metadataColumns, nonMetadataColumns, tableSchema)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1477,6 +1477,18 @@ class Dataset[T] private[sql](
       }
   }
 
+  /**
+   * Selects a metadata column based on its logical column name, and returns it as a [[Column]].
+   *
+   * A metadata column can be accessed this way even if the underlying data source defines a data
+   * column with a conflicting name.
+   *
+   * @group untypedrel
+   * @since 3.5.0
+   */
+  def metadataColumn(colName: String): Column =
+    Column(queryExecution.analyzed.getMetadataAttributeByName(colName))
+
   // Attach the dataset id and column position to the column reference, so that we can detect
   // ambiguous self-join correctly. See the rule `DetectAmbiguousSelfJoin`.
   // This must be called before we return a `Column` that contains `AttributeReference`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -297,9 +297,8 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
             // Replace references to the _metadata column. This will affect references to the column
             // itself but also where fields from the metadata struct are used.
             case MetadataStructColumn(AttributeReference(_, fields @ StructType(_), _, _)) =>
-              val reboundFields = fields.map(
-                field => metadataColumns.find(attr => attr.name == newFieldName(field.name)).get)
-              CreateStruct(reboundFields)
+              CreateStruct(fields.map(
+                field => metadataColumns.find(attr => attr.name == newFieldName(field.name)).get))
           }.transform {
             // Replace references to struct fields with the field values. This is to avoid creating
             // temporaries to improve performance.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Today, if a data source already has an output column called `_metadata`, queries cannot access the file-source metadata column that normally carries that name. 

This PR addresses the issue by automatically renaming any metadata column whose name conflicts with an output column. We also introduce a new dataframe method, `metadataColumn`, which mirrors the existing `col` method but (a) only works for metadata columns; and (b) will reliably find metadata columns even if they were renamed due to a name conflict.

### Why are the changes needed?

Today, it's too easy to lose access to metadata columns if the user's table happened to have the wrong column name. This sharp edge limits the utility of metadata columns in general, because the feature doesn't work reliably for all table schemas.

### Does this PR introduce _any_ user-facing change?

Suppose a table defines a `StringType` column called `_metadata`. Today, the metadata column is not accessible, and the example below would return the table's string column:
```scala
df.select("_metadata")
```

With the change, the original query still returns a string, but the file-source metadata column can be found and accessed by invoking `DataSet.metadataColumn`:
```scala
df.withColumn("m", df.metadataColumn("_metadata"))
```

NOTE: Adding a SQL user surface for accessing metadata columns with conflicting names is out of scope for this pull request and can be addressed as future work.

### How was this patch tested?

New unit tests added.