### PR TITLE
[SPARK-42935] [SQL] Add union required distribution push down

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4195,6 +4195,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val UNION_REQUIRED_DISTRIBUTION_PUSHDOWN =
+    buildConf("spark.sql.unionRequiredDistributionPushdown.enabled")
+      .internal()
+      .doc("Enables union spark plan required children distribution pushdown. This is useful " +
+        "when children output partitioning match union parent plan's required distribution")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.adaptive.{AdaptiveExecutionContext, InsertAdaptiveSparkPlan}
 import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableUnnecessaryBucketedScan}
 import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
-import org.apache.spark.sql.execution.exchange.EnsureRequirements
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, UnionDistributionPushdown}
 import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
 import org.apache.spark.sql.execution.streaming.{IncrementalExecution, OffsetSeqMetadata, WatermarkPropagator}
 import org.apache.spark.sql.internal.SQLConf
@@ -428,6 +428,7 @@ object QueryExecution {
       PlanDynamicPruningFilters(sparkSession),
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,
+      UnionDistributionPushdown,
       EnsureRequirements(),
       // `ReplaceHashWithSortAgg` needs to be added after `EnsureRequirements` to guarantee the
       // sort order of each node is checked to be valid.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -119,6 +119,7 @@ case class AdaptiveSparkPlanExec(
       EnsureRequirements(requiredDistribution.isDefined, requiredDistribution)
     Seq(
       RemoveRedundantProjects,
+      UnionDistributionPushdown,
       ensureRequirements,
       AdjustShuffleExchangePosition,
       ValidateSparkPlan,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/UnionDistributionPushdown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/UnionDistributionPushdown.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.exchange
+
+import java.io.{IOException, ObjectOutputStream}
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{SparkPlan, UnionExec, UnionZipExec}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.Utils
+
+/**
+ * Pushes parent's required distribution to [[UnionExec]] so that we can
+ * remove unnecessary shuffle exchange if any child output partitioning matches
+ * 1) the operator is UnionExec
+ * 2) the operator's output partitioning can not satisfy parent distribution
+ * 3) the operator's parent requires hashing or clustering distribution
+ * 4) the data types of operator's children output attributes are the same
+ */
+object UnionDistributionPushdown extends Rule[SparkPlan] {
+
+  def allChildrenSameDataType(unionExec: UnionExec): Boolean = {
+    (Seq(unionExec) ++ unionExec.children).map(_.output).transpose.map{ attrs =>
+      val firstAttr = attrs.head
+      attrs.forall(_.dataType == firstAttr.dataType)
+    }.forall(_ == true)
+  }
+
+  def createNewChildrenDistribution(unionExec: UnionExec,
+                                    unionRequired: Distribution): Seq[Distribution] = {
+    unionExec.children.map{ unionChild =>
+      // create output attributes map (union output exprId -> child output)
+      val attributes = unionExec.output.map(_.exprId).zip(unionChild.output).toMap
+      unionRequired match {
+        case distribution: ClusteredDistribution =>
+          val newExpressions = distribution.clustering.map(exp => exp.transformUp {
+            case attr: Attribute if attributes.contains(attr.exprId) => attributes(attr.exprId)
+          })
+          ClusteredDistribution(newExpressions, distribution.requireAllClusterKeys,
+            distribution.requiredNumPartitions)
+
+        case distribution => distribution
+      }
+    }
+  }
+
+  override def apply(plan: SparkPlan): SparkPlan = plan.transformUp {
+    case operator: SparkPlan if conf.getConf(SQLConf.UNION_REQUIRED_DISTRIBUTION_PUSHDOWN) &&
+      operator.children.exists(_.isInstanceOf[UnionExec]) =>
+      val newChildren = operator.children.zipWithIndex.map {
+        case (unionExec: UnionExec, childIndex: Int) if !unionExec.outputPartitioning.
+          satisfies(operator.requiredChildDistribution(childIndex)) =>
+          val unionRequired = operator.requiredChildDistribution(childIndex)
+          unionRequired match {
+            case _: ClusteredDistribution if allChildrenSameDataType(unionExec) =>
+              val requiredChildDistribution: Seq[Distribution] =
+                createNewChildrenDistribution(unionExec, unionRequired)
+              val numPartitions = unionRequired.requiredNumPartitions
+                .getOrElse(conf.numShufflePartitions)
+              val outputPartitioning = unionRequired.createPartitioning(numPartitions)
+              UnionZipExec(unionExec.children, requiredChildDistribution,
+                outputPartitioning)
+
+            case _: Distribution => unionExec
+          }
+
+        case (child, _) => child
+      }
+      operator.withNewChildren(newChildren)
+  }
+}
+
+/**
+ * Class representing partitions of UnionZipRDD, which maintains the list of
+ * corresponding partitions of parent RDDs.
+ */
+private[spark]
+class UnionZipRDDPartition(
+    @transient val rdds: Seq[RDD[_]],
+    override val index: Int
+  ) extends Partition {
+  var parents: Array[Partition] = rdds.map(_.partitions(index)).toArray
+
+  @throws(classOf[IOException])
+  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    // Update the reference to parent partition at the time of task serialization
+    parents = rdds.map(_.partitions(index)).toArray
+    oos.defaultWriteObject()
+  }
+}
+
+/**
+ * Class representing an RDD that can take multiple RDDs with same partition size and
+ * unify them into a single RDD while preserving the partition. So m RDDs with p partitions
+ * will be unified to a single RDD with p partitions, which the ith partition consists of the
+ * ith partition in each parent RDD.
+ */
+private[spark]
+class UnionZipRDD[T: ClassTag](
+    sc: SparkContext,
+    var rdds: Seq[RDD[T]]
+  ) extends RDD[T](sc, rdds.map(x => new OneToOneDependency(x))) {
+  require(rdds.nonEmpty)
+  require(rdds.map(_.partitions.length).toSet.size == 1,
+    "Parent RDDs have different partition size: " + rdds.map(_.partitions.length))
+
+  override def getPartitions: Array[Partition] = {
+    val numPartitions = rdds.head.partitions.length
+    (0 until numPartitions).map { index =>
+      new UnionZipRDDPartition(rdds, index)
+    }.toArray
+  }
+
+  override def compute(s: Partition, context: TaskContext): Iterator[T] = {
+    val parentPartitions = s.asInstanceOf[UnionZipRDDPartition].parents
+    rdds.zip(parentPartitions).iterator.flatMap {
+      case (rdd, p) => rdd.iterator(p, context)
+    }
+  }
+
+  override def clearDependencies(): Unit = {
+    super.clearDependencies()
+    rdds = null
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -54,7 +54,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprB :: exprA :: Nil, exprA :: exprB :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec1) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB))
         assert(rightKeys === Seq(exprB, exprA))
