### PR TITLE
[SPARK-42764][K8S] Parameterize the max number of attempts for driver props fetcher in KubernetesExecutorBackend

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
@@ -82,7 +82,7 @@ private[spark] object KubernetesExecutorBackend extends Logging {
         clientMode = true)
 
       var driver: RpcEndpointRef = null
-      val nTries = sys.env.getOrElse("EXECUTOR_DRIVER_PROPS_FETCHER_MAX_ATTEMPTS", 3).toInt
+      val nTries = sys.env.getOrElse("EXECUTOR_DRIVER_PROPS_FETCHER_MAX_ATTEMPTS", "3").toInt
       for (i <- 0 until nTries if driver == null) {
         try {
           driver = fetcher.setupEndpointRefByURI(arguments.driverUrl)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
@@ -82,7 +82,7 @@ private[spark] object KubernetesExecutorBackend extends Logging {
         clientMode = true)
 
       var driver: RpcEndpointRef = null
-      val nTries = sys.env.getOrElse("EXECUTOR_DRIVER_PROPS_FETCHER_MAX_ATTEMPTS", 3)
+      val nTries = sys.env.getOrElse("EXECUTOR_DRIVER_PROPS_FETCHER_MAX_ATTEMPTS", 3).toInt
       for (i <- 0 until nTries if driver == null) {
         try {
           driver = fetcher.setupEndpointRefByURI(arguments.driverUrl)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
@@ -82,7 +82,7 @@ private[spark] object KubernetesExecutorBackend extends Logging {
         clientMode = true)
 
       var driver: RpcEndpointRef = null
-      val nTries = 3
+      val nTries = sys.env.getOrElse("EXECUTOR_DRIVER_PROPS_FETCHER_MAX_ATTEMPTS", 3)
       for (i <- 0 until nTries if driver == null) {
         try {
           driver = fetcher.setupEndpointRefByURI(arguments.driverUrl)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to parameterize the max number of attempts for driver props fetcher in `KubernetesExecutorBackend` by introducing a new environment variable, `EXECUTOR_DRIVER_PROPS_FETCHER_MAX_ATTEMPTS`, for testing purpose.

Note that this feature is proposed as a new environment variable because this happens before getting `SparkConf` from the driver.

### Why are the changes needed?

In case of K8s network issues, the executor pods could fail with `UnknownHostException`. `EXECUTOR_DRIVER_PROPS_FETCHER_MAX_ATTEMPTS` could be helpful in that case.
```
Caused by: java.io.IOException: Failed to connect to pi-....svc/<unresolved>:7078
Caused by: java.net.UnknownHostException: pi-....svc
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.