### PR TITLE
[SPARK-42763][BUILD] Upgrade ZooKeeper from 3.6.3 to 3.6.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -266,6 +266,6 @@ xml-apis/1.4.01//xml-apis-1.4.01.jar
 xmlenc/0.52//xmlenc-0.52.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
-zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
-zookeeper/3.6.3//zookeeper-3.6.3.jar
+zookeeper-jute/3.6.4//zookeeper-jute-3.6.4.jar
+zookeeper/3.6.4//zookeeper-3.6.4.jar
 zstd-jni/1.5.4-2//zstd-jni-1.5.4-2.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -251,6 +251,6 @@ wildfly-openssl/1.0.7.Final//wildfly-openssl-1.0.7.Final.jar
 xbean-asm9-shaded/4.22//xbean-asm9-shaded-4.22.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
-zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
-zookeeper/3.6.3//zookeeper-3.6.3.jar
+zookeeper-jute/3.6.4//zookeeper-jute-3.6.4.jar
+zookeeper/3.6.4//zookeeper-3.6.4.jar
 zstd-jni/1.5.4-2//zstd-jni-1.5.4-2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <protobuf.version>3.22.0</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
-    <zookeeper.version>3.6.3</zookeeper.version>
+    <zookeeper.version>3.6.4</zookeeper.version>
     <curator.version>2.13.0</curator.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `ZooKeeper` from 3.6.3 to 3.6.4.

### Why are the changes needed?
Release Notes: https://zookeeper.apache.org/doc/r3.6.4/releasenotes.html
Routine upgrade, ZooKeeper 3.6.4 contains some bugfixes:
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/15246973/224519753-071d7e03-bac0-48bd-bc3d-3dd04c2f8ae2.png">

Why is 3.6.4 but not higher?
https://github.com/apache/spark/pull/37507
https://github.com/apache/spark/pull/32572

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.