### PR TITLE
[SPARK-42559][CONNECT][TESTS][FOLLOW-UP] Disable ANSI in several tests at DataFrameNaFunctionSuite.scala

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionSuite.scala
@@ -20,9 +20,10 @@ package org.apache.spark.sql
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.connect.client.util.QueryTest
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructType}
 
-class DataFrameNaFunctionSuite extends QueryTest {
+class DataFrameNaFunctionSuite extends QueryTest with SQLHelper {
   private def createDF(): DataFrame = {
     val sparkSession = spark
     import sparkSession.implicits._
@@ -386,17 +387,21 @@ class DataFrameNaFunctionSuite extends QueryTest {
   }
 
   test("replace float with nan") {
-    checkAnswer(
-      createNaNDF().na.replace("*", Map(1.0f -> Float.NaN)),
-      Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) ::
-        Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) :: Nil)
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
+      checkAnswer(
+        createNaNDF().na.replace("*", Map(1.0f -> Float.NaN)),
+        Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) ::
+          Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) :: Nil)
+    }
   }
 
   test("replace double with nan") {
-    checkAnswer(
-      createNaNDF().na.replace("*", Map(1.0 -> Double.NaN)),
-      Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) ::
-        Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) :: Nil)
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
+      checkAnswer(
+        createNaNDF().na.replace("*", Map(1.0 -> Double.NaN)),
+        Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) ::
+          Row(0, 0L, 0.toShort, 0.toByte, Float.NaN, Double.NaN) :: Nil)
+    }
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to disable ANSI mode in both `replace float with nan` and `replace double with nan` tests.

### Why are the changes needed?

To recover the build https://github.com/apache/spark/actions/runs/4349682658 with ANSI mode on.
Spark Connect side does not fully leverage the error framework yet .. so simply disabling it for now.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran them in IDE with ANSI mode on.