@@ -67,7 +67,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     EnsureRequirements.apply(smjExec2) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprB, exprA))
         assert(rightKeys === Seq(exprA, exprB))
       case other => fail(other.toString)
@@ -80,7 +80,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     EnsureRequirements.apply(smjExec3) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprC, exprD))
         assert(rightKeys === Seq(exprA, exprB))
       case other => fail(other.toString)
@@ -103,8 +103,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     )
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: KeyGroupedPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: KeyGroupedPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, _: KeyGroupedPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: KeyGroupedPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB, exprC))
         assert(rightKeys === Seq(exprB, exprA, exprD))
       case other => fail(other.toString)
@@ -141,7 +141,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     EnsureRequirements.apply(smjExec1) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprB, exprA))
         assert(rightKeys === Seq(exprB, exprC))
       case other => fail(other.toString)
@@ -155,7 +155,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     EnsureRequirements.apply(smjExec2) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprB, exprA))
         assert(rightKeys === Seq(exprB, exprC))
       case other => fail(other.toString)
@@ -167,7 +167,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprC :: exprB :: Nil, exprA :: exprB :: Nil, Inner, None, plan3, plan1)
     EnsureRequirements.apply(smjExec3) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(_: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprB, exprC))
         assert(rightKeys === Seq(exprB, exprA))
@@ -206,8 +206,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: Nil, exprB :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA))
         assert(rightKeys === Seq(exprB))
       case other => fail(other.toString)
@@ -222,8 +222,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     // corresponding cluster keys
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB))
         assert(rightKeys === Seq(exprB, exprC))
       case other => fail(other.toString)
@@ -233,8 +233,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprB :: exprA :: Nil, exprC :: exprB :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprB, exprA))
         assert(rightKeys === Seq(exprC, exprB))
       case other => fail(other.toString)
