### PR TITLE
[SPARK-42942][SQL] Support coalesce table cache stage partitions

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1421,7 +1421,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         >>> df.explain()
         == Physical Plan ==
-        InMemoryTableScan ...
+        AdaptiveSparkPlan isFinalPlan=false
+        +- InMemoryTableScan ...
         """
         self.is_cached = True
         self._jdf.cache()
@@ -1463,7 +1464,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         >>> df.explain()
         == Physical Plan ==
-        InMemoryTableScan ...
+        AdaptiveSparkPlan isFinalPlan=false
+        +- InMemoryTableScan ...
 
         Persists the data in the disk by specifying the storage level.
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -847,6 +847,15 @@ object SQLConf {
       .stringConf
       .createOptional
 
+  val COALESCE_CACHE_PARTITIONS_ENABLED =
+    buildConf("spark.sql.adaptive.coalesceCachePartitions.enabled")
+      .doc(s"When true and '${ADAPTIVE_EXECUTION_ENABLED.key}' is true, Spark will coalesce " +
+        "contiguous table cache partitions according to the target size (specified by " +
+        s"'${ADVISORY_PARTITION_SIZE_IN_BYTES.key}'), to avoid too many small tasks.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val SUBEXPRESSION_ELIMINATION_ENABLED =
     buildConf("spark.sql.subexpressionElimination.enabled")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CachedRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CachedRDD.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{Dependency, NarrowDependency, Partition, TaskContext}
+import org.apache.spark.rdd.RDD
+
+/**
+ * The [[Partition]] used by [[CachedRDD]].
+ */
+case class CachedRDDPartition(
+    index: Int,
+    originalPartitions: Array[Partition],
+    @transient originalPreferredLocations: Seq[String]) extends Partition
+
+/**
+ * It wraps the real cached RDD with coalesced partitions.
+ *
+ * @param prev The real cached RDD
+ * @param partitionSpecs the coalesced partitions
+ */
+class CachedRDD[T: ClassTag](
+    @transient var prev: RDD[T],
+    partitionSpecs: Seq[CoalescedPartitionSpec])
+  extends RDD[T](prev.context, Nil) { // Nil since we implement getDependencies
+
+  override protected def getPartitions: Array[Partition] = {
+    Array.tabulate[Partition](partitionSpecs.length) { i =>
+      val spec = partitionSpecs(i)
+      val originalPartitions = spec.startReducerIndex.until(spec.endReducerIndex)
+        .map(prev.partitions).toArray
+      val originalPreferredLocations = originalPartitions.flatMap(prev.preferredLocations)
+        .distinct.toSeq
+      CachedRDDPartition(i, originalPartitions, originalPreferredLocations)
+    }
+  }
+
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    split.asInstanceOf[CachedRDDPartition].originalPreferredLocations
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[T] = {
+    split.asInstanceOf[CachedRDDPartition].originalPartitions.iterator.flatMap { partition =>
+      firstParent[T].iterator(partition, context)
+    }
+  }
+
+  override def getDependencies: Seq[Dependency[_]] = {
+    Seq(new NarrowDependency(prev) {
+      def getParents(id: Int): Seq[Int] =
+        partitions(id).asInstanceOf[CachedRDDPartition].originalPartitions.map(_.index).toSeq
+    })
+  }
+
+  override def clearDependencies(): Unit = {
+    super.clearDependencies()
+    prev = null
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQECacheReadExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQECacheReadExec.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.{CachedRDD, CoalescedPartitionSpec, ShufflePartitionSpec, SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * A wrapper of table cache query stage, which follows the given partition arrangement.
+ * The RDD cache block is based on partition level, so we can not split the partition if it's
+ * skewed. When [[AQECacheReadExec]] happen that means there are some partitions can be coalesced.
+ *
+ * @param child           It should always be [[TableCacheQueryStageExec]].
+ * @param partitionSpecs  The partition specs that defines the arrangement, requires at least one
+ *                        partition.
+ */
+case class AQECacheReadExec(
+    child: SparkPlan,
+    partitionSpecs: Seq[ShufflePartitionSpec]) extends AQERead {
+  assert(partitionSpecs.forall(_.isInstanceOf[CoalescedPartitionSpec]))
+
+  override def outputPartitioning: Partitioning = {
+    outputPartitionWithCoalesced(partitionSpecs.length)
+  }
+
+  override lazy val metrics: Map[String, SQLMetric] =
+    Map("numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions"))
+
+  private def updateMetrics(): Unit = {
+    metrics("numPartitions") += partitionSpecs.length
+
+    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
+  }
+
+  override def stringArgs: Iterator[Any] = Iterator("coalesced")
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    updateMetrics()
+    val rdd = child.execute()
+    new CachedRDD(rdd, partitionSpecs.asInstanceOf[Seq[CoalescedPartitionSpec]])
+  }
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    updateMetrics()
+    val rdd = child.executeColumnar()
+    new CachedRDD(rdd, partitionSpecs.asInstanceOf[Seq[CoalescedPartitionSpec]])
+  }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQERead.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQERead.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning, RoundRobinPartitioning, SinglePartition, UnknownPartitioning}
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan, UnaryExecNode}
+
+abstract class AQERead extends UnaryExecNode {
+  def child: SparkPlan
+  def partitionSpecs: Seq[ShufflePartitionSpec]
+
+  assert(partitionSpecs.nonEmpty, s"${getClass.getSimpleName} requires at least one partition")
+
+  override final def output: Seq[Attribute] = child.output
+  override final def supportsColumnar: Boolean = child.supportsColumnar
+  override final def supportsRowBased: Boolean = child.supportsRowBased
+
+  def outputPartitionWithCoalesced(numPartitions: Int): Partitioning = {
+    // For coalesced shuffle read, the data distribution is not changed, only the number of
+    // partitions is changed.
+    child.outputPartitioning match {
+      case h: HashPartitioning =>
+        CurrentOrigin.withOrigin(h.origin)(h.copy(numPartitions = numPartitions))
+      case r: RangePartitioning =>
+        CurrentOrigin.withOrigin(r.origin)(r.copy(numPartitions = numPartitions))
+      // This can only happen for `REBALANCE_PARTITIONS_BY_NONE`, which uses
+      // `RoundRobinPartitioning` but we don't need to retain the number of partitions.
+      case r: RoundRobinPartitioning =>
+        r.copy(numPartitions = numPartitions)
+      case other@SinglePartition =>
+        throw new IllegalStateException(
+          "Unexpected partitioning for coalesced shuffle read: " + other)
+      case _ =>
+        // Spark plugins may have custom partitioning and may replace this operator
+        // during the postStageOptimization phase, so return UnknownPartitioning here
+        // rather than throw an exception
+        UnknownPartitioning(numPartitions)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -139,7 +139,8 @@ case class AdaptiveSparkPlanExec(
     CoalesceShufflePartitions(context.session),
     // `OptimizeShuffleWithLocalRead` needs to make use of 'AQEShuffleReadExec.partitionSpecs'
     // added by `CoalesceShufflePartitions`, and must be executed after it.
-    OptimizeShuffleWithLocalRead
+    OptimizeShuffleWithLocalRead,
+    CoalesceCachePartitions(context.session)
   )
 
   // This rule is stateful as it maintains the codegen stage ID. We can't create a fresh one every

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceCachePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceCachePartitions.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan, UnaryExecNode, UnionExec}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * A rule to coalesce the cache partitions based on the statistics, which can
+ * avoid many small reduce tasks that hurt performance.
+ */
+case class CoalesceCachePartitions(session: SparkSession) extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.getConf(SQLConf.COALESCE_CACHE_PARTITIONS_ENABLED)) {
+      return plan
+    }
+
+    val coalesceGroups = collectCoalesceGroups(plan)
+    val groups = coalesceGroups.map { tableCacheStages =>
+      val stageIds = tableCacheStages.map(_.id)
+      val bytesByPartitionIds = tableCacheStages.map(_.outputStats().map(_.bytesByPartitionId))
+      val inputPartitionSpecs = Seq.fill(bytesByPartitionIds.length)(None)
+      (tableCacheStages.map(_.id),
+        conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES),
+        bytesByPartitionIds,
+        inputPartitionSpecs,
+        s"For table cache stage(${stageIds.mkString(", ")})")
+    }
+    val specsMap = ShufflePartitionsUtil.coalescePartitionsByGroup(
+      groups, session.sparkContext.defaultParallelism)
+    if (specsMap.nonEmpty) {
+      updateCacheReads(plan, specsMap)
+    } else {
+      plan
+    }
+  }
+
+  private def updateCacheReads(
+      plan: SparkPlan,
+      specsMap: Map[Int, Seq[ShufflePartitionSpec]]): SparkPlan = plan match {
+    case stage: TableCacheQueryStageExec if specsMap.contains(stage.id) =>
+      AQECacheReadExec(stage, specsMap(stage.id))
+    case other => other.mapChildren(updateCacheReads(_, specsMap))
+  }
+
+  private def collectCoalesceGroups(
+      plan: SparkPlan): Seq[Seq[TableCacheQueryStageExec]] = plan match {
+    case unary: UnaryExecNode => collectCoalesceGroups(unary.child)
+    case union: UnionExec => union.children.flatMap(collectCoalesceGroups)
+    case p if p.collectLeaves().forall(_.isInstanceOf[TableCacheQueryStageExec]) =>
+      collectTableCacheStages(p) :: Nil
+    case _ => Seq.empty
+  }
+
+  private def collectTableCacheStages(plan: SparkPlan): Seq[TableCacheQueryStageExec] = plan match {
+    case tableCacheStage: TableCacheQueryStageExec => Seq(tableCacheStage)
+    case _ => plan.children.flatMap(collectTableCacheStages)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -1604,7 +1604,8 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
   test("SPARK-35332: Make cache plan disable configs configurable - check AQE") {
     withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "2",
       SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
-      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.COALESCE_CACHE_PARTITIONS_ENABLED.key -> "false") {
 
       withTempView("t1", "t2", "t3") {
         withSQLConf(SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> "false") {
@@ -1641,7 +1642,8 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
       withCache("t1", "t2", "t3") {
         withSQLConf(SQLConf.BUCKETING_ENABLED.key -> "true",
           SQLConf.FILES_MIN_PARTITION_NUM.key -> "1",
-          SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> "false") {
+          SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> "false",
+          SQLConf.COALESCE_CACHE_PARTITIONS_ENABLED.key -> "false") {
           sql("CACHE TABLE t1")
           assert(spark.table("t1").rdd.partitions.length == 2)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -23,6 +23,7 @@ import java.util.Locale
 import org.apache.spark.sql.catalyst.optimizer.RemoveNoopUnion
 import org.apache.spark.sql.catalyst.plans.logical.Union
 import org.apache.spark.sql.execution.{SparkPlan, UnionExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -30,7 +31,8 @@ import org.apache.spark.sql.test.{ExamplePoint, ExamplePointUDT, SharedSparkSess
 import org.apache.spark.sql.test.SQLTestData.NullStrings
 import org.apache.spark.sql.types._
 
-class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
+class DataFrameSetOperationsSuite extends QueryTest
+  with SharedSparkSession with AdaptiveSparkPlanHelper {
   import testImplicits._
 
   test("except") {
@@ -1381,7 +1383,7 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
         plan: SparkPlan,
         targetPlan: (SparkPlan) => Boolean,
         isColumnar: Boolean): Unit = {
-      val target = plan.collect {
+      val target = collect(plan) {
         case p if targetPlan(p) => p
       }
       assert(target.nonEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.datasources.{FileFormat, WriteFilesExec, WriteFilesSpec}
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, BroadcastExchangeLike, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
@@ -51,7 +51,8 @@ import org.apache.spark.unsafe.types.UTF8String
 /**
  * Test cases for the [[SparkSessionExtensions]].
  */
-class SparkSessionExtensionSuite extends SparkFunSuite with SQLHelper {
+class SparkSessionExtensionSuite extends SparkFunSuite
+  with SQLHelper with AdaptiveSparkPlanHelper {
   private def create(
       builder: SparkSessionExtensionsProvider): Seq[SparkSessionExtensionsProvider] = Seq(builder)
 
@@ -206,7 +207,7 @@ class SparkSessionExtensionSuite extends SparkFunSuite with SQLHelper {
       import session.implicits._
       val df = Seq((1, "a"), (2, "b")).toDF("i", "s")
       df.select("i").filter($"i" > 1).cache()
-      assert(df.filter($"i" > 1).select("i").queryExecution.executedPlan.find {
+      assert(find(df.filter($"i" > 1).select("i").queryExecution.executedPlan) {
         case _: org.apache.spark.sql.execution.columnar.InMemoryTableScanExec => true
         case _ => false
       }.isDefined)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.columnar.CachedBatch
 import org.apache.spark.sql.execution.{FilterExec, InputAdapter, WholeStageCodegenExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -48,7 +49,8 @@ class TestCachedBatchSerializer(
   }
 }
 
-class InMemoryColumnarQuerySuite extends QueryTest with SharedSparkSession {
+class InMemoryColumnarQuerySuite extends QueryTest
+  with SharedSparkSession with AdaptiveSparkPlanHelper {
   import testImplicits._
 
   setupTestData()
@@ -504,7 +506,7 @@ class InMemoryColumnarQuerySuite extends QueryTest with SharedSparkSession {
     // Push predicate to the cached table.
     val df2 = df1.where("y = 3")
 
-    val planBeforeFilter = df2.queryExecution.executedPlan.collect {
+    val planBeforeFilter = collect(df2.queryExecution.executedPlan) {
       case f: FilterExec => f.child
       case WholeStageCodegenExec(FilterExec(_, i: InputAdapter)) => i.child
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/PartitionBatchPruningSuite.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.sql.execution.columnar
 
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.test.SQLTestData._
 
 
-class PartitionBatchPruningSuite extends SharedSparkSession {
+class PartitionBatchPruningSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
 
   import testImplicits._
 
@@ -180,7 +181,7 @@ class PartitionBatchPruningSuite extends SharedSparkSession {
     val result = df.collect().map(_(0)).toArray
     assert(result.length === 1)
 
-    val (readPartitions, readBatches) = df.queryExecution.executedPlan.collect {
+    val (readPartitions, readBatches) = collect(df.queryExecution.executedPlan) {
         case in: InMemoryTableScanExec => (in.readPartitions.value, in.readBatches.value)
       }.head
     assert(readPartitions === 5)
@@ -201,7 +202,7 @@ class PartitionBatchPruningSuite extends SharedSparkSession {
         df.collect().map(_(0)).toArray
       }
 
-      val (readPartitions, readBatches) = df.queryExecution.executedPlan.collect {
+      val (readPartitions, readBatches) = collect(df.queryExecution.executedPlan) {
         case in: InMemoryTableScanExec => (in.readPartitions.value, in.readBatches.value)
       }.head
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a new rule `CoalesceCachePartitions` to support coalesce partitions with `TableCacheQueryStageExec`. In order to reuse the code path with `CoalesceShufflePartitions`, this pr also does a small refactor about how we coalesce partitions.

RDD cache use the RDD id and partition id as the block id, so it seems not possible to split skewd partitions like shuffle. To reduce complexity, this pr does not allow coalesce partitions with both shuffle and cache stage since shuffle read may contain skewed partition spec.

For example, the follow case can not be coalesced by both `CoalesceCachePartitions` and `CoalesceShufflePartitions`.
```
SMJ
  ShuffleQueryStage
  TableCacheStage
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Make AQE support coalesce table cache stage partitions.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, add a new config to control if coalesce partitions for  table cache stage.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add tests