### PR TITLE
[SPARK-41359][SQL] Use `PhysicalDataType` instead of DataType in UnsafeRow

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -67,9 +67,7 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
   }
 
   /**
-   *
-   * @param dt
-   * @return
+   * Field types that hold fixed-length, store the value directly in an 8-byte word
    */
   public static boolean isFixedLength(DataType dt) {
     if (dt instanceof UserDefinedType) {
@@ -84,9 +82,7 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
   }
 
   /**
-   *
-   * @param dt
-   * @return
+   * Field types that can be updated in place in UnsafeRows (e.g. we support set() for these types)
    */
   public static boolean isMutable(DataType dt) {
     if (dt instanceof UserDefinedType) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -66,6 +66,11 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
     return ((numFields + 63)/ 64) * 8;
   }
 
+  /**
+   *
+   * @param dt
+   * @return
+   */
   public static boolean isFixedLength(DataType dt) {
     if (dt instanceof UserDefinedType) {
       return isFixedLength(((UserDefinedType<?>) dt).sqlType());
@@ -74,16 +79,21 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
     if (pdt instanceof PhysicalDecimalType) {
       return ((DecimalType) dt).precision() <= Decimal.MAX_LONG_DIGITS();
     } else {
-      return pdt.isPrimitive();
+      return pdt instanceof PhysicalPrimitiveType;
     }
   }
 
+  /**
+   *
+   * @param dt
+   * @return
+   */
   public static boolean isMutable(DataType dt) {
     if (dt instanceof UserDefinedType) {
       return isMutable(((UserDefinedType<?>) dt).sqlType());
     }
     PhysicalDataType pdt = dt.physicalDataType();
-    return pdt.isPrimitive() || pdt instanceof PhysicalDecimalType ||
+    return pdt instanceof PhysicalPrimitiveType || pdt instanceof PhysicalDecimalType ||
       pdt instanceof PhysicalCalendarIntervalType;
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -19,83 +19,52 @@ package org.apache.spark.sql.catalyst.types
 
 import org.apache.spark.sql.types._
 
-sealed abstract class PhysicalDataType{
-  private[sql] def isPrimitive: Boolean
-}
+
+sealed abstract class PhysicalDataType
+
+sealed abstract class PhysicalPrimitiveType extends PhysicalDataType
 
 case class PhysicalArrayType(elementType: DataType, containsNull: Boolean)
-  extends PhysicalDataType {
-  override def isPrimitive: Boolean = false
-}
+  extends PhysicalDataType
 
-class PhysicalBinaryType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = false
-}
+class PhysicalBinaryType() extends PhysicalDataType
 case object PhysicalBinaryType extends PhysicalBinaryType
 
-class PhysicalBooleanType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = true
-}
+class PhysicalBooleanType() extends PhysicalPrimitiveType
 case object PhysicalBooleanType extends PhysicalBooleanType
 
-class PhysicalByteType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = true
-}
+class PhysicalByteType() extends PhysicalPrimitiveType
 case object PhysicalByteType extends PhysicalByteType
 
-class PhysicalCalendarIntervalType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = false
-}
+class PhysicalCalendarIntervalType() extends PhysicalDataType
 case object PhysicalCalendarIntervalType extends PhysicalCalendarIntervalType
 
-case class PhysicalDecimalType(precision: Int, scale: Int) extends PhysicalDataType {
-  override def isPrimitive: Boolean = false
-}
+case class PhysicalDecimalType(precision: Int, scale: Int) extends PhysicalDataType
 
-class PhysicalDoubleType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = true
-}
+class PhysicalDoubleType() extends PhysicalPrimitiveType
 case object PhysicalDoubleType extends PhysicalDoubleType
 
-class PhysicalFloatType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = true
-}
+class PhysicalFloatType() extends PhysicalPrimitiveType
 case object PhysicalFloatType extends PhysicalFloatType
 
-class PhysicalIntegerType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = true
-}
+class PhysicalIntegerType() extends PhysicalPrimitiveType
 case object PhysicalIntegerType extends PhysicalIntegerType
 
-class PhysicalLongType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = true
-}
+class PhysicalLongType() extends PhysicalPrimitiveType
 case object PhysicalLongType extends PhysicalLongType
 
 case class PhysicalMapType(keyType: DataType, valueType: DataType, valueContainsNull: Boolean)
-    extends PhysicalDataType {
-  override def isPrimitive: Boolean = false
-}
+    extends PhysicalDataType
 
-class PhysicalNullType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = true
-}
+class PhysicalNullType() extends PhysicalPrimitiveType
 case object PhysicalNullType extends PhysicalNullType
 
