### PR TITLE
Update code example formatting for protobuf parsing readme

### DIFF
--- a/docs/sql-data-sources-protobuf.md
+++ b/docs/sql-data-sources-protobuf.md
@@ -49,10 +49,8 @@ Kafka key-value record will be augmented with some metadata, such as the ingesti
 
 Spark SQL schema is generated based on the protobuf descriptor file or protobuf class passed to `from_protobuf` and `to_protobuf`. The specified protobuf class or protobuf descriptor file must match the data, otherwise, the behavior is undefined: it may fail or return arbitrary results.
 
-<div class="codetabs">
-
-<div data-lang="python" markdown="1">
-{% highlight python %}
+### python
+```python
 from pyspark.sql.protobuf.functions import from_protobuf, to_protobuf
 
 # `from_protobuf` and `to_protobuf` provides two schema choices. First, via the protobuf descriptor
@@ -107,12 +105,10 @@ query = output\
 .option("kafka.bootstrap.servers", "host1:port1,host2:port2")\
 .option("topic", "topic2")\
 .start()
+```
 
-{% endhighlight %}
-</div>
-
-<div data-lang="scala" markdown="1">
-{% highlight scala %}
+### scala
+```scala
 import org.apache.spark.sql.protobuf.functions._
 
 // `from_protobuf` and `to_protobuf` provides two schema choices. First, via the protobuf descriptor
@@ -172,12 +168,10 @@ val query = output
 .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
 .option("topic", "topic2")
 .start()
+```
 
-{% endhighlight %}
-</div>
-
-<div data-lang="java" markdown="1">
-{% highlight java %}
+### java
+```java
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.protobuf.functions.*;
 
@@ -235,11 +229,7 @@ StreamingQuery query = output
 .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
 .option("topic", "topic2")
 .start();
-
-{% endhighlight %}
-</div>
-
-</div>
+```
 
 ## Supported types for Protobuf -> Spark SQL conversion
 Currently Spark supports reading [protobuf scalar types](https://developers.google.com/protocol-buffers/docs/proto3#scalar), [enum types](https://developers.google.com/protocol-buffers/docs/proto3#enum), [nested type](https://developers.google.com/protocol-buffers/docs/proto3#nested), and [maps type](https://developers.google.com/protocol-buffers/docs/proto3#maps) under messages of Protobuf.
@@ -372,8 +362,7 @@ Setting `recursive.fields.max.depth` to 0 drops all recursive fields, setting it
 
 SQL Schema for the below protobuf message will vary based on the value of `recursive.fields.max.depth`.
 
-<div data-lang="scala" markdown="1">
-{% highlight scala %}
+```proto
 syntax  = "proto3"
 message Person {
   string name = 1;
@@ -386,6 +375,4 @@ message Person {
 0: struct<name: string, bff: null>
 1: struct<name string, bff: <name: string, bff: null>>
 2: struct<name string, bff: <name: string, bff: struct<name: string, bff: null>>> ...
-
-{% endhighlight %}
-</div>
+```


### PR DESCRIPTION
### What changes were proposed in this pull request?
I was reviewing this markdown document about proto parsing, and found that the formatting of code blocks looked incorrect:

some examples:
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/1002986/223468227-8fdd1db0-51ef-4c69-adaf-bca5f8ba92ce.png">
<img width="1124" alt="image" src="https://user-images.githubusercontent.com/1002986/223468420-a0813fe8-4546-48ce-b847-2ddac46bee07.png">

In this commit I changed the formatting to use github's markdown syntax for code blocks, " ``` ", and added syntax highlighting for each of them based on the language that it looked like.

They now look a bit more like this:
<img width="855" alt="image" src="https://user-images.githubusercontent.com/1002986/223469481-4b1e2cfc-1591-40f6-aec4-05eb0d5a463b.png">


### Why are the changes needed?
To help improve the readability of the documentation.


### Does this PR introduce _any_ user-facing change?
Yes, it updates user-facing documentation.

### How was this patch tested?
I inspected the github markdown preview to test that the changes looked correct.