### PR TITLE
[SPARK-42876][SQL] DataType's physicalDataType should be private[sql]

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ArrayType.scala
@@ -91,7 +91,7 @@ case class ArrayType(elementType: DataType, containsNull: Boolean) extends DataT
    */
   override def defaultSize: Int = 1 * elementType.defaultSize
 
-  override def physicalDataType: PhysicalDataType =
+  private[sql] override def physicalDataType: PhysicalDataType =
     PhysicalArrayType(elementType, containsNull)
 
   override def simpleString: String = s"array<${elementType.simpleString}>"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/BinaryType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/BinaryType.scala
@@ -45,7 +45,7 @@ class BinaryType private() extends AtomicType {
    */
   override def defaultSize: Int = 100
 
-  override def physicalDataType: PhysicalDataType = PhysicalBinaryType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalBinaryType
 
   private[spark] override def asNullable: BinaryType = this
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/BooleanType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/BooleanType.scala
@@ -42,7 +42,7 @@ class BooleanType private() extends AtomicType {
    */
   override def defaultSize: Int = 1
 
-  override def physicalDataType: PhysicalDataType = PhysicalBooleanType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalBooleanType
 
   private[spark] override def asNullable: BooleanType = this
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ByteType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ByteType.scala
@@ -45,7 +45,7 @@ class ByteType private() extends IntegralType {
    */
   override def defaultSize: Int = 1
 
-  override def physicalDataType: PhysicalDataType = PhysicalByteType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalByteType
 
   override def simpleString: String = "tinyint"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/CalendarIntervalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/CalendarIntervalType.scala
@@ -38,7 +38,7 @@ class CalendarIntervalType private() extends DataType {
 
   override def defaultSize: Int = 16
 
-  override def physicalDataType: PhysicalDataType = PhysicalCalendarIntervalType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalCalendarIntervalType
 
   override def typeName: String = "interval"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/CharType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/CharType.scala
@@ -33,7 +33,7 @@ case class CharType(length: Int) extends AtomicType {
   private[sql] val ordering = implicitly[Ordering[InternalType]]
 
   override def defaultSize: Int = length
-  override def physicalDataType: PhysicalDataType = PhysicalStringType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalStringType
   override def typeName: String = s"char($length)"
   override def toString: String = s"CharType($length)"
   private[spark] override def asNullable: CharType = this

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -119,7 +119,7 @@ abstract class DataType extends AbstractDataType {
 
   override private[sql] def acceptsType(other: DataType): Boolean = sameType(other)
 
-  def physicalDataType: PhysicalDataType = UninitializedPhysicalType
+  private[sql] def physicalDataType: PhysicalDataType = UninitializedPhysicalType
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DateType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DateType.scala
@@ -47,7 +47,7 @@ class DateType private() extends DatetimeType {
    */
   override def defaultSize: Int = 4
 
-  override def physicalDataType: PhysicalDataType = PhysicalIntegerType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalIntegerType
 
   private[spark] override def asNullable: DateType = this
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DayTimeIntervalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DayTimeIntervalType.scala
@@ -61,7 +61,7 @@ case class DayTimeIntervalType(startField: Byte, endField: Byte) extends AnsiInt
    */
   override def defaultSize: Int = 8
 
-  override def physicalDataType: PhysicalDataType = PhysicalLongType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalLongType
 
   private[spark] override def asNullable: DayTimeIntervalType = this
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -111,7 +111,8 @@ case class DecimalType(precision: Int, scale: Int) extends FractionalType {
    */
   override def defaultSize: Int = if (precision <= Decimal.MAX_LONG_DIGITS) 8 else 16
 
-  override def physicalDataType: PhysicalDataType = PhysicalDecimalType(precision, scale)
+  private[sql] override def physicalDataType: PhysicalDataType =
+    PhysicalDecimalType(precision, scale)
 
   override def simpleString: String = s"decimal($precision,$scale)"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
@@ -50,7 +50,7 @@ class DoubleType private() extends FractionalType {
    */
   override def defaultSize: Int = 8
 
-  override def physicalDataType: PhysicalDataType = PhysicalDoubleType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalDoubleType
 
   private[spark] override def asNullable: DoubleType = this
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
@@ -50,7 +50,7 @@ class FloatType private() extends FractionalType {
    */
   override def defaultSize: Int = 4
 
-  override def physicalDataType: PhysicalDataType = PhysicalFloatType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalFloatType
 
   private[spark] override def asNullable: FloatType = this
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/IntegerType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/IntegerType.scala
@@ -45,7 +45,7 @@ class IntegerType private() extends IntegralType {
    */
   override def defaultSize: Int = 4
 
-  override def physicalDataType: PhysicalDataType = PhysicalIntegerType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalIntegerType
 
   override def simpleString: String = "int"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/LongType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/LongType.scala
@@ -45,7 +45,7 @@ class LongType private() extends IntegralType {
    */
   override def defaultSize: Int = 8
 
-  override def physicalDataType: PhysicalDataType = PhysicalLongType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalLongType
 
   override def simpleString: String = "bigint"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/MapType.scala
@@ -68,7 +68,7 @@ case class MapType(
    */
   override def defaultSize: Int = 1 * (keyType.defaultSize + valueType.defaultSize)
 
-  override def physicalDataType: PhysicalDataType =
+  private[sql] override def physicalDataType: PhysicalDataType =
     PhysicalMapType(keyType, valueType, valueContainsNull)
 
   override def simpleString: String = s"map<${keyType.simpleString},${valueType.simpleString}>"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/NullType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/NullType.scala
@@ -32,7 +32,7 @@ class NullType private() extends DataType {
   // Defined with a private constructor so the companion object is the only possible instantiation.
   override def defaultSize: Int = 1
 
-  override def physicalDataType: PhysicalDataType = PhysicalNullType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalNullType
 
   private[spark] override def asNullable: NullType = this
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ShortType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ShortType.scala
@@ -45,7 +45,7 @@ class ShortType private() extends IntegralType {
    */
   override def defaultSize: Int = 2
 
-  override def physicalDataType: PhysicalDataType = PhysicalShortType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalShortType
 
   override def simpleString: String = "smallint"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -43,7 +43,7 @@ class StringType private() extends AtomicType {
    */
   override def defaultSize: Int = 20
 
-  override def physicalDataType: PhysicalDataType = PhysicalStringType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalStringType
 
   private[spark] override def asNullable: StringType = this
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -431,7 +431,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
    */
   override def defaultSize: Int = fields.map(_.dataType.defaultSize).sum
 
-  override def physicalDataType: PhysicalDataType = PhysicalStructType(fields)
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalStructType(fields)
 
   override def simpleString: String = {
     val fieldTypes = fields.view.map(field => s"${field.name}:${field.dataType.simpleString}").toSeq

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala
@@ -48,7 +48,7 @@ class TimestampNTZType private() extends DatetimeType {
    */
   override def defaultSize: Int = 8
 
-  override def physicalDataType: PhysicalDataType = PhysicalLongType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalLongType
 
   override def typeName: String = "timestamp_ntz"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampType.scala
@@ -49,7 +49,7 @@ class TimestampType private() extends DatetimeType {
    */
   override def defaultSize: Int = 8
 
-  override def physicalDataType: PhysicalDataType = PhysicalLongType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalLongType
 
   private[spark] override def asNullable: TimestampType = this
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
@@ -28,7 +28,7 @@ case class VarcharType(length: Int) extends AtomicType {
   require(length >= 0, "The length of varchar type cannot be negative.")
 
   private[sql] type InternalType = UTF8String
-  override def physicalDataType: PhysicalDataType = PhysicalStringType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalStringType
   @transient private[sql] lazy val tag = typeTag[InternalType]
   private[sql] val ordering = implicitly[Ordering[InternalType]]
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/YearMonthIntervalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/YearMonthIntervalType.scala
@@ -59,7 +59,7 @@ case class YearMonthIntervalType(startField: Byte, endField: Byte) extends AnsiI
    */
   override def defaultSize: Int = 4
 
-  override def physicalDataType: PhysicalDataType = PhysicalIntegerType
+  private[sql] override def physicalDataType: PhysicalDataType = PhysicalIntegerType
 
   private[spark] override def asNullable: YearMonthIntervalType = this
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`physicalDataType` should not be a public API but be private[sql].

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is to limit API scope to not expose unnecessary API to be public.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No since we have not released Spark 3.4.0 yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
N/A