### PR TITLE
[SPARK-42864][ML] Make `IsotonicRegression.PointsAccumulator` private

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -331,7 +331,7 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
     if (cleanInput.length <= 1) {
       cleanInput
     } else {
-      val pointsAccumulator = new IsotonicRegression.PointsAccumulator
+      val pointsAccumulator = new PointsAccumulator
 
       // Go through input points, merging all points with equal feature values into a single point.
       // Equality of features is defined by shouldAccumulate method. The label of the accumulated
@@ -490,15 +490,13 @@ class IsotonicRegression private (private var isotonic: Boolean) extends Seriali
       .sortBy(_._2)
     poolAdjacentViolators(parallelStepResult)
   }
-}
 
-object IsotonicRegression {
   /**
    * Utility class, holds a buffer of all points with unique features so far, and performs
    * weighted sum accumulation of points. Hides these details for better readability of the
    * main algorithm.
    */
-  class PointsAccumulator {
+  private class PointsAccumulator {
     private val output = ArrayBuffer[(Double, Double, Double)]()
     private var (currentLabel: Double, currentFeature: Double, currentWeight: Double) =
       (0d, 0d, 0d)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `IsotonicRegression.PointsAccumulator` private, which was introduced in https://github.com/apache/spark/commit/3d05c7e037eff79de8ef9f6231aca8340bcc65ef


### Why are the changes needed?
`PointsAccumulator` is implementation details, should not be exposed


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing UT