### PR TITLE
[SPARK-42719][CORE] `MapOutputTracker#getMapLocation` should respect `spark.shuffle.reduceLocality.enabled`

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1113,7 +1113,7 @@ private[spark] class MapOutputTrackerMaster(
       endMapIndex: Int): Seq[String] =
   {
     val shuffleStatus = shuffleStatuses.get(dep.shuffleId).orNull
-    if (shuffleStatus != null && shuffleLocalityEnabled) {
+    if (shuffleLocalityEnabled && shuffleStatus != null) {
       shuffleStatus.withMapStatuses { statuses =>
         if (startMapIndex < endMapIndex &&
           (startMapIndex >= 0 && endMapIndex <= statuses.length)) {

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1113,7 +1113,7 @@ private[spark] class MapOutputTrackerMaster(
       endMapIndex: Int): Seq[String] =
   {
     val shuffleStatus = shuffleStatuses.get(dep.shuffleId).orNull
-    if (shuffleStatus != null) {
+    if (shuffleStatus != null && shuffleLocalityEnabled) {
       shuffleStatus.withMapStatuses { statuses =>
         if (startMapIndex < endMapIndex &&
           (startMapIndex >= 0 && endMapIndex <= statuses.length)) {

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1112,8 +1112,10 @@ private[spark] class MapOutputTrackerMaster(
       startMapIndex: Int,
       endMapIndex: Int): Seq[String] =
   {
+    if (!shuffleLocalityEnabled) return Nil
+
     val shuffleStatus = shuffleStatuses.get(dep.shuffleId).orNull
-    if (shuffleLocalityEnabled && shuffleStatus != null) {
+    if (shuffleStatus != null) {
       shuffleStatus.withMapStatuses { statuses =>
         if (startMapIndex < endMapIndex &&
           (startMapIndex >= 0 && endMapIndex <= statuses.length)) {

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -1031,7 +1031,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     assert(npeCounter.intValue() == 0)
   }
 
-  test("SPARK-42719: `MapOutputTracker#getMapLocation` should respect `spark.shuffle.reduceLocality.enabled`") {
+  test("SPARK-42719: `MapOutputTracker#getMapLocation` should respect the config option") {
     val rpcEnv = createRpcEnv("test")
     val tracker = newTrackerMaster()
     val newConf = new SparkConf

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -1036,15 +1036,18 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     val newConf = new SparkConf
     newConf.set(SHUFFLE_REDUCE_LOCALITY_ENABLE, false)
     val tracker = newTrackerMaster(newConf)
-    tracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
-      new MapOutputTrackerMasterEndpoint(rpcEnv, tracker, newConf))
-    tracker.registerShuffle(10, 6, 1)
-    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
-      Array(2L), 5))
-    val mockShuffleDep = mock(classOf[ShuffleDependency[Int, Int, _]])
-    when(mockShuffleDep.shuffleId).thenReturn(10)
-    assert(tracker.getMapLocation(mockShuffleDep, 0, 1) === Nil)
-    tracker.stop()
-    rpcEnv.shutdown()
+    try {
+      tracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
+        new MapOutputTrackerMasterEndpoint(rpcEnv, tracker, newConf))
+      tracker.registerShuffle(10, 6, 1)
+      tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
+        Array(2L), 5))
+      val mockShuffleDep = mock(classOf[ShuffleDependency[Int, Int, _]])
+      when(mockShuffleDep.shuffleId).thenReturn(10)
+      assert(tracker.getMapLocation(mockShuffleDep, 0, 1) === Nil)
+    } finally {
+      tracker.stop()
+      rpcEnv.shutdown()
+    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -1030,4 +1030,21 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     rpcEnv.shutdown()
     assert(npeCounter.intValue() == 0)
   }
+
+  test("SPARK-42719: `MapOutputTracker#getMapLocation` should respect `spark.shuffle.reduceLocality.enabled`") {
+    val rpcEnv = createRpcEnv("test")
+    val tracker = newTrackerMaster()
+    val newConf = new SparkConf
+    newConf.set(SHUFFLE_REDUCE_LOCALITY_ENABLE, false)
+    tracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
+      new MapOutputTrackerMasterEndpoint(rpcEnv, tracker, newConf))
+    tracker.registerShuffle(10, 6, 1)
+    tracker.registerMapOutput(10, 0, MapStatus(BlockManagerId("a", "hostA", 1000),
+      Array(2L), 5))
+    val mockShuffleDep = mock(classOf[ShuffleDependency[Int, Int, _]])
+    when(mockShuffleDep.shuffleId).thenReturn(10)
+    assert(tracker.getMapLocation(mockShuffleDep, 0, 1) === Nil)
+    tracker.stop()
+    rpcEnv.shutdown()
+  }
 }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -1033,9 +1033,9 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
 
   test("SPARK-42719: `MapOutputTracker#getMapLocation` should respect the config option") {
     val rpcEnv = createRpcEnv("test")
-    val tracker = newTrackerMaster()
     val newConf = new SparkConf
     newConf.set(SHUFFLE_REDUCE_LOCALITY_ENABLE, false)
+    val tracker = newTrackerMaster(newConf)
     tracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
       new MapOutputTrackerMasterEndpoint(rpcEnv, tracker, newConf))
     tracker.registerShuffle(10, 6, 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
`MapOutputTracker#getMapLocation` should respect `spark.shuffle.reduceLocality.enabled`

### Why are the changes needed?

Discuss as https://github.com/apache/spark/pull/40307

getPreferredLocations in ShuffledRowRDD should return Nil at the very beginning in case spark.shuffle.reduceLocality.enabled = false (conceptually).

This logic is pushed into MapOutputTracker though - and getPreferredLocationsForShuffle honors spark.shuffle.reduceLocality.enabled - but getMapLocation does not.

So the fix would be to fix getMapLocation to honor the parameter.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New ut