@@ -250,8 +250,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprB :: Nil, exprA :: exprC :: exprC :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB, exprB))
         assert(rightKeys === Seq(exprA, exprC, exprC))
       case other => fail(other.toString)
@@ -265,8 +265,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprB :: Nil, exprA :: exprC :: exprC :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB, exprB))
         assert(rightKeys === Seq(exprA, exprC, exprC))
       case other => fail(other.toString)
@@ -280,8 +280,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprB :: Nil, exprA :: exprC :: exprD :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB, exprB))
         assert(rightKeys === Seq(exprA, exprC, exprD))
       case other => fail(other.toString)
@@ -295,8 +295,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprB :: Nil, exprA :: exprC :: exprC :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB, exprB))
         assert(rightKeys === Seq(exprA, exprC, exprC))
       case other => fail(other.toString)
@@ -313,7 +313,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(p: HashPartitioning, _, _, _), _), _) =>
           assert(leftKeys === Seq(exprA, exprB))
           assert(rightKeys === Seq(exprC, exprD))
@@ -331,7 +331,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(leftKeys, rightKeys, _, _,
         SortExec(_, _, ShuffleExchangeExec(p: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
           assert(leftKeys === Seq(exprA, exprB))
           assert(rightKeys === Seq(exprC, exprD))
           assert(p.expressions == Seq(exprB))
@@ -347,7 +347,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(p: HashPartitioning, _, _, _), _), _) =>
           assert(leftKeys === Seq(exprA, exprB))
           assert(rightKeys === Seq(exprC, exprD))
@@ -366,7 +366,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprB :: Nil, exprA :: exprC :: exprC :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
       SortExec(_, _, ShuffleExchangeExec(p: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB, exprB))
         assert(rightKeys === Seq(exprA, exprC, exprC))
@@ -382,7 +382,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprB :: Nil, exprA :: exprC :: exprD :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
       SortExec(_, _, ShuffleExchangeExec(p: HashPartitioning, _, _, _), _), _) =>
         assert(leftKeys === Seq(exprA, exprB, exprB))
         assert(rightKeys === Seq(exprA, exprC, exprD))
@@ -398,8 +398,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, SinglePartition, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, SinglePartition, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, SinglePartition, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, SinglePartition, _, _, _), _), _) =>
       case other => fail(other.toString)
     }
 
@@ -409,8 +409,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, SinglePartition, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, SinglePartition, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
       case other => fail(other.toString)
     }
 
@@ -421,8 +421,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _), _) =>
       case other => fail(other.toString)
     }
   }
@@ -456,7 +456,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
       EnsureRequirements.apply(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(right: HashPartitioning, _, _, _), _), _) =>
           assert(left.numPartitions == 10)
           assert(right.numPartitions == 10)
@@ -486,7 +486,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       }
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(right: HashPartitioning, _, _, _), _), _) =>
           assert(left.numPartitions == 1)
           assert(right.numPartitions == 1)
@@ -523,7 +523,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         Inner, None, plan1, plan2)
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: PartitioningCollection, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, left: PartitioningCollection, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(right: HashPartitioning, _, _, _), _), _) =>
           assert(left.numPartitions == 10)
           assert(right.numPartitions == 10)
@@ -541,7 +541,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
         SortExec(_, _, ShuffleExchangeExec(left: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: PartitioningCollection, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, right: PartitioningCollection, _, _, _), _), _) =>
           assert(left.numPartitions == 20)
           assert(left.expressions == Seq(exprC))
           assert(right.numPartitions == 20)
@@ -564,8 +564,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
       EnsureRequirements.apply(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: HashPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: HashPartitioning, _, _, _), _), _) =>
           assert(left.expressions === Seq(exprA, exprB))
           assert(right.expressions === Seq(exprC, exprD))
         case other => fail(other.toString)
@@ -581,7 +581,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
       EnsureRequirements.apply(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(right: HashPartitioning, _, _, _), _), _) =>
           assert(left.expressions === Seq(exprA, exprB))
           assert(right.expressions === Seq(exprC, exprD))
@@ -602,7 +602,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       EnsureRequirements.apply(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
         SortExec(_, _, ShuffleExchangeExec(left: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: HashPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, right: HashPartitioning, _, _, _), _), _) =>
           assert(left.expressions === Seq(exprA, exprB))
           assert(right.expressions === Seq(exprC, exprD))
           assert(left.numPartitions == 5)
