### PR TITLE
[SPARK-42975][SQL] Cast result type to timestamp type for string +/- interval

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -398,9 +398,13 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
             a.copy(right = Cast(a.right, a.left.dataType))
           case (DateType, CalendarIntervalType) =>
             DateAddInterval(l, r, ansiEnabled = mode == EvalMode.ANSI)
+          case (StringType, CalendarIntervalType | _: DayTimeIntervalType) =>
+            Cast(TimeAdd(l, r), TimestampType)
           case (_, CalendarIntervalType | _: DayTimeIntervalType) => Cast(TimeAdd(l, r), l.dataType)
           case (CalendarIntervalType, DateType) =>
             DateAddInterval(r, l, ansiEnabled = mode == EvalMode.ANSI)
+          case (CalendarIntervalType | _: DayTimeIntervalType, StringType) =>
+            Cast(TimeAdd(r, l), TimestampType)
           case (CalendarIntervalType | _: DayTimeIntervalType, _) => Cast(TimeAdd(r, l), r.dataType)
           case (DateType, dt) if dt != StringType => DateAdd(l, r)
           case (dt, DateType) if dt != StringType => DateAdd(r, l)
@@ -424,6 +428,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           case (DateType, CalendarIntervalType) =>
             DatetimeSub(l, r, DateAddInterval(l,
               UnaryMinus(r, mode == EvalMode.ANSI), ansiEnabled = mode == EvalMode.ANSI))
+          case (StringType, CalendarIntervalType | _: DayTimeIntervalType) =>
+            Cast(DatetimeSub(l, r, TimeAdd(l, UnaryMinus(r, mode == EvalMode.ANSI))), TimestampType)
           case (_, CalendarIntervalType | _: DayTimeIntervalType) =>
             Cast(DatetimeSub(l, r, TimeAdd(l, UnaryMinus(r, mode == EvalMode.ANSI))), l.dataType)
           case _ if AnyTimestampType.unapply(l) || AnyTimestampType.unapply(r) =>

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -1596,14 +1596,14 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select '4 11:11' - interval '4 22:12' day to minute
 -- !query analysis
