### PR TITLE
[SPARK-42679][CONNECT][PYTHON] createDataFrame doesn't work with non-nullable schema

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -52,12 +52,14 @@ from pyspark.sql.connect.conf import RuntimeConf
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.connect.plan import SQL, Range, LocalRelation, CachedRelation
 from pyspark.sql.connect.readwriter import DataFrameReader
+from pyspark.sql.connect.types import replace_with_arrow_column_name
 from pyspark.sql.pandas.serializers import ArrowStreamPandasSerializer
 from pyspark.sql.pandas.types import to_arrow_type, _get_local_timezone
 from pyspark.sql.session import classproperty, SparkSession as PySparkSession
 from pyspark.sql.types import (
     _infer_schema,
     _has_nulltype,
+    _has_non_nullable,
     _merge_type,
     Row,
     DataType,
@@ -240,10 +242,12 @@ class SparkSession:
                 _cols.extend([f"_{i + 1}" for i in range(cast(int, _num_cols), len(data.columns))])
                 _num_cols = len(_cols)
 
+            _target_schema: Optional[StructType] = None
             # Determine arrow types to coerce data when creating batches
             if isinstance(schema, StructType):
                 arrow_types = [to_arrow_type(f.dataType) for f in schema.fields]
                 _cols = [str(x) if not isinstance(x, str) else x for x in schema.fieldNames()]
+                _target_schema = schema
             elif isinstance(schema, DataType):
                 raise ValueError("Single data type %s is not supported with Arrow" % str(schema))
             else:
@@ -266,6 +270,9 @@ class SparkSession:
             _table = pa.Table.from_batches(
                 [ser._create_batch([(c, t) for (_, c), t in zip(data.items(), arrow_types)])]
             )
+            if _target_schema is not None and _has_non_nullable(_target_schema):
+                pa_schema = replace_with_arrow_column_name(_target_schema, _table.schema)
+                _table = _table.cast(target_schema=pa_schema)
 
         elif isinstance(data, np.ndarray):
             if data.ndim not in [1, 2]:
@@ -334,6 +341,10 @@ class SparkSession:
                         "a StructType Schema is required in this case"
                     )
                 _inferred_schema = _schema
+
+            if _schema is not None and _has_non_nullable(_schema):
+                if isinstance(_schema, StructType):
+                    _inferred_schema = _schema
 
             from pyspark.sql.connect.conversion import LocalDataToArrowConversion
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -52,14 +52,12 @@ from pyspark.sql.connect.conf import RuntimeConf
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.connect.plan import SQL, Range, LocalRelation, CachedRelation
 from pyspark.sql.connect.readwriter import DataFrameReader
-from pyspark.sql.connect.types import replace_with_arrow_column_name
 from pyspark.sql.pandas.serializers import ArrowStreamPandasSerializer
