### PR TITLE
[SPARK-42687][SS] Better error message for the unsupport `pivot` operation in Streaming

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -430,6 +430,9 @@ class RelationalGroupedDataset protected[sql](
    * @since 2.4.0
    */
   def pivot(pivotColumn: Column): RelationalGroupedDataset = {
+    if (df.isStreaming) {
+      throw new AnalysisException("pivot is not supported on a streaming DataFrames/Datasets")
+    }
     // This is to prevent unintended OOM errors when the number of distinct values is large
     val maxValues = df.sparkSession.sessionState.conf.dataFramePivotMaxValues
     // Get the distinct values of the column and sort them so its consistent

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -356,4 +356,19 @@ class DataFramePivotSuite extends QueryTest with SharedSparkSession {
         Row(LocalDateTime.of(2013, 1, 1, 0, 0, 0, 0), 48000.0, 30000.0) :: Nil
     )
   }
+
+  test("using pivot in streaming is not supported") {
+    val df = spark
+      .readStream
+      .format("rate")
+      .load()
+      .withColumn("key", expr(s"MOD(value, 10)"))
+      .groupBy($"key")
+
+    val e = intercept[AnalysisException] {
+      df.pivot("value").count()
+    }
+
+    assert(e.getMessage.contains("pivot is not supported on a streaming DataFrames/Datasets"))
+  }
 }


### PR DESCRIPTION
`pivot` is an unsupported operation in structured streaming but produces a bad error message that is quite misleading.

The following is the current error message for the pivot in SS:
```
AnalysisException: Queries with streaming sources must be executed with writeStream.start();
```

We should report that an unsupported operation is happening instead of stating another operation should start the stream.

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Throw AnalysisExeception when `pivot` is called in Structure Streaming


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Better error message for a better user journey


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT
