### PR TITLE
[SPARK-42733][CONNECT][PYTHON] Fix DataFrameWriter.save to work without path parameter

### DIFF
--- a/connector/connect/common/src/main/protobuf/spark/connect/commands.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/commands.proto
@@ -83,7 +83,11 @@ message WriteOperation {
   // (Optional) Format value according to the Spark documentation. Examples are: text, parquet, delta.
   optional string source = 2;
 
-  // (Optional) The destination of the write operation must be either a path or a table.
+  // (Optional)
+  //
+  // The destination of the write operation can be either a path or a table.
+  // If the destination is neither a path nor a table, such as jdbc and noop,
+  // the `save_type` should not be set.
   oneof save_type {
     string path = 3;
     SaveTable table = 4;

--- a/connector/connect/common/src/main/protobuf/spark/connect/commands.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/commands.proto
@@ -83,7 +83,7 @@ message WriteOperation {
   // (Optional) Format value according to the Spark documentation. Examples are: text, parquet, delta.
   optional string source = 2;
 
-  // The destination of the write operation must be either a path or a table.
+  // (Optional) The destination of the write operation must be either a path or a table.
   oneof save_type {
     string path = 3;
     SaveTable table = 4;

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1723,6 +1723,7 @@ class SparkConnectPlanner(val session: SparkSession) {
     }
 
     writeOperation.getSaveTypeCase match {
+      case proto.WriteOperation.SaveTypeCase.SAVETYPE_NOT_SET => w.save()
       case proto.WriteOperation.SaveTypeCase.PATH => w.save(writeOperation.getPath)
       case proto.WriteOperation.SaveTypeCase.TABLE =>
         val tableName = writeOperation.getTable.getTableName

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -554,7 +554,8 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
       parameters = Map("columnName" -> "`duplicatedcol`"))
   }
 
-  test("Writes fails without path or table") {
+  // TODO(SPARK-42733): Writes without path or table should work.
+  ignore("Writes fails without path or table") {
     assertThrows[UnsupportedOperationException] {
       transform(localRelation.write())
     }

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1436,10 +1436,6 @@ class WriteOperation(LogicalPlan):
                     )
         elif self.path is not None:
             plan.write_operation.path = self.path
-        else:
-            raise AssertionError(
-                "Invalid configuration of WriteCommand, neither path or table present."
-            )
 
         if self.mode is not None:
             wm = self.mode.lower()

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -688,9 +688,10 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
         wo.mode = "overwrite"
         wo.source = "parquet"
 
-        # Missing path or table name.
-        with self.assertRaises(AssertionError):
-            wo.command(None)
+        p = wo.command(None)
+        self.assertIsNotNone(p)
+        self.assertFalse(p.write_operation.HasField("path"))
+        self.assertFalse(p.write_operation.HasField("table"))
 
         wo.path = "path"
         p = wo.command(None)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `DataFrameWriter.save` to work without path parameter.

### Why are the changes needed?

`DataFrameWriter.save` should work without path parameter because some data sources, such as jdbc, noop, works without those parameters.

```py
>>> print(spark.range(10).write.format("noop").mode("append").save())
Traceback (most recent call last):
...
AssertionError: Invalid configuration of WriteCommand, neither path or table present.
```

### Does this PR introduce _any_ user-facing change?

The data sources that don't need path parameter will work.

```py
>>> print(spark.range(10).write.format("noop").mode("append").save())
None
```

### How was this patch tested?

Added a test.