### PR TITLE
[SPARK-42717][BUILD] Upgrade mysql-connector-java from 8.0.31 to 8.0.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1206,7 +1206,7 @@
       <dependency>
         <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
-        <version>8.0.31</version>
+        <version>8.0.32</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade mysql-connector-java from 8.0.31 to 8.0.32

### Why are the changes needed?
1.This version brings some bugs fixes, the release note as follows:
https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-32.html
    
2.Bugs Fixed(https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-32.html#connector-j-8-0-32-bug), eg:
<img width="955" alt="image" src="https://user-images.githubusercontent.com/15246973/223701685-b73c140f-1485-4c1b-83ef-a0df02866176.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.