### PR TITLE
[SPARK-42620][PS] Add `inclusive` parameter for (DataFrame|Series).between_time

### DIFF
--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -32,7 +32,8 @@ Upgrading from PySpark 3.5 to 4.0
 * In Spark 4.0, ``na_sentinel`` parameter from ``Index.factorize`` and `Series.factorize`` has been removed from pandas API on Spark, use ``use_na_sentinel`` instead.
 * In Spark 4.0, ``inplace`` parameter from ``Categorical.add_categories``, ``Categorical.remove_categories``, ``Categorical.set_categories``, ``Categorical.rename_categories``, ``Categorical.reorder_categories``, ``Categorical.as_ordered``, ``Categorical.as_unordered`` have been removed from pandas API on Spark.
 * In Spark 4.0, ``closed`` parameter from ``ps.date_range`` has been removed from pandas API on Spark.
-* In Spark 4.0, ``Series.between_time`` and ``DataFrame.between_time`` in Pandas on Spark  have a new parameter ``inclusive`` instead of two old parameters ``include_start`` and ``include_end``.
+* In Spark 4.0, ``include_start`` and ``include_end`` parameters from ``DataFrame.between_time`` have been removed from pandas API on Spark, use ``inclusive`` instead.
+* In Spark 4.0, ``include_start`` and ``include_end`` parameters from ``Series.between_time`` have been removed from pandas API on Spark, use ``inclusive`` instead.
 
 
 Upgrading from PySpark 3.3 to 3.4

--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -32,6 +32,7 @@ Upgrading from PySpark 3.5 to 4.0
 * In Spark 4.0, ``na_sentinel`` parameter from ``Index.factorize`` and `Series.factorize`` has been removed from pandas API on Spark, use ``use_na_sentinel`` instead.
 * In Spark 4.0, ``inplace`` parameter from ``Categorical.add_categories``, ``Categorical.remove_categories``, ``Categorical.set_categories``, ``Categorical.rename_categories``, ``Categorical.reorder_categories``, ``Categorical.as_ordered``, ``Categorical.as_unordered`` have been removed from pandas API on Spark.
 * In Spark 4.0, ``closed`` parameter from ``ps.date_range`` has been removed from pandas API on Spark.
+* In Spark 4.0, ``Series.between_time`` and ``DataFrame.between_time`` in Pandas on Spark  have a new parameter ``inclusive`` instead of two old parameters ``include_start`` and ``include_end``.
 
 
 Upgrading from PySpark 3.3 to 3.4

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -888,6 +888,11 @@ ERROR_CLASSES_JSON = """
       "Value for `<arg_name>` must be greater than <lower_bound> or less than <upper_bound>, got <actual>"
     ]
   },
+  "VALUE_NOT_ALLOWED" : {
+    "message" : [
+      "Value for `<arg_name>` has to be amongst the following values: <allowed_values>."
+    ]
+  },
   "WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION" : {
     "message" : [
       "Function `<func_name>` should take between 1 and 3 arguments, but provided function takes <num_args>."

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -853,6 +853,11 @@ ERROR_CLASSES_JSON = """
       "Value `<value>` cannot be accessed inside tasks."
     ]
   },
