### PR TITLE
[SPARK_42744] delete uploaded file when job finish for k8s

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -710,7 +710,7 @@ private[spark] object Config extends Logging {
     ConfigBuilder("spark.kubernetes.uploaded.files")
       .internal()
       .doc("Remember all uploaded uri by spark client, used to delete uris when app finished.")
-      .version("3.1.2-internal")
+      .version("3.5.0")
       .stringConf
       .toSequence
       .createWithDefault(Nil)
@@ -718,7 +718,7 @@ private[spark] object Config extends Logging {
   val KUBERNETES_UPLOAD_FILE_DELETE_ON_TERMINATION =
     ConfigBuilder("spark.kubernetes.uploaded.file.delete.on.termination")
       .doc("Deleting uploaded file when app finished")
-      .version("3.1.2")
+      .version("3.5.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -706,6 +706,22 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val KUBERNETES_FILE_UPLOADED_FAILS =
+    ConfigBuilder("spark.kubernetes.uploaded.files")
+      .internal()
+      .doc("Remember all uploaded uri by spark client, used to delete uris when app finished.")
+      .version("3.1.2-internal")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
+  val KUBERNETES_UPLOAD_FILE_DELETE_ON_TERMINATION =
+    ConfigBuilder("spark.kubernetes.uploaded.file.delete.on.termination")
+      .doc("Deleting uploaded file when app finished")
+      .version("3.1.2")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_EXECUTOR_CHECK_ALL_CONTAINERS =
     ConfigBuilder("spark.kubernetes.executor.checkAllContainers")
       .doc("If set to true, all containers in the executor pod will be checked when reporting" +

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -306,6 +306,25 @@ object KubernetesUtils extends Logging {
     }
   }
 
+  def deleteFileUri(uri: String, conf: SparkConf): Unit = {
+    logInfo(s"Try to deleted uploaded uri: $uri")
+    val fileUri = Utils.resolveURI(uri)
+    try {
+      val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
+      val fs = getHadoopFileSystem(Utils.resolveURI(uri), hadoopConf)
+      val path = new Path(uri)
+      if (fs.exists(path)) {
+        fs.delete(path, true)
+        logInfo(s"Deleted uploaded uri: $uri")
+      } else {
+        logInfo(s"Uploaded uri: $uri not exists.")
+      }
+    } catch {
+      case e: Exception =>
+        throw new SparkException(s"Deleting file ${fileUri.getPath} failed...", e)
+    }
+  }
+
   @Since("3.0.0")
   def uploadFileUri(uri: String, conf: Option[SparkConf] = None): String = {
     conf match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Let driver delete uploaded file when job finish.


### Why are the changes needed?
Now there is no deletion for files uploaded by client, which causes file leaks on remote file system.

### Does this PR introduce _any_ user-facing change?
Yes. This PR add a new configuration spark.kubernetes.uploaded.file.delete.on.termination. By default, this configuration is false and the behavior is the same with current version. When the configuration is set to true, driver will try to delete uploaded files when job finish.



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