@@ -620,7 +620,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       EnsureRequirements.apply(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
         SortExec(_, _, ShuffleExchangeExec(left: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: HashPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, right: HashPartitioning, _, _, _), _), _) =>
           assert(left.expressions === Seq(exprA, exprB))
           assert(right.expressions === Seq(exprC, exprD))
           assert(left.numPartitions == 5)
@@ -640,7 +640,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       EnsureRequirements.apply(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
         SortExec(_, _, ShuffleExchangeExec(left: HashPartitioning, _, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: HashPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, right: HashPartitioning, _, _, _), _), _) =>
           assert(left.expressions === Seq(exprA, exprB))
           assert(right.expressions === Seq(exprC, exprD))
           assert(left.numPartitions == 6)
@@ -685,7 +685,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
             exprA :: exprB :: Nil, exprC :: exprD :: Nil, Inner, None, plan1, plan2)
           EnsureRequirements.apply(smjExec) match {
             case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-            SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _), _),
+            SortExec(_, _, DummySparkPlan(_, _, left: HashPartitioning, _, _, _), _),
             SortExec(_, _, ShuffleExchangeExec(right: HashPartitioning, _, _, _), _), _) =>
               assert(leftKeys === Seq(exprA, exprB))
               assert(rightKeys === Seq(exprC, exprD))
@@ -727,7 +727,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       smjExec = SortMergeJoinExec(exprA :: Nil, exprC :: Nil, Inner, None, plan1, plan2)
       EnsureRequirements.apply(smjExec) match {
         case SortMergeJoinExec(leftKeys, rightKeys, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _, _), _),
         SortExec(_, _, ShuffleExchangeExec(right: HashPartitioning, _, _, _), _), _) =>
           assert(leftKeys === Seq(exprA))
           assert(rightKeys === Seq(exprC))
@@ -783,8 +783,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: Nil, exprA :: exprC :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
         assert(left.expressions === Seq(exprA, exprB))
         assert(right.expressions === Seq(exprA, exprC))
       case other => fail(other.toString)
@@ -803,8 +803,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: Nil, exprA :: exprC :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
         assert(left.expressions === Seq(bucket(4, exprA), bucket(16, exprB)))
         assert(right.expressions === Seq(bucket(4, exprA), bucket(16, exprC)))
       case other => fail(other.toString)
@@ -825,8 +825,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: Nil, exprA :: exprC :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _, _), _), _) =>
         assert(left.expressions === Seq(bucket(4, exprA), bucket(16, exprB)))
       case other => fail(other.toString)
     }
@@ -834,8 +834,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprC :: Nil, exprA :: exprB :: Nil, Inner, None, plan2, plan1)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, _: PartitioningCollection, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
         assert(right.expressions === Seq(bucket(4, exprA), bucket(16, exprB)))
       case other => fail(other.toString)
     }
@@ -851,8 +851,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: Nil, exprA :: exprC :: Nil, Inner, None, plan1, plan2)
     EnsureRequirements.apply(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
         assert(left.expressions === Seq(bucket(4, exprA), years(exprB)))
         assert(right.expressions === Seq(bucket(4, exprA), years(exprC)))
       case other => fail(other.toString)
@@ -895,8 +895,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprC :: Nil, exprA :: exprC :: exprB :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
         assert(left.expressions === Seq(bucket(4, exprB), years(exprC)))
         assert(right.expressions === Seq(bucket(4, exprC), years(exprB)))
       case other => fail(other.toString)
@@ -915,8 +915,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprB :: Nil, exprA :: exprC :: exprC :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
         assert(left.expressions === Seq(bucket(4, exprA), years(exprB)))
         assert(right.expressions === Seq(bucket(4, exprA), years(exprC)))
       case other => fail(other.toString)
@@ -933,8 +933,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       exprA :: exprB :: exprB :: Nil, exprA :: exprC :: exprC :: Nil, Inner, None, plan1, plan2)
     applyEnsureRequirementsWithSubsetKeys(smjExec) match {
       case SortMergeJoinExec(_, _, _, _,
-      SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
-      SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+      SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _, _), _),
+      SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
         assert(left.expressions === Seq(years(exprA), bucket(4, exprB), days(exprA)))
         assert(right.expressions === Seq(years(exprA), bucket(4, exprC), days(exprA)))
       case other => fail(other.toString)
