### PR TITLE
[SPARK-42897][SQL] Avoid evaluate variables multiple times for SMJ and SHJ fullOuter join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -365,7 +365,8 @@ case class ShuffledHashJoinExec(
        """.stripMargin
     val streamedKeyAnyNull = s"${streamedKeyExprCode.value}.anyNull()"
     // The streamedVars may be evaluated again in the following consumeFullOuterJoinRow method,
-    // so generate the condition checking code with their copies, to avoid side effects (ExprCode is mutable).
+    // so generate the condition checking code with their copies, to avoid side effects
+    // (ExprCode is mutable).
     val copiedStreamedVars = streamedVars.map(v => v.copy())
     val (streamedBefore, _) = splitVarsByCondition(streamedOutput, copiedStreamedVars)
     // Generate code for join condition

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -365,7 +365,7 @@ case class ShuffledHashJoinExec(
        """.stripMargin
     val streamedKeyAnyNull = s"${streamedKeyExprCode.value}.anyNull()"
     // The streamedVars may be evaluated again in the following consumeFullOuterJoinRow method,
-    // so generate the condition checking code with their copies.
+    // so generate the condition checking code with their copies, to avoid side effects (ExprCode is mutable).
     val copiedStreamedVars = streamedVars.map(v => v.copy())
     val (streamedBefore, _) = splitVarsByCondition(streamedOutput, copiedStreamedVars)
     // Generate code for join condition

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -364,10 +364,11 @@ case class ShuffledHashJoinExec(
          |${streamedKeyExprCode.code}
        """.stripMargin
     val streamedKeyAnyNull = s"${streamedKeyExprCode.value}.anyNull()"
-    val (streamedBefore, _) = splitVarsByCondition(streamedOutput, streamedVars.map(v => v.copy()))
+    val copiedStreamedVars = streamedVars.map(v => v.copy())
+    val (streamedBefore, _) = splitVarsByCondition(streamedOutput, copiedStreamedVars)
     // Generate code for join condition
-    val (_, conditionCheckWithoutStreamVars, _) = getJoinCondition(
-      ctx, streamedVars.map(_.copy(code = EmptyBlock)), streamedPlan, buildPlan, Some(buildRow))
+    val (_, conditionCheckWithoutStreamVars, _) =
+      getJoinCondition(ctx, copiedStreamedVars, streamedPlan, buildPlan, Some(buildRow))
     val conditionCheck =
       s"""$streamedBefore
          |$conditionCheckWithoutStreamVars

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -1013,14 +1013,17 @@ case class SortMergeJoinExec(
     val rightResultVars = genOneSideJoinVars(
       ctx, rightOutputRow, right, setDefaultValue = true)
     val resultVars = leftResultVars ++ rightResultVars
+    // The streamedVars may be evaluated again in the following consumeFullOuterJoinRow method,
+    // so generate the condition checking code with their copies.
     val copiedLeftResultVars = leftResultVars.map(v => v.copy())
     val (leftBefore, _) = splitVarsByCondition(left.output, copiedLeftResultVars)
     val (_, conditionCheckWithoutLeftVars, _) =
       getJoinCondition(ctx, copiedLeftResultVars, left, right, Some(rightOutputRow))
     val conditionCheck =
-      s"""$leftBefore
+      s"""
+         |$leftBefore
          |$conditionCheckWithoutLeftVars
-         |""".stripMargin
+       """.stripMargin
 
     // Generate code for result output in separate function, as we need to output result from
     // multiple places in join code.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -1014,7 +1014,8 @@ case class SortMergeJoinExec(
       ctx, rightOutputRow, right, setDefaultValue = true)
     val resultVars = leftResultVars ++ rightResultVars
     // The streamedVars may be evaluated again in the following consumeFullOuterJoinRow method,
-    // so generate the condition checking code with their copies.
+    // so generate the condition checking code with their copies, to avoid side effects
+    // (ExprCode is mutable).
     val copiedLeftResultVars = leftResultVars.map(v => v.copy())
     val (leftBefore, _) = splitVarsByCondition(left.output, copiedLeftResultVars)
     val (_, conditionCheckWithoutLeftVars, _) =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -1013,9 +1013,10 @@ case class SortMergeJoinExec(
     val rightResultVars = genOneSideJoinVars(
       ctx, rightOutputRow, right, setDefaultValue = true)
     val resultVars = leftResultVars ++ rightResultVars
-    val (leftBefore, _) = splitVarsByCondition(left.output, leftResultVars.map(v => v.copy()))
-    val (_, conditionCheckWithoutLeftVars, _) = getJoinCondition(
-      ctx, leftResultVars.map(_.copy(code = EmptyBlock)), left, right, Some(rightOutputRow))
+    val copiedLeftResultVars = leftResultVars.map(v => v.copy())
+    val (leftBefore, _) = splitVarsByCondition(left.output, copiedLeftResultVars)
+    val (_, conditionCheckWithoutLeftVars, _) =
+      getJoinCondition(ctx, copiedLeftResultVars, left, right, Some(rightOutputRow))
     val conditionCheck =
       s"""$leftBefore
          |$conditionCheckWithoutLeftVars

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -208,27 +208,16 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         Row(1, 4), Row(1, 7), Row(2, 2), Row(2, 5), Row(2, 8), Row(3, null), Row(4, null)))
 
       // test one join with non-equi condition
-      val joinWithNonEquiDF = df1.join(df2.hint(hint),
-        $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2", "full_outer")
+      val joinWithNonEquiDF = df1.select('k1, 'k1.as('k1_2)).join(df2.hint(hint),
+        $"k1" === $"k2" % 3 && $"k1_2" + 3 =!= $"k2" && $"k1_2" + 5 =!= $"k2",
+        "full_outer")
       assert(joinWithNonEquiDF.queryExecution.executedPlan.collect {
         case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
         case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
       }.size === 1)
-      checkAnswer(joinWithNonEquiDF, Seq(Row(0, 0), Row(0, 6), Row(0, 9), Row(1, 1),
-        Row(1, 7), Row(2, 2), Row(2, 8), Row(3, null), Row(4, null), Row(null, 3), Row(null, 4),
-        Row(null, 5)))
-
-      // test one join with non-equi condition
-      val joinWithNonEquiDF2 = df1.join(df2.hint(hint),
-        $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2" && $"k1" + 5 =!= $"k2", "full_outer")
-      assert(joinWithNonEquiDF2.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 1)
-      checkAnswer(joinWithNonEquiDF2, Seq(Row(0, 0), Row(0, 6), Row(0, 9), Row(1, 1),
-        Row(1, 7), Row(2, 2), Row(2, 8), Row(3, null), Row(4, null), Row(null, 3), Row(null, 4),
-        Row(null, 5)))
-
+      checkAnswer(joinWithNonEquiDF, Seq(Row(0, 0, 0), Row(0, 0, 6), Row(0, 0, 9), Row(1, 1, 1),
+        Row(1, 1, 7), Row(2, 2, 2), Row(2, 2, 8), Row(3, 3, null), Row(4, 4, null),
+        Row(null, null, 3), Row(null, null, 4), Row(null, null, 5)))
       // test two joins
       val twoJoinsDF = df1.join(df2.hint(hint), $"k1" === $"k2", "full_outer")
         .join(df3.hint(hint), $"k1" === $"k3" && $"k1" + $"k3" =!= 2, "full_outer")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

For example:
```
  val df1 = spark.range(5).select($"id".as("k1"))
  val df2 = spark.range(10).select($"id".as("k2"))
  df1.join(df2.hint("SHUFFLE_MERGE"),
      $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2" && $"k1" + 5 =!= $"k2", "full_outer")
```
the join condition `$"k1" + 3 =!= $"k2"` and `$"k1" + 5 =!= $"k2"` will evaluate the variable **k1** twice and caused the codegen failed.

```
09:43:30.155 ERROR org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator: failed to compile: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 257, Column 9: Redefinition of local variable "smj_isNull_9" 
org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 257, Column 9: Redefinition of local variable "smj_isNull_9" 
```

Before this PR, we will evaluate multiple times for the variables in the join condition, and throw `Redefinition of local variable`  exception.

### Why are the changes needed?

Bug fix for codegen issue in FullOuter SMJ.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added UT
