### PR TITLE
[SPARK-42617][PS] Support `isocalendar` from the pandas 2.0.0

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/indexing.rst
+++ b/python/docs/source/reference/pyspark.pandas/indexing.rst
@@ -338,8 +338,7 @@ Time/date components
    DatetimeIndex.minute
    DatetimeIndex.second
    DatetimeIndex.microsecond
-   DatetimeIndex.week
-   DatetimeIndex.weekofyear
+   DatetimeIndex.isocalendar
    DatetimeIndex.dayofweek
    DatetimeIndex.day_of_week
    DatetimeIndex.weekday

--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -313,8 +313,7 @@ Datetime Properties
    Series.dt.minute
    Series.dt.second
    Series.dt.microsecond
-   Series.dt.week
-   Series.dt.weekofyear
+   Series.dt.isocalendar
    Series.dt.dayofweek
    Series.dt.weekday
    Series.dt.dayofyear

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -121,6 +121,8 @@ class DatetimeMethods:
         """
         Calculate year, week, and day according to the ISO 8601 standard.
 
+            .. versionadded:: 3.5.0
+
         Returns
         -------
         DataFrame
@@ -143,7 +145,7 @@ class DatetimeMethods:
         Name: week, dtype: int64
         """
 
-        return_types = [self._data.index.dtype] + [int, int, int]
+        return_types = [self._data.index.dtype, int, int, int]
 
         def pandas_isocalendar(  # type: ignore[no-untyped-def]
             pdf,

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -121,6 +121,7 @@ class DatetimeMethods:
     def isocalendar(self) -> "ps.DataFrame":
         """
         Calculate year, week, and day according to the ISO 8601 standard.
+
         Returns
         -------
         DataFrame

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -128,7 +128,8 @@ class DatetimeMethods:
         DataFrame
             With columns year, week and day.
 
-        .. note:: Returns have int64 type instead of UInt32 as is in pandas due to UInt32 is not supported by spark
+        .. note:: Returns have int64 type instead of UInt32 as is in pandas due to UInt32
+            is not supported by spark
 
         Examples
         --------

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -125,9 +125,10 @@ class DatetimeMethods:
 
         Returns
         -------
-        Note: Results have int64 type instead of UInt32 as is in pandas due to UInt32 is not supported by spark
         DataFrame
             With columns year, week and day.
+
+        .. note:: Returns have int64 type instead of UInt32 as is in pandas due to UInt32 is not supported by spark
 
         Examples
         --------

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -121,7 +121,7 @@ class DatetimeMethods:
         """
         Calculate year, week, and day according to the ISO 8601 standard.
 
-            .. versionadded:: 3.5.0
+            .. versionadded:: 4.0.0
 
         Returns
         -------

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -139,6 +139,7 @@ class DatetimeMethods:
         2019-12-30     1
         2019-12-31     1
         2020-01-01     1
+        Name: week, dtype: int64
         """
 
         return_types = [self._data.index.dtype] + [int, int, int]

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -28,6 +28,8 @@ from pandas.tseries.offsets import DateOffset
 import pyspark.pandas as ps
 import pyspark.sql.functions as F
 from pyspark.sql.types import DateType, TimestampType, TimestampNTZType, LongType, IntegerType
+from pyspark.pandas import DataFrame
+from pyspark.pandas.config import option_context
 
 
 class DatetimeMethods:
@@ -116,26 +118,50 @@ class DatetimeMethods:
     def nanosecond(self) -> "ps.Series":
         raise NotImplementedError()
 
-    # TODO(SPARK-42617): Support isocalendar.week and replace it.
-    # See also https://github.com/pandas-dev/pandas/pull/33595.
-    @property
-    def week(self) -> "ps.Series":
+    def isocalendar(self) -> "ps.DataFrame":
         """
-        The week ordinal of the year.
+        Calculate year, week, and day according to the ISO 8601 standard.
+        Returns
+        -------
+        DataFrame
+            With columns year, week and day.
+        Examples
+        --------
+        >>> dfs = ps.from_pandas(pd.date_range(start='2019-12-29', freq='D', periods=4).to_series())
+        >>> dfs.dt.isocalendar()
+                    year  week  day
+        2019-12-29  2019    52    7
+        2019-12-30  2020     1    1
+        2019-12-31  2020     1    2
+        2020-01-01  2020     1    3
+        >>> dfs.dt.isocalendar().week
+        2019-12-29    52
+        2019-12-30     1
+        2019-12-31     1
+        2020-01-01     1
+        """
 
-        .. deprecated:: 3.4.0
-        """
-        warnings.warn(
-            "weekofyear and week have been deprecated.",
-            FutureWarning,
+        return_types = [self._data.index.dtype] + [int, int, int]
+
+        def pandas_isocalendar(  # type: ignore[no-untyped-def]
+            pdf,
+        ) -> ps.DataFrame[return_types]:  # type: ignore[valid-type]
+            # cast to int64 due to UInt32 is not supported by spark
+            return pdf[pdf.columns[0]].dt.isocalendar().astype(np.int64).reset_index()
+
+        with option_context("compute.default_index_type", "distributed"):
+            psdf = self._data.to_frame().pandas_on_spark.apply_batch(pandas_isocalendar)
+
+        return DataFrame(
+            psdf._internal.copy(
+                spark_frame=psdf._internal.spark_frame,
+                index_spark_columns=psdf._internal.data_spark_columns[:1],
+                index_fields=psdf._internal.data_fields[:1],
+                data_spark_columns=psdf._internal.data_spark_columns[1:],
+                data_fields=psdf._internal.data_fields[1:],
+                column_labels=[("year",), ("week",), ("day",)],
+            )
         )
-        return self._data.spark.transform(lambda c: F.weekofyear(c).cast(LongType()))
-
-    @property
-    def weekofyear(self) -> "ps.Series":
-        return self.week
-
-    weekofyear.__doc__ = week.__doc__
 
     @property
     def dayofweek(self) -> "ps.Series":

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -125,6 +125,7 @@ class DatetimeMethods:
 
         Returns
         -------
+        Note: Results have int64 type instead of UInt32 as is in pandas due to UInt32 is not supported by spark
         DataFrame
             With columns year, week and day.
 
@@ -137,6 +138,7 @@ class DatetimeMethods:
         2019-12-30  2020     1    1
         2019-12-31  2020     1    2
         2020-01-01  2020     1    3
+
         >>> dfs.dt.isocalendar().week
         2019-12-29    52
         2019-12-30     1

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -126,6 +126,7 @@ class DatetimeMethods:
         -------
         DataFrame
             With columns year, week and day.
+
         Examples
         --------
         >>> dfs = ps.from_pandas(pd.date_range(start='2019-12-29', freq='D', periods=4).to_series())

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -26,7 +26,7 @@ from pandas.tseries.offsets import DateOffset
 
 import pyspark.pandas as ps
 import pyspark.sql.functions as F
-from pyspark.sql.types import DateType, TimestampType, TimestampNTZType, LongType, IntegerType
+from pyspark.sql.types import DateType, TimestampType, TimestampNTZType, IntegerType
 from pyspark.pandas import DataFrame
 from pyspark.pandas.config import option_context
 

--- a/python/pyspark/pandas/datetimes.py
+++ b/python/pyspark/pandas/datetimes.py
@@ -18,7 +18,6 @@
 """
 Date/Time related functions on pandas-on-Spark Series
 """
-import warnings
 from typing import Any, Optional, Union, no_type_check
 
 import numpy as np

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -2007,7 +2007,7 @@ class Index(IndexOpsMixin):
 
         if isinstance(self, MultiIndex) and level is not None:
             self_names = self.names
-            self_names[level] = names  # type: ignore[index]
+            self_names[level] = names
             names = self_names
         return self.rename(name=names, inplace=inplace)
 
@@ -2077,7 +2077,7 @@ class Index(IndexOpsMixin):
                 [isinstance(item, tuple) for item in other]
             )
             if is_other_list_of_tuples:
-                other = MultiIndex.from_tuples(other)  # type: ignore[arg-type]
+                other = MultiIndex.from_tuples(other)
             else:
                 raise TypeError("other must be a MultiIndex or a list of tuples")
 

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -234,6 +234,36 @@ class DatetimeIndex(Index):
         return Index(self.to_series().dt.microsecond)
 
     def isocalendar(self) -> DataFrame:
+        """
+        Calculate year, week, and day according to the ISO 8601 standard.
+
+            .. versionadded:: 4.0.0
+
+        Returns
+        -------
+        DataFrame
+            With columns year, week and day.
+
+        .. note:: Returns have int64 type instead of UInt32 as is in pandas due to UInt32
+            is not supported by spark
+
+        Examples
+        --------
+        >>> psidxs = ps.from_pandas(pd.DatetimeIndex(["2019-12-29", "2019-12-30", "2019-12-31", "2020-01-01"]))
+        >>> psidxs.isocalendar()
+                    year  week  day
+        2019-12-29  2019    52    7
+        2019-12-30  2020     1    1
+        2019-12-31  2020     1    2
+        2020-01-01  2020     1    3
+
+        >>> psidxs.isocalendar().week
+        2019-12-29    52
+        2019-12-30     1
+        2019-12-31     1
+        2020-01-01     1
+        Name: week, dtype: int64
+        """
         return self.to_series().dt.isocalendar()
 
     @property

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -233,29 +233,6 @@ class DatetimeIndex(Index):
         )
         return Index(self.to_series().dt.microsecond)
 
