### PR TITLE
[SPARK-41876][CONNECT][PYTHON] Implement DataFrame.toLocalIterator

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -35,6 +35,7 @@ import sys
 from types import TracebackType
 from typing import (
     Iterable,
+    Iterator,
     Optional,
     Any,
     Union,
@@ -625,8 +626,8 @@ class SparkConnectClient(object):
 
         self._execute(req)
 
-    def _build_metrics(self, metrics: "pb2.ExecutePlanResponse.Metrics") -> List[PlanMetrics]:
-        return [
+    def _build_metrics(self, metrics: "pb2.ExecutePlanResponse.Metrics") -> Iterator[PlanMetrics]:
+        return (
             PlanMetrics(
                 x.name,
                 x.plan_id,
@@ -634,18 +635,25 @@ class SparkConnectClient(object):
                 [MetricValue(k, v.value, v.metric_type) for k, v in x.execution_metrics.items()],
             )
             for x in metrics.metrics
-        ]
+        )
 
     def _build_observed_metrics(
         self, metrics: List["pb2.ExecutePlanResponse.ObservedMetrics"]
-    ) -> List[PlanObservedMetrics]:
-        return [
-            PlanObservedMetrics(
-                x.name,
-                [v for v in x.values],
-            )
-            for x in metrics
-        ]
+    ) -> Iterator[PlanObservedMetrics]:
+        return (PlanObservedMetrics(x.name, [v for v in x.values]) for x in metrics)
+
+    def to_table_as_iterator(self, plan: pb2.Plan) -> Iterator[Union[StructType, "pa.Table"]]:
+        """
+        Return given plan as a PyArrow Table iterator.
+        """
+        logger.info(f"Executing plan {self._proto_to_string(plan)}")
+        req = self._execute_plan_request_with_metadata()
+        req.plan.CopyFrom(plan)
+        for response in self._execute_and_fetch_as_iterator(req):
+            if isinstance(response, StructType):
+                yield response
+            elif isinstance(response, pa.RecordBatch):
+                yield pa.Table.from_batches([response])
 
     def to_table(self, plan: pb2.Plan) -> Tuple["pa.Table", Optional[StructType]]:
         """
@@ -900,6 +908,57 @@ class SparkConnectClient(object):
         except grpc.RpcError as rpc_error:
             self._handle_error(rpc_error)
 
+    def _execute_and_fetch_as_iterator(
+        self, req: pb2.ExecutePlanRequest
+    ) -> Iterator[
+        Union[
+            "pa.RecordBatch",
+            StructType,
+            PlanMetrics,
+            PlanObservedMetrics,
+            Dict[str, Any],
+        ]
+    ]:
+        logger.info("ExecuteAndFetchAsIterator")
+
+        try:
+            for attempt in Retrying(
+                can_retry=SparkConnectClient.retry_exception, **self._retry_policy
+            ):
+                with attempt:
+                    for b in self._stub.ExecutePlan(req, metadata=self._builder.metadata()):
+                        if b.session_id != self._session_id:
+                            raise SparkConnectException(
+                                "Received incorrect session identifier for request: "
+                                f"{b.session_id} != {self._session_id}"
+                            )
+                        if b.HasField("metrics"):
+                            logger.debug("Received metric batch.")
+                            yield from self._build_metrics(b.metrics)
+                        if b.observed_metrics:
+                            logger.debug("Received observed metric batch.")
+                            yield from self._build_observed_metrics(b.observed_metrics)
+                        if b.HasField("schema"):
+                            logger.debug("Received the schema.")
+                            dt = types.proto_schema_to_pyspark_data_type(b.schema)
+                            assert isinstance(dt, StructType)
+                            yield dt
+                        if b.HasField("sql_command_result"):
+                            logger.debug("Received the SQL command result.")
+                            yield {"sql_command_result": b.sql_command_result.relation}
+                        if b.HasField("arrow_batch"):
+                            logger.debug(
+                                f"Received arrow batch rows={b.arrow_batch.row_count} "
+                                f"size={len(b.arrow_batch.data)}"
+                            )
+
+                            with pa.ipc.open_stream(b.arrow_batch.data) as reader:
+                                for batch in reader:
+                                    assert isinstance(batch, pa.RecordBatch)
+                                    yield batch
+        except grpc.RpcError as rpc_error:
+            self._handle_error(rpc_error)
+
     def _execute_and_fetch(
         self, req: pb2.ExecutePlanRequest
     ) -> Tuple[
@@ -911,49 +970,25 @@ class SparkConnectClient(object):
     ]:
         logger.info("ExecuteAndFetch")
 
-        m: Optional[pb2.ExecutePlanResponse.Metrics] = None
-        om: List[pb2.ExecutePlanResponse.ObservedMetrics] = []
+        observed_metrics: List[PlanObservedMetrics] = []
+        metrics: List[PlanMetrics] = []
         batches: List[pa.RecordBatch] = []
         schema: Optional[StructType] = None
-        properties = {}
-        try:
-            for attempt in Retrying(
-                can_retry=SparkConnectClient.retry_exception, **self._retry_policy
-            ):
-                with attempt:
-                    batches = []
-                    for b in self._stub.ExecutePlan(req, metadata=self._builder.metadata()):
-                        if b.session_id != self._session_id:
-                            raise SparkConnectException(
-                                "Received incorrect session identifier for request: "
-                                f"{b.session_id} != {self._session_id}"
-                            )
-                        if b.metrics is not None:
-                            logger.debug("Received metric batch.")
-                            m = b.metrics
-                        if b.observed_metrics is not None:
-                            logger.debug("Received observed metric batch.")
-                            om.extend(b.observed_metrics)
-                        if b.HasField("schema"):
-                            dt = types.proto_schema_to_pyspark_data_type(b.schema)
-                            assert isinstance(dt, StructType)
-                            schema = dt
-                        if b.HasField("sql_command_result"):
-                            properties["sql_command_result"] = b.sql_command_result.relation
-                        if b.HasField("arrow_batch"):
-                            logger.debug(
-                                f"Received arrow batch rows={b.arrow_batch.row_count} "
-                                f"size={len(b.arrow_batch.data)}"
-                            )
+        properties: Dict[str, Any] = {}
 
-                            with pa.ipc.open_stream(b.arrow_batch.data) as reader:
-                                for batch in reader:
-                                    assert isinstance(batch, pa.RecordBatch)
-                                    batches.append(batch)
-        except grpc.RpcError as rpc_error:
-            self._handle_error(rpc_error)
-        metrics: List[PlanMetrics] = self._build_metrics(m) if m is not None else []
-        observed_metrics: List[PlanObservedMetrics] = self._build_observed_metrics(om)
+        for response in self._execute_and_fetch_as_iterator(req):
+            if isinstance(response, StructType):
+                schema = response
+            elif isinstance(response, pa.RecordBatch):
+                batches.append(response)
+            elif isinstance(response, PlanMetrics):
+                metrics.append(response)
+            elif isinstance(response, PlanObservedMetrics):
+                observed_metrics.append(response)
+            elif isinstance(response, dict):
+                properties.update(**response)
+            else:
+                raise ValueError(f"Unknown response: {response}")
 
         if len(batches) > 0:
             table = pa.Table.from_batches(batches=batches)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1224,10 +1224,16 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 2.0.0
 
+        .. versionchanged:: 3.4.0
+            Supports Spark Connect.
+
         Parameters
         ----------
         prefetchPartitions : bool, optional
-            If Spark should pre-fetch the next partition  before it is needed.
+            If Spark should pre-fetch the next partition before it is needed.
+
+            .. versionchanged:: 3.4.0
+                This argument does not take effect for Spark Connect.
 
         Returns
         -------

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2832,7 +2832,6 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             "withWatermark",
             "foreach",
             "foreachPartition",
-            "toLocalIterator",
             "checkpoint",
             "localCheckpoint",
             "_repr_html_",

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -67,20 +67,8 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_toDF_with_schema_string(self):
         super().test_toDF_with_schema_string()
 
-    # TODO(SPARK-41876): Implement DataFrame `toLocalIterator`
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_to_local_iterator(self):
-        super().test_to_local_iterator()
-
-    # TODO(SPARK-41876): Implement DataFrame `toLocalIterator`
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_to_local_iterator_not_fully_consumed(self):
-        super().test_to_local_iterator_not_fully_consumed()
-
-    # TODO(SPARK-41876): Implement DataFrame `toLocalIterator`
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_to_local_iterator_prefetch(self):
-        super().test_to_local_iterator_prefetch()
+        self.check_to_local_iterator_not_fully_consumed()
 
     def test_to_pandas_for_array_of_struct(self):
         # Spark Connect's implementation is based on Arrow.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Implements `DataFrame.toLocalIterator`.

The argument `prefetchPartitions` won't take effect for Spark Connect.

### Why are the changes needed?

Missing API.

### Does this PR introduce _any_ user-facing change?

`DataFrame.toLocalIterator` will be available.

### How was this patch tested?

Enabled the related tests.