### PR TITLE
[SPARK-42765][CONNECT][PYTHON] Enable importing `pandas_udf` from `pyspark.sql.connect.functions`

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2467,6 +2467,8 @@ udf.__doc__ = pysparkfuncs.udf.__doc__
 
 
 def pandas_udf(*args: Any, **kwargs: Any) -> None:
+    # The implementation of pandas_udf is embedded in pyspark.sql.function.pandas_udf
+    # for code reuse.
     raise NotImplementedError("Please import pandas_udf from pyspark.sql.functions.")
 
 

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -54,6 +54,11 @@ from pyspark.sql.connect.udf import _create_udf
 from pyspark.sql import functions as pysparkfuncs
 from pyspark.sql.types import _from_numpy_type, DataType, StructType, ArrayType, StringType
 
+# The implementation of pandas_udf is embedded in pyspark.sql.function.pandas_udf
+# for code reuse.
+from pyspark.sql.functions import pandas_udf as pandas_udf
+
+
 if TYPE_CHECKING:
     from pyspark.sql.connect._typing import (
         ColumnOrName,
@@ -2464,12 +2469,6 @@ def udf(
 
 
 udf.__doc__ = pysparkfuncs.udf.__doc__
-
-
-def pandas_udf(*args: Any, **kwargs: Any) -> None:
-    # The implementation of pandas_udf is embedded in pyspark.sql.function.pandas_udf
-    # for code reuse.
-    raise NotImplementedError("Please import pandas_udf from pyspark.sql.functions.")
 
 
 def _test() -> None:

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2467,7 +2467,7 @@ udf.__doc__ = pysparkfuncs.udf.__doc__
 
 
 def pandas_udf(*args: Any, **kwargs: Any) -> None:
-    raise NotImplementedError("pandas_udf() is not implemented.")
+    raise NotImplementedError("Please import pandas_udf from pyspark.sql.functions.")
 
 
 def _test() -> None:

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -56,7 +56,7 @@ from pyspark.sql.types import _from_numpy_type, DataType, StructType, ArrayType,
 
 # The implementation of pandas_udf is embedded in pyspark.sql.function.pandas_udf
 # for code reuse.
-from pyspark.sql.functions import pandas_udf as pandas_udf
+from pyspark.sql.functions import pandas_udf  # noqa: F401
 
 
 if TYPE_CHECKING:

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -2393,14 +2393,13 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
             sdf.withColumn("A", sfun(sdf.c)).toPandas(),
         )
 
-    def test_unsupported_functions(self):
-        # SPARK-41928: Disable unsupported functions.
-
+    def test_pandas_udf_import(self):
         from pyspark.sql.connect import functions as CF
 
-        for f in ("pandas_udf",):
-            with self.assertRaises(NotImplementedError):
-                getattr(CF, f)()
+        with self.assertRaisesRegex(
+            NotImplementedError, "Please import pandas_udf from pyspark.sql.functions"
+        ):
+            getattr(CF, "pandas_udf")()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -2395,11 +2395,9 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
     def test_pandas_udf_import(self):
         from pyspark.sql.connect import functions as CF
+        from pyspark.sql import functions as SF
 
-        with self.assertRaisesRegex(
-            NotImplementedError, "Please import pandas_udf from pyspark.sql.functions"
-        ):
-            getattr(CF, "pandas_udf")()
+        self.assert_eq(getattr(CF, "pandas_udf"), getattr(SF, "pandas_udf"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable users to import pandas_udf via `pyspark.sql.connect.functions.pandas_udf`.
Previously, only `pyspark.sql.functions.pandas_udf` is supported.

### Why are the changes needed?
Usability.

### Does this PR introduce _any_ user-facing change?
Yes. Now users can import pandas_udf via `pyspark.sql.connect.functions.pandas_udf`.

Previously only `pyspark.sql.functions.pandas_udf` is supported in Connect; importing `pyspark.sql.connect.functions.pandas_udf` raises an error instead, as shown below

```sh
>>> pyspark.sql.connect.functions.pandas_udf()
Traceback (most recent call last):
...
NotImplementedError: pandas_udf() is not implemented.
```

Now, `pyspark.sql.connect.functions.pandas_udf` point to `pyspark.sql.functions.pandas_udf`, as shown below,
```sh
>>> from pyspark.sql.connect import functions as CF
>>> from pyspark.sql import functions as SF
>>> getattr(CF, "pandas_udf")
<function pandas_udf at 0x7f9c88812700>
>>> getattr(SF, "pandas_udf")
<function pandas_udf at 0x7f9c88812700>
```

### How was this patch tested?
Unit test.

SPARK-41661