### PR TITLE
[SPARK-42851][SQL] Replace EquivalentExpressions with mutable map in PhysicalAggregation

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -459,7 +459,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
       ArrayTransform(arr, lambda)
     }
     val equivalence = new EquivalentExpressions
-    val isNewExpr = equivalence.addExpr(tx)
+    val isNewExpr = !equivalence.addExpr(tx)
     val cseState = equivalence.getExprState(tx)
     assert(isNewExpr == cseState.isDefined)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{BinaryType, DataType, IntegerType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, IntegerType}
 
 class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("Semantic equals and hash") {
@@ -448,6 +448,20 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     e2.addExprTree(n2)
     assert(e2.getCommonSubexpressions.size == 1)
     assert(e2.getCommonSubexpressions.head == add)
+  }
+
+  test("SPARK-42851: Handle supportExpressions consistently across add and get") {
+    val tx = {
+      val arr = Literal(Array(1, 2))
+      val ArrayType(et, cn) = arr.dataType
+      val lv = NamedLambdaVariable("x", et, cn)
+      val lambda = LambdaFunction(lv, Seq(lv))
+      ArrayTransform(arr, lambda)
+    }
+    val equivalence = new EquivalentExpressions
+    val isNewExpr = equivalence.addExpr(tx)
+    val cseState = equivalence.getExprState(tx)
+    assert(isNewExpr == cseState.isDefined)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -1538,6 +1538,13 @@ class DataFrameAggregateSuite extends QueryTest
     )
     checkAnswer(res, Row(1, 1, 1) :: Row(4, 1, 2) :: Nil)
   }
+
+  test("SPARK-42851: common subexpression should consistently handle aggregate and result exprs") {
+    val res = sql(
+      "select max(transform(array(id), x -> x)), max(transform(array(id), x -> x)) from range(2)"
+    )
+    checkAnswer(res, Row(Array(1), Array(1)))
+  }
 }
 
 case class B(c: Option[Double])


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to replace `EquivalentExpressions` to a simple mutable map in `PhysicalAggregation`, the only place where `EquivalentExpressions.addExpr()` is used. `EquivalentExpressions` is useful for common subexpression elimination but in `PhysicalAggregation` it is used only to deduplicate whole expressions which can be easily done with a simple map.

### Why are the changes needed?
`EquivalentExpressions.addExpr()` is not guarded by `supportedExpression()` and so it can cause inconsistent results when used together with `EquivalentExpressions.getExprState()`. This PR proposes replacing `.addExpr()` with other alternatives as its boolean result is a bit counter-intuitive to other collections' `.add()` methods. It returns `false` if the expression was missing and either adds the expression or not depending on if the expression is deterministic.
After this PR we no longer use `EquivalentExpressions.addExpr()` so it can be deprecated or even removed...

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added new UTs from @rednaxelafx's PR: https://github.com/apache/spark/pull/40473. Please note that those UTs actually pass after https://github.com/apache/spark/pull/40475, but they are added here to make sure there will be no regression in the future.
