### PR TITLE
[SPARK-42813][K8S] Print application info when waitAppCompletion is false

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -180,8 +180,8 @@ private[spark] class Client(
         throw e
     }
 
+    val sId = Seq(conf.namespace, driverPodName).mkString(":")
     if (conf.get(WAIT_FOR_APP_COMPLETION)) {
-      val sId = Seq(conf.namespace, driverPodName).mkString(":")
       breakable {
         while (true) {
           val podWithName = kubernetesClient
@@ -202,6 +202,8 @@ private[spark] class Client(
           }
         }
       }
+    } else {
+      logInfo(s"Deployed Spark application ${conf.appId} with submission ID $sId into Kubernetes")
     }
   }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -180,7 +180,7 @@ private[spark] class Client(
         throw e
     }
 
-    val sId = Seq(conf.namespace, driverPodName).mkString(":")
+    val sId = Client.submissionId(conf.namespace, driverPodName)
     if (conf.get(WAIT_FOR_APP_COMPLETION)) {
       breakable {
         while (true) {
@@ -206,6 +206,10 @@ private[spark] class Client(
       logInfo(s"Deployed Spark application ${conf.appId} with submission ID $sId into Kubernetes")
     }
   }
+}
+
+private[spark] object Client {
+  def submissionId(namespace: String, driverPodName: String): String = s"$namespace:$driverPodName"
 }
 
 /**

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -203,7 +203,7 @@ private[spark] class Client(
         }
       }
     } else {
-      logInfo(s"Deployed Spark application ${conf.appName} with application ID ${conf.appName} " +
+      logInfo(s"Deployed Spark application ${conf.appName} with application ID ${conf.appId} " +
         s"and submission ID $sId into Kubernetes")
     }
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -203,7 +203,8 @@ private[spark] class Client(
         }
       }
     } else {
-      logInfo(s"Deployed Spark application ${conf.appId} with submission ID $sId into Kubernetes")
+      logInfo(s"Deployed Spark application ${conf.appName} with application ID ${conf.appName} " +
+        s"and submission ID $sId into Kubernetes")
     }
   }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
@@ -95,8 +95,8 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
     this.notifyAll()
   }
 
-  override def watchOrStop(sId: String): Boolean = if (conf.get(WAIT_FOR_APP_COMPLETION)) {
-    logInfo(s"Waiting for application ${conf.appName} with submission ID $sId to finish...")
+  override def watchOrStop(sId: String): Boolean = {
+    logInfo(s"Waiting for application ${conf.appId} with submission ID $sId to finish...")
     val interval = conf.get(REPORT_INTERVAL)
     synchronized {
       while (!podCompleted && !resourceTooOldReceived) {
@@ -109,12 +109,8 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
       logInfo(
         pod.map { p => s"Container final statuses:\n\n${containersDescription(p)}" }
           .getOrElse("No containers were found in the driver pod."))
-      logInfo(s"Application ${conf.appName} with submission ID $sId finished")
+      logInfo(s"Application ${conf.appId} with submission ID $sId finished")
     }
     podCompleted
-  } else {
-    logInfo(s"Deployed Spark application ${conf.appName} with submission ID $sId into Kubernetes")
-    // Always act like the application has completed since we don't want to wait for app completion
-    true
   }
 }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
@@ -96,7 +96,8 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
   }
 
   override def watchOrStop(sId: String): Boolean = {
-    logInfo(s"Waiting for application ${conf.appId} with submission ID $sId to finish...")
+    logInfo(s"Waiting for application ${conf.appName} with application ID ${conf.appId} " +
+      s"and submission ID $sId to finish...")
     val interval = conf.get(REPORT_INTERVAL)
     synchronized {
       while (!podCompleted && !resourceTooOldReceived) {
@@ -109,7 +110,8 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
       logInfo(
         pod.map { p => s"Container final statuses:\n\n${containersDescription(p)}" }
           .getOrElse("No containers were found in the driver pod."))
-      logInfo(s"Application ${conf.appId} with submission ID $sId finished")
+      logInfo(s"Application ${conf.appName} with application ID ${conf.appId} " +
+        s"and submission ID $sId finished")
     }
     podCompleted
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -369,8 +369,8 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     }
     val appId = KubernetesTestConf.APP_ID
     val sId = submissionId(kconf.namespace, POD_NAME)
-    logAppender.loggingEvents.map(_.getMessage.getFormattedMessage).exists { line =>
-      line === s"Application $appName with application ID $appId and submission ID $sId finished"
-    }
+    assert(logAppender.loggingEvents.map(_.getMessage.getFormattedMessage).contains(
+      s"Deployed Spark application $appName with application ID $appId " +
+      s"and submission ID $sId into Kubernetes"))
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -350,9 +350,11 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("SPARK-42813: Print application info when waitAppCompletion is false") {
+    val appName = "SPARK-42813"
     val logAppender = new LogAppender
     withLogAppender(logAppender) {
       val sparkConf = new SparkConf(loadDefaults = false)
+        .set("spark.app.name", appName)
         .set(WAIT_FOR_APP_COMPLETION, false)
       kconf = KubernetesTestConf.createDriverConf(sparkConf = sparkConf,
         resourceNamePrefix = Some(KUBERNETES_RESOURCE_PREFIX))
@@ -368,7 +370,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     val appId = KubernetesTestConf.APP_ID
     val sId = submissionId(kconf.namespace, POD_NAME)
     logAppender.loggingEvents.map(_.getMessage.getFormattedMessage).exists { line =>
-      line === s"Application $appId with submission ID $sId finished"
+      line === s"Application $appName with application ID $appId and submission ID $sId finished"
     }
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -368,7 +368,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     val appId = KubernetesTestConf.APP_ID
     val sId = submissionId(kconf.namespace, POD_NAME)
     logAppender.loggingEvents.map(_.getMessage.getFormattedMessage).exists { line =>
-      line.contains(s"Application $appId with submission ID $sId finished")
+      line === s"Application $appId with submission ID $sId finished"
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
On K8s cluster mode, 

1. when `spark.kubernetes.submission.waitAppCompletion=false`, print the application information on `spark-submit` exit, as it did before [SPARK-35174](https://issues.apache.org/jira/browse/SPARK-35174)

2. add `appId` in the output message

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

On K8s cluster mode, when `spark.kubernetes.submission.waitAppCompletion=false`,
before [SPARK-35174](https://issues.apache.org/jira/browse/SPARK-35174), the `spark-submit` will exit quickly w/ the basic application information.
```
logInfo(s"Deployed Spark application ${conf.appName} with submission ID $sId into Kubernetes")
```

After [SPARK-35174](https://issues.apache.org/jira/browse/SPARK-35174), those part of code is unreachable, so nothing is output.

This PR also proposes to add `appId` in the output message, to make it consistent w/ the context (if you look at the `LoggingPodStatusWatcherImpl`, this is kind of an exception, `... application $appId ...` is used in other places), and YARN.

https://github.com/apache/spark/blob/8860f69455e5a722626194c4797b4b42cccd4510/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala#L1311-L1318

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, changes contain
1) when `spark.kubernetes.submission.waitAppCompletion=false`, the user can see the app information when `spark-submit` exit.
2) the end of `spark-submit` information contains app id now, which is consistent w/ the context and other resource managers like YARN.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass CI.