### PR TITLE
[SPARK-42758][BUILD][MLLIB] Remove dependency on breeze

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1075,11 +1075,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.chuusai</groupId>
-        <artifactId>shapeless_${scala.binary.version}</artifactId>
-        <version>2.3.9</version>
-      </dependency>
-      <dependency>
         <groupId>org.json4s</groupId>
         <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
         <version>3.7.0-M11</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove dependency `shapeless` on breeze.

### Why are the changes needed?
After pr https://github.com/apache/spark/pull/37002, `shapeless` has been deleted in [spark-deps-hadoop-2-hive-2.3](https://github.com/apache/spark/pull/37002/files#diff-670b971a2758f55d602f0d1ef63f7af5f8d9ca095b5a55664bc3275e274ca395).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.