### PR TITLE
[SPARK-42831][SQL] Show result expressions in AggregateExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -873,9 +873,9 @@ case class HashAggregateExec(
         val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
         val outputString = truncatedString(output, "[", ", ", "]", maxFields)
         if (verbose) {
-          val resultString = resultExpressions.mkString(", results=[", ", ", "]")
-          s"HashAggregate(keys=$keyString, functions=$functionString$resultString" +
-            s", output=$outputString)"
+          val resultString = truncatedString(resultExpressions, "[", ", ", "]", maxFields)
+          s"HashAggregate(keys=$keyString, functions=$functionString, results=$resultString, " +
+            s"output=$outputString)"
         } else {
           s"HashAggregate(keys=$keyString, functions=$functionString)"
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -871,12 +871,17 @@ case class HashAggregateExec(
       case None =>
         val keyString = truncatedString(groupingExpressions, "[", ", ", "]", maxFields)
         val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
-        val outputString = truncatedString(output, "[", ", ", "]", maxFields)
-        if (verbose) {
-          s"HashAggregate(keys=$keyString, functions=$functionString, output=$outputString)"
+        val outputString = if (verbose) {
+          ", output=" + truncatedString(output, "[", ", ", "]", maxFields)
         } else {
-          s"HashAggregate(keys=$keyString, functions=$functionString)"
+          ""
         }
+        val resultString = if (resultExpressions.nonEmpty) {
+          s", results=${resultExpressions.mkString("[", ", ", "]")}"
+        } else {
+          ""
+        }
+        s"HashAggregate(keys=$keyString, functions=$functionString$resultString$outputString)"
       case Some(fallbackStartsAt) =>
         s"HashAggregateWithControlledFallback $groupingExpressions " +
           s"$allAggregateExpressions $resultExpressions fallbackStartsAt=$fallbackStartsAt"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -871,17 +871,14 @@ case class HashAggregateExec(
       case None =>
         val keyString = truncatedString(groupingExpressions, "[", ", ", "]", maxFields)
         val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
-        val outputString = if (verbose) {
-          ", output=" + truncatedString(output, "[", ", ", "]", maxFields)
+        val outputString = truncatedString(output, "[", ", ", "]", maxFields)
+        if (verbose) {
+          val resultString = resultExpressions.mkString(", results=[", ", ", "]")
+          s"HashAggregate(keys=$keyString, functions=$functionString$resultString" +
+            s", output=$outputString)"
         } else {
-          ""
+          s"HashAggregate(keys=$keyString, functions=$functionString)"
         }
-        val resultString = if (resultExpressions.nonEmpty) {
-          s", results=${resultExpressions.mkString("[", ", ", "]")}"
-        } else {
-          ""
-        }
-        s"HashAggregate(keys=$keyString, functions=$functionString$resultString$outputString)"
       case Some(fallbackStartsAt) =>
         s"HashAggregateWithControlledFallback $groupingExpressions " +
           s"$allAggregateExpressions $resultExpressions fallbackStartsAt=$fallbackStartsAt"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -134,9 +134,9 @@ case class ObjectHashAggregateExec(
     val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
     val outputString = truncatedString(output, "[", ", ", "]", maxFields)
     if (verbose) {
-      val resultString = resultExpressions.mkString(", results=[", ", ", "]")
-      s"ObjectHashAggregate(keys=$keyString, functions=$functionString$resultString" +
-        s", output=$outputString)"
+      val resultString = truncatedString(resultExpressions, "[", ", ", "]", maxFields)
+      s"ObjectHashAggregate(keys=$keyString, functions=$functionString, results=$resultString, " +
+        s"output=$outputString)"
     } else {
       s"ObjectHashAggregate(keys=$keyString, functions=$functionString)"
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -132,17 +132,14 @@ case class ObjectHashAggregateExec(
     val allAggregateExpressions = aggregateExpressions
     val keyString = truncatedString(groupingExpressions, "[", ", ", "]", maxFields)
     val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
-    val outputString = if (verbose) {
-      ", output=" + truncatedString(output, "[", ", ", "]", maxFields)
+    val outputString = truncatedString(output, "[", ", ", "]", maxFields)
+    if (verbose) {
+      val resultString = resultExpressions.mkString(", results=[", ", ", "]")
+      s"ObjectHashAggregate(keys=$keyString, functions=$functionString$resultString" +
+        s", output=$outputString)"
     } else {
-      ""
+      s"ObjectHashAggregate(keys=$keyString, functions=$functionString)"
     }
-    val resultString = if (resultExpressions.nonEmpty) {
-      s", results=${resultExpressions.mkString("[", ", ", "]")}"
-    } else {
-      ""
-    }
-    s"ObjectHashAggregate(keys=$keyString, functions=$functionString$resultString$outputString)"
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): ObjectHashAggregateExec =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -132,12 +132,17 @@ case class ObjectHashAggregateExec(
     val allAggregateExpressions = aggregateExpressions
     val keyString = truncatedString(groupingExpressions, "[", ", ", "]", maxFields)
     val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
-    val outputString = truncatedString(output, "[", ", ", "]", maxFields)
-    if (verbose) {
-      s"ObjectHashAggregate(keys=$keyString, functions=$functionString, output=$outputString)"
+    val outputString = if (verbose) {
+      ", output=" + truncatedString(output, "[", ", ", "]", maxFields)
     } else {
-      s"ObjectHashAggregate(keys=$keyString, functions=$functionString)"
+      ""
     }
+    val resultString = if (resultExpressions.nonEmpty) {
+      s", results=${resultExpressions.mkString("[", ", ", "]")}"
+    } else {
+      ""
+    }
+    s"ObjectHashAggregate(keys=$keyString, functions=$functionString$resultString$outputString)"
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): ObjectHashAggregateExec =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -116,8 +116,9 @@ case class SortAggregateExec(
     val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
     val outputString = truncatedString(output, "[", ", ", "]", maxFields)
     if (verbose) {
-      val resultString = resultExpressions.mkString(", results=[", ", ", "]")
-      s"SortAggregate(key=$keyString, functions=$functionString$resultString, output=$outputString)"
+      val resultString = truncatedString(resultExpressions, "[", ", ", "]", maxFields)
+      s"SortAggregate(key=$keyString, functions=$functionString, results=$resultString, " +
+        s"output=$outputString)"
     } else {
       s"SortAggregate(key=$keyString, functions=$functionString)"
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -114,12 +114,17 @@ case class SortAggregateExec(
 
     val keyString = truncatedString(groupingExpressions, "[", ", ", "]", maxFields)
     val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
-    val outputString = truncatedString(output, "[", ", ", "]", maxFields)
-    if (verbose) {
-      s"SortAggregate(key=$keyString, functions=$functionString, output=$outputString)"
+    val outputString = if (verbose) {
+      ", output=" + truncatedString(output, "[", ", ", "]", maxFields)
     } else {
-      s"SortAggregate(key=$keyString, functions=$functionString)"
+      ""
     }
+    val resultString = if (resultExpressions.nonEmpty) {
+      s", results=${resultExpressions.mkString("[", ", ", "]")}"
+    } else {
+      ""
+    }
+    s"SortAggregate(key=$keyString, functions=$functionString$resultString$outputString)"
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): SortAggregateExec =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortAggregateExec.scala
@@ -114,17 +114,13 @@ case class SortAggregateExec(
 
     val keyString = truncatedString(groupingExpressions, "[", ", ", "]", maxFields)
     val functionString = truncatedString(allAggregateExpressions, "[", ", ", "]", maxFields)
-    val outputString = if (verbose) {
-      ", output=" + truncatedString(output, "[", ", ", "]", maxFields)
+    val outputString = truncatedString(output, "[", ", ", "]", maxFields)
+    if (verbose) {
+      val resultString = resultExpressions.mkString(", results=[", ", ", "]")
+      s"SortAggregate(key=$keyString, functions=$functionString$resultString, output=$outputString)"
     } else {
-      ""
+      s"SortAggregate(key=$keyString, functions=$functionString)"
     }
-    val resultString = if (resultExpressions.nonEmpty) {
-      s", results=${resultExpressions.mkString("[", ", ", "]")}"
-    } else {
-      ""
-    }
-    s"SortAggregate(key=$keyString, functions=$functionString$resultString$outputString)"
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): SortAggregateExec =

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -71,12 +71,12 @@ Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL]
 
 == Physical Plan ==
 AdaptiveSparkPlan isFinalPlan=false
-+- HashAggregate(keys=[], functions=[sum(distinct val#x)], output=[sum(DISTINCT val)#xL])
++- HashAggregate(keys=[], functions=[sum(distinct val#x)], results=[sum(val#x)#xL AS sum(DISTINCT val)#xL], output=[sum(DISTINCT val)#xL])
    +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=x]
-      +- HashAggregate(keys=[], functions=[partial_sum(distinct val#x)], output=[sum#xL])
-         +- HashAggregate(keys=[val#x], functions=[], output=[val#x])
+      +- HashAggregate(keys=[], functions=[partial_sum(distinct val#x)], results=[sum#xL], output=[sum#xL])
+         +- HashAggregate(keys=[val#x], functions=[], results=[val#x], output=[val#x])
             +- Exchange hashpartitioning(val#x, 4), ENSURE_REQUIREMENTS, [plan_id=x]
-               +- HashAggregate(keys=[val#x], functions=[], output=[val#x])
+               +- HashAggregate(keys=[val#x], functions=[], results=[val#x], output=[val#x])
                   +- FileScan parquet spark_catalog.default.explain_temp1[val#x] Batched: true, DataFilters: [], Format: Parquet, Location [not included in comparison]/{warehouse_dir}/explain_temp1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<val:int>
 
 

--- a/sql/core/src/test/resources/sql-tests/results/explain-cbo.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-cbo.sql.out
@@ -66,11 +66,11 @@ AdaptiveSparkPlan isFinalPlan=false
    +- Filter (isnotnull(d#x) AND (cast(d#x as bigint) > Subquery subquery#x, [id=#x]))
       :  +- Subquery subquery#x, [id=#x]
       :     +- AdaptiveSparkPlan isFinalPlan=false
-      :        +- HashAggregate(keys=[], functions=[max(csales#xL)], output=[tpcds_cmax#xL])
-      :           +- HashAggregate(keys=[], functions=[partial_max(csales#xL)], output=[max#xL])
-      :              +- HashAggregate(keys=[], functions=[sum(b#x)], output=[csales#xL])
+      :        +- HashAggregate(keys=[], functions=[max(csales#xL)], results=[max(csales#xL)#xL AS tpcds_cmax#xL], output=[tpcds_cmax#xL])
+      :           +- HashAggregate(keys=[], functions=[partial_max(csales#xL)], results=[max#xL], output=[max#xL])
+      :              +- HashAggregate(keys=[], functions=[sum(b#x)], results=[sum(b#x)#xL AS csales#xL], output=[csales#xL])
       :                 +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=x]
-      :                    +- HashAggregate(keys=[], functions=[partial_sum(b#x)], output=[sum#xL])
+      :                    +- HashAggregate(keys=[], functions=[partial_sum(b#x)], results=[sum#xL], output=[sum#xL])
       :                       +- Project [b#x]
       :                          +- Filter (isnotnull(a#x) AND (a#x < 100))
       :                             +- FileScan parquet spark_catalog.default.explain_temp1[a#x,b#x] Batched: true, DataFilters: [isnotnull(a#x), (a#x < 100)], Format: Parquet, Location [not included in comparison]/{warehouse_dir}/explain_temp1], PartitionFilters: [], PushedFilters: [IsNotNull(a), LessThan(a,100)], ReadSchema: struct<a:int,b:int>

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -70,12 +70,12 @@ Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL]
    +- Relation spark_catalog.default.explain_temp1[key#x,val#x] parquet
 
 == Physical Plan ==
-*HashAggregate(keys=[], functions=[sum(distinct val#x)], output=[sum(DISTINCT val)#xL])
+*HashAggregate(keys=[], functions=[sum(distinct val#x)], results=[sum(val#x)#xL AS sum(DISTINCT val)#xL], output=[sum(DISTINCT val)#xL])
 +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=x]
-   +- *HashAggregate(keys=[], functions=[partial_sum(distinct val#x)], output=[sum#xL])
-      +- *HashAggregate(keys=[val#x], functions=[], output=[val#x])
+   +- *HashAggregate(keys=[], functions=[partial_sum(distinct val#x)], results=[sum#xL], output=[sum#xL])
+      +- *HashAggregate(keys=[val#x], functions=[], results=[val#x], output=[val#x])
          +- Exchange hashpartitioning(val#x, 4), ENSURE_REQUIREMENTS, [plan_id=x]
-            +- *HashAggregate(keys=[val#x], functions=[], output=[val#x])
+            +- *HashAggregate(keys=[val#x], functions=[], results=[val#x], output=[val#x])
                +- *ColumnarToRow
                   +- FileScan parquet spark_catalog.default.explain_temp1[val#x] Batched: true, DataFilters: [], Format: Parquet, Location [not included in comparison]/{warehouse_dir}/explain_temp1], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<val:int>
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

If the result expressions in AggregateExec are not empty, we should display them. Or we will get confused because some important expressions do not show up in the DAG.


### Why are the changes needed?

For example, the plan for query `SELECT sum(p) from values(cast(23.4 as decimal(7,2))) t(p)` was incorrect because the result expression `MakeDecimal(sum(UnscaledValue(p#0))#1L,17,2) AS sum(p)#2` is not displayed

Before

```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- HashAggregate(keys=[], functions=[sum(UnscaledValue(p#0))], output=[sum(p)#2])
   +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
      +- HashAggregate(keys=[], functions=[partial_sum(UnscaledValue(p#0))], output=[sum#5L])
         +- LocalTableScan [p#0]
```
After

```
== Physical Plan ==     
AdaptiveSparkPlan isFinalPlan=false
+- HashAggregate(keys=[], functions=[sum(UnscaledValue(p#0))], results=[MakeDecimal(sum(UnscaledValue(p#0))#1L,17,2) AS sum(p)#2], output=[sum(p)#2])
   +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [plan_id=38]
      +- HashAggregate(keys=[], functions=[partial_sum(UnscaledValue(p#0))], results=[sum#13L], output=[sum#13L])
         +- LocalTableScan [p#0]
```

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Local test
