### PR TITLE
[SPARK-42898][SQL] Mark that string/date casts do not need time zone id

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -267,8 +267,8 @@ object Cast extends QueryErrorsBase {
    * * Cast.castToTimestamp
    */
   def needsTimeZone(from: DataType, to: DataType): Boolean = (from, to) match {
-    case (StringType, TimestampType | DateType) => true
-    case (TimestampType | DateType, StringType) => true
+    case (StringType, TimestampType) => true
+    case (TimestampType, StringType) => true
     case (DateType, TimestampType) => true
     case (TimestampType, DateType) => true
     case (ArrayType(fromType, _), ArrayType(toType, _)) => needsTimeZone(fromType, toType)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This removes the need for a time zone id when casting from StringType -> DateType and DateType -> StringType.

### Why are the changes needed?
It is mostly for consistency with what the code is actually doing.  Marking it as needing A time zone id has no real impact to the actual execution.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
I just compiled it for now. I assume that the existing tests will cover it.