### PR TITLE
[SPARK-42895][CONNECT] Improve error messages for stopped Spark sessions

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -164,6 +164,11 @@ ERROR_CLASSES_JSON = """
       "Argument `<arg_name>` should be a WindowSpec, got <arg_type>."
     ]
   },
+  "REMOTE_SESSION_STOPPED" : {
+    "message" : [
+      "No active Spark session found. Please create a new Spark session before running the code."
+    ]
+  },
   "UNSUPPORTED_NUMPY_ARRAY_SCALAR" : {
     "message" : [
       "The type of array scalar '<dtype>' is not supported."

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -44,11 +44,6 @@ ERROR_CLASSES_JSON = """
       "Attribute `<attr_name>` is not supported in Spark Connect as it depends on the JVM. If you need to use this attribute, do not use Spark Connect when creating your session."
     ]
   },
-  "NO_ACTIVE_SESSION" : {
-    "message" : [
-      "No active Spark session found. Please create a new Spark session before running the code."
-    ]
-  },
   "NOT_BOOL" : {
     "message" : [
       "Argument `<arg_name>` should be a bool, got <arg_type>."
@@ -167,6 +162,11 @@ ERROR_CLASSES_JSON = """
   "NOT_WINDOWSPEC" : {
     "message" : [
       "Argument `<arg_name>` should be a WindowSpec, got <arg_type>."
+    ]
+  },
+  "NO_ACTIVE_SESSION" : {
+    "message" : [
+      "No active Spark session found. Please create a new Spark session before running the code."
     ]
   },
   "UNSUPPORTED_NUMPY_ARRAY_SCALAR" : {

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -44,6 +44,11 @@ ERROR_CLASSES_JSON = """
       "Attribute `<attr_name>` is not supported in Spark Connect as it depends on the JVM. If you need to use this attribute, do not use Spark Connect when creating your session."
     ]
   },
