### PR TITLE
[SPARK-42716][SQL] DataSourceV2 supports reporting key-grouped partitioning without HasPartitionKey

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -21,7 +21,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, RowOrdering, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical
-import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, SinglePartition}
+import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedPartitioning
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.execution.{ExplainUtils, LeafExecNode, SQLExecution}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -21,7 +21,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, RowOrdering, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical
-import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedPartitioning
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, KeyGroupedPartitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.execution.{ExplainUtils, LeafExecNode, SQLExecution}
@@ -100,7 +100,7 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
             KeyGroupedPartitioning(exprs, keyGroupedParts.size, keyGroupedParts.map(_.value),
               keyGroupedPartsInfo.originalParts.map(_.partitionKey()))
           }
-          .getOrElse(super.outputPartitioning)
+          .getOrElse(HashPartitioning(exprs, inputPartitions.size))
       case _ =>
         super.outputPartitioning
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -21,7 +21,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, RowOrdering, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, KeyGroupedPartitioning, SinglePartition}
+import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.execution.{ExplainUtils, LeafExecNode, SQLExecution}
@@ -99,8 +99,9 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
             val keyGroupedParts = keyGroupedPartsInfo.groupedParts
             KeyGroupedPartitioning(exprs, keyGroupedParts.size, keyGroupedParts.map(_.value),
               keyGroupedPartsInfo.originalParts.map(_.partitionKey()))
+          }.getOrElse {
+            KeyGroupedPartitioning(exprs, inputPartitions.size)
           }
-          .getOrElse(HashPartitioning(exprs, inputPartitions.size))
       case _ =>
         super.outputPartitioning
     }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaOrderAndPartitionAwareDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaOrderAndPartitionAwareDataSource.java
@@ -22,9 +22,6 @@ import java.util.Arrays;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.expressions.*;
 import org.apache.spark.sql.connector.read.*;
