### PR TITLE
[SPARK-42826][PS][DOCS] Add migration notes for update to supported pandas version.

### DIFF
--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -33,7 +33,7 @@ Upgrading from PySpark 3.3 to 3.4
 * In Spark 3.4, the ``Series.concat`` sort parameter will be respected to follow pandas 1.4 behaviors.
 * In Spark 3.4, the ``DataFrame.__setitem__`` will make a copy and replace pre-existing arrays, which will NOT be over-written to follow pandas 1.4 behaviors.
 * In Spark 3.4, the ``SparkSession.sql`` and the Pandas on Spark API ``sql`` have got new parameter ``args`` which provides binding of named parameters to their SQL literals.
-* In Spark 3.4, Pandas-on-Spark supports for the upcoming pandas 2.0. As a result, some APIs that are deprecated or removed in pandas 2.0 also be affected in Spark 3.4. Please refer to the [official pandas release notes](https://pandas.pydata.org/docs/dev/whatsnew/) for more details.
+* In Spark 3.4, Pandas API on Spark follows for the pandas 2.0, and some APIs were deprecated or removed in Spark 3.4 according to the changes made in pandas 2.0. Please refer to the [release notes of pandas](https://pandas.pydata.org/docs/dev/whatsnew/) for more details.
 
 
 Upgrading from PySpark 3.2 to 3.3

--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -33,6 +33,7 @@ Upgrading from PySpark 3.3 to 3.4
 * In Spark 3.4, the ``Series.concat`` sort parameter will be respected to follow pandas 1.4 behaviors.
 * In Spark 3.4, the ``DataFrame.__setitem__`` will make a copy and replace pre-existing arrays, which will NOT be over-written to follow pandas 1.4 behaviors.
 * In Spark 3.4, the ``SparkSession.sql`` and the Pandas on Spark API ``sql`` have got new parameter ``args`` which provides binding of named parameters to their SQL literals.
+* In Spark 3.4, Pandas-on-Spark supports for the upcoming pandas 2.0. As a result, some APIs that are deprecated or removed in pandas 2.0 also be affected in Spark 3.4. Please refer to the [official pandas release notes](https://pandas.pydata.org/docs/dev/whatsnew/) for more details.
 
 
 Upgrading from PySpark 3.2 to 3.3


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a migration note for update to supported pandas version.


### Why are the changes needed?

Some APIs have been deprecated or removed from SPARK-42593 to follow pandas 2.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review is required.