### PR TITLE
[SPARK-42814][BUILD] Upgrade maven plugins to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2768,7 +2768,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M2</version>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <id>enforce-versions</id>
@@ -2811,7 +2811,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
           <executions>
             <execution>
               <id>module-timestamp-property</id>
@@ -2913,7 +2913,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.10.1</version>
+          <version>3.11.0</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -2930,7 +2930,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M9</version>
+          <version>3.0.0</version>
           <!-- Note config is repeated in scalatest config -->
           <configuration>
             <includes>
@@ -3091,7 +3091,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.0</version>
           <configuration>
             <additionalJOptions>
               <additionalJOption>-Xdoclint:all</additionalJOption>
@@ -3169,7 +3169,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -204,7 +204,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.0.0</version>
             <executions>
               <execution>
                 <id>add-scala-test-sources</id>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade the following maven plugins

- maven-enforcer-plugin 3.0.0-M2 -> 3.2.1
- build-helper-maven-plugin 3.2.0 -> 3.3.0
- maven-compiler-plugin 3.10.1 -> 3.11.0
- maven-surefire-plugin 3.0.0-M9 -> 3.0.0
- maven-javadoc-plugin 3.4.1 -> 3.5.0
- maven-deploy-plugin 3.0.0 -> 3.1.0

### Why are the changes needed?
The release notes as follows:
- maven-enforcer-plugin
  - https://github.com/apache/maven-enforcer/releases/tag/enforcer-3.2.1
  - https://github.com/apache/maven-enforcer/releases/tag/enforcer-3.1.0

- build-helper-maven-plugin
  - https://github.com/mojohaus/build-helper-maven-plugin/releases/tag/build-helper-maven-plugin-3.3.0

- maven-compiler-plugin
  - https://github.com/apache/maven-compiler-plugin/releases/tag/maven-compiler-plugin-3.11.0

- maven-surefire-plugin
  - https://github.com/apache/maven-surefire/releases/tag/surefire-3.0.0

- maven-javadoc-plugin
  - https://github.com/apache/maven-javadoc-plugin/releases/tag/maven-javadoc-plugin-3.5.0

- maven-deploy-plugin
  - https://github.com/apache/maven-deploy-plugin/releases/tag/maven-deploy-plugin-3.1.0


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual: maven build&test, enforcer rejects lower versions of java and maven

