### PR TITLE
[SPARK-42698][CORE] SparkSubmit should also stop SparkContext when exit program in yarn mode and pass exitCode to AM side

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1014,9 +1014,9 @@ private[spark] class SparkSubmit extends Logging {
         exitCode = -1
         throw findCause(t)
     } finally {
-      if (args.master.startsWith("k8s") && !isShell(args.primaryResource) &&
-          !isSqlShell(args.mainClass) && !isThriftServer(args.mainClass) &&
-          !isConnectServer(args.mainClass)) {
+      if ((args.master.startsWith("k8s") || args.master.startsWith("yarn")) &&
+        !isShell(args.primaryResource) && !isSqlShell(args.mainClass) &&
+        !isThriftServer(args.mainClass) && !isConnectServer(args.mainClass)) {
         try {
           SparkContext.getActive.foreach(_.stop(exitCode))
         } catch {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1005,17 +1005,20 @@ private[spark] class SparkSubmit extends Logging {
         e
     }
 
+    var exitCode = 0
+
     try {
       app.start(childArgs.toArray, sparkConf)
     } catch {
       case t: Throwable =>
+        exitCode = 1;
         throw findCause(t)
     } finally {
       if (args.master.startsWith("k8s") && !isShell(args.primaryResource) &&
           !isSqlShell(args.mainClass) && !isThriftServer(args.mainClass) &&
           !isConnectServer(args.mainClass)) {
         try {
-          SparkContext.getActive.foreach(_.stop())
+          SparkContext.getActive.foreach(_.stop(exitCode))
         } catch {
           case e: Throwable => logError(s"Failed to close SparkContext: $e")
         }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1011,7 +1011,7 @@ private[spark] class SparkSubmit extends Logging {
       app.start(childArgs.toArray, sparkConf)
     } catch {
       case t: Throwable =>
-        exitCode = 1;
+        exitCode = -1
         throw findCause(t)
     } finally {
       if (args.master.startsWith("k8s") && !isShell(args.primaryResource) &&


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently when we run yarn-client mode in SparkSubmit, when we catch exceptions during `runMain()`
Spark won't call `SparkContext.stop()` since pr https://github.com/apache/spark/pull/33403 remove the behavior.
Then AM side will mark the application as SUCCESS.

In this pr, we will revert the behavior of https://github.com/apache/spark/pull/33403 then YARN mode, it will call `sc.stop()` in YARN env, and also, the client side will pass the correct exit code to the YARN AM side. 

This pr fixes this issue.

### Why are the changes needed?
Keep the same exit code between the client and AM


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Mannul tested

The screenshot is our internal platform to show each app's status, the application status information is from YARN rm and timeline service.

Before change 
<img width="1140" alt="截屏2023-03-08 上午11 45 31" src="https://user-images.githubusercontent.com/46485123/223614465-0496e9bb-3cd5-41d8-b2f6-05d960db6963.png">


After change 

<img width="1255" alt="截屏2023-03-08 上午11 45 13" src="https://user-images.githubusercontent.com/46485123/223614448-51f3706b-ba69-4821-a074-853ed10ea5a2.png">
