### PR TITLE
[MINOR][SQL][FOLLOWUP] Fix scalastyle in LimitPushDownThroughWindow

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushDownThroughWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushDownThroughWindow.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.{LIMIT, WINDOW}
  * }}}
  */
 object LimitPushDownThroughWindow extends Rule[LogicalPlan] {
-  // The window frame of Rank, DenseRank and RowNumber can only be UNBOUNDED PRECEDING to CURRENT ROW.
+  // The window frame of Rank, DenseRank and RowNumber can only be UNBOUNDED PRECEDING to
+  // CURRENT ROW.
   private def supportsPushdownThroughWindow(
       windowExpressions: Seq[NamedExpression]): Boolean = windowExpressions.forall {
     case Alias(WindowExpression(_: Rank | _: DenseRank | _: RowNumber, WindowSpecDefinition(Nil, _,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Although this is weird because of `[MINOR][SQL][FOLLOWUP]'. This PR aims to recover the CI failure on the master branch from the following commit.

https://github.com/apache/spark/commit/c75b3ab6f608037b6e210d60e29392f59d113a8a

### Why are the changes needed?

- https://github.com/apache/spark/actions/runs/4397853036

![Screenshot 2023-03-12 at 1 23 49 PM](https://user-images.githubusercontent.com/9700541/224571434-55a3b27f-619a-4c28-83b8-25c5657c7ee7.png)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.