### PR TITLE
[SPARK-42914][PYTHON][3.4] Reuse `transformUnregisteredFunction` for `DistributedSequenceID`.

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1250,6 +1250,10 @@ class SparkConnectPlanner(val session: SparkSession) {
           None
         }
 
+      // PS(Pandas API on Spark)-specific functions
+      case "distributed_sequence_id" if fun.getArgumentsCount == 0 =>
+        Some(DistributedSequenceID())
+
       case _ => None
     }
   }

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -974,3 +974,12 @@ class WindowExpression(Expression):
 
     def __repr__(self) -> str:
         return f"WindowExpression({str(self._windowFunction)}, ({str(self._windowSpec)}))"
+
+
+class DistributedSequenceID(Expression):
+    def to_plan(self, session: "SparkConnectClient") -> proto.Expression:
+        unresolved_function = UnresolvedFunction(name="distributed_sequence_id", args=[])
+        return unresolved_function.to_plan(session)
+
+    def __repr__(self) -> str:
+        return "DistributedSequenceID()"

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -1018,6 +1018,14 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
         self.assertEqual(cdf1.schema, sdf1.schema)
         self.assertEqual(cdf1.collect(), sdf1.collect())
 
+    def test_distributed_sequence_id(self):
+        cdf = self.connect.range(10)
+        expected = self.connect.range(0, 10).selectExpr("id as index", "id")
+        self.assertEqual(
+            cdf.select(Column(DistributedSequenceID()).alias("index"), "*").collect(),
+            expected.collect(),
+        )
+
 
 if __name__ == "__main__":
     import os

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -50,7 +50,7 @@ if should_test_connect:
     import pandas as pd
     from pyspark.sql.connect import functions as CF
     from pyspark.sql.connect.column import Column
-    from pyspark.sql.connect.expressions import LiteralExpression
+    from pyspark.sql.connect.expressions import DistributedSequenceID, LiteralExpression
     from pyspark.sql.connect.types import (
         JVM_BYTE_MIN,
         JVM_BYTE_MAX,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport for https://github.com/apache/spark/pull/40540

This PR proposes refactoring `DistributedSequenceID` by leveraging `transformUnregisteredFunction` and remote it from proto message.

### Why are the changes needed?

To follow the existing structure and make proto messages simpler.


### Does this PR introduce _any_ user-facing change?

No, it's used for internal purpose.


### How was this patch tested?

Updated UTs.
