### PR TITLE
[MINOR] Add comments of `xercesImpl` upgrade precautions in `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1426,6 +1426,7 @@
         <scope>test</scope>
       </dependency>
       <!-- Managed up to match Hadoop in HADOOP-16530 -->
+      <!-- When upgrading `xercesImpl` version, also need to change the version definition in `SparkBuild#DependencyOverrides`. -->
       <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1426,7 +1426,10 @@
         <scope>test</scope>
       </dependency>
       <!-- Managed up to match Hadoop in HADOOP-16530 -->
-      <!-- When upgrading `xercesImpl` version, also need to change the version definition in `SparkBuild#DependencyOverrides`. -->
+      <!--
+        When upgrading `xercesImpl` version, also need to change
+        the version definition in `SparkBuild#DependencyOverrides`.
+      -->
       <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just add comments of `xercesImpl` upgrade precautions in `pom.xml`.

### Why are the changes needed?
Add comments to remind developers that `xercesImpl` should update versions in both `pom.xml` and `SparkBuild.scala` at the same time.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions