### PR TITLE
[SPARK_42742]access apiserver by pod env

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -55,6 +55,14 @@ private[spark] object Config extends Logging {
       .stringConf
       .createWithDefault(KUBERNETES_MASTER_INTERNAL_URL)
 
+  val KUBERNETES_DRIVER_MASTER_URL_FROM_POD_ENV =
+    ConfigBuilder("spark.kubernetes.driver.master.from.pod.env")
+      .doc("If true, driver will get master url from pod env " +
+        "= https://{KUBERNETES_SERVICE_HOST}:{KUBERNETES_SERVICE_PORT_HTTPS}.")
+      .version("3.1.2")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_DRIVER_SERVICE_DELETE_ON_TERMINATION =
     ConfigBuilder("spark.kubernetes.driver.service.deleteOnTermination")
       .doc("If true, driver service will be deleted on Spark application termination. " +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -79,8 +79,16 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)).filter(_.exists)
       val serviceAccountCaCrt =
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH)).filter(_.exists)
+      val shouldGetMasterFromEnv = sc.conf.get(KUBERNETES_DRIVER_MASTER_URL_FROM_POD_ENV)
+      val masterUrl = if (shouldGetMasterFromEnv) {
+        val masterHost = System.getenv("KUBERNETES_SERVICE_HOST")
+        val masterPort = System.getenv("KUBERNETES_SERVICE_PORT_HTTPS")
+        "https://" + masterHost + ":" + masterPort
+      } else {
+        sc.conf.get(KUBERNETES_DRIVER_MASTER_URL)
+      }
       (KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX,
-        sc.conf.get(KUBERNETES_DRIVER_MASTER_URL),
+        masterUrl,
         serviceAccountToken,
         serviceAccountCaCrt)
     } else {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When start spark on k8s，driver pod  use spark.kubernetes.driver.master to get apiserver address. This config  us  https://kubernetes.default.svc/ as default and do not care about the apiserver port.

In our case, apiserver port is not 443 will driver will throw connectException. As k8s doc mentioned （https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/#directly-accessing-the-rest-api）, we can get master url by getting KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT_HTTPS environment variables from pod. So we add a new conf spark.kubernetes.driver.master.from.pod.env to allow driver get master url from env in cluster mode on k8s


### Why are the changes needed?
Add a new conf spark.kubernetes.driver.master.from.pod.env  to let the driver pod get apiserver automatically from pod env instead of by  spark.kubernetes.driver.master.

### Does this PR introduce _any_ user-facing change?
Yes. When user set new conf spark.kubernetes.driver.master.from.pod.env as true, the logic of driver get apiserver url will changed. In some case it will help user to get right apiserver url.
By default, the conf spark.kubernetes.driver.master.from.pod.env  is false, and the driver logic changes nothing.

### How was this patch tested?
No. the apiserver is mocked in unit test. we tested this feature in our k8s cluster