-class PhysicalShortType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = true
-}
+class PhysicalShortType() extends PhysicalPrimitiveType
 case object PhysicalShortType extends PhysicalShortType
 
-class PhysicalStringType() extends PhysicalDataType {
-  override def isPrimitive: Boolean = false
-}
+class PhysicalStringType() extends PhysicalDataType
 case object PhysicalStringType extends PhysicalStringType
 
-case class PhysicalStructType(fields: Array[StructField]) extends PhysicalDataType {
-  override def isPrimitive: Boolean = false
-}
+case class PhysicalStructType(fields: Array[StructField]) extends PhysicalDataType
 
-object UninitializedPhysicalType extends PhysicalDataType {
-  override def isPrimitive: Boolean = false
-}
+object UninitializedPhysicalType extends PhysicalDataType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -23,7 +23,8 @@ sealed abstract class PhysicalDataType{
   private[sql] def isPrimitive: Boolean
 }
 
-case class PhysicalArrayType(elementType: DataType, containsNull: Boolean) extends PhysicalDataType {
+case class PhysicalArrayType(elementType: DataType, containsNull: Boolean)
+  extends PhysicalDataType {
   override def isPrimitive: Boolean = false
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -24,8 +24,7 @@ sealed abstract class PhysicalDataType
 
 sealed abstract class PhysicalPrimitiveType extends PhysicalDataType
 
-case class PhysicalArrayType(elementType: DataType, containsNull: Boolean)
-  extends PhysicalDataType
+case class PhysicalArrayType(elementType: DataType, containsNull: Boolean) extends PhysicalDataType
 
 class PhysicalBinaryType() extends PhysicalDataType
 case object PhysicalBinaryType extends PhysicalBinaryType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/PhysicalDataType.scala
@@ -19,48 +19,82 @@ package org.apache.spark.sql.catalyst.types
 
 import org.apache.spark.sql.types._
 
-sealed abstract class PhysicalDataType
+sealed abstract class PhysicalDataType{
+  private[sql] def isPrimitive: Boolean
+}
 
-case class PhysicalArrayType(elementType: DataType, containsNull: Boolean) extends PhysicalDataType
+case class PhysicalArrayType(elementType: DataType, containsNull: Boolean) extends PhysicalDataType {
+  override def isPrimitive: Boolean = false
+}
 
-class PhysicalBinaryType() extends PhysicalDataType
+class PhysicalBinaryType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = false
+}
 case object PhysicalBinaryType extends PhysicalBinaryType
 
-class PhysicalBooleanType() extends PhysicalDataType
+class PhysicalBooleanType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = true
+}
 case object PhysicalBooleanType extends PhysicalBooleanType
 
-class PhysicalByteType() extends PhysicalDataType
+class PhysicalByteType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = true
+}
 case object PhysicalByteType extends PhysicalByteType
 
-class PhysicalCalendarIntervalType() extends PhysicalDataType
+class PhysicalCalendarIntervalType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = false
+}
 case object PhysicalCalendarIntervalType extends PhysicalCalendarIntervalType
 
-case class PhysicalDecimalType(precision: Int, scale: Int) extends PhysicalDataType
+case class PhysicalDecimalType(precision: Int, scale: Int) extends PhysicalDataType {
+  override def isPrimitive: Boolean = false
+}
 
-class PhysicalDoubleType() extends PhysicalDataType
+class PhysicalDoubleType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = true
+}
 case object PhysicalDoubleType extends PhysicalDoubleType
 
-class PhysicalFloatType() extends PhysicalDataType
+class PhysicalFloatType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = true
+}
 case object PhysicalFloatType extends PhysicalFloatType
 
-class PhysicalIntegerType() extends PhysicalDataType
+class PhysicalIntegerType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = true
+}
 case object PhysicalIntegerType extends PhysicalIntegerType
 
-class PhysicalLongType() extends PhysicalDataType
+class PhysicalLongType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = true
+}
 case object PhysicalLongType extends PhysicalLongType
 
 case class PhysicalMapType(keyType: DataType, valueType: DataType, valueContainsNull: Boolean)
-    extends PhysicalDataType
+    extends PhysicalDataType {
+  override def isPrimitive: Boolean = false
+}
 
-class PhysicalNullType() extends PhysicalDataType
+class PhysicalNullType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = true
+}
 case object PhysicalNullType extends PhysicalNullType
 
-class PhysicalShortType() extends PhysicalDataType
+class PhysicalShortType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = true
+}
 case object PhysicalShortType extends PhysicalShortType
 
-class PhysicalStringType() extends PhysicalDataType
+class PhysicalStringType() extends PhysicalDataType {
+  override def isPrimitive: Boolean = false
+}
 case object PhysicalStringType extends PhysicalStringType
 
