### PR TITLE
[SPARK-42695][SQL] Skew join handling in stream side of broadcast hash join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -217,12 +217,12 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
           shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
       }.getOrElse(shj)
 
-    case bhj@BroadcastHashJoinExec(_, _, joinType, _, _, ShuffleStage(s: ShuffleQueryStageExec),
+    case bhj @ BroadcastHashJoinExec(_, _, joinType, _, _, ShuffleStage(s: ShuffleQueryStageExec),
     BroadcastQueryStageExec(_, _, _), _, false) if canSplitLeftSide(joinType) =>
       optimizeBroadcastHashJoin(s).map(newLeft => bhj.copy(left = newLeft, isSkewJoin = true))
         .getOrElse(bhj)
 
-    case bhj@BroadcastHashJoinExec(_, _, joinType, _, _, BroadcastQueryStageExec(_, _, _),
+    case bhj @ BroadcastHashJoinExec(_, _, joinType, _, _, BroadcastQueryStageExec(_, _, _),
     ShuffleStage(s: ShuffleQueryStageExec), _, false) if canSplitRightSide(joinType) =>
       optimizeBroadcastHashJoin(s).map(newRight => bhj.copy(right = newRight, isSkewJoin = true))
         .getOrElse(bhj)
@@ -236,7 +236,7 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
       stats.bytesByPartitionId.exists(_ > skewThreshold)
     }
 
-    if (!isSkewed(shuffleStage.mapStats.get)) {
+    if (!shuffleStage.mapStats.forall(isSkewed(_))) {
       return None
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
@@ -49,9 +49,9 @@ case class PlanAdaptiveDynamicPruningFilters(
 
         val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
           find(rootPlan) {
-            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _, _) =>
               left.sameResult(exchange)
-            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _, _) =>
               right.sameResult(exchange)
             case _ => false
           }.isDefined

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/simpleCosting.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/simpleCosting.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
-import org.apache.spark.sql.execution.joins.ShuffledJoin
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledJoin}
 
 /**
  * A simple implementation of [[Cost]], which takes a number of [[Long]] as the cost value.
@@ -48,6 +48,7 @@ case class SimpleCostEvaluator(forceOptimizeSkewedJoin: Boolean) extends CostEva
     if (forceOptimizeSkewedJoin) {
       val numSkewJoins = plan.collect {
         case j: ShuffledJoin if j.isSkewJoin => j
+        case j: BroadcastHashJoinExec if j.isSkewJoin => j
       }.size
       // We put `-numSkewJoins` in the first 32 bits of the long value, so that it's compared first
       // when comparing the cost, and larger `numSkewJoins` means lower cost.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
@@ -58,9 +58,9 @@ case class PlanDynamicPruningFilters(sparkSession: SparkSession) extends Rule[Sp
         // the first to be applied (apart from `InsertAdaptiveSparkPlan`).
         val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
           plan.exists {
-            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _, _) =>
               left.sameResult(sparkPlan)
-            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _, _) =>
               right.sameResult(sparkPlan)
             case _ => false
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -45,7 +45,8 @@ case class BroadcastHashJoinExec(
     condition: Option[Expression],
     left: SparkPlan,
     right: SparkPlan,
-    isNullAwareAntiJoin: Boolean = false)
+    isNullAwareAntiJoin: Boolean = false,
+    isSkewJoin: Boolean = false)
   extends HashJoin {
 
   if (isNullAwareAntiJoin) {
@@ -244,4 +245,8 @@ case class BroadcastHashJoinExec(
   override protected def withNewChildrenInternal(
       newLeft: SparkPlan, newRight: SparkPlan): BroadcastHashJoinExec =
     copy(left = newLeft, right = newRight)
+
+  override def nodeName: String = {
+    if (isSkewJoin) super.nodeName + "(skew=true)" else super.nodeName
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -345,7 +345,7 @@ abstract class DynamicPartitionPruningSuiteBase
        """.stripMargin)
 
       val found = df.queryExecution.executedPlan.exists {
-        case BroadcastHashJoinExec(_, _, p: ExistenceJoin, _, _, _, _, _) => true
+        case BroadcastHashJoinExec(_, _, p: ExistenceJoin, _, _, _, _, _, _) => true
         case _ => false
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -701,8 +701,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       val distinctWithId = baseTable.distinct().withColumn("id", monotonically_increasing_id())
         .join(baseTable, "idx")
       assert(distinctWithId.queryExecution.executedPlan.exists {
-        case WholeStageCodegenExec(
-          ProjectExec(_, BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _))) => true
+        case WholeStageCodegenExec(ProjectExec(_,
+        BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _, _))) => true
         case _ => false
       })
       checkAnswer(distinctWithId, Seq(Row(1, 0), Row(1, 0)))
@@ -713,8 +713,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         baseTable.groupBy("idx").sum().withColumn("id", monotonically_increasing_id())
         .join(baseTable, "idx")
       assert(groupByWithId.queryExecution.executedPlan.exists {
-        case WholeStageCodegenExec(
-          ProjectExec(_, BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _))) => true
+        case WholeStageCodegenExec(ProjectExec(_,
+        BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _, _))) => true
         case _ => false
       })
       checkAnswer(groupByWithId, Seq(Row(1, 2, 0), Row(1, 2, 0)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2806,12 +2806,9 @@ class AdaptiveQueryExecSuite
         val (_, plan) = runAdaptiveAndVerifyResult(sqlText)
 
         val bhjs = collect(plan) {
-          case bhj: BroadcastHashJoinExec => bhj
+          case bhj: BroadcastHashJoinExec if bhj.isSkewJoin => bhj
         }
-
         assert(bhjs.nonEmpty)
-        val skewHandlingCount = bhjs.map(bhj => if (bhj.isSkewJoin) 1 else 0).sum
-        assert(skewHandlingCount == 1)
 
         val skewedShuffleReaders = collect(plan) {
           case c: AQEShuffleReadExec if c.isLocalRead => c


### PR DESCRIPTION
### What changes were proposed in this pull request?
We could handle the steam side skew of BroadcastHashJoin to improve the join performance

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/7522130/223371603-c83da69a-cf2c-445f-b937-2af92c5f0953.png" width="400" height="450"> | <img src="https://user-images.githubusercontent.com/7522130/223371590-56d4fd20-0c32-4806-967e-bb6e47851f29.png" width="400" height="450">


### Why are the changes needed?
We can extend the OptimizeSkewedJoin to handle this case

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
UT