### PR TITLE
[SPARK-42706][SQL][DOCS] Document the Spark SQL error classes in user-facing documentation.

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -102,3 +102,48 @@
           url: sql-ref-syntax.html#data-retrieval-statements
         - text: Auxiliary Statements
           url: sql-ref-syntax.html#auxiliary-statements
+- text: Error Conditions
+  url: sql-error-conditions.html
+  subitems:
+    - text: SQLSTATE Codes
+      url: sql-error-conditions-sqlstates.html
+    - text: CONNECT error class
+      url: sql-error-conditions-connect-error-class.html
+    - text: DATATYPE_MISMATCH error class
+      url: sql-error-conditions-datatype-mismatch-error-class.html
+    - text: INCOMPATIBLE_DATA_TO_TABLE error class
+      url: sql-error-conditions-incompatible-data-to-table-error-class.html
+    - text: INCOMPLETE_TYPE_DEFINITION error class
+      url: sql-error-conditions-incomplete-type-definition-error-class.html
+    - text: INCONSISTENT_BEHAVIOR_CROSS_VERSION error class
+      url: sql-error-conditions-inconsistent-behavior-cross-version-error-class.html
+    - text: INVALID_FORMAT error class
+      url: sql-error-conditions-invalid-format-error-class.html
+    - text: INVALID_OPTIONS error class
+      url: sql-error-conditions-invalid-options-error-class.html
+    - text: INVALID_PARAMETER_VALUE error class
+      url: sql-error-conditions-invalid-parameter-value-error-class.html
+    - text: INVALID_SCHEMA error class
+      url: sql-error-conditions-invalid-schema-error-class.html
+    - text: INVALID_SUBQUERY_EXPRESSION error class
+      url: sql-error-conditions-invalid-subquery-expression-error-class.html
+    - text: NOT_NULL_CONSTRAINT_VIOLATION error class
+      url: sql-error-conditions-not-null-constraint-violation-error-class.html
+    - text: UNRESOLVED_COLUMN error class
+      url: sql-error-conditions-unresolved-column-error-class.html
+    - text: UNRESOLVED_FIELD error class
+      url: sql-error-conditions-unresolved-field-error-class.html
+    - text: UNRESOLVED_MAP_KEY error class
+      url: sql-error-conditions-unresolved-map-key-error-class.html
+    - text: UNSUPPORTED_DESERIALIZER error class
+      url: sql-error-conditions-unsupported-deserializer-error-class.html
+    - text: UNSUPPORTED_FEATURE error class
+      url: sql-error-conditions-unsupported-feature-error-class.html
+    - text: UNSUPPORTED_GENERATOR error class
+      url: sql-error-conditions-unsupported-generator-error-class.html
+    - text: UNSUPPORTED_SAVE_MODE error class
+      url: sql-error-conditions-unsupported-save-mode-error-class.html
+    - text: UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY error class
+      url: sql-error-conditions-unsupported-subquery-expression-category-error-class.html
+    - text: WRONG_NUM_ARGS error class
+      url: sql-error-conditions-wrong-num-args-error-class.html

--- a/docs/sql-error-conditions-connect-error-class.md
+++ b/docs/sql-error-conditions-connect-error-class.md
@@ -1,0 +1,44 @@
+---
+layout: global
+title: CONNECT error class
+displayTitle: CONNECT error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+SQLSTATE: none assigned
+
+Generic Spark Connect error.
+
+This error class has the following derived error classes:
+
+## INTERCEPTOR_CTOR_MISSING
+
+Cannot instantiate GRPC interceptor because `<cls>` is missing a default constructor without arguments.
+
+## INTERCEPTOR_RUNTIME_ERROR
+
+Error instantiating GRPC interceptor: `<msg>`
+
+## PLUGIN_CTOR_MISSING
+
+Cannot instantiate Spark Connect plugin because `<cls>` is missing a default constructor without arguments.
+
+## PLUGIN_RUNTIME_ERROR
+
+Error instantiating Spark Connect plugin: `<msg>`
+
+

--- a/docs/sql-error-conditions-datatype-mismatch-error-class.md
+++ b/docs/sql-error-conditions-datatype-mismatch-error-class.md
@@ -1,0 +1,238 @@
+---
+layout: global
+title: DATATYPE_MISMATCH error class
+displayTitle: DATATYPE_MISMATCH error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot resolve `<sqlExpr>` due to data type mismatch:
+
+This error class has the following derived error classes:
+
+## ARRAY_FUNCTION_DIFF_TYPES
+
+Input to `<functionName>` should have been `<dataType>` followed by a value with same element type, but it's [`<leftType>`, `<rightType>`].
+
+## BINARY_ARRAY_DIFF_TYPES
+
+Input to function `<functionName>` should have been two `<arrayType>` with same element type, but it's [`<leftType>`, `<rightType>`].
+
+## BINARY_OP_DIFF_TYPES
+
+the left and right operands of the binary operator have incompatible types (`<left>` and `<right>`).
+
+## BINARY_OP_WRONG_TYPE
+
+the binary operator requires the input type `<inputType>`, not `<actualDataType>`.
+
+## BLOOM_FILTER_BINARY_OP_WRONG_TYPE
+
+The Bloom filter binary input to `<functionName>` should be either a constant value or a scalar subquery expression, but it's `<actual>`.
+
+## BLOOM_FILTER_WRONG_TYPE
+
+Input to function `<functionName>` should have been `<expectedLeft>` followed by value with `<expectedRight>`, but it's [`<actual>`].
+
+## CANNOT_CONVERT_TO_JSON
+
+Unable to convert column `<name>` of type `<type>` to JSON.
+
+## CANNOT_DROP_ALL_FIELDS
+
+Cannot drop all fields in struct.
+
+## CAST_WITHOUT_SUGGESTION
+
+cannot cast `<srcType>` to `<targetType>`.
+
+## CAST_WITH_CONF_SUGGESTION
+
+cannot cast `<srcType>` to `<targetType>` with ANSI mode on.
+
+If you have to cast `<srcType>` to `<targetType>`, you can set `<config>` as `<configVal>`.
+
+## CAST_WITH_FUNC_SUGGESTION
+
+cannot cast `<srcType>` to `<targetType>`.
+
+To convert values from `<srcType>` to `<targetType>`, you can use the functions `<functionNames>` instead.
+
+## CREATE_MAP_KEY_DIFF_TYPES
+
+The given keys of function `<functionName>` should all be the same type, but they are `<dataType>`.
+
+## CREATE_MAP_VALUE_DIFF_TYPES
+
+The given values of function `<functionName>` should all be the same type, but they are `<dataType>`.
+
+## CREATE_NAMED_STRUCT_WITHOUT_FOLDABLE_STRING
+
+Only foldable `STRING` expressions are allowed to appear at odd position, but they are `<inputExprs>`.
+
+## DATA_DIFF_TYPES
+
+Input to `<functionName>` should all be the same type, but it's `<dataType>`.
+
+## FILTER_NOT_BOOLEAN
+
+Filter expression `<filter>` of type `<type>` is not a boolean.
+
+## HASH_MAP_TYPE
+
+Input to the function `<functionName>` cannot contain elements of the "MAP" type. In Spark, same maps may have different hashcode, thus hash expressions are prohibited on "MAP" elements. To restore previous behavior set "spark.sql.legacy.allowHashOnMapType" to "true".
+
+## INPUT_SIZE_NOT_ONE
+
+Length of `<exprName>` should be 1.
+
+## INVALID_ARG_VALUE
+
+The `<inputName>` value must to be a `<requireType>` literal of `<validValues>`, but got `<inputValue>`.
+
+## INVALID_JSON_MAP_KEY_TYPE
+
+Input schema `<schema>` can only contain STRING as a key type for a MAP.
+
+## INVALID_JSON_SCHEMA
+
+Input schema `<schema>` must be a struct, an array or a map.
+
+## INVALID_MAP_KEY_TYPE
+
+The key of map cannot be/contain `<keyType>`.
+
+## INVALID_ORDERING_TYPE
+
+The `<functionName>` does not support ordering on type `<dataType>`.
+
+## IN_SUBQUERY_DATA_TYPE_MISMATCH
+
+The data type of one or more elements in the left hand side of an IN subquery is not compatible with the data type of the output of the subquery. Mismatched columns: [`<mismatchedColumns>`], left side: [`<leftType>`], right side: [`<rightType>`].
+
+## IN_SUBQUERY_LENGTH_MISMATCH
+
+The number of columns in the left hand side of an IN subquery does not match the number of columns in the output of subquery. Left hand side columns(length: `<leftLength>`): [`<leftColumns>`], right hand side columns(length: `<rightLength>`): [`<rightColumns>`].
+
+## MAP_CONCAT_DIFF_TYPES
+
+The `<functionName>` should all be of type map, but it's `<dataType>`.
+
+## MAP_FUNCTION_DIFF_TYPES
+
+Input to `<functionName>` should have been `<dataType>` followed by a value with same key type, but it's [`<leftType>`, `<rightType>`].
+
+## MAP_ZIP_WITH_DIFF_TYPES
+
+Input to the `<functionName>` should have been two maps with compatible key types, but it's [`<leftType>`, `<rightType>`].
+
+## NON_FOLDABLE_INPUT
+
+the input `<inputName>` should be a foldable `<inputType>` expression; however, got `<inputExpr>`.
+
+## NON_STRING_TYPE
+
+all arguments must be strings.
+
+## NULL_TYPE
+
+Null typed values cannot be used as arguments of `<functionName>`.
+
+## PARAMETER_CONSTRAINT_VIOLATION
+
+The `<leftExprName>`(`<leftExprValue>`) must be `<constraint>` the `<rightExprName>`(`<rightExprValue>`).
+
+## RANGE_FRAME_INVALID_TYPE
+
+The data type `<orderSpecType>` used in the order specification does not match the data type `<valueBoundaryType>` which is used in the range frame.
+
+## RANGE_FRAME_MULTI_ORDER
+
+A range window frame with value boundaries cannot be used in a window specification with multiple order by expressions: `<orderSpec>`.
+
+## RANGE_FRAME_WITHOUT_ORDER
+
+A range window frame cannot be used in an unordered window specification.
+
+## SEQUENCE_WRONG_INPUT_TYPES
+
+`<functionName>` uses the wrong parameter type. The parameter type must conform to:
+
+1. The start and stop expressions must resolve to the same type.
+
+2. If start and stop expressions resolve to the `<startType>` type, then the step expression must resolve to the `<stepType>` type.
+
+3. Otherwise, if start and stop expressions resolve to the `<otherStartType>` type, then the step expression must resolve to the same type.
+
+## SPECIFIED_WINDOW_FRAME_DIFF_TYPES
+
+Window frame bounds `<lower>` and `<upper>` do not have the same type: `<lowerType>` <> `<upperType>`.
+
+## SPECIFIED_WINDOW_FRAME_INVALID_BOUND
+
+Window frame upper bound `<upper>` does not follow the lower bound `<lower>`.
+
+## SPECIFIED_WINDOW_FRAME_UNACCEPTED_TYPE
+
+The data type of the `<location>` bound `<exprType>` does not match the expected data type `<expectedType>`.
+
+## SPECIFIED_WINDOW_FRAME_WITHOUT_FOLDABLE
+
+Window frame `<location>` bound `<expression>` is not a literal.
+
+## SPECIFIED_WINDOW_FRAME_WRONG_COMPARISON
+
+The lower bound of a window frame must be `<comparison>` to the upper bound.
+
+## STACK_COLUMN_DIFF_TYPES
+
+The data type of the column (`<columnIndex>`) do not have the same type: `<leftType>` (`<leftParamIndex>`) <> `<rightType>` (`<rightParamIndex>`).
+
+## UNEXPECTED_CLASS_TYPE
+
+class `<className>` not found.
+
+## UNEXPECTED_INPUT_TYPE
+
+Parameter `<paramIndex>` requires the `<requiredType>` type, however `<inputSql>` has the type `<inputType>`.
+
+## UNEXPECTED_NULL
+
+The `<exprName>` must not be null.
+
+## UNEXPECTED_RETURN_TYPE
+
+The `<functionName>` requires return `<expectedType>` type, but the actual is `<actualType>` type.
+
+## UNEXPECTED_STATIC_METHOD
+
+cannot find a static method `<methodName>` that matches the argument types in `<className>`.
+
+## UNSUPPORTED_INPUT_TYPE
+
+The input of `<functionName>` can't be `<dataType>` type data.
+
+## VALUE_OUT_OF_RANGE
+
+The `<exprName>` must be between `<valueRange>` (current value = `<currentValue>`).
+
+## WRONG_NUM_ENDPOINTS
+
+The number of endpoints must be >= 2 to construct intervals but the actual number is `<actualNumber>`.
+
+

