### PR TITLE
[SPARK-42508][BUILD][FOLLOW-UP] Exlcude org.apache.spark.ml.param.FloatParam$ for Scala 2.13

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -74,6 +74,7 @@ object MimaExcludes {
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.param.DoubleParam"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.param.IntParam"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.param.FloatParam"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.param.FloatParam$"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.param.LongParam"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.param.BooleanParam"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.param.IntArrayParam"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/40097 that proposes to exclude org.apache.spark.ml.param.FloatParam$ for Scala 2.13:

```
[error] spark-mllib: Failed binary compatibility check against org.apache.spark:spark-mllib_2.13:3.3.0! Found 1 potential problems (filtered 646)
[error]  * object org.apache.spark.ml.param.FloatParam does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ml.param.FloatParam$")
[error] java.lang.RuntimeException: Failed binary compatibility check against org.apache.spark:spark-mllib_2.13:3.3.0! Found 1 potential problems (filtered 646)
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at com.typesafe.tools.mima.plugin.SbtMima$.reportModuleErrors(SbtMima.scala:89)
[error] 	at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$projectSettings$2(MimaPlugin.scala:36)
[error] 	at com.typesafe.tools.mima.plugin.MimaPlugin$.$anonfun$projectSettings$2$adapted(MimaPlugin.scala:26)
[error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
```

See https://github.com/apache/spark/actions/runs/4430000174/jobs/7771194350.

### Why are the changes needed?

To make Scala 2.13 build pass

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the build after this gets merged at https://github.com/apache/spark/actions.