-from pyspark.sql.pandas.types import to_arrow_type, _get_local_timezone
+from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type, _get_local_timezone
 from pyspark.sql.session import classproperty, SparkSession as PySparkSession
 from pyspark.sql.types import (
     _infer_schema,
     _has_nulltype,
-    _has_non_nullable,
     _merge_type,
     Row,
     DataType,
@@ -242,12 +240,12 @@ class SparkSession:
                 _cols.extend([f"_{i + 1}" for i in range(cast(int, _num_cols), len(data.columns))])
                 _num_cols = len(_cols)
 
-            _target_schema: Optional[StructType] = None
             # Determine arrow types to coerce data when creating batches
+            arrow_schema: Optional[pa.Schema] = None
             if isinstance(schema, StructType):
-                arrow_types = [to_arrow_type(f.dataType) for f in schema.fields]
+                arrow_schema = to_arrow_schema(schema)
+                arrow_types = [field.type for field in arrow_schema]
                 _cols = [str(x) if not isinstance(x, str) else x for x in schema.fieldNames()]
-                _target_schema = schema
             elif isinstance(schema, DataType):
                 raise ValueError("Single data type %s is not supported with Arrow" % str(schema))
             else:
@@ -270,9 +268,10 @@ class SparkSession:
             _table = pa.Table.from_batches(
                 [ser._create_batch([(c, t) for (_, c), t in zip(data.items(), arrow_types)])]
             )
-            if _target_schema is not None and _has_non_nullable(_target_schema):
-                pa_schema = replace_with_arrow_column_name(_target_schema, _table.schema)
-                _table = _table.cast(target_schema=pa_schema)
+
+            if isinstance(schema, StructType):
+                assert arrow_schema is not None
+                _table = _table.rename_columns(schema.names).cast(arrow_schema)
 
         elif isinstance(data, np.ndarray):
             if data.ndim not in [1, 2]:
@@ -318,32 +317,34 @@ class SparkSession:
                 # we need to convert it to [[1], [2], [3]] to be able to infer schema.
                 _data = [[d] for d in _data]
 
-            _inferred_schema = self._inferSchemaFromList(_data, _cols)
-
-            if _cols is not None and cast(int, _num_cols) < len(_cols):
-                _num_cols = len(_cols)
-
-            if _has_nulltype(_inferred_schema):
-                # For cases like createDataFrame([("Alice", None, 80.1)], schema)
-                # we can not infer the schema from the data itself.
-                warnings.warn("failed to infer the schema from data")
-                if _schema is None and _schema_str is not None:
-                    _parsed = self.client._analyze(
-                        method="ddl_parse", ddl_string=_schema_str
-                    ).parsed
-                    if isinstance(_parsed, StructType):
-                        _schema = _parsed
-                    elif isinstance(_parsed, DataType):
-                        _schema = StructType().add("value", _parsed)
-                if _schema is None or not isinstance(_schema, StructType):
-                    raise ValueError(
-                        "Some of types cannot be determined after inferring, "
-                        "a StructType Schema is required in this case"
-                    )
-                _inferred_schema = _schema
-
-            if _schema is not None and _has_non_nullable(_schema):
+            if _schema is not None:
                 if isinstance(_schema, StructType):
+                    _inferred_schema = _schema
+                else:
+                    _inferred_schema = StructType().add("value", _schema)
+            else:
+                _inferred_schema = self._inferSchemaFromList(_data, _cols)
+
+                if _cols is not None and cast(int, _num_cols) < len(_cols):
+                    _num_cols = len(_cols)
+
+                if _has_nulltype(_inferred_schema):
+                    # For cases like createDataFrame([("Alice", None, 80.1)], schema)
+                    # we can not infer the schema from the data itself.
+                    warnings.warn("failed to infer the schema from data")
+                    if _schema is None and _schema_str is not None:
+                        _parsed = self.client._analyze(
+                            method="ddl_parse", ddl_string=_schema_str
+                        ).parsed
+                        if isinstance(_parsed, StructType):
+                            _schema = _parsed
+                        elif isinstance(_parsed, DataType):
+                            _schema = StructType().add("value", _parsed)
+                    if _schema is None or not isinstance(_schema, StructType):
+                        raise ValueError(
+                            "Some of types cannot be determined after inferring, "
+                            "a StructType Schema is required in this case"
+                        )
                     _inferred_schema = _schema
 
             from pyspark.sql.connect.conversion import LocalDataToArrowConversion

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -325,6 +325,17 @@ def to_arrow_type(dt: DataType) -> "pa.DataType":
     return arrow_type
 
 
+def replace_with_arrow_column_name(schema: StructType, arrow_schema: "pa.Schema") -> "pa.Schema":
+    """Replace with arrow column name"""
+    import pyarrow as pa
+
+    fields = [
+        pa.field(field2.name, to_arrow_type(field1.dataType), nullable=field1.nullable)
+        for (field1, field2) in zip(schema, arrow_schema)
+    ]
+    return pa.schema(fields)
+
+
 def to_arrow_schema(schema: StructType) -> "pa.Schema":
     """Convert a schema from Spark to Arrow"""
     fields = [

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2890,13 +2890,13 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         )
 
     def test_schema_has_nullable(self):
-        schema_false = StructType([StructField("id", IntegerType(), False)])
+        schema_false = StructType().add("id", IntegerType(), False)
         cdf1 = self.connect.createDataFrame([[1]], schema=schema_false)
         sdf1 = self.spark.createDataFrame([[1]], schema=schema_false)
         self.assertEqual(cdf1.schema, sdf1.schema)
         self.assertEqual(cdf1.collect(), sdf1.collect())
 
-        schema_true = StructType([StructField("id", IntegerType(), True)])
+        schema_true = StructType().add("id", IntegerType(), True)
         cdf2 = self.connect.createDataFrame([[1]], schema=schema_true)
         sdf2 = self.spark.createDataFrame([[1]], schema=schema_true)
         self.assertEqual(cdf2.schema, sdf2.schema)
@@ -2904,15 +2904,49 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         pdf1 = cdf1.toPandas()
         cdf3 = self.connect.createDataFrame(pdf1, cdf1.schema)
-        sdf3 = self.spark.createDataFrame(pdf1, cdf1.schema)
+        sdf3 = self.spark.createDataFrame(pdf1, sdf1.schema)
         self.assertEqual(cdf3.schema, sdf3.schema)
         self.assertEqual(cdf3.collect(), sdf3.collect())
 
         pdf2 = cdf2.toPandas()
         cdf4 = self.connect.createDataFrame(pdf2, cdf2.schema)
-        sdf4 = self.spark.createDataFrame(pdf2, cdf2.schema)
+        sdf4 = self.spark.createDataFrame(pdf2, sdf2.schema)
         self.assertEqual(cdf4.schema, sdf4.schema)
         self.assertEqual(cdf4.collect(), sdf4.collect())
+
+    def test_array_has_nullable(self):
+        schema_array_false = StructType().add("arr", ArrayType(IntegerType(), False))
+        cdf1 = self.connect.createDataFrame([Row([1, 2]), Row([3])], schema=schema_array_false)
+        sdf1 = self.spark.createDataFrame([Row([1, 2]), Row([3])], schema=schema_array_false)
+        self.assertEqual(cdf1.schema, sdf1.schema)
+        self.assertEqual(cdf1.collect(), sdf1.collect())
+
+        schema_array_true = StructType().add("arr", ArrayType(IntegerType(), True))
+        cdf2 = self.connect.createDataFrame([Row([1, None]), Row([3])], schema=schema_array_true)
+        sdf2 = self.spark.createDataFrame([Row([1, None]), Row([3])], schema=schema_array_true)
+        self.assertEqual(cdf2.schema, sdf2.schema)
+        self.assertEqual(cdf2.collect(), sdf2.collect())
+
+    def test_map_has_nullable(self):
+        schema_map_false = StructType().add("map", MapType(StringType(), IntegerType(), False))
+        cdf1 = self.connect.createDataFrame(
+            [Row({"a": 1, "b": 2}), Row({"a": 3})], schema=schema_map_false
+        )
+        sdf1 = self.spark.createDataFrame(
+            [Row({"a": 1, "b": 2}), Row({"a": 3})], schema=schema_map_false
+        )
+        self.assertEqual(cdf1.schema, sdf1.schema)
+        self.assertEqual(cdf1.collect(), sdf1.collect())
+
+        schema_map_true = StructType().add("map", MapType(StringType(), IntegerType(), True))
+        cdf2 = self.connect.createDataFrame(
+            [Row({"a": 1, "b": None}), Row({"a": 3})], schema=schema_map_true
+        )
+        sdf2 = self.spark.createDataFrame(
+            [Row({"a": 1, "b": None}), Row({"a": 3})], schema=schema_map_true
+        )
+        self.assertEqual(cdf2.schema, sdf2.schema)
+        self.assertEqual(cdf2.collect(), sdf2.collect())
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2889,6 +2889,31 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.connect.sql("show functions").collect(), self.spark.sql("show functions").collect()
         )
 
