### PR TITLE
[SPARK-42656][CONNECT][Followup] Improve the script to start spark-connect server

### DIFF
--- a/connector/connect/bin/spark-connect
+++ b/connector/connect/bin/spark-connect
@@ -22,11 +22,12 @@ FWDIR="$(cd "`dirname "$0"`"/../../..; pwd)"
 cd "$FWDIR"
 export SPARK_HOME=$FWDIR
 
-# Build the jars needed for spark submit and spark connect
-build/sbt package
-
 SCALA_BINARY_VER=`grep "scala.binary.version" "${SPARK_HOME}/pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
+SCALA_ARG=$(if [ "${SCALA_BINARY_VER}" == "2.13" ]; then echo "-Pscala-2.13"; else echo ""; fi)
+
+# Build the jars needed for spark submit and spark connect
+build/sbt "${SCALA_ARG}" -Phive package
 
 CONNECT_JAR=`ls "${SPARK_HOME}"/connector/connect/server/target/scala-"${SCALA_BINARY_VER}"/spark-connect-assembly*.jar | paste -sd ',' -`
 
-exec "${SPARK_HOME}"/bin/spark-submit --class org.apache.spark.sql.connect.SimpleSparkConnectService "$CONNECT_JAR"
+exec "${SPARK_HOME}"/bin/spark-submit "$@" --class org.apache.spark.sql.connect.SimpleSparkConnectService "$CONNECT_JAR"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make the server to start with Hive dependency and make the script to build with the correct scala version set in pom files.
Also allow the server to take any extra spark configurations.

### Why are the changes needed?
Adding hive dependency to allow some tests of write ops easier.
Allow the server to start with the same Scala version set in the project.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually tested.