### PR TITLE
[SPARK-42908][PYTHON] Raise RuntimeError when SparkContext is required but not initialized

### DIFF
--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -25,7 +25,7 @@ from typing import Dict, Optional, TYPE_CHECKING, cast
 from py4j.java_gateway import JVMView
 
 from pyspark.sql.column import Column, _to_java_column
-from pyspark.sql.utils import require_spark_context_initialized
+from pyspark.sql.utils import get_active_spark_context
 from pyspark.util import _print_missing_jar
 
 if TYPE_CHECKING:
@@ -76,7 +76,7 @@ def from_avro(
     [Row(value=Row(avro=Row(age=2, name='Alice')))]
     """
 
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     try:
         jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.from_avro(
             _to_java_column(data), jsonFormatSchema, options or {}
@@ -121,7 +121,7 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
     [Row(suite=bytearray(b'\\x02\\x00'))]
     """
 
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     try:
         if jsonFormatSchema == "":
             jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.to_avro(

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -20,7 +20,10 @@ A collections of builtin avro functions
 """
 
 
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Dict, Optional, TYPE_CHECKING, cast
+
+from py4j.java_gateway import JVMView
+
 from pyspark.sql.column import Column, _to_java_column
 from pyspark.sql.utils import require_spark_context_initialized
 from pyspark.util import _print_missing_jar
@@ -75,7 +78,7 @@ def from_avro(
 
     sc = require_spark_context_initialized()
     try:
-        jc = sc._jvm.org.apache.spark.sql.avro.functions.from_avro(
+        jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.from_avro(
             _to_java_column(data), jsonFormatSchema, options or {}
         )
     except TypeError as e:
@@ -121,9 +124,11 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
     sc = require_spark_context_initialized()
     try:
         if jsonFormatSchema == "":
-            jc = sc._jvm.org.apache.spark.sql.avro.functions.to_avro(_to_java_column(data))
+            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.to_avro(
+                _to_java_column(data)
+            )
         else:
-            jc = sc._jvm.org.apache.spark.sql.avro.functions.to_avro(
+            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.to_avro(
                 _to_java_column(data), jsonFormatSchema
             )
     except TypeError as e:

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -21,8 +21,8 @@ A collections of builtin avro functions
 
 
 from typing import Dict, Optional, TYPE_CHECKING
-from pyspark import SparkContext
 from pyspark.sql.column import Column, _to_java_column
+from pyspark.sql.utils import require_spark_context_initialized
 from pyspark.util import _print_missing_jar
 
 if TYPE_CHECKING:
@@ -73,8 +73,7 @@ def from_avro(
     [Row(value=Row(avro=Row(age=2, name='Alice')))]
     """
 
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     try:
         jc = sc._jvm.org.apache.spark.sql.avro.functions.from_avro(
             _to_java_column(data), jsonFormatSchema, options or {}
@@ -119,8 +118,7 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
     [Row(suite=bytearray(b'\\x02\\x00'))]
     """
 
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     try:
         if jsonFormatSchema == "":
             jc = sc._jvm.org.apache.spark.sql.avro.functions.to_avro(_to_java_column(data))

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -61,7 +61,7 @@ from pyspark.sql.types import (
     Row,
     _parse_datatype_json_string,
 )
-from pyspark.sql.utils import require_spark_context_initialized
+from pyspark.sql.utils import get_active_spark_context
 from pyspark.sql.pandas.conversion import PandasConversionMixin
 from pyspark.sql.pandas.map_ops import PandasMapOpsMixin
 
@@ -4894,7 +4894,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                 error_class="NOT_DICT",
                 message_parameters={"arg_name": "metadata", "arg_type": type(metadata).__name__},
             )
-        sc = require_spark_context_initialized()
+        sc = get_active_spark_context()
         jmeta = cast(JVMView, sc._jvm).org.apache.spark.sql.types.Metadata.fromJson(
             json.dumps(metadata)
         )

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -61,6 +61,7 @@ from pyspark.sql.types import (
     Row,
     _parse_datatype_json_string,
 )
+from pyspark.sql.utils import require_spark_context_initialized
 from pyspark.sql.pandas.conversion import PandasConversionMixin
 from pyspark.sql.pandas.map_ops import PandasMapOpsMixin
 
@@ -4893,8 +4894,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                 error_class="NOT_DICT",
                 message_parameters={"arg_name": "metadata", "arg_type": type(metadata).__name__},
             )
-        sc = SparkContext._active_spark_context
-        assert sc is not None and sc._jvm is not None
+        sc = require_spark_context_initialized()
         jmeta = sc._jvm.org.apache.spark.sql.types.Metadata.fromJson(json.dumps(metadata))
         return DataFrame(self._jdf.withMetadata(columnName, jmeta), self.sparkSession)
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -39,7 +39,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from py4j.java_gateway import JavaObject
+from py4j.java_gateway import JavaObject, JVMView
 
 from pyspark import copy_func, _NoValue
 from pyspark._globals import _NoValueType
@@ -4895,7 +4895,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                 message_parameters={"arg_name": "metadata", "arg_type": type(metadata).__name__},
             )
         sc = require_spark_context_initialized()
-        jmeta = sc._jvm.org.apache.spark.sql.types.Metadata.fromJson(json.dumps(metadata))
+        jmeta = cast(JVMView, sc._jvm).org.apache.spark.sql.types.Metadata.fromJson(
+            json.dumps(metadata)
+        )
         return DataFrame(self._jdf.withMetadata(columnName, jmeta), self.sparkSession)
 
     @overload

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -49,7 +49,12 @@ from pyspark.sql.udf import UserDefinedFunction, _create_py_udf  # noqa: F401
 
 # Keep pandas_udf and PandasUDFType import for backwards compatible import; moved in SPARK-28264
 from pyspark.sql.pandas.functions import pandas_udf, PandasUDFType  # noqa: F401
-from pyspark.sql.utils import to_str, has_numpy, try_remote_functions
+from pyspark.sql.utils import (
+    to_str,
+    has_numpy,
+    try_remote_functions,
+    require_spark_context_initialized,
+)
 
 if TYPE_CHECKING:
     from pyspark.sql._typing import (
@@ -101,8 +106,7 @@ def _invoke_function_over_seq_of_columns(name: str, cols: "Iterable[ColumnOrName
     Invokes unary JVM function identified by name with
     and wraps the result with :class:`~pyspark.sql.Column`.
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     return _invoke_function(name, _to_seq(sc, cols, _to_java_column))
 
 
@@ -2676,8 +2680,7 @@ def broadcast(df: DataFrame) -> DataFrame:
     +-----+---+
     """
 
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     return DataFrame(sc._jvm.functions.broadcast(df._jdf), df.sparkSession)
 
 
@@ -2891,8 +2894,7 @@ def count_distinct(col: "ColumnOrName", *cols: "ColumnOrName") -> Column:
     |                           4|
     +----------------------------+
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     return _invoke_function(
         "count_distinct", _to_java_column(col), _to_seq(sc, cols, _to_java_column)
     )
@@ -3304,8 +3306,7 @@ def percentile_approx(
      |-- key: long (nullable = true)
      |-- median: double (nullable = true)
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
 
     if isinstance(percentage, (list, tuple)):
         # A local list
@@ -6226,8 +6227,7 @@ def concat_ws(sep: str, *cols: "ColumnOrName") -> Column:
     >>> df.select(concat_ws('-', df.s, df.d).alias('s')).collect()
     [Row(s='abcd-123')]
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     return _invoke_function("concat_ws", sep, _to_seq(sc, cols, _to_java_column))
 
 
@@ -6360,8 +6360,7 @@ def format_string(format: str, *cols: "ColumnOrName") -> Column:
     >>> df.select(format_string('%d %s', df.a, df.b).alias('v')).collect()
     [Row(v='5 hello')]
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     return _invoke_function("format_string", format, _to_seq(sc, cols, _to_java_column))
 
 
@@ -7419,8 +7418,7 @@ def array_join(
     >>> df.select(array_join(df.data, ",", "NULL").alias("joined")).collect()
     [Row(joined='a,b,c'), Row(joined='a,NULL')]
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    require_spark_context_initialized()
     if null_replacement is None:
         return _invoke_function("array_join", _to_java_column(col), delimiter)
     else:
@@ -8259,8 +8257,7 @@ def json_tuple(col: "ColumnOrName", *fields: str) -> Column:
     >>> df.select(df.key, json_tuple(df.jstring, 'f1', 'f2')).collect()
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     return _invoke_function("json_tuple", _to_java_column(col), _to_seq(sc, fields))
 
 
@@ -9212,8 +9209,7 @@ def from_csv(
     [Row(csv=Row(s='abc'))]
     """
 
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    require_spark_context_initialized()
     if isinstance(schema, str):
         schema = _create_column_from_literal(schema)
     elif isinstance(schema, Column):
@@ -9239,8 +9235,7 @@ def _unresolved_named_lambda_variable(*name_parts: Any) -> Column:
     ----------
     name_parts : str
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     name_parts_seq = _to_seq(sc, name_parts)
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
     return Column(sc._jvm.Column(expressions.UnresolvedNamedLambdaVariable(name_parts_seq)))
@@ -9288,8 +9283,7 @@ def _create_lambda(f: Callable) -> Callable:
     """
     parameters = _get_lambda_parameters(f)
 
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
 
     argnames = ["x", "y", "z"]
@@ -9330,8 +9324,7 @@ def _invoke_higher_order_function(
 
     :return: a Column
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
     expr = getattr(expressions, name)
 
@@ -10047,8 +10040,7 @@ def bucket(numBuckets: Union[Column, int], col: "ColumnOrName") -> Column:
             message_parameters={"arg_name": "numBuckets", "arg_type": type(numBuckets).__name__},
         )
 
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    require_spark_context_initialized()
     numBuckets = (
         _create_column_from_literal(numBuckets)
         if isinstance(numBuckets, int)
@@ -10100,8 +10092,7 @@ def call_udf(udfName: str, *cols: "ColumnOrName") -> Column:
     |         cc|
     +-----------+
     """
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     return _invoke_function("call_udf", udfName, _to_seq(sc, cols, _to_java_column))
 
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -55,7 +55,7 @@ from pyspark.sql.utils import (
     to_str,
     has_numpy,
     try_remote_functions,
-    require_spark_context_initialized,
+    get_active_spark_context,
 )
 
 if TYPE_CHECKING:
@@ -108,7 +108,7 @@ def _invoke_function_over_seq_of_columns(name: str, cols: "Iterable[ColumnOrName
     Invokes unary JVM function identified by name with
     and wraps the result with :class:`~pyspark.sql.Column`.
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     return _invoke_function(name, _to_seq(sc, cols, _to_java_column))
 
 
@@ -2682,7 +2682,7 @@ def broadcast(df: DataFrame) -> DataFrame:
     +-----+---+
     """
 
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     return DataFrame(cast(JVMView, sc._jvm).functions.broadcast(df._jdf), df.sparkSession)
 
 
@@ -2896,7 +2896,7 @@ def count_distinct(col: "ColumnOrName", *cols: "ColumnOrName") -> Column:
     |                           4|
     +----------------------------+
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     return _invoke_function(
         "count_distinct", _to_java_column(col), _to_seq(sc, cols, _to_java_column)
     )
@@ -3308,7 +3308,7 @@ def percentile_approx(
      |-- key: long (nullable = true)
      |-- median: double (nullable = true)
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
 
     if isinstance(percentage, (list, tuple)):
         # A local list
@@ -6229,7 +6229,7 @@ def concat_ws(sep: str, *cols: "ColumnOrName") -> Column:
     >>> df.select(concat_ws('-', df.s, df.d).alias('s')).collect()
     [Row(s='abcd-123')]
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     return _invoke_function("concat_ws", sep, _to_seq(sc, cols, _to_java_column))
 
 
@@ -6362,7 +6362,7 @@ def format_string(format: str, *cols: "ColumnOrName") -> Column:
     >>> df.select(format_string('%d %s', df.a, df.b).alias('v')).collect()
     [Row(v='5 hello')]
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     return _invoke_function("format_string", format, _to_seq(sc, cols, _to_java_column))
 
 
@@ -7420,7 +7420,7 @@ def array_join(
     >>> df.select(array_join(df.data, ",", "NULL").alias("joined")).collect()
     [Row(joined='a,b,c'), Row(joined='a,NULL')]
     """
-    require_spark_context_initialized()
+    get_active_spark_context()
     if null_replacement is None:
         return _invoke_function("array_join", _to_java_column(col), delimiter)
     else:
@@ -8259,7 +8259,7 @@ def json_tuple(col: "ColumnOrName", *fields: str) -> Column:
     >>> df.select(df.key, json_tuple(df.jstring, 'f1', 'f2')).collect()
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     return _invoke_function("json_tuple", _to_java_column(col), _to_seq(sc, fields))
 
 
@@ -9211,7 +9211,7 @@ def from_csv(
     [Row(csv=Row(s='abc'))]
     """
 
-    require_spark_context_initialized()
+    get_active_spark_context()
     if isinstance(schema, str):
         schema = _create_column_from_literal(schema)
     elif isinstance(schema, Column):
@@ -9237,7 +9237,7 @@ def _unresolved_named_lambda_variable(*name_parts: Any) -> Column:
     ----------
     name_parts : str
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     name_parts_seq = _to_seq(sc, name_parts)
     expressions = cast(JVMView, sc._jvm).org.apache.spark.sql.catalyst.expressions
     return Column(
@@ -9287,7 +9287,7 @@ def _create_lambda(f: Callable) -> Callable:
     """
     parameters = _get_lambda_parameters(f)
 
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     expressions = cast(JVMView, sc._jvm).org.apache.spark.sql.catalyst.expressions
 
     argnames = ["x", "y", "z"]
@@ -9328,7 +9328,7 @@ def _invoke_higher_order_function(
 
     :return: a Column
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     expressions = cast(JVMView, sc._jvm).org.apache.spark.sql.catalyst.expressions
     expr = getattr(expressions, name)
 
@@ -10044,7 +10044,7 @@ def bucket(numBuckets: Union[Column, int], col: "ColumnOrName") -> Column:
             message_parameters={"arg_name": "numBuckets", "arg_type": type(numBuckets).__name__},
         )
 
-    require_spark_context_initialized()
+    get_active_spark_context()
     numBuckets = (
         _create_column_from_literal(numBuckets)
         if isinstance(numBuckets, int)
@@ -10096,7 +10096,7 @@ def call_udf(udfName: str, *cols: "ColumnOrName") -> Column:
     |         cc|
     +-----------+
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     return _invoke_function("call_udf", udfName, _to_seq(sc, cols, _to_java_column))
 
 

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -21,8 +21,8 @@ A collections of builtin protobuf functions
 
 
 from typing import Dict, Optional, TYPE_CHECKING
-from pyspark import SparkContext
 from pyspark.sql.column import Column, _to_java_column
+from pyspark.sql.utils import require_spark_context_initialized
 from pyspark.util import _print_missing_jar
 
 if TYPE_CHECKING:
@@ -117,8 +117,7 @@ def from_protobuf(
     +------------------+
     """
 
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     try:
         if descFilePath is not None:
             jc = sc._jvm.org.apache.spark.sql.protobuf.functions.from_protobuf(
@@ -212,8 +211,7 @@ def to_protobuf(
     +----------------------------+
     """
 
-    sc = SparkContext._active_spark_context
-    assert sc is not None and sc._jvm is not None
+    sc = require_spark_context_initialized()
     try:
         if descFilePath is not None:
             jc = sc._jvm.org.apache.spark.sql.protobuf.functions.to_protobuf(

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -25,7 +25,7 @@ from typing import Dict, Optional, TYPE_CHECKING, cast
 from py4j.java_gateway import JVMView
 
 from pyspark.sql.column import Column, _to_java_column
-from pyspark.sql.utils import require_spark_context_initialized
+from pyspark.sql.utils import get_active_spark_context
 from pyspark.util import _print_missing_jar
 
 if TYPE_CHECKING:
@@ -120,7 +120,7 @@ def from_protobuf(
     +------------------+
     """
 
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     try:
         if descFilePath is not None:
             jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.from_protobuf(
@@ -214,7 +214,7 @@ def to_protobuf(
     +----------------------------+
     """
 
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     try:
         if descFilePath is not None:
             jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.to_protobuf(

--- a/python/pyspark/sql/protobuf/functions.py
+++ b/python/pyspark/sql/protobuf/functions.py
@@ -20,7 +20,10 @@ A collections of builtin protobuf functions
 """
 
 
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Dict, Optional, TYPE_CHECKING, cast
+
+from py4j.java_gateway import JVMView
+
 from pyspark.sql.column import Column, _to_java_column
 from pyspark.sql.utils import require_spark_context_initialized
 from pyspark.util import _print_missing_jar
@@ -120,11 +123,11 @@ def from_protobuf(
     sc = require_spark_context_initialized()
     try:
         if descFilePath is not None:
-            jc = sc._jvm.org.apache.spark.sql.protobuf.functions.from_protobuf(
+            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.from_protobuf(
                 _to_java_column(data), messageName, descFilePath, options or {}
             )
         else:
-            jc = sc._jvm.org.apache.spark.sql.protobuf.functions.from_protobuf(
+            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.from_protobuf(
                 _to_java_column(data), messageName, options or {}
             )
     except TypeError as e:
@@ -214,11 +217,11 @@ def to_protobuf(
     sc = require_spark_context_initialized()
     try:
         if descFilePath is not None:
-            jc = sc._jvm.org.apache.spark.sql.protobuf.functions.to_protobuf(
+            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.to_protobuf(
                 _to_java_column(data), messageName, descFilePath, options or {}
             )
         else:
-            jc = sc._jvm.org.apache.spark.sql.protobuf.functions.to_protobuf(
+            jc = cast(JVMView, sc._jvm).org.apache.spark.sql.protobuf.functions.to_protobuf(
                 _to_java_column(data), messageName, options or {}
             )
 

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -902,7 +902,7 @@ class UDFInitializationTests(unittest.TestCase):
     def test_err_parse_type_when_no_sc(self):
         with self.assertRaisesRegex(
             RuntimeError,
-            "SparkContext must be initialized for JVM access.",
+            "SparkContext or SparkSession should be created first",
         ):
             udf(lambda x: x, "integer")
 

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -899,6 +899,13 @@ class UDFInitializationTests(unittest.TestCase):
             "SparkSession shouldn't be initialized when UserDefinedFunction is created.",
         )
 
+    def test_err_parse_type_when_no_sc(self):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "SparkContext must be initialized in order to parse a DDL-formatted type string",
+        ):
+            udf(lambda x: x, "integer")
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.test_udf import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -902,7 +902,7 @@ class UDFInitializationTests(unittest.TestCase):
     def test_err_parse_type_when_no_sc(self):
         with self.assertRaisesRegex(
             RuntimeError,
-            "SparkContext must be initialized in order to parse a DDL-formatted type string",
+            "SparkContext must be initialized for JVM access.",
         ):
             udf(lambda x: x, "integer")
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1211,7 +1211,10 @@ def _parse_datatype_string(s: str) -> DataType:
     from pyspark import SparkContext
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
+    if sc is None:
+        raise RuntimeError(
+            "SparkContext must be initialized in order to parse a DDL-formatted type string."
+        )
 
     def from_ddl_schema(type_str: str) -> DataType:
         assert sc is not None and sc._jvm is not None

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -46,7 +46,7 @@ from typing import (
 )
 
 from py4j.protocol import register_input_converter
-from py4j.java_gateway import GatewayClient, JavaClass, JavaGateway, JavaObject
+from py4j.java_gateway import GatewayClient, JavaClass, JavaGateway, JavaObject, JVMView
 
 from pyspark.serializers import CloudPickleSerializer
 from pyspark.sql.utils import has_numpy, require_spark_context_initialized
@@ -1212,12 +1212,14 @@ def _parse_datatype_string(s: str) -> DataType:
 
     def from_ddl_schema(type_str: str) -> DataType:
         return _parse_datatype_json_string(
-            sc._jvm.org.apache.spark.sql.types.StructType.fromDDL(type_str).json()
+            cast(JVMView, sc._jvm).org.apache.spark.sql.types.StructType.fromDDL(type_str).json()
         )
 
     def from_ddl_datatype(type_str: str) -> DataType:
         return _parse_datatype_json_string(
-            sc._jvm.org.apache.spark.sql.api.python.PythonSQLUtils.parseDataType(type_str).json()
+            cast(JVMView, sc._jvm)
+            .org.apache.spark.sql.api.python.PythonSQLUtils.parseDataType(type_str)
+            .json()
         )
 
     try:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1208,8 +1208,6 @@ def _parse_datatype_string(s: str) -> DataType:
         ...
     ParseException:...
     """
-    from pyspark import SparkContext
-
     sc = require_spark_context_initialized()
 
     def from_ddl_schema(type_str: str) -> DataType:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -49,7 +49,7 @@ from py4j.protocol import register_input_converter
 from py4j.java_gateway import GatewayClient, JavaClass, JavaGateway, JavaObject
 
 from pyspark.serializers import CloudPickleSerializer
-from pyspark.sql.utils import has_numpy
+from pyspark.sql.utils import has_numpy, require_spark_context_initialized
 
 if has_numpy:
     import numpy as np
@@ -1210,20 +1210,14 @@ def _parse_datatype_string(s: str) -> DataType:
     """
     from pyspark import SparkContext
 
-    sc = SparkContext._active_spark_context
-    if sc is None:
-        raise RuntimeError(
-            "SparkContext must be initialized in order to parse a DDL-formatted type string."
-        )
+    sc = require_spark_context_initialized()
 
     def from_ddl_schema(type_str: str) -> DataType:
-        assert sc is not None and sc._jvm is not None
         return _parse_datatype_json_string(
             sc._jvm.org.apache.spark.sql.types.StructType.fromDDL(type_str).json()
         )
 
     def from_ddl_datatype(type_str: str) -> DataType:
-        assert sc is not None and sc._jvm is not None
         return _parse_datatype_json_string(
             sc._jvm.org.apache.spark.sql.api.python.PythonSQLUtils.parseDataType(type_str).json()
         )

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -49,7 +49,7 @@ from py4j.protocol import register_input_converter
 from py4j.java_gateway import GatewayClient, JavaClass, JavaGateway, JavaObject, JVMView
 
 from pyspark.serializers import CloudPickleSerializer
-from pyspark.sql.utils import has_numpy, require_spark_context_initialized
+from pyspark.sql.utils import has_numpy, get_active_spark_context
 
 if has_numpy:
     import numpy as np
@@ -1208,7 +1208,7 @@ def _parse_datatype_string(s: str) -> DataType:
         ...
     ParseException:...
     """
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
 
     def from_ddl_schema(type_str: str) -> DataType:
         return _parse_datatype_json_string(

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -40,7 +40,7 @@ from pyspark.sql.types import (
     StructType,
     _parse_datatype_string,
 )
-from pyspark.sql.utils import require_spark_context_initialized
+from pyspark.sql.utils import get_active_spark_context
 from pyspark.sql.pandas.types import to_arrow_type
 from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
 
@@ -340,7 +340,7 @@ class UserDefinedFunction:
         return judf
 
     def __call__(self, *cols: "ColumnOrName") -> Column:
-        sc = require_spark_context_initialized()
+        sc = get_active_spark_context()
         profiler: Optional[Profiler] = None
         memory_profiler: Optional[Profiler] = None
         if sc.profiler_collector:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -40,6 +40,7 @@ from pyspark.sql.types import (
     StructType,
     _parse_datatype_string,
 )
+from pyspark.sql.utils import require_spark_context_initialized
 from pyspark.sql.pandas.types import to_arrow_type
 from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
 
@@ -339,8 +340,7 @@ class UserDefinedFunction:
         return judf
 
     def __call__(self, *cols: "ColumnOrName") -> Column:
-        sc = SparkContext._active_spark_context
-        assert sc is not None
+        sc = require_spark_context_initialized()
         profiler: Optional[Profiler] = None
         memory_profiler: Optional[Profiler] = None
         if sc.profiler_collector:

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -193,7 +193,7 @@ def try_remote_windowspec(f: FuncT) -> FuncT:
     return cast(FuncT, wrapped)
 
 
-def require_spark_context_initialized() -> Optional[SparkContext]:
+def require_spark_context_initialized() -> SparkContext:
     """Raise RuntimeError if SparkContext is not initialized,
     otherwise, returns the active SparkContext."""
     sc = SparkContext._active_spark_context

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -193,6 +193,15 @@ def try_remote_windowspec(f: FuncT) -> FuncT:
     return cast(FuncT, wrapped)
 
 
+def require_spark_context_initialized() -> Optional[SparkContext]:
+    """Raise RuntimeError if SparkContext is not initialized,
+    otherwise, returns the active SparkContext."""
+    sc = SparkContext._active_spark_context
+    if sc is None or sc._jvm is None:
+        raise RuntimeError("SparkContext must be initialized for JVM access.")
+    return sc
+
+
 def try_remote_observation(f: FuncT) -> FuncT:
     """Mark API supported from Spark Connect."""
 

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -193,12 +193,12 @@ def try_remote_windowspec(f: FuncT) -> FuncT:
     return cast(FuncT, wrapped)
 
 
-def require_spark_context_initialized() -> SparkContext:
+def get_active_spark_context() -> SparkContext:
     """Raise RuntimeError if SparkContext is not initialized,
     otherwise, returns the active SparkContext."""
     sc = SparkContext._active_spark_context
     if sc is None or sc._jvm is None:
-        raise RuntimeError("SparkContext must be initialized for JVM access.")
+        raise RuntimeError("SparkContext or SparkSession should be created first.")
     return sc
 
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -23,7 +23,7 @@ from pyspark.sql.column import _to_seq, _to_java_column
 from pyspark.sql.utils import (
     try_remote_window,
     try_remote_windowspec,
-    require_spark_context_initialized,
+    get_active_spark_context,
 )
 
 if TYPE_CHECKING:
@@ -35,7 +35,7 @@ __all__ = ["Window", "WindowSpec"]
 def _to_java_cols(cols: Tuple[Union["ColumnOrName", List["ColumnOrName_"]], ...]) -> JavaObject:
     if len(cols) == 1 and isinstance(cols[0], list):
         cols = cols[0]  # type: ignore[assignment]
-    sc = require_spark_context_initialized()
+    sc = get_active_spark_context()
     return _to_seq(sc, cast(Iterable["ColumnOrName"], cols), _to_java_column)
 
 
@@ -125,7 +125,7 @@ class Window:
         |  3|       b|         3|
         +---+--------+----------+
         """
-        sc = require_spark_context_initialized()
+        sc = get_active_spark_context()
         jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.partitionBy(
             _to_java_cols(cols)
         )
@@ -182,7 +182,7 @@ class Window:
         |  3|       b|         1|
         +---+--------+----------+
         """
-        sc = require_spark_context_initialized()
+        sc = get_active_spark_context()
         jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.orderBy(
             _to_java_cols(cols)
         )
@@ -267,7 +267,7 @@ class Window:
             start = Window.unboundedPreceding
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
-        sc = require_spark_context_initialized()
+        sc = get_active_spark_context()
         jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.rowsBetween(
             start, end
         )
@@ -355,7 +355,7 @@ class Window:
             start = Window.unboundedPreceding
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
-        sc = require_spark_context_initialized()
+        sc = get_active_spark_context()
         jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.rangeBetween(
             start, end
         )

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -19,9 +19,12 @@ from typing import cast, Iterable, List, Tuple, TYPE_CHECKING, Union
 
 from py4j.java_gateway import JavaObject
 
-from pyspark import SparkContext
 from pyspark.sql.column import _to_seq, _to_java_column
-from pyspark.sql.utils import try_remote_window, try_remote_windowspec
+from pyspark.sql.utils import (
+    try_remote_window,
+    try_remote_windowspec,
+    require_spark_context_initialized,
+)
 
 if TYPE_CHECKING:
     from pyspark.sql._typing import ColumnOrName, ColumnOrName_
@@ -30,10 +33,9 @@ __all__ = ["Window", "WindowSpec"]
 
 
 def _to_java_cols(cols: Tuple[Union["ColumnOrName", List["ColumnOrName_"]], ...]) -> JavaObject:
-    sc = SparkContext._active_spark_context
     if len(cols) == 1 and isinstance(cols[0], list):
         cols = cols[0]  # type: ignore[assignment]
-    assert sc is not None
+    sc = require_spark_context_initialized()
     return _to_seq(sc, cast(Iterable["ColumnOrName"], cols), _to_java_column)
 
 
@@ -123,8 +125,7 @@ class Window:
         |  3|       b|         3|
         +---+--------+----------+
         """
-        sc = SparkContext._active_spark_context
-        assert sc is not None and sc._jvm is not None
+        sc = require_spark_context_initialized()
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.partitionBy(_to_java_cols(cols))
         return WindowSpec(jspec)
 
@@ -179,8 +180,7 @@ class Window:
         |  3|       b|         1|
         +---+--------+----------+
         """
-        sc = SparkContext._active_spark_context
-        assert sc is not None and sc._jvm is not None
+        sc = require_spark_context_initialized()
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.orderBy(_to_java_cols(cols))
         return WindowSpec(jspec)
 
@@ -263,8 +263,7 @@ class Window:
             start = Window.unboundedPreceding
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
-        sc = SparkContext._active_spark_context
-        assert sc is not None and sc._jvm is not None
+        sc = require_spark_context_initialized()
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rowsBetween(start, end)
         return WindowSpec(jspec)
 
@@ -350,8 +349,7 @@ class Window:
             start = Window.unboundedPreceding
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
-        sc = SparkContext._active_spark_context
-        assert sc is not None and sc._jvm is not None
+        sc = require_spark_context_initialized()
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rangeBetween(start, end)
         return WindowSpec(jspec)
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -17,7 +17,7 @@
 import sys
 from typing import cast, Iterable, List, Tuple, TYPE_CHECKING, Union
 
-from py4j.java_gateway import JavaObject
+from py4j.java_gateway import JavaObject, JVMView
 
 from pyspark.sql.column import _to_seq, _to_java_column
 from pyspark.sql.utils import (
@@ -126,7 +126,9 @@ class Window:
         +---+--------+----------+
         """
         sc = require_spark_context_initialized()
-        jspec = sc._jvm.org.apache.spark.sql.expressions.Window.partitionBy(_to_java_cols(cols))
+        jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.partitionBy(
+            _to_java_cols(cols)
+        )
         return WindowSpec(jspec)
 
     @staticmethod
@@ -181,7 +183,9 @@ class Window:
         +---+--------+----------+
         """
         sc = require_spark_context_initialized()
-        jspec = sc._jvm.org.apache.spark.sql.expressions.Window.orderBy(_to_java_cols(cols))
+        jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.orderBy(
+            _to_java_cols(cols)
+        )
         return WindowSpec(jspec)
 
     @staticmethod
@@ -264,7 +268,9 @@ class Window:
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
         sc = require_spark_context_initialized()
-        jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rowsBetween(start, end)
+        jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.rowsBetween(
+            start, end
+        )
         return WindowSpec(jspec)
 
     @staticmethod
@@ -350,7 +356,9 @@ class Window:
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
         sc = require_spark_context_initialized()
-        jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rangeBetween(start, end)
+        jspec = cast(JVMView, sc._jvm).org.apache.spark.sql.expressions.Window.rangeBetween(
+            start, end
+        )
         return WindowSpec(jspec)
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Raise RuntimeError when SparkContext is required but not initialized.

### Why are the changes needed?
Error improvement.

### Does this PR introduce _any_ user-facing change?
Error type and message change. 

Raise a RuntimeError with a clear message (rather than an AssertionError) when SparkContext is required but not initialized yet.

### How was this patch tested?
Unit test.
