### PR TITLE
[SPARK-42957][INFRA] `release-build.sh` should not remove SBOM artifacts

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -473,7 +473,7 @@ if [[ "$1" == "publish-release" ]]; then
   pushd $tmp_repo/org/apache/spark
 
   # Remove any extra files generated during install
-  find . -type f |grep -v \.jar |grep -v \.pom | xargs rm
+  find . -type f |grep -v \.jar |grep -v \.pom |grep -v \.xml |grep -v \.json | xargs rm
 
   echo "Creating hash and signature files"
   # this must have .asc, .md5 and .sha1 - it really doesn't like anything else there


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to prevent `release-build.sh` from removing SBOM artifacts.

### Why are the changes needed?

According to the snapshot publishing result, we are publishing `.json` and `.xml` files successfully.
- https://repository.apache.org/content/repositories/snapshots/org/apache/spark/spark-core_2.12/3.4.1-SNAPSHOT/spark-core_2.12-3.4.1-20230324.001223-34-cyclonedx.json
- https://repository.apache.org/content/repositories/snapshots/org/apache/spark/spark-core_2.12/3.4.1-SNAPSHOT/spark-core_2.12-3.4.1-20230324.001223-34-cyclonedx.xml

However, `release-build.sh` removes them during release. The following is the result of Apache Spark 3.4.0 RC4.
- https://repository.apache.org/content/repositories/orgapachespark-1438/org/apache/spark/spark-core_2.12/3.4.0/

### Does this PR introduce _any_ user-facing change?

Yes, the users will see the SBOM on released artifacts.

### How was this patch tested?

This should be tested during release process.