-    @property
-    def week(self) -> Index:
-        """
-        The week ordinal of the year.
-
-        .. deprecated:: 3.5.0
-        """
-        warnings.warn(
-            "`week` is deprecated in 3.5.0 and will be removed in 4.0.0.",
-            FutureWarning,
-        )
-        return Index(self.to_series().dt.week)
-
-    @property
-    def weekofyear(self) -> Index:
-        warnings.warn(
-            "`weekofyear` is deprecated in 3.5.0 and will be removed in 4.0.0.",
-            FutureWarning,
-        )
-        return Index(self.to_series().dt.weekofyear)
-
-    weekofyear.__doc__ = week.__doc__
-
     def isocalendar(self) -> DataFrame:
         return self.to_series().dt.isocalendar()
 

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -249,7 +249,9 @@ class DatetimeIndex(Index):
 
         Examples
         --------
-        >>> psidxs = ps.from_pandas(pd.DatetimeIndex(["2019-12-29", "2019-12-30", "2019-12-31", "2020-01-01"]))
+        >>> psidxs = ps.from_pandas(
+        ...     pd.DatetimeIndex(["2019-12-29", "2019-12-30", "2019-12-31", "2020-01-01"])
+        ... )
         >>> psidxs.isocalendar()
                     year  week  day
         2019-12-29  2019    52    7

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -17,7 +17,6 @@
 import datetime
 import warnings
 from functools import partial
