### PR TITLE
[SPARK-42799][BUILD] Update SBT build `xercesImpl` version to match with `pom.xml`

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1082,7 +1082,7 @@ object DependencyOverrides {
   lazy val guavaVersion = sys.props.get("guava.version").getOrElse("14.0.1")
   lazy val settings = Seq(
     dependencyOverrides += "com.google.guava" % "guava" % guavaVersion,
-    dependencyOverrides += "xerces" % "xercesImpl" % "2.12.0",
+    dependencyOverrides += "xerces" % "xercesImpl" % "2.12.2",
     dependencyOverrides += "jline" % "jline" % "2.14.6",
     dependencyOverrides += "org.apache.avro" % "avro" % "1.11.1")
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `XercesImpl` version to `2.12.2` from `2.12.0` in order to match with the version of `pom.xml`.

https://github.com/apache/spark/blob/149e020a5ca88b2db9c56a9d48e0c1c896b57069/pom.xml#L1429-L1433

### Why are the changes needed?

When we updated this version via SPARK-39183, we missed to update `SparkBuild.scala`.

- https://github.com/apache/spark/pull/36544

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only change because the release artifact' dependency is managed by Maven.

### How was this patch tested?

Pass the CIs.