### PR TITLE
[SPARK-42818][CONNECT][PYTHON][FOLLOWUP] Add versionchanged

### DIFF
--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -862,6 +862,9 @@ class DataFrameReader(OptionUtils):
 
         .. versionadded:: 1.4.0
 
+        .. versionchanged:: 3.4.0
+            Supports Spark Connect.
+
         Parameters
         ----------
         table : str
@@ -1868,6 +1871,9 @@ class DataFrameWriter(OptionUtils):
         """Saves the content of the :class:`DataFrame` to an external database table via JDBC.
 
         .. versionadded:: 1.4.0
+
+        .. versionchanged:: 3.4.0
+            Supports Spark Connect.
 
         Parameters
         ----------


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up of #40450.

Adds `versionchanged` to the docstring.

### Why are the changes needed?

The `versionchanged` is missing in the API newly supported in Spark Connect.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.