### PR TITLE
[SPARK-42973][CONNECT][BUILD] Upgrade buf to v1.16.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -580,7 +580,7 @@ jobs:
     - name: Install dependencies for Python code generation check
       run: |
         # See more in "Installation" https://docs.buf.build/installation#tarball
-        curl -LO https://github.com/bufbuild/buf/releases/download/v1.15.1/buf-Linux-x86_64.tar.gz
+        curl -LO https://github.com/bufbuild/buf/releases/download/v1.16.0/buf-Linux-x86_64.tar.gz
         mkdir -p $HOME/buf
         tar -xvzf buf-Linux-x86_64.tar.gz -C $HOME/buf --strip-components 1
         python3.9 -m pip install 'protobuf==3.19.5' 'mypy-protobuf==3.3.0'

--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -120,7 +120,7 @@ Prerequisite
 
 PySpark development requires to build Spark that needs a proper JDK installed, etc. See `Building Spark <https://spark.apache.org/docs/latest/building-spark.html>`_ for more details.
 
-Note that if you intend to contribute to Spark Connect in Python, ``buf`` version ``1.15.1`` is required, see `Buf Installation <https://docs.buf.build/installation>`_ for more details.
+Note that if you intend to contribute to Spark Connect in Python, ``buf`` version ``1.16.0`` is required, see `Buf Installation <https://docs.buf.build/installation>`_ for more details.
 
 Conda
 ~~~~~


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade buf from 1.15.1 to 1.16.0

### Why are the changes needed?
Release Notes: https://github.com/bufbuild/buf/releases
<img width="774" alt="image" src="https://user-images.githubusercontent.com/15246973/228708437-cd951d9d-fc27-4d15-9e87-2fcf9cad4960.png">

https://github.com/bufbuild/buf/compare/v1.15.1...v1.16.0

Manually test: dev/connect-gen-protos.sh
This upgrade will not change the generated files.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test and Pass GA.