+    def test_schema_has_nullable(self):
+        schema_false = StructType([StructField("id", IntegerType(), False)])
+        cdf1 = self.connect.createDataFrame([[1]], schema=schema_false)
+        sdf1 = self.spark.createDataFrame([[1]], schema=schema_false)
+        self.assertEqual(cdf1.schema, sdf1.schema)
+        self.assertEqual(cdf1.collect(), sdf1.collect())
+
+        schema_true = StructType([StructField("id", IntegerType(), True)])
+        cdf2 = self.connect.createDataFrame([[1]], schema=schema_true)
+        sdf2 = self.spark.createDataFrame([[1]], schema=schema_true)
+        self.assertEqual(cdf2.schema, sdf2.schema)
+        self.assertEqual(cdf2.collect(), sdf2.collect())
+
+        pdf1 = cdf1.toPandas()
+        cdf3 = self.connect.createDataFrame(pdf1, cdf1.schema)
+        sdf3 = self.spark.createDataFrame(pdf1, cdf1.schema)
+        self.assertEqual(cdf3.schema, sdf3.schema)
+        self.assertEqual(cdf3.collect(), sdf3.collect())
+
+        pdf2 = cdf2.toPandas()
+        cdf4 = self.connect.createDataFrame(pdf2, cdf2.schema)
+        sdf4 = self.spark.createDataFrame(pdf2, cdf2.schema)
+        self.assertEqual(cdf4.schema, sdf4.schema)
+        self.assertEqual(cdf4.collect(), sdf4.collect())
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class ClientTests(unittest.TestCase):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1599,6 +1599,18 @@ def _has_nulltype(dt: DataType) -> bool:
         return isinstance(dt, NullType)
 
 
