### PR TITLE
[SPARK-42974][CORE] Restore `Utils#createTempDir` use `ShutdownHookManager#registerShutdownDeleteDir` to cleanup tempDir

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -381,7 +381,8 @@ public class JavaUtils {
    * automatically deleted when the VM shuts down if `useDeleteOnExit` is true, otherwise,
    * user needs to manually clean `tempdir`.
    */
-  public static File createTempDir(String root, String namePrefix, boolean useDeleteOnExit) throws IOException {
+  public static File createTempDir(
+      String root, String namePrefix, boolean useDeleteOnExit) throws IOException {
     if (root == null) root = System.getProperty("java.io.tmpdir");
     if (namePrefix == null) namePrefix = "spark";
     File dir = createDirectory(root, namePrefix);

--- a/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -373,18 +373,21 @@ public class JavaUtils {
    * The directory will be automatically deleted when the VM shuts down.
    */
   public static File createTempDir() throws IOException {
-    return createTempDir(System.getProperty("java.io.tmpdir"), "spark");
+    return createTempDir(System.getProperty("java.io.tmpdir"), "spark", true);
   }
 
   /**
    * Create a temporary directory inside the given parent directory. The directory will be
-   * automatically deleted when the VM shuts down.
+   * automatically deleted when the VM shuts down if `useDeleteOnExit` is true, otherwise,
+   * user needs to manually clean `tempdir`.
    */
-  public static File createTempDir(String root, String namePrefix) throws IOException {
+  public static File createTempDir(String root, String namePrefix, boolean useDeleteOnExit) throws IOException {
     if (root == null) root = System.getProperty("java.io.tmpdir");
     if (namePrefix == null) namePrefix = "spark";
     File dir = createDirectory(root, namePrefix);
-    dir.deleteOnExit();
+    if (useDeleteOnExit) {
+      dir.deleteOnExit();
+    }
     return dir;
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -330,7 +330,9 @@ private[spark] object Utils extends Logging {
   def createTempDir(
       root: String = System.getProperty("java.io.tmpdir"),
       namePrefix: String = "spark"): File = {
-    JavaUtils.createTempDir(root, namePrefix)
+    val dir = JavaUtils.createTempDir(root, namePrefix, false)
+    ShutdownHookManager.registerShutdownDeleteDir(dir)
+    dir
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-39204, `Utils#createTempDir` change to use `JavaUtils#createTempDir` and always use `deleteOnExit` to cleanup tempDir. But `DeleteOnExitHook.files` will not be cleaned up until the JVM exits, even if the file has been manually deleted,  this will cause memory leak.

So this pr restore `Utils#createTempDir` use `ShutdownHookManager#registerShutdownDeleteDir` to cleanup `tempDir` and the `Utils#deleteRecursively` will call `ShutdownHookManager#removeShutdownDeleteDir` to clean up registered `tempDir` .

### Why are the changes needed?
Restore `Utils#createTempDir` use `ShutdownHookManager#registerShutdownDeleteDir` to cleanup tempDir to avoid memory leak.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
