### PR TITLE
[SPARK-41233][FOLLOWUP] Refactor `array_prepend` with `RuntimeReplaceable`

### DIFF
--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_array_append.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_array_append.explain
@@ -1,2 +1,2 @@
-Project [array_insert(e#0, (size(e#0, false) + 1), 1) AS array_append(e, 1)#0]
+Project [array_append(e#0, 1) AS array_append(e, 1)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_array_append.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_array_append.explain
@@ -1,2 +1,2 @@
-Project [array_append(e#0, 1) AS array_append(e, 1)#0]
+Project [array_insert(e#0, (size(e#0, false) + 1), 1) AS array_append(e, 1)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_array_prepend.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_array_prepend.explain
@@ -1,2 +1,2 @@
-Project [array_insert(e#0, 0, 1) AS array_prepend(e, 1)#0]
+Project [array_insert(e#0, 1, 1) AS array_prepend(e, 1)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_array_prepend.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_array_prepend.explain
@@ -1,2 +1,2 @@
-Project [array_prepend(e#0, 1) AS array_prepend(e, 1)#0]
+Project [array_insert(e#0, 0, 1) AS array_prepend(e, 1)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -5030,12 +5030,12 @@ case class ArrayCompact(child: Expression)
 case class ArrayAppend(arr: Expression, ele: Expression) extends InsertArrayOneSide {
 
   override lazy val replacement: Expression =
-    ArrayInsert(arr, Add(ArraySize(left), Literal(1)), ele)
+    ArrayInsert(arr, Add(ArraySize(arr), Literal(1)), ele)
 
   override def prettyName: String = "array_append"
 
   override protected def withNewChildrenInternal(
-      newLeft: Expression, newRight: Expression): Expression = {
+      newLeft: Expression, newRight: Expression): ArrayAppend = {
     copy(arr = newLeft, ele = newRight)
   }
 }
@@ -5065,7 +5065,7 @@ case class ArrayPrepend(arr: Expression, ele: Expression) extends InsertArrayOne
   override def prettyName: String = "array_prepend"
 
   override protected def withNewChildrenInternal(
-      newLeft: Expression, newRight: Expression): Expression = {
+      newLeft: Expression, newRight: Expression): ArrayPrepend = {
     copy(arr = newLeft, ele = newRight)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1418,7 +1418,7 @@ case class ArrayContains(left: Expression, right: Expression)
 case class ArrayPrepend(left: Expression, right: Expression) extends RuntimeReplaceable
   with ImplicitCastInputTypes with BinaryLike[Expression] with QueryErrorsBase {
 
-  override lazy val replacement: Expression = ArrayInsert(left, Literal(0), right)
+  override lazy val replacement: Expression = ArrayInsert(left, Literal(1), right)
 
   override def inputTypes: Seq[AbstractDataType] = {
     (left.dataType, right.dataType) match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1397,8 +1397,28 @@ case class ArrayContains(left: Expression, right: Expression)
     copy(left = newLeft, right = newRight)
 }
 
-trait InsertArrayOneSide extends RuntimeReplaceable
+@ExpressionDescription(
+  usage = """
+      _FUNC_(array, element) - Add the element at the beginning of the array passed as first
+      argument. Type of element should be the same as the type of the elements of the array.
+      Null element is also prepended to the array. But if the array passed is NULL
+      output is NULL
+    """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(array('b', 'd', 'c', 'a'), 'd');
+       ["d","b","d","c","a"]
+      > SELECT _FUNC_(array(1, 2, 3, null), null);
+       [null,1,2,3,null]
+      > SELECT _FUNC_(CAST(null as Array<Int>), 2);
+       NULL
+  """,
+  group = "array_funcs",
+  since = "3.5.0")
+case class ArrayPrepend(left: Expression, right: Expression) extends RuntimeReplaceable
   with ImplicitCastInputTypes with BinaryLike[Expression] with QueryErrorsBase {
+
+  override lazy val replacement: Expression = ArrayInsert(left, Literal(0), right)
 
   override def inputTypes: Seq[AbstractDataType] = {
     (left.dataType, right.dataType) match {
@@ -1434,6 +1454,13 @@ trait InsertArrayOneSide extends RuntimeReplaceable
           )
         )
     }
+  }
+
+  override def prettyName: String = "array_prepend"
+
+  override protected def withNewChildrenInternal(
+      newLeft: Expression, newRight: Expression): ArrayPrepend = {
+    copy(left = newLeft, right = newRight)
   }
 }
 
@@ -5021,45 +5048,128 @@ case class ArrayCompact(child: Expression)
   """,
   since = "3.4.0",
   group = "array_funcs")
-case class ArrayAppend(left: Expression, right: Expression) extends InsertArrayOneSide {
-
-  override lazy val replacement: Expression =
-    ArrayInsert(left, Add(ArraySize(left), Literal(1)), right)
-
+case class ArrayAppend(left: Expression, right: Expression)
+  extends BinaryExpression
+    with ImplicitCastInputTypes
+    with ComplexTypeMergingExpression
+    with QueryErrorsBase {
   override def prettyName: String = "array_append"
 
-  override protected def withNewChildrenInternal(
-      newLeft: Expression, newRight: Expression): ArrayAppend = {
-    copy(left = newLeft, right = newRight)
+  @transient protected lazy val elementType: DataType =
+    inputTypes.head.asInstanceOf[ArrayType].elementType
+
+  override def inputTypes: Seq[AbstractDataType] = {
+    (left.dataType, right.dataType) match {
+      case (ArrayType(e1, hasNull), e2) =>
+        TypeCoercion.findTightestCommonType(e1, e2) match {
+          case Some(dt) => Seq(ArrayType(dt, hasNull), dt)
+          case _ => Seq.empty
+        }
+      case _ => Seq.empty
+    }
   }
-}
 
-@ExpressionDescription(
-  usage = """
-      _FUNC_(array, element) - Add the element at the beginning of the array passed as first
-      argument. Type of element should be the same as the type of the elements of the array.
-      Null element is also prepended to the array. But if the array passed is NULL
-      output is NULL
-    """,
-  examples = """
-    Examples:
-      > SELECT _FUNC_(array('b', 'd', 'c', 'a'), 'd');
-       ["d","b","d","c","a"]
-      > SELECT _FUNC_(array(1, 2, 3, null), null);
-       [null,1,2,3,null]
-      > SELECT _FUNC_(CAST(null as Array<Int>), 2);
-       NULL
-  """,
-  group = "array_funcs",
-  since = "3.5.0")
-case class ArrayPrepend(left: Expression, right: Expression) extends InsertArrayOneSide {
-
-  override lazy val replacement: Expression = ArrayInsert(left, Literal(0), right)
-
-  override def prettyName: String = "array_prepend"
-
-  override protected def withNewChildrenInternal(
-      newLeft: Expression, newRight: Expression): ArrayPrepend = {
-    copy(left = newLeft, right = newRight)
+  override def checkInputDataTypes(): TypeCheckResult = {
+    (left.dataType, right.dataType) match {
+      case (ArrayType(e1, _), e2) if DataTypeUtils.sameType(e1, e2) => TypeCheckResult.TypeCheckSuccess
+      case (ArrayType(e1, _), e2) => DataTypeMismatch(
+        errorSubClass = "ARRAY_FUNCTION_DIFF_TYPES",
+        messageParameters = Map(
+          "functionName" -> toSQLId(prettyName),
+          "leftType" -> toSQLType(left.dataType),
+          "rightType" -> toSQLType(right.dataType),
+          "dataType" -> toSQLType(ArrayType)
+        ))
+      case _ =>
+        DataTypeMismatch(
+          errorSubClass = "UNEXPECTED_INPUT_TYPE",
+          messageParameters = Map(
+            "paramIndex" -> "0",
+            "requiredType" -> toSQLType(ArrayType),
+            "inputSql" -> toSQLExpr(left),
+            "inputType" -> toSQLType(left.dataType)
+          )
+        )
+    }
   }
+
+  override def eval(input: InternalRow): Any = {
+    val value1 = left.eval(input)
+    if (value1 == null) {
+      null
+    } else {
+      val value2 = right.eval(input)
+      nullSafeEval(value1, value2)
+    }
+  }
+
+  override protected def nullSafeEval(arr: Any, elementData: Any): Any = {
+    val arrayData = arr.asInstanceOf[ArrayData]
+    val numberOfElements = arrayData.numElements() + 1
+    if (numberOfElements > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
+      throw QueryExecutionErrors.concatArraysWithElementsExceedLimitError(numberOfElements)
+    }
+    val finalData = new Array[Any](numberOfElements)
+    arrayData.foreach(elementType, finalData.update)
+    finalData.update(arrayData.numElements(), elementData)
+    new GenericArrayData(finalData)
+  }
+
+  override def nullable: Boolean = left.nullable
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val leftGen = left.genCode(ctx)
+    val rightGen = right.genCode(ctx)
+    val f = (eval1: String, eval2: String) => {
+      val newArraySize = ctx.freshName("newArraySize")
+      val i = ctx.freshName("i")
+      val values = ctx.freshName("values")
+      val allocation = CodeGenerator.createArrayData(
+        values, elementType, newArraySize, s" $prettyName failed.")
+      val assignment = CodeGenerator.createArrayAssignment(
+        values, elementType, eval1, i, i, left.dataType.asInstanceOf[ArrayType].containsNull)
+      s"""
+         |int $newArraySize = $eval1.numElements() + 1;
+         |$allocation
+         |int $i = 0;
+         |while ($i < $eval1.numElements()) {
+         |  $assignment
+         |  $i ++;
+         |}
+         |${CodeGenerator.setArrayElement(values, elementType, i, eval2, Some(rightGen.isNull))}
+         |${ev.value} = $values;
+         |""".stripMargin
+    }
+    val resultCode = f(leftGen.value, rightGen.value)
+    if (nullable) {
+      val nullSafeEval =
+        leftGen.code + rightGen.code + ctx.nullSafeExec(left.nullable, leftGen.isNull) {
+          s"""
+            ${ev.isNull} = false; // resultCode could change nullability.
+            $resultCode
+          """
+        }
+      ev.copy(code =
+        code"""
+        boolean ${ev.isNull} = true;
+        ${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
+        $nullSafeEval
+      """)
+    } else {
+      ev.copy(code =
+        code"""
+        ${leftGen.code}
+        ${rightGen.code}
+        ${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
+        $resultCode""", isNull = FalseLiteral)
+    }
+  }
+
+  /**
+   * Returns the [[DataType]] of the result of evaluating this expression. It is invalid to query
+   * the dataType of an unresolved expression (i.e., when `resolved` == false).
+   */
+  override def dataType: DataType = if (right.nullable) left.dataType.asNullable else left.dataType
+  protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): ArrayAppend =
+    copy(left = newLeft, right = newRight)
+
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1400,9 +1400,6 @@ case class ArrayContains(left: Expression, right: Expression)
 trait InsertArrayOneSide extends RuntimeReplaceable
   with ImplicitCastInputTypes with BinaryLike[Expression] with QueryErrorsBase {
 
-  protected def arr: Expression
-  protected def ele: Expression
-
   override def inputTypes: Seq[AbstractDataType] = {
     (left.dataType, right.dataType) match {
       case (ArrayType(e1, hasNull), e2) =>
@@ -1438,9 +1435,6 @@ trait InsertArrayOneSide extends RuntimeReplaceable
         )
     }
   }
-
-  override def left: Expression = arr
-  override def right: Expression = ele
 }
 
 /**
@@ -5027,16 +5021,16 @@ case class ArrayCompact(child: Expression)
   """,
   since = "3.4.0",
   group = "array_funcs")
-case class ArrayAppend(arr: Expression, ele: Expression) extends InsertArrayOneSide {
+case class ArrayAppend(left: Expression, right: Expression) extends InsertArrayOneSide {
 
   override lazy val replacement: Expression =
-    ArrayInsert(arr, Add(ArraySize(arr), Literal(1)), ele)
+    ArrayInsert(left, Add(ArraySize(left), Literal(1)), right)
 
   override def prettyName: String = "array_append"
 
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): ArrayAppend = {
-    copy(arr = newLeft, ele = newRight)
+    copy(left = newLeft, right = newRight)
   }
 }
 
@@ -5058,14 +5052,14 @@ case class ArrayAppend(arr: Expression, ele: Expression) extends InsertArrayOneS
   """,
   group = "array_funcs",
   since = "3.5.0")
-case class ArrayPrepend(arr: Expression, ele: Expression) extends InsertArrayOneSide {
+case class ArrayPrepend(left: Expression, right: Expression) extends InsertArrayOneSide {
 
-  override lazy val replacement: Expression = ArrayInsert(arr, Literal(0), ele)
+  override lazy val replacement: Expression = ArrayInsert(left, Literal(0), right)
 
   override def prettyName: String = "array_prepend"
 
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): ArrayPrepend = {
-    copy(arr = newLeft, ele = newRight)
+    copy(left = newLeft, right = newRight)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1459,9 +1459,8 @@ case class ArrayPrepend(left: Expression, right: Expression) extends RuntimeRepl
   override def prettyName: String = "array_prepend"
 
   override protected def withNewChildrenInternal(
-      newLeft: Expression, newRight: Expression): ArrayPrepend = {
+      newLeft: Expression, newRight: Expression): ArrayPrepend =
     copy(left = newLeft, right = newRight)
-  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1397,120 +1397,27 @@ case class ArrayContains(left: Expression, right: Expression)
     copy(left = newLeft, right = newRight)
 }
 
-// scalastyle:off line.size.limit
-@ExpressionDescription(
-  usage = """
-      _FUNC_(array, element) - Add the element at the beginning of the array passed as first
-      argument. Type of element should be the same as the type of the elements of the array.
-      Null element is also prepended to the array. But if the array passed is NULL
-      output is NULL
-    """,
-  examples = """
-    Examples:
-      > SELECT _FUNC_(array('b', 'd', 'c', 'a'), 'd');
-       ["d","b","d","c","a"]
-      > SELECT _FUNC_(array(1, 2, 3, null), null);
-       [null,1,2,3,null]
-      > SELECT _FUNC_(CAST(null as Array<Int>), 2);
-       NULL
-  """,
-  group = "array_funcs",
-  since = "3.5.0")
-case class ArrayPrepend(left: Expression, right: Expression)
-  extends BinaryExpression
-    with ImplicitCastInputTypes
-    with ComplexTypeMergingExpression
-    with QueryErrorsBase {
+trait ArrayInsertEnd extends RuntimeReplaceable
+  with ImplicitCastInputTypes with BinaryLike[Expression] with QueryErrorsBase {
 
-  override def nullable: Boolean = left.nullable
+  protected def arr: Expression
+  protected def ele: Expression
 
-  @transient protected lazy val elementType: DataType =
-    inputTypes.head.asInstanceOf[ArrayType].elementType
-
-  override def eval(input: InternalRow): Any = {
-    val value1 = left.eval(input)
-    if (value1 == null) {
-      null
-    } else {
-      val value2 = right.eval(input)
-      nullSafeEval(value1, value2)
+  override def inputTypes: Seq[AbstractDataType] = {
+    (left.dataType, right.dataType) match {
+      case (ArrayType(e1, hasNull), e2) =>
+        TypeCoercion.findTightestCommonType(e1, e2) match {
+          case Some(dt) => Seq(ArrayType(dt, hasNull), dt)
+          case _ => Seq.empty
+        }
+      case _ => Seq.empty
     }
   }
-  override def nullSafeEval(arr: Any, elementData: Any): Any = {
-    val arrayData = arr.asInstanceOf[ArrayData]
-    val numberOfElements = arrayData.numElements() + 1
-    if (numberOfElements > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
-      throw QueryExecutionErrors.concatArraysWithElementsExceedLimitError(numberOfElements)
-    }
-    val finalData = new Array[Any](numberOfElements)
-    finalData.update(0, elementData)
-    arrayData.foreach(elementType, (i: Int, v: Any) => finalData.update(i + 1, v))
-    new GenericArrayData(finalData)
-  }
-  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val leftGen = left.genCode(ctx)
-    val rightGen = right.genCode(ctx)
-    val f = (arr: String, value: String) => {
-      val newArraySize = s"$arr.numElements() + 1"
-      val newArray = ctx.freshName("newArray")
-      val i = ctx.freshName("i")
-      val iPlus1 = s"$i+1"
-      val zero = "0"
-      val allocation = CodeGenerator.createArrayData(
-        newArray,
-        elementType,
-        newArraySize,
-        s" $prettyName failed.")
-      val assignment =
-        CodeGenerator.createArrayAssignment(newArray, elementType, arr, iPlus1, i, false)
-      val newElemAssignment =
-        CodeGenerator.setArrayElement(newArray, elementType, zero, value, Some(rightGen.isNull))
-      s"""
-         |$allocation
-         |$newElemAssignment
-         |for (int $i = 0; $i < $arr.numElements(); $i ++) {
-         |  $assignment
-         |}
-         |${ev.value} = $newArray;
-         |""".stripMargin
-    }
-    val resultCode = f(leftGen.value, rightGen.value)
-    if(nullable) {
-      val nullSafeEval = leftGen.code + rightGen.code + ctx.nullSafeExec(nullable, leftGen.isNull) {
-        s"""
-           |${ev.isNull} = false;
-           |${resultCode}
-           |""".stripMargin
-      }
-      ev.copy(code =
-        code"""
-          |boolean ${ev.isNull} = true;
-          |${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
-          |$nullSafeEval
-        """.stripMargin
-      )
-    } else {
-      ev.copy(code =
-        code"""
-          |${leftGen.code}
-          |${rightGen.code}
-          |${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
-          |$resultCode
-        """.stripMargin, isNull = FalseLiteral)
-    }
-  }
-
-  override def prettyName: String = "array_prepend"
-
-  override protected def withNewChildrenInternal(
-      newLeft: Expression, newRight: Expression): ArrayPrepend =
-    copy(left = newLeft, right = newRight)
-
-  override def dataType: DataType = if (right.nullable) left.dataType.asNullable else left.dataType
 
   override def checkInputDataTypes(): TypeCheckResult = {
     (left.dataType, right.dataType) match {
-      case (ArrayType(e1, _), e2) if DataTypeUtils.sameType(e1, e2) => TypeCheckResult.TypeCheckSuccess
+      case (ArrayType(e1, _), e2) if DataTypeUtils.sameType(e1, e2) =>
+        TypeCheckResult.TypeCheckSuccess
       case (ArrayType(e1, _), e2) => DataTypeMismatch(
         errorSubClass = "ARRAY_FUNCTION_DIFF_TYPES",
         messageParameters = Map(
@@ -1531,16 +1438,9 @@ case class ArrayPrepend(left: Expression, right: Expression)
         )
     }
   }
-  override def inputTypes: Seq[AbstractDataType] = {
-    (left.dataType, right.dataType) match {
-      case (ArrayType(e1, hasNull), e2) =>
-        TypeCoercion.findTightestCommonType(e1, e2) match {
-          case Some(dt) => Seq(ArrayType(dt, hasNull), dt)
-          case _ => Seq.empty
-        }
-      case _ => Seq.empty
-    }
-  }
+
+  override def left: Expression = arr
+  override def right: Expression = ele
 }
 
 /**
@@ -5127,128 +5027,46 @@ case class ArrayCompact(child: Expression)
   """,
   since = "3.4.0",
   group = "array_funcs")
-case class ArrayAppend(left: Expression, right: Expression)
-  extends BinaryExpression
-    with ImplicitCastInputTypes
-    with ComplexTypeMergingExpression
-    with QueryErrorsBase {
+case class ArrayAppend(arr: Expression, ele: Expression) extends ArrayInsertEnd {
+
+  override lazy val replacement: Expression =
+    ArrayInsert(arr, Add(ArraySize(left), Literal(1)), ele)
+
   override def prettyName: String = "array_append"
 
-  @transient protected lazy val elementType: DataType =
-    inputTypes.head.asInstanceOf[ArrayType].elementType
-
-  override def inputTypes: Seq[AbstractDataType] = {
-    (left.dataType, right.dataType) match {
-      case (ArrayType(e1, hasNull), e2) =>
-        TypeCoercion.findTightestCommonType(e1, e2) match {
-          case Some(dt) => Seq(ArrayType(dt, hasNull), dt)
-          case _ => Seq.empty
-        }
-      case _ => Seq.empty
-    }
+  override protected def withNewChildrenInternal(
+      newLeft: Expression, newRight: Expression): Expression = {
+    copy(arr = newLeft, ele = newRight)
   }
+}
 
-  override def checkInputDataTypes(): TypeCheckResult = {
-    (left.dataType, right.dataType) match {
-      case (ArrayType(e1, _), e2) if DataTypeUtils.sameType(e1, e2) => TypeCheckResult.TypeCheckSuccess
-      case (ArrayType(e1, _), e2) => DataTypeMismatch(
-        errorSubClass = "ARRAY_FUNCTION_DIFF_TYPES",
-        messageParameters = Map(
-          "functionName" -> toSQLId(prettyName),
-          "leftType" -> toSQLType(left.dataType),
-          "rightType" -> toSQLType(right.dataType),
-          "dataType" -> toSQLType(ArrayType)
-        ))
-      case _ =>
-        DataTypeMismatch(
-          errorSubClass = "UNEXPECTED_INPUT_TYPE",
-          messageParameters = Map(
-            "paramIndex" -> "0",
-            "requiredType" -> toSQLType(ArrayType),
-            "inputSql" -> toSQLExpr(left),
-            "inputType" -> toSQLType(left.dataType)
-          )
-        )
-    }
+@ExpressionDescription(
+  usage = """
+      _FUNC_(array, element) - Add the element at the beginning of the array passed as first
+      argument. Type of element should be the same as the type of the elements of the array.
+      Null element is also prepended to the array. But if the array passed is NULL
+      output is NULL
+    """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(array('b', 'd', 'c', 'a'), 'd');
+       ["d","b","d","c","a"]
+      > SELECT _FUNC_(array(1, 2, 3, null), null);
+       [null,1,2,3,null]
+      > SELECT _FUNC_(CAST(null as Array<Int>), 2);
+       NULL
+  """,
+  group = "array_funcs",
+  since = "3.5.0")
+case class ArrayPrepend(arr: Expression, ele: Expression) extends ArrayInsertEnd {
+
+  override lazy val replacement: Expression =
+    ArrayInsert(arr, Literal(0), ele)
+
+  override def prettyName: String = "array_prepend"
+
+  override protected def withNewChildrenInternal(
+      newLeft: Expression, newRight: Expression): Expression = {
+    copy(arr = newLeft, ele = newRight)
   }
-
-  override def eval(input: InternalRow): Any = {
-    val value1 = left.eval(input)
-    if (value1 == null) {
-      null
-    } else {
-      val value2 = right.eval(input)
-      nullSafeEval(value1, value2)
-    }
-  }
-
-  override protected def nullSafeEval(arr: Any, elementData: Any): Any = {
-    val arrayData = arr.asInstanceOf[ArrayData]
-    val numberOfElements = arrayData.numElements() + 1
-    if (numberOfElements > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
-      throw QueryExecutionErrors.concatArraysWithElementsExceedLimitError(numberOfElements)
-    }
-    val finalData = new Array[Any](numberOfElements)
-    arrayData.foreach(elementType, finalData.update)
-    finalData.update(arrayData.numElements(), elementData)
-    new GenericArrayData(finalData)
-  }
-
-  override def nullable: Boolean = left.nullable
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val leftGen = left.genCode(ctx)
-    val rightGen = right.genCode(ctx)
-    val f = (eval1: String, eval2: String) => {
-      val newArraySize = ctx.freshName("newArraySize")
-      val i = ctx.freshName("i")
-      val values = ctx.freshName("values")
-      val allocation = CodeGenerator.createArrayData(
-        values, elementType, newArraySize, s" $prettyName failed.")
-      val assignment = CodeGenerator.createArrayAssignment(
-        values, elementType, eval1, i, i, left.dataType.asInstanceOf[ArrayType].containsNull)
-      s"""
-         |int $newArraySize = $eval1.numElements() + 1;
-         |$allocation
-         |int $i = 0;
-         |while ($i < $eval1.numElements()) {
-         |  $assignment
-         |  $i ++;
-         |}
-         |${CodeGenerator.setArrayElement(values, elementType, i, eval2, Some(rightGen.isNull))}
-         |${ev.value} = $values;
-         |""".stripMargin
-    }
-    val resultCode = f(leftGen.value, rightGen.value)
-    if (nullable) {
-      val nullSafeEval =
-        leftGen.code + rightGen.code + ctx.nullSafeExec(left.nullable, leftGen.isNull) {
-          s"""
-            ${ev.isNull} = false; // resultCode could change nullability.
-            $resultCode
-          """
-        }
-      ev.copy(code =
-        code"""
-        boolean ${ev.isNull} = true;
-        ${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
-        $nullSafeEval
-      """)
-    } else {
-      ev.copy(code =
-        code"""
-        ${leftGen.code}
-        ${rightGen.code}
-        ${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
-        $resultCode""", isNull = FalseLiteral)
-    }
-  }
-
-  /**
-   * Returns the [[DataType]] of the result of evaluating this expression. It is invalid to query
-   * the dataType of an unresolved expression (i.e., when `resolved` == false).
-   */
-  override def dataType: DataType = if (right.nullable) left.dataType.asNullable else left.dataType
-  protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): ArrayAppend =
-    copy(left = newLeft, right = newRight)
-
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1397,7 +1397,7 @@ case class ArrayContains(left: Expression, right: Expression)
     copy(left = newLeft, right = newRight)
 }
 
-trait ArrayInsertEnd extends RuntimeReplaceable
+trait InsertArrayOneSide extends RuntimeReplaceable
   with ImplicitCastInputTypes with BinaryLike[Expression] with QueryErrorsBase {
 
   protected def arr: Expression
@@ -5027,7 +5027,7 @@ case class ArrayCompact(child: Expression)
   """,
   since = "3.4.0",
   group = "array_funcs")
-case class ArrayAppend(arr: Expression, ele: Expression) extends ArrayInsertEnd {
+case class ArrayAppend(arr: Expression, ele: Expression) extends InsertArrayOneSide {
 
   override lazy val replacement: Expression =
     ArrayInsert(arr, Add(ArraySize(left), Literal(1)), ele)
@@ -5058,7 +5058,7 @@ case class ArrayAppend(arr: Expression, ele: Expression) extends ArrayInsertEnd 
   """,
   group = "array_funcs",
   since = "3.5.0")
-case class ArrayPrepend(arr: Expression, ele: Expression) extends ArrayInsertEnd {
+case class ArrayPrepend(arr: Expression, ele: Expression) extends InsertArrayOneSide {
 
   override lazy val replacement: Expression = ArrayInsert(arr, Literal(0), ele)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -5060,8 +5060,7 @@ case class ArrayAppend(arr: Expression, ele: Expression) extends ArrayInsertEnd 
   since = "3.5.0")
 case class ArrayPrepend(arr: Expression, ele: Expression) extends ArrayInsertEnd {
 
-  override lazy val replacement: Expression =
-    ArrayInsert(arr, Literal(0), ele)
+  override lazy val replacement: Expression = ArrayInsert(arr, Literal(0), ele)
 
   override def prettyName: String = "array_prepend"
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -1855,50 +1855,6 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     checkEvaluation(ArrayRepeat(Literal("hi"), Literal(null, IntegerType)), null)
   }
 
-  test("SPARK-41233: ArrayPrepend") {
-    val a0 = Literal.create(Seq(1, 2, 3, 4), ArrayType(IntegerType))
-    val a1 = Literal.create(Seq("a", "b", "c"), ArrayType(StringType))
-    val a2 = Literal.create(Seq.empty[Integer], ArrayType(IntegerType))
-    val a3 = Literal.create(null, ArrayType(StringType))
-
-    checkEvaluation(ArrayPrepend(a0, Literal(0)), Seq(0, 1, 2, 3, 4))
-    checkEvaluation(ArrayPrepend(a1, Literal("a")), Seq("a", "a", "b", "c"))
-    checkEvaluation(ArrayPrepend(a2, Literal(1)), Seq(1))
-    checkEvaluation(ArrayPrepend(a2, Literal(null, IntegerType)), Seq(null))
-    checkEvaluation(ArrayPrepend(a3, Literal("a")), null)
-    checkEvaluation(ArrayPrepend(a3, Literal(null, StringType)), null)
-
-    // complex data types
-    val data = Seq[Array[Byte]](
-      Array[Byte](5, 6),
-      Array[Byte](1, 2),
-      Array[Byte](1, 2),
-      Array[Byte](5, 6))
-    val b0 = Literal.create(
-      data,
-      ArrayType(BinaryType))
-    val b1 = Literal.create(Seq[Array[Byte]](Array[Byte](2, 1), null), ArrayType(BinaryType))
-    val nullBinary = Literal.create(null, BinaryType)
-    // Calling ArrayPrepend with a null element should result in NULL being prepended to the array
-    val dataWithNullPrepended = null +: data
-    checkEvaluation(ArrayPrepend(b0, nullBinary), dataWithNullPrepended)
-    val dataToPrepend1 = Literal.create(Array[Byte](5, 6), BinaryType)
-    checkEvaluation(
-      ArrayPrepend(b1, dataToPrepend1),
-      Seq[Array[Byte]](Array[Byte](5, 6), Array[Byte](2, 1), null))
-
-    val c0 = Literal.create(
-      Seq[Seq[Int]](Seq[Int](1, 2), Seq[Int](3, 4)),
-      ArrayType(ArrayType(IntegerType)))
-    val dataToPrepend2 = Literal.create(Seq[Int](5, 6), ArrayType(IntegerType))
-    checkEvaluation(
-      ArrayPrepend(c0, dataToPrepend2),
-      Seq(Seq[Int](5, 6), Seq[Int](1, 2), Seq[Int](3, 4)))
-    checkEvaluation(
-      ArrayPrepend(c0, Literal.create(Seq.empty[Int], ArrayType(IntegerType))),
-      Seq(Seq.empty[Int], Seq[Int](1, 2), Seq[Int](3, 4)))
-  }
-
   test("Array remove") {
     val a0 = Literal.create(Seq(1, 2, 3, 2, 2, 5), ArrayType(IntegerType))
     val a1 = Literal.create(Seq("b", "a", "a", "c", "b"), ArrayType(StringType))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -2722,50 +2722,8 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
   }
 
   test("ArrayAppend Expression Test") {
-    checkEvaluation(
-      ArrayAppend(
-        Literal.create(null, ArrayType(StringType)),
-        Literal.create("c", StringType)),
-      null)
-
-    checkEvaluation(
-      ArrayAppend(
-        Literal.create(null, ArrayType(StringType)),
-        Literal.create(null, StringType)),
-      null)
-
-    checkEvaluation(
-      ArrayAppend(
-        Literal.create(Seq(""), ArrayType(StringType)),
-        Literal.create(null, StringType)),
-      Seq("", null))
-
-    checkEvaluation(
-      ArrayAppend(
-        Literal.create(Seq("a", "b", "c"), ArrayType(StringType)),
-        Literal.create(null, StringType)),
-      Seq("a", "b", "c", null))
-
-    checkEvaluation(
-      ArrayAppend(
-        Literal.create(Seq(Double.NaN, 1d, 2d), ArrayType(DoubleType)),
-        Literal.create(3d, DoubleType)),
-      Seq(Double.NaN, 1d, 2d, 3d))
-    // Null entry check
-    checkEvaluation(
-      ArrayAppend(
-        Literal.create(Seq(null, 1d, 2d), ArrayType(DoubleType)),
-        Literal.create(3d, DoubleType)),
-      Seq(null, 1d, 2d, 3d))
-
-    checkEvaluation(
-      ArrayAppend(
-        Literal.create(Seq("a", "b", "c"), ArrayType(StringType)),
-        Literal.create("c", StringType)),
-      Seq("a", "b", "c", "c"))
-
     assert(
-      ArrayAppend(
+      new ArrayAppend(
         Literal.create(Seq(null, 1d, 2d), ArrayType(DoubleType)),
         Literal.create(3, IntegerType))
         .checkInputDataTypes() ==
@@ -2780,7 +2738,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
 
 
     assert(
-      ArrayAppend(
+      new ArrayAppend(
         Literal.create("Hi", StringType),
         Literal.create("Spark", StringType))
         .checkInputDataTypes() == DataTypeMismatch(
@@ -2793,7 +2751,6 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
         )
       )
     )
-
   }
 
   test("SPARK-42401: Array insert of null value (explicit)") {
@@ -2807,13 +2764,6 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     val a = Literal.create(Seq("b", "a", "c"), ArrayType(StringType, false))
     checkEvaluation(ArrayInsert(
       a, Literal(5), Literal.create("q", StringType)), Seq("b", "a", "c", null, "q")
-    )
-  }
-
-  test("SPARK-42401: Array append of null value") {
-    val a = Literal.create(Seq("b", "a", "c"), ArrayType(StringType, false))
-    checkEvaluation(ArrayAppend(
-      a, Literal.create(null, StringType)), Seq("b", "a", "c", null)
     )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -2723,7 +2723,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
 
   test("ArrayAppend Expression Test") {
     assert(
-      new ArrayAppend(
+      ArrayAppend(
         Literal.create(Seq(null, 1d, 2d), ArrayType(DoubleType)),
         Literal.create(3, IntegerType))
         .checkInputDataTypes() ==
@@ -2738,7 +2738,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
 
 
     assert(
-      new ArrayAppend(
+      ArrayAppend(
         Literal.create("Hi", StringType),
         Literal.create("Spark", StringType))
         .checkInputDataTypes() == DataTypeMismatch(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -2678,6 +2678,48 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
   }
 
   test("ArrayAppend Expression Test") {
+    checkEvaluation(
+      ArrayAppend(
+        Literal.create(null, ArrayType(StringType)),
+        Literal.create("c", StringType)),
+      null)
+
+    checkEvaluation(
+      ArrayAppend(
+        Literal.create(null, ArrayType(StringType)),
+        Literal.create(null, StringType)),
+      null)
+
+    checkEvaluation(
+      ArrayAppend(
+        Literal.create(Seq(""), ArrayType(StringType)),
+        Literal.create(null, StringType)),
+      Seq("", null))
+
+    checkEvaluation(
+      ArrayAppend(
+        Literal.create(Seq("a", "b", "c"), ArrayType(StringType)),
+        Literal.create(null, StringType)),
+      Seq("a", "b", "c", null))
+
+    checkEvaluation(
+      ArrayAppend(
+        Literal.create(Seq(Double.NaN, 1d, 2d), ArrayType(DoubleType)),
+        Literal.create(3d, DoubleType)),
+      Seq(Double.NaN, 1d, 2d, 3d))
+    // Null entry check
+    checkEvaluation(
+      ArrayAppend(
+        Literal.create(Seq(null, 1d, 2d), ArrayType(DoubleType)),
+        Literal.create(3d, DoubleType)),
+      Seq(null, 1d, 2d, 3d))
+
+    checkEvaluation(
+      ArrayAppend(
+        Literal.create(Seq("a", "b", "c"), ArrayType(StringType)),
+        Literal.create("c", StringType)),
+      Seq("a", "b", "c", "c"))
+
     assert(
       ArrayAppend(
         Literal.create(Seq(null, 1d, 2d), ArrayType(DoubleType)),
@@ -2707,6 +2749,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
         )
       )
     )
+
   }
 
   test("SPARK-42401: Array insert of null value (explicit)") {
@@ -2720,6 +2763,13 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     val a = Literal.create(Seq("b", "a", "c"), ArrayType(StringType, false))
     checkEvaluation(ArrayInsert(
       a, Literal(5), Literal.create("q", StringType)), Seq("b", "a", "c", null, "q")
+    )
+  }
+
+  test("SPARK-42401: Array append of null value") {
+    val a = Literal.create(Seq("b", "a", "c"), ArrayType(StringType, false))
+    checkEvaluation(ArrayAppend(
+      a, Literal.create(null, StringType)), Seq("b", "a", "c", null)
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -2717,6 +2717,22 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     ).toDF("a", "b")
     checkAnswer(df2.selectExpr("array_prepend(a, b)"),
       Seq(Row(Seq("d", "a", "b", "c")), Row(null), Row(Seq(null, "x", "y", "z")), Row(null)))
+    val dataA = Seq[Array[Byte]](
+      Array[Byte](5, 6),
+      Array[Byte](1, 2),
+      Array[Byte](1, 2),
+      Array[Byte](5, 6))
+    val dataB = Seq[Array[Int]](Array[Int](1, 2), Array[Int](3, 4))
+    val df3 = Seq((dataA, dataB)).toDF("a", "b")
+    val dataToPrepend = Array[Byte](5, 6)
+    checkAnswer(
+      df3.select(array_prepend($"a", null), array_prepend($"a", dataToPrepend)),
+      Seq(Row(null +: dataA, dataToPrepend +: dataA)))
+    checkAnswer(
+      df3.select(array_prepend($"b", Array.empty[Int]), array_prepend($"b", Array[Int](5, 6))),
+      Seq(Row(
+        Seq(Seq.empty[Int], Seq[Int](1, 2), Seq[Int](3, 4)),
+        Seq(Seq[Int](5, 6), Seq[Int](1, 2), Seq[Int](3, 4)))))
   }
 
   test("array remove") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Recently, Spark SQL supported `array_insert` and `array_prepend`. All implementations are individual.
In fact, `array_prepend` is special case of `array_insert` and we can reuse the `array_insert` by extends `RuntimeReplaceable`.


### Why are the changes needed?
Simplify the implementation of `array_prepend`.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
Exists test case.
