### PR TITLE
[SPARK-42769][K8S] Add `SPARK_DRIVER_POD_IP` env variable to executor pods

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Constants.scala
@@ -54,6 +54,7 @@ private[spark] object Constants {
   val UI_PORT_NAME = "spark-ui"
 
   // Environment Variables
+  val ENV_DRIVER_POD_IP = "SPARK_DRIVER_POD_IP"
   val ENV_DRIVER_URL = "SPARK_DRIVER_URL"
   val ENV_EXECUTOR_CORES = "SPARK_EXECUTOR_CORES"
   val ENV_EXECUTOR_MEMORY = "SPARK_EXECUTOR_MEMORY"

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -81,6 +81,7 @@ case "$1" in
     CMD=(
       "$SPARK_HOME/bin/spark-submit"
       --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --conf "spark.executorEnv.SPARK_DRIVER_POD_IP=$SPARK_DRIVER_BIND_ADDRESS"
       --deploy-mode client
       "$@"
     )

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -159,6 +159,15 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
       runSparkRemoteCheckAndVerifyCompletion(appArgs = Array(REMOTE_PAGE_RANK_FILE_NAME))
     }
   }
+
+  test("SPARK-42769: All executor pods have ENV_DRIVER_POD_IP env variable", k8sTestTag) {
+    runSparkPiAndVerifyCompletion(
+      executorPodChecker = (executorPod: Pod) => {
+        doBasicExecutorPodCheck(executorPod)
+        executorPod.getSpec.getContainers.get(0).getEnv.asScala
+          .exists(envVar => envVar.getName == "SPARK_DRIVER_POD_IP")
+      })
+  }
 }
 
 private[spark] object BasicTestsSuite extends SparkFunSuite {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -160,7 +160,7 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
     }
   }
 
-  test("SPARK-42769: All executor pods have ENV_DRIVER_POD_IP env variable", k8sTestTag) {
+  test("SPARK-42769: All executor pods have SPARK_DRIVER_POD_IP env variable", k8sTestTag) {
     runSparkPiAndVerifyCompletion(
       executorPodChecker = (executorPod: Pod) => {
         doBasicExecutorPodCheck(executorPod)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Like `SPARK_EXECUTOR_POD_IP`, this PR aims to add a new environment variable `ENV_DRIVER_POD_IP` to all executor pods.
```bash
$ kubectl get pod pi-exec-1 -oyaml | grep -C1 SPARK_DRIVER_POD_IP
      value: "0"
    - name: SPARK_DRIVER_POD_IP
      value: 10.1.0.99
```

### Why are the changes needed?

This is helpful for some executor pods to connect driver pods via IP.

### Does this PR introduce _any_ user-facing change?

No, this is a new environment variable.

### How was this patch tested?

Pass the CIs with the newly added test case.