### PR TITLE
[SPARK-42775][SQL] Throw exception when ApproximatePercentile result doesn't fit into output decimal type.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -203,7 +203,8 @@ case class ApproximatePercentile(
       case LongType => doubleResult.map(_.toLong)
       case FloatType => doubleResult.map(_.toFloat)
       case DoubleType => doubleResult
-      case _: DecimalType => doubleResult.map(Decimal(_))
+      case dt: DecimalType =>
+        doubleResult.map(Decimal(_).toPrecision(dt.precision, dt.scale, nullOnOverflow = false))
       case other: DataType =>
         throw QueryExecutionErrors.dataTypeUnexpectedError(other)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixed the counter-intuitive behaviors of the `ApproximatePercentile` expression mentioned in https://issues.apache.org/jira/browse/SPARK-42775. See the following *user-facing* changes for details.

### Does this PR introduce _any_ user-facing change?

Yes. When working on decimals, this expression has the same output type as the input type. When the result that doesn't fit into output decimal type, it silently produces the result since the `Decimal` object is capable of representing decimals of arbitrary precision and scale. However, this can lead to weird behaviors because the value doesn't fit into its type. We should throw an exception immediately.

Old results:

```sql
-- ApproximatePercentile will first cast decimal value 9999999999999999999 into double, which results in 1E20, and cast 1E20 back into decimal, which doesn't fit the type decimal(19, 0).
-- Here it is producing "NULL" because the value doesn't fit into its type, but it is actually not NULL.
spark-sql> select approx_percentile(col, 0.5) from values (9999999999999999999) as tab(col);
NULL
spark-sql> select approx_percentile(col, 0.5) is null from values (9999999999999999999) as tab(col);
false
spark-sql> select cast(approx_percentile(col, 0.5) as string) from values (9999999999999999999) as tab(col);
10000000000000000000
```

New results:

```sql
spark-sql> select approx_percentile(col, 0.5) from values (9999999999999999999) as tab(col);
throws SparkArithmeticException
```

### How was this patch tested?

Pass existing tests and some new tests.