-Project [cast(4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE as string) AS 4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE#x]
+Project [cast(4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE as timestamp) AS 4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE#x]
 +- OneRowRelation
 
 
 -- !query
 select '4 12:12:12' + interval '4 22:12' day to minute
 -- !query analysis
-Project [cast(cast(4 12:12:12 as timestamp) + INTERVAL '4 22:12' DAY TO MINUTE as string) AS 4 12:12:12 + INTERVAL '4 22:12' DAY TO MINUTE#x]
+Project [cast(cast(4 12:12:12 as timestamp) + INTERVAL '4 22:12' DAY TO MINUTE as timestamp) AS 4 12:12:12 + INTERVAL '4 22:12' DAY TO MINUTE#x]
 +- OneRowRelation
 
 
@@ -1662,7 +1662,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select str - interval '4 22:12' day to minute from interval_view
 -- !query analysis
-Project [cast(str#x - INTERVAL '4 22:12' DAY TO MINUTE as string) AS str - INTERVAL '4 22:12' DAY TO MINUTE#x]
+Project [cast(str#x - INTERVAL '4 22:12' DAY TO MINUTE as timestamp) AS str - INTERVAL '4 22:12' DAY TO MINUTE#x]
 +- SubqueryAlias interval_view
    +- View (`interval_view`, [str#x])
       +- Project [cast(str#x as string) AS str#x]
@@ -1673,7 +1673,7 @@ Project [cast(str#x - INTERVAL '4 22:12' DAY TO MINUTE as string) AS str - INTER
 -- !query
 select str + interval '4 22:12' day to minute from interval_view
 -- !query analysis
-Project [cast(cast(str#x as timestamp) + INTERVAL '4 22:12' DAY TO MINUTE as string) AS str + INTERVAL '4 22:12' DAY TO MINUTE#x]
+Project [cast(cast(str#x as timestamp) + INTERVAL '4 22:12' DAY TO MINUTE as timestamp) AS str + INTERVAL '4 22:12' DAY TO MINUTE#x]
 +- SubqueryAlias interval_view
    +- View (`interval_view`, [str#x])
       +- Project [cast(str#x as string) AS str#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/timestamp.sql.out
@@ -787,3 +787,17 @@ select timestampdiff(YEAR, date'2022-02-15', date'2023-02-15')
 select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query analysis
+Project [cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x, cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x]
++- OneRowRelation
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query analysis
+Project [cast(2023-01-08 - INTERVAL '7' DAY as timestamp) AS 2023-01-08 - INTERVAL '7' DAY#x, (cast(2023-01-01 as timestamp) >= cast(2023-01-08 - INTERVAL '7' DAY as timestamp)) AS (2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY)#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/datetime-legacy.sql.out
@@ -1802,3 +1802,17 @@ select timestampdiff(YEAR, date'2022-02-15', date'2023-02-15')
 select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query analysis
+Project [cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x, cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x]
++- OneRowRelation
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query analysis
+Project [cast(2023-01-08 - INTERVAL '7' DAY as timestamp) AS 2023-01-08 - INTERVAL '7' DAY#x, (cast(2023-01-01 as timestamp) >= cast(2023-01-08 - INTERVAL '7' DAY as timestamp)) AS (2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY)#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/extract.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/extract.sql.out
@@ -1126,7 +1126,7 @@ Project [extract(second, c#x) AS extract(second FROM c)#x]
 -- !query
 select c - j from t
 -- !query analysis
-Project [cast(c#x - j#x as string) AS c - j#x]
+Project [cast(c#x - j#x as timestamp) AS c - j#x]
 +- SubqueryAlias t
    +- View (`t`, [c#x,ntz#x,i#x,j#x])
       +- Project [cast(c#x as string) AS c#x, cast(ntz#x as timestamp_ntz) AS ntz#x, cast(i#x as interval year to month) AS i#x, cast(j#x as interval day to second) AS j#x]
@@ -1137,7 +1137,7 @@ Project [cast(c#x - j#x as string) AS c - j#x]
 -- !query
 select day(c - j) from t
 -- !query analysis
-Project [day(cast(cast(c#x - j#x as string) as date)) AS day(c - j)#x]
+Project [day(cast(cast(c#x - j#x as timestamp) as date)) AS day(c - j)#x]
 +- SubqueryAlias t
    +- View (`t`, [c#x,ntz#x,i#x,j#x])
       +- Project [cast(c#x as string) AS c#x, cast(ntz#x as timestamp_ntz) AS ntz#x, cast(i#x as interval year to month) AS i#x, cast(j#x as interval day to second) AS j#x]
@@ -1148,7 +1148,7 @@ Project [day(cast(cast(c#x - j#x as string) as date)) AS day(c - j)#x]
 -- !query
 select extract(day from c - j) from t
 -- !query analysis
-Project [extract(day, cast(c#x - j#x as string)) AS extract(day FROM c - j)#x]
+Project [extract(day, cast(c#x - j#x as timestamp)) AS extract(day FROM c - j)#x]
 +- SubqueryAlias t
    +- View (`t`, [c#x,ntz#x,i#x,j#x])
       +- Project [cast(c#x as string) AS c#x, cast(ntz#x as timestamp_ntz) AS ntz#x, cast(i#x as interval year to month) AS i#x, cast(j#x as interval day to second) AS j#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -1596,14 +1596,14 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select '4 11:11' - interval '4 22:12' day to minute
 -- !query analysis
-Project [cast(4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE as string) AS 4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE#x]
+Project [cast(4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE as timestamp) AS 4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE#x]
 +- OneRowRelation
 
 
 -- !query
 select '4 12:12:12' + interval '4 22:12' day to minute
 -- !query analysis
-Project [cast(cast(4 12:12:12 as timestamp) + INTERVAL '4 22:12' DAY TO MINUTE as string) AS 4 12:12:12 + INTERVAL '4 22:12' DAY TO MINUTE#x]
+Project [cast(cast(4 12:12:12 as timestamp) + INTERVAL '4 22:12' DAY TO MINUTE as timestamp) AS 4 12:12:12 + INTERVAL '4 22:12' DAY TO MINUTE#x]
 +- OneRowRelation
 
 
@@ -1662,7 +1662,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select str - interval '4 22:12' day to minute from interval_view
 -- !query analysis
-Project [cast(str#x - INTERVAL '4 22:12' DAY TO MINUTE as string) AS str - INTERVAL '4 22:12' DAY TO MINUTE#x]
+Project [cast(str#x - INTERVAL '4 22:12' DAY TO MINUTE as timestamp) AS str - INTERVAL '4 22:12' DAY TO MINUTE#x]
 +- SubqueryAlias interval_view
    +- View (`interval_view`, [str#x])
       +- Project [cast(str#x as string) AS str#x]
@@ -1673,7 +1673,7 @@ Project [cast(str#x - INTERVAL '4 22:12' DAY TO MINUTE as string) AS str - INTER
 -- !query
 select str + interval '4 22:12' day to minute from interval_view
 -- !query analysis
-Project [cast(cast(str#x as timestamp) + INTERVAL '4 22:12' DAY TO MINUTE as string) AS str + INTERVAL '4 22:12' DAY TO MINUTE#x]
+Project [cast(cast(str#x as timestamp) + INTERVAL '4 22:12' DAY TO MINUTE as timestamp) AS str + INTERVAL '4 22:12' DAY TO MINUTE#x]
 +- SubqueryAlias interval_view
    +- View (`interval_view`, [str#x])
       +- Project [cast(str#x as string) AS str#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestamp.sql.out
@@ -859,3 +859,17 @@ select timestampdiff(YEAR, date'2022-02-15', date'2023-02-15')
 select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query analysis
+Project [cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x, cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x]
++- OneRowRelation
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query analysis
+Project [cast(2023-01-08 - INTERVAL '7' DAY as timestamp) AS 2023-01-08 - INTERVAL '7' DAY#x, (cast(2023-01-01 as timestamp) >= cast(2023-01-08 - INTERVAL '7' DAY as timestamp)) AS (2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY)#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestampNTZ/timestamp-ansi.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestampNTZ/timestamp-ansi.sql.out
@@ -806,3 +806,17 @@ select timestampdiff(YEAR, date'2022-02-15', date'2023-02-15')
 select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query analysis
+Project [cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x, cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x]
++- OneRowRelation
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query analysis
+Project [cast(2023-01-08 - INTERVAL '7' DAY as timestamp) AS 2023-01-08 - INTERVAL '7' DAY#x, (cast(2023-01-01 as timestamp) >= cast(2023-01-08 - INTERVAL '7' DAY as timestamp)) AS (2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY)#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/timestampNTZ/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/timestampNTZ/timestamp.sql.out
@@ -866,3 +866,17 @@ select timestampdiff(YEAR, date'2022-02-15', date'2023-02-15')
 select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query analysis
+Project [cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x, cast(cast(2023-01-01 as timestamp) + INTERVAL '7' DAY as timestamp) AS 2023-01-01 + INTERVAL '7' DAY#x]
++- OneRowRelation
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query analysis
+Project [cast(2023-01-08 - INTERVAL '7' DAY as timestamp) AS 2023-01-08 - INTERVAL '7' DAY#x, (cast(2023-01-01 as timestamp) >= cast(2023-01-08 - INTERVAL '7' DAY as timestamp)) AS (2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY)#x]
++- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/typeCoercion/native/dateTimeOperations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/typeCoercion/native/dateTimeOperations.sql.out
@@ -178,14 +178,14 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select cast('2017-12-11' as string) + interval 2 day
 -- !query analysis
-Project [cast(cast(cast(2017-12-11 as string) as timestamp) + INTERVAL '2' DAY as string) AS CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY#x]
+Project [cast(cast(cast(2017-12-11 as string) as timestamp) + INTERVAL '2' DAY as timestamp) AS CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY#x]
 +- OneRowRelation
 
 
 -- !query
 select cast('2017-12-11 09:30:00' as string) + interval 2 day
 -- !query analysis
-Project [cast(cast(cast(2017-12-11 09:30:00 as string) as timestamp) + INTERVAL '2' DAY as string) AS CAST(2017-12-11 09:30:00 AS STRING) + INTERVAL '2' DAY#x]
+Project [cast(cast(cast(2017-12-11 09:30:00 as string) as timestamp) + INTERVAL '2' DAY as timestamp) AS CAST(2017-12-11 09:30:00 AS STRING) + INTERVAL '2' DAY#x]
 +- OneRowRelation
 
 
@@ -422,14 +422,14 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select interval 2 day + cast('2017-12-11' as string)
 -- !query analysis
-Project [cast(cast(cast(2017-12-11 as string) as timestamp) + INTERVAL '2' DAY as string) AS CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY#x]
+Project [cast(cast(cast(2017-12-11 as string) as timestamp) + INTERVAL '2' DAY as timestamp) AS CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY#x]
 +- OneRowRelation
 
 
 -- !query
 select interval 2 day + cast('2017-12-11 09:30:00' as string)
 -- !query analysis
-Project [cast(cast(cast(2017-12-11 09:30:00 as string) as timestamp) + INTERVAL '2' DAY as string) AS CAST(2017-12-11 09:30:00 AS STRING) + INTERVAL '2' DAY#x]
+Project [cast(cast(cast(2017-12-11 09:30:00 as string) as timestamp) + INTERVAL '2' DAY as timestamp) AS CAST(2017-12-11 09:30:00 AS STRING) + INTERVAL '2' DAY#x]
 +- OneRowRelation
 
 
@@ -666,14 +666,14 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select cast('2017-12-11' as string) - interval 2 day
 -- !query analysis
-Project [cast(cast(2017-12-11 as string) - INTERVAL '2' DAY as string) AS CAST(2017-12-11 AS STRING) - INTERVAL '2' DAY#x]
+Project [cast(cast(2017-12-11 as string) - INTERVAL '2' DAY as timestamp) AS CAST(2017-12-11 AS STRING) - INTERVAL '2' DAY#x]
 +- OneRowRelation
 
 
 -- !query
 select cast('2017-12-11 09:30:00' as string) - interval 2 day
 -- !query analysis
-Project [cast(cast(2017-12-11 09:30:00 as string) - INTERVAL '2' DAY as string) AS CAST(2017-12-11 09:30:00 AS STRING) - INTERVAL '2' DAY#x]
+Project [cast(cast(2017-12-11 09:30:00 as string) - INTERVAL '2' DAY as timestamp) AS CAST(2017-12-11 09:30:00 AS STRING) - INTERVAL '2' DAY#x]
 +- OneRowRelation
 
 

--- a/sql/core/src/test/resources/sql-tests/inputs/timestamp.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestamp.sql
@@ -155,3 +155,7 @@ select timestampdiff(MONTH, timestamp'2022-02-14 01:02:03', timestamp'2022-01-14
 select timestampdiff(MINUTE, timestamp'2022-02-14 01:02:03', timestamp'2022-02-14 02:00:03');
 select timestampdiff(YEAR, date'2022-02-15', date'2023-02-15');
 select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59');
+
+-- string +/- interval and interval + string
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01';
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day;

--- a/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
@@ -1041,3 +1041,19 @@ select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 struct<timestampdiff(SECOND, DATE '2022-02-15', TIMESTAMP '2022-02-14 23:59:59'):bigint>
 -- !query output
 -1
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query schema
+struct<2023-01-01 + INTERVAL '7' DAY:timestamp,2023-01-01 + INTERVAL '7' DAY:timestamp>
+-- !query output
+2023-01-08 00:00:00	2023-01-08 00:00:00
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query schema
+struct<2023-01-08 - INTERVAL '7' DAY:timestamp,(2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY):boolean>
+-- !query output
+2023-01-01 00:00:00	true

--- a/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-legacy.sql.out
@@ -2084,3 +2084,19 @@ select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 struct<timestampdiff(SECOND, DATE '2022-02-15', TIMESTAMP '2022-02-14 23:59:59'):bigint>
 -- !query output
 -1
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query schema
+struct<2023-01-01 + INTERVAL '7' DAY:timestamp,2023-01-01 + INTERVAL '7' DAY:timestamp>
+-- !query output
+2023-01-08 00:00:00	2023-01-08 00:00:00
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query schema
+struct<2023-01-08 - INTERVAL '7' DAY:timestamp,(2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY):boolean>
+-- !query output
+2023-01-01 00:00:00	true

--- a/sql/core/src/test/resources/sql-tests/results/extract.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/extract.sql.out
@@ -868,7 +868,7 @@ struct<extract(second FROM c):decimal(8,6)>
 -- !query
 select c - j from t
 -- !query schema
-struct<c - j:string>
+struct<c - j:timestamp>
 -- !query output
 2011-04-04 14:18:02.334456
 

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1824,7 +1824,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select '4 11:11' - interval '4 22:12' day to minute
 -- !query schema
-struct<4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE:string>
+struct<4 11:11 - INTERVAL '4 22:12' DAY TO MINUTE:timestamp>
 -- !query output
 NULL
 
@@ -1832,7 +1832,7 @@ NULL
 -- !query
 select '4 12:12:12' + interval '4 22:12' day to minute
 -- !query schema
-struct<4 12:12:12 + INTERVAL '4 22:12' DAY TO MINUTE:string>
+struct<4 12:12:12 + INTERVAL '4 22:12' DAY TO MINUTE:timestamp>
 -- !query output
 NULL
 
@@ -1896,7 +1896,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select str - interval '4 22:12' day to minute from interval_view
 -- !query schema
-struct<str - INTERVAL '4 22:12' DAY TO MINUTE:string>
+struct<str - INTERVAL '4 22:12' DAY TO MINUTE:timestamp>
 -- !query output
 NULL
 
@@ -1904,7 +1904,7 @@ NULL
 -- !query
 select str + interval '4 22:12' day to minute from interval_view
 -- !query schema
-struct<str + INTERVAL '4 22:12' DAY TO MINUTE:string>
+struct<str + INTERVAL '4 22:12' DAY TO MINUTE:timestamp>
 -- !query output
 NULL
 

--- a/sql/core/src/test/resources/sql-tests/results/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestamp.sql.out
@@ -1037,3 +1037,19 @@ select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 struct<timestampdiff(SECOND, DATE '2022-02-15', TIMESTAMP '2022-02-14 23:59:59'):bigint>
 -- !query output
 -1
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query schema
+struct<2023-01-01 + INTERVAL '7' DAY:timestamp,2023-01-01 + INTERVAL '7' DAY:timestamp>
+-- !query output
+2023-01-08 00:00:00	2023-01-08 00:00:00
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query schema
+struct<2023-01-08 - INTERVAL '7' DAY:timestamp,(2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY):boolean>
+-- !query output
+2023-01-01 00:00:00	true

--- a/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
@@ -1032,3 +1032,19 @@ select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 struct<timestampdiff(SECOND, DATE '2022-02-15', TIMESTAMP_NTZ '2022-02-14 23:59:59'):bigint>
 -- !query output
 -1
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query schema
+struct<2023-01-01 + INTERVAL '7' DAY:timestamp,2023-01-01 + INTERVAL '7' DAY:timestamp>
+-- !query output
+2023-01-08 00:00:00	2023-01-08 00:00:00
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query schema
+struct<2023-01-08 - INTERVAL '7' DAY:timestamp,(2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY):boolean>
+-- !query output
+2023-01-01 00:00:00	true

--- a/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp.sql.out
@@ -1013,3 +1013,19 @@ select timestampdiff(SECOND, date'2022-02-15', timestamp'2022-02-14 23:59:59')
 struct<timestampdiff(SECOND, DATE '2022-02-15', TIMESTAMP_NTZ '2022-02-14 23:59:59'):bigint>
 -- !query output
 -1
+
+
+-- !query
+select '2023-01-01' + interval '7' day, interval '7' day + '2023-01-01'
+-- !query schema
+struct<2023-01-01 + INTERVAL '7' DAY:timestamp,2023-01-01 + INTERVAL '7' DAY:timestamp>
+-- !query output
+2023-01-08 00:00:00	2023-01-08 00:00:00
+
+
+-- !query
+select '2023-01-08' - interval '7' day, '2023-01-01' >= '2023-01-08' - interval '7' day
+-- !query schema
+struct<2023-01-08 - INTERVAL '7' DAY:timestamp,(2023-01-01 >= 2023-01-08 - INTERVAL '7' DAY):boolean>
+-- !query output
+2023-01-01 00:00:00	true

--- a/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/dateTimeOperations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/typeCoercion/native/dateTimeOperations.sql.out
@@ -192,7 +192,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select cast('2017-12-11' as string) + interval 2 day
 -- !query schema
-struct<CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY:string>
+struct<CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY:timestamp>
 -- !query output
 2017-12-13 00:00:00
 
@@ -200,7 +200,7 @@ struct<CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY:string>
 -- !query
 select cast('2017-12-11 09:30:00' as string) + interval 2 day
 -- !query schema
-struct<CAST(2017-12-11 09:30:00 AS STRING) + INTERVAL '2' DAY:string>
+struct<CAST(2017-12-11 09:30:00 AS STRING) + INTERVAL '2' DAY:timestamp>
 -- !query output
 2017-12-13 09:30:00
 
@@ -458,7 +458,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select interval 2 day + cast('2017-12-11' as string)
 -- !query schema
-struct<CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY:string>
+struct<CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY:timestamp>
 -- !query output
 2017-12-13 00:00:00
 
@@ -466,7 +466,7 @@ struct<CAST(2017-12-11 AS STRING) + INTERVAL '2' DAY:string>
 -- !query
 select interval 2 day + cast('2017-12-11 09:30:00' as string)
 -- !query schema
-struct<CAST(2017-12-11 09:30:00 AS STRING) + INTERVAL '2' DAY:string>
+struct<CAST(2017-12-11 09:30:00 AS STRING) + INTERVAL '2' DAY:timestamp>
 -- !query output
 2017-12-13 09:30:00
 
@@ -724,7 +724,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 select cast('2017-12-11' as string) - interval 2 day
 -- !query schema
-struct<CAST(2017-12-11 AS STRING) - INTERVAL '2' DAY:string>
+struct<CAST(2017-12-11 AS STRING) - INTERVAL '2' DAY:timestamp>
 -- !query output
 2017-12-09 00:00:00
 
@@ -732,7 +732,7 @@ struct<CAST(2017-12-11 AS STRING) - INTERVAL '2' DAY:string>
 -- !query
 select cast('2017-12-11 09:30:00' as string) - interval 2 day
 -- !query schema
-struct<CAST(2017-12-11 09:30:00 AS STRING) - INTERVAL '2' DAY:string>
+struct<CAST(2017-12-11 09:30:00 AS STRING) - INTERVAL '2' DAY:timestamp>
 -- !query output
 2017-12-09 09:30:00
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes it cast the result type of string +/- interval to timestamp type instead of string type.

### Why are the changes needed?

Both of them should evaluate to `true`. Otherwise, users will be confused:
```sql
select '2023-01-01' >= '2023-01-08' - interval '7' day;
select '2023-01-01' >= date_sub('2023-01-08', 7);
```


### Does this PR introduce _any_ user-facing change?

This PR changed the result type.

### How was this patch tested?

Unit test.