### PR TITLE
[SPARK-42712][PYTHON][DOC] Improve docstring of mapInPandas and mapInArrow

### DIFF
--- a/python/pyspark/sql/pandas/map_ops.py
+++ b/python/pyspark/sql/pandas/map_ops.py
@@ -45,7 +45,7 @@ class PandasMapOpsMixin:
         returned iterator of `pandas.DataFrame`\\s are combined as a :class:`DataFrame`.
         Each `pandas.DataFrame` size can be controlled by
         `spark.sql.execution.arrow.maxRecordsPerBatch`. The size of the function's input and
-        output might be different.
+        output can be different.
 
         .. versionadded:: 3.0.0
 
@@ -110,7 +110,7 @@ class PandasMapOpsMixin:
         returned iterator of `pyarrow.RecordBatch`\\s are combined as a :class:`DataFrame`.
         Each `pyarrow.RecordBatch` size can be controlled by
         `spark.sql.execution.arrow.maxRecordsPerBatch`. The size of the function's input and
-        output might be different.
+        output can be different.
 
         .. versionadded:: 3.3.0
 

--- a/python/pyspark/sql/pandas/map_ops.py
+++ b/python/pyspark/sql/pandas/map_ops.py
@@ -44,7 +44,8 @@ class PandasMapOpsMixin:
         together as an iterator of `pandas.DataFrame`\\s to the function and the
         returned iterator of `pandas.DataFrame`\\s are combined as a :class:`DataFrame`.
         Each `pandas.DataFrame` size can be controlled by
-        `spark.sql.execution.arrow.maxRecordsPerBatch`.
+        `spark.sql.execution.arrow.maxRecordsPerBatch`. The size of the function's input and
+        output might be different.
 
         .. versionadded:: 3.0.0
 
@@ -108,7 +109,8 @@ class PandasMapOpsMixin:
         together as an iterator of `pyarrow.RecordBatch`\\s to the function and the
         returned iterator of `pyarrow.RecordBatch`\\s are combined as a :class:`DataFrame`.
         Each `pyarrow.RecordBatch` size can be controlled by
-        `spark.sql.execution.arrow.maxRecordsPerBatch`.
+        `spark.sql.execution.arrow.maxRecordsPerBatch`. The size of the function's input and
+        output might be different.
 
         .. versionadded:: 3.3.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve docstring of mapInPandas and mapInArrow 

### Why are the changes needed?
For readability. We call out they are not scalar - the input and output of the function might be of different sizes.

### Does this PR introduce _any_ user-facing change?
No. Doc change only.


### How was this patch tested?
Existing tests.