### PR TITLE
[SPARK-42665][CONNECT][Test] Mute Scala Client UDF test

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -76,8 +76,7 @@ class ClientE2ETestSuite extends RemoteSparkSession {
     assert(result(2) == 2)
   }
 
-  // TODO (SPARK-42665): Ignore this test until the udf is fully implemented.
-  ignore("simple udf") {
+  ignore("SPARK-42665: Ignore simple udf test until the udf is fully implemented.") {
     def dummyUdf(x: Int): Int = x + 5
     val myUdf = udf(dummyUdf _)
     val df = spark.range(5).select(myUdf(Column("id")))

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -76,7 +76,8 @@ class ClientE2ETestSuite extends RemoteSparkSession {
     assert(result(2) == 2)
   }
 
-  test("simple udf") {
+  // TODO (SPARK-42665): Ignore this test until the udf is fully implemented.
+  ignore("simple udf") {
     def dummyUdf(x: Int): Int = x + 5
     val myUdf = udf(dummyUdf _)
     val df = spark.range(5).select(myUdf(Column("id")))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mute the UDF test.

### Why are the changes needed?
The test fails during maven test runs because the server cannot find the udf in the classpath. The test will be fixed once the udf artifact sync is finished.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
N/A