### PR TITLE
[SPARK-42656][SPARK SHELL][CONNECT][FOLLOWUP] Add same `ClassNotFoundException` catch to `repl.Main` for Scala 2.13

### DIFF
--- a/repl/src/main/scala-2.13/org/apache/spark/repl/Main.scala
+++ b/repl/src/main/scala-2.13/org/apache/spark/repl/Main.scala
@@ -129,6 +129,11 @@ object Main extends Logging {
       sparkContext = sparkSession.sparkContext
       sparkSession
     } catch {
+      case e: ClassNotFoundException if isShellSession && e.getMessage.contains(
+        "org.apache.spark.sql.connect.SparkConnectPlugin") =>
+        logError("Failed to load spark connect plugin.")
+        logError("You need to build Spark with -Pconnect.")
+        sys.exit(1)
       case e: Exception if isShellSession =>
         logError("Failed to initialize Spark session.", e)
         sys.exit(1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add the same `ClassNotFoundException` catch  to `repl.Main` for Scala 2.13 as https://github.com/apache/spark/pull/40305 due `org/apache/spark/repl/Main.scala` is Scala version sensitive。




### Why are the changes needed?
Make sure Scala 2.12 and 2.13 have the same logic 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual check