+  "VALUE_NOT_ALLOWED" : {
+    "message" : [
+      "Value for `<arg_name>` has to be amongst the following values: <allowed_values>."
+    ]
+  },
   "VALUE_NOT_ANY_OR_ALL" : {
     "message" : [
       "Value for `<arg_name>` must be 'any' or 'all', got '<arg_value>'."
@@ -886,11 +891,6 @@ ERROR_CLASSES_JSON = """
   "VALUE_OUT_OF_BOUND" : {
     "message" : [
       "Value for `<arg_name>` must be greater than <lower_bound> or less than <upper_bound>, got <actual>"
-    ]
-  },
-  "VALUE_NOT_ALLOWED" : {
-    "message" : [
-      "Value for `<arg_name>` has to be amongst the following values: <allowed_values>."
     ]
   },
   "WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION" : {

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3501,14 +3501,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             ).resolved_copy
             return DataFrame(internal)
 
-    # TODO(SPARK-42620): Add `inclusive` parameter and replace `include_start` & `include_end`.
-    # See https://github.com/pandas-dev/pandas/issues/43248
     def between_time(
         self,
         start_time: Union[datetime.time, str],
         end_time: Union[datetime.time, str],
-        include_start: bool = True,
-        include_end: bool = True,
+        inclusive: str = "both",
         axis: Axis = 0,
     ) -> "DataFrame":
         """
@@ -3523,16 +3520,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             Initial time as a time filter limit.
         end_time : datetime.time or str
             End time as a time filter limit.
-        include_start : bool, default True
-            Whether the start time needs to be included in the result.
-
-            .. deprecated:: 3.4.0
-
-        include_end : bool, default True
-            Whether the end time needs to be included in the result.
-
-            .. deprecated:: 3.4.0
-
+        inclusive : {"both", "neither", "left", "right"}, default "both"
+            Include boundaries; whether to set each bound as closed or open.
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Determine range time on index or columns value.
 
@@ -3586,6 +3575,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, ps.DatetimeIndex):
             raise TypeError("Index must be DatetimeIndex")
 
+        if inclusive not in ["left", "right", "both", "neither"]:
+            msg = "Inclusive has to be either 'both', 'neither', 'left' or 'right'"
+            raise ValueError(msg)
+
         psdf = self.copy()
         psdf.index.name = verify_temp_column_name(psdf, "__index_name__")
         return_types = [psdf.index.dtype] + list(psdf.dtypes)
@@ -3593,7 +3586,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         def pandas_between_time(  # type: ignore[no-untyped-def]
             pdf,
         ) -> ps.DataFrame[return_types]:  # type: ignore[valid-type]
-            return pdf.between_time(start_time, end_time, include_start, include_end).reset_index()
+            return pdf.between_time(start_time, end_time, inclusive).reset_index()
 
         # apply_batch will remove the index of the pandas-on-Spark DataFrame and attach a
         # default index, which will never be used. Use "distributed" index as a dummy to

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -59,6 +59,8 @@ from pandas.api.types import (  # type: ignore[attr-defined]
 )
 from pandas.tseries.frequencies import DateOffset, to_offset
 
+from pyspark.errors import PySparkValueError
+
 if TYPE_CHECKING:
     from pandas.io.formats.style import Styler
 
@@ -3522,6 +3524,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             End time as a time filter limit.
         inclusive : {"both", "neither", "left", "right"}, default "both"
             Include boundaries; whether to set each bound as closed or open.
+
+            .. versionadded:: 4.0.0
+
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Determine range time on index or columns value.
 
@@ -3575,9 +3580,12 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if not isinstance(self.index, ps.DatetimeIndex):
             raise TypeError("Index must be DatetimeIndex")
 
-        if inclusive not in ["left", "right", "both", "neither"]:
-            msg = "Inclusive has to be either 'both', 'neither', 'left' or 'right'"
-            raise ValueError(msg)
+        allowed_inclusive_values = ["left", "right", "both", "neither"]
+        if inclusive not in allowed_inclusive_values:
+            raise PySparkValueError(
+                error_class="VALUE_NOT_ALLOWED",
+                message_parameters={"arg_name": "inclusive", "allowed_values": str(allowed_inclusive_values)},
+            )
 
         psdf = self.copy()
         psdf.index.name = verify_temp_column_name(psdf, "__index_name__")

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3584,7 +3584,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if inclusive not in allowed_inclusive_values:
             raise PySparkValueError(
                 error_class="VALUE_NOT_ALLOWED",
-                message_parameters={"arg_name": "inclusive", "allowed_values": str(allowed_inclusive_values)},
+                message_parameters={
+                    "arg_name": "inclusive",
+                    "allowed_values": str(allowed_inclusive_values),
+                },
             )
 
         psdf = self.copy()

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -6739,6 +6739,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             End time as a time filter limit.
         inclusive : {"both", "neither", "left", "right"}, default "both"
             Include boundaries; whether to set each bound as closed or open.
+
+            .. versionadded:: 3.5.0
+
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Determine range time on index or columns value.
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -6718,14 +6718,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         return (left_ser.copy(), right.copy()) if copy else (left_ser, right)
 
-    # TODO(SPARK-42620): Add `inclusive` parameter and replace `include_start` & `include_end`.
-    # See https://github.com/pandas-dev/pandas/issues/43248
     def between_time(
         self,
         start_time: Union[datetime.time, str],
         end_time: Union[datetime.time, str],
-        include_start: bool = True,
-        include_end: bool = True,
+        inclusive: str = "both",
         axis: Axis = 0,
     ) -> "Series":
         """
@@ -6740,16 +6737,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             Initial time as a time filter limit.
         end_time : datetime.time or str
             End time as a time filter limit.
-        include_start : bool, default True
-            Whether the start time needs to be included in the result.
-
-            .. deprecated:: 3.4.0
-
-        include_end : bool, default True
-            Whether the end time needs to be included in the result.
-
-            .. deprecated:: 3.4.0
-
+        inclusive : {"both", "neither", "left", "right"}, default "both"
+            Include boundaries; whether to set each bound as closed or open.
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Determine range time on index or columns value.
 
@@ -6787,7 +6776,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         dtype: int64
         """
         return first_series(
-            self.to_frame().between_time(start_time, end_time, include_start, include_end, axis)
+            self.to_frame().between_time(start_time, end_time, inclusive, axis)
         ).rename(self.name)
 
     def at_time(

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -6740,7 +6740,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         inclusive : {"both", "neither", "left", "right"}, default "both"
             Include boundaries; whether to set each bound as closed or open.
 
-            .. versionadded:: 3.5.0
+            .. versionadded:: 4.0.0
 
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Determine range time on index or columns value.

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -187,7 +187,10 @@ class FrameReindexingMixin:
         self.check_error(
             exception=ctx.exception,
             error_class="VALUE_NOT_ALLOWED",
-            message_parameters={"arg_name": "inclusive", "allowed_values": str(["left", "right", "both", "neither"])},
+            message_parameters={
+                "arg_name": "inclusive",
+                "allowed_values": str(["left", "right", "both", "neither"]),
+            },
         )
 
     def test_drop(self):

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -22,6 +22,7 @@ import pandas as pd
 from pandas.tseries.offsets import DateOffset
 
 from pyspark import pandas as ps
+from pyspark.errors import PySparkValueError
 from pyspark.pandas.config import option_context
 from pyspark.testing.pandasutils import ComparisonTestBase
 from pyspark.testing.sqlutils import SQLTestUtils
@@ -115,10 +116,6 @@ class FrameReindexingMixin:
         with self.assertRaisesRegex(TypeError, "Index must be DatetimeIndex"):
             psdf.at_time("0:15")
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43557): Enable DataFrameSlowTests.test_between_time for pandas 2.0.0.",
-    )
     def test_between_time(self):
         idx = pd.date_range("2018-04-09", periods=4, freq="1D20min")
         pdf = pd.DataFrame({"A": [1, 2, 3, 4]}, index=idx)
