### PR TITLE
[SPARK-42700][BUILD] Add `h2` as test dependency of connect-server module

### DIFF
--- a/connector/connect/server/pom.xml
+++ b/connector/connect/server/pom.xml
@@ -209,7 +209,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.1.214</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Run the following commands

```
build/mvn clean install -DskipTests -pl connector/connect/server -am
build/mvn test -pl connector/connect/server
```

then we can see the following error message due to [SPARK-42555](https://issues.apache.org/jira/browse/SPARK-42555) A adds the loading `org.h2.Driver` in `beforeAll` of `ProtoToParsedPlanTestSuite`, but 

```
ProtoToParsedPlanTestSuite:
*** RUN ABORTED ***
  java.lang.ClassNotFoundException: org.h2.Driver
  at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
  at java.base/java.lang.Class.forName0(Native Method)
  at java.base/java.lang.Class.forName(Class.java:398)
  at org.apache.spark.util.Utils$.classForName(Utils.scala:225)
  at org.apache.spark.sql.connect.ProtoToParsedPlanTestSuite.beforeAll(ProtoToParsedPlanTestSuite.scala:68)
  at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
  at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
  at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
  ...
```

So this pr add `h2` as test dependency of connect-server module to make maven test pass.

 

### Why are the changes needed?
Add `h2` as test dependency of connect-server module to make maven test pass.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
manual check：
```
build/mvn clean install -DskipTests -pl connector/connect/server -am
build/mvn test -pl connector/connect/server
```
with this pr, all test passed
