### PR TITLE
[SPARK-42739][BUILD] Ensure release tag to be pushed to release branch

### DIFF
--- a/dev/create-release/release-tag.sh
+++ b/dev/create-release/release-tag.sh
@@ -122,7 +122,7 @@ if ! is_dry_run; then
   git push origin $RELEASE_TAG
   if [[ $RELEASE_VERSION != *"preview"* ]]; then
     git push origin HEAD:$GIT_BRANCH
-    if git branch -r --contains tags/$RELEASE_TAG ; then
+    if git branch -r --contains tags/$RELEASE_TAG | grep origin; then
       echo "Pushed $RELEASE_TAG to $GIT_BRANCH."
     else
       echo "Failed to push $RELEASE_TAG to $GIT_BRANCH. Please start over."

--- a/dev/create-release/release-tag.sh
+++ b/dev/create-release/release-tag.sh
@@ -122,6 +122,12 @@ if ! is_dry_run; then
   git push origin $RELEASE_TAG
   if [[ $RELEASE_VERSION != *"preview"* ]]; then
     git push origin HEAD:$GIT_BRANCH
+    if git branch -r --contains tags/$RELEASE_TAG ; then
+      echo "Pushed $RELEASE_TAG to $GIT_BRANCH."
+    else
+      echo "Failed to push $RELEASE_TAG to $GIT_BRANCH. Please start over."
+      exit 1
+    fi
   else
     echo "It's preview release. We only push $RELEASE_TAG to remote."
   fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the release script, add a check to ensure release tag to be pushed to release branch.


### Why are the changes needed?
To ensure the success of a RC cut. Otherwise, release conductors have to manually check that.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual test.

```
~/spark [_d_branch] $ git commit -am '_d_commmit'
...
~/spark [_d_branch] $ git tag '_d_tag'
~/spark [_d_branch] $ git push origin _d_tag
~/spark [_d_branch] $ git branch -r --contains tags/_d_tag | grep origin
~/spark [_d_branch] $ echo $?
1
~/spark [_d_branch] $ git push origin HEAD:_d_branch
...
~/spark [_d_branch] $ git branch -r --contains tags/_d_tag | grep origin
  origin/_d_branch
~/spark [_d_branch] $ echo $?                                           
0

```

In tags.log, there will be
```
To https://gitbox.apache.org/repos/asf/spark.git
   49cf58e30c..bc1671023c  HEAD -> branch-3.4
  origin/branch-3.4
Pushed v3.4.0-rc4 to branch-3.4.
```