### PR TITLE
[SPARK-42721][CONNECT][FOLLOWUP] Apply scalafmt to LoggingInterceptor

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/LoggingInterceptor.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/LoggingInterceptor.scala
@@ -31,9 +31,9 @@ import io.grpc.ServerInterceptor
 import org.apache.spark.internal.Logging
 
 /**
- * A gRPC interceptor to log RPC requests and responses. It logs the protobufs as JSON.
- * Useful for local development. An ID is logged for each RPC so that requests and corresponding
- * responses can be exactly matched.
+ * A gRPC interceptor to log RPC requests and responses. It logs the protobufs as JSON. Useful for
+ * local development. An ID is logged for each RPC so that requests and corresponding responses
+ * can be exactly matched.
  */
 class LoggingInterceptor extends ServerInterceptor with Logging {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to fix Scala linter failure at `LoggingInterceptor.scala`.

### Why are the changes needed?

To recover CI.

- **master**: https://github.com/apache/spark/actions/runs/4389407261/jobs/7686936044
- **branch-3.4**: https://github.com/apache/spark/actions/runs/4389407870/jobs/7686935027
```
The scalafmt check failed on connector/connect at following occurrences:

Requires formatting: LoggingInterceptor.scala

Before submitting your change, please make sure to format your code using the following command:
./build/mvn -Pscala-2.12 scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect/common -pl connector/connect/server -pl connector/connect/client/jvm
Error: Process completed with exit code 1.
```

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass the CI.