### PR TITLE
[SPARK-42584][CONNECT] Improve output of `Column.explain`

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1211,13 +1211,17 @@ class Column private[sql] (private[sql] val expr: proto.Expression) extends Logg
    * @group df_ops
    * @since 3.4.0
    */
-  def explain(extended: Boolean): Unit = {
+  def explain(extended: Boolean)(implicit spark: SparkSession): Unit = {
     // scalastyle:off println
-    if (extended) {
-      println(expr)
-    } else {
-      println(toString)
-    }
+
+    assert(spark != null)
+    val a = spark.explainExpr(expr, extended)
+    println(a)
+//    if (extended) {
+//      println(expr)
+//    } else {
+//      println(toString)
+//    }
     // scalastyle:on println
   }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1214,8 +1214,8 @@ class Column private[sql] (private[sql] val expr: proto.Expression) extends Logg
   def explain(extended: Boolean)(implicit spark: SparkSession): Unit = {
     // scalastyle:off println
     assert(spark != null)
-    val a = spark.explainExpr(expr, extended)
-    println(a)
+    val explainString = spark.explainExpr(expr, extended)
+    println(explainString)
     // scalastyle:on println
   }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1213,15 +1213,9 @@ class Column private[sql] (private[sql] val expr: proto.Expression) extends Logg
    */
   def explain(extended: Boolean)(implicit spark: SparkSession): Unit = {
     // scalastyle:off println
-
     assert(spark != null)
     val a = spark.explainExpr(expr, extended)
     println(a)
-//    if (extended) {
-//      println(expr)
-//    } else {
-//      println(toString)
-//    }
     // scalastyle:on println
   }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -408,6 +408,10 @@ class SparkSession private[sql] (
     client.semanticHash(plan).getSemanticHash.getResult
   }
 
+  private[sql] def explainExpr(expr: proto.Expression, extended: Boolean): String = {
+    client.explainExpr(expr, extended).getExplainExpression.getExplainString
+  }
+
   private[sql] def execute[T](plan: proto.Plan, encoder: AgnosticEncoder[T]): SparkResult[T] = {
     val value = client.execute(plan)
     val result = new SparkResult(value, allocator, encoder)

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -166,6 +166,16 @@ private[sql] class SparkConnectClient(
     analyze(builder)
   }
 
+  def explainExpr(expr: proto.Expression, extended: Boolean): proto.AnalyzePlanResponse = {
+    val builder = proto.AnalyzePlanRequest.newBuilder()
+    builder.setExplainExpression(
+      proto.AnalyzePlanRequest.ExplainExpression
+        .newBuilder()
+        .setExpr(expr)
+        .setExtended(extended))
+    analyze(builder)
+  }
+
   private def analyze(builder: proto.AnalyzePlanRequest.Builder): proto.AnalyzePlanResponse = {
     val request = builder
       .setUserContext(userContext)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -355,6 +355,12 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper {
     testCapturedStdOut(df.explain("formatted"), "Range", "Arguments: ")
   }
 
+  test("Expression explain") {
+    val col = Column("a") + Column("b")
+    assert(captureStdOut(col.explain(false)) == "(a + b)\n")
+    assert(captureStdOut(col.explain(true)) == "('a + 'b)\n")
+  }
+
   test("Dataset result collection") {
     def checkResult(rows: TraversableOnce[java.lang.Long], expectedValues: Long*): Unit = {
       rows.toIterator.zipAll(expectedValues.iterator, null, null).foreach {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ColumnTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ColumnTestSuite.scala
@@ -166,16 +166,16 @@ class ColumnTestSuite extends ConnectFunSuite {
     capturedOut.toString()
   }
 
-  test("explain") {
-    val x = fn.col("a") + fn.col("b")
-    val explain1 = captureStdOut(x.explain(false))
-    val explain2 = captureStdOut(x.explain(true))
-    assert(explain1 == explain2)
-    val expectedFragments = Seq("unresolved_function", "function_name: \"+\"", "arguments")
-    expectedFragments.foreach { fragment =>
-      assert(explain1.contains(fragment))
-    }
-  }
+//  test("explain") {
+//    val x = fn.col("a") + fn.col("b")
+//    val explain1 = captureStdOut(x.explain(false))
+//    val explain2 = captureStdOut(x.explain(true))
+//    assert(explain1 == explain2)
+//    val expectedFragments = Seq("unresolved_function", "function_name: \"+\"", "arguments")
+//    expectedFragments.foreach { fragment =>
+//      assert(explain1.contains(fragment))
+//    }
+//  }
 
   private def testColName(dataType: DataType, f: ColumnName => StructField): Unit = {
     test("ColumnName " + dataType.catalogString) {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ColumnTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ColumnTestSuite.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.spark.sql
 
-import java.io.ByteArrayOutputStream
-
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{functions => fn}
@@ -159,23 +157,6 @@ class ColumnTestSuite extends ConnectFunSuite {
     val a = fn.col("a")
     assert(a.asc == a.asc_nulls_first)
   }
-
-  private def captureStdOut(block: => Unit): String = {
-    val capturedOut = new ByteArrayOutputStream()
-    Console.withOut(capturedOut)(block)
-    capturedOut.toString()
-  }
-
-//  test("explain") {
-//    val x = fn.col("a") + fn.col("b")
-//    val explain1 = captureStdOut(x.explain(false))
-//    val explain2 = captureStdOut(x.explain(true))
-//    assert(explain1 == explain2)
-//    val expectedFragments = Seq("unresolved_function", "function_name: \"+\"", "arguments")
-//    expectedFragments.foreach { fragment =>
-//      assert(explain1.contains(fragment))
-//    }
-//  }
 
   private def testColName(dataType: DataType, f: ColumnName => StructField): Unit = {
     test("ColumnName " + dataType.catalogString) {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -127,7 +127,7 @@ object SparkConnectServerUtils {
 
 trait RemoteSparkSession extends ConnectFunSuite with BeforeAndAfterAll {
   import SparkConnectServerUtils._
-  var spark: SparkSession = _
+  implicit var spark: SparkSession = _
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/connector/connect/common/src/main/protobuf/spark/connect/base.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/base.proto
@@ -99,6 +99,7 @@ message AnalyzePlanRequest {
     Persist persist = 14;
     Unpersist unpersist = 15;
     GetStorageLevel get_storage_level = 16;
+    ExplainExpression explain_expression = 17;
   }
 
   message Schema {
@@ -201,6 +202,14 @@ message AnalyzePlanRequest {
     // (Required) The logical plan to get the storage level.
     Relation relation = 1;
   }
+
+  // Explains the expression based on extended is true or not.
+  message ExplainExpression {
+    // (Required) The expression to be analyzed.
+    Expression expr = 1;
+
+    bool extended = 2;
+  }
 }
 
 // Response to performing analysis of the query. Contains relevant metadata to be able to
@@ -222,6 +231,7 @@ message AnalyzePlanResponse {
     Persist persist = 12;
     Unpersist unpersist = 13;
     GetStorageLevel get_storage_level = 14;
+    ExplainExpression explain_expression = 15;
   }
 
   message Schema {
@@ -272,6 +282,10 @@ message AnalyzePlanResponse {
   message GetStorageLevel {
     // (Required) The StorageLevel as a result of get_storage_level request.
     StorageLevel storage_level = 1;
+  }
+
+  message ExplainExpression {
+    string explain_string = 1;
   }
 }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
@@ -23,7 +23,7 @@ import io.grpc.stub.StreamObserver
 
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{Column, Dataset, SparkSession}
+import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, InvalidPlanInput, StorageLevelProtoConverter}
 import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 import org.apache.spark.sql.execution.{CodegenMode, CostMode, ExtendedMode, FormattedMode, SimpleMode}

--- a/python/pyspark/sql/connect/proto/base_pb2.py
+++ b/python/pyspark/sql/connect/proto/base_pb2.py
@@ -37,7 +37,7 @@ from pyspark.sql.connect.proto import types_pb2 as spark_dot_connect_dot_types__
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x18spark/connect/base.proto\x12\rspark.connect\x1a\x19google/protobuf/any.proto\x1a\x1cspark/connect/commands.proto\x1a\x1fspark/connect/expressions.proto\x1a\x1dspark/connect/relations.proto\x1a\x19spark/connect/types.proto"t\n\x04Plan\x12-\n\x04root\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationH\x00R\x04root\x12\x32\n\x07\x63ommand\x18\x02 \x01(\x0b\x32\x16.spark.connect.CommandH\x00R\x07\x63ommandB\t\n\x07op_type"z\n\x0bUserContext\x12\x17\n\x07user_id\x18\x01 \x01(\tR\x06userId\x12\x1b\n\tuser_name\x18\x02 \x01(\tR\x08userName\x12\x35\n\nextensions\x18\xe7\x07 \x03(\x0b\x32\x14.google.protobuf.AnyR\nextensions"\xb0\x01\n\x0cStorageLevel\x12\x19\n\x08use_disk\x18\x01 \x01(\x08R\x07useDisk\x12\x1d\n\nuse_memory\x18\x02 \x01(\x08R\tuseMemory\x12 \n\x0cuse_off_heap\x18\x03 \x01(\x08R\nuseOffHeap\x12"\n\x0c\x64\x65serialized\x18\x04 \x01(\x08R\x0c\x64\x65serialized\x12 \n\x0breplication\x18\x05 \x01(\x05R\x0breplication"\xd0\x12\n\x12\x41nalyzePlanRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x0cuser_context\x18\x02 \x01(\x0b\x32\x1a.spark.connect.UserContextR\x0buserContext\x12$\n\x0b\x63lient_type\x18\x03 \x01(\tH\x01R\nclientType\x88\x01\x01\x12\x42\n\x06schema\x18\x04 \x01(\x0b\x32(.spark.connect.AnalyzePlanRequest.SchemaH\x00R\x06schema\x12\x45\n\x07\x65xplain\x18\x05 \x01(\x0b\x32).spark.connect.AnalyzePlanRequest.ExplainH\x00R\x07\x65xplain\x12O\n\x0btree_string\x18\x06 \x01(\x0b\x32,.spark.connect.AnalyzePlanRequest.TreeStringH\x00R\ntreeString\x12\x46\n\x08is_local\x18\x07 \x01(\x0b\x32).spark.connect.AnalyzePlanRequest.IsLocalH\x00R\x07isLocal\x12R\n\x0cis_streaming\x18\x08 \x01(\x0b\x32-.spark.connect.AnalyzePlanRequest.IsStreamingH\x00R\x0bisStreaming\x12O\n\x0binput_files\x18\t \x01(\x0b\x32,.spark.connect.AnalyzePlanRequest.InputFilesH\x00R\ninputFiles\x12U\n\rspark_version\x18\n \x01(\x0b\x32..spark.connect.AnalyzePlanRequest.SparkVersionH\x00R\x0csparkVersion\x12I\n\tddl_parse\x18\x0b \x01(\x0b\x32*.spark.connect.AnalyzePlanRequest.DDLParseH\x00R\x08\x64\x64lParse\x12X\n\x0esame_semantics\x18\x0c \x01(\x0b\x32/.spark.connect.AnalyzePlanRequest.SameSemanticsH\x00R\rsameSemantics\x12U\n\rsemantic_hash\x18\r \x01(\x0b\x32..spark.connect.AnalyzePlanRequest.SemanticHashH\x00R\x0csemanticHash\x12\x45\n\x07persist\x18\x0e \x01(\x0b\x32).spark.connect.AnalyzePlanRequest.PersistH\x00R\x07persist\x12K\n\tunpersist\x18\x0f \x01(\x0b\x32+.spark.connect.AnalyzePlanRequest.UnpersistH\x00R\tunpersist\x12_\n\x11get_storage_level\x18\x10 \x01(\x0b\x32\x31.spark.connect.AnalyzePlanRequest.GetStorageLevelH\x00R\x0fgetStorageLevel\x1a\x31\n\x06Schema\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\xbb\x02\n\x07\x45xplain\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x12X\n\x0c\x65xplain_mode\x18\x02 \x01(\x0e\x32\x35.spark.connect.AnalyzePlanRequest.Explain.ExplainModeR\x0b\x65xplainMode"\xac\x01\n\x0b\x45xplainMode\x12\x1c\n\x18\x45XPLAIN_MODE_UNSPECIFIED\x10\x00\x12\x17\n\x13\x45XPLAIN_MODE_SIMPLE\x10\x01\x12\x19\n\x15\x45XPLAIN_MODE_EXTENDED\x10\x02\x12\x18\n\x14\x45XPLAIN_MODE_CODEGEN\x10\x03\x12\x15\n\x11\x45XPLAIN_MODE_COST\x10\x04\x12\x1a\n\x16\x45XPLAIN_MODE_FORMATTED\x10\x05\x1a\x35\n\nTreeString\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x32\n\x07IsLocal\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x36\n\x0bIsStreaming\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x35\n\nInputFiles\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x0e\n\x0cSparkVersion\x1a)\n\x08\x44\x44LParse\x12\x1d\n\nddl_string\x18\x01 \x01(\tR\tddlString\x1ay\n\rSameSemantics\x12\x34\n\x0btarget_plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\ntargetPlan\x12\x32\n\nother_plan\x18\x02 \x01(\x0b\x32\x13.spark.connect.PlanR\totherPlan\x1a\x37\n\x0cSemanticHash\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x97\x01\n\x07Persist\x12\x33\n\x08relation\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x08relation\x12\x45\n\rstorage_level\x18\x02 \x01(\x0b\x32\x1b.spark.connect.StorageLevelH\x00R\x0cstorageLevel\x88\x01\x01\x42\x10\n\x0e_storage_level\x1an\n\tUnpersist\x12\x33\n\x08relation\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x08relation\x12\x1f\n\x08\x62locking\x18\x02 \x01(\x08H\x00R\x08\x62locking\x88\x01\x01\x42\x0b\n\t_blocking\x1a\x46\n\x0fGetStorageLevel\x12\x33\n\x08relation\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x08relationB\t\n\x07\x61nalyzeB\x0e\n\x0c_client_type"\x99\r\n\x13\x41nalyzePlanResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12\x43\n\x06schema\x18\x02 \x01(\x0b\x32).spark.connect.AnalyzePlanResponse.SchemaH\x00R\x06schema\x12\x46\n\x07\x65xplain\x18\x03 \x01(\x0b\x32*.spark.connect.AnalyzePlanResponse.ExplainH\x00R\x07\x65xplain\x12P\n\x0btree_string\x18\x04 \x01(\x0b\x32-.spark.connect.AnalyzePlanResponse.TreeStringH\x00R\ntreeString\x12G\n\x08is_local\x18\x05 \x01(\x0b\x32*.spark.connect.AnalyzePlanResponse.IsLocalH\x00R\x07isLocal\x12S\n\x0cis_streaming\x18\x06 \x01(\x0b\x32..spark.connect.AnalyzePlanResponse.IsStreamingH\x00R\x0bisStreaming\x12P\n\x0binput_files\x18\x07 \x01(\x0b\x32-.spark.connect.AnalyzePlanResponse.InputFilesH\x00R\ninputFiles\x12V\n\rspark_version\x18\x08 \x01(\x0b\x32/.spark.connect.AnalyzePlanResponse.SparkVersionH\x00R\x0csparkVersion\x12J\n\tddl_parse\x18\t \x01(\x0b\x32+.spark.connect.AnalyzePlanResponse.DDLParseH\x00R\x08\x64\x64lParse\x12Y\n\x0esame_semantics\x18\n \x01(\x0b\x32\x30.spark.connect.AnalyzePlanResponse.SameSemanticsH\x00R\rsameSemantics\x12V\n\rsemantic_hash\x18\x0b \x01(\x0b\x32/.spark.connect.AnalyzePlanResponse.SemanticHashH\x00R\x0csemanticHash\x12\x46\n\x07persist\x18\x0c \x01(\x0b\x32*.spark.connect.AnalyzePlanResponse.PersistH\x00R\x07persist\x12L\n\tunpersist\x18\r \x01(\x0b\x32,.spark.connect.AnalyzePlanResponse.UnpersistH\x00R\tunpersist\x12`\n\x11get_storage_level\x18\x0e \x01(\x0b\x32\x32.spark.connect.AnalyzePlanResponse.GetStorageLevelH\x00R\x0fgetStorageLevel\x1a\x39\n\x06Schema\x12/\n\x06schema\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x06schema\x1a\x30\n\x07\x45xplain\x12%\n\x0e\x65xplain_string\x18\x01 \x01(\tR\rexplainString\x1a-\n\nTreeString\x12\x1f\n\x0btree_string\x18\x01 \x01(\tR\ntreeString\x1a$\n\x07IsLocal\x12\x19\n\x08is_local\x18\x01 \x01(\x08R\x07isLocal\x1a\x30\n\x0bIsStreaming\x12!\n\x0cis_streaming\x18\x01 \x01(\x08R\x0bisStreaming\x1a"\n\nInputFiles\x12\x14\n\x05\x66iles\x18\x01 \x03(\tR\x05\x66iles\x1a(\n\x0cSparkVersion\x12\x18\n\x07version\x18\x01 \x01(\tR\x07version\x1a;\n\x08\x44\x44LParse\x12/\n\x06parsed\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x06parsed\x1a\'\n\rSameSemantics\x12\x16\n\x06result\x18\x01 \x01(\x08R\x06result\x1a&\n\x0cSemanticHash\x12\x16\n\x06result\x18\x01 \x01(\x05R\x06result\x1a\t\n\x07Persist\x1a\x0b\n\tUnpersist\x1aS\n\x0fGetStorageLevel\x12@\n\rstorage_level\x18\x01 \x01(\x0b\x32\x1b.spark.connect.StorageLevelR\x0cstorageLevelB\x08\n\x06result"\xd1\x01\n\x12\x45xecutePlanRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x0cuser_context\x18\x02 \x01(\x0b\x32\x1a.spark.connect.UserContextR\x0buserContext\x12\'\n\x04plan\x18\x03 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x12$\n\x0b\x63lient_type\x18\x04 \x01(\tH\x00R\nclientType\x88\x01\x01\x42\x0e\n\x0c_client_type"\xfb\t\n\x13\x45xecutePlanResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12P\n\x0b\x61rrow_batch\x18\x02 \x01(\x0b\x32-.spark.connect.ExecutePlanResponse.ArrowBatchH\x00R\narrowBatch\x12\x63\n\x12sql_command_result\x18\x05 \x01(\x0b\x32\x33.spark.connect.ExecutePlanResponse.SqlCommandResultH\x00R\x10sqlCommandResult\x12\x35\n\textension\x18\xe7\x07 \x01(\x0b\x32\x14.google.protobuf.AnyH\x00R\textension\x12\x44\n\x07metrics\x18\x04 \x01(\x0b\x32*.spark.connect.ExecutePlanResponse.MetricsR\x07metrics\x12]\n\x10observed_metrics\x18\x06 \x03(\x0b\x32\x32.spark.connect.ExecutePlanResponse.ObservedMetricsR\x0fobservedMetrics\x12/\n\x06schema\x18\x07 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x06schema\x1aG\n\x10SqlCommandResult\x12\x33\n\x08relation\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x08relation\x1a=\n\nArrowBatch\x12\x1b\n\trow_count\x18\x01 \x01(\x03R\x08rowCount\x12\x12\n\x04\x64\x61ta\x18\x02 \x01(\x0cR\x04\x64\x61ta\x1a\x85\x04\n\x07Metrics\x12Q\n\x07metrics\x18\x01 \x03(\x0b\x32\x37.spark.connect.ExecutePlanResponse.Metrics.MetricObjectR\x07metrics\x1a\xcc\x02\n\x0cMetricObject\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x17\n\x07plan_id\x18\x02 \x01(\x03R\x06planId\x12\x16\n\x06parent\x18\x03 \x01(\x03R\x06parent\x12z\n\x11\x65xecution_metrics\x18\x04 \x03(\x0b\x32M.spark.connect.ExecutePlanResponse.Metrics.MetricObject.ExecutionMetricsEntryR\x10\x65xecutionMetrics\x1a{\n\x15\x45xecutionMetricsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12L\n\x05value\x18\x02 \x01(\x0b\x32\x36.spark.connect.ExecutePlanResponse.Metrics.MetricValueR\x05value:\x02\x38\x01\x1aX\n\x0bMetricValue\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n\x05value\x18\x02 \x01(\x03R\x05value\x12\x1f\n\x0bmetric_type\x18\x03 \x01(\tR\nmetricType\x1a`\n\x0fObservedMetrics\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x39\n\x06values\x18\x02 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06valuesB\x0f\n\rresponse_type"A\n\x08KeyValue\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x19\n\x05value\x18\x02 \x01(\tH\x00R\x05value\x88\x01\x01\x42\x08\n\x06_value"\x84\x08\n\rConfigRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x0cuser_context\x18\x02 \x01(\x0b\x32\x1a.spark.connect.UserContextR\x0buserContext\x12\x44\n\toperation\x18\x03 \x01(\x0b\x32&.spark.connect.ConfigRequest.OperationR\toperation\x12$\n\x0b\x63lient_type\x18\x04 \x01(\tH\x00R\nclientType\x88\x01\x01\x1a\xf2\x03\n\tOperation\x12\x34\n\x03set\x18\x01 \x01(\x0b\x32 .spark.connect.ConfigRequest.SetH\x00R\x03set\x12\x34\n\x03get\x18\x02 \x01(\x0b\x32 .spark.connect.ConfigRequest.GetH\x00R\x03get\x12W\n\x10get_with_default\x18\x03 \x01(\x0b\x32+.spark.connect.ConfigRequest.GetWithDefaultH\x00R\x0egetWithDefault\x12G\n\nget_option\x18\x04 \x01(\x0b\x32&.spark.connect.ConfigRequest.GetOptionH\x00R\tgetOption\x12>\n\x07get_all\x18\x05 \x01(\x0b\x32#.spark.connect.ConfigRequest.GetAllH\x00R\x06getAll\x12:\n\x05unset\x18\x06 \x01(\x0b\x32".spark.connect.ConfigRequest.UnsetH\x00R\x05unset\x12P\n\ris_modifiable\x18\x07 \x01(\x0b\x32).spark.connect.ConfigRequest.IsModifiableH\x00R\x0cisModifiableB\t\n\x07op_type\x1a\x34\n\x03Set\x12-\n\x05pairs\x18\x01 \x03(\x0b\x32\x17.spark.connect.KeyValueR\x05pairs\x1a\x19\n\x03Get\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keys\x1a?\n\x0eGetWithDefault\x12-\n\x05pairs\x18\x01 \x03(\x0b\x32\x17.spark.connect.KeyValueR\x05pairs\x1a\x1f\n\tGetOption\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keys\x1a\x30\n\x06GetAll\x12\x1b\n\x06prefix\x18\x01 \x01(\tH\x00R\x06prefix\x88\x01\x01\x42\t\n\x07_prefix\x1a\x1b\n\x05Unset\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keys\x1a"\n\x0cIsModifiable\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keysB\x0e\n\x0c_client_type"z\n\x0e\x43onfigResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12-\n\x05pairs\x18\x02 \x03(\x0b\x32\x17.spark.connect.KeyValueR\x05pairs\x12\x1a\n\x08warnings\x18\x03 \x03(\tR\x08warnings"\xe7\x06\n\x13\x41\x64\x64\x41rtifactsRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x0cuser_context\x18\x02 \x01(\x0b\x32\x1a.spark.connect.UserContextR\x0buserContext\x12$\n\x0b\x63lient_type\x18\x06 \x01(\tH\x01R\nclientType\x88\x01\x01\x12@\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32(.spark.connect.AddArtifactsRequest.BatchH\x00R\x05\x62\x61tch\x12Z\n\x0b\x62\x65gin_chunk\x18\x04 \x01(\x0b\x32\x37.spark.connect.AddArtifactsRequest.BeginChunkedArtifactH\x00R\nbeginChunk\x12H\n\x05\x63hunk\x18\x05 \x01(\x0b\x32\x30.spark.connect.AddArtifactsRequest.ArtifactChunkH\x00R\x05\x63hunk\x1a\x35\n\rArtifactChunk\x12\x12\n\x04\x64\x61ta\x18\x01 \x01(\x0cR\x04\x64\x61ta\x12\x10\n\x03\x63rc\x18\x02 \x01(\x03R\x03\x63rc\x1ao\n\x13SingleChunkArtifact\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x44\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x30.spark.connect.AddArtifactsRequest.ArtifactChunkR\x04\x64\x61ta\x1a]\n\x05\x42\x61tch\x12T\n\tartifacts\x18\x01 \x03(\x0b\x32\x36.spark.connect.AddArtifactsRequest.SingleChunkArtifactR\tartifacts\x1a\xc1\x01\n\x14\x42\x65ginChunkedArtifact\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n\x0btotal_bytes\x18\x02 \x01(\x03R\ntotalBytes\x12\x1d\n\nnum_chunks\x18\x03 \x01(\x03R\tnumChunks\x12U\n\rinitial_chunk\x18\x04 \x01(\x0b\x32\x30.spark.connect.AddArtifactsRequest.ArtifactChunkR\x0cinitialChunkB\t\n\x07payloadB\x0e\n\x0c_client_type"\xbc\x01\n\x14\x41\x64\x64\x41rtifactsResponse\x12Q\n\tartifacts\x18\x01 \x03(\x0b\x32\x33.spark.connect.AddArtifactsResponse.ArtifactSummaryR\tartifacts\x1aQ\n\x0f\x41rtifactSummary\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12*\n\x11is_crc_successful\x18\x02 \x01(\x08R\x0fisCrcSuccessful2\xed\x02\n\x13SparkConnectService\x12X\n\x0b\x45xecutePlan\x12!.spark.connect.ExecutePlanRequest\x1a".spark.connect.ExecutePlanResponse"\x00\x30\x01\x12V\n\x0b\x41nalyzePlan\x12!.spark.connect.AnalyzePlanRequest\x1a".spark.connect.AnalyzePlanResponse"\x00\x12G\n\x06\x43onfig\x12\x1c.spark.connect.ConfigRequest\x1a\x1d.spark.connect.ConfigResponse"\x00\x12[\n\x0c\x41\x64\x64\x41rtifacts\x12".spark.connect.AddArtifactsRequest\x1a#.spark.connect.AddArtifactsResponse"\x00(\x01\x42"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
+    b'\n\x18spark/connect/base.proto\x12\rspark.connect\x1a\x19google/protobuf/any.proto\x1a\x1cspark/connect/commands.proto\x1a\x1fspark/connect/expressions.proto\x1a\x1dspark/connect/relations.proto\x1a\x19spark/connect/types.proto"t\n\x04Plan\x12-\n\x04root\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationH\x00R\x04root\x12\x32\n\x07\x63ommand\x18\x02 \x01(\x0b\x32\x16.spark.connect.CommandH\x00R\x07\x63ommandB\t\n\x07op_type"z\n\x0bUserContext\x12\x17\n\x07user_id\x18\x01 \x01(\tR\x06userId\x12\x1b\n\tuser_name\x18\x02 \x01(\tR\x08userName\x12\x35\n\nextensions\x18\xe7\x07 \x03(\x0b\x32\x14.google.protobuf.AnyR\nextensions"\xb0\x01\n\x0cStorageLevel\x12\x19\n\x08use_disk\x18\x01 \x01(\x08R\x07useDisk\x12\x1d\n\nuse_memory\x18\x02 \x01(\x08R\tuseMemory\x12 \n\x0cuse_off_heap\x18\x03 \x01(\x08R\nuseOffHeap\x12"\n\x0c\x64\x65serialized\x18\x04 \x01(\x08R\x0c\x64\x65serialized\x12 \n\x0breplication\x18\x05 \x01(\x05R\x0breplication"\x96\x14\n\x12\x41nalyzePlanRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x0cuser_context\x18\x02 \x01(\x0b\x32\x1a.spark.connect.UserContextR\x0buserContext\x12$\n\x0b\x63lient_type\x18\x03 \x01(\tH\x01R\nclientType\x88\x01\x01\x12\x42\n\x06schema\x18\x04 \x01(\x0b\x32(.spark.connect.AnalyzePlanRequest.SchemaH\x00R\x06schema\x12\x45\n\x07\x65xplain\x18\x05 \x01(\x0b\x32).spark.connect.AnalyzePlanRequest.ExplainH\x00R\x07\x65xplain\x12O\n\x0btree_string\x18\x06 \x01(\x0b\x32,.spark.connect.AnalyzePlanRequest.TreeStringH\x00R\ntreeString\x12\x46\n\x08is_local\x18\x07 \x01(\x0b\x32).spark.connect.AnalyzePlanRequest.IsLocalH\x00R\x07isLocal\x12R\n\x0cis_streaming\x18\x08 \x01(\x0b\x32-.spark.connect.AnalyzePlanRequest.IsStreamingH\x00R\x0bisStreaming\x12O\n\x0binput_files\x18\t \x01(\x0b\x32,.spark.connect.AnalyzePlanRequest.InputFilesH\x00R\ninputFiles\x12U\n\rspark_version\x18\n \x01(\x0b\x32..spark.connect.AnalyzePlanRequest.SparkVersionH\x00R\x0csparkVersion\x12I\n\tddl_parse\x18\x0b \x01(\x0b\x32*.spark.connect.AnalyzePlanRequest.DDLParseH\x00R\x08\x64\x64lParse\x12X\n\x0esame_semantics\x18\x0c \x01(\x0b\x32/.spark.connect.AnalyzePlanRequest.SameSemanticsH\x00R\rsameSemantics\x12U\n\rsemantic_hash\x18\r \x01(\x0b\x32..spark.connect.AnalyzePlanRequest.SemanticHashH\x00R\x0csemanticHash\x12\x45\n\x07persist\x18\x0e \x01(\x0b\x32).spark.connect.AnalyzePlanRequest.PersistH\x00R\x07persist\x12K\n\tunpersist\x18\x0f \x01(\x0b\x32+.spark.connect.AnalyzePlanRequest.UnpersistH\x00R\tunpersist\x12_\n\x11get_storage_level\x18\x10 \x01(\x0b\x32\x31.spark.connect.AnalyzePlanRequest.GetStorageLevelH\x00R\x0fgetStorageLevel\x12\x64\n\x12\x65xplain_expression\x18\x11 \x01(\x0b\x32\x33.spark.connect.AnalyzePlanRequest.ExplainExpressionH\x00R\x11\x65xplainExpression\x1a\x31\n\x06Schema\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\xbb\x02\n\x07\x45xplain\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x12X\n\x0c\x65xplain_mode\x18\x02 \x01(\x0e\x32\x35.spark.connect.AnalyzePlanRequest.Explain.ExplainModeR\x0b\x65xplainMode"\xac\x01\n\x0b\x45xplainMode\x12\x1c\n\x18\x45XPLAIN_MODE_UNSPECIFIED\x10\x00\x12\x17\n\x13\x45XPLAIN_MODE_SIMPLE\x10\x01\x12\x19\n\x15\x45XPLAIN_MODE_EXTENDED\x10\x02\x12\x18\n\x14\x45XPLAIN_MODE_CODEGEN\x10\x03\x12\x15\n\x11\x45XPLAIN_MODE_COST\x10\x04\x12\x1a\n\x16\x45XPLAIN_MODE_FORMATTED\x10\x05\x1a\x35\n\nTreeString\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x32\n\x07IsLocal\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x36\n\x0bIsStreaming\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x35\n\nInputFiles\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x0e\n\x0cSparkVersion\x1a)\n\x08\x44\x44LParse\x12\x1d\n\nddl_string\x18\x01 \x01(\tR\tddlString\x1ay\n\rSameSemantics\x12\x34\n\x0btarget_plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\ntargetPlan\x12\x32\n\nother_plan\x18\x02 \x01(\x0b\x32\x13.spark.connect.PlanR\totherPlan\x1a\x37\n\x0cSemanticHash\x12\'\n\x04plan\x18\x01 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x1a\x97\x01\n\x07Persist\x12\x33\n\x08relation\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x08relation\x12\x45\n\rstorage_level\x18\x02 \x01(\x0b\x32\x1b.spark.connect.StorageLevelH\x00R\x0cstorageLevel\x88\x01\x01\x42\x10\n\x0e_storage_level\x1an\n\tUnpersist\x12\x33\n\x08relation\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x08relation\x12\x1f\n\x08\x62locking\x18\x02 \x01(\x08H\x00R\x08\x62locking\x88\x01\x01\x42\x0b\n\t_blocking\x1a\x46\n\x0fGetStorageLevel\x12\x33\n\x08relation\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x08relation\x1a^\n\x11\x45xplainExpression\x12-\n\x04\x65xpr\x18\x01 \x01(\x0b\x32\x19.spark.connect.ExpressionR\x04\x65xpr\x12\x1a\n\x08\x65xtended\x18\x02 \x01(\x08R\x08\x65xtendedB\t\n\x07\x61nalyzeB\x0e\n\x0c_client_type"\xbc\x0e\n\x13\x41nalyzePlanResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12\x43\n\x06schema\x18\x02 \x01(\x0b\x32).spark.connect.AnalyzePlanResponse.SchemaH\x00R\x06schema\x12\x46\n\x07\x65xplain\x18\x03 \x01(\x0b\x32*.spark.connect.AnalyzePlanResponse.ExplainH\x00R\x07\x65xplain\x12P\n\x0btree_string\x18\x04 \x01(\x0b\x32-.spark.connect.AnalyzePlanResponse.TreeStringH\x00R\ntreeString\x12G\n\x08is_local\x18\x05 \x01(\x0b\x32*.spark.connect.AnalyzePlanResponse.IsLocalH\x00R\x07isLocal\x12S\n\x0cis_streaming\x18\x06 \x01(\x0b\x32..spark.connect.AnalyzePlanResponse.IsStreamingH\x00R\x0bisStreaming\x12P\n\x0binput_files\x18\x07 \x01(\x0b\x32-.spark.connect.AnalyzePlanResponse.InputFilesH\x00R\ninputFiles\x12V\n\rspark_version\x18\x08 \x01(\x0b\x32/.spark.connect.AnalyzePlanResponse.SparkVersionH\x00R\x0csparkVersion\x12J\n\tddl_parse\x18\t \x01(\x0b\x32+.spark.connect.AnalyzePlanResponse.DDLParseH\x00R\x08\x64\x64lParse\x12Y\n\x0esame_semantics\x18\n \x01(\x0b\x32\x30.spark.connect.AnalyzePlanResponse.SameSemanticsH\x00R\rsameSemantics\x12V\n\rsemantic_hash\x18\x0b \x01(\x0b\x32/.spark.connect.AnalyzePlanResponse.SemanticHashH\x00R\x0csemanticHash\x12\x46\n\x07persist\x18\x0c \x01(\x0b\x32*.spark.connect.AnalyzePlanResponse.PersistH\x00R\x07persist\x12L\n\tunpersist\x18\r \x01(\x0b\x32,.spark.connect.AnalyzePlanResponse.UnpersistH\x00R\tunpersist\x12`\n\x11get_storage_level\x18\x0e \x01(\x0b\x32\x32.spark.connect.AnalyzePlanResponse.GetStorageLevelH\x00R\x0fgetStorageLevel\x12\x65\n\x12\x65xplain_expression\x18\x0f \x01(\x0b\x32\x34.spark.connect.AnalyzePlanResponse.ExplainExpressionH\x00R\x11\x65xplainExpression\x1a\x39\n\x06Schema\x12/\n\x06schema\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x06schema\x1a\x30\n\x07\x45xplain\x12%\n\x0e\x65xplain_string\x18\x01 \x01(\tR\rexplainString\x1a-\n\nTreeString\x12\x1f\n\x0btree_string\x18\x01 \x01(\tR\ntreeString\x1a$\n\x07IsLocal\x12\x19\n\x08is_local\x18\x01 \x01(\x08R\x07isLocal\x1a\x30\n\x0bIsStreaming\x12!\n\x0cis_streaming\x18\x01 \x01(\x08R\x0bisStreaming\x1a"\n\nInputFiles\x12\x14\n\x05\x66iles\x18\x01 \x03(\tR\x05\x66iles\x1a(\n\x0cSparkVersion\x12\x18\n\x07version\x18\x01 \x01(\tR\x07version\x1a;\n\x08\x44\x44LParse\x12/\n\x06parsed\x18\x01 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x06parsed\x1a\'\n\rSameSemantics\x12\x16\n\x06result\x18\x01 \x01(\x08R\x06result\x1a&\n\x0cSemanticHash\x12\x16\n\x06result\x18\x01 \x01(\x05R\x06result\x1a\t\n\x07Persist\x1a\x0b\n\tUnpersist\x1aS\n\x0fGetStorageLevel\x12@\n\rstorage_level\x18\x01 \x01(\x0b\x32\x1b.spark.connect.StorageLevelR\x0cstorageLevel\x1a:\n\x11\x45xplainExpression\x12%\n\x0e\x65xplain_string\x18\x01 \x01(\tR\rexplainStringB\x08\n\x06result"\xd1\x01\n\x12\x45xecutePlanRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x0cuser_context\x18\x02 \x01(\x0b\x32\x1a.spark.connect.UserContextR\x0buserContext\x12\'\n\x04plan\x18\x03 \x01(\x0b\x32\x13.spark.connect.PlanR\x04plan\x12$\n\x0b\x63lient_type\x18\x04 \x01(\tH\x00R\nclientType\x88\x01\x01\x42\x0e\n\x0c_client_type"\xfb\t\n\x13\x45xecutePlanResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12P\n\x0b\x61rrow_batch\x18\x02 \x01(\x0b\x32-.spark.connect.ExecutePlanResponse.ArrowBatchH\x00R\narrowBatch\x12\x63\n\x12sql_command_result\x18\x05 \x01(\x0b\x32\x33.spark.connect.ExecutePlanResponse.SqlCommandResultH\x00R\x10sqlCommandResult\x12\x35\n\textension\x18\xe7\x07 \x01(\x0b\x32\x14.google.protobuf.AnyH\x00R\textension\x12\x44\n\x07metrics\x18\x04 \x01(\x0b\x32*.spark.connect.ExecutePlanResponse.MetricsR\x07metrics\x12]\n\x10observed_metrics\x18\x06 \x03(\x0b\x32\x32.spark.connect.ExecutePlanResponse.ObservedMetricsR\x0fobservedMetrics\x12/\n\x06schema\x18\x07 \x01(\x0b\x32\x17.spark.connect.DataTypeR\x06schema\x1aG\n\x10SqlCommandResult\x12\x33\n\x08relation\x18\x01 \x01(\x0b\x32\x17.spark.connect.RelationR\x08relation\x1a=\n\nArrowBatch\x12\x1b\n\trow_count\x18\x01 \x01(\x03R\x08rowCount\x12\x12\n\x04\x64\x61ta\x18\x02 \x01(\x0cR\x04\x64\x61ta\x1a\x85\x04\n\x07Metrics\x12Q\n\x07metrics\x18\x01 \x03(\x0b\x32\x37.spark.connect.ExecutePlanResponse.Metrics.MetricObjectR\x07metrics\x1a\xcc\x02\n\x0cMetricObject\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x17\n\x07plan_id\x18\x02 \x01(\x03R\x06planId\x12\x16\n\x06parent\x18\x03 \x01(\x03R\x06parent\x12z\n\x11\x65xecution_metrics\x18\x04 \x03(\x0b\x32M.spark.connect.ExecutePlanResponse.Metrics.MetricObject.ExecutionMetricsEntryR\x10\x65xecutionMetrics\x1a{\n\x15\x45xecutionMetricsEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12L\n\x05value\x18\x02 \x01(\x0b\x32\x36.spark.connect.ExecutePlanResponse.Metrics.MetricValueR\x05value:\x02\x38\x01\x1aX\n\x0bMetricValue\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n\x05value\x18\x02 \x01(\x03R\x05value\x12\x1f\n\x0bmetric_type\x18\x03 \x01(\tR\nmetricType\x1a`\n\x0fObservedMetrics\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x39\n\x06values\x18\x02 \x03(\x0b\x32!.spark.connect.Expression.LiteralR\x06valuesB\x0f\n\rresponse_type"A\n\x08KeyValue\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x19\n\x05value\x18\x02 \x01(\tH\x00R\x05value\x88\x01\x01\x42\x08\n\x06_value"\x84\x08\n\rConfigRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x0cuser_context\x18\x02 \x01(\x0b\x32\x1a.spark.connect.UserContextR\x0buserContext\x12\x44\n\toperation\x18\x03 \x01(\x0b\x32&.spark.connect.ConfigRequest.OperationR\toperation\x12$\n\x0b\x63lient_type\x18\x04 \x01(\tH\x00R\nclientType\x88\x01\x01\x1a\xf2\x03\n\tOperation\x12\x34\n\x03set\x18\x01 \x01(\x0b\x32 .spark.connect.ConfigRequest.SetH\x00R\x03set\x12\x34\n\x03get\x18\x02 \x01(\x0b\x32 .spark.connect.ConfigRequest.GetH\x00R\x03get\x12W\n\x10get_with_default\x18\x03 \x01(\x0b\x32+.spark.connect.ConfigRequest.GetWithDefaultH\x00R\x0egetWithDefault\x12G\n\nget_option\x18\x04 \x01(\x0b\x32&.spark.connect.ConfigRequest.GetOptionH\x00R\tgetOption\x12>\n\x07get_all\x18\x05 \x01(\x0b\x32#.spark.connect.ConfigRequest.GetAllH\x00R\x06getAll\x12:\n\x05unset\x18\x06 \x01(\x0b\x32".spark.connect.ConfigRequest.UnsetH\x00R\x05unset\x12P\n\ris_modifiable\x18\x07 \x01(\x0b\x32).spark.connect.ConfigRequest.IsModifiableH\x00R\x0cisModifiableB\t\n\x07op_type\x1a\x34\n\x03Set\x12-\n\x05pairs\x18\x01 \x03(\x0b\x32\x17.spark.connect.KeyValueR\x05pairs\x1a\x19\n\x03Get\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keys\x1a?\n\x0eGetWithDefault\x12-\n\x05pairs\x18\x01 \x03(\x0b\x32\x17.spark.connect.KeyValueR\x05pairs\x1a\x1f\n\tGetOption\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keys\x1a\x30\n\x06GetAll\x12\x1b\n\x06prefix\x18\x01 \x01(\tH\x00R\x06prefix\x88\x01\x01\x42\t\n\x07_prefix\x1a\x1b\n\x05Unset\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keys\x1a"\n\x0cIsModifiable\x12\x12\n\x04keys\x18\x01 \x03(\tR\x04keysB\x0e\n\x0c_client_type"z\n\x0e\x43onfigResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12-\n\x05pairs\x18\x02 \x03(\x0b\x32\x17.spark.connect.KeyValueR\x05pairs\x12\x1a\n\x08warnings\x18\x03 \x03(\tR\x08warnings"\xe7\x06\n\x13\x41\x64\x64\x41rtifactsRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x0cuser_context\x18\x02 \x01(\x0b\x32\x1a.spark.connect.UserContextR\x0buserContext\x12$\n\x0b\x63lient_type\x18\x06 \x01(\tH\x01R\nclientType\x88\x01\x01\x12@\n\x05\x62\x61tch\x18\x03 \x01(\x0b\x32(.spark.connect.AddArtifactsRequest.BatchH\x00R\x05\x62\x61tch\x12Z\n\x0b\x62\x65gin_chunk\x18\x04 \x01(\x0b\x32\x37.spark.connect.AddArtifactsRequest.BeginChunkedArtifactH\x00R\nbeginChunk\x12H\n\x05\x63hunk\x18\x05 \x01(\x0b\x32\x30.spark.connect.AddArtifactsRequest.ArtifactChunkH\x00R\x05\x63hunk\x1a\x35\n\rArtifactChunk\x12\x12\n\x04\x64\x61ta\x18\x01 \x01(\x0cR\x04\x64\x61ta\x12\x10\n\x03\x63rc\x18\x02 \x01(\x03R\x03\x63rc\x1ao\n\x13SingleChunkArtifact\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x44\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x30.spark.connect.AddArtifactsRequest.ArtifactChunkR\x04\x64\x61ta\x1a]\n\x05\x42\x61tch\x12T\n\tartifacts\x18\x01 \x03(\x0b\x32\x36.spark.connect.AddArtifactsRequest.SingleChunkArtifactR\tartifacts\x1a\xc1\x01\n\x14\x42\x65ginChunkedArtifact\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n\x0btotal_bytes\x18\x02 \x01(\x03R\ntotalBytes\x12\x1d\n\nnum_chunks\x18\x03 \x01(\x03R\tnumChunks\x12U\n\rinitial_chunk\x18\x04 \x01(\x0b\x32\x30.spark.connect.AddArtifactsRequest.ArtifactChunkR\x0cinitialChunkB\t\n\x07payloadB\x0e\n\x0c_client_type"\xbc\x01\n\x14\x41\x64\x64\x41rtifactsResponse\x12Q\n\tartifacts\x18\x01 \x03(\x0b\x32\x33.spark.connect.AddArtifactsResponse.ArtifactSummaryR\tartifacts\x1aQ\n\x0f\x41rtifactSummary\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12*\n\x11is_crc_successful\x18\x02 \x01(\x08R\x0fisCrcSuccessful2\xed\x02\n\x13SparkConnectService\x12X\n\x0b\x45xecutePlan\x12!.spark.connect.ExecutePlanRequest\x1a".spark.connect.ExecutePlanResponse"\x00\x30\x01\x12V\n\x0b\x41nalyzePlan\x12!.spark.connect.AnalyzePlanRequest\x1a".spark.connect.AnalyzePlanResponse"\x00\x12G\n\x06\x43onfig\x12\x1c.spark.connect.ConfigRequest\x1a\x1d.spark.connect.ConfigResponse"\x00\x12[\n\x0c\x41\x64\x64\x41rtifacts\x12".spark.connect.AddArtifactsRequest\x1a#.spark.connect.AddArtifactsResponse"\x00(\x01\x42"\n\x1eorg.apache.spark.connect.protoP\x01\x62\x06proto3'
 )
 
 
@@ -58,6 +58,9 @@ _ANALYZEPLANREQUEST_SEMANTICHASH = _ANALYZEPLANREQUEST.nested_types_by_name["Sem
 _ANALYZEPLANREQUEST_PERSIST = _ANALYZEPLANREQUEST.nested_types_by_name["Persist"]
 _ANALYZEPLANREQUEST_UNPERSIST = _ANALYZEPLANREQUEST.nested_types_by_name["Unpersist"]
 _ANALYZEPLANREQUEST_GETSTORAGELEVEL = _ANALYZEPLANREQUEST.nested_types_by_name["GetStorageLevel"]
+_ANALYZEPLANREQUEST_EXPLAINEXPRESSION = _ANALYZEPLANREQUEST.nested_types_by_name[
+    "ExplainExpression"
+]
 _ANALYZEPLANRESPONSE = DESCRIPTOR.message_types_by_name["AnalyzePlanResponse"]
 _ANALYZEPLANRESPONSE_SCHEMA = _ANALYZEPLANRESPONSE.nested_types_by_name["Schema"]
 _ANALYZEPLANRESPONSE_EXPLAIN = _ANALYZEPLANRESPONSE.nested_types_by_name["Explain"]
@@ -72,6 +75,9 @@ _ANALYZEPLANRESPONSE_SEMANTICHASH = _ANALYZEPLANRESPONSE.nested_types_by_name["S
 _ANALYZEPLANRESPONSE_PERSIST = _ANALYZEPLANRESPONSE.nested_types_by_name["Persist"]
 _ANALYZEPLANRESPONSE_UNPERSIST = _ANALYZEPLANRESPONSE.nested_types_by_name["Unpersist"]
 _ANALYZEPLANRESPONSE_GETSTORAGELEVEL = _ANALYZEPLANRESPONSE.nested_types_by_name["GetStorageLevel"]
+_ANALYZEPLANRESPONSE_EXPLAINEXPRESSION = _ANALYZEPLANRESPONSE.nested_types_by_name[
+    "ExplainExpression"
+]
 _EXECUTEPLANREQUEST = DESCRIPTOR.message_types_by_name["ExecutePlanRequest"]
 _EXECUTEPLANRESPONSE = DESCRIPTOR.message_types_by_name["ExecutePlanResponse"]
 _EXECUTEPLANRESPONSE_SQLCOMMANDRESULT = _EXECUTEPLANRESPONSE.nested_types_by_name[
@@ -270,6 +276,15 @@ AnalyzePlanRequest = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.AnalyzePlanRequest.GetStorageLevel)
             },
         ),
+        "ExplainExpression": _reflection.GeneratedProtocolMessageType(
+            "ExplainExpression",
+            (_message.Message,),
+            {
+                "DESCRIPTOR": _ANALYZEPLANREQUEST_EXPLAINEXPRESSION,
+                "__module__": "spark.connect.base_pb2"
+                # @@protoc_insertion_point(class_scope:spark.connect.AnalyzePlanRequest.ExplainExpression)
+            },
+        ),
         "DESCRIPTOR": _ANALYZEPLANREQUEST,
         "__module__": "spark.connect.base_pb2"
         # @@protoc_insertion_point(class_scope:spark.connect.AnalyzePlanRequest)
@@ -289,6 +304,7 @@ _sym_db.RegisterMessage(AnalyzePlanRequest.SemanticHash)
 _sym_db.RegisterMessage(AnalyzePlanRequest.Persist)
 _sym_db.RegisterMessage(AnalyzePlanRequest.Unpersist)
 _sym_db.RegisterMessage(AnalyzePlanRequest.GetStorageLevel)
+_sym_db.RegisterMessage(AnalyzePlanRequest.ExplainExpression)
 
 AnalyzePlanResponse = _reflection.GeneratedProtocolMessageType(
     "AnalyzePlanResponse",
@@ -411,6 +427,15 @@ AnalyzePlanResponse = _reflection.GeneratedProtocolMessageType(
                 # @@protoc_insertion_point(class_scope:spark.connect.AnalyzePlanResponse.GetStorageLevel)
             },
         ),
+        "ExplainExpression": _reflection.GeneratedProtocolMessageType(
+            "ExplainExpression",
+            (_message.Message,),
+            {
+                "DESCRIPTOR": _ANALYZEPLANRESPONSE_EXPLAINEXPRESSION,
+                "__module__": "spark.connect.base_pb2"
+                # @@protoc_insertion_point(class_scope:spark.connect.AnalyzePlanResponse.ExplainExpression)
+            },
+        ),
         "DESCRIPTOR": _ANALYZEPLANRESPONSE,
         "__module__": "spark.connect.base_pb2"
         # @@protoc_insertion_point(class_scope:spark.connect.AnalyzePlanResponse)
@@ -430,6 +455,7 @@ _sym_db.RegisterMessage(AnalyzePlanResponse.SemanticHash)
 _sym_db.RegisterMessage(AnalyzePlanResponse.Persist)
 _sym_db.RegisterMessage(AnalyzePlanResponse.Unpersist)
 _sym_db.RegisterMessage(AnalyzePlanResponse.GetStorageLevel)
+_sym_db.RegisterMessage(AnalyzePlanResponse.ExplainExpression)
 
 ExecutePlanRequest = _reflection.GeneratedProtocolMessageType(
     "ExecutePlanRequest",
@@ -722,117 +748,121 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _STORAGELEVEL._serialized_start = 434
     _STORAGELEVEL._serialized_end = 610
     _ANALYZEPLANREQUEST._serialized_start = 613
-    _ANALYZEPLANREQUEST._serialized_end = 2997
-    _ANALYZEPLANREQUEST_SCHEMA._serialized_start = 1808
-    _ANALYZEPLANREQUEST_SCHEMA._serialized_end = 1857
-    _ANALYZEPLANREQUEST_EXPLAIN._serialized_start = 1860
-    _ANALYZEPLANREQUEST_EXPLAIN._serialized_end = 2175
-    _ANALYZEPLANREQUEST_EXPLAIN_EXPLAINMODE._serialized_start = 2003
-    _ANALYZEPLANREQUEST_EXPLAIN_EXPLAINMODE._serialized_end = 2175
-    _ANALYZEPLANREQUEST_TREESTRING._serialized_start = 2177
-    _ANALYZEPLANREQUEST_TREESTRING._serialized_end = 2230
-    _ANALYZEPLANREQUEST_ISLOCAL._serialized_start = 2232
-    _ANALYZEPLANREQUEST_ISLOCAL._serialized_end = 2282
-    _ANALYZEPLANREQUEST_ISSTREAMING._serialized_start = 2284
-    _ANALYZEPLANREQUEST_ISSTREAMING._serialized_end = 2338
-    _ANALYZEPLANREQUEST_INPUTFILES._serialized_start = 2340
-    _ANALYZEPLANREQUEST_INPUTFILES._serialized_end = 2393
-    _ANALYZEPLANREQUEST_SPARKVERSION._serialized_start = 2395
-    _ANALYZEPLANREQUEST_SPARKVERSION._serialized_end = 2409
-    _ANALYZEPLANREQUEST_DDLPARSE._serialized_start = 2411
-    _ANALYZEPLANREQUEST_DDLPARSE._serialized_end = 2452
-    _ANALYZEPLANREQUEST_SAMESEMANTICS._serialized_start = 2454
-    _ANALYZEPLANREQUEST_SAMESEMANTICS._serialized_end = 2575
-    _ANALYZEPLANREQUEST_SEMANTICHASH._serialized_start = 2577
-    _ANALYZEPLANREQUEST_SEMANTICHASH._serialized_end = 2632
-    _ANALYZEPLANREQUEST_PERSIST._serialized_start = 2635
-    _ANALYZEPLANREQUEST_PERSIST._serialized_end = 2786
-    _ANALYZEPLANREQUEST_UNPERSIST._serialized_start = 2788
-    _ANALYZEPLANREQUEST_UNPERSIST._serialized_end = 2898
-    _ANALYZEPLANREQUEST_GETSTORAGELEVEL._serialized_start = 2900
-    _ANALYZEPLANREQUEST_GETSTORAGELEVEL._serialized_end = 2970
-    _ANALYZEPLANRESPONSE._serialized_start = 3000
-    _ANALYZEPLANRESPONSE._serialized_end = 4689
-    _ANALYZEPLANRESPONSE_SCHEMA._serialized_start = 4108
-    _ANALYZEPLANRESPONSE_SCHEMA._serialized_end = 4165
-    _ANALYZEPLANRESPONSE_EXPLAIN._serialized_start = 4167
-    _ANALYZEPLANRESPONSE_EXPLAIN._serialized_end = 4215
-    _ANALYZEPLANRESPONSE_TREESTRING._serialized_start = 4217
-    _ANALYZEPLANRESPONSE_TREESTRING._serialized_end = 4262
-    _ANALYZEPLANRESPONSE_ISLOCAL._serialized_start = 4264
-    _ANALYZEPLANRESPONSE_ISLOCAL._serialized_end = 4300
-    _ANALYZEPLANRESPONSE_ISSTREAMING._serialized_start = 4302
-    _ANALYZEPLANRESPONSE_ISSTREAMING._serialized_end = 4350
-    _ANALYZEPLANRESPONSE_INPUTFILES._serialized_start = 4352
-    _ANALYZEPLANRESPONSE_INPUTFILES._serialized_end = 4386
-    _ANALYZEPLANRESPONSE_SPARKVERSION._serialized_start = 4388
-    _ANALYZEPLANRESPONSE_SPARKVERSION._serialized_end = 4428
-    _ANALYZEPLANRESPONSE_DDLPARSE._serialized_start = 4430
-    _ANALYZEPLANRESPONSE_DDLPARSE._serialized_end = 4489
-    _ANALYZEPLANRESPONSE_SAMESEMANTICS._serialized_start = 4491
-    _ANALYZEPLANRESPONSE_SAMESEMANTICS._serialized_end = 4530
-    _ANALYZEPLANRESPONSE_SEMANTICHASH._serialized_start = 4532
-    _ANALYZEPLANRESPONSE_SEMANTICHASH._serialized_end = 4570
-    _ANALYZEPLANRESPONSE_PERSIST._serialized_start = 2635
-    _ANALYZEPLANRESPONSE_PERSIST._serialized_end = 2644
-    _ANALYZEPLANRESPONSE_UNPERSIST._serialized_start = 2788
-    _ANALYZEPLANRESPONSE_UNPERSIST._serialized_end = 2799
-    _ANALYZEPLANRESPONSE_GETSTORAGELEVEL._serialized_start = 4596
-    _ANALYZEPLANRESPONSE_GETSTORAGELEVEL._serialized_end = 4679
-    _EXECUTEPLANREQUEST._serialized_start = 4692
-    _EXECUTEPLANREQUEST._serialized_end = 4901
-    _EXECUTEPLANRESPONSE._serialized_start = 4904
-    _EXECUTEPLANRESPONSE._serialized_end = 6179
-    _EXECUTEPLANRESPONSE_SQLCOMMANDRESULT._serialized_start = 5410
-    _EXECUTEPLANRESPONSE_SQLCOMMANDRESULT._serialized_end = 5481
-    _EXECUTEPLANRESPONSE_ARROWBATCH._serialized_start = 5483
-    _EXECUTEPLANRESPONSE_ARROWBATCH._serialized_end = 5544
-    _EXECUTEPLANRESPONSE_METRICS._serialized_start = 5547
-    _EXECUTEPLANRESPONSE_METRICS._serialized_end = 6064
-    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT._serialized_start = 5642
-    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT._serialized_end = 5974
-    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT_EXECUTIONMETRICSENTRY._serialized_start = 5851
-    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT_EXECUTIONMETRICSENTRY._serialized_end = 5974
-    _EXECUTEPLANRESPONSE_METRICS_METRICVALUE._serialized_start = 5976
-    _EXECUTEPLANRESPONSE_METRICS_METRICVALUE._serialized_end = 6064
-    _EXECUTEPLANRESPONSE_OBSERVEDMETRICS._serialized_start = 6066
-    _EXECUTEPLANRESPONSE_OBSERVEDMETRICS._serialized_end = 6162
-    _KEYVALUE._serialized_start = 6181
-    _KEYVALUE._serialized_end = 6246
-    _CONFIGREQUEST._serialized_start = 6249
-    _CONFIGREQUEST._serialized_end = 7277
-    _CONFIGREQUEST_OPERATION._serialized_start = 6469
-    _CONFIGREQUEST_OPERATION._serialized_end = 6967
-    _CONFIGREQUEST_SET._serialized_start = 6969
-    _CONFIGREQUEST_SET._serialized_end = 7021
-    _CONFIGREQUEST_GET._serialized_start = 7023
-    _CONFIGREQUEST_GET._serialized_end = 7048
-    _CONFIGREQUEST_GETWITHDEFAULT._serialized_start = 7050
-    _CONFIGREQUEST_GETWITHDEFAULT._serialized_end = 7113
-    _CONFIGREQUEST_GETOPTION._serialized_start = 7115
-    _CONFIGREQUEST_GETOPTION._serialized_end = 7146
-    _CONFIGREQUEST_GETALL._serialized_start = 7148
-    _CONFIGREQUEST_GETALL._serialized_end = 7196
-    _CONFIGREQUEST_UNSET._serialized_start = 7198
-    _CONFIGREQUEST_UNSET._serialized_end = 7225
-    _CONFIGREQUEST_ISMODIFIABLE._serialized_start = 7227
-    _CONFIGREQUEST_ISMODIFIABLE._serialized_end = 7261
-    _CONFIGRESPONSE._serialized_start = 7279
-    _CONFIGRESPONSE._serialized_end = 7401
-    _ADDARTIFACTSREQUEST._serialized_start = 7404
-    _ADDARTIFACTSREQUEST._serialized_end = 8275
-    _ADDARTIFACTSREQUEST_ARTIFACTCHUNK._serialized_start = 7791
-    _ADDARTIFACTSREQUEST_ARTIFACTCHUNK._serialized_end = 7844
-    _ADDARTIFACTSREQUEST_SINGLECHUNKARTIFACT._serialized_start = 7846
-    _ADDARTIFACTSREQUEST_SINGLECHUNKARTIFACT._serialized_end = 7957
-    _ADDARTIFACTSREQUEST_BATCH._serialized_start = 7959
-    _ADDARTIFACTSREQUEST_BATCH._serialized_end = 8052
-    _ADDARTIFACTSREQUEST_BEGINCHUNKEDARTIFACT._serialized_start = 8055
-    _ADDARTIFACTSREQUEST_BEGINCHUNKEDARTIFACT._serialized_end = 8248
-    _ADDARTIFACTSRESPONSE._serialized_start = 8278
-    _ADDARTIFACTSRESPONSE._serialized_end = 8466
-    _ADDARTIFACTSRESPONSE_ARTIFACTSUMMARY._serialized_start = 8385
-    _ADDARTIFACTSRESPONSE_ARTIFACTSUMMARY._serialized_end = 8466
-    _SPARKCONNECTSERVICE._serialized_start = 8469
-    _SPARKCONNECTSERVICE._serialized_end = 8834
+    _ANALYZEPLANREQUEST._serialized_end = 3195
+    _ANALYZEPLANREQUEST_SCHEMA._serialized_start = 1910
+    _ANALYZEPLANREQUEST_SCHEMA._serialized_end = 1959
+    _ANALYZEPLANREQUEST_EXPLAIN._serialized_start = 1962
+    _ANALYZEPLANREQUEST_EXPLAIN._serialized_end = 2277
+    _ANALYZEPLANREQUEST_EXPLAIN_EXPLAINMODE._serialized_start = 2105
+    _ANALYZEPLANREQUEST_EXPLAIN_EXPLAINMODE._serialized_end = 2277
+    _ANALYZEPLANREQUEST_TREESTRING._serialized_start = 2279
+    _ANALYZEPLANREQUEST_TREESTRING._serialized_end = 2332
+    _ANALYZEPLANREQUEST_ISLOCAL._serialized_start = 2334
+    _ANALYZEPLANREQUEST_ISLOCAL._serialized_end = 2384
+    _ANALYZEPLANREQUEST_ISSTREAMING._serialized_start = 2386
+    _ANALYZEPLANREQUEST_ISSTREAMING._serialized_end = 2440
+    _ANALYZEPLANREQUEST_INPUTFILES._serialized_start = 2442
+    _ANALYZEPLANREQUEST_INPUTFILES._serialized_end = 2495
+    _ANALYZEPLANREQUEST_SPARKVERSION._serialized_start = 2497
+    _ANALYZEPLANREQUEST_SPARKVERSION._serialized_end = 2511
+    _ANALYZEPLANREQUEST_DDLPARSE._serialized_start = 2513
+    _ANALYZEPLANREQUEST_DDLPARSE._serialized_end = 2554
+    _ANALYZEPLANREQUEST_SAMESEMANTICS._serialized_start = 2556
+    _ANALYZEPLANREQUEST_SAMESEMANTICS._serialized_end = 2677
+    _ANALYZEPLANREQUEST_SEMANTICHASH._serialized_start = 2679
+    _ANALYZEPLANREQUEST_SEMANTICHASH._serialized_end = 2734
+    _ANALYZEPLANREQUEST_PERSIST._serialized_start = 2737
+    _ANALYZEPLANREQUEST_PERSIST._serialized_end = 2888
+    _ANALYZEPLANREQUEST_UNPERSIST._serialized_start = 2890
+    _ANALYZEPLANREQUEST_UNPERSIST._serialized_end = 3000
+    _ANALYZEPLANREQUEST_GETSTORAGELEVEL._serialized_start = 3002
+    _ANALYZEPLANREQUEST_GETSTORAGELEVEL._serialized_end = 3072
+    _ANALYZEPLANREQUEST_EXPLAINEXPRESSION._serialized_start = 3074
+    _ANALYZEPLANREQUEST_EXPLAINEXPRESSION._serialized_end = 3168
+    _ANALYZEPLANRESPONSE._serialized_start = 3198
+    _ANALYZEPLANRESPONSE._serialized_end = 5050
+    _ANALYZEPLANRESPONSE_SCHEMA._serialized_start = 4409
+    _ANALYZEPLANRESPONSE_SCHEMA._serialized_end = 4466
+    _ANALYZEPLANRESPONSE_EXPLAIN._serialized_start = 4468
+    _ANALYZEPLANRESPONSE_EXPLAIN._serialized_end = 4516
+    _ANALYZEPLANRESPONSE_TREESTRING._serialized_start = 4518
+    _ANALYZEPLANRESPONSE_TREESTRING._serialized_end = 4563
+    _ANALYZEPLANRESPONSE_ISLOCAL._serialized_start = 4565
+    _ANALYZEPLANRESPONSE_ISLOCAL._serialized_end = 4601
+    _ANALYZEPLANRESPONSE_ISSTREAMING._serialized_start = 4603
+    _ANALYZEPLANRESPONSE_ISSTREAMING._serialized_end = 4651
+    _ANALYZEPLANRESPONSE_INPUTFILES._serialized_start = 4653
+    _ANALYZEPLANRESPONSE_INPUTFILES._serialized_end = 4687
+    _ANALYZEPLANRESPONSE_SPARKVERSION._serialized_start = 4689
+    _ANALYZEPLANRESPONSE_SPARKVERSION._serialized_end = 4729
+    _ANALYZEPLANRESPONSE_DDLPARSE._serialized_start = 4731
+    _ANALYZEPLANRESPONSE_DDLPARSE._serialized_end = 4790
+    _ANALYZEPLANRESPONSE_SAMESEMANTICS._serialized_start = 4792
+    _ANALYZEPLANRESPONSE_SAMESEMANTICS._serialized_end = 4831
+    _ANALYZEPLANRESPONSE_SEMANTICHASH._serialized_start = 4833
+    _ANALYZEPLANRESPONSE_SEMANTICHASH._serialized_end = 4871
+    _ANALYZEPLANRESPONSE_PERSIST._serialized_start = 2737
+    _ANALYZEPLANRESPONSE_PERSIST._serialized_end = 2746
+    _ANALYZEPLANRESPONSE_UNPERSIST._serialized_start = 2890
+    _ANALYZEPLANRESPONSE_UNPERSIST._serialized_end = 2901
+    _ANALYZEPLANRESPONSE_GETSTORAGELEVEL._serialized_start = 4897
+    _ANALYZEPLANRESPONSE_GETSTORAGELEVEL._serialized_end = 4980
+    _ANALYZEPLANRESPONSE_EXPLAINEXPRESSION._serialized_start = 4982
+    _ANALYZEPLANRESPONSE_EXPLAINEXPRESSION._serialized_end = 5040
+    _EXECUTEPLANREQUEST._serialized_start = 5053
+    _EXECUTEPLANREQUEST._serialized_end = 5262
+    _EXECUTEPLANRESPONSE._serialized_start = 5265
+    _EXECUTEPLANRESPONSE._serialized_end = 6540
+    _EXECUTEPLANRESPONSE_SQLCOMMANDRESULT._serialized_start = 5771
+    _EXECUTEPLANRESPONSE_SQLCOMMANDRESULT._serialized_end = 5842
+    _EXECUTEPLANRESPONSE_ARROWBATCH._serialized_start = 5844
+    _EXECUTEPLANRESPONSE_ARROWBATCH._serialized_end = 5905
+    _EXECUTEPLANRESPONSE_METRICS._serialized_start = 5908
+    _EXECUTEPLANRESPONSE_METRICS._serialized_end = 6425
+    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT._serialized_start = 6003
+    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT._serialized_end = 6335
+    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT_EXECUTIONMETRICSENTRY._serialized_start = 6212
+    _EXECUTEPLANRESPONSE_METRICS_METRICOBJECT_EXECUTIONMETRICSENTRY._serialized_end = 6335
+    _EXECUTEPLANRESPONSE_METRICS_METRICVALUE._serialized_start = 6337
+    _EXECUTEPLANRESPONSE_METRICS_METRICVALUE._serialized_end = 6425
+    _EXECUTEPLANRESPONSE_OBSERVEDMETRICS._serialized_start = 6427
+    _EXECUTEPLANRESPONSE_OBSERVEDMETRICS._serialized_end = 6523
+    _KEYVALUE._serialized_start = 6542
+    _KEYVALUE._serialized_end = 6607
+    _CONFIGREQUEST._serialized_start = 6610
+    _CONFIGREQUEST._serialized_end = 7638
+    _CONFIGREQUEST_OPERATION._serialized_start = 6830
+    _CONFIGREQUEST_OPERATION._serialized_end = 7328
+    _CONFIGREQUEST_SET._serialized_start = 7330
+    _CONFIGREQUEST_SET._serialized_end = 7382
+    _CONFIGREQUEST_GET._serialized_start = 7384
+    _CONFIGREQUEST_GET._serialized_end = 7409
+    _CONFIGREQUEST_GETWITHDEFAULT._serialized_start = 7411
+    _CONFIGREQUEST_GETWITHDEFAULT._serialized_end = 7474
+    _CONFIGREQUEST_GETOPTION._serialized_start = 7476
+    _CONFIGREQUEST_GETOPTION._serialized_end = 7507
+    _CONFIGREQUEST_GETALL._serialized_start = 7509
+    _CONFIGREQUEST_GETALL._serialized_end = 7557
+    _CONFIGREQUEST_UNSET._serialized_start = 7559
+    _CONFIGREQUEST_UNSET._serialized_end = 7586
+    _CONFIGREQUEST_ISMODIFIABLE._serialized_start = 7588
+    _CONFIGREQUEST_ISMODIFIABLE._serialized_end = 7622
+    _CONFIGRESPONSE._serialized_start = 7640
+    _CONFIGRESPONSE._serialized_end = 7762
+    _ADDARTIFACTSREQUEST._serialized_start = 7765
+    _ADDARTIFACTSREQUEST._serialized_end = 8636
+    _ADDARTIFACTSREQUEST_ARTIFACTCHUNK._serialized_start = 8152
+    _ADDARTIFACTSREQUEST_ARTIFACTCHUNK._serialized_end = 8205
+    _ADDARTIFACTSREQUEST_SINGLECHUNKARTIFACT._serialized_start = 8207
+    _ADDARTIFACTSREQUEST_SINGLECHUNKARTIFACT._serialized_end = 8318
+    _ADDARTIFACTSREQUEST_BATCH._serialized_start = 8320
+    _ADDARTIFACTSREQUEST_BATCH._serialized_end = 8413
+    _ADDARTIFACTSREQUEST_BEGINCHUNKEDARTIFACT._serialized_start = 8416
+    _ADDARTIFACTSREQUEST_BEGINCHUNKEDARTIFACT._serialized_end = 8609
+    _ADDARTIFACTSRESPONSE._serialized_start = 8639
+    _ADDARTIFACTSRESPONSE._serialized_end = 8827
+    _ADDARTIFACTSRESPONSE_ARTIFACTSUMMARY._serialized_start = 8746
+    _ADDARTIFACTSRESPONSE_ARTIFACTSUMMARY._serialized_end = 8827
+    _SPARKCONNECTSERVICE._serialized_start = 8830
+    _SPARKCONNECTSERVICE._serialized_end = 9195
 # @@protoc_insertion_point(module_scope)

--- a/python/pyspark/sql/connect/proto/base_pb2.pyi
+++ b/python/pyspark/sql/connect/proto/base_pb2.pyi
@@ -508,6 +508,30 @@ class AnalyzePlanRequest(google.protobuf.message.Message):
             self, field_name: typing_extensions.Literal["relation", b"relation"]
         ) -> None: ...
 
+    class ExplainExpression(google.protobuf.message.Message):
+        """Explains the expression based on extended is true or not."""
+
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        EXPR_FIELD_NUMBER: builtins.int
+        EXTENDED_FIELD_NUMBER: builtins.int
+        @property
+        def expr(self) -> pyspark.sql.connect.proto.expressions_pb2.Expression:
+            """(Required) The expression to be analyzed."""
+        extended: builtins.bool
+        def __init__(
+            self,
+            *,
+            expr: pyspark.sql.connect.proto.expressions_pb2.Expression | None = ...,
+            extended: builtins.bool = ...,
+        ) -> None: ...
+        def HasField(
+            self, field_name: typing_extensions.Literal["expr", b"expr"]
+        ) -> builtins.bool: ...
+        def ClearField(
+            self, field_name: typing_extensions.Literal["expr", b"expr", "extended", b"extended"]
+        ) -> None: ...
+
     SESSION_ID_FIELD_NUMBER: builtins.int
     USER_CONTEXT_FIELD_NUMBER: builtins.int
     CLIENT_TYPE_FIELD_NUMBER: builtins.int
@@ -524,6 +548,7 @@ class AnalyzePlanRequest(google.protobuf.message.Message):
     PERSIST_FIELD_NUMBER: builtins.int
     UNPERSIST_FIELD_NUMBER: builtins.int
     GET_STORAGE_LEVEL_FIELD_NUMBER: builtins.int
+    EXPLAIN_EXPRESSION_FIELD_NUMBER: builtins.int
     session_id: builtins.str
     """(Required)
 
@@ -565,6 +590,8 @@ class AnalyzePlanRequest(google.protobuf.message.Message):
     def unpersist(self) -> global___AnalyzePlanRequest.Unpersist: ...
     @property
     def get_storage_level(self) -> global___AnalyzePlanRequest.GetStorageLevel: ...
+    @property
+    def explain_expression(self) -> global___AnalyzePlanRequest.ExplainExpression: ...
     def __init__(
         self,
         *,
@@ -584,6 +611,7 @@ class AnalyzePlanRequest(google.protobuf.message.Message):
         persist: global___AnalyzePlanRequest.Persist | None = ...,
         unpersist: global___AnalyzePlanRequest.Unpersist | None = ...,
         get_storage_level: global___AnalyzePlanRequest.GetStorageLevel | None = ...,
+        explain_expression: global___AnalyzePlanRequest.ExplainExpression | None = ...,
     ) -> None: ...
     def HasField(
         self,
@@ -598,6 +626,8 @@ class AnalyzePlanRequest(google.protobuf.message.Message):
             b"ddl_parse",
             "explain",
             b"explain",
+            "explain_expression",
+            b"explain_expression",
             "get_storage_level",
             b"get_storage_level",
             "input_files",
@@ -637,6 +667,8 @@ class AnalyzePlanRequest(google.protobuf.message.Message):
             b"ddl_parse",
             "explain",
             b"explain",
+            "explain_expression",
+            b"explain_expression",
             "get_storage_level",
             b"get_storage_level",
             "input_files",
@@ -686,6 +718,7 @@ class AnalyzePlanRequest(google.protobuf.message.Message):
         "persist",
         "unpersist",
         "get_storage_level",
+        "explain_expression",
     ] | None: ...
 
 global___AnalyzePlanRequest = AnalyzePlanRequest
@@ -880,6 +913,20 @@ class AnalyzePlanResponse(google.protobuf.message.Message):
             self, field_name: typing_extensions.Literal["storage_level", b"storage_level"]
         ) -> None: ...
 
+    class ExplainExpression(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        EXPLAIN_STRING_FIELD_NUMBER: builtins.int
+        explain_string: builtins.str
+        def __init__(
+            self,
+            *,
+            explain_string: builtins.str = ...,
+        ) -> None: ...
+        def ClearField(
+            self, field_name: typing_extensions.Literal["explain_string", b"explain_string"]
+        ) -> None: ...
+
     SESSION_ID_FIELD_NUMBER: builtins.int
     SCHEMA_FIELD_NUMBER: builtins.int
     EXPLAIN_FIELD_NUMBER: builtins.int
@@ -894,6 +941,7 @@ class AnalyzePlanResponse(google.protobuf.message.Message):
     PERSIST_FIELD_NUMBER: builtins.int
     UNPERSIST_FIELD_NUMBER: builtins.int
     GET_STORAGE_LEVEL_FIELD_NUMBER: builtins.int
+    EXPLAIN_EXPRESSION_FIELD_NUMBER: builtins.int
     session_id: builtins.str
     @property
     def schema(self) -> global___AnalyzePlanResponse.Schema: ...
@@ -921,6 +969,8 @@ class AnalyzePlanResponse(google.protobuf.message.Message):
     def unpersist(self) -> global___AnalyzePlanResponse.Unpersist: ...
     @property
     def get_storage_level(self) -> global___AnalyzePlanResponse.GetStorageLevel: ...
+    @property
+    def explain_expression(self) -> global___AnalyzePlanResponse.ExplainExpression: ...
     def __init__(
         self,
         *,
@@ -938,6 +988,7 @@ class AnalyzePlanResponse(google.protobuf.message.Message):
         persist: global___AnalyzePlanResponse.Persist | None = ...,
         unpersist: global___AnalyzePlanResponse.Unpersist | None = ...,
         get_storage_level: global___AnalyzePlanResponse.GetStorageLevel | None = ...,
+        explain_expression: global___AnalyzePlanResponse.ExplainExpression | None = ...,
     ) -> None: ...
     def HasField(
         self,
@@ -946,6 +997,8 @@ class AnalyzePlanResponse(google.protobuf.message.Message):
             b"ddl_parse",
             "explain",
             b"explain",
+            "explain_expression",
+            b"explain_expression",
             "get_storage_level",
             b"get_storage_level",
             "input_files",
@@ -979,6 +1032,8 @@ class AnalyzePlanResponse(google.protobuf.message.Message):
             b"ddl_parse",
             "explain",
             b"explain",
+            "explain_expression",
+            b"explain_expression",
             "get_storage_level",
             b"get_storage_level",
             "input_files",
@@ -1023,6 +1078,7 @@ class AnalyzePlanResponse(google.protobuf.message.Message):
         "persist",
         "unpersist",
         "get_storage_level",
+        "explain_expression",
     ] | None: ...
 
 global___AnalyzePlanResponse = AnalyzePlanResponse


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, connect display the structure of the proto in both the regular and extended version of explain. We should display a more compact sql-a-like string for the regular version.


### Why are the changes needed?
Improve output of Column.explain so as display the same as the explain API of sql expression.

### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New test cases.
