### PR TITLE
[SPARK-42711][BUILD]Update usage info and shellcheck warn/error fix for build/sbt tool

### DIFF
--- a/build/sbt
+++ b/build/sbt
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-SELF=$(cd $(dirname $0) && pwd)
+SELF=$(cd "$(dirname "$0")" && pwd)
 . "$SELF/util.sh"
 
 # When creating new tests for Spark SQL Hive, the HADOOP_CLASSPATH must contain the hive jars so
@@ -40,7 +40,7 @@ declare -r default_sbt_opts="-Xss64m"
 
 usage() {
  cat <<EOM
-Usage: $script_name [options]
+Usage: $(basename "$0") [options]
 
   -h | -help         print this message
   -v | -verbose      this runner is chattier
@@ -108,8 +108,8 @@ loadConfigFile() {
 }
 
 # if sbtopts files exist, prepend their contents to $@ so it can be processed by this runner
-[[ -f "$etc_sbt_opts_file" ]] && set -- $(loadConfigFile "$etc_sbt_opts_file") "$@"
-[[ -f "$sbt_opts_file" ]] && set -- $(loadConfigFile "$sbt_opts_file") "$@"
+[[ -f "$etc_sbt_opts_file" ]] && set -- "$(loadConfigFile "$etc_sbt_opts_file")" "$@"
+[[ -f "$sbt_opts_file" ]] && set -- "$(loadConfigFile "$sbt_opts_file")" "$@"
 
 exit_status=127
 saved_stty=""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The build/sbt script's usage information have several error. See the info below:
```
(base) spark% ./build/sbt -help
Usage:  [options]

  -h | -help         print this message
  -v | -verbose      this runner is chattier

```
There is no script name after the usage. With this change, the info become:
```
(base) spark % ./build/sbt -help
Usage: sbt [options]

  -h | -help         print this message
  -v | -verbose      this runner is chattier

```
This changes also fix several shellcheck error.
 
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the user of build/sbt tool will see usage information updated.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manual check the script codes.
