### PR TITLE
[SPARK-42809][BUILD] Upgrade scala-maven-plugin from 4.8.0 to 4.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
       errors building different Hadoop versions.
       See: SPARK-36547, SPARK-38394.
        -->
-    <scala-maven-plugin.version>4.8.0</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.8.1</scala-maven-plugin.version>
     <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade scala-maven-plugin from 4.8.0 to 4.8.1.

### Why are the changes needed?
Routine upgrade.
https://github.com/davidB/scala-maven-plugin/compare/4.8.0...4.8.1

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.