### PR TITLE
[SPARK-42022][CONNECT][PYTHON] Fix createDataFrame to autogenerate missing column names

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -235,6 +235,9 @@ class SparkSession:
             # If no schema supplied by user then get the names of columns only
             if schema is None:
                 _cols = [str(x) if not isinstance(x, str) else x for x in data.columns]
+            elif isinstance(schema, (list, tuple)) and _num_cols < len(data.columns):
+                _cols = _cols + [f"_{i + 1}" for i in range(_num_cols, len(data.columns))]
+                _num_cols = len(_cols)
 
             # Determine arrow types to coerce data when creating batches
             if isinstance(schema, StructType):
@@ -308,6 +311,9 @@ class SparkSession:
                 _data = [[d] for d in _data]
 
             _inferred_schema = self._inferSchemaFromList(_data, _cols)
+
+            if _cols is not None and _num_cols < len(_cols):
+                _num_cols = len(_cols)
 
             if _has_nulltype(_inferred_schema):
                 # For cases like createDataFrame([("Alice", None, 80.1)], schema)

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -235,8 +235,9 @@ class SparkSession:
             # If no schema supplied by user then get the names of columns only
             if schema is None:
                 _cols = [str(x) if not isinstance(x, str) else x for x in data.columns]
-            elif isinstance(schema, (list, tuple)) and _num_cols < len(data.columns):
-                _cols = _cols + [f"_{i + 1}" for i in range(_num_cols, len(data.columns))]
+            elif isinstance(schema, (list, tuple)) and cast(int, _num_cols) < len(data.columns):
+                assert isinstance(_cols, list)
+                _cols.extend([f"_{i + 1}" for i in range(cast(int, _num_cols), len(data.columns))])
                 _num_cols = len(_cols)
 
             # Determine arrow types to coerce data when creating batches
@@ -312,7 +313,7 @@ class SparkSession:
 
             _inferred_schema = self._inferSchemaFromList(_data, _cols)
 
-            if _cols is not None and _num_cols < len(_cols):
+            if _cols is not None and cast(int, _num_cols) < len(_cols):
                 _num_cols = len(_cols)
 
             if _has_nulltype(_inferred_schema):

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -90,11 +90,6 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
     def test_infer_schema(self):
         super().test_infer_schema()
 
-    # TODO(SPARK-42022): createDataFrame should autogenerate missing column names
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_infer_schema_not_enough_names(self):
-        super().test_infer_schema_not_enough_names()
-
     # TODO(SPARK-42020): createDataFrame with UDT
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_infer_schema_specification(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `createDataFrame` to autogenerate missing column names.

### Why are the changes needed?

Currently the number of the column names specified to `createDataFrame` does not match the actual number of columns, it raises an error:

```py
>>> spark.createDataFrame([["a", "b"]], ["col1"])
Traceback (most recent call last):
...
ValueError: Length mismatch: Expected axis has 1 elements, new values have 2 elements
```

but it should auto-generate the missing column names.

### Does this PR introduce _any_ user-facing change?

It will auto-generate the missing columns:

```py
>>> spark.createDataFrame([["a", "b"]], ["col1"])
DataFrame[col1: string, _2: string]
```

### How was this patch tested?

Enabled the related test.