### PR TITLE
[SPARK-42784] should still create subDir when the number of subDir in merge dir is less than conf

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -273,7 +273,7 @@ private[spark] class DiskBlockManager(
       Utils.getConfiguredLocalDirs(conf).foreach { rootDir =>
         try {
           val mergeDir = new File(rootDir, mergeDirName)
-          if (!mergeDir.exists()) {
+          if (!mergeDir.exists() || mergeDir.listFiles().length < subDirsPerLocalDir) {
             // This executor does not find merge_manager directory, it will try to create
             // the merge_manager directory and the sub directories.
             logDebug(s"Try to create $mergeDir and its sub dirs since the " +

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -108,8 +108,8 @@ class DiskBlockManagerSuite extends SparkFunSuite {
     assert(Utils.getConfiguredLocalDirs(testConf).map(
       rootDir => new File(rootDir, DiskBlockManager.MERGE_DIRECTORY))
       .filter(mergeDir => mergeDir.exists()).length === 2)
-    // mergeDir0 will be skipped as it already exists
-    assert(mergeDir0.list().length === 0)
+    // mergeDir0 can not be skipped evenif it already exists
+    assert(mergeDir0.list().length === testConf.get(config.DISKSTORE_SUB_DIRECTORIES))
     // Sub directories get created under mergeDir1
     assert(mergeDir1.list().length === testConf.get(config.DISKSTORE_SUB_DIRECTORIES))
   }

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -108,7 +108,7 @@ class DiskBlockManagerSuite extends SparkFunSuite {
     assert(Utils.getConfiguredLocalDirs(testConf).map(
       rootDir => new File(rootDir, DiskBlockManager.MERGE_DIRECTORY))
       .filter(mergeDir => mergeDir.exists()).length === 2)
-    // mergeDir0 can not be skipped evenif it already exists
+    // mergeDir0 can not be skipped even if it already exists
     assert(mergeDir0.list().length === testConf.get(config.DISKSTORE_SUB_DIRECTORIES))
     // Sub directories get created under mergeDir1
     assert(mergeDir1.list().length === testConf.get(config.DISKSTORE_SUB_DIRECTORIES))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixed a minor issue with diskBlockManager after push-based shuffle is enabled


### Why are the changes needed?
this bug will affect the efficiency of push based shuffle


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test
