### PR TITLE
[SPARK-42971][CORE] Change to print `workdir` if `appDirs` is null when worker handle `WorkDirCleanup` event

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -516,8 +516,7 @@ private[deploy] class Worker(
         val cleanupFuture: concurrent.Future[Unit] = concurrent.Future {
           val appDirs = workDir.listFiles()
           if (appDirs == null) {
-            throw new IOException(
-              s"ERROR: Failed to list files in ${appDirs.mkString("dirs(", ", ", ")")}")
+            throw new IOException(s"ERROR: Failed to list files in $workDir")
           }
           appDirs.filter { dir =>
             // the directory is used by an application - check that the application is not running


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change to print `workdir` if `appDirs` is null when worker handle `WorkDirCleanup` event.


### Why are the changes needed?
Print `appDirs` ause a NPE because `appDirs` is null and from the context, what should be printed is `workdir`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