-import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
-import org.apache.spark.sql.connector.read.partitioning.Partitioning;
-import org.apache.spark.sql.connector.read.partitioning.UnknownPartitioning;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class JavaOrderAndPartitionAwareDataSource extends JavaPartitionAwareDataSource {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaOrderAndPartitionAwareScanBuilder.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaOrderAndPartitionAwareScanBuilder.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.apache.spark.sql.connector;
 
 import org.apache.spark.sql.connector.expressions.Expression;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaOrderAndPartitionAwareScanBuilder.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaOrderAndPartitionAwareScanBuilder.java
@@ -1,0 +1,54 @@
+package test.org.apache.spark.sql.connector;
+
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.SortOrder;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.SupportsReportOrdering;
+import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
+import org.apache.spark.sql.connector.read.partitioning.Partitioning;
+import org.apache.spark.sql.connector.read.partitioning.UnknownPartitioning;
+
+public class JavaOrderAndPartitionAwareScanBuilder extends JavaPartitionAwareScanBuilder
+    implements SupportsReportOrdering {
+
+    private final Partitioning partitioning;
+    private final SortOrder[] ordering;
+
+    JavaOrderAndPartitionAwareScanBuilder(InputPartition[] partitions, String partitionKeys, String orderKeys) {
+        super(partitions);
+
+        if (partitionKeys != null) {
+            String[] keys = partitionKeys.split(",");
+            Expression[] clustering = new Transform[keys.length];
+            for (int i = 0; i < keys.length; i++) {
+                clustering[i] = Expressions.identity(keys[i]);
+            }
+            this.partitioning = new KeyGroupedPartitioning(clustering, 2);
+        } else {
+            this.partitioning = new UnknownPartitioning(2);
+        }
+
+        if (orderKeys != null) {
+            String[] keys = orderKeys.split(",");
+            this.ordering = new SortOrder[keys.length];
+            for (int i = 0; i < keys.length; i++) {
+                this.ordering[i] = new JavaOrderAndPartitionAwareDataSource.MySortOrder(keys[i]);
+            }
+        } else {
+            this.ordering = new SortOrder[0];
+        }
+    }
+
+    @Override
+    public Partitioning outputPartitioning() {
+        return this.partitioning;
+    }
+
+    @Override
+    public SortOrder[] outputOrdering() {
+        return this.ordering;
+    }
+
+}

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareDataSource.java
@@ -18,18 +18,14 @@
 package test.org.apache.spark.sql.connector;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.TestingV2Source;
 import org.apache.spark.sql.connector.catalog.Table;
-import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.read.*;
-import org.apache.spark.sql.connector.read.partitioning.Partitioning;
-import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 public class JavaPartitionAwareDataSource implements TestingV2Source {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareDataSourceWithKey.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareDataSourceWithKey.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.apache.spark.sql.connector;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.read.HasPartitionKey;
+import org.apache.spark.sql.connector.read.InputPartition;
+
+import java.util.Arrays;
+
+public class JavaPartitionAwareDataSourceWithKey extends JavaPartitionAwareDataSource {
+  @Override
+  protected InputPartition[] getPartitions() {
+    return new InputPartition[]{
+      new SpecificInputPartitionWithKey(new int[]{1, 1}, new int[]{4, 4}),
+      new SpecificInputPartitionWithKey(new int[]{3}, new int[]{6}),
+      new SpecificInputPartitionWithKey(new int[]{2}, new int[]{6}),
+      new SpecificInputPartitionWithKey(new int[]{4}, new int[]{2}),
+      new SpecificInputPartitionWithKey(new int[]{4}, new int[]{2})
+    };
+  }
+
+  static class SpecificInputPartitionWithKey extends SpecificInputPartition implements HasPartitionKey {
+    SpecificInputPartitionWithKey(int[] i, int[] j) {
+      super(i, j);
+      assert i.length > 0;
+      assert Arrays.stream(i).allMatch(k -> k == i[0]);
+    }
+
+    @Override
+    public InternalRow partitionKey() {
+      return new GenericInternalRow(new Object[] {i[0]});
+    }
+  }
+}

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareScanBuilder.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareScanBuilder.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package test.org.apache.spark.sql.connector;
 
 import org.apache.spark.sql.connector.expressions.Expression;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareScanBuilder.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaPartitionAwareScanBuilder.java
@@ -1,0 +1,36 @@
+package test.org.apache.spark.sql.connector;
+
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.connector.read.SupportsReportPartitioning;
+import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
+import org.apache.spark.sql.connector.read.partitioning.Partitioning;
+
+public class JavaPartitionAwareScanBuilder
+    extends JavaSimpleScanBuilder implements SupportsReportPartitioning {
+    private final InputPartition[] partitions;
+
+    public JavaPartitionAwareScanBuilder(InputPartition[] partitions) {
+        this.partitions = partitions;
+    }
+
+    @Override
+    public InputPartition[] planInputPartitions() {
+        return this.partitions;
+    }
+
+    @Override
+    public PartitionReaderFactory createReaderFactory() {
+        return new JavaPartitionAwareDataSource.SpecificReaderFactory();
+    }
+
+    @Override
+    public Partitioning outputPartitioning() {
+        Expression[] clustering = new Transform[] { Expressions.identity("i") };
+        return new KeyGroupedPartitioning(clustering, partitions.length);
+    }
+}
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -105,7 +105,7 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
       val distribution = physical.ClusteredDistribution(
         Seq(TransformExpression(BucketFunction, Seq(attr("ts")), Some(32))))
 
-      checkQueryPlan(df, distribution, physical.HashPartitioning(distribution.clustering, 32))
+      checkQueryPlan(df, distribution, physical.KeyGroupedPartitioning(distribution.clustering, 32))
     }
   }
 
@@ -175,7 +175,7 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
       val distribution = physical.ClusteredDistribution(
         Seq(TransformExpression(BucketFunction, Seq(attr("ts")), Some(32))))
 
-      checkQueryPlan(df, distribution, physical.HashPartitioning(distribution.clustering, 32))
+      checkQueryPlan(df, distribution, physical.KeyGroupedPartitioning(distribution.clustering, 32))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
A `DataSourceV2` reporting a `KeyGroupedPartitioning` through `SupportsReportPartitioning` does not have to implement `HasPartitionKey`, and is thus not limited to a single key per partition.

### Why are the changes needed?
Before Spark 3.3, `DataSourceV2` implementations could report a `ClusteredDistribution` with more than just a single cluster value per partition. This allowed Spark to exploit the existing partitioning and avoid an extra hash partitioning shuffle step. Transformations like `groupBy` or window functions (with the right group / partitioning keys) would then be executed on the partitioning provided by the data source.

### Does this PR introduce _any_ user-facing change?
This improves performance as existing partitioning is reused.

### How was this patch tested?
Existing tests have been fixed. They falsely reported partitions with multiple keys via `HasPartitionKey`.