-case class PhysicalStructType(fields: Array[StructField]) extends PhysicalDataType
+case class PhysicalStructType(fields: Array[StructField]) extends PhysicalDataType {
+  override def isPrimitive: Boolean = false
+}
 
-object UninitializedPhysicalType extends PhysicalDataType
+object UninitializedPhysicalType extends PhysicalDataType {
+  override def isPrimitive: Boolean = false
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -69,6 +69,19 @@ object DataTypeTestUtils {
     YearMonthIntervalType(YEAR),
     YearMonthIntervalType(MONTH))
 
+  val unsafeRowMutableFieldTypes: Seq[DataType] = Seq(
+    NullType,
+    BooleanType,
+    ShortType,
+    IntegerType,
+    LongType,
+    FloatType,
+    DoubleType,
+    DateType,
+    TimestampType,
+    TimestampNTZType
+  )
+
   /**
    * Instances of all [[NumericType]]s and [[CalendarIntervalType]]
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeTestUtils.scala
@@ -50,7 +50,7 @@ object DataTypeTestUtils {
   val numericTypes: Set[NumericType] = integralType ++ fractionalTypes
 
   // TODO: remove this once we find out how to handle decimal properly in property check
-  val numericTypeWithoutDecimal: Set[DataType] = integralType ++ Set(DoubleType, FloatType)
+  val numericTypeWithoutDecimal: Set[NumericType] = integralType ++ Set(DoubleType, FloatType)
 
   val dayTimeIntervalTypes: Seq[DayTimeIntervalType] = Seq(
     DayTimeIntervalType(DAY),
@@ -91,7 +91,7 @@ object DataTypeTestUtils {
   /**
    * All the types that support ordering
    */
-  val ordered: Set[DataType] = numericTypeWithoutDecimal ++ Set(
+  val ordered: Set[AtomicType] = numericTypeWithoutDecimal ++ Set(
     BooleanType,
     TimestampType,
     TimestampNTZType,
@@ -102,12 +102,12 @@ object DataTypeTestUtils {
   /**
    * All the types that we can use in a property check
    */
-  val propertyCheckSupported: Set[DataType] = ordered
+  val propertyCheckSupported: Set[AtomicType] = ordered
 
   /**
    * Instances of all [[AtomicType]]s.
    */
-  val atomicTypes: Set[DataType] = numericTypes ++ Set(
+  val atomicTypes: Set[AtomicType] = numericTypes ++ Set(
     BinaryType,
     BooleanType,
     DateType,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -17,14 +17,13 @@
 
 package org.apache.spark.sql.hive.execution
 
-import scala.collection.JavaConverters._
 import scala.util.Random
 
 import test.org.apache.spark.sql.MyDoubleAvg
 import test.org.apache.spark.sql.MyDoubleSum
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.expressions.{CodegenObjectFactoryMode, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
 import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hive.test.TestHiveSingleton

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.types.DataTypeTestUtils.dayTimeIntervalTypes
+import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, unsafeRowMutableFieldTypes}
 import org.apache.spark.tags.SlowHiveTest
 import org.apache.spark.unsafe.UnsafeAlignedOffset
 
@@ -891,12 +891,12 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
       FloatType, DoubleType, DecimalType(25, 5), DecimalType(6, 5),
       DateType, TimestampType,
       ArrayType(IntegerType), MapType(StringType, LongType), struct,
-      new TestUDT.MyDenseVectorUDT()) ++ dayTimeIntervalTypes
+      new TestUDT.MyDenseVectorUDT()) ++ dayTimeIntervalTypes ++ unsafeRowMutableFieldTypes
     // Right now, we will use SortAggregate to handle UDAFs.
     // UnsafeRow.mutableFieldTypes.asScala.toSeq will trigger SortAggregate to use
     // UnsafeRow as the aggregation buffer. While, dataTypes will trigger
     // SortAggregate to use a safe row as the aggregation buffer.
-    Seq(dataTypes, UnsafeRow.mutableFieldTypes.asScala.toSeq).foreach { dataTypes =>
+    Seq(dataTypes).foreach { dataTypes =>
       val fields = dataTypes.zipWithIndex.map { case (dataType, index) =>
         StructField(s"col$index", dataType, nullable = true)
       }


### PR DESCRIPTION
What changes were proposed in this pull request?
The main change of this pr is refactor UnsafeRow#isMutable  and UnsafeRow#isFixedLength  method to use PhysicalDataType instead of DataType.

Why are the changes needed?
Simplify type match.

Does this PR introduce any user-facing change?
No

How was this patch tested?
Existing UnsafeRowSuite