+def _has_non_nullable(dt: DataType) -> bool:
+    """Return whether there is non-nullable in `dt`"""
+    if isinstance(dt, StructType):
+        return any(not f.nullable or _has_non_nullable(f.dataType) for f in dt.fields)
+    elif isinstance(dt, ArrayType):
+        return _has_non_nullable((dt.elementType))
+    elif isinstance(dt, MapType):
+        return _has_non_nullable(dt.keyType) or _has_non_nullable(dt.valueType)
+    else:
+        return False
+
+
 @overload
 def _merge_type(a: StructType, b: StructType, name: Optional[str] = None) -> StructType:
     ...

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1599,18 +1599,6 @@ def _has_nulltype(dt: DataType) -> bool:
         return isinstance(dt, NullType)
 
 
-def _has_non_nullable(dt: DataType) -> bool:
-    """Return whether there is non-nullable in `dt`"""
-    if isinstance(dt, StructType):
-        return any(not f.nullable or _has_non_nullable(f.dataType) for f in dt.fields)
-    elif isinstance(dt, ArrayType):
-        return _has_non_nullable((dt.elementType))
-    elif isinstance(dt, MapType):
-        return _has_non_nullable(dt.keyType) or _has_non_nullable(dt.valueType)
-    else:
-        return False
-
-
 @overload
 def _merge_type(a: StructType, b: StructType, name: Optional[str] = None) -> StructType:
     ...


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `spark.createDataFrame` to apply the given schema to work with non-nullable data types.

### Why are the changes needed?

Currently `spark.createDataFrame` won't work with non-nullable schema as below:

```py
>>> from pyspark.sql.types import *
>>> schema_false = StructType([StructField("id", IntegerType(), False)])
>>> spark.createDataFrame([[1]], schema=schema_false)
Traceback (most recent call last):
...
pyspark.errors.exceptions.connect.AnalysisException: [NULLABLE_COLUMN_OR_FIELD] Column or field `id` is nullable while it's required to be non-nullable.
```

whereas it works fine with nullable schema:

```py
>>> from pyspark.sql.types import *
>>> schema_false = StructType([StructField("id", IntegerType(), False)])
>>> spark.createDataFrame([[1]], schema=schema_false)
DataFrame[id: int]
```

### Does this PR introduce _any_ user-facing change?

`spark.createDataFrame` with non-nullable schema will work.

### How was this patch tested?

Added related tests.