--- a/docs/sql-error-conditions-incompatible-data-to-table-error-class.md
+++ b/docs/sql-error-conditions-incompatible-data-to-table-error-class.md
@@ -1,0 +1,64 @@
+---
+layout: global
+title: INCOMPATIBLE_DATA_TO_TABLE error class
+displayTitle: INCOMPATIBLE_DATA_TO_TABLE error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+SQLSTATE: none assigned
+
+Cannot write incompatible data to table `<tableName>`:
+
+This error class has the following derived error classes:
+
+## AMBIGUOUS_COLUMN_NAME
+
+Ambiguous column name in the input data: `<colPath>`.
+
+## CANNOT_FIND_DATA
+
+Cannot find data for output column `<colPath>`.
+
+## CANNOT_SAFELY_CAST
+
+Cannot safely cast `<colPath>`: `<from>` to `<to>`.
+
+## EXTRA_STRUCT_FIELDS
+
+Cannot write extra fields to struct `<colPath>`: `<extraCols>`.
+
+## NULLABLE_ARRAY_ELEMENTS
+
+Cannot write nullable elements to array of non-nulls: `<colPath>`.
+
+## NULLABLE_COLUMN
+
+Cannot write nullable values to non-null column `<colPath>`.
+
+## NULLABLE_MAP_VALUES
+
+Cannot write nullable elements to array of non-nulls: `<colPath>`.
+
+## STRUCT_MISSING_FIELDS
+
+Struct `<colPath>` missing fields: `<missingFields>`.
+
+## UNEXPECTED_COLUMN_NAME
+
+Struct `<colPath>` `<order>`-th field name does not match (may be out of order): expected `<expected>`, found `<found>`.
+
+

--- a/docs/sql-error-conditions-incomplete-type-definition-error-class.md
+++ b/docs/sql-error-conditions-incomplete-type-definition-error-class.md
@@ -1,0 +1,40 @@
+---
+layout: global
+title: INCOMPLETE_TYPE_DEFINITION error class
+displayTitle: INCOMPLETE_TYPE_DEFINITION error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42K01](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Incomplete complex type:
+
+This error class has the following derived error classes:
+
+## ARRAY
+
+The definition of "ARRAY" type is incomplete. You must provide an element type. For example: "ARRAY`<elementType>`".
+
+## MAP
+
+The definition of "MAP" type is incomplete. You must provide a key type and a value type. For example: "MAP<TIMESTAMP, INT>".
+
+## STRUCT
+
+The definition of "STRUCT" type is incomplete. You must provide at least one field type. For example: "STRUCT<name STRING, phone DECIMAL(10, 0)>".
+
+

--- a/docs/sql-error-conditions-inconsistent-behavior-cross-version-error-class.md
+++ b/docs/sql-error-conditions-inconsistent-behavior-cross-version-error-class.md
@@ -1,0 +1,82 @@
+---
+layout: global
+title: INCONSISTENT_BEHAVIOR_CROSS_VERSION error class
+displayTitle: INCONSISTENT_BEHAVIOR_CROSS_VERSION error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42K0B](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+You may get a different result due to the upgrading to
+
+This error class has the following derived error classes:
+
+## DATETIME_PATTERN_RECOGNITION
+
+Spark >= 3.0:
+
+Fail to recognize `<pattern>` pattern in the DateTimeFormatter. 1) You can set `<config>` to "LEGACY" to restore the behavior before Spark 3.0. 2) You can form a valid datetime pattern with the guide from '`<docroot>`/sql-ref-datetime-pattern.html'.
+
+## PARSE_DATETIME_BY_NEW_PARSER
+
+Spark >= 3.0:
+
+Fail to parse `<datetime>` in the new parser. You can set `<config>` to "LEGACY" to restore the behavior before Spark 3.0, or set to "CORRECTED" and treat it as an invalid datetime string.
+
+## READ_ANCIENT_DATETIME
+
+Spark >= 3.0:
+
+reading dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z
+
+from `<format>` files can be ambiguous, as the files may be written by
+
+Spark 2.x or legacy versions of Hive, which uses a legacy hybrid calendar
+
+that is different from Spark 3.0+'s Proleptic Gregorian calendar.
+
+See more details in SPARK-31404. You can set the SQL config `<config>` or
+
+the datasource option `<option>` to "LEGACY" to rebase the datetime values
+
+w.r.t. the calendar difference during reading. To read the datetime values
+
+as it is, set the SQL config or the datasource option to "CORRECTED".
+
+## WRITE_ANCIENT_DATETIME
+
+Spark >= 3.0:
+
+writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z
+
+into `<format>` files can be dangerous, as the files may be read by Spark 2.x
+
+or legacy versions of Hive later, which uses a legacy hybrid calendar that
+
+is different from Spark 3.0+'s Proleptic Gregorian calendar. See more
+
+details in SPARK-31404. You can set `<config>` to "LEGACY" to rebase the
+
+datetime values w.r.t. the calendar difference during writing, to get maximum
+
+interoperability. Or set the config to "CORRECTED" to write the datetime
+
+values as it is, if you are sure that the written files will only be read by
+
+Spark 3.0+ or other systems that use Proleptic Gregorian calendar.
+
+