@@ -1041,8 +1041,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         exprA :: exprB :: exprC :: Nil, exprA :: exprC :: exprB :: Nil, Inner, None, plan1, plan2)
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, left: KeyGroupedPartitioning, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
           assert(left.expressions === Seq(bucket(4, exprB), bucket(8, exprC)))
           assert(right.expressions === Seq(bucket(4, exprC), bucket(8, exprB)))
         case other => fail(other.toString)
@@ -1062,8 +1062,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         exprA :: exprB :: exprC :: Nil, exprA :: exprC :: exprB :: Nil, Inner, None, plan1, plan2)
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: PartitioningCollection, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, left: PartitioningCollection, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: KeyGroupedPartitioning, _, _, _), _), _) =>
           assert(left.partitionings.length == 2)
           assert(left.partitionings.head.isInstanceOf[KeyGroupedPartitioning])
           assert(left.partitionings.head.asInstanceOf[KeyGroupedPartitioning].expressions ==
@@ -1096,8 +1096,8 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         exprA :: exprB :: exprC :: Nil, exprA :: exprC :: exprB :: Nil, Inner, None, plan1, plan2)
       applyEnsureRequirementsWithSubsetKeys(smjExec) match {
         case SortMergeJoinExec(_, _, _, _,
-        SortExec(_, _, DummySparkPlan(_, _, left: PartitioningCollection, _, _), _),
-        SortExec(_, _, DummySparkPlan(_, _, right: PartitioningCollection, _, _), _), _) =>
+        SortExec(_, _, DummySparkPlan(_, _, left: PartitioningCollection, _, _, _), _),
+        SortExec(_, _, DummySparkPlan(_, _, right: PartitioningCollection, _, _, _), _), _) =>
           assert(left.partitionings.length == 2)
           assert(left.partitionings.head.isInstanceOf[KeyGroupedPartitioning])
           assert(left.partitionings.head.asInstanceOf[KeyGroupedPartitioning].expressions ==

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/UnionZipRDDSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/UnionZipRDDSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.exchange
+
+import org.apache.spark.{SharedSparkContext, SparkFunSuite, TaskContext}
+
+class UnionZipRDDSuite extends SparkFunSuite with SharedSparkContext {
+
+  test("UnionZipRDD raises exception if children RDD partition size are not the same") {
+    val rdd1 = sc.makeRDD(Seq(1, 2, 3, 4), numSlices = 2)
+    val rdd2 = sc.makeRDD(Seq(5, 6, 7, 8), numSlices = 3)
+    intercept[IllegalArgumentException] {
+      new UnionZipRDD(sc, Seq(rdd1, rdd2))
+    }
+  }
+
+  test("UnionZipRDD partition data") {
+    val rdd1 = sc.makeRDD(Seq(1, 2, 3, 4), numSlices = 2)
+    val rdd2 = sc.makeRDD(Seq(5, 6, 7, 8), numSlices = 2)
+    val unionZipRdd = new UnionZipRDD(sc, Seq(rdd1, rdd2))
+    val tContext = TaskContext.empty()
+    val partition1 = unionZipRdd.compute(unionZipRdd.partitions(0), tContext).toList
+    val partition2 = unionZipRdd.compute(unionZipRdd.partitions(1), tContext).toList
+
+    assert(unionZipRdd.partitions.length == 2)
+    assert(partition1 == List(1, 2, 5, 6))
+    assert(partition2 == List(3, 4, 7, 8))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
We  indroduce a new idea to optimize exchange plan when union spark plan output partitoning can't match parent plan's required distribution.

1. First introduce a new RDD, it consists of parent rdds that has the same partition size. The ith parttition corresponds to ith partition of each parent rdd.
2. Then push the required distribution to union plan's children. If any child output partitioning matches the required distribution , we can reduce this child shuffle operation.


### Why are the changes needed?
Union plan does not take full advantage of children plan output partitionings when output partitoning can't match parent plan's required distribution.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
org.apache.spark.sql.execution.PlannerSuite
org.apache.spark.sql.execution.exchange.UnionZipRDDSuite
