### PR TITLE
[SPARK-42906][K8S] Replace a starting digit with `x` in resource name prefix

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -261,7 +261,7 @@ private[spark] object KubernetesConf {
       .toLowerCase(Locale.ROOT)
       .replaceAll("[^a-z0-9\\-]", "x")
       .replaceAll("-+", "-")
-      .replaceAll("^[0-9\\-]+", "x")
+      .replaceAll("^[0-9\\-]", "x")
   }
 
   def getAppNameLabel(appName: String): String = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -255,13 +255,17 @@ private[spark] object KubernetesConf {
     s"spark-${UUID.randomUUID().toString.replaceAll("-", "")}"
 
   def getResourceNamePrefix(appName: String): String = {
-    val id = KubernetesUtils.uniqueID()
-    s"$appName-$id"
-      .trim
-      .toLowerCase(Locale.ROOT)
-      .replaceAll("[^a-z0-9\\-]", "-")
-      .replaceAll("-+", "-")
-      .replaceAll("^[0-9\\-]+", "")
+    var prefix = ""
+    while (prefix.isEmpty) {
+      val id = KubernetesUtils.uniqueID()
+      prefix = s"$appName-$id"
+        .trim
+        .toLowerCase(Locale.ROOT)
+        .replaceAll("[^a-z0-9\\-]", "-")
+        .replaceAll("-+", "-")
+        .replaceAll("^[0-9\\-]+", "")
+    }
+    prefix
   }
 
   def getAppNameLabel(appName: String): String = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -259,9 +259,10 @@ private[spark] object KubernetesConf {
     s"$appName-$id"
       .trim
       .toLowerCase(Locale.ROOT)
-      .replaceAll("[^a-z0-9\\-]", "x")
+      .replaceAll("[^a-z0-9\\-]", "-")
       .replaceAll("-+", "-")
-      .replaceAll("^[0-9\\-]", "x")
+      .replaceAll("^-", "")
+      .replaceAll("^[0-9]", "x")
   }
 
   def getAppNameLabel(appName: String): String = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -261,7 +261,7 @@ private[spark] object KubernetesConf {
       .toLowerCase(Locale.ROOT)
       .replaceAll("[^a-z0-9\\-]", "x")
       .replaceAll("-+", "-")
-      .replaceAll("^[0-9\\-]+", "")
+      .replaceAll("^[0-9\\-]+", "x")
   }
 
   def getAppNameLabel(appName: String): String = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -261,7 +261,7 @@ private[spark] object KubernetesConf {
       .toLowerCase(Locale.ROOT)
       .replaceAll("[^a-z0-9\\-]", "-")
       .replaceAll("-+", "-")
-      .replaceAll("^-", "")
+      .replaceAll("^[0-9\\-]+", "")
   }
 
   def getAppNameLabel(appName: String): String = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -255,17 +255,13 @@ private[spark] object KubernetesConf {
     s"spark-${UUID.randomUUID().toString.replaceAll("-", "")}"
 
   def getResourceNamePrefix(appName: String): String = {
-    var prefix = ""
-    while (prefix.isEmpty) {
-      val id = KubernetesUtils.uniqueID()
-      prefix = s"$appName-$id"
-        .trim
-        .toLowerCase(Locale.ROOT)
-        .replaceAll("[^a-z0-9\\-]", "-")
-        .replaceAll("-+", "-")
-        .replaceAll("^[0-9\\-]+", "")
-    }
-    prefix
+    val id = KubernetesUtils.uniqueID()
+    s"$appName-$id"
+      .trim
+      .toLowerCase(Locale.ROOT)
+      .replaceAll("[^a-z0-9\\-]", "x")
+      .replaceAll("-+", "-")
+      .replaceAll("^[0-9\\-]+", "")
   }
 
   def getAppNameLabel(appName: String): String = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -252,7 +252,7 @@ class KubernetesConfSuite extends SparkFunSuite {
   }
 
   test("SPARK-40869: Resource name prefix should not start with a hyphen") {
-    assert(KubernetesConf.getResourceNamePrefix("_hello_").startsWith("xhellox"))
+    assert(KubernetesConf.getResourceNamePrefix("_hello_").startsWith("hello"))
   }
 
   test("SPARK-42906: Resource name prefix should start with an alphabetic character") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -257,7 +257,11 @@ class KubernetesConfSuite extends SparkFunSuite {
 
   test("SPARK-42906: Resource name prefix should start with an alphabetic character") {
     // scalastyle:off nonascii
-    assert(KubernetesConf.getResourceNamePrefix("你好-123").startsWith("xx-123"))
+    assert(KubernetesConf.getResourceNamePrefix("你好-123").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    assert(KubernetesConf.getResourceNamePrefix("---123").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    assert(KubernetesConf.getResourceNamePrefix("123---").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    assert(KubernetesConf.getResourceNamePrefix("------").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    assert(KubernetesConf.getResourceNamePrefix("123456").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
     // scalastyle:on nonascii
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -257,11 +257,9 @@ class KubernetesConfSuite extends SparkFunSuite {
 
   test("SPARK-42906: Resource name prefix should start with an alphabetic character") {
     // scalastyle:off nonascii
-    assert(KubernetesConf.getResourceNamePrefix("你好-123").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
-    assert(KubernetesConf.getResourceNamePrefix("---123").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
-    assert(KubernetesConf.getResourceNamePrefix("123---").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
-    assert(KubernetesConf.getResourceNamePrefix("------").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
-    assert(KubernetesConf.getResourceNamePrefix("123456").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    Seq("你好-123", "---123", "123---", "------", "123456").foreach { appName =>
     // scalastyle:on nonascii
+      assert(KubernetesConf.getResourceNamePrefix(appName).matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    }
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -254,4 +254,10 @@ class KubernetesConfSuite extends SparkFunSuite {
   test("SPARK-40869: Resource name prefix should not start with a hyphen") {
     assert(KubernetesConf.getResourceNamePrefix("_hello_").startsWith("hello"))
   }
+
+  test("SPARK-42906: Resource name prefix should start with an alphabetic character") {
+    // scalastyle:off nonascii
+    assert(KubernetesConf.getResourceNamePrefix("你好-123").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    // scalastyle:on nonascii
+  }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -252,12 +252,12 @@ class KubernetesConfSuite extends SparkFunSuite {
   }
 
   test("SPARK-40869: Resource name prefix should not start with a hyphen") {
-    assert(KubernetesConf.getResourceNamePrefix("_hello_").startsWith("hello"))
+    assert(KubernetesConf.getResourceNamePrefix("_hello_").startsWith("xhellox"))
   }
 
   test("SPARK-42906: Resource name prefix should start with an alphabetic character") {
     // scalastyle:off nonascii
-    assert(KubernetesConf.getResourceNamePrefix("你好-123").matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    assert(KubernetesConf.getResourceNamePrefix("你好-123").startsWith("xx-123"))
     // scalastyle:on nonascii
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -425,7 +425,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
       defaultProfile)
     val podConfigured1 = step1.configurePod(baseDriverPod)
     assert(podConfigured1.pod.getMetadata.getName
-      .startsWith("xyzxabcxxixamxaxappxnamexwxxsomexabbrs"))
+      .startsWith("xyz-abc-i-am-a-app-name-w-some-abbrs"))
 
     // scalastyle:off nonascii
     baseConf.set("spark.app.name", "time.is the#most￥valuable_—thing。it's&about?time.")
@@ -436,7 +436,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
 
     val podConfigured2 = step2.configurePod(baseDriverPod)
     assert(podConfigured2.pod.getMetadata.getName
-      .startsWith("timexisxthexmostxvaluablexxthingxitxsxaboutxtimex-"))
+      .startsWith("time-is-the-most-valuable-thing-it-s-about-time-"))
 
   }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -425,7 +425,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
       defaultProfile)
     val podConfigured1 = step1.configurePod(baseDriverPod)
     assert(podConfigured1.pod.getMetadata.getName
-      .startsWith("xyz-abc-i-am-a-app-name-w-some-abbrs"))
+      .startsWith("xyzxabcxxixamxaxappxnamexwxxsomexabbrs"))
 
     // scalastyle:off nonascii
     baseConf.set("spark.app.name", "time.is the#most￥valuable_—thing。it's&about?time.")
@@ -436,7 +436,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
 
     val podConfigured2 = step2.configurePod(baseDriverPod)
     assert(podConfigured2.pod.getMetadata.getName
-      .startsWith("time-is-the-most-valuable-thing-it-s-about-time-"))
+      .startsWith("timexisxthexmostxvaluablexxthingxitxsxaboutxtimex-"))
 
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Change the generated resource name prefix to meet K8s requirements

> DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In current implementation, the following app name causes error
```
bin/spark-submit \
	 --master k8s://https://*.*.*.*:6443 \
	 --deploy-mode cluster \
	 --name 你好_187609 \
         ...
```

```
Exception in thread "main" io.fabric8.kubernetes.client.KubernetesClientException: 
Failure executing: 
  POST at: https://*.*.*.*:6443/api/v1/namespaces/spark/services. 
Message:
  Service "187609-f19020870d12c349-driver-svc" is invalid: metadata.name: Invalid value: "187609-f19020870d12c349-driver-svc": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?'). 
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT.