### PR TITLE
[SPARK-42753] ReusedExchange refers to non-existent nodes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
@@ -27,21 +27,22 @@ import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveS
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 
 object ExplainUtils extends AdaptiveSparkPlanHelper {
+
   /**
    * Given a input physical plan, performs the following tasks.
-   *   1. Computes the whole stage codegen id for current operator and records it in the
-   *      operator by setting a tag.
-   *   2. Generate the two part explain output for this plan.
+   *   1. Computes the whole stage codegen id for current operator and records it in the operator
+   *      by setting a tag. 2. Generate the two part explain output for this plan.
    *      1. First part explains the operator tree with each operator tagged with an unique
-   *         identifier.
-   *      2. Second part explains each operator in a verbose manner.
+   *         identifier. 2. Second part explains each operator in a verbose manner.
    *
    * Note : This function skips over subqueries. They are handled by its caller.
    *
-   * @param plan Input query plan to process
-   * @param append function used to append the explain output
-   * @param collectedOperators The IDs of the operators that are already collected and we shouldn't
-   *                           collect again.
+   * @param plan
+   *   Input query plan to process
+   * @param append
+   *   function used to append the explain output
+   * @param collectedOperators
+   *   The IDs of the operators that are already collected and we shouldn't collect again.
    */
   private def processPlanSkippingSubqueries[T <: QueryPlan[T]](
       plan: T,
@@ -50,12 +51,7 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
     try {
       generateWholeStageCodegenIds(plan)
 
-      QueryPlan.append(
-        plan,
-        append,
-        verbose = false,
-        addSuffix = false,
-        printOperatorId = true)
+      QueryPlan.append(plan, append, verbose = false, addSuffix = false, printOperatorId = true)
 
       append("\n")
 
@@ -69,12 +65,15 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
   }
 
   /**
-   * This function is part of a fix for SPARK-42753: process subtree for ReusedExchange with unknown
-   * child. It traverses the input plan and adds visited nodes to HashSet of Operators and Hashset
-   * of Reused Exchanges.
-   * @param plan Input query plan
-   * @param operators HashSet of operators traversed
-   * @param reusedExchanges HashSet of ReusedExchanges traversed
+   * This function is part of a fix for SPARK-42753: process subtree for ReusedExchange with
+   * unknown child. It traverses the input plan and adds visited nodes to HashSet of Operators and
+   * Hashset of Reused Exchanges.
+   * @param plan
+   *   Input query plan
+   * @param operators
+   *   HashSet of operators traversed
+   * @param reusedExchanges
+   *   HashSet of ReusedExchanges traversed
    */
   private def processReusedExchanges(
       plan: QueryPlan[_],
@@ -114,21 +113,20 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
 
   /**
    * Given a input physical plan, performs the following tasks.
-   *   1. Generates the explain output for the input plan excluding the subquery plans.
-   *   2. Generates the explain output for each subquery referenced in the plan.
+   *   1. Generates the explain output for the input plan excluding the subquery plans. 2.
+   *      Generates the explain output for each subquery referenced in the plan.
    */
   def processPlan[T <: QueryPlan[T]](plan: T, append: String => Unit): Unit = {
     try {
       var currentOperatorID = 0
-      currentOperatorID = generateOperatorIDs(plan, currentOperatorID, false,
-        HashSet.empty[QueryPlan[_]])
+      currentOperatorID =
+        generateOperatorIDs(plan, currentOperatorID, false, HashSet.empty[QueryPlan[_]])
 
       val subqueries = ArrayBuffer.empty[(SparkPlan, Expression, BaseSubqueryExec)]
       getSubqueries(plan, subqueries)
 
-      currentOperatorID = subqueries.foldLeft(currentOperatorID) {
-        (curId, plan) => generateOperatorIDs(plan._3.child, curId, false,
-          HashSet.empty[QueryPlan[_]])
+      currentOperatorID = subqueries.foldLeft(currentOperatorID) { (curId, plan) =>
+        generateOperatorIDs(plan._3.child, curId, false, HashSet.empty[QueryPlan[_]])
       }
 
       // SPARK-42753: Process subtree for a ReusedExchange with unknown child
@@ -149,10 +147,9 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
           r.setTagValue(r.UNKNOWN_CHILD_ID, ())
           r
         }
-        .foldLeft(currentOperatorID) {
-          (curId, r) =>
-            assert(curId >= currentOperatorID)
-            generateOperatorIDs(r.child, curId, true, operators)
+        .foldLeft(currentOperatorID) { (curId, r) =>
+          assert(curId >= currentOperatorID)
+          generateOperatorIDs(r.child, curId, true, operators)
         }
 
       val collectedOperators = BitSet.empty
@@ -164,8 +161,9 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
           append("\n===== Subqueries =====\n\n")
         }
         i = i + 1
-        append(s"Subquery:$i Hosting operator id = " +
-          s"${getOpId(sub._1)} Hosting Expression = ${sub._2}\n")
+        append(
+          s"Subquery:$i Hosting operator id = " +
+            s"${getOpId(sub._1)} Hosting Expression = ${sub._2}\n")
 
         // For each subquery expression in the parent plan, process its child plan to compute
         // the explain output. In case of subquery reuse, we don't print subquery plan more
@@ -182,25 +180,27 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
 
   /**
    * Traverses the supplied input plan in a bottom-up fashion and records the operator id via
-   * setting a tag in the operator.
-   * Note :
-   * - Operator such as WholeStageCodegenExec and InputAdapter are skipped as they don't
-   *     appear in the explain output.
-   * - Operator identifier starts at startOperatorID + 1
+   * setting a tag in the operator. Note :
+   *   - Operator such as WholeStageCodegenExec and InputAdapter are skipped as they don't appear
+   *     in the explain output.
+   *   - Operator identifier starts at startOperatorID + 1
    *
-   * @param plan Input query plan to process
-   * @param startOperatorID The start value of operation id. The subsequent operations will be
-   *                        assigned higher value.
-   * @param overwrite Whether to overwrite existing IDs if they already exist. This is needed
-   *                 for an edge case in SPARK-42753 to overwrite any potential existing IDs on a
-   *                 ReusedExchange child subtree that were generated from previous AQE iteration.
-   * @param overwriteExclusions These are operators to avoid overwriting. Only takes effect if
-   *                            overwrite = true. This is needed for an edge case in SPARK-42753
-   *                            where some nodes in the subtree need to be overwritten and others
-   *                            don't because they are already correctly ID'd in the current plan
-   *                            iteration.
-   * @return The last generated operation id for this input plan. This is to ensure we always
-   *         assign incrementing unique id to each operator.
+   * @param plan
+   *   Input query plan to process
+   * @param startOperatorID
+   *   The start value of operation id. The subsequent operations will be assigned higher value.
+   * @param overwrite
+   *   Whether to overwrite existing IDs if they already exist. This is needed for an edge case in
+   *   SPARK-42753 to overwrite any potential existing IDs on a ReusedExchange child subtree that
+   *   were generated from previous AQE iteration.
+   * @param overwriteExclusions
+   *   These are operators to avoid overwriting. Only takes effect if overwrite = true. This is
+   *   needed for an edge case in SPARK-42753 where some nodes in the subtree need to be
+   *   overwritten and others don't because they are already correctly ID'd in the current plan
+   *   iteration.
+   * @return
+   *   The last generated operation id for this input plan. This is to ensure we always assign
+   *   incrementing unique id to each operator.
    */
   private def generateOperatorIDs(
       plan: QueryPlan[_],
@@ -216,29 +216,29 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
     def setOpId(plan: QueryPlan[_]): Unit =
       if ((overwrite && !overwriteExclusions.contains(plan)) ||
         plan.getTagValue(QueryPlan.OP_ID_TAG).isEmpty) {
-      currentOperationID += 1
-      plan.setTagValue(QueryPlan.OP_ID_TAG, currentOperationID)
-    }
+        currentOperationID += 1
+        plan.setTagValue(QueryPlan.OP_ID_TAG, currentOperationID)
+      }
 
     plan.foreachUp {
       case _: WholeStageCodegenExec =>
       case _: InputAdapter =>
       case p: AdaptiveSparkPlanExec =>
-        currentOperationID = generateOperatorIDs(p.executedPlan, currentOperationID,
-          overwrite, overwriteExclusions)
+        currentOperationID =
+          generateOperatorIDs(p.executedPlan, currentOperationID, overwrite, overwriteExclusions)
         if (!p.executedPlan.fastEquals(p.initialPlan)) {
-          currentOperationID = generateOperatorIDs(p.initialPlan, currentOperationID,
-            overwrite, overwriteExclusions)
+          currentOperationID =
+            generateOperatorIDs(p.initialPlan, currentOperationID, overwrite, overwriteExclusions)
         }
         setOpId(p)
       case p: QueryStageExec =>
-        currentOperationID = generateOperatorIDs(p.plan, currentOperationID,
-          overwrite, overwriteExclusions)
+        currentOperationID =
+          generateOperatorIDs(p.plan, currentOperationID, overwrite, overwriteExclusions)
         setOpId(p)
       case other: QueryPlan[_] =>
         setOpId(other)
-        currentOperationID = other.innerChildren.foldLeft(currentOperationID) {
-          (curId, plan) => generateOperatorIDs(plan, curId, overwrite, overwriteExclusions)
+        currentOperationID = other.innerChildren.foldLeft(currentOperationID) { (curId, plan) =>
+          generateOperatorIDs(plan, curId, overwrite, overwriteExclusions)
         }
     }
     currentOperationID
@@ -248,10 +248,12 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
    * Traverses the supplied input plan in a bottom-up fashion and collects operators with assigned
    * ids.
    *
-   * @param plan Input query plan to process
-   * @param operators An output parameter that contains the operators.
-   * @param collectedOperators The IDs of the operators that are already collected and we shouldn't
-   *                           collect again.
+   * @param plan
+   *   Input query plan to process
+   * @param operators
+   *   An output parameter that contains the operators.
+   * @param collectedOperators
+   *   The IDs of the operators that are already collected and we shouldn't collect again.
    */
   private def collectOperatorsWithID(
       plan: QueryPlan[_],
@@ -290,8 +292,8 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
   }
 
   /**
-   * Traverses the supplied input plan in a top-down fashion and records the
-   * whole stage code gen id in the plan via setting a tag.
+   * Traverses the supplied input plan in a top-down fashion and records the whole stage code gen
+   * id in the plan via setting a tag.
    */
   private def generateWholeStageCodegenIds(plan: QueryPlan[_]): Unit = {
     var currentCodegenId = -1
@@ -329,9 +331,7 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
 
   /**
    * Given a input plan, returns an array of tuples comprising of :
-   *  1. Hosting operator id.
-   *  2. Hosting expression
-   *  3. Subquery plan
+   *   1. Hosting operator id. 2. Hosting expression 3. Subquery plan
    */
   private def getSubqueries(
       plan: => QueryPlan[_],
@@ -342,21 +342,20 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
       case q: QueryStageExec =>
         getSubqueries(q.plan, subqueries)
       case p: SparkPlan =>
-        p.expressions.foreach (_.collect {
-          case e: PlanExpression[_] =>
-            e.plan match {
-              case s: BaseSubqueryExec =>
-                subqueries += ((p, e, s))
-                getSubqueries(s, subqueries)
-              case _ =>
-            }
+        p.expressions.foreach(_.collect { case e: PlanExpression[_] =>
+          e.plan match {
+            case s: BaseSubqueryExec =>
+              subqueries += ((p, e, s))
+              getSubqueries(s, subqueries)
+            case _ =>
+          }
         })
     }
   }
 
   /**
-   * Returns the operator identifier for the supplied plan by retrieving the
-   * `operationId` tag value.
+   * Returns the operator identifier for the supplied plan by retrieving the `operationId` tag
+   * value.
    */
   def getOpId(plan: QueryPlan[_]): String = {
     plan.getTagValue(QueryPlan.OP_ID_TAG).map(v => s"$v").getOrElse("unknown")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExplainUtils.scala
@@ -69,7 +69,7 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
   }
 
   /**
-   * This function is part of a fix for SC-122182: process subtree for ReusedExchange with unknown
+   * This function is part of a fix for SPARK-42753: process subtree for ReusedExchange with unknown
    * child. It traverses the input plan and adds visited nodes to HashSet of Operators and Hashset
    * of Reused Exchanges.
    * @param plan Input query plan
@@ -133,7 +133,7 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
           HashSet.empty[QueryPlan[_]])
       }
 
-      // SC-122182: Process subtree for a ReusedExchange with unknown child
+      // SPARK-42753: Process subtree for a ReusedExchange with unknown child
       // Get all the operators and ReusedExchanges that have generated ID
       val reusedExchanges = HashSet.empty[ReusedExchangeExec]
       val operators = HashSet.empty[QueryPlan[_]]
@@ -194,10 +194,10 @@ object ExplainUtils extends AdaptiveSparkPlanHelper {
    * @param startOperatorID The start value of operation id. The subsequent operations will be
    *                        assigned higher value.
    * @param overwrite Whether to overwrite existing IDs if they already exist. This is needed
-   *                 for an edge case in SC-122182 to overwrite any potential existing IDs on a
+   *                 for an edge case in SPARK-42753 to overwrite any potential existing IDs on a
    *                 ReusedExchange child subtree that were generated from previous AQE iteration.
    * @param overwriteExclusions These are operators to avoid overwriting. Only takes effect if
-   *                            overwrite = true. This is needed for an edge case in SC-122182 where
+   *                            overwrite = true. This is needed for an edge case in SPARK-42753 where
    *                            some nodes in the subtree need to be overwritten and others don't
    *                            because they are already correctly ID'd in the current plan
    *                            iteration.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * Base class for operators that exchange data among multiple threads or processes.
  *
  * Exchanges are the key class of operators that enable parallelism. Although the implementation
- * differs significantly, the concept is similar to the exchange operator described in "Volcano --
- * An Extensible and Parallel Query Evaluation System" by Goetz Graefe.
+ * differs significantly, the concept is similar to the exchange operator described in
+ * "Volcano -- An Extensible and Parallel Query Evaluation System" by Goetz Graefe.
  */
 abstract class Exchange extends UnaryExecNode {
   override def output: Seq[Attribute] = child.output
@@ -47,7 +47,7 @@ abstract class Exchange extends UnaryExecNode {
  * preserve the original ids because they're what downstream operators are expecting.
  */
 case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchange)
-    extends LeafExecNode {
+  extends LeafExecNode {
   val UNKNOWN_CHILD_ID = TreeNodeTag[Unit]("UNKNOWN_CHILD_ID")
 
   override def supportsColumnar: Boolean = child.supportsColumnar
@@ -71,10 +71,9 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
   // to update the attribute ids in `outputPartitioning` and `outputOrdering`.
   private[sql] lazy val updateAttr: Expression => Expression = {
     val originalAttrToNewAttr = AttributeMap(child.output.zip(output))
-    e =>
-      e.transform { case attr: Attribute =>
-        originalAttrToNewAttr.getOrElse(attr, attr)
-      }
+    e => e.transform {
+      case attr: Attribute => originalAttrToNewAttr.getOrElse(attr, attr)
+    }
   }
 
   override def outputPartitioning: Partitioning = child.outputPartitioning match {
@@ -95,38 +94,23 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
   }
 
   override def generateTreeString(
-      depth: Int,
-      lastChildren: Seq[Boolean],
-      append: String => Unit,
-      verbose: Boolean,
-      prefix: String = "",
-      addSuffix: Boolean = false,
-      maxFields: Int,
-      printNodeId: Boolean,
-      indent: Int = 0): Unit = {
-    super.generateTreeString(
-      depth,
-      lastChildren,
-      append,
-      verbose,
-      prefix,
-      addSuffix,
-      maxFields,
-      printNodeId,
-      indent)
-    // SPARK-42753 Recursively append subtree of the child if that child is an UNKNOWN child
-    // whereby that child has not been printed anywhere else
-    if (this.getTagValue(UNKNOWN_CHILD_ID).isDefined) {
-      child.generateTreeString(
-        depth + 1,
-        lastChildren :+ true,
-        append,
-        verbose,
-        prefix,
-        addSuffix,
-        maxFields,
-        printNodeId = printNodeId,
-        indent = indent)
-    }
+    depth: Int,
+    lastChildren: Seq[Boolean],
+    append: String => Unit,
+    verbose: Boolean,
+    prefix: String = "",
+    addSuffix: Boolean = false,
+    maxFields: Int,
+    printNodeId: Boolean,
+    indent: Int = 0): Unit = {
+      super.generateTreeString(depth, lastChildren, append, verbose, prefix, addSuffix,
+        maxFields, printNodeId, indent)
+      // SPARK-42753 Recursively append subtree of the child if that child is an UNKNOWN child
+      // whereby that child has not been printed anywhere else
+      if (this.getTagValue(UNKNOWN_CHILD_ID).isDefined) {
+        child.generateTreeString(
+          depth + 1, lastChildren :+ true, append, verbose, prefix, addSuffix,
+          maxFields, printNodeId = printNodeId, indent = indent)
+      }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -105,7 +105,8 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
     indent: Int = 0): Unit = {
       super.generateTreeString(depth, lastChildren, append, verbose, prefix, addSuffix,
         maxFields, printNodeId, indent)
-      // Recursively append subtree of the child if that child has not been appended anywhere else
+      // SPARK-42753 Recursively append subtree of the child if that child is an UNKNOWN child
+      // whereby that child has not been printed anywhere else
       if (this.getTagValue(UNKNOWN_CHILD_ID).isDefined) {
         child.generateTreeString(
           depth + 1, lastChildren :+ true, append, verbose, prefix, addSuffix,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -22,6 +22,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -47,6 +48,7 @@ abstract class Exchange extends UnaryExecNode {
  */
 case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchange)
   extends LeafExecNode {
+  val UNKNOWN_CHILD_ID = TreeNodeTag[Unit]("UNKNOWN_CHILD_ID")
 
   override def supportsColumnar: Boolean = child.supportsColumnar
 
@@ -89,5 +91,25 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
        |$formattedNodeName [Reuses operator id: $reuse_op_str]
        |${ExplainUtils.generateFieldString("Output", output)}
        |""".stripMargin
+  }
+
+  override def generateTreeString(
+    depth: Int,
+    lastChildren: Seq[Boolean],
+    append: String => Unit,
+    verbose: Boolean,
+    prefix: String = "",
+    addSuffix: Boolean = false,
+    maxFields: Int,
+    printNodeId: Boolean,
+    indent: Int = 0): Unit = {
+      super.generateTreeString(depth, lastChildren, append, verbose, prefix, addSuffix,
+        maxFields, printNodeId, indent)
+      // Recursively append subtree of the child if that child has not been appended anywhere else
+      if (this.getTagValue(UNKNOWN_CHILD_ID).isDefined) {
+        child.generateTreeString(
+          depth + 1, lastChildren :+ true, append, verbose, prefix, addSuffix,
+          maxFields, printNodeId = printNodeId, indent = indent)
+      }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -31,8 +31,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * Base class for operators that exchange data among multiple threads or processes.
  *
  * Exchanges are the key class of operators that enable parallelism. Although the implementation
- * differs significantly, the concept is similar to the exchange operator described in
- * "Volcano -- An Extensible and Parallel Query Evaluation System" by Goetz Graefe.
+ * differs significantly, the concept is similar to the exchange operator described in "Volcano --
+ * An Extensible and Parallel Query Evaluation System" by Goetz Graefe.
  */
 abstract class Exchange extends UnaryExecNode {
   override def output: Seq[Attribute] = child.output
@@ -47,7 +47,7 @@ abstract class Exchange extends UnaryExecNode {
  * preserve the original ids because they're what downstream operators are expecting.
  */
 case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchange)
-  extends LeafExecNode {
+    extends LeafExecNode {
   val UNKNOWN_CHILD_ID = TreeNodeTag[Unit]("UNKNOWN_CHILD_ID")
 
   override def supportsColumnar: Boolean = child.supportsColumnar
@@ -71,9 +71,10 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
   // to update the attribute ids in `outputPartitioning` and `outputOrdering`.
   private[sql] lazy val updateAttr: Expression => Expression = {
     val originalAttrToNewAttr = AttributeMap(child.output.zip(output))
-    e => e.transform {
-      case attr: Attribute => originalAttrToNewAttr.getOrElse(attr, attr)
-    }
+    e =>
+      e.transform { case attr: Attribute =>
+        originalAttrToNewAttr.getOrElse(attr, attr)
+      }
   }
 
   override def outputPartitioning: Partitioning = child.outputPartitioning match {
@@ -94,23 +95,38 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
   }
 
   override def generateTreeString(
-    depth: Int,
-    lastChildren: Seq[Boolean],
-    append: String => Unit,
-    verbose: Boolean,
-    prefix: String = "",
-    addSuffix: Boolean = false,
-    maxFields: Int,
-    printNodeId: Boolean,
-    indent: Int = 0): Unit = {
-      super.generateTreeString(depth, lastChildren, append, verbose, prefix, addSuffix,
-        maxFields, printNodeId, indent)
-      // SPARK-42753 Recursively append subtree of the child if that child is an UNKNOWN child
-      // whereby that child has not been printed anywhere else
-      if (this.getTagValue(UNKNOWN_CHILD_ID).isDefined) {
-        child.generateTreeString(
-          depth + 1, lastChildren :+ true, append, verbose, prefix, addSuffix,
-          maxFields, printNodeId = printNodeId, indent = indent)
-      }
+      depth: Int,
+      lastChildren: Seq[Boolean],
+      append: String => Unit,
+      verbose: Boolean,
+      prefix: String = "",
+      addSuffix: Boolean = false,
+      maxFields: Int,
+      printNodeId: Boolean,
+      indent: Int = 0): Unit = {
+    super.generateTreeString(
+      depth,
+      lastChildren,
+      append,
+      verbose,
+      prefix,
+      addSuffix,
+      maxFields,
+      printNodeId,
+      indent)
+    // SPARK-42753 Recursively append subtree of the child if that child is an UNKNOWN child
+    // whereby that child has not been printed anywhere else
+    if (this.getTagValue(UNKNOWN_CHILD_ID).isDefined) {
+      child.generateTreeString(
+        depth + 1,
+        lastChildren :+ true,
+        append,
+        verbose,
+        prefix,
+        addSuffix,
+        maxFields,
+        printNodeId = printNodeId,
+        indent = indent)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -774,7 +774,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
       statistics)
   }
 
-  test("SC-122182: Process subtree for ReusedExchange with unknown child") {
+  test("SPARK-42753: Process subtree for ReusedExchange with unknown child") {
     // Simulate a simplified subtree with a ReusedExchange pointing to an Exchange node that has
     // no ID. This is a rare edge cases that could arise during AQE if there are multiple
     // ReusedExchanges. We check to make sure the child Exchange gets an ID and gets printed

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.plans.physical.UnknownPartitioning
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand
 import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.functions._

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -793,10 +793,23 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
 
     val expectedTree = """|ReusedExchange (1)
                           |+- Exchange (3)
-                          |   +- Range (2)""".stripMargin
+                          |   +- Range (2)
+                          |
+                          |
+                          |(1) ReusedExchange [Reuses operator id: 3]
+                          |Output: []
+                          |
+                          |(2) Range
+                          |Output [1]: [id#xL]
+                          |Arguments: Range (0, 1000, step=1, splits=Some(10))
+                          |
+                          |(3) Exchange
+                          |Input [1]: [id#xL]
+                          |Arguments: UnknownPartitioning(10), ENSURE_REQUIREMENTS, [plan_id=x]
+                          |""".stripMargin
 
-    assert(results.contains(expectedTree))
-    assert(results.contains("(1) ReusedExchange [Reuses operator id: 3]"))
+    results = results.replaceAll("#\\d+", "#x").replaceAll("plan_id=\\d+", "plan_id=x")
+    assert(results == expectedTree)
   }
 
   test("SPARK-42753: Two ReusedExchange Sharing Same Subtree") {
@@ -826,12 +839,12 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
                           |Output: []
                           |
                           |(4) Range
-                          |Output [1]: [id#0L]
+                          |Output [1]: [id#xL]
                           |Arguments: Range (0, 1000, step=1, splits=Some(10))
                           |
                           |(5) Exchange
-                          |Input [1]: [id#0L]
-                          |Arguments: UnknownPartitioning(10), ENSURE_REQUIREMENTS, [plan_id=1]
+                          |Input [1]: [id#xL]
+                          |Arguments: UnknownPartitioning(10), ENSURE_REQUIREMENTS, [plan_id=x]
                           |
                           |(2) ReusedExchange [Reuses operator id: 5]
                           |Output: []
@@ -840,6 +853,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
                           |Join type: Inner
                           |Join condition: None
                           |""".stripMargin
+    results = results.replaceAll("#\\d+", "#x").replaceAll("plan_id=\\d+", "plan_id=x")
     assert(results == expectedTree)
   }
 
@@ -874,29 +888,29 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
                           |Output: []
                           |
                           |(6) Range
-                          |Output [1]: [id#0L]
+                          |Output [1]: [id#xL]
                           |Arguments: Range (0, 1000, step=1, splits=Some(10))
                           |
                           |(7) Exchange
-                          |Input [1]: [id#0L]
-                          |Arguments: UnknownPartitioning(10), ENSURE_REQUIREMENTS, [plan_id=1]
+                          |Input [1]: [id#xL]
+                          |Arguments: UnknownPartitioning(10), ENSURE_REQUIREMENTS, [plan_id=x]
                           |
                           |(2) ReusedExchange [Reuses operator id: 5]
                           |Output: []
                           |
                           |(4) Range
-                          |Output [1]: [id#1L]
+                          |Output [1]: [id#xL]
                           |Arguments: Range (0, 1000, step=1, splits=Some(10))
                           |
                           |(5) Exchange
-                          |Input [1]: [id#1L]
-                          |Arguments: UnknownPartitioning(10), ENSURE_REQUIREMENTS, [plan_id=4]
+                          |Input [1]: [id#xL]
+                          |Arguments: UnknownPartitioning(10), ENSURE_REQUIREMENTS, [plan_id=x]
                           |
                           |(3) SortMergeJoin
                           |Join type: Inner
                           |Join condition: None
                           |""".stripMargin
-
+    results = results.replaceAll("#\\d+", "#x").replaceAll("plan_id=\\d+", "plan_id=x")
     assert(results == expectedTree)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.catalyst.plans.physical.UnknownPartitioning
 import org.apache.spark.sql.catalyst.plans.Inner
+import org.apache.spark.sql.catalyst.plans.physical.UnknownPartitioning
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -46,8 +46,7 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
   }
 
   /**
-   * Get the explain by running the sql. The explain mode should be part of the
-   * sql text itself.
+   * Get the explain by running the sql. The explain mode should be part of the sql text itself.
    */
   protected def withNormalizedExplain(queryText: String)(f: String => Unit) = {
     val output = new java.io.ByteArrayOutputStream()
@@ -62,7 +61,9 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
    * Runs the plan and makes sure the plans contains all of the keywords.
    */
   protected def checkKeywordsExistsInExplain(
-      df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
+      df: DataFrame,
+      mode: ExplainMode,
+      keywords: String*): Unit = {
     withNormalizedExplain(df, mode) { normalizedOutput =>
       for (key <- keywords) {
         assert(normalizedOutput.contains(key))
@@ -78,7 +79,9 @@ trait ExplainSuiteHelper extends QueryTest with SharedSparkSession {
    * Runs the plan and makes sure the plans does not contain any of the keywords.
    */
   protected def checkKeywordsNotExistsInExplain(
-      df: DataFrame, mode: ExplainMode, keywords: String*): Unit = {
+      df: DataFrame,
+      mode: ExplainMode,
+      keywords: String*): Unit = {
     withNormalizedExplain(df, mode) { normalizedOutput =>
       for (key <- keywords) {
         assert(!normalizedOutput.contains(key))
@@ -97,21 +100,23 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
   }
 
   test("SPARK-23034 show rdd names in RDD scan nodes (DataFrame)") {
-    val rddWithName = spark.sparkContext.parallelize(ExplainSingleData(1) :: Nil).setName("testRdd")
+    val rddWithName =
+      spark.sparkContext.parallelize(ExplainSingleData(1) :: Nil).setName("testRdd")
     val df = spark.createDataFrame(rddWithName)
     checkKeywordsExistsInExplain(df, keywords = "Scan testRdd")
   }
 
   test("SPARK-24850 InMemoryRelation string representation does not include cached plan") {
     val df = Seq(1).toDF("a").cache()
-    checkKeywordsExistsInExplain(df,
-      keywords = "InMemoryRelation", "StorageLevel(disk, memory, deserialized, 1 replicas)")
+    checkKeywordsExistsInExplain(
+      df,
+      keywords = "InMemoryRelation",
+      "StorageLevel(disk, memory, deserialized, 1 replicas)")
   }
 
   test("optimized plan should show the rewritten expression") {
     withTempView("test_agg") {
-      sql(
-        """
+      sql("""
           |CREATE TEMPORARY VIEW test_agg AS SELECT * FROM VALUES
           |  (1, true), (1, false),
           |  (2, true),
@@ -123,7 +128,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
       // simple explain of queries having every/some/any aggregates. Optimized
       // plan should show the rewritten aggregate expression.
       val df = sql("SELECT k, every(v), some(v), any(v) FROM test_agg GROUP BY k")
-      checkKeywordsExistsInExplain(df,
+      checkKeywordsExistsInExplain(
+        df,
         "Aggregate [k#x], [k#x, every(v#x) AS every(v)#x, some(v#x) AS some(v)#x, " +
           "any(v#x) AS any(v)#x]")
     }
@@ -131,26 +137,30 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     withTable("t") {
       sql("CREATE TABLE t(col TIMESTAMP) USING parquet")
       val df = sql("SELECT date_part('month', col) FROM t")
-      checkKeywordsExistsInExplain(df,
+      checkKeywordsExistsInExplain(
+        df,
         "Project [month(cast(col#x as date)) AS date_part(month, col)#x]")
     }
   }
 
   test("explain inline tables cross-joins") {
-    val df = sql(
-      """
+    val df = sql("""
         |SELECT * FROM VALUES ('one', 1), ('three', null)
         |  CROSS JOIN VALUES ('one', 1), ('three', null)
       """.stripMargin)
-    checkKeywordsExistsInExplain(df,
+    checkKeywordsExistsInExplain(
+      df,
       "Join Cross",
       ":- LocalRelation [col1#x, col2#x]",
       "+- LocalRelation [col1#x, col2#x]")
   }
 
   test("explain table valued functions") {
-    checkKeywordsExistsInExplain(sql("select * from RaNgE(2)"), "Range (0, 2, step=1, splits=None)")
-    checkKeywordsExistsInExplain(sql("SELECT * FROM range(3) CROSS JOIN range(3)"),
+    checkKeywordsExistsInExplain(
+      sql("select * from RaNgE(2)"),
+      "Range (0, 2, step=1, splits=None)")
+    checkKeywordsExistsInExplain(
+      sql("SELECT * FROM range(3) CROSS JOIN range(3)"),
       "Join Cross",
       ":- Range (0, 3, step=1, splits=None)",
       "+- Range (0, 3, step=1, splits=None)")
@@ -160,25 +170,23 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     checkKeywordsExistsInExplain(
       sql("SELECT * FROM VALUES (0, 1) AS (a, b), LATERAL (SELECT a)"),
       "LateralJoin lateral-subquery#x [a#x], Inner",
-      "Project [outer(a#x) AS a#x]"
-    )
+      "Project [outer(a#x) AS a#x]")
   }
 
   test("explain string functions") {
     // Check if catalyst combine nested `Concat`s
-    val df1 = sql(
-      """
+    val df1 = sql("""
         |SELECT (col1 || col2 || col3 || col4) col
         |  FROM (SELECT id col1, id col2, id col3, id col4 FROM range(10))
       """.stripMargin)
-    checkKeywordsExistsInExplain(df1,
+    checkKeywordsExistsInExplain(
+      df1,
       "Project [concat(cast(id#xL as string), cast(id#xL as string), cast(id#xL as string)" +
         ", cast(id#xL as string)) AS col#x]")
 
     // Check if catalyst combine nested `Concat`s if concatBinaryAsString=false
     withSQLConf(SQLConf.CONCAT_BINARY_AS_STRING.key -> "false") {
-      val df2 = sql(
-        """
+      val df2 = sql("""
           |SELECT ((col1 || col2) || (col3 || col4)) col
           |FROM (
           |  SELECT
@@ -189,13 +197,13 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
           |  FROM range(10)
           |)
         """.stripMargin)
-      checkKeywordsExistsInExplain(df2,
+      checkKeywordsExistsInExplain(
+        df2,
         "Project [concat(cast(id#xL as string), cast((id#xL + 1) as string), " +
           "cast(encode(cast((id#xL + 2) as string), utf-8) as string), " +
           "cast(encode(cast((id#xL + 3) as string), utf-8) as string)) AS col#x]")
 
-      val df3 = sql(
-        """
+      val df3 = sql("""
           |SELECT (col1 || (col3 || col4)) col
           |FROM (
           |  SELECT
@@ -205,7 +213,8 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
           |  FROM range(10)
           |)
         """.stripMargin)
-      checkKeywordsExistsInExplain(df3,
+      checkKeywordsExistsInExplain(
+        df3,
         "Project [concat(cast(id#xL as string), " +
           "cast(encode(cast((id#xL + 2) as string), utf-8) as string), " +
           "cast(encode(cast((id#xL + 3) as string), utf-8) as string)) AS col#x]")
@@ -226,29 +235,39 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     // AND                                               conjunction
     // OR                                                disjunction
     // ---------------------------------------------------------------------------------------
-    checkKeywordsExistsInExplain(sql("select '1' || 1 + 2"),
-      "Project [13", " AS (concat(1, 1) + 2)#x")
-    checkKeywordsExistsInExplain(sql("select 1 - 2 || 'b'"),
+    checkKeywordsExistsInExplain(
+      sql("select '1' || 1 + 2"),
+      "Project [13",
+      " AS (concat(1, 1) + 2)#x")
+    checkKeywordsExistsInExplain(
+      sql("select 1 - 2 || 'b'"),
       "Project [-1b AS concat((1 - 2), b)#x]")
-    checkKeywordsExistsInExplain(sql("select 2 * 4  + 3 || 'b'"),
+    checkKeywordsExistsInExplain(
+      sql("select 2 * 4  + 3 || 'b'"),
       "Project [11b AS concat(((2 * 4) + 3), b)#x]")
-    checkKeywordsExistsInExplain(sql("select 3 + 1 || 'a' || 4 / 2"),
+    checkKeywordsExistsInExplain(
+      sql("select 3 + 1 || 'a' || 4 / 2"),
       "Project [4a2.0 AS concat(concat((3 + 1), a), (4 / 2))#x]")
-    checkKeywordsExistsInExplain(sql("select 1 == 1 OR 'a' || 'b' ==  'ab'"),
+    checkKeywordsExistsInExplain(
+      sql("select 1 == 1 OR 'a' || 'b' ==  'ab'"),
       "Project [true AS ((1 = 1) OR (concat(a, b) = ab))#x]")
-    checkKeywordsExistsInExplain(sql("select 'a' || 'c' == 'ac' AND 2 == 3"),
+    checkKeywordsExistsInExplain(
+      sql("select 'a' || 'c' == 'ac' AND 2 == 3"),
       "Project [false AS ((concat(a, c) = ac) AND (2 = 3))#x]")
   }
 
   test("explain for these functions; use range to avoid constant folding") {
-    val df = sql("select ifnull(id, 1), nullif(id, 1), nvl(id, 1), nvl2(id, 1, 2) " +
-      "from range(2)")
-    checkKeywordsExistsInExplain(df,
+    val df = sql(
+      "select ifnull(id, 1), nullif(id, 1), nvl(id, 1), nvl2(id, 1, 2) " +
+        "from range(2)")
+    checkKeywordsExistsInExplain(
+      df,
       "Project [id#xL AS ifnull(id, 1)#xL, if ((id#xL = 1)) null " +
         "else id#xL AS nullif(id, 1)#xL, id#xL AS nvl(id, 1)#xL, 1 AS nvl2(id, 1, 2)#x]")
   }
 
-  test("SPARK-26659: explain of DataWritingCommandExec should not contain duplicate cmd.nodeName") {
+  test(
+    "SPARK-26659: explain of DataWritingCommandExec should not contain duplicate cmd.nodeName") {
     withTable("temptable") {
       val df = sql("create table temptable using parquet as select * from range(2)")
       withNormalizedExplain(df, SimpleMode) { normalizedOutput =>
@@ -280,48 +299,52 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
 
   test("explain formatted - check presence of subquery in case of DPP") {
     withTable("df1", "df2") {
-      withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+      withSQLConf(
+        SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
         SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
         SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
-          spark.range(1000).select(col("id"), col("id").as("k"))
-            .write
-            .partitionBy("k")
-            .format("parquet")
-            .mode("overwrite")
-            .saveAsTable("df1")
+        spark
+          .range(1000)
+          .select(col("id"), col("id").as("k"))
+          .write
+          .partitionBy("k")
+          .format("parquet")
+          .mode("overwrite")
+          .saveAsTable("df1")
 
-          spark.range(100)
-            .select(col("id"), col("id").as("k"))
-            .write
-            .partitionBy("k")
-            .format("parquet")
-            .mode("overwrite")
-            .saveAsTable("df2")
+        spark
+          .range(100)
+          .select(col("id"), col("id").as("k"))
+          .write
+          .partitionBy("k")
+          .format("parquet")
+          .mode("overwrite")
+          .saveAsTable("df2")
 
-          val sqlText =
-            """
+        val sqlText =
+          """
               |EXPLAIN FORMATTED SELECT df1.id, df2.k
               |FROM df1 JOIN df2 ON df1.k = df2.k AND df2.id < 2
               |""".stripMargin
 
-          val expected_pattern1 =
-            "Subquery:1 Hosting operator id = 1 Hosting Expression = k#xL IN subquery#x"
-          val expected_pattern2 =
-            "PartitionFilters: \\[isnotnull\\(k#xL\\), dynamicpruningexpression\\(k#xL " +
-              "IN subquery#x\\)\\]"
-          val expected_pattern3 =
-            "Location: InMemoryFileIndex \\[\\S*org.apache.spark.sql.ExplainSuite" +
-              "/df2/\\S*, ... 99 entries\\]"
-          val expected_pattern4 =
-            "Location: InMemoryFileIndex \\[\\S*org.apache.spark.sql.ExplainSuite" +
-              "/df1/\\S*, ... 999 entries\\]"
-          withNormalizedExplain(sqlText) { normalizedOutput =>
-            assert(expected_pattern1.r.findAllMatchIn(normalizedOutput).length == 1)
-            assert(expected_pattern2.r.findAllMatchIn(normalizedOutput).length == 1)
-            assert(expected_pattern3.r.findAllMatchIn(normalizedOutput).length == 2)
-            assert(expected_pattern4.r.findAllMatchIn(normalizedOutput).length == 1)
-          }
+        val expected_pattern1 =
+          "Subquery:1 Hosting operator id = 1 Hosting Expression = k#xL IN subquery#x"
+        val expected_pattern2 =
+          "PartitionFilters: \\[isnotnull\\(k#xL\\), dynamicpruningexpression\\(k#xL " +
+            "IN subquery#x\\)\\]"
+        val expected_pattern3 =
+          "Location: InMemoryFileIndex \\[\\S*org.apache.spark.sql.ExplainSuite" +
+            "/df2/\\S*, ... 99 entries\\]"
+        val expected_pattern4 =
+          "Location: InMemoryFileIndex \\[\\S*org.apache.spark.sql.ExplainSuite" +
+            "/df1/\\S*, ... 999 entries\\]"
+        withNormalizedExplain(sqlText) { normalizedOutput =>
+          assert(expected_pattern1.r.findAllMatchIn(normalizedOutput).length == 1)
+          assert(expected_pattern2.r.findAllMatchIn(normalizedOutput).length == 1)
+          assert(expected_pattern3.r.findAllMatchIn(normalizedOutput).length == 2)
+          assert(expected_pattern4.r.findAllMatchIn(normalizedOutput).length == 1)
         }
+      }
     }
   }
 
@@ -349,9 +372,10 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
 
     val simpleExplainOutput = getNormalizedExplain(testDf, SimpleMode)
     assert(simpleExplainOutput.startsWith("== Physical Plan =="))
-    Seq("== Parsed Logical Plan ==",
-        "== Analyzed Logical Plan ==",
-        "== Optimized Logical Plan ==").foreach { planType =>
+    Seq(
+      "== Parsed Logical Plan ==",
+      "== Analyzed Logical Plan ==",
+      "== Optimized Logical Plan ==").foreach { planType =>
       assert(!simpleExplainOutput.contains(planType))
     }
     checkKeywordsExistsInExplain(
@@ -386,8 +410,11 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     val token = "MyToken"
     val value = "value"
     val options = Map("password" -> password, "token" -> token, "key" -> value)
-    val cmd = SaveIntoDataSourceCommand(spark.range(10).logicalPlan, new TestOptionsSource,
-      options, SaveMode.Overwrite)
+    val cmd = SaveIntoDataSourceCommand(
+      spark.range(10).logicalPlan,
+      new TestOptionsSource,
+      options,
+      SaveMode.Overwrite)
 
     Seq(SimpleMode, ExtendedMode, FormattedMode).foreach { mode =>
       checkKeywordsExistsInExplain(cmd, mode, value)
@@ -423,8 +450,9 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
   test("Dataset.toExplainString has mode as string") {
     val df = spark.range(10).toDF
     def assertExplainOutput(mode: ExplainMode): Unit = {
-      assert(df.queryExecution.explainString(mode).replaceAll("#\\d+", "#x").trim ===
-        getNormalizedExplain(df, mode).trim)
+      assert(
+        df.queryExecution.explainString(mode).replaceAll("#\\d+", "#x").trim ===
+          getNormalizedExplain(df, mode).trim)
     }
     assertExplainOutput(SimpleMode)
     assertExplainOutput(ExtendedMode)
@@ -440,17 +468,23 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
 
   test("SPARK-31504: Output fields in formatted Explain should have determined order") {
     withTempPath { path =>
-      spark.range(10).selectExpr("id as a", "id as b", "id as c", "id as d", "id as e")
-        .write.mode("overwrite").parquet(path.getAbsolutePath)
+      spark
+        .range(10)
+        .selectExpr("id as a", "id as b", "id as c", "id as d", "id as e")
+        .write
+        .mode("overwrite")
+        .parquet(path.getAbsolutePath)
       val df1 = spark.read.parquet(path.getAbsolutePath)
       val df2 = spark.read.parquet(path.getAbsolutePath)
-      assert(getNormalizedExplain(df1, FormattedMode) === getNormalizedExplain(df2, FormattedMode))
+      assert(
+        getNormalizedExplain(df1, FormattedMode) === getNormalizedExplain(df2, FormattedMode))
     }
   }
 
   test("Coalesced bucket info should be a part of explain string") {
     withTable("t1", "t2") {
-      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0",
+      withSQLConf(
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0",
         SQLConf.COALESCE_BUCKETS_IN_JOIN_ENABLED.key -> "true") {
         Seq(1, 2).toDF("i").write.bucketBy(8, "i").saveAsTable("t1")
         Seq(2, 3).toDF("i").write.bucketBy(4, "i").saveAsTable("t2")
@@ -482,21 +516,23 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
              |ReadSchema: struct\\<value:int\\>
              |""".stripMargin.trim
 
-        spark.range(10)
+        spark
+          .range(10)
           .select(col("id"), col("id").as("value"))
-          .write.option("header", true)
+          .write
+          .option("header", true)
           .partitionBy("id")
           .format(fmt)
           .save(basePath)
         val readSchema =
           StructType(Seq(StructField("id", IntegerType), StructField("value", IntegerType)))
         withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
-          val df = spark
-            .read
+          val df = spark.read
             .schema(readSchema)
             .option("header", true)
             .format(fmt)
-            .load(basePath).where($"id" > 1 && $"value" > 2)
+            .load(basePath)
+            .where($"id" > 1 && $"value" > 2)
           val normalizedOutput = getNormalizedExplain(df, FormattedMode)
           assert(expectedPlanFragment.r.findAllMatchIn(normalizedOutput).length == 1)
         }
@@ -608,8 +644,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
         |(21) AdaptiveSparkPlan
         |Output [4]: [k#x, count(v1)#xL, sum(v1)#xL, avg(v2)#x]
         |Arguments: isFinalPlan=true
-        |""".stripMargin
-    )
+        |""".stripMargin)
     checkKeywordsNotExistsInExplain(testDf, FormattedMode, "unknown")
   }
 
@@ -629,7 +664,9 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
 
   test("SPARK-35884: Explain formatted with subquery") {
     withTempView("t1", "t2") {
-      spark.range(100).select($"id" % 10 as "key", $"id" as "value")
+      spark
+        .range(100)
+        .select($"id" % 10 as "key", $"id" as "value")
         .createOrReplaceTempView("t1")
       spark.range(10).createOrReplaceTempView("t2")
       val query =
@@ -640,7 +677,9 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
           |""".stripMargin
       val df = sql(query).toDF()
       df.collect()
-      checkKeywordsExistsInExplain(df, FormattedMode,
+      checkKeywordsExistsInExplain(
+        df,
+        FormattedMode,
         """
           |(2) Filter [codegen id : 2]
           |Input [1]: [id#xL]
@@ -666,8 +705,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
           |(20) AdaptiveSparkPlan
           |Output [1]: [max(id)#xL]
           |Arguments: isFinalPlan=true
-          |""".stripMargin
-      )
+          |""".stripMargin)
       checkKeywordsNotExistsInExplain(df, FormattedMode, "unknown")
     }
   }
@@ -707,9 +745,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
       val df2 = spark.table("t2")
 
       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
-        checkKeywordsExistsInExplain(
-          df1.join(df2, df1("i") === df2("i")),
-          "Bucketed: true")
+        checkKeywordsExistsInExplain(df1.join(df2, df1("i") === df2("i")), "Bucketed: true")
       }
 
       withSQLConf(SQLConf.BUCKETING_ENABLED.key -> "false") {
@@ -718,11 +754,9 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
           "Bucketed: false (disabled by configuration)")
       }
 
-      checkKeywordsExistsInExplain(df1, "Bucketed: false (disabled by query planner)" )
+      checkKeywordsExistsInExplain(df1, "Bucketed: false (disabled by query planner)")
 
-      checkKeywordsExistsInExplain(
-        df1.select("j"),
-        "Bucketed: false (bucket column(s) not read)")
+      checkKeywordsExistsInExplain(df1.select("j"), "Bucketed: false (bucket column(s) not read)")
     }
   }
 
@@ -762,23 +796,18 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
     val df = Seq(1, 2).toDF("c").distinct()
     val statistics = "Statistics(sizeInBytes=32.0 B, rowCount=2)"
 
-    checkKeywordsNotExistsInExplain(
-      df,
-      FormattedMode,
-      statistics)
+    checkKeywordsNotExistsInExplain(df, FormattedMode, statistics)
 
     df.collect()
-    checkKeywordsExistsInExplain(
-      df,
-      FormattedMode,
-      statistics)
+    checkKeywordsExistsInExplain(df, FormattedMode, statistics)
   }
 
   test("SPARK-42753: Process subtree for ReusedExchange with unknown child") {
     // Simulate a simplified subtree with a ReusedExchange pointing to an Exchange node that has
     // no ID. This is a rare edge cases that could arise during AQE if there are multiple
     // ReusedExchanges. We check to make sure the child Exchange gets an ID and gets printed
-    val exchange = ShuffleExchangeExec(UnknownPartitioning(10),
+    val exchange = ShuffleExchangeExec(
+      UnknownPartitioning(10),
       RangeExec(org.apache.spark.sql.catalyst.plans.logical.Range(0, 1000, 1, 10)))
     val reused = ReusedExchangeExec(Seq.empty, exchange)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR addresses a rare bug with the EXPLAIN function and Spark UI that can happen when AQE takes effect with multiple ReusedExchange nodes. The bug causes the ReusedExchange to point to an unknown child since that child subtree was "pruned" in a previous AQE iteration. 

This PR fixes the issue by finding all the ReusedExchange nodes in the tree that have a `child` node that has NOT been processed in the final plan (meaning it has no ID or it has an incorrect ID generated from the previous AQE iteration). It then traverses the child subtree and generates correct IDs for them. We print this missing subtree in a new section called `Adaptively Optimized Out Exchanges`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


Below is an example to demonstrate the root cause:

> AdaptiveSparkPlan
>   |-- SomeNode X (subquery xxx)
>       |-- Exchange A
>           |-- SomeNode Y
>               |-- Exchange B
> 
> Subquery:Hosting operator = SomeNode Hosting Expression = xxx dynamicpruning#388
> AdaptiveSparkPlan
>   |-- SomeNode M
>       |-- Exchange C
>           |-- SomeNode N
>               |-- Exchange D
> 

Step 1: Exchange B is materialized and the QueryStage is added to stage cache

Step 2: Exchange D reuses Exchange B

Step 3: Exchange C is materialized and the QueryStage is added to stage cache

Step 4: Exchange A reuses Exchange C

Then the final plan looks like:

> AdaptiveSparkPlan
>   |-- SomeNode X (subquery xxx)
>       |-- Exchange A -> ReusedExchange (reuses Exchange C)
> 
> 
> Subquery:Hosting operator = SomeNode Hosting Expression = xxx dynamicpruning#388
> AdaptiveSparkPlan
>   |-- SomeNode M
>       |-- Exchange C -> PhotonShuffleMapStage ....
>           |-- SomeNode N
>               |-- Exchange D -> ReusedExchange (reuses Exchange B)
> 

As a result, the ReusedExchange (reuses Exchange B) will refer to a non-exist node.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


**Explain Text Before and After**
**Before:**
```
+- ReusedExchange (105)

(105) ReusedExchange [Reuses operator id: unknown]
Output [3]: [sr_customer_sk#303, sr_store_sk#307, sum#413L]
```

**After:**
```
+- ReusedExchange (105)
   +- Exchange (132)
      +- * HashAggregate (131)
         +- * Project (130)
            +- * BroadcastHashJoin Inner BuildRight (129)
               :- * Filter (128)
               :  +- * ColumnarToRow (127)
               :     +- Scan parquet hive_metastore.tpcds_sf1000_delta.store_returns (126)
               +- ShuffleQueryStage (115), Statistics(sizeInBytes=5.7 KiB, rowCount=366, [d_date_sk#234 -> ColumnStat(Some(362),Some(2415022),Some(2488070),Some(0),Some(4),Some(4),None,2)], isRuntime=true)
                  +- ReusedExchange (114)


(105) ReusedExchange [Reuses operator id: 132]
Output [3]: [sr_customer_sk#217, sr_store_sk#221, sum#327L]

(126) Scan parquet hive_metastore.tpcds_sf1000_delta.store_returns
Output [4]: [sr_customer_sk#217, sr_store_sk#221, sr_return_amt#225, sr_returned_date_sk#214]
Batched: true
Location: PreparedDeltaFileIndex [dbfs:/mnt/performance-datasets/2018TPC/tpcds-2.4/sf1000_delta/store_returns]
PartitionFilters: [isnotnull(sr_returned_date_sk#214), dynamicpruningexpression(sr_returned_date_sk#214 IN dynamicpruning#329)]
PushedFilters: [IsNotNull(sr_store_sk)]
ReadSchema: struct<sr_customer_sk:int,sr_store_sk:int,sr_return_amt:decimal(7,2)>

(127) ColumnarToRow
Input [4]: [sr_customer_sk#217, sr_store_sk#221, sr_return_amt#225, sr_returned_date_sk#214]

(128) Filter
Input [4]: [sr_customer_sk#217, sr_store_sk#221, sr_return_amt#225, sr_returned_date_sk#214]
Condition : isnotnull(sr_store_sk#221)

(114) ReusedExchange [Reuses operator id: 8]
Output [1]: [d_date_sk#234]

(115) ShuffleQueryStage
Output [1]: [d_date_sk#234]
Arguments: 2, Statistics(sizeInBytes=5.7 KiB, rowCount=366, [d_date_sk#234 -> ColumnStat(Some(362),Some(2415022),Some(2488070),Some(0),Some(4),Some(4),None,2)], isRuntime=true)

(129) BroadcastHashJoin
Left keys [1]: [sr_returned_date_sk#214]
Right keys [1]: [d_date_sk#234]
Join type: Inner
Join condition: None

(130) Project
Output [3]: [sr_customer_sk#217, sr_store_sk#221, sr_return_amt#225]
Input [5]: [sr_customer_sk#217, sr_store_sk#221, sr_return_amt#225, sr_returned_date_sk#214, d_date_sk#234]

(131) HashAggregate
Input [3]: [sr_customer_sk#217, sr_store_sk#221, sr_return_amt#225]
Keys [2]: [sr_customer_sk#217, sr_store_sk#221]
Functions [1]: [partial_sum(UnscaledValue(sr_return_amt#225)) AS sum#327L]
Aggregate Attributes [1]: [sum#326L]
Results [3]: [sr_customer_sk#217, sr_store_sk#221, sum#327L]

(132) Exchange
Input [3]: [sr_customer_sk#217, sr_store_sk#221, sum#327L]
Arguments: hashpartitioning(sr_store_sk#221, 200), ENSURE_REQUIREMENTS, [plan_id=1791]
```

**Spark UI Before and After**

**Before:**
<img width="339" alt="Screenshot 2023-03-10 at 10 52 46 AM" src="https://user-images.githubusercontent.com/83618776/224406011-e622ad11-37e6-48c6-b556-cd5c7708e237.png">

**After:**
![image](https://user-images.githubusercontent.com/83618776/224406076-4fcbf918-2a8d-4776-b91a-36815752cf2a.png)


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit tests were added to `ExplainSuite`. And manually tested with ExplainSuite.