### PR TITLE
[SPARK-41233][CONNECT][PYTHON] Add array_prepend to Spark Connect Python client

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -1248,6 +1248,13 @@ def array_position(col: "ColumnOrName", value: Any) -> Column:
 array_position.__doc__ = pysparkfuncs.array_position.__doc__
 
 
+def array_prepend(col: "ColumnOrName", value: Any) -> Column:
+    return _invoke_function("array_prepend", _to_col(col), lit(value))
+
+
+array_prepend.__doc__ = pysparkfuncs.array_prepend.__doc__
+
+
 def array_remove(col: "ColumnOrName", element: Any) -> Column:
     return _invoke_function("array_remove", _to_col(col), lit(element))
 

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -1088,6 +1088,20 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
             sdf.select(SF.array_append(sdf.a, sdf.f)).toPandas(),
         )
 
+        # test array_prepend
+        self.assert_eq(
+            cdf.select(CF.array_prepend(cdf.a, "xyz")).toPandas(),
+            sdf.select(SF.array_prepend(sdf.a, "xyz")).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.array_prepend(cdf.a, CF.lit("ab"))).toPandas(),
+            sdf.select(SF.array_prepend(sdf.a, SF.lit("ab"))).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.array_prepend(cdf.a, cdf.f)).toPandas(),
+            sdf.select(SF.array_prepend(sdf.a, sdf.f)).toPandas(),
+        )
+
         # test array_insert
         self.assert_eq(
             cdf.select(CF.array_insert(cdf.a, -5, "ab")).toPandas(),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #38947.

Add `array_prepend` function to Spark Connect Python client.

### Why are the changes needed?

`array_prepend` was added at #38947 without Spark Connect Python client.

### Does this PR introduce _any_ user-facing change?

`array_prepend`  will be available in Spark Connect Python client.

### How was this patch tested?

Enabled the related test.