+  "NO_ACTIVE_SESSION" : {
+    "message" : [
+      "No active Spark session found. Please create a new Spark session before running the code."
+    ]
+  },
   "NOT_BOOL" : {
     "message" : [
       "Argument `<arg_name>` should be a bool, got <arg_type>."
@@ -162,11 +167,6 @@ ERROR_CLASSES_JSON = """
   "NOT_WINDOWSPEC" : {
     "message" : [
       "Argument `<arg_name>` should be a WindowSpec, got <arg_type>."
-    ]
-  },
-  "REMOTE_SESSION_STOPPED" : {
-    "message" : [
-      "No active Spark session found. Please create a new Spark session before running the code."
     ]
   },
   "UNSUPPORTED_NUMPY_ARRAY_SCALAR" : {

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -514,8 +514,11 @@ class SparkConnectClient(object):
     """
 
     @classmethod
-    def retry_exception(cls, e: grpc.RpcError) -> bool:
-        return e.code() == grpc.StatusCode.UNAVAILABLE
+    def retry_exception(cls, e: Exception) -> bool:
+        if isinstance(e, grpc.RpcError):
+            return e.code() == grpc.StatusCode.UNAVAILABLE
+        else:
+            return False
 
     def __init__(
         self,

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -959,8 +959,8 @@ class SparkConnectClient(object):
                                 for batch in reader:
                                     assert isinstance(batch, pa.RecordBatch)
                                     yield batch
-        except grpc.RpcError as rpc_error:
-            self._handle_error(rpc_error)
+        except Exception as error:
+            self._handle_error(error)
 
     def _execute_and_fetch(
         self, req: pb2.ExecutePlanRequest
@@ -1057,7 +1057,7 @@ class SparkConnectClient(object):
             if "Cannot invoke RPC" in str(error) and "closed" in str(error):
                 raise SparkConnectException(
                     error_class="NO_ACTIVE_SESSION", message_parameters=dict()
-                )
+                ) from None
         raise error
 
     def _handle_rpc_error(self, rpc_error: grpc.RpcError) -> NoReturn:

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -1056,13 +1056,9 @@ class SparkConnectClient(object):
         elif isinstance(error, ValueError):
             if "Cannot invoke RPC" in str(error) and "closed" in str(error):
                 raise SparkConnectException(
-                    error_class="NO_ACTIVE_SESSION",
-                    message_parameters=dict()
+                    error_class="NO_ACTIVE_SESSION", message_parameters=dict()
                 )
-            else:
-                raise error
-        else:
-            raise error
+        raise error
 
     def _handle_rpc_error(self, rpc_error: grpc.RpcError) -> NoReturn:
         """

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -883,8 +883,8 @@ class SparkConnectClient(object):
                         )
                     return AnalyzeResult.fromProto(resp)
             raise SparkConnectException("Invalid state during retry exception handling.")
-        except grpc.RpcError as rpc_error:
-            self._handle_error(rpc_error)
+        except Exception as error:
+            self._handle_error(error)
 
     def _execute(self, req: pb2.ExecutePlanRequest) -> None:
         """
@@ -908,8 +908,8 @@ class SparkConnectClient(object):
                                 "Received incorrect session identifier for request: "
                                 f"{b.session_id} != {self._session_id}"
                             )
-        except grpc.RpcError as rpc_error:
-            self._handle_error(rpc_error)
+        except Exception as error:
+            self._handle_error(error)
 
     def _execute_and_fetch_as_iterator(
         self, req: pb2.ExecutePlanRequest
@@ -1035,10 +1035,36 @@ class SparkConnectClient(object):
                         )
                     return ConfigResult.fromProto(resp)
             raise SparkConnectException("Invalid state during retry exception handling.")
-        except grpc.RpcError as rpc_error:
-            self._handle_error(rpc_error)
+        except Exception as error:
+            self._handle_error(error)
 
-    def _handle_error(self, rpc_error: grpc.RpcError) -> NoReturn:
+    def _handle_error(self, error: Exception) -> NoReturn:
+        """
+        Handle errors that occur during RPC calls.
+
+        Parameters
+        ----------
+        error : Exception
+            An exception thrown during RPC calls.
+
+        Returns
+        -------
+        Throws the appropriate internal Python exception.
+        """
+        if isinstance(error, grpc.RpcError):
+            self._handle_rpc_error(cast(grpc.RpcError, error))
+        elif isinstance(error, ValueError):
+            if "Cannot invoke RPC" in str(error) and "closed" in str(error):
+                raise SparkConnectException(
+                    error_class="NO_ACTIVE_SESSION",
+                    message_parameters=dict()
+                )
+            else:
+                raise error
+        else:
+            raise error
+
+    def _handle_rpc_error(self, rpc_error: grpc.RpcError) -> NoReturn:
         """
         Error handling helper for dealing with GRPC Errors. On the server side, certain
         exceptions are enriched with additional RPC Status information. These are

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -1052,7 +1052,7 @@ class SparkConnectClient(object):
         Throws the appropriate internal Python exception.
         """
         if isinstance(error, grpc.RpcError):
-            self._handle_rpc_error(cast(grpc.RpcError, error))
+            self._handle_rpc_error(error)
         elif isinstance(error, ValueError):
             if "Cannot invoke RPC" in str(error) and "closed" in str(error):
                 raise SparkConnectException(

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -18,7 +18,6 @@ from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
 
-import functools
 import os
 import warnings
 from collections.abc import Sized
@@ -68,7 +67,7 @@ from pyspark.sql.types import (
     TimestampType,
 )
 from pyspark.sql.utils import to_str
-from pyspark.errors import PySparkAttributeError, PySparkValueError
+from pyspark.errors import PySparkAttributeError
 
 if TYPE_CHECKING:
     from pyspark.sql.connect._typing import OptionalPrimitiveType
@@ -79,17 +78,6 @@ if TYPE_CHECKING:
 # `_active_spark_session` stores the active spark connect session created by
 # `SparkSession.builder.getOrCreate`. It is used by ML code.
 _active_spark_session = None
-
-
-def require_active_session(func):
-    @functools.wraps(func)
-    def wrapped(*args: Any, **kwargs: Any) -> Any:
-        global _active_spark_session
-        if _active_spark_session is None:
-            raise PySparkValueError(error_class="REMOTE_SESSION_STOPPED", message_parameters=dict())
-        return func(*args, **kwargs)
-
-    return wrapped
 
 
 class SparkSession:
@@ -168,14 +156,12 @@ class SparkSession:
         # Parse the connection string.
         self._client = SparkConnectClient(connectionString)
 
-    @require_active_session
     def table(self, tableName: str) -> DataFrame:
         return self.read.table(tableName)
 
     table.__doc__ = PySparkSession.table.__doc__
 
     @property
-    @require_active_session
     def read(self) -> "DataFrameReader":
         return DataFrameReader(self)
 
@@ -212,7 +198,6 @@ class SparkSession:
             ),
         )
 
-    @require_active_session
     def createDataFrame(
         self,
         data: Union["pd.DataFrame", "np.ndarray", Iterable[Any]],
@@ -406,7 +391,6 @@ class SparkSession:
 
     createDataFrame.__doc__ = PySparkSession.createDataFrame.__doc__
 
-    @require_active_session
     def sql(self, sqlQuery: str, args: Optional[Dict[str, str]] = None) -> "DataFrame":
         cmd = SQL(sqlQuery, args)
         data, properties = self.client.execute_command(cmd.command(self._client))
@@ -417,7 +401,6 @@ class SparkSession:
 
     sql.__doc__ = PySparkSession.sql.__doc__
 
-    @require_active_session
     def range(
         self,
         start: int,
@@ -444,7 +427,6 @@ class SparkSession:
     range.__doc__ = PySparkSession.range.__doc__
 
     @property
-    @require_active_session
     def catalog(self) -> "Catalog":
         from pyspark.sql.connect.catalog import Catalog
 
@@ -496,7 +478,6 @@ class SparkSession:
         raise NotImplementedError("newSession() is not implemented.")
 
     @property
-    @require_active_session
     def conf(self) -> RuntimeConf:
         return RuntimeConf(self.client)
 
@@ -538,7 +519,6 @@ class SparkSession:
         )
 
     @property
-    @require_active_session
     def udf(self) -> "UDFRegistration":
         from pyspark.sql.connect.udf import UDFRegistration
 
@@ -547,7 +527,6 @@ class SparkSession:
     udf.__doc__ = PySparkSession.udf.__doc__
 
     @property
-    @require_active_session
     def version(self) -> str:
         result = self._client._analyze(method="spark_version").spark_version
         assert result is not None

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -23,7 +23,12 @@ import shutil
 import tempfile
 from collections import defaultdict
 
-from pyspark.errors import PySparkAttributeError, PySparkTypeError, PySparkValueError, PySparkException
+from pyspark.errors import (
+    PySparkAttributeError,
+    PySparkTypeError,
+    PySparkValueError,
+    PySparkException,
+)
 from pyspark.sql import SparkSession as PySparkSession, Row
 from pyspark.sql.types import (
     StructType,
@@ -143,6 +148,8 @@ class SparkConnectSQLTestCase(ReusedConnectTestCase, SQLTestUtils, PandasOnSpark
     def spark_connect_clean_up_test_data(cls):
         cls.spark.sql("DROP TABLE IF EXISTS {}".format(cls.tbl_name))
         cls.spark.sql("DROP TABLE IF EXISTS {}".format(cls.tbl_name2))
+        cls.spark.sql("DROP TABLE IF EXISTS {}".format(cls.tbl_name3))
+        cls.spark.sql("DROP TABLE IF EXISTS {}".format(cls.tbl_name4))
         cls.spark.sql("DROP TABLE IF EXISTS {}".format(cls.tbl_name_empty))
 
 
@@ -2988,11 +2995,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
 class SparkConnectSessionTests(SparkConnectSQLTestCase):
     def _check_no_active_session_error(self, e: PySparkException):
-        self.check_error(
-            exception=e,
-            error_class="NO_ACTIVE_SESSION",
-            message_parameters=dict()
-        )
+        self.check_error(exception=e, error_class="NO_ACTIVE_SESSION", message_parameters=dict())
 
     def test_stop_session(self):
         df = self.connect.sql("select 1 as a, 2 as b")

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -26,7 +26,6 @@ from collections import defaultdict
 from pyspark.errors import (
     PySparkAttributeError,
     PySparkTypeError,
-    PySparkValueError,
     PySparkException,
 )
 from pyspark.sql import SparkSession as PySparkSession, Row


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves error messages when users attempt to invoke session operations on a stopped Spark session.

### Why are the changes needed?
To make the error messages more user-friendly.

For example:
```python
spark.stop()
spark.sql("select 1")
```
Before this PR, this code will throw two exceptions:
```
ValueError: Cannot invoke RPC: Channel closed!

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  ...
    return e.code() == grpc.StatusCode.UNAVAILABLE
AttributeError: 'ValueError' object has no attribute 'code'
```

After this PR, it will show this exception:
```
[NO_ACTIVE_SESSION] No active Spark session found. Please create a new Spark session before running the code.
```

### Does this PR introduce _any_ user-facing change?
Yes. This PR modifies the error messages.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test.