### PR TITLE
[SPARK-42893][PYTHON][3.4] Block Arrow-optimized Python UDFs

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -10095,8 +10095,6 @@ def unwrap_udt(col: "ColumnOrName") -> Column:
 def udf(
     f: Callable[..., Any],
     returnType: "DataTypeOrString" = StringType(),
-    *,
-    useArrow: Optional[bool] = None,
 ) -> "UserDefinedFunctionLike":
     ...
 
@@ -10104,8 +10102,6 @@ def udf(
 @overload
 def udf(
     f: Optional["DataTypeOrString"] = None,
-    *,
-    useArrow: Optional[bool] = None,
 ) -> Callable[[Callable[..., Any]], "UserDefinedFunctionLike"]:
     ...
 
@@ -10114,7 +10110,6 @@ def udf(
 def udf(
     *,
     returnType: "DataTypeOrString" = StringType(),
-    useArrow: Optional[bool] = None,
 ) -> Callable[[Callable[..., Any]], "UserDefinedFunctionLike"]:
     ...
 
@@ -10123,8 +10118,6 @@ def udf(
 def udf(
     f: Optional[Union[Callable[..., Any], "DataTypeOrString"]] = None,
     returnType: "DataTypeOrString" = StringType(),
-    *,
-    useArrow: Optional[bool] = None,
 ) -> Union["UserDefinedFunctionLike", Callable[[Callable[..., Any]], "UserDefinedFunctionLike"]]:
     """Creates a user defined function (UDF).
 
@@ -10140,9 +10133,6 @@ def udf(
     returnType : :class:`pyspark.sql.types.DataType` or str
         the return type of the user-defined function. The value can be either a
         :class:`pyspark.sql.types.DataType` object or a DDL-formatted type string.
-    useArrow : bool or None
-        whether to use Arrow to optimize the (de)serialization. When it is None, the
-        Spark config "spark.sql.execution.pythonUDF.arrow.enabled" takes effect.
 
     Examples
     --------
@@ -10224,12 +10214,9 @@ def udf(
             _create_py_udf,
             returnType=return_type,
             evalType=PythonEvalType.SQL_BATCHED_UDF,
-            useArrow=useArrow,
         )
     else:
-        return _create_py_udf(
-            f=f, returnType=returnType, evalType=PythonEvalType.SQL_BATCHED_UDF, useArrow=useArrow
-        )
+        return _create_py_udf(f=f, returnType=returnType, evalType=PythonEvalType.SQL_BATCHED_UDF)
 
 
 def _test() -> None:

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -76,47 +76,6 @@ class PythonUDFArrowTests(BaseUDFTestsMixin, ReusedSQLTestCase):
         self.assertEquals(row[0], "[1 2 3]")
         self.assertEquals(row[1], "{'a': 'b'}")
 
-    def test_use_arrow(self):
-        # useArrow=True
-        row_true = (
-            self.spark.range(1)
-            .selectExpr(
-                "array(1, 2, 3) as array",
-            )
-            .select(
-                udf(lambda x: str(x), useArrow=True)("array"),
-            )
-            .first()
-        )
-
-        # useArrow=None
-        row_none = (
-            self.spark.range(1)
-            .selectExpr(
-                "array(1, 2, 3) as array",
-            )
-            .select(
-                udf(lambda x: str(x), useArrow=None)("array"),
-            )
-            .first()
-        )
-
-        # The input is a NumPy array when the Arrow optimization is on.
-        self.assertEquals(row_true[0], row_none[0])  # "[1 2 3]"
-
-        # useArrow=False
-        row_false = (
-            self.spark.range(1)
-            .selectExpr(
-                "array(1, 2, 3) as array",
-            )
-            .select(
-                udf(lambda x: str(x), useArrow=False)("array"),
-            )
-            .first()
-        )
-        self.assertEquals(row_false[0], "[1, 2, 3]")
-
 
 if __name__ == "__main__":
     from pyspark.sql.tests.test_arrow_python_udf import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -838,47 +838,6 @@ class UDFTests(BaseUDFTestsMixin, ReusedSQLTestCase):
         cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "false")
 
 
-def test_use_arrow(self):
-    # useArrow=True
-    row_true = (
-        self.spark.range(1)
-        .selectExpr(
-            "array(1, 2, 3) as array",
-        )
-        .select(
-            udf(lambda x: str(x), useArrow=True)("array"),
-        )
-        .first()
-    )
-    # The input is a NumPy array when the Arrow optimization is on.
-    self.assertEquals(row_true[0], "[1 2 3]")
-
-    # useArrow=None
-    row_none = (
-        self.spark.range(1)
-        .selectExpr(
-            "array(1, 2, 3) as array",
-        )
-        .select(
-            udf(lambda x: str(x), useArrow=None)("array"),
-        )
-        .first()
-    )
-
-    # useArrow=False
-    row_false = (
-        self.spark.range(1)
-        .selectExpr(
-            "array(1, 2, 3) as array",
-        )
-        .select(
-            udf(lambda x: str(x), useArrow=False)("array"),
-        )
-        .first()
-    )
-    self.assertEquals(row_false[0], row_none[0])  # "[1, 2, 3]"
-
-
 class UDFInitializationTests(unittest.TestCase):
     def tearDown(self):
         if SparkSession._instantiatedSession is not None:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -85,7 +85,6 @@ def _create_py_udf(
     f: Callable[..., Any],
     returnType: "DataTypeOrString",
     evalType: int,
-    useArrow: Optional[bool] = None,
 ) -> "UserDefinedFunctionLike":
     # The following table shows the results when the type coercion in Arrow is needed, that is,
     # when the user-specified return type(SQL Type) of the UDF and the actual instance(Python
@@ -117,14 +116,10 @@ def _create_py_udf(
     from pyspark.sql import SparkSession
 
     session = SparkSession._instantiatedSession
-    if session is None:
-        is_arrow_enabled = False
-    else:
-        is_arrow_enabled = (
-            session.conf.get("spark.sql.execution.pythonUDF.arrow.enabled") == "true"
-            if useArrow is None
-            else useArrow
-        )
+    is_arrow_enabled = (
+        session is not None
+        and session.conf.get("spark.sql.execution.pythonUDF.arrow.enabled") == "true"
+    )
 
     regular_udf = _create_udf(f, returnType, evalType)
     return_type = regular_udf.returnType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2819,6 +2819,7 @@ object SQLConf {
 
   val PYTHON_UDF_ARROW_ENABLED =
     buildConf("spark.sql.execution.pythonUDF.arrow.enabled")
+      .internal()
       .doc("Enable Arrow optimization in regular Python UDFs. This optimization " +
         "can only be enabled for atomic output types and input types except struct and map types " +
         "when the given function takes at least one argument.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Block the usage of Arrow-optimized Python UDFs in Apache Spark 3.4.0. 

### Why are the changes needed?
Considering the upcoming improvements on the result inconsistencies between traditional Pickled Python UDFs and Arrow-optimized Python UDFs, we'd better block the feature, otherwise, users who try out the feature will expect behavior changes in the next release.

In addition, since Spark Connect Python Client(SCPC) has been introduced in Spark 3.4, we'd better ensure the feature is ready in both vanilla PySpark and SCPC at the same time for compatibility.

### Does this PR introduce _any_ user-facing change?
Yes. Arrow-optimized Python UDFs are blocked.

### How was this patch tested?
Existing tests.

SPARK-40307