### PR TITLE
[SPARK-41006][K8S] Generate new ConfigMap names for each run

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -43,7 +43,7 @@ private[spark] object KubernetesClientUtils extends Logging {
 
   val configMapNameExecutor: String = configMapName(s"spark-exec-${KubernetesUtils.uniqueID()}")
 
-  val configMapNameDriver: String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
+  def configMapNameDriver: String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
 
   private def buildStringFromPropertiesMap(configMapName: String,
       propertiesMap: Map[String, String]): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When using the Spark Kubernetes library to launch multiple jobs, the name for the config maps is only generated once, meaning all jobs will try to use the same one. This results in an error.

Relates issue: https://issues.apache.org/jira/browse/SPARK-41006

This PR makes the name of the config-maps dynamic so that each run gets its own. Relate Unit Tests have been updated to take the change into account.

### Why are the changes needed?
The change is needed to allow launching multiple jobs using the Spark Kubernetes library.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
The fixed library has been tested on a private K8S cluster to ensure we can launch multiple jobs with the config maps getting different names.
