### PR TITLE
[MINOR][DOCS][PYTHON] Update some urls about deprecated repository pyspark.pandas

### DIFF
--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2726,7 +2726,7 @@ class Frame(object, metaclass=ABCMeta):
         return Rolling(self, window=window, min_periods=min_periods)
 
     # TODO: 'center' and 'axis' parameter should be implemented.
-    #   'axis' implementation, refer https://github.com/pyspark.pandas/pull/607
+    #   'axis' implementation, refer https://github.com/databricks/koalas/pull/607
     def expanding(self: FrameLike, min_periods: int = 1) -> "Expanding[FrameLike]":
         """
         Provide expanding transformations.

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2282,7 +2282,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             # the index in some cases.
             # When Spark output type is specified, without executing it, we don't know
             # if we should restore the index or not. For instance, see the example in
-            # https://github.com/pyspark.pandas/issues/628.
+            # https://github.com/databricks/koalas/issues/628.
             pdf, _, _, _, _ = InternalFrame.prepare_pandas_frame(
                 pdf, retain_index=retain_index, prefer_timestamp_ntz=prefer_timestamp_ntz
             )

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -208,7 +208,7 @@ def _get_local_scope() -> Dict[str, Any]:
         return inspect.stack()[_CAPTURE_SCOPES][0].f_locals
     except Exception:
         # TODO (rxin, thunterdb): use a narrower scope exception.
-        # See https://github.com/pyspark.pandas/pull/448
+        # See https://github.com/databricks/koalas/pull/448
         return {}
 
 
@@ -224,7 +224,7 @@ def _get_ipython_scope() -> Dict[str, Any]:
         return shell.user_ns
     except Exception:
         # TODO (rxin, thunterdb): use a narrower scope exception.
-        # See https://github.com/pyspark.pandas/pull/448
+        # See https://github.com/databricks/koalas/pull/448
         return None
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix some deprecated urls 


### Why are the changes needed?
Repository about https://github.com/pyspark.pandas was deprecated, using https://github.com/databricks/koalas replace.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Matched urls and existing tests
