### PR TITLE
[MINOR] scheduler micro opts

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
@@ -103,11 +103,8 @@ class TaskInfo(
     // finishTime should be set larger than 0, otherwise "finished" below will return false.
     assert(time > 0)
     finishTime = time
-    if (state == TaskState.FAILED) {
-      failed = true
-    } else if (state == TaskState.KILLED) {
-      killed = true
-    }
+    failed = state == TaskState.FAILED
+    killed = state == TaskState.KILLED
   }
 
   private[spark] def launchSucceeded(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Scheduler micro optimizations to speed up the scheduling loop.

### Why are the changes needed?
The scheduler is single threaded and the faster we can schedule the faster a query executes. Changes to the scheduler usually adversely affect scheduling throughput which makes it hard to prototype novel changes. Getting some headroom makes experimentation faster while not hurting production.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.
