### PR TITLE
[SPARK-42945][CONNECT] Support PYSPARK_JVM_STACKTRACE_ENABLED in Spark Connect

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -99,5 +99,5 @@ object Connect {
           |""".stripMargin)
       .version("3.5.0")
       .intConf
-      .createWithDefault(4096)
+      .createWithDefault(2048)
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -90,4 +90,14 @@ object Connect {
       .stringConf
       .toSequence
       .createWithDefault(Nil)
+
+  val CONNECT_JVM_STACK_TRACE_SIZE =
+    ConfigBuilder("spark.connect.jvmStacktrace.size")
+      .doc("""
+          |Sets the maximum stack trace size to display when
+          |`spark.sql.pyspark.jvmStacktrace.enabled` is true.
+          |""".stripMargin)
+      .version("3.5.0")
+      .bytesConf(ByteUnit.KiB)
+      .createWithDefault(4096)
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -91,13 +91,13 @@ object Connect {
       .toSequence
       .createWithDefault(Nil)
 
-  val CONNECT_JVM_STACK_TRACE_SIZE =
-    ConfigBuilder("spark.connect.jvmStacktrace.size")
+  val CONNECT_JVM_STACK_TRACE_MAX_SIZE =
+    ConfigBuilder("spark.connect.jvmStacktrace.maxSize")
       .doc("""
           |Sets the maximum stack trace size to display when
           |`spark.sql.pyspark.jvmStacktrace.enabled` is true.
           |""".stripMargin)
       .version("3.5.0")
-      .bytesConf(ByteUnit.KiB)
+      .intConf
       .createWithDefault(4096)
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -84,8 +84,10 @@ class SparkConnectService(debug: Boolean)
       .putMetadata("classes", compact(render(allClasses(st.getClass).map(_.getName))))
 
     val withStackTrace = if (stackTraceEnabled) {
+      import org.apache.spark.sql.connect.config.Connect.CONNECT_JVM_STACK_TRACE_SIZE
       val stackTrace = ExceptionUtils.getStackTrace(st)
-      errorInfo.putMetadata("stackTrace", StringUtils.abbreviate(stackTrace, 4096))
+      val size = SparkEnv.get.conf.get(CONNECT_JVM_STACK_TRACE_SIZE).toInt
+      errorInfo.putMetadata("stackTrace", StringUtils.abbreviate(stackTrace, size))
     } else {
       errorInfo
     }
@@ -126,8 +128,8 @@ class SparkConnectService(debug: Boolean)
         .getOrCreateIsolatedSession(userId, sessionId)
         .session
     val stackTraceEnabled = try {
-      session.conf.get(
-        org.apache.spark.sql.internal.SQLConf.PYSPARK_JVM_STACKTRACE_ENABLED.key).toBoolean
+      import org.apache.spark.sql.internal.SQLConf.PYSPARK_JVM_STACKTRACE_ENABLED
+      session.conf.get(PYSPARK_JVM_STACKTRACE_ENABLED.key).toBoolean
     } catch {
       case NonFatal(_) => true
     }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -125,14 +125,7 @@ class SparkConnectService(debug: Boolean)
       SparkConnectService
         .getOrCreateIsolatedSession(userId, sessionId)
         .session
-    val stackTraceEnabled =
-      try {
-        session.conf.get(PYSPARK_JVM_STACKTRACE_ENABLED.key).toBoolean
-      } catch {
-        case NonFatal(e) =>
-          logWarning(s"Failed to get Spark conf `PYSPARK_JVM_STACKTRACE_ENABLED`: $e")
-          true
-      }
+    val stackTraceEnabled = session.conf.get(PYSPARK_JVM_STACKTRACE_ENABLED.key, "true").toBoolean
 
     {
       case se: SparkException if isPythonExecutionException(se) =>

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -49,6 +49,10 @@ def convert_exception(info: "ErrorInfo", message: str) -> SparkConnectException:
     if "classes" in info.metadata:
         classes = json.loads(info.metadata["classes"])
 
+    if "stackTrace" in info.metadata:
+        stackTrace = info.metadata["stackTrace"]
+        message += f"\n\nJVM stacktrace:\n{stackTrace}"
+
     if "org.apache.spark.sql.catalyst.parser.ParseException" in classes:
         return ParseException(message)
     # Order matters. ParseException inherits AnalysisException.

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3125,14 +3125,13 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
 
 class SparkConnectSessionTests(SparkConnectSQLTestCase):
-
     def setUp(self) -> None:
         self.connect = (
             PySparkSession.builder.config(conf=self.conf())
-                .appName(self.__class__.__name__)
-                .remote("local[4]")
-                .getOrCreate()
-            )
+            .appName(self.__class__.__name__)
+            .remote("local[4]")
+            .getOrCreate()
+        )
 
     def _check_no_active_session_error(self, e: PySparkException):
         self.check_error(exception=e, error_class="NO_ACTIVE_SESSION", message_parameters=dict())
@@ -3171,28 +3170,34 @@ class SparkConnectSessionTests(SparkConnectSQLTestCase):
         with self.assertRaises(AnalysisException) as e:
             self.connect.sql("select x").collect()
         self.assertTrue("JVM stacktrace" in e.exception.message)
-        self.assertTrue("at org.apache.spark.sql.catalyst.analysis.CheckAnalysis" in e.exception.message)
+        self.assertTrue(
+            "at org.apache.spark.sql.catalyst.analysis.CheckAnalysis" in e.exception.message
+        )
 
         self.connect.conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "false")
         with self.assertRaises(AnalysisException) as e:
             self.connect.sql("select x").collect()
 
         self.assertFalse("JVM stacktrace" in e.exception.message)
-        self.assertFalse("org.apache.spark.sql.catalyst.analysis.CheckAnalysis" in e.exception.message)
+        self.assertFalse(
+            "at org.apache.spark.sql.catalyst.analysis.CheckAnalysis" in e.exception.message
+        )
 
         # Create a new session with a different stack trace size.
         self.connect.stop()
         connect = (
             PySparkSession.builder.config(conf=self.conf())
-                .config("spark.connect.jvmStacktrace.size", 128)
-                .remote("local[4]")
-                .getOrCreate()
-            )
+            .config("spark.connect.jvmStacktrace.size", 128)
+            .remote("local[4]")
+            .getOrCreate()
+        )
         connect.conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "true")
         with self.assertRaises(AnalysisException) as e:
             connect.sql("select x").collect()
         self.assertTrue("JVM stacktrace" in e.exception.message)
-        self.assertFalse("org.apache.spark.sql.catalyst.analysis.CheckAnalysis" in e.exception.message)
+        self.assertFalse(
+            "at org.apache.spark.sql.catalyst.analysis.CheckAnalysis" in e.exception.message
+        )
 
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -250,6 +250,17 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         with self.assertRaises(AnalysisException):
             df.collect()
 
+    def test_error_stack_trace(self):
+        self.connect.conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "true")
+        with self.assertRaises(AnalysisException) as e:
+            self.connect.sql("select x").collect()
+        self.assertTrue("JVM stacktrace" in e.exception.message)
+
+        self.connect.conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "false")
+        with self.assertRaises(AnalysisException) as e:
+            self.connect.sql("select x").collect()
+        self.assertTrue("JVM stacktrace" not in e.exception.message)
+
     def test_simple_read(self):
         df = self.connect.read.table(self.tbl_name)
         data = df.limit(10).toPandas()

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -146,7 +146,11 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         """
         Override this in subclasses to supply a more specific conf
         """
-        return SparkConf(loadDefaults=False)
+        conf = SparkConf(loadDefaults=False)
+        # Disable JVM stack trace in Spark Connect tests to prevent the
+        # HTTP header size from exceeding the maximum allowed size.
+        conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "false")
+        return conf
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR supports `spark.sql.pyspark.jvmStacktrace.enabled` in Spark Connect to optionally show the JVM stack trace.

It also adds a new Spark Connect config ,`spark.connect.jvmStacktrace.maxSize` (default: 4096), to adjust the stack trace size. This is to prevent the HTTP header size from exceeding the maximum allowed size.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To support an existing config that works with legacy PySpark.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test.