### PR TITLE
[SPARK-42707][CONNECT][DOCS] Update developer documentation about API stability warning

### DIFF
--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -1,8 +1,5 @@
 # Spark Connect
 
-**Spark Connect is a strictly experimental feature and under heavy development.
-All APIs should be considered volatile and should not be used in production.**
-
 This module contains the implementation of Spark Connect which is a logical plan
 facade for the implementation in Spark. Spark Connect is directly integrated into the build
 of Spark.

--- a/python/pyspark/sql/connect/__init__.py
+++ b/python/pyspark/sql/connect/__init__.py
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-"""Currently Spark Connect is very experimental and the APIs to interact with
-Spark through this API are can be changed at any time without warning."""
+"""Spark Connect cleint"""

--- a/python/pyspark/sql/connect/__init__.py
+++ b/python/pyspark/sql/connect/__init__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-"""Spark Connect cleint"""
+"""Spark Connect client"""


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the developer documentation by removing the warnings about API compatibility.

### Why are the changes needed?

We actually are going to keep the compatibility there. Such warnings cause a misconception that we can just break the compatibility there.

### Does this PR introduce _any_ user-facing change?

No, it's developer-only docs.

### How was this patch tested?

Linters in CI should test it out.
