### PR TITLE
[MINOR][DOCS] Remove SparkSession constructor invocation in the example

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -178,11 +178,6 @@ class SparkSession(SparkConversionMixin):
     ...         .config("spark.some.config.option", "some-value")
     ...         .getOrCreate()
     ... )
-
-    Create a Spark session from a Spark context.
-
-    >>> sc = spark.sparkContext
-    >>> spark = SparkSession(sc)
     """
 
     class Builder:

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -178,6 +178,16 @@ class SparkSession(SparkConversionMixin):
     ...         .config("spark.some.config.option", "some-value")
     ...         .getOrCreate()
     ... )
+
+    Create a Spark session with Spark Connect.
+
+    >>> spark = (
+    ...     SparkSession.builder
+    ...         .remote("sc://localhost")
+    ...         .appName("Word Count")
+    ...         .config("spark.some.config.option", "some-value")
+    ...         .getOrCreate()
+    ... )  # doctest: +SKIP
     """
 
     class Builder:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to Remove SparkSession constructor invocation in the example.

While I am here, I piggyback and add an example of Spark Connect.

### Why are the changes needed?

SparkSession's constructor is not meant to be exposed to the end users. This is also hidden in Scala side.

### Does this PR introduce _any_ user-facing change?

Yes, it removes the usage of SparkSession constructor in the user facing docs.

### How was this patch tested?

Linters should verify the changes in the CI.