### PR TITLE
[SPARK-42903][PYTHON][DOCS] Avoid documenting None as as a return value in docstring

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -385,10 +385,6 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         name : str
             Name of the view.
 
-        Returns
-        -------
-        None
-
         Examples
         --------
         Create a local temporary view named 'people'.
@@ -426,10 +422,6 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         name : str
             Name of the view.
 
-        Returns
-        -------
-        None
-
         Examples
         --------
         Create a global temporary view.
@@ -466,10 +458,6 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         ----------
         name : str
             Name of the view.
-
-        Returns
-        -------
-        None
 
         Examples
         --------
@@ -591,10 +579,6 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
-
-        Returns
-        -------
-        None
 
         Examples
         --------
@@ -856,10 +840,6 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         vertical : bool, optional
             If set to ``True``, print output rows vertically (one line
             per column value).
-
-        Returns
-        -------
-        None
 
         Examples
         --------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove None as as a return value in docstring.

### Why are the changes needed?

To be consistent with the current documentation. Also, it's idiomatic to don't specify the return for `return None`.

### Does this PR introduce _any_ user-facing change?

Yes, it changes the user-facing documentation.

### How was this patch tested?

Doc build in the CI should verify them.