### PR TITLE
[SPARK-42890] [UI] add repeat identifier on SQL UI

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
@@ -17,12 +17,18 @@
 
 package org.apache.spark.sql.execution
 
+import java.util.{IdentityHashMap => JavaIdentityMap}
+
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec}
-import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
+import org.apache.spark.sql.execution.columnar.{CachedRDDBuilder, InMemoryTableScanExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.metric.SQLMetricInfo
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.IdGenerator
 
 /**
  * :: DeveloperApi ::
@@ -51,15 +57,27 @@ class SparkPlanInfo(
 
 private[execution] object SparkPlanInfo {
 
-  def fromSparkPlan(plan: SparkPlan): SparkPlanInfo = {
-    val children = plan match {
-      case ReusedExchangeExec(_, child) => child :: Nil
-      case ReusedSubqueryExec(child) => child :: Nil
-      case a: AdaptiveSparkPlanExec => a.executedPlan :: Nil
-      case stage: QueryStageExec => stage.plan :: Nil
-      case inMemTab: InMemoryTableScanExec => inMemTab.relation.cachedPlan :: Nil
-      case _ => plan.children ++ plan.subqueries
+  def fromSparkPlan(plan: SparkPlan, inMemoryRelationEncountered:
+  JavaIdentityMap[CachedRDDBuilder, Integer] = new JavaIdentityMap[CachedRDDBuilder, Integer](),
+  idGenerator: IdGenerator = new IdGenerator()): SparkPlanInfo = {
+    val (children, decoratedPlanForStringGeneration) = plan match {
+      case ReusedExchangeExec(_, child) => (child :: Nil) -> plan
+      case ReusedSubqueryExec(child) => (child :: Nil) -> plan
+      case a: AdaptiveSparkPlanExec => (a.executedPlan :: Nil) -> plan
+      case stage: QueryStageExec => (stage.plan :: Nil) -> plan
+      case inMemTab: InMemoryTableScanExec =>
+        if (inMemoryRelationEncountered.containsKey(inMemTab.relation.cacheBuilder)) {
+          // get the id from the map
+          val id = inMemoryRelationEncountered.get(inMemTab.relation.cacheBuilder)
+          Seq.empty -> WrapperInMemoryTableScanExec(id, inMemTab)
+        } else {
+          val id = idGenerator.next
+          inMemoryRelationEncountered.put(inMemTab.relation.cacheBuilder, id)
+          (inMemTab.relation.cachedPlan :: Nil) -> WrapperInMemoryTableScanExec(id, inMemTab)
+        }
+      case _ => (plan.children ++ plan.subqueries) -> plan
     }
+
     val metrics = plan.metrics.toSeq.map { case (key, metric) =>
       new SQLMetricInfo(metric.name.getOrElse(key), metric.id, metric.metricType)
     }
@@ -69,11 +87,23 @@ private[execution] object SparkPlanInfo {
       case fileScan: FileSourceScanExec => fileScan.metadata
       case _ => Map[String, String]()
     }
-    new SparkPlanInfo(
-      plan.nodeName,
-      plan.simpleString(SQLConf.get.maxToStringFields),
-      children.map(fromSparkPlan),
-      metadata,
-      metrics)
+
+    val simpleString = decoratedPlanForStringGeneration.simpleString(SQLConf.get.maxToStringFields)
+
+    new SparkPlanInfo(decoratedPlanForStringGeneration.nodeName,
+      simpleString, children.map(child => fromSparkPlan(child,
+        inMemoryRelationEncountered, idGenerator)), metadata, metrics)
+  }
+
+  private case class WrapperInMemoryTableScanExec(repeatId: Int, imr: InMemoryTableScanExec)
+    extends LeafExecNode {
+    private val prefix = s"InMemoryTableScan(Repeat Identifier: $repeatId) "
+
+    override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException
+
+    override def output: Seq[Attribute] = imr.output
+    override def simpleString(maxFields: Int): String = s"$prefix ${imr.simpleString(maxFields)}"
+
+    override def nodeName: String = s"${imr.nodeName}(Repeat Identifier: $repeatId)"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -786,19 +786,19 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
       sql("CREATE TEMPORARY VIEW inMemoryTable AS SELECT 1 AS c1")
       sql("CACHE TABLE inMemoryTable")
       testSparkPlanMetrics(spark.table("inMemoryTable"), 1,
-        Map(0L -> (("Scan In-memory table inMemoryTable", Map.empty)))
+        Map(0L -> (("Scan In-memory table inMemoryTable(Repeat Identifier: 1)", Map.empty)))
       )
 
       sql("CREATE TEMPORARY VIEW ```a``b``` AS SELECT 2 AS c1")
       sql("CACHE TABLE ```a``b```")
       testSparkPlanMetrics(spark.table("```a``b```"), 1,
-        Map(0L -> (("Scan In-memory table ```a``b```", Map.empty)))
+        Map(0L -> (("Scan In-memory table ```a``b```(Repeat Identifier: 1)", Map.empty)))
       )
     }
 
     // Show InMemoryTableScan on UI
     testSparkPlanMetrics(spark.range(1).cache().select("id"), 1,
-      Map(0L -> (("InMemoryTableScan", Map.empty)))
+      Map(0L -> (("InMemoryTableScan(Repeat Identifier: 1)", Map.empty)))
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanInfoSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanInfoSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.ui
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -24,12 +26,31 @@ class SparkPlanInfoSuite extends SharedSparkSession {
 
   import testImplicits._
 
-  def validateSparkPlanInfo(sparkPlanInfo: SparkPlanInfo): Unit = {
+  val imrExtractionPattern =
+    """InMemoryTableScan\(Repeat Identifier: [0-9]+\)""".r
+
+  def validateSparkPlanInfo(sparkPlanInfo: SparkPlanInfo,
+  repeatMapWithChildrenCount: mutable.HashMap[String, Int] = new mutable.HashMap[String, Int]()):
+  Unit = {
     sparkPlanInfo.nodeName match {
+      case s if sparkPlanInfo.simpleString.startsWith("InMemoryTableScan(Repeat Identifier") =>
+        val currentChildrenCount = repeatMapWithChildrenCount.getOrElse(s, 0)
+        repeatMapWithChildrenCount.put(sparkPlanInfo.simpleString,
+          currentChildrenCount + sparkPlanInfo.children.length)
       case "InMemoryTableScan" => assert(sparkPlanInfo.children.length == 1)
-      case _ => sparkPlanInfo.children.foreach(validateSparkPlanInfo)
+      case _ => sparkPlanInfo.children.foreach(validateSparkPlanInfo(_, repeatMapWithChildrenCount))
+    }
+    repeatMapWithChildrenCount.foreach {
+      case (_, childrenCount) => assert(childrenCount == 1 || childrenCount == 0)
     }
   }
+
+  def extractIMRWithRepeatIdentifier(sparkPlanInfo: SparkPlanInfo): Seq[String] =
+    sparkPlanInfo.nodeName match {
+      case s if imrExtractionPattern.unapplySeq(s).isDefined =>
+        s :: Nil
+      case _ => sparkPlanInfo.children.flatMap(extractIMRWithRepeatIdentifier(_))
+    }
 
   test("SparkPlanInfo creation from SparkPlan with InMemoryTableScan node") {
     val dfWithCache = Seq(
@@ -40,5 +61,51 @@ class SparkPlanInfoSuite extends SharedSparkSession {
     val planInfoResult = SparkPlanInfo.fromSparkPlan(dfWithCache.queryExecution.executedPlan)
 
     validateSparkPlanInfo(planInfoResult)
+  }
+
+  test("SparkPlanInfo containing wrapper plan for InMemoryRelation") {
+    val dfWithCache = Seq(
+      (1, 1),
+      (2, 2)
+    ).toDF().filter("_1 > 1").cache()
+
+    val planInfoResult = SparkPlanInfo.fromSparkPlan(dfWithCache.queryExecution.executedPlan)
+    validateSparkPlanInfo(planInfoResult)
+  }
+
+  test("Repeat IMR is skipped") {
+    val dfWithCache = Seq(
+      (1, 1),
+      (2, 2)
+    ).toDF().filter("_1 > 1").cache()
+    val joinedDf = dfWithCache.join(dfWithCache)
+
+    val planInfoResult = SparkPlanInfo.fromSparkPlan(joinedDf.queryExecution.executedPlan)
+    validateSparkPlanInfo(planInfoResult)
+    // ensure that same IMRs are not generating different Ids
+    // id should be incremented by 1 only
+    val imrs = extractIMRWithRepeatIdentifier(planInfoResult)
+    assert(imrs.toSet.size == 1)
+  }
+
+  test("distinct IMR are not skipped ") {
+    val dfWithCache1 = Seq(
+      (1, 1),
+      (2, 2)
+    ).toDF("a", "b").filter("a > 1").cache()
+
+    val dfWithCache2 = Seq(
+      (1, 1),
+      (2, 2),
+      (3, 2)
+    ).toDF("x", "y").filter("y > 1").cache()
+
+    val joinedDf = dfWithCache1.join(dfWithCache2)
+    val planInfoResult = SparkPlanInfo.fromSparkPlan(joinedDf.queryExecution.executedPlan)
+    validateSparkPlanInfo(planInfoResult)
+    // ensure that same IMRs are  generating different Ids
+    // id should be incremented by 2 only
+    val imrs = extractIMRWithRepeatIdentifier(planInfoResult)
+    assert(imrs.toSet.size == 2)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
On the SQL page in the Web UI, this PR aims to add a repeat identifier to distinguish which InMemoryTableScan is being used at a certain location on the DAG. Ideally this would work in sync with changes from SPARK-42829.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Currently there is no distinction for which InMemoryTableScan is being used at a specific point in the DAG.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes, on the SQL page in the UI when there is a InMemoryTableScan. One example is
<img width="1012" alt="Screen Shot 2023-03-22 at 2 06 14 PM" src="https://user-images.githubusercontent.com/16739760/227093764-618cee51-bd0a-4c27-9945-2cc122819c74.png">
<!--

Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Manual test locally in SQL UI along with a few Unit Tests
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