-from pydoc import doc
 from typing import Any, Optional, Union, cast, no_type_check
 
 import pandas as pd

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -26,7 +26,6 @@ from pyspark._globals import _NoValue
 
 from pyspark import pandas as ps
 from pyspark.pandas import DataFrame
-from pyspark.pandas.datetimes import DatetimeMethods
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.missing.indexes import MissingPandasLikeDatetimeIndex
 from pyspark.pandas.series import Series, first_series

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -17,6 +17,7 @@
 import datetime
 import warnings
 from functools import partial
+from pydoc import doc
 from typing import Any, Optional, Union, cast, no_type_check
 
 import pandas as pd
@@ -25,6 +26,8 @@ from pandas.tseries.offsets import DateOffset
 from pyspark._globals import _NoValue
 
 from pyspark import pandas as ps
+from pyspark.pandas import DataFrame
+from pyspark.pandas.datetimes import DatetimeMethods
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.missing.indexes import MissingPandasLikeDatetimeIndex
 from pyspark.pandas.series import Series, first_series
@@ -254,6 +257,9 @@ class DatetimeIndex(Index):
         return Index(self.to_series().dt.weekofyear)
 
     weekofyear.__doc__ = week.__doc__
+
+    def isocalendar(self) -> DataFrame:
+        return self.to_series().dt.isocalendar()
 
     @property
     def dayofweek(self) -> Index:

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -158,7 +158,8 @@ def from_pandas(pobj: Union[pd.DataFrame, pd.Series, pd.Index]) -> Union[Series,
         raise TypeError("Unknown data type: {}".format(type(pobj).__name__))
 
 
-_range = range  # built-in range
+# built-in range
+_range: Type[range] = range  # type: ignore[assignment]
 
 
 def range(

--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -267,6 +267,10 @@ class DatetimeIndexTestsMixin:
         mapper_pser = pd.Series([1, 2, 3], index=pidx)
         self.assert_eq(psidx.map(mapper_pser), pidx.map(mapper_pser))
 
+    def test_isocalendar(self):
+        for psidx, pidx in self.idx_pairs:
+            self.assert_eq(psidx.isocalendar().astype(int), pidx.isocalendar().astype(int))
+
 
 class DatetimeIndexTests(DatetimeIndexTestsMixin, PandasOnSparkTestCase, TestUtils):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -99,14 +99,6 @@ class DatetimeIndexTestsMixin:
             self.assert_eq(psidx.day_of_year, pidx.day_of_year)
             self.assert_eq(psidx.day_of_week, pidx.day_of_week)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("2.0.0"):
-            for psidx, pidx in self.idx_pairs:
-                self.assert_eq(psidx.isocalendar().week, pidx.isocalendar().week.astype(np.int64))
-        else:
-            for psidx, pidx in self.idx_pairs:
-                self.assert_eq(psidx.week, pidx.week)
-                self.assert_eq(psidx.weekofyear, pidx.weekofyear)
-
     def test_ceil(self):
         for psidx, pidx in self.idx_pairs:
             for freq in self.fixed_freqs:
@@ -257,6 +249,7 @@ class DatetimeIndexTestsMixin:
     def test_isocalendar(self):
         for psidx, pidx in self.idx_pairs:
             self.assert_eq(psidx.isocalendar().astype(int), pidx.isocalendar().astype(int))
+            self.assert_eq(psidx.isocalendar().week, pidx.isocalendar().week.astype(np.int64))
 
 
 class DatetimeIndexTests(DatetimeIndexTestsMixin, PandasOnSparkTestCase, TestUtils):

--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -19,6 +19,7 @@ import datetime
 
 from distutils.version import LooseVersion
 
+import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
@@ -99,22 +100,8 @@ class DatetimeIndexTestsMixin:
             self.assert_eq(psidx.day_of_week, pidx.day_of_week)
 
         if LooseVersion(pd.__version__) >= LooseVersion("2.0.0"):
-            # TODO(SPARK-42617): Support isocalendar.week and replace it.
-            expected_results = [
-                ps.Index([1]),
-                ps.Index([1, 1, 13]),
-                ps.Index([52, 52, 1]),
-                ps.Index([52, 52, 52]),
-                ps.Index([52, 52, 52]),
-                ps.Index([52, 52, 52]),
-                ps.Index([52, 52, 52]),
-                ps.Index([52, 52, 52]),
-                ps.Index([52, 1, 2]),
-                ps.Index([13, 26, 39]),
-            ]
-            for psidx, expected_result in zip(self.psidxs, expected_results):
-                self.assert_eq(psidx.week, expected_result)
-                self.assert_eq(psidx.weekofyear, expected_result)
+            for psidx, pidx in self.idx_pairs:
+                self.assert_eq(psidx.isocalendar().week, pidx.isocalendar().week.astype(np.int64))
         else:
             for psidx, pidx in self.idx_pairs:
                 self.assert_eq(psidx.week, pidx.week)

--- a/python/pyspark/pandas/tests/indexes/test_datetime_property.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime_property.py
@@ -18,6 +18,7 @@
 import datetime
 import unittest
 
+import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
@@ -83,23 +84,7 @@ class DatetimeIndexPropertyTestsMixin:
             self.assert_eq(psidx.is_leap_year, pd.Index(pidx.is_leap_year))
             self.assert_eq(psidx.day_of_year, pidx.day_of_year)
             self.assert_eq(psidx.day_of_week, pidx.day_of_week)
-
-        # TODO(SPARK-42617): Support isocalendar.week and replace it.
-        expected_results = [
-            ps.Index([1]),
-            ps.Index([1, 1, 13]),
-            ps.Index([52, 52, 1]),
-            ps.Index([52, 52, 52]),
-            ps.Index([52, 52, 52]),
-            ps.Index([52, 52, 52]),
-            ps.Index([52, 52, 52]),
-            ps.Index([52, 52, 52]),
-            ps.Index([52, 1, 2]),
-            ps.Index([13, 26, 39]),
-        ]
-        for psidx, expected_result in zip(self.psidxs, expected_results):
-            self.assert_eq(psidx.week, expected_result)
-            self.assert_eq(psidx.weekofyear, expected_result)
+            self.assert_eq(psidx.isocalendar().week, pidx.isocalendar().week.astype(np.int64))
 
 
 class DatetimeIndexPropertyTests(DatetimeIndexPropertyTestsMixin, PandasOnSparkTestCase, TestUtils):

--- a/python/pyspark/pandas/tests/test_series_datetime.py
+++ b/python/pyspark/pandas/tests/test_series_datetime.py
@@ -214,6 +214,9 @@ class SeriesDateTimeTestsMixin:
     def test_dayofweek(self):
         self.check_func(lambda x: x.dt.dayofweek)
 
+    def test_isocalendar(self):
+        self.check_func(lambda x: x.dt.isocalendar().astype(np.int64))
+
     def test_weekday(self):
         self.check_func(lambda x: x.dt.weekday)
 

--- a/python/pyspark/pandas/tests/test_series_datetime.py
+++ b/python/pyspark/pandas/tests/test_series_datetime.py
@@ -197,20 +197,6 @@ class SeriesDateTimeTestsMixin:
         with self.assertRaises(NotImplementedError):
             self.check_func(lambda x: x.dt.nanosecond)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-42617): Support `isocalendar`",
-    )
-    def test_week(self):
-        self.check_func(lambda x: x.dt.week)
-
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-42617): Support `isocalendar`",
-    )
-    def test_weekofyear(self):
-        self.check_func(lambda x: x.dt.weekofyear)
-
     def test_dayofweek(self):
         self.check_func(lambda x: x.dt.dayofweek)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support `isocalendar` from the pandas 2.0.0

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When pandas 2.0.0 is released, we should match the behavior in pandas API on Spark.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Added new method `DatetimeIndex.isocalendar` and removed two depreceted `DatetimeIndex.week` and `DatetimeIndex.weekofyear`
```
dfs = ps.from_pandas(pd.date_range(start='2019-12-29', freq='D', periods=4).to_series())
dfs.dt.isocalendar()
                    year  week  day
        2019-12-29  2019    52    7
        2019-12-30  2020     1    1
        2019-12-31  2020     1    2
        2020-01-01  2020     1    3
dfs.dt.isocalendar().week
        2019-12-29    52
        2019-12-30     1
        2019-12-31     1
        2020-01-01     1
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT was updated