@@ -167,6 +164,31 @@ class FrameReindexingMixin:
         psdf = ps.DataFrame({"A": [1, 2, 3, 4]})
         with self.assertRaisesRegex(TypeError, "Index must be DatetimeIndex"):
             psdf.between_time("0:15", "0:45")
+
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(
+            pdf.between_time("0:15", "0:45", inclusive="neither").sort_index(),
+            psdf.between_time("0:15", "0:45", inclusive="neither").sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.between_time("0:15", "0:45", inclusive="left").sort_index(),
+            psdf.between_time("0:15", "0:45", inclusive="left").sort_index(),
+        )
+
+        self.assert_eq(
+            pdf.between_time("0:15", "0:45", inclusive="right").sort_index(),
+            psdf.between_time("0:15", "0:45", inclusive="right").sort_index(),
+        )
+
+        with self.assertRaises(PySparkValueError) as ctx:
+            psdf.between_time("0:15", "0:45", inclusive="")
+
+        self.check_error(
+            exception=ctx.exception,
+            error_class="VALUE_NOT_ALLOWED",
+            message_parameters={"arg_name": "inclusive", "allowed_values": str(["left", "right", "both", "neither"])},
+        )
 
     def test_drop(self):
         pdf = pd.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]}, index=np.random.rand(2))
@@ -854,7 +876,8 @@ class FrameReindexingMixin:
 
 
 class FrameReidexingTests(FrameReindexingMixin, ComparisonTestBase, SQLTestUtils):
-    pass
+    def test_between_time(self):
+        super().test_between_time()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -879,8 +879,7 @@ class FrameReindexingMixin:
 
 
 class FrameReidexingTests(FrameReindexingMixin, ComparisonTestBase, SQLTestUtils):
-    def test_between_time(self):
-        super().test_between_time()
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/series/test_compute.py
+++ b/python/pyspark/pandas/tests/series/test_compute.py
@@ -600,7 +600,10 @@ class SeriesComputeMixin:
         self.check_error(
             exception=ctx.exception,
             error_class="VALUE_NOT_ALLOWED",
-            message_parameters={"arg_name": "inclusive", "allowed_values": str(["left", "right", "both", "neither"])},
+            message_parameters={
+                "arg_name": "inclusive",
+                "allowed_values": str(["left", "right", "both", "neither"]),
+            },
         )
 
     def test_at_time(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add `inclusive` parameter for (DataFrame|Series).between_time to support the pandas 2.0.0

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When pandas 2.0.0 is released, we should match the behavior in pandas API on Spark.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, the API changes

Before:
` (DataFrame|Series).between_time(start_time, end_time, include_start, include_end, axis)`

After:
` (DataFrame|Series).between_time(start_time, end_time, inclusive, axis)`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests were updated
