### PR TITLE
[SPARK-42710][CONNECT][PYTHON] Rename FrameMap proto to MapPartitions

### DIFF
--- a/connector/connect/common/src/main/protobuf/spark/connect/relations.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/relations.proto
@@ -60,7 +60,7 @@ message Relation {
     Unpivot unpivot = 25;
     ToSchema to_schema = 26;
     RepartitionByExpression repartition_by_expression = 27;
-    FrameMap frame_map = 28;
+    MapPartitions map_partitions = 28;
     CollectMetrics collect_metrics = 29;
     Parse parse = 30;
 
@@ -780,11 +780,11 @@ message RepartitionByExpression {
   optional int32 num_partitions = 3;
 }
 
-message FrameMap {
-  // (Required) Input relation for a Frame Map API: mapInPandas, mapInArrow.
+message MapPartitions {
+  // (Required) Input relation for a mapPartitions-equivalent API: mapInPandas, mapInArrow.
   Relation input = 1;
 
-  // (Required) Input user-defined function of a Frame Map API.
+  // (Required) Input user-defined function.
   CommonInlineUserDefinedFunction func = 2;
 }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -114,8 +114,8 @@ class SparkConnectPlanner(val session: SparkSession) {
       case proto.Relation.RelTypeCase.UNPIVOT => transformUnpivot(rel.getUnpivot)
       case proto.Relation.RelTypeCase.REPARTITION_BY_EXPRESSION =>
         transformRepartitionByExpression(rel.getRepartitionByExpression)
-      case proto.Relation.RelTypeCase.FRAME_MAP =>
-        transformFrameMap(rel.getFrameMap)
+      case proto.Relation.RelTypeCase.MAP_PARTITIONS =>
+        transformMapPartitions(rel.getMapPartitions)
       case proto.Relation.RelTypeCase.COLLECT_METRICS =>
         transformCollectMetrics(rel.getCollectMetrics)
       case proto.Relation.RelTypeCase.PARSE => transformParse(rel.getParse)
@@ -471,7 +471,7 @@ class SparkConnectPlanner(val session: SparkSession) {
       .logicalPlan
   }
 
-  private def transformFrameMap(rel: proto.FrameMap): LogicalPlan = {
+  private def transformMapPartitions(rel: proto.MapPartitions): LogicalPlan = {
     val commonUdf = rel.getFunc
     val pythonUdf = transformPythonUDF(commonUdf)
     pythonUdf.evalType match {

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1585,7 +1585,7 @@ class DataFrame:
         )
 
         return DataFrame.withPlan(
-            plan.FrameMap(child=self._plan, function=udf_obj, cols=self.columns),
+            plan.MapPartitions(child=self._plan, function=udf_obj, cols=self.columns),
             session=self._session,
         )
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1901,8 +1901,8 @@ class ListCatalogs(LogicalPlan):
         return proto.Relation(catalog=proto.Catalog(list_catalogs=proto.ListCatalogs()))
 
 
-class FrameMap(LogicalPlan):
-    """Logical plan object for a Frame Map API: mapInPandas, mapInArrow."""
+class MapPartitions(LogicalPlan):
+    """Logical plan object for a mapPartitions-equivalent API: mapInPandas, mapInArrow."""
 
     def __init__(
         self, child: Optional["LogicalPlan"], function: "UserDefinedFunction", cols: List[str]
@@ -1914,8 +1914,8 @@ class FrameMap(LogicalPlan):
     def plan(self, session: "SparkConnectClient") -> proto.Relation:
         assert self._child is not None
         plan = self._create_proto_relation()
-        plan.frame_map.input.CopyFrom(self._child.plan(session))
-        plan.frame_map.func.CopyFrom(self._func.to_plan_udf(session))
+        plan.map_partitions.input.CopyFrom(self._child.plan(session))
+        plan.map_partitions.func.CopyFrom(self._func.to_plan_udf(session))
         return plan
 
 

--- a/python/pyspark/sql/connect/proto/relations_pb2.py
+++ b/python/pyspark/sql/connect/proto/relations_pb2.py
@@ -36,7 +36,7 @@ from pyspark.sql.connect.proto import catalog_pb2 as spark_dot_connect_dot_catal
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1dspark/connect/relations.proto\x12\rspark.connect\x1a\x19google/protobuf/any.proto\x1a\x1fspark/connect/expressions.proto\x1a\x19spark/connect/types.proto\x1a\x1bspark/connect/catalog.proto"\xa9\x13\n\x08Relation\x12\x35\n\x06\x63ommon\x18\x01 \x01(\x0b\x32\x1d.spark.connect.RelationCommonR\x06\x63ommon\x12)\n\x04read\x18\x02 \x01(\x0b\x32\x13.spark.connect.ReadH\x00R\x04read\x12\x32\n\x07project\x18\x03 \x01(\x0b\x32\x16.spark.connect.ProjectH\x00R\x07project\x12/\n\x06\x66ilter\x18\x04 \x01(\x0b\x32\x15.spark.connect.FilterH\x00R\x06\x66ilter\x12)\n\x04join\x18\x05 \x01(\x0b\x32\x13.spark.connect.JoinH\x00R\x04join\x12\x34\n\x06set_op\x18\x06 \x01(\x0b\x32\x1b.spark.connect.SetOperationH\x00R\x05setOp\x12)\n\x04sort\x18\x07 \x01(\x0b\x32\x13.spark.connect.SortH\x00R\x04sort\x12,\n\x05limit\x18\x08 \x01(\x0b\x32\x14.spark.connect.LimitH\x00R\x05limit\x12\x38\n\taggregate\x18\t \x01(\x0b\x32\x18.spark.connect.AggregateH\x00R\taggregate\x12&\n\x03sql\x18\n \x01(\x0b\x32\x12.spark.connect.SQLH\x00R\x03sql\x12\x45\n\x0elocal_relation\x18\x0b \x01(\x0b\x32\x1c.spark.connect.LocalRelationH\x00R\rlocalRelation\x12/\n\x06sample\x18\x0c \x01(\x0b\x32\x15.spark.connect.SampleH\x00R\x06sample\x12/\n\x06offset\x18\r \x01(\x0b\x32\x15.spark.connect.OffsetH\x00R\x06offset\x12>\n\x0b\x64\x65\x64uplicate\x18\x0e \x01(\x0b\x32\x1a.spark.connect.DeduplicateH\x00R\x0b\x64\x65\x64uplicate\x12,\n\x05range\x18\x0f \x01(\x0b\x32\x14.spark.connect.RangeH\x00R\x05range\x12\x45\n\x0esubquery_alias\x18\x10 \x01(\x0b\x32\x1c.spark.connect.SubqueryAliasH\x00R\rsubqueryAlias\x12>\n\x0brepartition\x18\x11 \x01(\x0b\x32\x1a.spark.connect.RepartitionH\x00R\x0brepartition\x12*\n\x05to_df\x18\x12 \x01(\x0b\x32\x13.spark.connect.ToDFH\x00R\x04toDf\x12U\n\x14with_columns_renamed\x18\x13 \x01(\x0b\x32!.spark.connect.WithColumnsRenamedH\x00R\x12withColumnsRenamed\x12<\n\x0bshow_string\x18\x14 \x01(\x0b\x32\x19.spark.connect.ShowStringH\x00R\nshowString\x12)\n\x04\x64rop\x18\x15 \x01(\x0b\x32\x13.spark.connect.DropH\x00R\x04\x64rop\x12)\n\x04tail\x18\x16 \x01(\x0b\x32\x13.spark.connect.TailH\x00R\x04tail\x12?\n\x0cwith_columns\x18\x17 \x01(\x0b\x32\x1a.spark.connect.WithColumnsH\x00R\x0bwithColumns\x12)\n\x04hint\x18\x18 \x01(\x0b\x32\x13.spark.connect.HintH\x00R\x04hint\x12\x32\n\x07unpivot\x18\x19 \x01(\x0b\x32\x16.spark.connect.UnpivotH\x00R\x07unpivot\x12\x36\n\tto_schema\x18\x1a \x01(\x0b\x32\x17.spark.connect.ToSchemaH\x00R\x08toSchema\x12\x64\n\x19repartition_by_expression\x18\x1b \x01(\x0b\x32&.spark.connect.RepartitionByExpressionH\x00R\x17repartitionByExpression\x12\x36\n\tframe_map\x18\x1c \x01(\x0b\x32\x17.spark.connect.FrameMapH\x00R\x08\x66rameMap\x12H\n\x0f\x63ollect_metrics\x18\x1d \x01(\x0b\x32\x1d.spark.connect.CollectMetricsH\x00R\x0e\x63ollectMetrics\x12,\n\x05parse\x18\x1e \x01(\x0b\x32\x14.spark.connect.ParseH\x00R\x05parse\x12\x30\n\x07\x66ill_na\x18Z \x01(\x0b\x32\x15.spark.connect.NAFillH\x00R\x06\x66illNa\x12\x30\n\x07\x64rop_na\x18[ \x01(\x0b\x32\x15.spark.connect.NADropH\x00R\x06\x64ropNa\x12\x34\n\x07replace\x18\\ \x01(\x0b\x32\x18.spark.connect.NAReplaceH\x00R\x07replace\x12\x36\n\x07summary\x18\x64 \x01(\x0b\x32\x1a.spark.connect.StatSummaryH\x00R\x07summary\x12\x39\n\x08\x63rosstab\x18\x65 \x01(\x0b\x32\x1b.spark.connect.StatCrosstabH\x00R\x08\x63rosstab\x12\x39\n\x08\x64\x65scribe\x18\x66 \x01(\x0b\x32\x1b.spark.connect.StatDescribeH\x00R\x08\x64\x65scribe\x12*\n\x03\x63ov\x18g \x01(\x0b\x32\x16.spark.connect.StatCovH\x00R\x03\x63ov\x12-\n\x04\x63orr\x18h \x01(\x0b\x32\x17.spark.connect.StatCorrH\x00R\x04\x63orr\x12L\n\x0f\x61pprox_quantile\x18i \x01(\x0b\x32!.spark.connect.StatApproxQuantileH\x00R\x0e\x61pproxQuantile\x12=\n\nfreq_items\x18j \x01(\x0b\x32\x1c.spark.connect.StatFreqItemsH\x00R\tfreqItems\x12:\n\tsample_by\x18k \x01(\x0b\x32\x1b.spark.connect.StatSampleByH\x00R\x08sampleBy\x12\x33\n\x07\x63\x61talog\x18\xc8\x01 \x01(\x0b\x32\x16.spark.connect.CatalogH\x00R\x07\x63\x61talog\x12\x35\n\textension\x18\xe6\x07 \x01(\x0b\x32\x14.google.protobuf.AnyH\x00R\textension\x12\x33\n\x07unknown\x18\xe7\x07 \x01(\x0b\x32\x16.spark.connect.UnknownH\x00R\x07unknownB\n\n\x08rel_type"\t\n\x07Unknown"[\n\x0eRelationCommon\x12\x1f\n\x0bsource_info\x18\x01 \x01(\tR\nsourceInfo\x12\x1c\n\x07plan_id\x18\x02 \x01(\x03H\x00R\x06planId\x88\x01\x01\x42\n\n\x08_plan_id"\x86\x01\n\x03SQL\x12\x14\n\x05query\x18\x01 \x01(\tR\x05query\x12\x30\n\x04\x61rgs\x18\x02 \x03(\x0b\x32\x1c.spark.connect.SQL.ArgsEntryR\x04\x61rgs\x1a\x37\n\tArgsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01"\xf0\x03\n\x04Read\x12\x41\n\x0bnamed_table\x18\x01 \x01(\x0b\x32\x1e.spark.connect.Read.NamedTableH\x00R\nnamedTable\x12\x41\n\x0b\x64\x61ta_source\x18\x02 \x01(\x0b\x32\x1e.spark.connect.Read.DataSourceH\x00R\ndataSource\x1a=\n\nNamedTable\x12/\n\x13unparsed_identifier\x18\x01 \x01(\tR\x12unparsedIdentifier\x1a\x95\x02\n\nDataSource\x12\x1b\n\x06\x66ormat\x18\x01 \x01(\tH\x00R\x06\x66ormat\x88\x01\x01\x12\x1b\n\x06schema\x18\x02 \x01(\tH\x01R\x06schema\x88\x01\x01\x12\x45\n\x07options\x18\x03 \x03(\x0b\x32+.spark.connect.Read.DataSource.OptionsEntryR\x07options\x12\x14\n\x05paths\x18\x04 \x03(\tR\x05paths\x12\x1e\n\npredicates\x18\x05 \x03(\tR\npredicates\x1a:\n\x0cOptionsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\t\n\x07_formatB\t\n\x07_schemaB\x0b\n\tread_type"u\n\x07Project\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12;\n\x0b\x65xpressions\x18\x03 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x0b\x65xpressions"p\n\x06\x46ilter\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x37\n\tcondition\x18\x02 \x01(\x0b\x32\x19.spark.connect.ExpressionR\tcondition"\xd7\x03\n\x04Join\x12+\n\x04left\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x04left\x12-\n\x05right\x18\x02 \x01(\x0b\x32\x17.spark.connect.RelationR\x05right\x12@\n\x0ejoin_condition\x18\x03 \x01(\x0b\x32\x19.spark.connect.ExpressionR\rjoinCondition\x12\x39\n\tjoin_type\x18\x04 \x01(\x0e\x32\x1c.spark.connect.Join.JoinTypeR\x08joinType\x12#\n\rusing_columns\x18\x05 \x03(\tR\x0cusingColumns"\xd0\x01\n\x08JoinType\x12\x19\n\x15JOIN_TYPE_UNSPECIFIED\x10\x00\x12\x13\n\x0fJOIN_TYPE_INNER\x10\x01\x12\x18\n\x14JOIN_TYPE_FULL_OUTER\x10\x02\x12\x18\n\x14JOIN_TYPE_LEFT_OUTER\x10\x03\x12\x19\n\x15JOIN_TYPE_RIGHT_OUTER\x10\x04\x12\x17\n\x13JOIN_TYPE_LEFT_ANTI\x10\x05\x12\x17\n\x13JOIN_TYPE_LEFT_SEMI\x10\x06\x12\x13\n\x0fJOIN_TYPE_CROSS\x10\x07"\xdf\x03\n\x0cSetOperation\x12\x36\n\nleft_input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\tleftInput\x12\x38\n\x0bright_input\x18\x02 \x01(\x0b\x32\x17.spark.connect.RelationR\nrightInput\x12\x45\n\x0bset_op_type\x18\x03 \x01(\x0e\x32%.spark.connect.SetOperation.SetOpTypeR\tsetOpType\x12\x1a\n\x06is_all\x18\x04 \x01(\x08H\x00R\x05isAll\x88\x01\x01\x12\x1c\n\x07\x62y_name\x18\x05 \x01(\x08H\x01R\x06\x62yName\x88\x01\x01\x12\x37\n\x15\x61llow_missing_columns\x18\x06 \x01(\x08H\x02R\x13\x61llowMissingColumns\x88\x01\x01"r\n\tSetOpType\x12\x1b\n\x17SET_OP_TYPE_UNSPECIFIED\x10\x00\x12\x19\n\x15SET_OP_TYPE_INTERSECT\x10\x01\x12\x15\n\x11SET_OP_TYPE_UNION\x10\x02\x12\x16\n\x12SET_OP_TYPE_EXCEPT\x10\x03\x42\t\n\x07_is_allB\n\n\x08_by_nameB\x18\n\x16_allow_missing_columns"L\n\x05Limit\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x14\n\x05limit\x18\x02 \x01(\x05R\x05limit"O\n\x06Offset\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x16\n\x06offset\x18\x02 \x01(\x05R\x06offset"K\n\x04Tail\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x14\n\x05limit\x18\x02 \x01(\x05R\x05limit"\xc6\x04\n\tAggregate\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x41\n\ngroup_type\x18\x02 \x01(\x0e\x32".spark.connect.Aggregate.GroupTypeR\tgroupType\x12L\n\x14grouping_expressions\x18\x03 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x13groupingExpressions\x12N\n\x15\x61ggregate_expressions\x18\x04 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x14\x61ggregateExpressions\x12\x34\n\x05pivot\x18\x05 \x01(\x0b\x32\x1e.spark.connect.Aggregate.PivotR\x05pivot\x1ao\n\x05Pivot\x12+\n\x03\x63ol\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x03\x63ol\x12\x39\n\x06values\x18\x02 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values"\x81\x01\n\tGroupType\x12\x1a\n\x16GROUP_TYPE_UNSPECIFIED\x10\x00\x12\x16\n\x12GROUP_TYPE_GROUPBY\x10\x01\x12\x15\n\x11GROUP_TYPE_ROLLUP\x10\x02\x12\x13\n\x0fGROUP_TYPE_CUBE\x10\x03\x12\x14\n\x10GROUP_TYPE_PIVOT\x10\x04"\xa0\x01\n\x04Sort\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x39\n\x05order\x18\x02 \x03(\x0b\x32#.spark.connect.Expression.SortOrderR\x05order\x12 \n\tis_global\x18\x03 \x01(\x08H\x00R\x08isGlobal\x88\x01\x01\x42\x0c\n\n_is_global"\x8d\x01\n\x04\x44rop\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x33\n\x07\x63olumns\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x07\x63olumns\x12!\n\x0c\x63olumn_names\x18\x03 \x03(\tR\x0b\x63olumnNames"\xab\x01\n\x0b\x44\x65\x64uplicate\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12!\n\x0c\x63olumn_names\x18\x02 \x03(\tR\x0b\x63olumnNames\x12\x32\n\x13\x61ll_columns_as_keys\x18\x03 \x01(\x08H\x00R\x10\x61llColumnsAsKeys\x88\x01\x01\x42\x16\n\x14_all_columns_as_keys"Y\n\rLocalRelation\x12\x17\n\x04\x64\x61ta\x18\x01 \x01(\x0cH\x00R\x04\x64\x61ta\x88\x01\x01\x12\x1b\n\x06schema\x18\x02 \x01(\tH\x01R\x06schema\x88\x01\x01\x42\x07\n\x05_dataB\t\n\x07_schema"\x91\x02\n\x06Sample\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x1f\n\x0blower_bound\x18\x02 \x01(\x01R\nlowerBound\x12\x1f\n\x0bupper_bound\x18\x03 \x01(\x01R\nupperBound\x12.\n\x10with_replacement\x18\x04 \x01(\x08H\x00R\x0fwithReplacement\x88\x01\x01\x12\x17\n\x04seed\x18\x05 \x01(\x03H\x01R\x04seed\x88\x01\x01\x12/\n\x13\x64\x65terministic_order\x18\x06 \x01(\x08R\x12\x64\x65terministicOrderB\x13\n\x11_with_replacementB\x07\n\x05_seed"\x91\x01\n\x05Range\x12\x19\n\x05start\x18\x01 \x01(\x03H\x00R\x05start\x88\x01\x01\x12\x10\n\x03\x65nd\x18\x02 \x01(\x03R\x03\x65nd\x12\x12\n\x04step\x18\x03 \x01(\x03R\x04step\x12*\n\x0enum_partitions\x18\x04 \x01(\x05H\x01R\rnumPartitions\x88\x01\x01\x42\x08\n\x06_startB\x11\n\x0f_num_partitions"r\n\rSubqueryAlias\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x14\n\x05\x61lias\x18\x02 \x01(\tR\x05\x61lias\x12\x1c\n\tqualifier\x18\x03 \x03(\tR\tqualifier"\x8e\x01\n\x0bRepartition\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12%\n\x0enum_partitions\x18\x02 \x01(\x05R\rnumPartitions\x12\x1d\n\x07shuffle\x18\x03 \x01(\x08H\x00R\x07shuffle\x88\x01\x01\x42\n\n\x08_shuffle"\x8e\x01\n\nShowString\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x19\n\x08num_rows\x18\x02 \x01(\x05R\x07numRows\x12\x1a\n\x08truncate\x18\x03 \x01(\x05R\x08truncate\x12\x1a\n\x08vertical\x18\x04 \x01(\x08R\x08vertical"\\\n\x0bStatSummary\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x1e\n\nstatistics\x18\x02 \x03(\tR\nstatistics"Q\n\x0cStatDescribe\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols"e\n\x0cStatCrosstab\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ol1\x18\x02 \x01(\tR\x04\x63ol1\x12\x12\n\x04\x63ol2\x18\x03 \x01(\tR\x04\x63ol2"`\n\x07StatCov\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ol1\x18\x02 \x01(\tR\x04\x63ol1\x12\x12\n\x04\x63ol2\x18\x03 \x01(\tR\x04\x63ol2"\x89\x01\n\x08StatCorr\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ol1\x18\x02 \x01(\tR\x04\x63ol1\x12\x12\n\x04\x63ol2\x18\x03 \x01(\tR\x04\x63ol2\x12\x1b\n\x06method\x18\x04 \x01(\tH\x00R\x06method\x88\x01\x01\x42\t\n\x07_method"\xa4\x01\n\x12StatApproxQuantile\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12$\n\rprobabilities\x18\x03 \x03(\x01R\rprobabilities\x12%\n\x0erelative_error\x18\x04 \x01(\x01R\rrelativeError"}\n\rStatFreqItems\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12\x1d\n\x07support\x18\x03 \x01(\x01H\x00R\x07support\x88\x01\x01\x42\n\n\x08_support"\xb5\x02\n\x0cStatSampleBy\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12+\n\x03\x63ol\x18\x02 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x03\x63ol\x12\x42\n\tfractions\x18\x03 \x03(\x0b\x32$.spark.connect.StatSampleBy.FractionR\tfractions\x12\x17\n\x04seed\x18\x05 \x01(\x03H\x00R\x04seed\x88\x01\x01\x1a\x63\n\x08\x46raction\x12;\n\x07stratum\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x07stratum\x12\x1a\n\x08\x66raction\x18\x02 \x01(\x01R\x08\x66ractionB\x07\n\x05_seed"\x86\x01\n\x06NAFill\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12\x39\n\x06values\x18\x03 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values"\x86\x01\n\x06NADrop\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12\'\n\rmin_non_nulls\x18\x03 \x01(\x05H\x00R\x0bminNonNulls\x88\x01\x01\x42\x10\n\x0e_min_non_nulls"\xa8\x02\n\tNAReplace\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12H\n\x0creplacements\x18\x03 \x03(\x0b\x32$.spark.connect.NAReplace.ReplacementR\x0creplacements\x1a\x8d\x01\n\x0bReplacement\x12>\n\told_value\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x08oldValue\x12>\n\tnew_value\x18\x02 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x08newValue"X\n\x04ToDF\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12!\n\x0c\x63olumn_names\x18\x02 \x03(\tR\x0b\x63olumnNames"\xef\x01\n\x12WithColumnsRenamed\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x65\n\x12rename_columns_map\x18\x02 \x03(\x0b\x32\x37.spark.connect.WithColumnsRenamed.RenameColumnsMapEntryR\x10renameColumnsMap\x1a\x43\n\x15RenameColumnsMapEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01"w\n\x0bWithColumns\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x39\n\x07\x61liases\x18\x02 \x03(\x0b\x32\x1f.spark.connect.Expression.AliasR\x07\x61liases"\x84\x01\n\x04Hint\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04name\x18\x02 \x01(\tR\x04name\x12\x39\n\nparameters\x18\x03 \x03(\x0b\x32\x19.spark.connect.ExpressionR\nparameters"\xc7\x02\n\x07Unpivot\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12+\n\x03ids\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x03ids\x12:\n\x06values\x18\x03 \x01(\x0b\x32\x1d.spark.connect.Unpivot.ValuesH\x00R\x06values\x88\x01\x01\x12\x30\n\x14variable_column_name\x18\x04 \x01(\tR\x12variableColumnName\x12*\n\x11value_column_name\x18\x05 \x01(\tR\x0fvalueColumnName\x1a;\n\x06Values\x12\x31\n\x06values\x18\x01 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x06valuesB\t\n\x07_values"j\n\x08ToSchema\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12/\n\x06schema\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x06schema"\xcb\x01\n\x17RepartitionByExpression\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x42\n\x0fpartition_exprs\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x0epartitionExprs\x12*\n\x0enum_partitions\x18\x03 \x01(\x05H\x00R\rnumPartitions\x88\x01\x01\x42\x11\n\x0f_num_partitions"}\n\x08\x46rameMap\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x42\n\x04\x66unc\x18\x02 \x01(\x0b\x32..spark.connect.CommonInlineUserDefinedFunctionR\x04\x66unc"\x88\x01\n\x0e\x43ollectMetrics\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04name\x18\x02 \x01(\tR\x04name\x12\x33\n\x07metrics\x18\x03 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x07metrics"\x84\x03\n\x05Parse\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x38\n\x06\x66ormat\x18\x02 \x01(\x0e\x32 .spark.connect.Parse.ParseFormatR\x06\x66ormat\x12\x34\n\x06schema\x18\x03 \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x06schema\x88\x01\x01\x12;\n\x07options\x18\x04 \x03(\x0b\x32!.spark.connect.Parse.OptionsEntryR\x07options\x1a:\n\x0cOptionsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01"X\n\x0bParseFormat\x12\x1c\n\x18PARSE_FORMAT_UNSPECIFIED\x10\x00\x12\x14\n\x10PARSE_FORMAT_CSV\x10\x01\x12\x15\n\x11PARSE_FORMAT_JSON\x10\x02\x42\t\n\x07_schemaB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
+    b'\n\x1dspark/connect/relations.proto\x12\rspark.connect\x1a\x19google/protobuf/any.proto\x1a\x1fspark/connect/expressions.proto\x1a\x19spark/connect/types.proto\x1a\x1bspark/connect/catalog.proto"\xb8\x13\n\x08Relation\x12\x35\n\x06\x63ommon\x18\x01 \x01(\x0b\x32\x1d.spark.connect.RelationCommonR\x06\x63ommon\x12)\n\x04read\x18\x02 \x01(\x0b\x32\x13.spark.connect.ReadH\x00R\x04read\x12\x32\n\x07project\x18\x03 \x01(\x0b\x32\x16.spark.connect.ProjectH\x00R\x07project\x12/\n\x06\x66ilter\x18\x04 \x01(\x0b\x32\x15.spark.connect.FilterH\x00R\x06\x66ilter\x12)\n\x04join\x18\x05 \x01(\x0b\x32\x13.spark.connect.JoinH\x00R\x04join\x12\x34\n\x06set_op\x18\x06 \x01(\x0b\x32\x1b.spark.connect.SetOperationH\x00R\x05setOp\x12)\n\x04sort\x18\x07 \x01(\x0b\x32\x13.spark.connect.SortH\x00R\x04sort\x12,\n\x05limit\x18\x08 \x01(\x0b\x32\x14.spark.connect.LimitH\x00R\x05limit\x12\x38\n\taggregate\x18\t \x01(\x0b\x32\x18.spark.connect.AggregateH\x00R\taggregate\x12&\n\x03sql\x18\n \x01(\x0b\x32\x12.spark.connect.SQLH\x00R\x03sql\x12\x45\n\x0elocal_relation\x18\x0b \x01(\x0b\x32\x1c.spark.connect.LocalRelationH\x00R\rlocalRelation\x12/\n\x06sample\x18\x0c \x01(\x0b\x32\x15.spark.connect.SampleH\x00R\x06sample\x12/\n\x06offset\x18\r \x01(\x0b\x32\x15.spark.connect.OffsetH\x00R\x06offset\x12>\n\x0b\x64\x65\x64uplicate\x18\x0e \x01(\x0b\x32\x1a.spark.connect.DeduplicateH\x00R\x0b\x64\x65\x64uplicate\x12,\n\x05range\x18\x0f \x01(\x0b\x32\x14.spark.connect.RangeH\x00R\x05range\x12\x45\n\x0esubquery_alias\x18\x10 \x01(\x0b\x32\x1c.spark.connect.SubqueryAliasH\x00R\rsubqueryAlias\x12>\n\x0brepartition\x18\x11 \x01(\x0b\x32\x1a.spark.connect.RepartitionH\x00R\x0brepartition\x12*\n\x05to_df\x18\x12 \x01(\x0b\x32\x13.spark.connect.ToDFH\x00R\x04toDf\x12U\n\x14with_columns_renamed\x18\x13 \x01(\x0b\x32!.spark.connect.WithColumnsRenamedH\x00R\x12withColumnsRenamed\x12<\n\x0bshow_string\x18\x14 \x01(\x0b\x32\x19.spark.connect.ShowStringH\x00R\nshowString\x12)\n\x04\x64rop\x18\x15 \x01(\x0b\x32\x13.spark.connect.DropH\x00R\x04\x64rop\x12)\n\x04tail\x18\x16 \x01(\x0b\x32\x13.spark.connect.TailH\x00R\x04tail\x12?\n\x0cwith_columns\x18\x17 \x01(\x0b\x32\x1a.spark.connect.WithColumnsH\x00R\x0bwithColumns\x12)\n\x04hint\x18\x18 \x01(\x0b\x32\x13.spark.connect.HintH\x00R\x04hint\x12\x32\n\x07unpivot\x18\x19 \x01(\x0b\x32\x16.spark.connect.UnpivotH\x00R\x07unpivot\x12\x36\n\tto_schema\x18\x1a \x01(\x0b\x32\x17.spark.connect.ToSchemaH\x00R\x08toSchema\x12\x64\n\x19repartition_by_expression\x18\x1b \x01(\x0b\x32&.spark.connect.RepartitionByExpressionH\x00R\x17repartitionByExpression\x12\x45\n\x0emap_partitions\x18\x1c \x01(\x0b\x32\x1c.spark.connect.MapPartitionsH\x00R\rmapPartitions\x12H\n\x0f\x63ollect_metrics\x18\x1d \x01(\x0b\x32\x1d.spark.connect.CollectMetricsH\x00R\x0e\x63ollectMetrics\x12,\n\x05parse\x18\x1e \x01(\x0b\x32\x14.spark.connect.ParseH\x00R\x05parse\x12\x30\n\x07\x66ill_na\x18Z \x01(\x0b\x32\x15.spark.connect.NAFillH\x00R\x06\x66illNa\x12\x30\n\x07\x64rop_na\x18[ \x01(\x0b\x32\x15.spark.connect.NADropH\x00R\x06\x64ropNa\x12\x34\n\x07replace\x18\\ \x01(\x0b\x32\x18.spark.connect.NAReplaceH\x00R\x07replace\x12\x36\n\x07summary\x18\x64 \x01(\x0b\x32\x1a.spark.connect.StatSummaryH\x00R\x07summary\x12\x39\n\x08\x63rosstab\x18\x65 \x01(\x0b\x32\x1b.spark.connect.StatCrosstabH\x00R\x08\x63rosstab\x12\x39\n\x08\x64\x65scribe\x18\x66 \x01(\x0b\x32\x1b.spark.connect.StatDescribeH\x00R\x08\x64\x65scribe\x12*\n\x03\x63ov\x18g \x01(\x0b\x32\x16.spark.connect.StatCovH\x00R\x03\x63ov\x12-\n\x04\x63orr\x18h \x01(\x0b\x32\x17.spark.connect.StatCorrH\x00R\x04\x63orr\x12L\n\x0f\x61pprox_quantile\x18i \x01(\x0b\x32!.spark.connect.StatApproxQuantileH\x00R\x0e\x61pproxQuantile\x12=\n\nfreq_items\x18j \x01(\x0b\x32\x1c.spark.connect.StatFreqItemsH\x00R\tfreqItems\x12:\n\tsample_by\x18k \x01(\x0b\x32\x1b.spark.connect.StatSampleByH\x00R\x08sampleBy\x12\x33\n\x07\x63\x61talog\x18\xc8\x01 \x01(\x0b\x32\x16.spark.connect.CatalogH\x00R\x07\x63\x61talog\x12\x35\n\textension\x18\xe6\x07 \x01(\x0b\x32\x14.google.protobuf.AnyH\x00R\textension\x12\x33\n\x07unknown\x18\xe7\x07 \x01(\x0b\x32\x16.spark.connect.UnknownH\x00R\x07unknownB\n\n\x08rel_type"\t\n\x07Unknown"[\n\x0eRelationCommon\x12\x1f\n\x0bsource_info\x18\x01 \x01(\tR\nsourceInfo\x12\x1c\n\x07plan_id\x18\x02 \x01(\x03H\x00R\x06planId\x88\x01\x01\x42\n\n\x08_plan_id"\x86\x01\n\x03SQL\x12\x14\n\x05query\x18\x01 \x01(\tR\x05query\x12\x30\n\x04\x61rgs\x18\x02 \x03(\x0b\x32\x1c.spark.connect.SQL.ArgsEntryR\x04\x61rgs\x1a\x37\n\tArgsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01"\xf0\x03\n\x04Read\x12\x41\n\x0bnamed_table\x18\x01 \x01(\x0b\x32\x1e.spark.connect.Read.NamedTableH\x00R\nnamedTable\x12\x41\n\x0b\x64\x61ta_source\x18\x02 \x01(\x0b\x32\x1e.spark.connect.Read.DataSourceH\x00R\ndataSource\x1a=\n\nNamedTable\x12/\n\x13unparsed_identifier\x18\x01 \x01(\tR\x12unparsedIdentifier\x1a\x95\x02\n\nDataSource\x12\x1b\n\x06\x66ormat\x18\x01 \x01(\tH\x00R\x06\x66ormat\x88\x01\x01\x12\x1b\n\x06schema\x18\x02 \x01(\tH\x01R\x06schema\x88\x01\x01\x12\x45\n\x07options\x18\x03 \x03(\x0b\x32+.spark.connect.Read.DataSource.OptionsEntryR\x07options\x12\x14\n\x05paths\x18\x04 \x03(\tR\x05paths\x12\x1e\n\npredicates\x18\x05 \x03(\tR\npredicates\x1a:\n\x0cOptionsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01\x42\t\n\x07_formatB\t\n\x07_schemaB\x0b\n\tread_type"u\n\x07Project\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12;\n\x0b\x65xpressions\x18\x03 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x0b\x65xpressions"p\n\x06\x46ilter\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x37\n\tcondition\x18\x02 \x01(\x0b\x32\x19.spark.connect.ExpressionR\tcondition"\xd7\x03\n\x04Join\x12+\n\x04left\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x04left\x12-\n\x05right\x18\x02 \x01(\x0b\x32\x17.spark.connect.RelationR\x05right\x12@\n\x0ejoin_condition\x18\x03 \x01(\x0b\x32\x19.spark.connect.ExpressionR\rjoinCondition\x12\x39\n\tjoin_type\x18\x04 \x01(\x0e\x32\x1c.spark.connect.Join.JoinTypeR\x08joinType\x12#\n\rusing_columns\x18\x05 \x03(\tR\x0cusingColumns"\xd0\x01\n\x08JoinType\x12\x19\n\x15JOIN_TYPE_UNSPECIFIED\x10\x00\x12\x13\n\x0fJOIN_TYPE_INNER\x10\x01\x12\x18\n\x14JOIN_TYPE_FULL_OUTER\x10\x02\x12\x18\n\x14JOIN_TYPE_LEFT_OUTER\x10\x03\x12\x19\n\x15JOIN_TYPE_RIGHT_OUTER\x10\x04\x12\x17\n\x13JOIN_TYPE_LEFT_ANTI\x10\x05\x12\x17\n\x13JOIN_TYPE_LEFT_SEMI\x10\x06\x12\x13\n\x0fJOIN_TYPE_CROSS\x10\x07"\xdf\x03\n\x0cSetOperation\x12\x36\n\nleft_input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\tleftInput\x12\x38\n\x0bright_input\x18\x02 \x01(\x0b\x32\x17.spark.connect.RelationR\nrightInput\x12\x45\n\x0bset_op_type\x18\x03 \x01(\x0e\x32%.spark.connect.SetOperation.SetOpTypeR\tsetOpType\x12\x1a\n\x06is_all\x18\x04 \x01(\x08H\x00R\x05isAll\x88\x01\x01\x12\x1c\n\x07\x62y_name\x18\x05 \x01(\x08H\x01R\x06\x62yName\x88\x01\x01\x12\x37\n\x15\x61llow_missing_columns\x18\x06 \x01(\x08H\x02R\x13\x61llowMissingColumns\x88\x01\x01"r\n\tSetOpType\x12\x1b\n\x17SET_OP_TYPE_UNSPECIFIED\x10\x00\x12\x19\n\x15SET_OP_TYPE_INTERSECT\x10\x01\x12\x15\n\x11SET_OP_TYPE_UNION\x10\x02\x12\x16\n\x12SET_OP_TYPE_EXCEPT\x10\x03\x42\t\n\x07_is_allB\n\n\x08_by_nameB\x18\n\x16_allow_missing_columns"L\n\x05Limit\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x14\n\x05limit\x18\x02 \x01(\x05R\x05limit"O\n\x06Offset\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x16\n\x06offset\x18\x02 \x01(\x05R\x06offset"K\n\x04Tail\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x14\n\x05limit\x18\x02 \x01(\x05R\x05limit"\xc6\x04\n\tAggregate\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x41\n\ngroup_type\x18\x02 \x01(\x0e\x32".spark.connect.Aggregate.GroupTypeR\tgroupType\x12L\n\x14grouping_expressions\x18\x03 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x13groupingExpressions\x12N\n\x15\x61ggregate_expressions\x18\x04 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x14\x61ggregateExpressions\x12\x34\n\x05pivot\x18\x05 \x01(\x0b\x32\x1e.spark.connect.Aggregate.PivotR\x05pivot\x1ao\n\x05Pivot\x12+\n\x03\x63ol\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x03\x63ol\x12\x39\n\x06values\x18\x02 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values"\x81\x01\n\tGroupType\x12\x1a\n\x16GROUP_TYPE_UNSPECIFIED\x10\x00\x12\x16\n\x12GROUP_TYPE_GROUPBY\x10\x01\x12\x15\n\x11GROUP_TYPE_ROLLUP\x10\x02\x12\x13\n\x0fGROUP_TYPE_CUBE\x10\x03\x12\x14\n\x10GROUP_TYPE_PIVOT\x10\x04"\xa0\x01\n\x04Sort\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x39\n\x05order\x18\x02 \x03(\x0b\x32#.spark.connect.Expression.SortOrderR\x05order\x12 \n\tis_global\x18\x03 \x01(\x08H\x00R\x08isGlobal\x88\x01\x01\x42\x0c\n\n_is_global"\x8d\x01\n\x04\x44rop\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x33\n\x07\x63olumns\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x07\x63olumns\x12!\n\x0c\x63olumn_names\x18\x03 \x03(\tR\x0b\x63olumnNames"\xab\x01\n\x0b\x44\x65\x64uplicate\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12!\n\x0c\x63olumn_names\x18\x02 \x03(\tR\x0b\x63olumnNames\x12\x32\n\x13\x61ll_columns_as_keys\x18\x03 \x01(\x08H\x00R\x10\x61llColumnsAsKeys\x88\x01\x01\x42\x16\n\x14_all_columns_as_keys"Y\n\rLocalRelation\x12\x17\n\x04\x64\x61ta\x18\x01 \x01(\x0cH\x00R\x04\x64\x61ta\x88\x01\x01\x12\x1b\n\x06schema\x18\x02 \x01(\tH\x01R\x06schema\x88\x01\x01\x42\x07\n\x05_dataB\t\n\x07_schema"\x91\x02\n\x06Sample\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x1f\n\x0blower_bound\x18\x02 \x01(\x01R\nlowerBound\x12\x1f\n\x0bupper_bound\x18\x03 \x01(\x01R\nupperBound\x12.\n\x10with_replacement\x18\x04 \x01(\x08H\x00R\x0fwithReplacement\x88\x01\x01\x12\x17\n\x04seed\x18\x05 \x01(\x03H\x01R\x04seed\x88\x01\x01\x12/\n\x13\x64\x65terministic_order\x18\x06 \x01(\x08R\x12\x64\x65terministicOrderB\x13\n\x11_with_replacementB\x07\n\x05_seed"\x91\x01\n\x05Range\x12\x19\n\x05start\x18\x01 \x01(\x03H\x00R\x05start\x88\x01\x01\x12\x10\n\x03\x65nd\x18\x02 \x01(\x03R\x03\x65nd\x12\x12\n\x04step\x18\x03 \x01(\x03R\x04step\x12*\n\x0enum_partitions\x18\x04 \x01(\x05H\x01R\rnumPartitions\x88\x01\x01\x42\x08\n\x06_startB\x11\n\x0f_num_partitions"r\n\rSubqueryAlias\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x14\n\x05\x61lias\x18\x02 \x01(\tR\x05\x61lias\x12\x1c\n\tqualifier\x18\x03 \x03(\tR\tqualifier"\x8e\x01\n\x0bRepartition\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12%\n\x0enum_partitions\x18\x02 \x01(\x05R\rnumPartitions\x12\x1d\n\x07shuffle\x18\x03 \x01(\x08H\x00R\x07shuffle\x88\x01\x01\x42\n\n\x08_shuffle"\x8e\x01\n\nShowString\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x19\n\x08num_rows\x18\x02 \x01(\x05R\x07numRows\x12\x1a\n\x08truncate\x18\x03 \x01(\x05R\x08truncate\x12\x1a\n\x08vertical\x18\x04 \x01(\x08R\x08vertical"\\\n\x0bStatSummary\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x1e\n\nstatistics\x18\x02 \x03(\tR\nstatistics"Q\n\x0cStatDescribe\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols"e\n\x0cStatCrosstab\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ol1\x18\x02 \x01(\tR\x04\x63ol1\x12\x12\n\x04\x63ol2\x18\x03 \x01(\tR\x04\x63ol2"`\n\x07StatCov\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ol1\x18\x02 \x01(\tR\x04\x63ol1\x12\x12\n\x04\x63ol2\x18\x03 \x01(\tR\x04\x63ol2"\x89\x01\n\x08StatCorr\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ol1\x18\x02 \x01(\tR\x04\x63ol1\x12\x12\n\x04\x63ol2\x18\x03 \x01(\tR\x04\x63ol2\x12\x1b\n\x06method\x18\x04 \x01(\tH\x00R\x06method\x88\x01\x01\x42\t\n\x07_method"\xa4\x01\n\x12StatApproxQuantile\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12$\n\rprobabilities\x18\x03 \x03(\x01R\rprobabilities\x12%\n\x0erelative_error\x18\x04 \x01(\x01R\rrelativeError"}\n\rStatFreqItems\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12\x1d\n\x07support\x18\x03 \x01(\x01H\x00R\x07support\x88\x01\x01\x42\n\n\x08_support"\xb5\x02\n\x0cStatSampleBy\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12+\n\x03\x63ol\x18\x02 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x03\x63ol\x12\x42\n\tfractions\x18\x03 \x03(\x0b\x32$.spark.connect.StatSampleBy.FractionR\tfractions\x12\x17\n\x04seed\x18\x05 \x01(\x03H\x00R\x04seed\x88\x01\x01\x1a\x63\n\x08\x46raction\x12;\n\x07stratum\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x07stratum\x12\x1a\n\x08\x66raction\x18\x02 \x01(\x01R\x08\x66ractionB\x07\n\x05_seed"\x86\x01\n\x06NAFill\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12\x39\n\x06values\x18\x03 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06values"\x86\x01\n\x06NADrop\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12\'\n\rmin_non_nulls\x18\x03 \x01(\x05H\x00R\x0bminNonNulls\x88\x01\x01\x42\x10\n\x0e_min_non_nulls"\xa8\x02\n\tNAReplace\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04\x63ols\x18\x02 \x03(\tR\x04\x63ols\x12H\n\x0creplacements\x18\x03 \x03(\x0b\x32$.spark.connect.NAReplace.ReplacementR\x0creplacements\x1a\x8d\x01\n\x0bReplacement\x12>\n\told_value\x18\x01 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x08oldValue\x12>\n\tnew_value\x18\x02 \x01(\x0b\x32!.spark.connect.Expression.LiteralR\x08newValue"X\n\x04ToDF\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12!\n\x0c\x63olumn_names\x18\x02 \x03(\tR\x0b\x63olumnNames"\xef\x01\n\x12WithColumnsRenamed\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x65\n\x12rename_columns_map\x18\x02 \x03(\x0b\x32\x37.spark.connect.WithColumnsRenamed.RenameColumnsMapEntryR\x10renameColumnsMap\x1a\x43\n\x15RenameColumnsMapEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01"w\n\x0bWithColumns\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x39\n\x07\x61liases\x18\x02 \x03(\x0b\x32\x1f.spark.connect.Expression.AliasR\x07\x61liases"\x84\x01\n\x04Hint\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04name\x18\x02 \x01(\tR\x04name\x12\x39\n\nparameters\x18\x03 \x03(\x0b\x32\x19.spark.connect.ExpressionR\nparameters"\xc7\x02\n\x07Unpivot\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12+\n\x03ids\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x03ids\x12:\n\x06values\x18\x03 \x01(\x0b\x32\x1d.spark.connect.Unpivot.ValuesH\x00R\x06values\x88\x01\x01\x12\x30\n\x14variable_column_name\x18\x04 \x01(\tR\x12variableColumnName\x12*\n\x11value_column_name\x18\x05 \x01(\tR\x0fvalueColumnName\x1a;\n\x06Values\x12\x31\n\x06values\x18\x01 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x06valuesB\t\n\x07_values"j\n\x08ToSchema\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12/\n\x06schema\x18\x02 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x06schema"\xcb\x01\n\x17RepartitionByExpression\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x42\n\x0fpartition_exprs\x18\x02 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x0epartitionExprs\x12*\n\x0enum_partitions\x18\x03 \x01(\x05H\x00R\rnumPartitions\x88\x01\x01\x42\x11\n\x0f_num_partitions"\x82\x01\n\rMapPartitions\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x42\n\x04\x66unc\x18\x02 \x01(\x0b\x32..spark.connect.CommonInlineUserDefinedFunctionR\x04\x66unc"\x88\x01\n\x0e\x43ollectMetrics\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x12\n\x04name\x18\x02 \x01(\tR\x04name\x12\x33\n\x07metrics\x18\x03 \x03(\x0b\x32\x19.spark.connect.ExpressionR\x07metrics"\x84\x03\n\x05Parse\x12-\n\x05input\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x05input\x12\x38\n\x06\x66ormat\x18\x02 \x01(\x0e\x32 .spark.connect.Parse.ParseFormatR\x06\x66ormat\x12\x34\n\x06schema\x18\x03 \x01(\x0b\x32\x17.spark.connect.DataTypeH\x00R\x06schema\x88\x01\x01\x12;\n\x07options\x18\x04 \x03(\x0b\x32!.spark.connect.Parse.OptionsEntryR\x07options\x1a:\n\x0cOptionsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n\x05value\x18\x02 \x01(\tR\x05value:\x02\x38\x01"X\n\x0bParseFormat\x12\x1c\n\x18PARSE_FORMAT_UNSPECIFIED\x10\x00\x12\x14\n\x10PARSE_FORMAT_CSV\x10\x01\x12\x15\n\x11PARSE_FORMAT_JSON\x10\x02\x42\t\n\x07_schemaB"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
 )
 
 
@@ -91,11 +91,14 @@ _UNPIVOT = DESCRIPTOR.message_types_by_name["Unpivot"]
 _UNPIVOT_VALUES = _UNPIVOT.nested_types_by_name["Values"]
 _TOSCHEMA = DESCRIPTOR.message_types_by_name["ToSchema"]
 _REPARTITIONBYEXPRESSION = DESCRIPTOR.message_types_by_name["RepartitionByExpression"]
-_FRAMEMAP = DESCRIPTOR.message_types_by_name["FrameMap"]
+_MAPPARTITIONS = DESCRIPTOR.message_types_by_name["MapPartitions"]
 _COLLECTMETRICS = DESCRIPTOR.message_types_by_name["CollectMetrics"]
+_PARSE = DESCRIPTOR.message_types_by_name["Parse"]
+_PARSE_OPTIONSENTRY = _PARSE.nested_types_by_name["OptionsEntry"]
 _JOIN_JOINTYPE = _JOIN.enum_types_by_name["JoinType"]
 _SETOPERATION_SETOPTYPE = _SETOPERATION.enum_types_by_name["SetOpType"]
 _AGGREGATE_GROUPTYPE = _AGGREGATE.enum_types_by_name["GroupType"]
+_PARSE_PARSEFORMAT = _PARSE.enum_types_by_name["ParseFormat"]
 Relation = _reflection.GeneratedProtocolMessageType(
     "Relation",
     (_message.Message,),
@@ -626,16 +629,16 @@ RepartitionByExpression = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(RepartitionByExpression)
 
-FrameMap = _reflection.GeneratedProtocolMessageType(
-    "FrameMap",
+MapPartitions = _reflection.GeneratedProtocolMessageType(
+    "MapPartitions",
     (_message.Message,),
     {
-        "DESCRIPTOR": _FRAMEMAP,
+        "DESCRIPTOR": _MAPPARTITIONS,
         "__module__": "spark.connect.relations_pb2"
-        # @@protoc_insertion_point(class_scope:spark.connect.FrameMap)
+        # @@protoc_insertion_point(class_scope:spark.connect.MapPartitions)
     },
 )
-_sym_db.RegisterMessage(FrameMap)
+_sym_db.RegisterMessage(MapPartitions)
 
 CollectMetrics = _reflection.GeneratedProtocolMessageType(
     "CollectMetrics",
@@ -648,6 +651,27 @@ CollectMetrics = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(CollectMetrics)
 
+Parse = _reflection.GeneratedProtocolMessageType(
+    "Parse",
+    (_message.Message,),
+    {
+        "OptionsEntry": _reflection.GeneratedProtocolMessageType(
+            "OptionsEntry",
+            (_message.Message,),
+            {
+                "DESCRIPTOR": _PARSE_OPTIONSENTRY,
+                "__module__": "spark.connect.relations_pb2"
+                # @@protoc_insertion_point(class_scope:spark.connect.Parse.OptionsEntry)
+            },
+        ),
+        "DESCRIPTOR": _PARSE,
+        "__module__": "spark.connect.relations_pb2"
+        # @@protoc_insertion_point(class_scope:spark.connect.Parse)
+    },
+)
+_sym_db.RegisterMessage(Parse)
+_sym_db.RegisterMessage(Parse.OptionsEntry)
+
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None
@@ -658,112 +682,120 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _READ_DATASOURCE_OPTIONSENTRY._serialized_options = b"8\001"
     _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._options = None
     _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_options = b"8\001"
+    _PARSE_OPTIONSENTRY._options = None
+    _PARSE_OPTIONSENTRY._serialized_options = b"8\001"
     _RELATION._serialized_start = 165
-    _RELATION._serialized_end = 2592
-    _UNKNOWN._serialized_start = 2594
-    _UNKNOWN._serialized_end = 2603
-    _RELATIONCOMMON._serialized_start = 2605
-    _RELATIONCOMMON._serialized_end = 2696
-    _SQL._serialized_start = 2699
-    _SQL._serialized_end = 2833
-    _SQL_ARGSENTRY._serialized_start = 2778
-    _SQL_ARGSENTRY._serialized_end = 2833
-    _READ._serialized_start = 2836
-    _READ._serialized_end = 3332
-    _READ_NAMEDTABLE._serialized_start = 2978
-    _READ_NAMEDTABLE._serialized_end = 3039
-    _READ_DATASOURCE._serialized_start = 3042
-    _READ_DATASOURCE._serialized_end = 3319
-    _READ_DATASOURCE_OPTIONSENTRY._serialized_start = 3239
-    _READ_DATASOURCE_OPTIONSENTRY._serialized_end = 3297
-    _PROJECT._serialized_start = 3334
-    _PROJECT._serialized_end = 3451
-    _FILTER._serialized_start = 3453
-    _FILTER._serialized_end = 3565
-    _JOIN._serialized_start = 3568
-    _JOIN._serialized_end = 4039
-    _JOIN_JOINTYPE._serialized_start = 3831
-    _JOIN_JOINTYPE._serialized_end = 4039
-    _SETOPERATION._serialized_start = 4042
-    _SETOPERATION._serialized_end = 4521
-    _SETOPERATION_SETOPTYPE._serialized_start = 4358
-    _SETOPERATION_SETOPTYPE._serialized_end = 4472
-    _LIMIT._serialized_start = 4523
-    _LIMIT._serialized_end = 4599
-    _OFFSET._serialized_start = 4601
-    _OFFSET._serialized_end = 4680
-    _TAIL._serialized_start = 4682
-    _TAIL._serialized_end = 4757
-    _AGGREGATE._serialized_start = 4760
-    _AGGREGATE._serialized_end = 5342
-    _AGGREGATE_PIVOT._serialized_start = 5099
-    _AGGREGATE_PIVOT._serialized_end = 5210
-    _AGGREGATE_GROUPTYPE._serialized_start = 5213
-    _AGGREGATE_GROUPTYPE._serialized_end = 5342
-    _SORT._serialized_start = 5345
-    _SORT._serialized_end = 5505
-    _DROP._serialized_start = 5508
-    _DROP._serialized_end = 5649
-    _DEDUPLICATE._serialized_start = 5652
-    _DEDUPLICATE._serialized_end = 5823
-    _LOCALRELATION._serialized_start = 5825
-    _LOCALRELATION._serialized_end = 5914
-    _SAMPLE._serialized_start = 5917
-    _SAMPLE._serialized_end = 6190
-    _RANGE._serialized_start = 6193
-    _RANGE._serialized_end = 6338
-    _SUBQUERYALIAS._serialized_start = 6340
-    _SUBQUERYALIAS._serialized_end = 6454
-    _REPARTITION._serialized_start = 6457
-    _REPARTITION._serialized_end = 6599
-    _SHOWSTRING._serialized_start = 6602
-    _SHOWSTRING._serialized_end = 6744
-    _STATSUMMARY._serialized_start = 6746
-    _STATSUMMARY._serialized_end = 6838
-    _STATDESCRIBE._serialized_start = 6840
-    _STATDESCRIBE._serialized_end = 6921
-    _STATCROSSTAB._serialized_start = 6923
-    _STATCROSSTAB._serialized_end = 7024
-    _STATCOV._serialized_start = 7026
-    _STATCOV._serialized_end = 7122
-    _STATCORR._serialized_start = 7125
-    _STATCORR._serialized_end = 7262
-    _STATAPPROXQUANTILE._serialized_start = 7265
-    _STATAPPROXQUANTILE._serialized_end = 7429
-    _STATFREQITEMS._serialized_start = 7431
-    _STATFREQITEMS._serialized_end = 7556
-    _STATSAMPLEBY._serialized_start = 7559
-    _STATSAMPLEBY._serialized_end = 7868
-    _STATSAMPLEBY_FRACTION._serialized_start = 7760
-    _STATSAMPLEBY_FRACTION._serialized_end = 7859
-    _NAFILL._serialized_start = 7871
-    _NAFILL._serialized_end = 8005
-    _NADROP._serialized_start = 8008
-    _NADROP._serialized_end = 8142
-    _NAREPLACE._serialized_start = 8145
-    _NAREPLACE._serialized_end = 8441
-    _NAREPLACE_REPLACEMENT._serialized_start = 8300
-    _NAREPLACE_REPLACEMENT._serialized_end = 8441
-    _TODF._serialized_start = 8443
-    _TODF._serialized_end = 8531
-    _WITHCOLUMNSRENAMED._serialized_start = 8534
-    _WITHCOLUMNSRENAMED._serialized_end = 8773
-    _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_start = 8706
-    _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_end = 8773
-    _WITHCOLUMNS._serialized_start = 8775
-    _WITHCOLUMNS._serialized_end = 8894
-    _HINT._serialized_start = 8897
-    _HINT._serialized_end = 9029
-    _UNPIVOT._serialized_start = 9032
-    _UNPIVOT._serialized_end = 9359
-    _UNPIVOT_VALUES._serialized_start = 9289
-    _UNPIVOT_VALUES._serialized_end = 9348
-    _TOSCHEMA._serialized_start = 9361
-    _TOSCHEMA._serialized_end = 9467
-    _REPARTITIONBYEXPRESSION._serialized_start = 9470
-    _REPARTITIONBYEXPRESSION._serialized_end = 9673
-    _FRAMEMAP._serialized_start = 9675
-    _FRAMEMAP._serialized_end = 9800
-    _COLLECTMETRICS._serialized_start = 9803
-    _COLLECTMETRICS._serialized_end = 9939
+    _RELATION._serialized_end = 2653
+    _UNKNOWN._serialized_start = 2655
+    _UNKNOWN._serialized_end = 2664
+    _RELATIONCOMMON._serialized_start = 2666
+    _RELATIONCOMMON._serialized_end = 2757
+    _SQL._serialized_start = 2760
+    _SQL._serialized_end = 2894
+    _SQL_ARGSENTRY._serialized_start = 2839
+    _SQL_ARGSENTRY._serialized_end = 2894
+    _READ._serialized_start = 2897
+    _READ._serialized_end = 3393
+    _READ_NAMEDTABLE._serialized_start = 3039
+    _READ_NAMEDTABLE._serialized_end = 3100
+    _READ_DATASOURCE._serialized_start = 3103
+    _READ_DATASOURCE._serialized_end = 3380
+    _READ_DATASOURCE_OPTIONSENTRY._serialized_start = 3300
+    _READ_DATASOURCE_OPTIONSENTRY._serialized_end = 3358
+    _PROJECT._serialized_start = 3395
+    _PROJECT._serialized_end = 3512
+    _FILTER._serialized_start = 3514
+    _FILTER._serialized_end = 3626
+    _JOIN._serialized_start = 3629
+    _JOIN._serialized_end = 4100
+    _JOIN_JOINTYPE._serialized_start = 3892
+    _JOIN_JOINTYPE._serialized_end = 4100
+    _SETOPERATION._serialized_start = 4103
+    _SETOPERATION._serialized_end = 4582
+    _SETOPERATION_SETOPTYPE._serialized_start = 4419
+    _SETOPERATION_SETOPTYPE._serialized_end = 4533
+    _LIMIT._serialized_start = 4584
+    _LIMIT._serialized_end = 4660
+    _OFFSET._serialized_start = 4662
+    _OFFSET._serialized_end = 4741
+    _TAIL._serialized_start = 4743
+    _TAIL._serialized_end = 4818
+    _AGGREGATE._serialized_start = 4821
+    _AGGREGATE._serialized_end = 5403
+    _AGGREGATE_PIVOT._serialized_start = 5160
+    _AGGREGATE_PIVOT._serialized_end = 5271
+    _AGGREGATE_GROUPTYPE._serialized_start = 5274
+    _AGGREGATE_GROUPTYPE._serialized_end = 5403
+    _SORT._serialized_start = 5406
+    _SORT._serialized_end = 5566
+    _DROP._serialized_start = 5569
+    _DROP._serialized_end = 5710
+    _DEDUPLICATE._serialized_start = 5713
+    _DEDUPLICATE._serialized_end = 5884
+    _LOCALRELATION._serialized_start = 5886
+    _LOCALRELATION._serialized_end = 5975
+    _SAMPLE._serialized_start = 5978
+    _SAMPLE._serialized_end = 6251
+    _RANGE._serialized_start = 6254
+    _RANGE._serialized_end = 6399
+    _SUBQUERYALIAS._serialized_start = 6401
+    _SUBQUERYALIAS._serialized_end = 6515
+    _REPARTITION._serialized_start = 6518
+    _REPARTITION._serialized_end = 6660
+    _SHOWSTRING._serialized_start = 6663
+    _SHOWSTRING._serialized_end = 6805
+    _STATSUMMARY._serialized_start = 6807
+    _STATSUMMARY._serialized_end = 6899
+    _STATDESCRIBE._serialized_start = 6901
+    _STATDESCRIBE._serialized_end = 6982
+    _STATCROSSTAB._serialized_start = 6984
+    _STATCROSSTAB._serialized_end = 7085
+    _STATCOV._serialized_start = 7087
+    _STATCOV._serialized_end = 7183
+    _STATCORR._serialized_start = 7186
+    _STATCORR._serialized_end = 7323
+    _STATAPPROXQUANTILE._serialized_start = 7326
+    _STATAPPROXQUANTILE._serialized_end = 7490
+    _STATFREQITEMS._serialized_start = 7492
+    _STATFREQITEMS._serialized_end = 7617
+    _STATSAMPLEBY._serialized_start = 7620
+    _STATSAMPLEBY._serialized_end = 7929
+    _STATSAMPLEBY_FRACTION._serialized_start = 7821
+    _STATSAMPLEBY_FRACTION._serialized_end = 7920
+    _NAFILL._serialized_start = 7932
+    _NAFILL._serialized_end = 8066
+    _NADROP._serialized_start = 8069
+    _NADROP._serialized_end = 8203
+    _NAREPLACE._serialized_start = 8206
+    _NAREPLACE._serialized_end = 8502
+    _NAREPLACE_REPLACEMENT._serialized_start = 8361
+    _NAREPLACE_REPLACEMENT._serialized_end = 8502
+    _TODF._serialized_start = 8504
+    _TODF._serialized_end = 8592
+    _WITHCOLUMNSRENAMED._serialized_start = 8595
+    _WITHCOLUMNSRENAMED._serialized_end = 8834
+    _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_start = 8767
+    _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_end = 8834
+    _WITHCOLUMNS._serialized_start = 8836
+    _WITHCOLUMNS._serialized_end = 8955
+    _HINT._serialized_start = 8958
+    _HINT._serialized_end = 9090
+    _UNPIVOT._serialized_start = 9093
+    _UNPIVOT._serialized_end = 9420
+    _UNPIVOT_VALUES._serialized_start = 9350
+    _UNPIVOT_VALUES._serialized_end = 9409
+    _TOSCHEMA._serialized_start = 9422
+    _TOSCHEMA._serialized_end = 9528
+    _REPARTITIONBYEXPRESSION._serialized_start = 9531
+    _REPARTITIONBYEXPRESSION._serialized_end = 9734
+    _MAPPARTITIONS._serialized_start = 9737
+    _MAPPARTITIONS._serialized_end = 9867
+    _COLLECTMETRICS._serialized_start = 9870
+    _COLLECTMETRICS._serialized_end = 10006
+    _PARSE._serialized_start = 10009
+    _PARSE._serialized_end = 10397
+    _PARSE_OPTIONSENTRY._serialized_start = 3300
+    _PARSE_OPTIONSENTRY._serialized_end = 3358
+    _PARSE_PARSEFORMAT._serialized_start = 10298
+    _PARSE_PARSEFORMAT._serialized_end = 10386
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/relations_pb2.py
+++ b/python/pyspark/sql/connect/proto/relations_pb2.py
@@ -93,12 +93,9 @@ _TOSCHEMA = DESCRIPTOR.message_types_by_name["ToSchema"]
 _REPARTITIONBYEXPRESSION = DESCRIPTOR.message_types_by_name["RepartitionByExpression"]
 _FRAMEMAP = DESCRIPTOR.message_types_by_name["FrameMap"]
 _COLLECTMETRICS = DESCRIPTOR.message_types_by_name["CollectMetrics"]
-_PARSE = DESCRIPTOR.message_types_by_name["Parse"]
-_PARSE_OPTIONSENTRY = _PARSE.nested_types_by_name["OptionsEntry"]
 _JOIN_JOINTYPE = _JOIN.enum_types_by_name["JoinType"]
 _SETOPERATION_SETOPTYPE = _SETOPERATION.enum_types_by_name["SetOpType"]
 _AGGREGATE_GROUPTYPE = _AGGREGATE.enum_types_by_name["GroupType"]
-_PARSE_PARSEFORMAT = _PARSE.enum_types_by_name["ParseFormat"]
 Relation = _reflection.GeneratedProtocolMessageType(
     "Relation",
     (_message.Message,),
@@ -651,27 +648,6 @@ CollectMetrics = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(CollectMetrics)
 
-Parse = _reflection.GeneratedProtocolMessageType(
-    "Parse",
-    (_message.Message,),
-    {
-        "OptionsEntry": _reflection.GeneratedProtocolMessageType(
-            "OptionsEntry",
-            (_message.Message,),
-            {
-                "DESCRIPTOR": _PARSE_OPTIONSENTRY,
-                "__module__": "spark.connect.relations_pb2"
-                # @@protoc_insertion_point(class_scope:spark.connect.Parse.OptionsEntry)
-            },
-        ),
-        "DESCRIPTOR": _PARSE,
-        "__module__": "spark.connect.relations_pb2"
-        # @@protoc_insertion_point(class_scope:spark.connect.Parse)
-    },
-)
-_sym_db.RegisterMessage(Parse)
-_sym_db.RegisterMessage(Parse.OptionsEntry)
-
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None
@@ -682,120 +658,112 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _READ_DATASOURCE_OPTIONSENTRY._serialized_options = b"8\001"
     _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._options = None
     _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_options = b"8\001"
-    _PARSE_OPTIONSENTRY._options = None
-    _PARSE_OPTIONSENTRY._serialized_options = b"8\001"
     _RELATION._serialized_start = 165
-    _RELATION._serialized_end = 2638
-    _UNKNOWN._serialized_start = 2640
-    _UNKNOWN._serialized_end = 2649
-    _RELATIONCOMMON._serialized_start = 2651
-    _RELATIONCOMMON._serialized_end = 2742
-    _SQL._serialized_start = 2745
-    _SQL._serialized_end = 2879
-    _SQL_ARGSENTRY._serialized_start = 2824
-    _SQL_ARGSENTRY._serialized_end = 2879
-    _READ._serialized_start = 2882
-    _READ._serialized_end = 3378
-    _READ_NAMEDTABLE._serialized_start = 3024
-    _READ_NAMEDTABLE._serialized_end = 3085
-    _READ_DATASOURCE._serialized_start = 3088
-    _READ_DATASOURCE._serialized_end = 3365
-    _READ_DATASOURCE_OPTIONSENTRY._serialized_start = 3285
-    _READ_DATASOURCE_OPTIONSENTRY._serialized_end = 3343
-    _PROJECT._serialized_start = 3380
-    _PROJECT._serialized_end = 3497
-    _FILTER._serialized_start = 3499
-    _FILTER._serialized_end = 3611
-    _JOIN._serialized_start = 3614
-    _JOIN._serialized_end = 4085
-    _JOIN_JOINTYPE._serialized_start = 3877
-    _JOIN_JOINTYPE._serialized_end = 4085
-    _SETOPERATION._serialized_start = 4088
-    _SETOPERATION._serialized_end = 4567
-    _SETOPERATION_SETOPTYPE._serialized_start = 4404
-    _SETOPERATION_SETOPTYPE._serialized_end = 4518
-    _LIMIT._serialized_start = 4569
-    _LIMIT._serialized_end = 4645
-    _OFFSET._serialized_start = 4647
-    _OFFSET._serialized_end = 4726
-    _TAIL._serialized_start = 4728
-    _TAIL._serialized_end = 4803
-    _AGGREGATE._serialized_start = 4806
-    _AGGREGATE._serialized_end = 5388
-    _AGGREGATE_PIVOT._serialized_start = 5145
-    _AGGREGATE_PIVOT._serialized_end = 5256
-    _AGGREGATE_GROUPTYPE._serialized_start = 5259
-    _AGGREGATE_GROUPTYPE._serialized_end = 5388
-    _SORT._serialized_start = 5391
-    _SORT._serialized_end = 5551
-    _DROP._serialized_start = 5554
-    _DROP._serialized_end = 5695
-    _DEDUPLICATE._serialized_start = 5698
-    _DEDUPLICATE._serialized_end = 5869
-    _LOCALRELATION._serialized_start = 5871
-    _LOCALRELATION._serialized_end = 5960
-    _SAMPLE._serialized_start = 5963
-    _SAMPLE._serialized_end = 6236
-    _RANGE._serialized_start = 6239
-    _RANGE._serialized_end = 6384
-    _SUBQUERYALIAS._serialized_start = 6386
-    _SUBQUERYALIAS._serialized_end = 6500
-    _REPARTITION._serialized_start = 6503
-    _REPARTITION._serialized_end = 6645
-    _SHOWSTRING._serialized_start = 6648
-    _SHOWSTRING._serialized_end = 6790
-    _STATSUMMARY._serialized_start = 6792
-    _STATSUMMARY._serialized_end = 6884
-    _STATDESCRIBE._serialized_start = 6886
-    _STATDESCRIBE._serialized_end = 6967
-    _STATCROSSTAB._serialized_start = 6969
-    _STATCROSSTAB._serialized_end = 7070
-    _STATCOV._serialized_start = 7072
-    _STATCOV._serialized_end = 7168
-    _STATCORR._serialized_start = 7171
-    _STATCORR._serialized_end = 7308
-    _STATAPPROXQUANTILE._serialized_start = 7311
-    _STATAPPROXQUANTILE._serialized_end = 7475
-    _STATFREQITEMS._serialized_start = 7477
-    _STATFREQITEMS._serialized_end = 7602
-    _STATSAMPLEBY._serialized_start = 7605
-    _STATSAMPLEBY._serialized_end = 7914
-    _STATSAMPLEBY_FRACTION._serialized_start = 7806
-    _STATSAMPLEBY_FRACTION._serialized_end = 7905
-    _NAFILL._serialized_start = 7917
-    _NAFILL._serialized_end = 8051
-    _NADROP._serialized_start = 8054
-    _NADROP._serialized_end = 8188
-    _NAREPLACE._serialized_start = 8191
-    _NAREPLACE._serialized_end = 8487
-    _NAREPLACE_REPLACEMENT._serialized_start = 8346
-    _NAREPLACE_REPLACEMENT._serialized_end = 8487
-    _TODF._serialized_start = 8489
-    _TODF._serialized_end = 8577
-    _WITHCOLUMNSRENAMED._serialized_start = 8580
-    _WITHCOLUMNSRENAMED._serialized_end = 8819
-    _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_start = 8752
-    _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_end = 8819
-    _WITHCOLUMNS._serialized_start = 8821
-    _WITHCOLUMNS._serialized_end = 8940
-    _HINT._serialized_start = 8943
-    _HINT._serialized_end = 9075
-    _UNPIVOT._serialized_start = 9078
-    _UNPIVOT._serialized_end = 9405
-    _UNPIVOT_VALUES._serialized_start = 9335
-    _UNPIVOT_VALUES._serialized_end = 9394
-    _TOSCHEMA._serialized_start = 9407
-    _TOSCHEMA._serialized_end = 9513
-    _REPARTITIONBYEXPRESSION._serialized_start = 9516
-    _REPARTITIONBYEXPRESSION._serialized_end = 9719
-    _FRAMEMAP._serialized_start = 9721
-    _FRAMEMAP._serialized_end = 9846
-    _COLLECTMETRICS._serialized_start = 9849
-    _COLLECTMETRICS._serialized_end = 9985
-    _PARSE._serialized_start = 9988
-    _PARSE._serialized_end = 10376
-    _PARSE_OPTIONSENTRY._serialized_start = 3285
-    _PARSE_OPTIONSENTRY._serialized_end = 3343
-    _PARSE_PARSEFORMAT._serialized_start = 10277
-    _PARSE_PARSEFORMAT._serialized_end = 10365
+    _RELATION._serialized_end = 2592
+    _UNKNOWN._serialized_start = 2594
+    _UNKNOWN._serialized_end = 2603
+    _RELATIONCOMMON._serialized_start = 2605
+    _RELATIONCOMMON._serialized_end = 2696
+    _SQL._serialized_start = 2699
+    _SQL._serialized_end = 2833
+    _SQL_ARGSENTRY._serialized_start = 2778
+    _SQL_ARGSENTRY._serialized_end = 2833
+    _READ._serialized_start = 2836
+    _READ._serialized_end = 3332
+    _READ_NAMEDTABLE._serialized_start = 2978
+    _READ_NAMEDTABLE._serialized_end = 3039
+    _READ_DATASOURCE._serialized_start = 3042
+    _READ_DATASOURCE._serialized_end = 3319
+    _READ_DATASOURCE_OPTIONSENTRY._serialized_start = 3239
+    _READ_DATASOURCE_OPTIONSENTRY._serialized_end = 3297
+    _PROJECT._serialized_start = 3334
+    _PROJECT._serialized_end = 3451
+    _FILTER._serialized_start = 3453
+    _FILTER._serialized_end = 3565
+    _JOIN._serialized_start = 3568
+    _JOIN._serialized_end = 4039
+    _JOIN_JOINTYPE._serialized_start = 3831
+    _JOIN_JOINTYPE._serialized_end = 4039
+    _SETOPERATION._serialized_start = 4042
+    _SETOPERATION._serialized_end = 4521
+    _SETOPERATION_SETOPTYPE._serialized_start = 4358
+    _SETOPERATION_SETOPTYPE._serialized_end = 4472
+    _LIMIT._serialized_start = 4523
+    _LIMIT._serialized_end = 4599
+    _OFFSET._serialized_start = 4601
+    _OFFSET._serialized_end = 4680
+    _TAIL._serialized_start = 4682
+    _TAIL._serialized_end = 4757
+    _AGGREGATE._serialized_start = 4760
+    _AGGREGATE._serialized_end = 5342
+    _AGGREGATE_PIVOT._serialized_start = 5099
+    _AGGREGATE_PIVOT._serialized_end = 5210
+    _AGGREGATE_GROUPTYPE._serialized_start = 5213
+    _AGGREGATE_GROUPTYPE._serialized_end = 5342
+    _SORT._serialized_start = 5345
+    _SORT._serialized_end = 5505
+    _DROP._serialized_start = 5508
+    _DROP._serialized_end = 5649
+    _DEDUPLICATE._serialized_start = 5652
+    _DEDUPLICATE._serialized_end = 5823
+    _LOCALRELATION._serialized_start = 5825
+    _LOCALRELATION._serialized_end = 5914
+    _SAMPLE._serialized_start = 5917
+    _SAMPLE._serialized_end = 6190
+    _RANGE._serialized_start = 6193
+    _RANGE._serialized_end = 6338
+    _SUBQUERYALIAS._serialized_start = 6340
+    _SUBQUERYALIAS._serialized_end = 6454
+    _REPARTITION._serialized_start = 6457
+    _REPARTITION._serialized_end = 6599
+    _SHOWSTRING._serialized_start = 6602
+    _SHOWSTRING._serialized_end = 6744
+    _STATSUMMARY._serialized_start = 6746
+    _STATSUMMARY._serialized_end = 6838
+    _STATDESCRIBE._serialized_start = 6840
+    _STATDESCRIBE._serialized_end = 6921
+    _STATCROSSTAB._serialized_start = 6923
+    _STATCROSSTAB._serialized_end = 7024
+    _STATCOV._serialized_start = 7026
+    _STATCOV._serialized_end = 7122
+    _STATCORR._serialized_start = 7125
+    _STATCORR._serialized_end = 7262
+    _STATAPPROXQUANTILE._serialized_start = 7265
+    _STATAPPROXQUANTILE._serialized_end = 7429
+    _STATFREQITEMS._serialized_start = 7431
+    _STATFREQITEMS._serialized_end = 7556
+    _STATSAMPLEBY._serialized_start = 7559
+    _STATSAMPLEBY._serialized_end = 7868
+    _STATSAMPLEBY_FRACTION._serialized_start = 7760
+    _STATSAMPLEBY_FRACTION._serialized_end = 7859
+    _NAFILL._serialized_start = 7871
+    _NAFILL._serialized_end = 8005
+    _NADROP._serialized_start = 8008
+    _NADROP._serialized_end = 8142
+    _NAREPLACE._serialized_start = 8145
+    _NAREPLACE._serialized_end = 8441
+    _NAREPLACE_REPLACEMENT._serialized_start = 8300
+    _NAREPLACE_REPLACEMENT._serialized_end = 8441
+    _TODF._serialized_start = 8443
+    _TODF._serialized_end = 8531
+    _WITHCOLUMNSRENAMED._serialized_start = 8534
+    _WITHCOLUMNSRENAMED._serialized_end = 8773
+    _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_start = 8706
+    _WITHCOLUMNSRENAMED_RENAMECOLUMNSMAPENTRY._serialized_end = 8773
+    _WITHCOLUMNS._serialized_start = 8775
+    _WITHCOLUMNS._serialized_end = 8894
+    _HINT._serialized_start = 8897
+    _HINT._serialized_end = 9029
+    _UNPIVOT._serialized_start = 9032
+    _UNPIVOT._serialized_end = 9359
+    _UNPIVOT_VALUES._serialized_start = 9289
+    _UNPIVOT_VALUES._serialized_end = 9348
+    _TOSCHEMA._serialized_start = 9361
+    _TOSCHEMA._serialized_end = 9467
+    _REPARTITIONBYEXPRESSION._serialized_start = 9470
+    _REPARTITIONBYEXPRESSION._serialized_end = 9673
+    _FRAMEMAP._serialized_start = 9675
+    _FRAMEMAP._serialized_end = 9800
+    _COLLECTMETRICS._serialized_start = 9803
+    _COLLECTMETRICS._serialized_end = 9939
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/relations_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/relations_pb2.pyi
@@ -89,7 +89,7 @@ class Relation(google.protobuf.message.Message):
     UNPIVOT_FIELD_NUMBER: builtins.int
     TO_SCHEMA_FIELD_NUMBER: builtins.int
     REPARTITION_BY_EXPRESSION_FIELD_NUMBER: builtins.int
-    FRAME_MAP_FIELD_NUMBER: builtins.int
+    MAP_PARTITIONS_FIELD_NUMBER: builtins.int
     COLLECT_METRICS_FIELD_NUMBER: builtins.int
     PARSE_FIELD_NUMBER: builtins.int
     FILL_NA_FIELD_NUMBER: builtins.int
@@ -161,7 +161,7 @@ class Relation(google.protobuf.message.Message):
     @property
     def repartition_by_expression(self) -> global___RepartitionByExpression: ...
     @property
-    def frame_map(self) -> global___FrameMap: ...
+    def map_partitions(self) -> global___MapPartitions: ...
     @property
     def collect_metrics(self) -> global___CollectMetrics: ...
     @property
@@ -230,7 +230,7 @@ class Relation(google.protobuf.message.Message):
         unpivot: global___Unpivot | None = ...,
         to_schema: global___ToSchema | None = ...,
         repartition_by_expression: global___RepartitionByExpression | None = ...,
-        frame_map: global___FrameMap | None = ...,
+        map_partitions: global___MapPartitions | None = ...,
         collect_metrics: global___CollectMetrics | None = ...,
         parse: global___Parse | None = ...,
         fill_na: global___NAFill | None = ...,
@@ -281,8 +281,6 @@ class Relation(google.protobuf.message.Message):
             b"fill_na",
             "filter",
             b"filter",
-            "frame_map",
-            b"frame_map",
             "freq_items",
             b"freq_items",
             "hint",
@@ -293,6 +291,8 @@ class Relation(google.protobuf.message.Message):
             b"limit",
             "local_relation",
             b"local_relation",
+            "map_partitions",
+            b"map_partitions",
             "offset",
             b"offset",
             "parse",
@@ -376,8 +376,6 @@ class Relation(google.protobuf.message.Message):
             b"fill_na",
             "filter",
             b"filter",
-            "frame_map",
-            b"frame_map",
             "freq_items",
             b"freq_items",
             "hint",
@@ -388,6 +386,8 @@ class Relation(google.protobuf.message.Message):
             b"limit",
             "local_relation",
             b"local_relation",
+            "map_partitions",
+            b"map_partitions",
             "offset",
             b"offset",
             "parse",
@@ -467,7 +467,7 @@ class Relation(google.protobuf.message.Message):
         "unpivot",
         "to_schema",
         "repartition_by_expression",
-        "frame_map",
+        "map_partitions",
         "collect_metrics",
         "parse",
         "fill_na",
@@ -2706,17 +2706,17 @@ class RepartitionByExpression(google.protobuf.message.Message):
 
 global___RepartitionByExpression = RepartitionByExpression
 
-class FrameMap(google.protobuf.message.Message):
+class MapPartitions(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
     INPUT_FIELD_NUMBER: builtins.int
     FUNC_FIELD_NUMBER: builtins.int
     @property
     def input(self) -> global___Relation:
-        """(Required) Input relation for a Frame Map API: mapInPandas, mapInArrow."""
+        """(Required) Input relation for a mapPartitions-equivalent API: mapInPandas, mapInArrow."""
     @property
     def func(self) -> pyspark.sql.connect.proto.expressions_pb2.CommonInlineUserDefinedFunction:
-        """(Required) Input user-defined function of a Frame Map API."""
+        """(Required) Input user-defined function."""
     def __init__(
         self,
         *,
@@ -2731,7 +2731,7 @@ class FrameMap(google.protobuf.message.Message):
         self, field_name: typing_extensions.Literal["func", b"func", "input", b"input"]
     ) -> None: ...
 
-global___FrameMap = FrameMap
+global___MapPartitions = MapPartitions
 
 class CollectMetrics(google.protobuf.message.Message):
     """Collect arbitrary (named) metrics from a dataset."""


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename FrameMap proto to MapPartitions.


### Why are the changes needed?
For readability.

Frame Map API refers to mapInPandas and mapInArrow, which are equivalent to MapPartitions.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.

SPARK-41661