--- a/docs/sql-error-conditions-invalid-format-error-class.md
+++ b/docs/sql-error-conditions-invalid-format-error-class.md
@@ -1,0 +1,68 @@
+---
+layout: global
+title: INVALID_FORMAT error class
+displayTitle: INVALID_FORMAT error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42601](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The format is invalid: `<format>`.
+
+This error class has the following derived error classes:
+
+## CONT_THOUSANDS_SEPS
+
+Thousands separators (, or G) must have digits in between them in the number format.
+
+## CUR_MUST_BEFORE_DEC
+
+Currency characters must appear before any decimal point in the number format.
+
+## CUR_MUST_BEFORE_DIGIT
+
+Currency characters must appear before digits in the number format.
+
+## EMPTY
+
+The number format string cannot be empty.
+
+## ESC_AT_THE_END
+
+The escape character is not allowed to end with.
+
+## ESC_IN_THE_MIDDLE
+
+The escape character is not allowed to precede `<char>`.
+
+## THOUSANDS_SEPS_MUST_BEFORE_DEC
+
+Thousands separators (, or G) may not appear after the decimal point in the number format.
+
+## UNEXPECTED_TOKEN
+
+Found the unexpected `<token>` in the format string; the structure of the format string must match: [MI|S] [$] [0|9|G|,]* [.|D] [0|9]* [$] [PR|MI|S].
+
+## WRONG_NUM_DIGIT
+
+The format string requires at least one number digit.
+
+## WRONG_NUM_TOKEN
+
+At most one `<token>` is allowed in the number format.
+
+

--- a/docs/sql-error-conditions-invalid-format-error-class.md
+++ b/docs/sql-error-conditions-invalid-format-error-class.md
@@ -55,7 +55,7 @@ Thousands separators (, or G) may not appear after the decimal point in the numb
 
 ## UNEXPECTED_TOKEN
 
-Found the unexpected `<token>` in the format string; the structure of the format string must match: [MI|S] [$] [0|9|G|,]* [.|D] [0|9]* [$] [PR|MI|S].
+Found the unexpected `<token>` in the format string; the structure of the format string must match: `[MI|S]` `[$]` `[0|9|G|,]*` `[.|D]` `[0|9]*` `[$]` `[PR|MI|S]`.
 
 ## WRONG_NUM_DIGIT
 

--- a/docs/sql-error-conditions-invalid-options-error-class.md
+++ b/docs/sql-error-conditions-invalid-options-error-class.md
@@ -1,0 +1,36 @@
+---
+layout: global
+title: INVALID_OPTIONS error class
+displayTitle: INVALID_OPTIONS error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42K06](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Invalid options:
+
+This error class has the following derived error classes:
+
+## NON_MAP_FUNCTION
+
+Must use the `map()` function for options.
+
+## NON_STRING_TYPE
+
+A type of keys and values in `map()` must be string, but got `<mapType>`.
+
+

--- a/docs/sql-error-conditions-invalid-parameter-value-error-class.md
+++ b/docs/sql-error-conditions-invalid-parameter-value-error-class.md
@@ -1,0 +1,44 @@
+---
+layout: global
+title: INVALID_PARAMETER_VALUE error class
+displayTitle: INVALID_PARAMETER_VALUE error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 22023](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The value of parameter(s) `<parameter>` in `<functionName>` is invalid:
+
+This error class has the following derived error classes:
+
+## AES_KEY
+
+detail message: `<detailMessage>`
+
+## AES_KEY_LENGTH
+
+expects a binary value with 16, 24 or 32 bytes, but got `<actualLength>` bytes.
+
+## PATTERN
+
+`<value>`.
+
+## ZERO_INDEX
+
+expects %1$, %2$ and so on, but got %0$.
+
+

--- a/docs/sql-error-conditions-invalid-parameter-value-error-class.md
+++ b/docs/sql-error-conditions-invalid-parameter-value-error-class.md
@@ -39,6 +39,6 @@ expects a binary value with 16, 24 or 32 bytes, but got `<actualLength>` bytes.
 
 ## ZERO_INDEX
 
-expects %1$, %2$ and so on, but got %0$.
+expects `%1$`, `%2$` and so on, but got `%0$`.
 
 

--- a/docs/sql-error-conditions-invalid-schema-error-class.md
+++ b/docs/sql-error-conditions-invalid-schema-error-class.md
@@ -1,0 +1,42 @@
+---
+layout: global
+title: INVALID_SCHEMA error class
+displayTitle: INVALID_SCHEMA error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42K07](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The input schema `<inputSchema>` is not a valid schema string.
+
+This error class has the following derived error classes:
+
+## NON_STRING_LITERAL
+
+The input expression must be string literal and not null.
+
+## NON_STRUCT_TYPE
+
+The input expression should be evaluated to struct type, but got `<dataType>`.
+
+## PARSE_ERROR
+
+Cannot parse the schema:
+
+`<reason>`
+
+

--- a/docs/sql-error-conditions-invalid-subquery-expression-error-class.md
+++ b/docs/sql-error-conditions-invalid-subquery-expression-error-class.md
@@ -1,0 +1,32 @@
+---
+layout: global
+title: INVALID_SUBQUERY_EXPRESSION error class
+displayTitle: INVALID_SUBQUERY_EXPRESSION error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42823](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Invalid subquery:
+
+This error class has the following derived error classes:
+
+## SCALAR_SUBQUERY_RETURN_MORE_THAN_ONE_OUTPUT_COLUMN
+
+Scalar subquery must return only one column, but got `<number>`.
+
+

--- a/docs/sql-error-conditions-not-null-constraint-violation-error-class.md
+++ b/docs/sql-error-conditions-not-null-constraint-violation-error-class.md
@@ -1,0 +1,36 @@
+---
+layout: global
+title: NOT_NULL_CONSTRAINT_VIOLATION error class
+displayTitle: NOT_NULL_CONSTRAINT_VIOLATION error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Assigning a NULL is not allowed here.
+
+This error class has the following derived error classes:
+
+## ARRAY_ELEMENT
+
+The array `<columnPath>` is defined to contain only elements that are NOT NULL.
+
+## MAP_VALUE
+
+The map `<columnPath>` is defined to contain only values that are NOT NULL.
+
+

--- a/docs/sql-error-conditions-sqlstates.md
+++ b/docs/sql-error-conditions-sqlstates.md
@@ -1,0 +1,720 @@
+---
+layout: global
+title: SQLSTATE Codes
+displayTitle: SQLSTATE Codes
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+Most error classes returned by Spark SQL are associated with a 5 character `SQLSTATE`.
+A `SQLSTATE` is a SQL standard encoding for error conditions commonly used by `JDBC`, `ODBC`, and other client APIs.
+
+A `SQLSTATE` consists of two portions: A two character class, and a three character subclass.
+Each character must be a digit `'0'` to `'9'` or `'A'` to `'Z'`.
+
+While many `SQLSTATE` values are prescribed by the SQL standard, others are common in the industry, specific to Spark.
+
+For an ordered list of error classes see: [Error Conditions in Spark SQL](sql-error-conditions.html)
+
+Spark SQL uses the following `SQLSTATE` classes:
+
+## Class `0A`: feature not supported
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>0A000</td>
+  <td>feature not supported</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#invalid_pandas_udf_placement">INVALID_PANDAS_UDF_PLACEMENT</a>, <a href="sql-error-conditions.html#star_group_by_pos">STAR_GROUP_BY_POS</a>, <a href="sql-error-conditions.html#unsupported_arrowtype">UNSUPPORTED_ARROWTYPE</a>, <a href="sql-error-conditions.html#unsupported_datatype">UNSUPPORTED_DATATYPE</a>, <a href="unsupported-deserializer-error-class.md">UNSUPPORTED_DESERIALIZER</a>, <a href="unsupported-feature-error-class.md">UNSUPPORTED_FEATURE</a>, <a href="unsupported-generator-error-class.md">UNSUPPORTED_GENERATOR</a>, <a href="unsupported-subquery-expression-category-error-class.md">UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY</a>, <a href="sql-error-conditions.html#unsupported_typed_literal">UNSUPPORTED_TYPED_LITERAL</a>
+  </td>
+</tr>
+    
+</table>
+## Class `21`: cardinality violation
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>21000</td>
+  <td>cardinality violation</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#scalar_subquery_too_many_rows">SCALAR_SUBQUERY_TOO_MANY_ROWS</a>
+  </td>
+</tr>
+    
+</table>
+## Class `22`: data exception
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>22003</td>
+  <td>numeric value out of range</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="arithmetic-overflow-error-class.md">ARITHMETIC_OVERFLOW</a>, <a href="sql-error-conditions.html#cast_overflow">CAST_OVERFLOW</a>, <a href="sql-error-conditions.html#cast_overflow_in_table_insert">CAST_OVERFLOW_IN_TABLE_INSERT</a>, <a href="sql-error-conditions.html#decimal_precision_exceeds_max_precision">DECIMAL_PRECISION_EXCEEDS_MAX_PRECISION</a>, <a href="sql-error-conditions.html#element_at_by_index_zero">ELEMENT_AT_BY_INDEX_ZERO</a>, <a href="sql-error-conditions.html#incorrect_end_offset">INCORRECT_END_OFFSET</a>, <a href="sql-error-conditions.html#incorrect_ramp_up_rate">INCORRECT_RAMP_UP_RATE</a>, <a href="invalid-array-index-error-class.md">INVALID_ARRAY_INDEX</a>, <a href="invalid-array-index-in-element-at-error-class.md">INVALID_ARRAY_INDEX_IN_ELEMENT_AT</a>, <a href="sql-error-conditions.html#numeric_out_of_supported_range">NUMERIC_OUT_OF_SUPPORTED_RANGE</a>, <a href="sql-error-conditions.html#numeric_value_out_of_range">NUMERIC_VALUE_OUT_OF_RANGE</a>
+  </td>
+</tr>
+    <tr>
+  <td>22007</td>
+  <td>invalid datetime format</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#cannot_parse_timestamp">CANNOT_PARSE_TIMESTAMP</a>
+  </td>
+</tr>
+    <tr>
+  <td>22008</td>
+  <td>datetime field overflow</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#datetime_overflow">DATETIME_OVERFLOW</a>
+  </td>
+</tr>
+    <tr>
+  <td>2200E</td>
+  <td>null value in array target</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#null_map_key">NULL_MAP_KEY</a>
+  </td>
+</tr>
+    <tr>
+  <td>22012</td>
+  <td>division by zero</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="divide-by-zero-error-class.md">DIVIDE_BY_ZERO</a>, <a href="sql-error-conditions.html#interval_divided_by_zero">INTERVAL_DIVIDED_BY_ZERO</a>
+  </td>
+</tr>
+    <tr>
+  <td>22015</td>
+  <td>interval field overflow</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#interval_arithmetic_overflow">INTERVAL_ARITHMETIC_OVERFLOW</a>
+  </td>
+</tr>
+    <tr>
+  <td>22018</td>
+  <td>invalid character value for cast</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#cannot_parse_decimal">CANNOT_PARSE_DECIMAL</a>, <a href="cast-invalid-input-error-class.md">CAST_INVALID_INPUT</a>, <a href="sql-error-conditions.html#conversion_invalid_input">CONVERSION_INVALID_INPUT</a>
+  </td>
+</tr>
+    <tr>
+  <td>22023</td>
+  <td>invalid parameter value</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#invalid_fraction_of_second">INVALID_FRACTION_OF_SECOND</a>, <a href="invalid-parameter-value-error-class.md">INVALID_PARAMETER_VALUE</a>, <a href="sql-error-conditions.html#second_function_argument_not_integer">SECOND_FUNCTION_ARGUMENT_NOT_INTEGER</a>
+  </td>
+</tr>
+    <tr>
+  <td>22032</td>
+  <td>invalid JSON text</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#invalid_json_root_field">INVALID_JSON_ROOT_FIELD</a>, <a href="sql-error-conditions.html#invalid_json_schema_map_type">INVALID_JSON_SCHEMA_MAP_TYPE</a>
+  </td>
+</tr>
+    <tr>
+  <td>2203G</td>
+  <td>sql_json_item_cannot_be_cast_to_target_type</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#cannot_parse_json_field">CANNOT_PARSE_JSON_FIELD</a>
+  </td>
+</tr>
+    <tr>
+  <td>22546</td>
+  <td>The value for a routine argument is not valid.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#cannot_decode_url">CANNOT_DECODE_URL</a>
+  </td>
+</tr>
+    
+</table>
+## Class `23`: integrity constraint violation
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>23505</td>
+  <td>A violation of the constraint imposed by a unique index or a unique constraint occurred.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#duplicated_map_key">DUPLICATED_MAP_KEY</a>, <a href="sql-error-conditions.html#duplicate_key">DUPLICATE_KEY</a>
+  </td>
+</tr>
+    
+</table>
+## Class `2B`: dependent privilege descriptors still exist
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>2BP01</td>
+  <td>dependent_objects_still_exist</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#schema_not_empty">SCHEMA_NOT_EMPTY</a>
+  </td>
+</tr>
+    
+</table>
+## Class `38`: external routine exception
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>38000</td>
+  <td>external routine exception</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#failed_function_call">FAILED_FUNCTION_CALL</a>
+  </td>
+</tr>
+    
+</table>
+## Class `39`: external routine invocation exception
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>39000</td>
+  <td>external routine invocation exception</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#failed_execute_udf">FAILED_EXECUTE_UDF</a>
+  </td>
+</tr>
+    
+</table>
+## Class `42`: syntax error or access rule violation
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>42000</td>
+  <td>syntax error or access rule violation</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#ambiguous_reference_to_fields">AMBIGUOUS_REFERENCE_TO_FIELDS</a>, <a href="sql-error-conditions.html#invalid_column_or_field_data_type">INVALID_COLUMN_OR_FIELD_DATA_TYPE</a>, <a href="sql-error-conditions.html#invalid_extract_base_field_type">INVALID_EXTRACT_BASE_FIELD_TYPE</a>, <a href="sql-error-conditions.html#invalid_extract_field_type">INVALID_EXTRACT_FIELD_TYPE</a>, <a href="sql-error-conditions.html#invalid_field_name">INVALID_FIELD_NAME</a>, <a href="sql-error-conditions.html#invalid_set_syntax">INVALID_SET_SYNTAX</a>, <a href="sql-error-conditions.html#invalid_sql_syntax">INVALID_SQL_SYNTAX</a>, <a href="sql-error-conditions.html#non_partition_column">NON_PARTITION_COLUMN</a>, <a href="not-null-constraint-violation-error-class.md">NOT_NULL_CONSTRAINT_VIOLATION</a>, <a href="sql-error-conditions.html#nullable_column_or_field">NULLABLE_COLUMN_OR_FIELD</a>, <a href="sql-error-conditions.html#nullable_row_id_attributes">NULLABLE_ROW_ID_ATTRIBUTES</a>
+  </td>
+</tr>
+    <tr>
+  <td>42601</td>
+  <td>A character, token, or clause is invalid or missing.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#identifier_too_many_name_parts">IDENTIFIER_TOO_MANY_NAME_PARTS</a>, <a href="sql-error-conditions.html#invalid_extract_field">INVALID_EXTRACT_FIELD</a>, <a href="invalid-format-error-class.md">INVALID_FORMAT</a>, <a href="sql-error-conditions.html#parse_syntax_error">PARSE_SYNTAX_ERROR</a>, <a href="sql-error-conditions.html#unclosed_bracketed_comment">UNCLOSED_BRACKETED_COMMENT</a>
+  </td>
+</tr>
+    <tr>
+  <td>42602</td>
+  <td>A character that is invalid in a name has been detected.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#invalid_identifier">INVALID_IDENTIFIER</a>, <a href="sql-error-conditions.html#invalid_property_key">INVALID_PROPERTY_KEY</a>, <a href="sql-error-conditions.html#invalid_property_value">INVALID_PROPERTY_VALUE</a>
+  </td>
+</tr>
+    <tr>
+  <td>42604</td>
+  <td>An invalid numeric or string constant has been detected.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#empty_json_field_value">EMPTY_JSON_FIELD_VALUE</a>, <a href="sql-error-conditions.html#invalid_typed_literal">INVALID_TYPED_LITERAL</a>
+  </td>
+</tr>
+    <tr>
+  <td>42605</td>
+  <td>The number of arguments specified for a scalar function is invalid.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="wrong-num-args-error-class.md">WRONG_NUM_ARGS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42607</td>
+  <td>An operand of an aggregate function or CONCAT operator is invalid.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#nested_aggregate_function">NESTED_AGGREGATE_FUNCTION</a>
+  </td>
+</tr>
+    <tr>
+  <td>42613</td>
+  <td>Clauses are mutually exclusive.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#incompatible_join_types">INCOMPATIBLE_JOIN_TYPES</a>, <a href="sql-error-conditions.html#invalid_lateral_join_type">INVALID_LATERAL_JOIN_TYPE</a>, <a href="sql-error-conditions.html#non_last_matched_clause_omit_condition">NON_LAST_MATCHED_CLAUSE_OMIT_CONDITION</a>, <a href="sql-error-conditions.html#non_last_not_matched_by_source_clause_omit_condition">NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION</a>, <a href="sql-error-conditions.html#non_last_not_matched_by_target_clause_omit_condition">NON_LAST_NOT_MATCHED_BY_TARGET_CLAUSE_OMIT_CONDITION</a>
+  </td>
+</tr>
+    <tr>
+  <td>42614</td>
+  <td>A duplicate keyword or clause is invalid.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#repeated_clause">REPEATED_CLAUSE</a>
+  </td>
+</tr>
+    <tr>
+  <td>42617</td>
+  <td>The statement string is blank or empty.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#parse_empty_statement">PARSE_EMPTY_STATEMENT</a>
+  </td>
+</tr>
+    <tr>
+  <td>42702</td>
+  <td>A column reference is ambiguous, because of duplicate names.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#ambiguous_column_or_field">AMBIGUOUS_COLUMN_OR_FIELD</a>, <a href="sql-error-conditions.html#ambiguous_lateral_column_alias">AMBIGUOUS_LATERAL_COLUMN_ALIAS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42703</td>
+  <td>An undefined column or parameter name was detected.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#column_not_found">COLUMN_NOT_FOUND</a>, <a href="unresolved-column-error-class.md">UNRESOLVED_COLUMN</a>, <a href="unresolved-field-error-class.md">UNRESOLVED_FIELD</a>, <a href="unresolved-map-key-error-class.md">UNRESOLVED_MAP_KEY</a>, <a href="sql-error-conditions.html#unresolved_using_column_for_join">UNRESOLVED_USING_COLUMN_FOR_JOIN</a>
+  </td>
+</tr>
+    <tr>
+  <td>42704</td>
+  <td>An undefined object or constraint name was detected.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#ambiguous_reference">AMBIGUOUS_REFERENCE</a>, <a href="sql-error-conditions.html#default_database_not_exists">DEFAULT_DATABASE_NOT_EXISTS</a>, <a href="sql-error-conditions.html#field_not_found">FIELD_NOT_FOUND</a>, <a href="sql-error-conditions.html#index_not_found">INDEX_NOT_FOUND</a>, <a href="sql-error-conditions.html#schema_not_found">SCHEMA_NOT_FOUND</a>, <a href="sql-error-conditions.html#unrecognized_sql_type">UNRECOGNIZED_SQL_TYPE</a>
+  </td>
+</tr>
+    <tr>
+  <td>42710</td>
+  <td>A duplicate object or constraint name was detected.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#create_table_column_option_duplicate">CREATE_TABLE_COLUMN_OPTION_DUPLICATE</a>, <a href="sql-error-conditions.html#index_already_exists">INDEX_ALREADY_EXISTS</a>, <a href="sql-error-conditions.html#location_already_exists">LOCATION_ALREADY_EXISTS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42711</td>
+  <td>A duplicate column name was detected in the object definition or ALTER TABLE statement.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#column_already_exists">COLUMN_ALREADY_EXISTS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42723</td>
+  <td>A routine with the same signature already exists in the schema, module, or compound block where it is defined.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#routine_already_exists">ROUTINE_ALREADY_EXISTS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42803</td>
+  <td>A column reference in the SELECT or HAVING clause is invalid, because it is not a grouping column; or a column reference in the GROUP BY clause is invalid.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#grouping_column_mismatch">GROUPING_COLUMN_MISMATCH</a>, <a href="sql-error-conditions.html#grouping_id_column_mismatch">GROUPING_ID_COLUMN_MISMATCH</a>, <a href="missing-aggregation-error-class.md">MISSING_AGGREGATION</a>, <a href="sql-error-conditions.html#missing_group_by">MISSING_GROUP_BY</a>, <a href="sql-error-conditions.html#unresolved_all_in_group_by">UNRESOLVED_ALL_IN_GROUP_BY</a>
+  </td>
+</tr>
+    <tr>
+  <td>42805</td>
+  <td>An integer in the ORDER BY clause does not identify a column of the result table.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#group_by_pos_out_of_range">GROUP_BY_POS_OUT_OF_RANGE</a>, <a href="sql-error-conditions.html#order_by_pos_out_of_range">ORDER_BY_POS_OUT_OF_RANGE</a>
+  </td>
+</tr>
+    <tr>
+  <td>42809</td>
+  <td>The identified object is not the type of object to which the statement applies.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#forbidden_operation">FORBIDDEN_OPERATION</a>
+  </td>
+</tr>
+    <tr>
+  <td>42818</td>
+  <td>The operands of an operator or function are not compatible or comparable.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#incomparable_pivot_column">INCOMPARABLE_PIVOT_COLUMN</a>
+  </td>
+</tr>
+    <tr>
+  <td>42823</td>
+  <td>Multiple columns are returned from a subquery that only allows one column.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="invalid-subquery-expression-error-class.md">INVALID_SUBQUERY_EXPRESSION</a>
+  </td>
+</tr>
+    <tr>
+  <td>42825</td>
+  <td>The rows of UNION, INTERSECT, EXCEPT, or VALUES do not have compatible columns.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#cannot_merge_incompatible_data_type">CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE</a>, <a href="sql-error-conditions.html#incompatible_column_type">INCOMPATIBLE_COLUMN_TYPE</a>
+  </td>
+</tr>
+    <tr>
+  <td>42826</td>
+  <td>The rows of UNION, INTERSECT, EXCEPT, or VALUES do not have the same number of columns.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#num_columns_mismatch">NUM_COLUMNS_MISMATCH</a>
+  </td>
+</tr>
+    <tr>
+  <td>42846</td>
+  <td>Cast from source type to target type is not supported.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#cannot_cast_datatype">CANNOT_CAST_DATATYPE</a>
+  </td>
+</tr>
+    <tr>
+  <td>42883</td>
+  <td>No routine was found with a matching signature.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#routine_not_found">ROUTINE_NOT_FOUND</a>, <a href="unresolved-routine-error-class.md">UNRESOLVED_ROUTINE</a>
+  </td>
+</tr>
+    <tr>
+  <td>428C4</td>
+  <td>The number of elements on each side of the predicate operator is not the same.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#unpivot_value_size_mismatch">UNPIVOT_VALUE_SIZE_MISMATCH</a>
+  </td>
+</tr>
+    <tr>
+  <td>428EK</td>
+  <td>The schema qualifier is not valid.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#temp_view_name_too_many_name_parts">TEMP_VIEW_NAME_TOO_MANY_NAME_PARTS</a>
+  </td>
+</tr>
+    <tr>
+  <td>428FT</td>
+  <td>The partitioning clause specified on CREATE or ALTER is not valid.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#partitions_already_exist">PARTITIONS_ALREADY_EXIST</a>, <a href="sql-error-conditions.html#partitions_not_found">PARTITIONS_NOT_FOUND</a>
+  </td>
+</tr>
+    <tr>
+  <td>42903</td>
+  <td>Invalid use of an aggregate function or OLAP function.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="group-by-aggregate-error-class.md">GROUP_BY_AGGREGATE</a>, <a href="sql-error-conditions.html#group_by_pos_aggregate">GROUP_BY_POS_AGGREGATE</a>, <a href="sql-error-conditions.html#invalid_where_condition">INVALID_WHERE_CONDITION</a>
+  </td>
+</tr>
+    <tr>
+  <td>429BB</td>
+  <td>The data type of a column, parameter, or SQL variable is not supported.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#cannot_recognize_hive_type">CANNOT_RECOGNIZE_HIVE_TYPE</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K01</td>
+  <td>data type not fully specified</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#datatype_missing_size">DATATYPE_MISSING_SIZE</a>, <a href="incomplete-type-definition-error-class.md">INCOMPLETE_TYPE_DEFINITION</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K02</td>
+  <td>data source not found</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#data_source_not_found">DATA_SOURCE_NOT_FOUND</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K03</td>
+  <td>File not found</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#path_not_found">PATH_NOT_FOUND</a>, <a href="sql-error-conditions.html#rename_src_path_not_found">RENAME_SRC_PATH_NOT_FOUND</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K04</td>
+  <td>Duplicate file</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#failed_rename_path">FAILED_RENAME_PATH</a>, <a href="sql-error-conditions.html#path_already_exists">PATH_ALREADY_EXISTS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K05</td>
+  <td>Name is not valid</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#invalid_empty_location">INVALID_EMPTY_LOCATION</a>, <a href="sql-error-conditions.html#requires_single_part_namespace">REQUIRES_SINGLE_PART_NAMESPACE</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K06</td>
+  <td>Invalid type for options</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="invalid-options-error-class.md">INVALID_OPTIONS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K07</td>
+  <td>Not a valid schema literal</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="invalid-schema-error-class.md">INVALID_SCHEMA</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K08</td>
+  <td>Not a constant</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#non_literal_pivot_values">NON_LITERAL_PIVOT_VALUES</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K09</td>
+  <td>Data type mismatch</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="datatype-mismatch-error-class.md">DATATYPE_MISMATCH</a>, <a href="sql-error-conditions.html#pivot_value_data_type_mismatch">PIVOT_VALUE_DATA_TYPE_MISMATCH</a>, <a href="sql-error-conditions.html#unexpected_input_type">UNEXPECTED_INPUT_TYPE</a>, <a href="sql-error-conditions.html#unpivot_value_data_type_mismatch">UNPIVOT_VALUE_DATA_TYPE_MISMATCH</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K0A</td>
+  <td>Invalid UNPIVOT clause</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#unpivot_requires_attributes">UNPIVOT_REQUIRES_ATTRIBUTES</a>, <a href="sql-error-conditions.html#unpivot_requires_value_columns">UNPIVOT_REQUIRES_VALUE_COLUMNS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42K0B</td>
+  <td>Legacy feature blocked</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="inconsistent-behavior-cross-version-error-class.md">INCONSISTENT_BEHAVIOR_CROSS_VERSION</a>
+  </td>
+</tr>
+    <tr>
+  <td>42KD9</td>
+  <td>Cannot infer table schema.</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#unable_to_infer_schema">UNABLE_TO_INFER_SCHEMA</a>
+  </td>
+</tr>
+    <tr>
+  <td>42P01</td>
+  <td>undefined_table</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="table-or-view-not-found-error-class.md">TABLE_OR_VIEW_NOT_FOUND</a>, <a href="sql-error-conditions.html#view_not_found">VIEW_NOT_FOUND</a>
+  </td>
+</tr>
+    <tr>
+  <td>42P02</td>
+  <td>undefined_parameter</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#unbound_sql_parameter">UNBOUND_SQL_PARAMETER</a>
+  </td>
+</tr>
+    <tr>
+  <td>42P06</td>
+  <td>duplicate_schema</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#schema_already_exists">SCHEMA_ALREADY_EXISTS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42P07</td>
+  <td>duplicate_table</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#table_or_view_already_exists">TABLE_OR_VIEW_ALREADY_EXISTS</a>, <a href="sql-error-conditions.html#temp_table_or_view_already_exists">TEMP_TABLE_OR_VIEW_ALREADY_EXISTS</a>, <a href="sql-error-conditions.html#view_already_exists">VIEW_ALREADY_EXISTS</a>
+  </td>
+</tr>
+    <tr>
+  <td>42P20</td>
+  <td>windowing_error</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#unsupported_expr_for_window">UNSUPPORTED_EXPR_FOR_WINDOW</a>
+  </td>
+</tr>
+    
+</table>
+## Class `46`: java ddl 1
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>46110</td>
+  <td>unsupported feature</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#cannot_modify_config">CANNOT_MODIFY_CONFIG</a>
+  </td>
+</tr>
+    <tr>
+  <td>46121</td>
+  <td>invalid column name</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#invalid_column_name_as_path">INVALID_COLUMN_NAME_AS_PATH</a>
+  </td>
+</tr>
+    
+</table>
+## Class `53`: insufficient resources
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>53200</td>
+  <td>out_of_memory</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#unable_to_acquire_memory">UNABLE_TO_ACQUIRE_MEMORY</a>
+  </td>
+</tr>
+    
+</table>
+## Class `54`: program limit exceeded
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>54000</td>
+  <td>program limit exceeded</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#grouping_size_limit_exceeded">GROUPING_SIZE_LIMIT_EXCEEDED</a>, <a href="sql-error-conditions.html#too_many_array_elements">TOO_MANY_ARRAY_ELEMENTS</a>
+  </td>
+</tr>
+    
+</table>
+## Class `XX`: internal error
+
+<table class="table">
+<tr><th>SQLSTATE</th><th>Description and issuing error classes</th></tr>
+<tr>
+  <td>XX000</td>
+  <td>internal error</td>
+</tr>
+<tr>
+  <td></td>
+  <td><a href="sql-error-conditions.html#internal_error">INTERNAL_ERROR</a>
+  </td>
+</tr>
+    
+</table>
+
+
+.. include:: /shared/replacements.md

--- a/docs/sql-error-conditions-unresolved-column-error-class.md
+++ b/docs/sql-error-conditions-unresolved-column-error-class.md
@@ -1,0 +1,36 @@
+---
+layout: global
+title: UNRESOLVED_COLUMN error class
+displayTitle: UNRESOLVED_COLUMN error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42703](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+A column or function parameter with name `<objectName>` cannot be resolved.
+
+This error class has the following derived error classes:
+
+## WITHOUT_SUGGESTION
+
+
+
+## WITH_SUGGESTION
+
+Did you mean one of the following? [`<proposal>`].
+
+

--- a/docs/sql-error-conditions-unresolved-field-error-class.md
+++ b/docs/sql-error-conditions-unresolved-field-error-class.md
@@ -1,0 +1,36 @@
+---
+layout: global
+title: UNRESOLVED_FIELD error class
+displayTitle: UNRESOLVED_FIELD error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42703](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+A field with name `<fieldName>` cannot be resolved with the struct-type column `<columnPath>`.
+
+This error class has the following derived error classes:
+
+## WITHOUT_SUGGESTION
+
+
+
+## WITH_SUGGESTION
+
+Did you mean one of the following? [`<proposal>`].
+
+

--- a/docs/sql-error-conditions-unresolved-map-key-error-class.md
+++ b/docs/sql-error-conditions-unresolved-map-key-error-class.md
@@ -1,0 +1,36 @@
+---
+layout: global
+title: UNRESOLVED_MAP_KEY error class
+displayTitle: UNRESOLVED_MAP_KEY error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42703](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot resolve column `<objectName>` as a map key. If the key is a string literal, add the single quotes '' around it.
+
+This error class has the following derived error classes:
+
+## WITHOUT_SUGGESTION
+
+
+
+## WITH_SUGGESTION
+
+Otherwise did you mean one of the following column(s)? [`<proposal>`].
+
+

--- a/docs/sql-error-conditions-unsupported-deserializer-error-class.md
+++ b/docs/sql-error-conditions-unsupported-deserializer-error-class.md
@@ -1,0 +1,36 @@
+---
+layout: global
+title: UNSUPPORTED_DESERIALIZER error class
+displayTitle: UNSUPPORTED_DESERIALIZER error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+The deserializer is not supported:
+
+This error class has the following derived error classes:
+
+## DATA_TYPE_MISMATCH
+
+need a(n) `<desiredType>` field but got `<dataType>`.
+
+## FIELD_NUMBER_MISMATCH
+
+try to map `<schema>` to Tuple`<ordinal>`, but failed as the number of fields does not line up.
+
+

--- a/docs/sql-error-conditions-unsupported-feature-error-class.md
+++ b/docs/sql-error-conditions-unsupported-feature-error-class.md
@@ -1,0 +1,140 @@
+---
+layout: global
+title: UNSUPPORTED_FEATURE error class
+displayTitle: UNSUPPORTED_FEATURE error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+The feature is not supported:
+
+This error class has the following derived error classes:
+
+## AES_MODE
+
+AES-`<mode>` with the padding `<padding>` by the `<functionName>` function.
+
+## ANALYZE_UNCACHED_TEMP_VIEW
+
+The ANALYZE TABLE FOR COLUMNS command can operate on temporary views that have been cached already. Consider to cache the view `<viewName>`.
+
+## ANALYZE_UNSUPPORTED_COLUMN_TYPE
+
+The ANALYZE TABLE FOR COLUMNS command does not support the type `<columnType>` of the column `<columnName>` in the table `<tableName>`.
+
+## ANALYZE_VIEW
+
+The ANALYZE TABLE command does not support views.
+
+## CATALOG_OPERATION
+
+Catalog `<catalogName>` does not support `<operation>`.
+
+## COMBINATION_QUERY_RESULT_CLAUSES
+
+Combination of ORDER BY/SORT BY/DISTRIBUTE BY/CLUSTER BY.
+
+## DESC_TABLE_COLUMN_PARTITION
+
+DESC TABLE COLUMN for a specific partition.
+
+## INSERT_PARTITION_SPEC_IF_NOT_EXISTS
+
+INSERT INTO `<tableName>` with IF NOT EXISTS in the PARTITION spec.
+
+## LATERAL_COLUMN_ALIAS_IN_AGGREGATE_FUNC
+
+Referencing a lateral column alias `<lca>` in the aggregate function `<aggFunc>`.
+
+## LATERAL_COLUMN_ALIAS_IN_AGGREGATE_WITH_WINDOW_AND_HAVING
+
+Referencing lateral column alias `<lca>` in the aggregate query both with window expressions and with having clause. Please rewrite the aggregate query by removing the having clause or removing lateral alias reference in the SELECT list.
+
+## LATERAL_COLUMN_ALIAS_IN_GROUP_BY
+
+Referencing a lateral column alias via GROUP BY alias/ALL is not supported yet.
+
+## LATERAL_COLUMN_ALIAS_IN_WINDOW
+
+Referencing a lateral column alias `<lca>` in window expression `<windowExpr>`.
+
+## LATERAL_JOIN_USING
+
+JOIN USING with LATERAL correlation.
+
+## LITERAL_TYPE
+
+Literal for '`<value>`' of `<type>`.
+
+## MULTIPLE_BUCKET_TRANSFORMS
+
+Multiple bucket TRANSFORMs.
+
+## MULTI_ACTION_ALTER
+
+The target JDBC server hosting table `<tableName>` does not support ALTER TABLE with multiple actions. Split the ALTER TABLE up into individual actions to avoid this error.
+
+## ORC_TYPE_CAST
+
+Unable to convert `<orcType>` of Orc to data type `<toType>`.
+
+## PANDAS_UDAF_IN_PIVOT
+
+Pandas user defined aggregate function in the PIVOT clause.
+
+## PIVOT_AFTER_GROUP_BY
+
+PIVOT clause following a GROUP BY clause. Consider pushing the GROUP BY into a subquery.
+
+## PIVOT_TYPE
+
+Pivoting by the value '`<value>`' of the column data type `<type>`.
+
+## PYTHON_UDF_IN_ON_CLAUSE
+
+Python UDF in the ON clause of a `<joinType>` JOIN. In case of an INNNER JOIN consider rewriting to a CROSS JOIN with a WHERE clause.
+
+## SET_NAMESPACE_PROPERTY
+
+`<property>` is a reserved namespace property, `<msg>`.
+
+## SET_PROPERTIES_AND_DBPROPERTIES
+
+set PROPERTIES and DBPROPERTIES at the same time.
+
+## SET_TABLE_PROPERTY
+
+`<property>` is a reserved table property, `<msg>`.
+
+## TABLE_OPERATION
+
+Table `<tableName>` does not support `<operation>`. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by "spark.sql.catalog".
+
+## TOO_MANY_TYPE_ARGUMENTS_FOR_UDF_CLASS
+
+UDF class with `<num>` type arguments.
+
+## TRANSFORM_DISTINCT_ALL
+
+TRANSFORM with the DISTINCT/ALL clause.
+
+## TRANSFORM_NON_HIVE
+
+TRANSFORM with SERDE is only supported in hive mode.
+
+

--- a/docs/sql-error-conditions-unsupported-generator-error-class.md
+++ b/docs/sql-error-conditions-unsupported-generator-error-class.md
@@ -1,0 +1,44 @@
+---
+layout: global
+title: UNSUPPORTED_GENERATOR error class
+displayTitle: UNSUPPORTED_GENERATOR error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+The generator is not supported:
+
+This error class has the following derived error classes:
+
+## MULTI_GENERATOR
+
+only one generator allowed per `<clause>` clause but found `<num>`: `<generators>`.
+
+## NESTED_IN_EXPRESSIONS
+
+nested in expressions `<expression>`.
+
+## NOT_GENERATOR
+
+`<functionName>` is expected to be a generator. However, its class is `<classCanonicalName>`, which is not a generator.
+
+## OUTSIDE_SELECT
+
+outside the SELECT clause, found: `<plan>`.
+
+

--- a/docs/sql-error-conditions-unsupported-save-mode-error-class.md
+++ b/docs/sql-error-conditions-unsupported-save-mode-error-class.md
@@ -1,0 +1,36 @@
+---
+layout: global
+title: UNSUPPORTED_SAVE_MODE error class
+displayTitle: UNSUPPORTED_SAVE_MODE error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+SQLSTATE: none assigned
+
+The save mode `<saveMode>` is not supported for:
+
+This error class has the following derived error classes:
+
+## EXISTENT_PATH
+
+an existent path.
+
+## NON_EXISTENT_PATH
+
+a non-existent path.
+
+

--- a/docs/sql-error-conditions-unsupported-subquery-expression-category-error-class.md
+++ b/docs/sql-error-conditions-unsupported-subquery-expression-category-error-class.md
@@ -1,0 +1,76 @@
+---
+layout: global
+title: UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY error class
+displayTitle: UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+Unsupported subquery expression:
+
+This error class has the following derived error classes:
+
+## ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED
+
+Accessing outer query column is not allowed in this location`<treeNode>`.
+
+## AGGREGATE_FUNCTION_MIXED_OUTER_LOCAL_REFERENCES
+
+Found an aggregate function in a correlated predicate that has both outer and local references, which is not supported: `<function>`.
+
+## CORRELATED_COLUMN_IS_NOT_ALLOWED_IN_PREDICATE
+
+Correlated column is not allowed in predicate: `<treeNode>`.
+
+## CORRELATED_COLUMN_NOT_FOUND
+
+A correlated outer name reference within a subquery expression body was not found in the enclosing query: `<value>`.
+
+## CORRELATED_REFERENCE
+
+Expressions referencing the outer query are not supported outside of WHERE/HAVING clauses: `<sqlExprs>`.
+
+## LATERAL_JOIN_CONDITION_NON_DETERMINISTIC
+
+Lateral join condition cannot be non-deterministic: `<condition>`.
+
+## MUST_AGGREGATE_CORRELATED_SCALAR_SUBQUERY
+
+Correlated scalar subqueries must be aggregated to return at most one row.
+
+## NON_CORRELATED_COLUMNS_IN_GROUP_BY
+
+A GROUP BY clause in a scalar correlated subquery cannot contain non-correlated columns: `<value>`.
+
+## NON_DETERMINISTIC_LATERAL_SUBQUERIES
+
+Non-deterministic lateral subqueries are not supported when joining with outer relations that produce more than one row`<treeNode>`.
+
+## UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE
+
+Correlated column reference '`<expr>`' cannot be `<dataType>` type.
+
+## UNSUPPORTED_CORRELATED_SCALAR_SUBQUERY
+
+Correlated scalar subqueries can only be used in filters, aggregations, projections, and UPDATE/MERGE/DELETE commands`<treeNode>`.
+
+## UNSUPPORTED_IN_EXISTS_SUBQUERY
+
+IN/EXISTS predicate subqueries can only be used in filters, joins, aggregations, window functions, projections, and UPDATE/MERGE/DELETE commands`<treeNode>`.
+
+

--- a/docs/sql-error-conditions-wrong-num-args-error-class.md
+++ b/docs/sql-error-conditions-wrong-num-args-error-class.md
@@ -1,0 +1,36 @@
+---
+layout: global
+title: WRONG_NUM_ARGS error class
+displayTitle: WRONG_NUM_ARGS error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: 42605](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The `<functionName>` requires `<expectedNum>` parameters but the actual number is `<actualNum>`.
+
+This error class has the following derived error classes:
+
+## WITHOUT_SUGGESTION
+
+Please, refer to '`<docroot>`/sql-ref-functions.html' for a fix.
+
+## WITH_SUGGESTION
+
+If you have to call this function with `<legacyNum>` parameters, set the legacy configuration `<legacyConfKey>` to `<legacyConfValue>`.
+
+

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -415,14 +415,6 @@ SQLSTATE: none assigned
 
 Detected an incompatible DataSourceRegister. Please remove the incompatible library from classpath or upgrade it. Error: `<message>`
 
-### [INCOMPATIBLE_DATA_TO_TABLE](sql-error-conditions-incompatible-data-to-table-error-class.html)
-
-SQLSTATE: none assigned
-
-Cannot write incompatible data to table `<tableName>`:
-
- For more details see [INCOMPATIBLE_DATA_TO_TABLE](sql-error-conditions-incompatible-data-to-table-error-class.html)
-
 ### INCOMPATIBLE_JOIN_TYPES
 
 [SQLSTATE: 42613](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1,0 +1,1350 @@
+---
+layout: global
+title: Error Conditions
+displayTitle: Error Conditions
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+This is a list of common, named error conditions returned by Spark SQL.
+
+Also see [SQLSTATE Codes](sql-error-conditions-sqlstates.html).
+
+### AMBIGUOUS_COLUMN_OR_FIELD
+
+[SQLSTATE: 42702](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Column or field `<name>` is ambiguous and has `<n>` matches.
+
+### AMBIGUOUS_LATERAL_COLUMN_ALIAS
+
+[SQLSTATE: 42702](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Lateral column alias `<name>` is ambiguous and has `<n>` matches.
+
+### AMBIGUOUS_REFERENCE
+
+[SQLSTATE: 42704](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Reference `<name>` is ambiguous, could be: `<referenceNames>`.
+
+### AMBIGUOUS_REFERENCE_TO_FIELDS
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Ambiguous reference to the field `<field>`. It appears `<count>` times in the schema.
+
+### ARITHMETIC_OVERFLOW
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+`<message>`.`<alternative>` If necessary set `<config>` to "false" to bypass this error.
+
+### CANNOT_CAST_DATATYPE
+
+[SQLSTATE: 42846](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot cast `<sourceType>` to `<targetType>`.
+
+### CANNOT_CONSTRUCT_PROTOBUF_DESCRIPTOR
+
+SQLSTATE: none assigned
+
+Error constructing FileDescriptor for `<descFilePath>`.
+
+### CANNOT_CONVERT_PROTOBUF_FIELD_TYPE_TO_SQL_TYPE
+
+SQLSTATE: none assigned
+
+Cannot convert Protobuf `<protobufColumn>` to SQL `<sqlColumn>` because schema is incompatible (protobufType = `<protobufType>`, sqlType = `<sqlType>`).
+
+### CANNOT_CONVERT_PROTOBUF_MESSAGE_TYPE_TO_SQL_TYPE
+
+SQLSTATE: none assigned
+
+Unable to convert `<protobufType>` of Protobuf to SQL type `<toType>`.
+
+### CANNOT_CONVERT_SQL_TYPE_TO_PROTOBUF_ENUM_TYPE
+
+SQLSTATE: none assigned
+
+Cannot convert SQL `<sqlColumn>` to Protobuf `<protobufColumn>` because `<data>` cannot be written since it's not defined in ENUM `<enumString>`.
+
+### CANNOT_CONVERT_SQL_TYPE_TO_PROTOBUF_FIELD_TYPE
+
+SQLSTATE: none assigned
+
+Cannot convert SQL `<sqlColumn>` to Protobuf `<protobufColumn>` because schema is incompatible (protobufType = `<protobufType>`, sqlType = `<sqlType>`).
+
+### CANNOT_DECODE_URL
+
+[SQLSTATE: 22546](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Cannot decode url : `<url>`.
+
+### CANNOT_LOAD_FUNCTION_CLASS
+
+SQLSTATE: none assigned
+
+Cannot load class `<className>` when registering the function `<functionName>`, please make sure it is on the classpath.
+
+### CANNOT_LOAD_PROTOBUF_CLASS
+
+SQLSTATE: none assigned
+
+Could not load Protobuf class with name `<protobufClassName>`. `<explanation>`.
+
+### CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE
+
+[SQLSTATE: 42825](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Failed to merge incompatible data types `<left>` and `<right>`.
+
+### CANNOT_MODIFY_CONFIG
+
+[SQLSTATE: 46110](sql-error-conditions-sqlstates.html#class-46-java-ddl-1)
+
+Cannot modify the value of the Spark config: `<key>`.
+
+See also '`<docroot>`/sql-migration-guide.html#ddl-statements'.
+
+### CANNOT_PARSE_DECIMAL
+
+[SQLSTATE: 22018](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Cannot parse decimal.
+
+### CANNOT_PARSE_JSON_FIELD
+
+[SQLSTATE: 2203G](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Cannot parse the field name `<fieldName>` and the value `<fieldValue>` of the JSON token type `<jsonType>` to target Spark data type `<dataType>`.
+
+### CANNOT_PARSE_PROTOBUF_DESCRIPTOR
+
+SQLSTATE: none assigned
+
+Error parsing file `<descFilePath>` descriptor byte[] into Descriptor object.
+
+### CANNOT_PARSE_TIMESTAMP
+
+[SQLSTATE: 22007](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+`<message>`. If necessary set `<ansiConfig>` to "false" to bypass this error.
+
+### CANNOT_READ_FILE_FOOTER
+
+SQLSTATE: none assigned
+
+Could not read footer for file: `<file>`.
+
+### CANNOT_RECOGNIZE_HIVE_TYPE
+
+[SQLSTATE: 429BB](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot recognize hive type string: `<fieldType>`, column: `<fieldName>`.
+
+### CANNOT_RESTORE_PERMISSIONS_FOR_PATH
+
+SQLSTATE: none assigned
+
+Failed to set permissions on created path `<path>` back to `<permission>`.
+
+### CANNOT_UP_CAST_DATATYPE
+
+SQLSTATE: none assigned
+
+Cannot up cast `<expression>` from `<sourceType>` to `<targetType>`.
+
+`<details>`
+
+### CAST_INVALID_INPUT
+
+[SQLSTATE: 22018](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The value `<expression>` of the type `<sourceType>` cannot be cast to `<targetType>` because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. If necessary set `<ansiConfig>` to "false" to bypass this error.
+
+### CAST_OVERFLOW
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The value `<value>` of the type `<sourceType>` cannot be cast to `<targetType>` due to an overflow. Use `try_cast` to tolerate overflow and return NULL instead. If necessary set `<ansiConfig>` to "false" to bypass this error.
+
+### CAST_OVERFLOW_IN_TABLE_INSERT
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Fail to insert a value of `<sourceType>` type into the `<targetType>` type column `<columnName>` due to an overflow. Use `try_cast` on the input value to tolerate overflow and return NULL instead.
+
+### COLUMN_ALREADY_EXISTS
+
+[SQLSTATE: 42711](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The column `<columnName>` already exists. Consider to choose another name or rename the existing column.
+
+### COLUMN_NOT_FOUND
+
+[SQLSTATE: 42703](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The column `<colName>` cannot be found. Verify the spelling and correctness of the column name according to the SQL config `<caseSensitiveConfig>`.
+
+### COMPARATOR_RETURNS_NULL
+
+SQLSTATE: none assigned
+
+The comparator has returned a NULL for a comparison between `<firstValue>` and `<secondValue>`. It should return a positive integer for "greater than", 0 for "equal" and a negative integer for "less than". To revert to deprecated behavior where NULL is treated as 0 (equal), you must set "spark.sql.legacy.allowNullComparisonResultInArraySort" to "true".
+
+### CONCURRENT_QUERY
+
+SQLSTATE: none assigned
+
+Another instance of this query was just started by a concurrent session.
+
+### [CONNECT](sql-error-conditions-connect-error-class.html)
+
+SQLSTATE: none assigned
+
+Generic Spark Connect error.
+
+ For more details see [CONNECT](sql-error-conditions-connect-error-class.html)
+
+### CONVERSION_INVALID_INPUT
+
+[SQLSTATE: 22018](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The value `<str>` (`<fmt>`) cannot be converted to `<targetType>` because it is malformed. Correct the value as per the syntax, or change its format. Use `<suggestion>` to tolerate malformed input and return NULL instead.
+
+### CREATE_TABLE_COLUMN_OPTION_DUPLICATE
+
+[SQLSTATE: 42710](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+CREATE TABLE column `<columnName>` specifies option "`<optionName>`" more than once, which is invalid.
+
+### [DATATYPE_MISMATCH](sql-error-conditions-datatype-mismatch-error-class.html)
+
+[SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot resolve `<sqlExpr>` due to data type mismatch:
+
+ For more details see [DATATYPE_MISMATCH](sql-error-conditions-datatype-mismatch-error-class.html)
+
+### DATATYPE_MISSING_SIZE
+
+[SQLSTATE: 42K01](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+DataType `<type>` requires a length parameter, for example `<type>`(10). Please specify the length.
+
+### DATA_SOURCE_NOT_FOUND
+
+[SQLSTATE: 42K02](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Failed to find the data source: `<provider>`. Please find packages at `https://spark.apache.org/third-party-projects.html`.
+
+### DATETIME_OVERFLOW
+
+[SQLSTATE: 22008](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Datetime operation overflow: `<operation>`.
+
+### DECIMAL_PRECISION_EXCEEDS_MAX_PRECISION
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Decimal precision `<precision>` exceeds max precision `<maxPrecision>`.
+
+### DEFAULT_DATABASE_NOT_EXISTS
+
+[SQLSTATE: 42704](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Default database `<defaultDatabase>` does not exist, please create it first or change default database to ``<defaultDatabase>``.
+
+### DIVIDE_BY_ZERO
+
+[SQLSTATE: 22012](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set `<config>` to "false" to bypass this error.
+
+### DUPLICATED_MAP_KEY
+
+[SQLSTATE: 23505](sql-error-conditions-sqlstates.html#class-23-integrity-constraint-violation)
+
+Duplicate map key `<key>` was found, please check the input data. If you want to remove the duplicated keys, you can set `<mapKeyDedupPolicy>` to "LAST_WIN" so that the key inserted at last takes precedence.
+
+### DUPLICATE_KEY
+
+[SQLSTATE: 23505](sql-error-conditions-sqlstates.html#class-23-integrity-constraint-violation)
+
+Found duplicate keys `<keyColumn>`.
+
+### ELEMENT_AT_BY_INDEX_ZERO
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The index 0 is invalid. An index shall be either < 0 or > 0 (the first element has index 1).
+
+### EMPTY_JSON_FIELD_VALUE
+
+[SQLSTATE: 42604](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Failed to parse an empty string for data type `<dataType>`.
+
+### ENCODER_NOT_FOUND
+
+SQLSTATE: none assigned
+
+Not found an encoder of the type `<typeName>` to Spark SQL internal representation. Consider to change the input type to one of supported at '`<docroot>`/sql-ref-datatypes.html'.
+
+### FAILED_EXECUTE_UDF
+
+[SQLSTATE: 39000](sql-error-conditions-sqlstates.html#class-39-external-routine-invocation-exception)
+
+Failed to execute user defined function (`<functionName>`: (`<signature>`) => `<result>`).
+
+### FAILED_FUNCTION_CALL
+
+[SQLSTATE: 38000](sql-error-conditions-sqlstates.html#class-38-external-routine-exception)
+
+Failed preparing of the function `<funcName>` for call. Please, double check function's arguments.
+
+### FAILED_RENAME_PATH
+
+[SQLSTATE: 42K04](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Failed to rename `<sourcePath>` to `<targetPath>` as destination already exists.
+
+### FIELD_NOT_FOUND
+
+[SQLSTATE: 42704](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+No such struct field `<fieldName>` in `<fields>`.
+
+### FORBIDDEN_OPERATION
+
+[SQLSTATE: 42809](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The operation `<statement>` is not allowed on the `<objectType>`: `<objectName>`.
+
+### GENERATED_COLUMN_WITH_DEFAULT_VALUE
+
+SQLSTATE: none assigned
+
+A column cannot have both a default value and a generation expression but column `<colName>` has default value: (`<defaultValue>`) and generation expression: (`<genExpr>`).
+
+### GRAPHITE_SINK_INVALID_PROTOCOL
+
+SQLSTATE: none assigned
+
+Invalid Graphite protocol: `<protocol>`.
+
+### GRAPHITE_SINK_PROPERTY_MISSING
+
+SQLSTATE: none assigned
+
+Graphite sink requires '`<property>`' property.
+
+### GROUPING_COLUMN_MISMATCH
+
+[SQLSTATE: 42803](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Column of grouping (`<grouping>`) can't be found in grouping columns `<groupingColumns>`.
+
+### GROUPING_ID_COLUMN_MISMATCH
+
+[SQLSTATE: 42803](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Columns of grouping_id (`<groupingIdColumn>`) does not match grouping columns (`<groupByColumns>`).
+
+### GROUPING_SIZE_LIMIT_EXCEEDED
+
+[SQLSTATE: 54000](sql-error-conditions-sqlstates.html#class-54-program-limit-exceeded)
+
+Grouping sets size cannot be greater than `<maxSize>`.
+
+### GROUP_BY_AGGREGATE
+
+[SQLSTATE: 42903](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Aggregate functions are not allowed in GROUP BY, but found `<sqlExpr>`.
+
+### GROUP_BY_POS_AGGREGATE
+
+[SQLSTATE: 42903](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+GROUP BY `<index>` refers to an expression `<aggExpr>` that contains an aggregate function. Aggregate functions are not allowed in GROUP BY.
+
+### GROUP_BY_POS_OUT_OF_RANGE
+
+[SQLSTATE: 42805](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+GROUP BY position `<index>` is not in select list (valid range is [1, `<size>`]).
+
+### IDENTIFIER_TOO_MANY_NAME_PARTS
+
+[SQLSTATE: 42601](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+`<identifier>` is not a valid identifier as it has more than 2 name parts.
+
+### INCOMPARABLE_PIVOT_COLUMN
+
+[SQLSTATE: 42818](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Invalid pivot column `<columnName>`. Pivot columns must be comparable.
+
+### INCOMPATIBLE_COLUMN_TYPE
+
+[SQLSTATE: 42825](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+`<operator>` can only be performed on tables with compatible column types. The `<columnOrdinalNumber>` column of the `<tableOrdinalNumber>` table is <dataType1> type which is not compatible with <dataType2> at the same column of the first table.`<hint>`.
+
+### INCOMPATIBLE_DATASOURCE_REGISTER
+
+SQLSTATE: none assigned
+
+Detected an incompatible DataSourceRegister. Please remove the incompatible library from classpath or upgrade it. Error: `<message>`
+
+### [INCOMPATIBLE_DATA_TO_TABLE](sql-error-conditions-incompatible-data-to-table-error-class.html)
+
+SQLSTATE: none assigned
+
+Cannot write incompatible data to table `<tableName>`:
+
+ For more details see [INCOMPATIBLE_DATA_TO_TABLE](sql-error-conditions-incompatible-data-to-table-error-class.html)
+
+### INCOMPATIBLE_JOIN_TYPES
+
+[SQLSTATE: 42613](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The join types <joinType1> and <joinType2> are incompatible.
+
+### INCOMPATIBLE_VIEW_SCHEMA_CHANGE
+
+SQLSTATE: none assigned
+
+The SQL query of view `<viewName>` has an incompatible schema change and column `<colName>` cannot be resolved. Expected `<expectedNum>` columns named `<colName>` but got `<actualCols>`.
+
+Please try to re-create the view by running: `<suggestion>`.
+
+### [INCOMPLETE_TYPE_DEFINITION](sql-error-conditions-incomplete-type-definition-error-class.html)
+
+[SQLSTATE: 42K01](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Incomplete complex type:
+
+ For more details see [INCOMPLETE_TYPE_DEFINITION](sql-error-conditions-incomplete-type-definition-error-class.html)
+
+### [INCONSISTENT_BEHAVIOR_CROSS_VERSION](sql-error-conditions-inconsistent-behavior-cross-version-error-class.html)
+
+[SQLSTATE: 42K0B](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+You may get a different result due to the upgrading to
+
+ For more details see [INCONSISTENT_BEHAVIOR_CROSS_VERSION](sql-error-conditions-inconsistent-behavior-cross-version-error-class.html)
+
+### INCORRECT_END_OFFSET
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Max offset with `<rowsPerSecond>` rowsPerSecond is `<maxSeconds>`, but it's `<endSeconds>` now.
+
+### INCORRECT_RAMP_UP_RATE
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Max offset with `<rowsPerSecond>` rowsPerSecond is `<maxSeconds>`, but 'rampUpTimeSeconds' is `<rampUpTimeSeconds>`.
+
+### INDEX_ALREADY_EXISTS
+
+[SQLSTATE: 42710](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot create the index `<indexName>` on table `<tableName>` because it already exists.
+
+### INDEX_NOT_FOUND
+
+[SQLSTATE: 42704](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot find the index `<indexName>` on table `<tableName>`.
+
+### INTERNAL_ERROR
+
+[SQLSTATE: XX000](sql-error-conditions-sqlstates.html#class-XX-internal-error)
+
+`<message>`
+
+### INTERVAL_ARITHMETIC_OVERFLOW
+
+[SQLSTATE: 22015](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+`<message>`.`<alternative>`
+
+### INTERVAL_DIVIDED_BY_ZERO
+
+[SQLSTATE: 22012](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead.
+
+### INVALID_ARRAY_INDEX
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The index `<indexValue>` is out of bounds. The array has `<arraySize>` elements. Use the SQL function `get()` to tolerate accessing element at invalid index and return NULL instead. If necessary set `<ansiConfig>` to "false" to bypass this error.
+
+### INVALID_ARRAY_INDEX_IN_ELEMENT_AT
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The index `<indexValue>` is out of bounds. The array has `<arraySize>` elements. Use `try_element_at` to tolerate accessing element at invalid index and return NULL instead. If necessary set `<ansiConfig>` to "false" to bypass this error.
+
+### INVALID_BUCKET_FILE
+
+SQLSTATE: none assigned
+
+Invalid bucket file: `<path>`.
+
+### INVALID_BYTE_STRING
+
+SQLSTATE: none assigned
+
+The expected format is ByteString, but was `<unsupported>` (`<class>`).
+
+### INVALID_COLUMN_NAME_AS_PATH
+
+[SQLSTATE: 46121](sql-error-conditions-sqlstates.html#class-46-java-ddl-1)
+
+The datasource `<datasource>` cannot save the column `<columnName>` because its name contains some characters that are not allowed in file paths. Please, use an alias to rename it.
+
+### INVALID_COLUMN_OR_FIELD_DATA_TYPE
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Column or field `<name>` is of type `<type>` while it's required to be `<expectedType>`.
+
+### INVALID_EMPTY_LOCATION
+
+[SQLSTATE: 42K05](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The location name cannot be empty string, but ``<location>`` was given.
+
+### INVALID_EXTRACT_BASE_FIELD_TYPE
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Can't extract a value from `<base>`. Need a complex type [STRUCT, ARRAY, MAP] but got `<other>`.
+
+### INVALID_EXTRACT_FIELD
+
+[SQLSTATE: 42601](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot extract `<field>` from `<expr>`.
+
+### INVALID_EXTRACT_FIELD_TYPE
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Field name should be a non-null string literal, but it's `<extraction>`.
+
+### INVALID_FIELD_NAME
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Field name `<fieldName>` is invalid: `<path>` is not a struct.
+
+### [INVALID_FORMAT](sql-error-conditions-invalid-format-error-class.html)
+
+[SQLSTATE: 42601](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The format is invalid: `<format>`.
+
+ For more details see [INVALID_FORMAT](sql-error-conditions-invalid-format-error-class.html)
+
+### INVALID_FRACTION_OF_SECOND
+
+[SQLSTATE: 22023](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The fraction of sec must be zero. Valid range is [0, 60]. If necessary set `<ansiConfig>` to "false" to bypass this error.
+
+### INVALID_IDENTIFIER
+
+[SQLSTATE: 42602](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The identifier `<ident>` is invalid. Please, consider quoting it with back-quotes as ``<ident>``.
+
+### INVALID_JSON_ROOT_FIELD
+
+[SQLSTATE: 22032](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Cannot convert JSON root field to target Spark type.
+
+### INVALID_JSON_SCHEMA_MAP_TYPE
+
+[SQLSTATE: 22032](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Input schema `<jsonSchema>` can only contain STRING as a key type for a MAP.
+
+### INVALID_LATERAL_JOIN_TYPE
+
+[SQLSTATE: 42613](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The `<joinType>` JOIN with LATERAL correlation is not allowed because an OUTER subquery cannot correlate to its join partner. Remove the LATERAL correlation or use an INNER JOIN, or LEFT OUTER JOIN instead.
+
+### [INVALID_OPTIONS](sql-error-conditions-invalid-options-error-class.html)
+
+[SQLSTATE: 42K06](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Invalid options:
+
+ For more details see [INVALID_OPTIONS](sql-error-conditions-invalid-options-error-class.html)
+
+### INVALID_PANDAS_UDF_PLACEMENT
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+The group aggregate pandas UDF `<functionList>` cannot be invoked together with as other, non-pandas aggregate functions.
+
+### [INVALID_PARAMETER_VALUE](sql-error-conditions-invalid-parameter-value-error-class.html)
+
+[SQLSTATE: 22023](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The value of parameter(s) `<parameter>` in `<functionName>` is invalid:
+
+ For more details see [INVALID_PARAMETER_VALUE](sql-error-conditions-invalid-parameter-value-error-class.html)
+
+### INVALID_PROPERTY_KEY
+
+[SQLSTATE: 42602](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+`<key>` is an invalid property key, please use quotes, e.g. SET `<key>`=`<value>`.
+
+### INVALID_PROPERTY_VALUE
+
+[SQLSTATE: 42602](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+`<value>` is an invalid property value, please use quotes, e.g. SET `<key>`=`<value>`
+
+### [INVALID_SCHEMA](sql-error-conditions-invalid-schema-error-class.html)
+
+[SQLSTATE: 42K07](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The input schema `<inputSchema>` is not a valid schema string.
+
+ For more details see [INVALID_SCHEMA](sql-error-conditions-invalid-schema-error-class.html)
+
+### INVALID_SET_SYNTAX
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Expected format is 'SET', 'SET key', or 'SET key=value'. If you want to include special characters in key, or include semicolon in value, please use backquotes, e.g., SET `key`=`value`.
+
+### INVALID_SQL_ARG
+
+SQLSTATE: none assigned
+
+The argument `<name>` of `sql()` is invalid. Consider to replace it by a SQL literal.
+
+### INVALID_SQL_SYNTAX
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Invalid SQL syntax: `<inputString>`.
+
+### [INVALID_SUBQUERY_EXPRESSION](sql-error-conditions-invalid-subquery-expression-error-class.html)
+
+[SQLSTATE: 42823](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Invalid subquery:
+
+ For more details see [INVALID_SUBQUERY_EXPRESSION](sql-error-conditions-invalid-subquery-expression-error-class.html)
+
+### INVALID_TEMP_OBJ_REFERENCE
+
+SQLSTATE: none assigned
+
+Cannot create the persistent object `<objName>` of the type `<obj>` because it references to the temporary object `<tempObjName>` of the type `<tempObj>`. Please make the temporary object `<tempObjName>` persistent, or make the persistent object `<objName>` temporary.
+
+### INVALID_TYPED_LITERAL
+
+[SQLSTATE: 42604](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The value of the typed literal `<valueType>` is invalid: `<value>`.
+
+### INVALID_WHERE_CONDITION
+
+[SQLSTATE: 42903](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The WHERE condition `<condition>` contains invalid expressions: `<expressionList>`.
+
+Rewrite the query to avoid window functions, aggregate functions, and generator functions in the WHERE clause.
+
+### LOCATION_ALREADY_EXISTS
+
+[SQLSTATE: 42710](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot name the managed table as `<identifier>`, as its associated location `<location>` already exists. Please pick a different table name, or remove the existing location first.
+
+### MALFORMED_CSV_RECORD
+
+SQLSTATE: none assigned
+
+Malformed CSV record: `<badRecord>`
+
+### MALFORMED_PROTOBUF_MESSAGE
+
+SQLSTATE: none assigned
+
+Malformed Protobuf messages are detected in message deserialization. Parse Mode: `<failFastMode>`. To process malformed protobuf message as null result, try setting the option 'mode' as 'PERMISSIVE'.
+
+### MALFORMED_RECORD_IN_PARSING
+
+SQLSTATE: none assigned
+
+Malformed records are detected in record parsing: `<badRecord>`.
+
+Parse Mode: `<failFastMode>`. To process malformed records as null result, try setting the option 'mode' as 'PERMISSIVE'.
+
+### MISSING_AGGREGATION
+
+[SQLSTATE: 42803](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The non-aggregating expression `<expression>` is based on columns which are not participating in the GROUP BY clause.
+
+Add the columns or the expression to the GROUP BY, aggregate the expression, or use `<expressionAnyValue>` if you do not care which of the values within a group is returned.
+
+### MISSING_GROUP_BY
+
+[SQLSTATE: 42803](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The query does not include a GROUP BY clause. Add GROUP BY or turn it into the window functions using OVER clauses.
+
+### MULTI_UDF_INTERFACE_ERROR
+
+SQLSTATE: none assigned
+
+Not allowed to implement multiple UDF interfaces, UDF class `<className>`.
+
+### NESTED_AGGREGATE_FUNCTION
+
+[SQLSTATE: 42607](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+It is not allowed to use an aggregate function in the argument of another aggregate function. Please use the inner aggregate function in a sub-query.
+
+### NON_LAST_MATCHED_CLAUSE_OMIT_CONDITION
+
+[SQLSTATE: 42613](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+When there are more than one MATCHED clauses in a MERGE statement, only the last MATCHED clause can omit the condition.
+
+### NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION
+
+[SQLSTATE: 42613](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+When there are more than one NOT MATCHED BY SOURCE clauses in a MERGE statement, only the last NOT MATCHED BY SOURCE clause can omit the condition.
+
+### NON_LAST_NOT_MATCHED_BY_TARGET_CLAUSE_OMIT_CONDITION
+
+[SQLSTATE: 42613](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+When there are more than one NOT MATCHED [BY TARGET] clauses in a MERGE statement, only the last NOT MATCHED [BY TARGET] clause can omit the condition.
+
+### NON_LITERAL_PIVOT_VALUES
+
+[SQLSTATE: 42K08](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Literal expressions required for pivot values, found `<expression>`.
+
+### NON_PARTITION_COLUMN
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+PARTITION clause cannot contain the non-partition column: `<columnName>`.
+
+### NOT_A_PARTITIONED_TABLE
+
+SQLSTATE: none assigned
+
+Operation `<operation>` is not allowed for `<tableIdentWithDB>` because it is not a partitioned table.
+
+### [NOT_NULL_CONSTRAINT_VIOLATION](sql-error-conditions-not-null-constraint-violation-error-class.html)
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Assigning a NULL is not allowed here.
+
+ For more details see [NOT_NULL_CONSTRAINT_VIOLATION](sql-error-conditions-not-null-constraint-violation-error-class.html)
+
+### NO_HANDLER_FOR_UDAF
+
+SQLSTATE: none assigned
+
+No handler for UDAF '`<functionName>`'. Use sparkSession.udf.register(...) instead.
+
+### NO_SQL_TYPE_IN_PROTOBUF_SCHEMA
+
+SQLSTATE: none assigned
+
+Cannot find `<catalystFieldPath>` in Protobuf schema.
+
+### NO_UDF_INTERFACE
+
+SQLSTATE: none assigned
+
+UDF class `<className>` doesn't implement any UDF interface.
+
+### NULLABLE_COLUMN_OR_FIELD
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Column or field `<name>` is nullable while it's required to be non-nullable.
+
+### NULLABLE_ROW_ID_ATTRIBUTES
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Row ID attributes cannot be nullable: `<nullableRowIdAttrs>`.
+
+### NULL_MAP_KEY
+
+[SQLSTATE: 2200E](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Cannot use null as map key.
+
+### NUMERIC_OUT_OF_SUPPORTED_RANGE
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The value `<value>` cannot be interpreted as a numeric since it has more than 38 digits.
+
+### NUMERIC_VALUE_OUT_OF_RANGE
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+`<value>` cannot be represented as Decimal(`<precision>`, `<scale>`). If necessary set `<config>` to "false" to bypass this error, and return NULL instead.
+
+### NUM_COLUMNS_MISMATCH
+
+[SQLSTATE: 42826](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+`<operator>` can only be performed on inputs with the same number of columns, but the first input has `<firstNumColumns>` columns and the `<invalidOrdinalNum>` input has `<invalidNumColumns>` columns.
+
+### ORDER_BY_POS_OUT_OF_RANGE
+
+[SQLSTATE: 42805](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+ORDER BY position `<index>` is not in select list (valid range is [1, `<size>`]).
+
+### PARSE_EMPTY_STATEMENT
+
+[SQLSTATE: 42617](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Syntax error, unexpected empty statement.
+
+### PARSE_SYNTAX_ERROR
+
+[SQLSTATE: 42601](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Syntax error at or near `<error>``<hint>`.
+
+### PARTITIONS_ALREADY_EXIST
+
+[SQLSTATE: 428FT](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot ADD or RENAME TO partition(s) `<partitionList>` in table `<tableName>` because they already exist.
+
+Choose a different name, drop the existing partition, or add the IF NOT EXISTS clause to tolerate a pre-existing partition.
+
+### PARTITIONS_NOT_FOUND
+
+[SQLSTATE: 428FT](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The partition(s) `<partitionList>` cannot be found in table `<tableName>`.
+
+Verify the partition specification and table name.
+
+To tolerate the error on drop use ALTER TABLE … DROP IF EXISTS PARTITION.
+
+### PATH_ALREADY_EXISTS
+
+[SQLSTATE: 42K04](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Path `<outputPath>` already exists. Set mode as "overwrite" to overwrite the existing path.
+
+### PATH_NOT_FOUND
+
+[SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Path does not exist: `<path>`.
+
+### PIVOT_VALUE_DATA_TYPE_MISMATCH
+
+[SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Invalid pivot value '`<value>`': value data type `<valueType>` does not match pivot column data type `<pivotType>`.
+
+### PLAN_VALIDATION_FAILED_RULE_EXECUTOR
+
+SQLSTATE: none assigned
+
+The input plan of `<ruleExecutor>` is invalid: `<reason>`
+
+### PLAN_VALIDATION_FAILED_RULE_IN_BATCH
+
+SQLSTATE: none assigned
+
+Rule `<rule>` in batch `<batch>` generated an invalid plan: `<reason>`
+
+### PROTOBUF_DEPENDENCY_NOT_FOUND
+
+SQLSTATE: none assigned
+
+Could not find dependency: `<dependencyName>`.
+
+### PROTOBUF_DESCRIPTOR_FILE_NOT_FOUND
+
+SQLSTATE: none assigned
+
+Error reading Protobuf descriptor file at path: `<filePath>`.
+
+### PROTOBUF_FIELD_MISSING
+
+SQLSTATE: none assigned
+
+Searching for `<field>` in Protobuf schema at `<protobufSchema>` gave `<matchSize>` matches. Candidates: `<matches>`.
+
+### PROTOBUF_FIELD_MISSING_IN_SQL_SCHEMA
+
+SQLSTATE: none assigned
+
+Found `<field>` in Protobuf schema but there is no match in the SQL schema.
+
+### PROTOBUF_FIELD_TYPE_MISMATCH
+
+SQLSTATE: none assigned
+
+Type mismatch encountered for field: `<field>`.
+
+### PROTOBUF_MESSAGE_NOT_FOUND
+
+SQLSTATE: none assigned
+
+Unable to locate Message `<messageName>` in Descriptor.
+
+### PROTOBUF_TYPE_NOT_SUPPORT
+
+SQLSTATE: none assigned
+
+Protobuf type not yet supported: `<protobufType>`.
+
+### RECURSIVE_PROTOBUF_SCHEMA
+
+SQLSTATE: none assigned
+
+Found recursive reference in Protobuf schema, which can not be processed by Spark by default: `<fieldDescriptor>`. try setting the option `recursive.fields.max.depth` 0 to 10. Going beyond 10 levels of recursion is not allowed.
+
+### RENAME_SRC_PATH_NOT_FOUND
+
+[SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Failed to rename as `<sourcePath>` was not found.
+
+### REPEATED_CLAUSE
+
+[SQLSTATE: 42614](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The `<clause>` clause may be used at most once per `<operation>` operation.
+
+### REQUIRES_SINGLE_PART_NAMESPACE
+
+[SQLSTATE: 42K05](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+`<sessionCatalog>` requires a single-part namespace, but got `<namespace>`.
+
+### ROUTINE_ALREADY_EXISTS
+
+[SQLSTATE: 42723](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot create the function `<routineName>` because it already exists.
+
+Choose a different name, drop or replace the existing function, or add the IF NOT EXISTS clause to tolerate a pre-existing function.
+
+### ROUTINE_NOT_FOUND
+
+[SQLSTATE: 42883](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The function `<routineName>` cannot be found. Verify the spelling and correctness of the schema and catalog.
+
+If you did not qualify the name with a schema and catalog, verify the current_schema() output, or qualify the name with the correct schema and catalog.
+
+To tolerate the error on drop use DROP FUNCTION IF EXISTS.
+
+### SCALAR_SUBQUERY_TOO_MANY_ROWS
+
+[SQLSTATE: 21000](sql-error-conditions-sqlstates.html#class-21-cardinality-violation)
+
+More than one row returned by a subquery used as an expression.
+
+### SCHEMA_ALREADY_EXISTS
+
+[SQLSTATE: 42P06](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot create schema `<schemaName>` because it already exists.
+
+Choose a different name, drop the existing schema, or add the IF NOT EXISTS clause to tolerate pre-existing schema.
+
+### SCHEMA_NOT_EMPTY
+
+[SQLSTATE: 2BP01](sql-error-conditions-sqlstates.html#class-2B-dependent-privilege-descriptors-still-exist)
+
+Cannot drop a schema `<schemaName>` because it contains objects.
+
+Use DROP SCHEMA ... CASCADE to drop the schema and all its objects.
+
+### SCHEMA_NOT_FOUND
+
+[SQLSTATE: 42704](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The schema `<schemaName>` cannot be found. Verify the spelling and correctness of the schema and catalog.
+
+If you did not qualify the name with a catalog, verify the current_schema() output, or qualify the name with the correct catalog.
+
+To tolerate the error on drop use DROP SCHEMA IF EXISTS.
+
+### SECOND_FUNCTION_ARGUMENT_NOT_INTEGER
+
+[SQLSTATE: 22023](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The second argument of `<functionName>` function needs to be an integer.
+
+### SORT_BY_WITHOUT_BUCKETING
+
+SQLSTATE: none assigned
+
+sortBy must be used together with bucketBy.
+
+### STAR_GROUP_BY_POS
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+Star (*) is not allowed in a select list when GROUP BY an ordinal position is used.
+
+### STATIC_PARTITION_COLUMN_IN_INSERT_COLUMN_LIST
+
+SQLSTATE: none assigned
+
+Static partition column `<staticName>` is also specified in the column list.
+
+### STREAM_FAILED
+
+SQLSTATE: none assigned
+
+Query [id = `<id>`, runId = `<runId>`] terminated with exception: `<message>`
+
+### TABLE_OR_VIEW_ALREADY_EXISTS
+
+[SQLSTATE: 42P07](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot create table or view `<relationName>` because it already exists.
+
+Choose a different name, drop or replace the existing object, or add the IF NOT EXISTS clause to tolerate pre-existing objects.
+
+### TABLE_OR_VIEW_NOT_FOUND
+
+[SQLSTATE: 42P01](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The table or view `<relationName>` cannot be found. Verify the spelling and correctness of the schema and catalog.
+
+If you did not qualify the name with a schema, verify the current_schema() output, or qualify the name with the correct schema and catalog.
+
+To tolerate the error on drop use DROP VIEW IF EXISTS or DROP TABLE IF EXISTS.
+
+### TASK_WRITE_FAILED
+
+SQLSTATE: none assigned
+
+Task failed while writing rows to `<path>`.
+
+### TEMP_TABLE_OR_VIEW_ALREADY_EXISTS
+
+[SQLSTATE: 42P07](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot create the temporary view `<relationName>` because it already exists.
+
+Choose a different name, drop or replace the existing view,  or add the IF NOT EXISTS clause to tolerate pre-existing views.
+
+### TEMP_VIEW_NAME_TOO_MANY_NAME_PARTS
+
+[SQLSTATE: 428EK](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+CREATE TEMPORARY VIEW or the corresponding Dataset APIs only accept single-part view names, but got: `<actualName>`.
+
+### TOO_MANY_ARRAY_ELEMENTS
+
+[SQLSTATE: 54000](sql-error-conditions-sqlstates.html#class-54-program-limit-exceeded)
+
+Cannot initialize array with `<numElements>` elements of size `<size>`.
+
+### UNABLE_TO_ACQUIRE_MEMORY
+
+[SQLSTATE: 53200](sql-error-conditions-sqlstates.html#class-53-insufficient-resources)
+
+Unable to acquire `<requestedBytes>` bytes of memory, got `<receivedBytes>`.
+
+### UNABLE_TO_CONVERT_TO_PROTOBUF_MESSAGE_TYPE
+
+SQLSTATE: none assigned
+
+Unable to convert SQL type `<toType>` to Protobuf type `<protobufType>`.
+
+### UNABLE_TO_INFER_SCHEMA
+
+[SQLSTATE: 42KD9](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Unable to infer schema for `<format>`. It must be specified manually.
+
+### UNBOUND_SQL_PARAMETER
+
+[SQLSTATE: 42P02](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Found the unbound parameter: `<name>`. Please, fix `args` and provide a mapping of the parameter to a SQL literal.
+
+### UNCLOSED_BRACKETED_COMMENT
+
+[SQLSTATE: 42601](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Found an unclosed bracketed comment. Please, append */ at the end of the comment.
+
+### UNEXPECTED_INPUT_TYPE
+
+[SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Parameter `<paramIndex>` of function `<functionName>` requires the `<requiredType>` type, however `<inputSql>` has the type `<inputType>`.
+
+### UNKNOWN_PROTOBUF_MESSAGE_TYPE
+
+SQLSTATE: none assigned
+
+Attempting to treat `<descriptorName>` as a Message, but it was `<containingType>`.
+
+### UNPIVOT_REQUIRES_ATTRIBUTES
+
+[SQLSTATE: 42K0A](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+UNPIVOT requires all given `<given>` expressions to be columns when no `<empty>` expressions are given. These are not columns: [`<expressions>`].
+
+### UNPIVOT_REQUIRES_VALUE_COLUMNS
+
+[SQLSTATE: 42K0A](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+At least one value column needs to be specified for UNPIVOT, all columns specified as ids.
+
+### UNPIVOT_VALUE_DATA_TYPE_MISMATCH
+
+[SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Unpivot value columns must share a least common type, some types do not: [`<types>`].
+
+### UNPIVOT_VALUE_SIZE_MISMATCH
+
+[SQLSTATE: 428C4](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+All unpivot value columns must have the same size as there are value column names (`<names>`).
+
+### UNRECOGNIZED_SQL_TYPE
+
+[SQLSTATE: 42704](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Unrecognized SQL type `<typeName>`.
+
+### UNRESOLVED_ALL_IN_GROUP_BY
+
+[SQLSTATE: 42803](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot infer grouping columns for GROUP BY ALL based on the select clause. Please explicitly specify the grouping columns.
+
+### [UNRESOLVED_COLUMN](sql-error-conditions-unresolved-column-error-class.html)
+
+[SQLSTATE: 42703](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+A column or function parameter with name `<objectName>` cannot be resolved.
+
+ For more details see [UNRESOLVED_COLUMN](sql-error-conditions-unresolved-column-error-class.html)
+
+### [UNRESOLVED_FIELD](sql-error-conditions-unresolved-field-error-class.html)
+
+[SQLSTATE: 42703](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+A field with name `<fieldName>` cannot be resolved with the struct-type column `<columnPath>`.
+
+ For more details see [UNRESOLVED_FIELD](sql-error-conditions-unresolved-field-error-class.html)
+
+### [UNRESOLVED_MAP_KEY](sql-error-conditions-unresolved-map-key-error-class.html)
+
+[SQLSTATE: 42703](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot resolve column `<objectName>` as a map key. If the key is a string literal, add the single quotes '' around it.
+
+ For more details see [UNRESOLVED_MAP_KEY](sql-error-conditions-unresolved-map-key-error-class.html)
+
+### UNRESOLVED_ROUTINE
+
+[SQLSTATE: 42883](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot resolve function `<routineName>` on search path `<searchPath>`.
+
+### UNRESOLVED_USING_COLUMN_FOR_JOIN
+
+[SQLSTATE: 42703](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+USING column `<colName>` cannot be resolved on the `<side>` side of the join. The `<side>`-side columns: [`<suggestion>`].
+
+### UNSUPPORTED_ARROWTYPE
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+Unsupported arrow type `<typeName>`.
+
+### UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY
+
+SQLSTATE: none assigned
+
+Unsupported data source type for direct query on files: `<dataSourceType>`
+
+### UNSUPPORTED_DATATYPE
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+Unsupported data type `<typeName>`.
+
+### [UNSUPPORTED_DESERIALIZER](sql-error-conditions-unsupported-deserializer-error-class.html)
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+The deserializer is not supported:
+
+ For more details see [UNSUPPORTED_DESERIALIZER](sql-error-conditions-unsupported-deserializer-error-class.html)
+
+### UNSUPPORTED_EXPRESSION_GENERATED_COLUMN
+
+SQLSTATE: none assigned
+
+Cannot create generated column `<fieldName>` with generation expression `<expressionStr>` because `<reason>`.
+
+### UNSUPPORTED_EXPR_FOR_OPERATOR
+
+SQLSTATE: none assigned
+
+A query operator contains one or more unsupported expressions. Consider to rewrite it to avoid window functions, aggregate functions, and generator functions in the WHERE clause.
+
+Invalid expressions: [`<invalidExprSqls>`]
+
+### UNSUPPORTED_EXPR_FOR_WINDOW
+
+[SQLSTATE: 42P20](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Expression `<sqlExpr>` not supported within a window function.
+
+### [UNSUPPORTED_FEATURE](sql-error-conditions-unsupported-feature-error-class.html)
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+The feature is not supported:
+
+ For more details see [UNSUPPORTED_FEATURE](sql-error-conditions-unsupported-feature-error-class.html)
+
+### [UNSUPPORTED_GENERATOR](sql-error-conditions-unsupported-generator-error-class.html)
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+The generator is not supported:
+
+ For more details see [UNSUPPORTED_GENERATOR](sql-error-conditions-unsupported-generator-error-class.html)
+
+### UNSUPPORTED_GROUPING_EXPRESSION
+
+SQLSTATE: none assigned
+
+grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup.
+
+### [UNSUPPORTED_SAVE_MODE](sql-error-conditions-unsupported-save-mode-error-class.html)
+
+SQLSTATE: none assigned
+
+The save mode `<saveMode>` is not supported for:
+
+ For more details see [UNSUPPORTED_SAVE_MODE](sql-error-conditions-unsupported-save-mode-error-class.html)
+
+### [UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY](sql-error-conditions-unsupported-subquery-expression-category-error-class.html)
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+Unsupported subquery expression:
+
+ For more details see [UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY](sql-error-conditions-unsupported-subquery-expression-category-error-class.html)
+
+### UNSUPPORTED_TYPED_LITERAL
+
+[SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
+
+Literals of the type `<unsupportedType>` are not supported. Supported types are `<supportedTypes>`.
+
+### UNTYPED_SCALA_UDF
+
+SQLSTATE: none assigned
+
+You're using untyped Scala UDF, which does not have the input type information. Spark may blindly pass null to the Scala closure with primitive-type argument, and the closure will see the default value of the Java type for the null argument, e.g. `udf((x: Int) => x, IntegerType)`, the result is 0 for null input. To get rid of this error, you could:
+
+1. use typed Scala UDF APIs(without return type parameter), e.g. `udf((x: Int) => x)`.
+
+2. use Java UDF APIs, e.g. `udf(new UDF1[String, Integer] { override def call(s: String): Integer = s.length() }, IntegerType)`, if input types are all non primitive.
+
+3. set "spark.sql.legacy.allowUntypedScalaUDF" to "true" and use this API with caution.
+
+### VIEW_ALREADY_EXISTS
+
+[SQLSTATE: 42P07](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Cannot create view `<relationName>` because it already exists.
+
+Choose a different name, drop or replace the existing object, or add the IF NOT EXISTS clause to tolerate pre-existing objects.
+
+### VIEW_NOT_FOUND
+
+[SQLSTATE: 42P01](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The view `<relationName>` cannot be found. Verify the spelling and correctness of the schema and catalog.
+
+If you did not qualify the name with a schema, verify the current_schema() output, or qualify the name with the correct schema and catalog.
+
+To tolerate the error on drop use DROP VIEW IF EXISTS.
+
+### WRITE_STREAM_NOT_ALLOWED
+
+SQLSTATE: none assigned
+
+`writeStream` can be called only on streaming Dataset/DataFrame.
+
+### WRONG_COMMAND_FOR_OBJECT_TYPE
+
+SQLSTATE: none assigned
+
+The operation `<operation>` requires a `<requiredType>`. But `<objectName>` is a `<foundType>`. Use `<alternative>` instead.
+
+### [WRONG_NUM_ARGS](sql-error-conditions-wrong-num-args-error-class.html)
+
+[SQLSTATE: 42605](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+The `<functionName>` requires `<expectedNum>` parameters but the actual number is `<actualNum>`.
+
+ For more details see [WRONG_NUM_ARGS](sql-error-conditions-wrong-num-args-error-class.html)
+
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to document Spark SQL error classes to [Spark SQL Guide](https://spark.apache.org/docs/latest/sql-programming-guide.html).

- Error Conditions
<img width="1077" alt="Screen Shot 2023-03-08 at 8 54 43 PM" src="https://user-images.githubusercontent.com/44108233/223706823-7817b57d-c032-4817-a440-7f79119fa0b4.png">

- SQLSTATE Codes
<img width="1139" alt="Screen Shot 2023-03-08 at 8 54 54 PM" src="https://user-images.githubusercontent.com/44108233/223706860-3f64b00b-fa0d-47e0-b154-0d7be92b8637.png">

- Error Classes that includes sub-error classes (`INVALID_FORMAT` as an example)
<img width="1045" alt="Screen Shot 2023-03-08 at 9 10 22 PM" src="https://user-images.githubusercontent.com/44108233/223709925-74144f41-8836-45dc-b851-5d96ac8aa38c.png">


### Why are the changes needed?

To improve the usability for error messages for Spark SQL.


### Does this PR introduce _any_ user-facing change?

No API change, but yes, it's user-facing documentation.


### How was this patch tested?

Manually built docs and check the contents one-by-one compare to [error-classes.json](https://github.com/apache/spark/blob/master/core/src/main/resources/error/error-classes.json).