### PR TITLE
[SPARK-42830] [UI] Link skipped stages on Spark UI

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/spark-dag-viz.js
@@ -229,14 +229,26 @@ function renderDagVizForJob(svgContainer) {
     var isSkipped = metadata.attr("skipped") === "true";
     var container;
     if (isSkipped) {
-      container = svgContainer
+      var attemptId = 0;
+      if (metadata.attr("skipStage") != -1){
+        stageId = metadata.attr("skipStage")
+        var stageLink = uiRoot + appBasePath + "/stages/stage/?id=" + stageId + "&attempt=" + attemptId;
+        container = svgContainer
+            .append("a")
+            .attr("xlink:href", stageLink)
+            .append("g")
+            .attr("id", containerId)
+            .attr("skipped", "true");
+      } else {
+        container = svgContainer
         .append("g")
         .attr("id", containerId)
         .attr("skipped", "true");
+      }
     } else {
       // Link each graph to the corresponding stage page (TODO: handle stage attempts)
-      var attemptId = 0;
-      var stageLink = uiRoot + appBasePath + "/stages/stage/?id=" + stageId + "&attempt=" + attemptId;
+      attemptId = 0;
+      stageLink = uiRoot + appBasePath + "/stages/stage/?id=" + stageId + "&attempt=" + attemptId;
       container = svgContainer
         .append("a")
         .attr("xlink:href", stageLink)

--- a/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusStore.scala
@@ -789,8 +789,14 @@ private[spark] class AppStatusStore(
 
     stages.map { id =>
       val g = store.read(classOf[RDDOperationGraphWrapper], id).toRDDOperationGraph()
+      val original = try {
+        store.read(classOf[SkippedStageData], id).originalStage
+      } catch {
+        case _: NoSuchElementException => -1
+      }
       if (job.skippedStages.contains(id) && !g.rootCluster.name.contains("skipped")) {
-        g.rootCluster.setName(g.rootCluster.name + " (skipped)")
+        g.rootCluster.setName(g.rootCluster.name + " (skipped)"
+          + "\nOriginal Stage: " + original)
       }
       g
     }

--- a/core/src/main/scala/org/apache/spark/status/storeTypes.scala
+++ b/core/src/main/scala/org/apache/spark/status/storeTypes.scala
@@ -506,6 +506,13 @@ private[spark] class RDDOperationClusterWrapper(
 
 }
 
+private[spark] class SkippedStageData(
+ @KVIndexParam val stage: Int,
+ val originalStage: Int) {
+  @JsonIgnore
+  @KVIndex("id")
+  private def id: Int = stage
+}
 private[spark] class RDDOperationGraphWrapper(
     @KVIndexParam val stageId: Int,
     val edges: collection.Seq[RDDOperationEdge],

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -519,7 +519,12 @@ private[spark] object UIUtils extends Logging {
           graphs.map { g =>
             val stageId = g.rootCluster.id.replaceAll(RDDOperationGraph.STAGE_CLUSTER_PREFIX, "")
             val skipped = g.rootCluster.name.contains("skipped").toString
-            <div class="stage-metadata" stage-id={stageId} skipped={skipped}>
+            val skipStage = if (skipped == "true") {
+              g.rootCluster.name.split("Original Stage:")(1).trim
+            } else {
+              ""
+            }
+            <div class="stage-metadata" stage-id={stageId} skipped={skipped} skipStage={skipStage}>
               <div class="dot-file">{RDDOperationGraph.makeDotFile(g)}</div>
               { g.incomingEdges.map { e => <div class="incoming-edge">{e.fromId},{e.toId}</div> } }
               { g.outgoingEdges.map { e => <div class="outgoing-edge">{e.fromId},{e.toId}</div> } }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Adds text on the UI that shows which executed stage a skipped stage on the UI refers to.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Helps find the execution details, in terms of  figuring out which stages from earlier jobs feed into a later stage in a specific job.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes, the jobs page can look like the following, where the skipped stage is now clickable and redirects to the stage that was actually executed 
<img width="357" alt="Screen Shot 2023-03-20 at 5 36 14 PM" src="https://user-images.githubusercontent.com/16739760/226529417-a2384904-7e46-48f6-bcd5-c708416e6353.png">
<!--

Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Manual test locally on UI.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
