### PR TITLE
[WIP][SPARK-42715][SQL] Tips for Optimizing NegativeArraySizeException

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
@@ -204,7 +204,12 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
    * by copying from ORC VectorizedRowBatch columns to Spark ColumnarBatch columns.
    */
   private boolean nextBatch() throws IOException {
-    recordReader.nextBatch(wrap.batch());
+    try {
+      recordReader.nextBatch(wrap.batch());
+    } catch (NegativeArraySizeException e) {
+      throw new NegativeArraySizeException("Cause by too many data in batch size, " +
+              "try to set spark.sql.orc.columnarReaderBatchSize less.");
+    }
     int batchSize = wrap.batch().size;
     if (batchSize == 0) {
       return false;


### PR DESCRIPTION
### What changes were proposed in this pull request?
In orc batch read, the byte arrays is used to store the data of the read columns. When the total data of this batch exceeds Int.MaxValue can be caused NegativeArraySizeException, catch and throw the same exeception with a friendly msg.


### Why are the changes needed?
Friendly msg where read orc file get exception about java.lang.NegativeArraySizeException.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.
