### PR TITLE
[SPARK-42741][SQL] Do not unwrap casts in binary comparison when literal is null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -129,7 +129,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
     // moving cast to the literal side.
     case be @ BinaryComparison(
       Cast(fromExp, toType: NumericType, _, _), Literal(value, literalType))
-        if canImplicitlyCast(fromExp, toType, literalType) =>
+        if canImplicitlyCast(fromExp, toType, literalType) && value != null =>
       Some(simplifyNumericComparison(be, fromExp, toType, value))
 
     case be @ BinaryComparison(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -145,14 +145,14 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
     // 2. this rule only handles the case when both `fromExp` and value in `in.list` are of numeric
     // type.
     // 3. this rule doesn't optimize In when `in.list` contains an expression that is not literal.
-    case in @ In(Cast(fromExp, toType: NumericType, _, _), list @ Seq(firstLit, _*))
+    case in @ In(Cast(fromExp, toType: NumericType, tz, mode), list @ Seq(firstLit, _*))
       if canImplicitlyCast(fromExp, toType, firstLit.dataType) && in.inSetConvertible =>
 
       val buildIn = {
         (nullList: ArrayBuffer[Literal], canCastList: ArrayBuffer[Literal]) =>
           // cast null value to fromExp.dataType, to make sure the new return list is in the same
           // data type.
-          val newList = nullList.map(lit => Cast(lit, fromExp.dataType)) ++ canCastList
+          val newList = nullList.map(lit => Cast(lit, fromExp.dataType, tz, mode)) ++ canCastList
           In(fromExp, newList.toSeq)
       }
       simplifyIn(fromExp, toType, list, buildIn)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -196,7 +196,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     })
   }
 
-  test("unwrap casts when literal is null") {
+  test("SPARK-42741: Do not unwrap casts in binary comparison when literal is null") {
     val intLit = Literal.create(null, IntegerType)
     val nullLit = Literal.create(null, BooleanType)
     assertEquivalent(castInt(f) > intLit, nullLit)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -401,7 +401,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
 
     // Null date literal should be handled by NullPropagation
     assertEquivalent(castDate(f5) > nullLit || castDate(f6) > nullLit,
-      Literal.create(null, BooleanType) || Literal.create(null, BooleanType))
+      castDate(f5) > nullLit || castDate(f6) > nullLit)
   }
 
   private val ts1 = LocalDateTime.of(2023, 1, 1, 23, 59, 59, 99999000)
@@ -412,7 +412,8 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
   private def castInt(e: Expression): Expression = Cast(e, IntegerType)
   private def castDouble(e: Expression): Expression = Cast(e, DoubleType)
   private def castDecimal2(e: Expression): Expression = Cast(e, DecimalType(10, 4))
-  private def castDate(e: Expression): Expression = Cast(e, DateType)
+  private def castDate(e: Expression): Expression =
+    Cast(e, DateType, Some(conf.sessionLocalTimeZone))
   private def castTimestamp(e: Expression): Expression =
     Cast(e, TimestampType, Some(conf.sessionLocalTimeZone))
   private def castTimestampNTZ(e: Expression): Expression =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `UnwrapCastInBinaryComparison` not to unwrap casts in binary comparison when literal is null.

### Why are the changes needed?

In order to make the logic of `UnwrapCastInBinaryComparison` more clear. Null literals are already handled by `NullPropagation`:
https://github.com/apache/spark/blob/2de0d45887509fac8d5fc9448764a0e71f618797/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala#L823-L824

https://github.com/apache/spark/blob/2de0d45887509fac8d5fc9448764a0e71f618797/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala#L850-L851



### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests.