### PR TITLE
[SPARK-42793][CONNECT] `connect` module requires `build_profile_flags`

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -277,6 +277,7 @@ connect = Module(
     source_file_regexes=[
         "connector/connect",
     ],
+    build_profile_flags=["-Pconnect"],
     sbt_test_goals=[
         "connect/test",
         "connect-client-jvm/test",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `build_profile_flags` to `connect` module.

### Why are the changes needed?

SPARK-42656 added `connect` profile.
https://github.com/apache/spark/blob/4db8e7b7944302a3929dd6a1197ea1385eecc46a/assembly/pom.xml#L155-L164

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Pass the CIs.