### PR TITLE
[SPARK-42316][SQL] Assign name to _LEGACY_ERROR_TEMP_2044

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -35,6 +35,12 @@
     ],
     "sqlState" : "22003"
   },
+  "BINARY_ARITHMETIC_CAUSE_OVERFLOW" : {
+    "message" : [
+      "<value1> <symbol> <value2> caused overflow."
+    ],
+    "sqlState" : "22003"
+  },
   "CANNOT_CAST_DATATYPE" : {
     "message" : [
       "Cannot cast <sourceType> to <targetType>."
@@ -3872,11 +3878,6 @@
   "_LEGACY_ERROR_TEMP_2043" : {
     "message" : [
       "- <sqlValue> caused overflow."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2044" : {
-    "message" : [
-      "<sqlValue1> <symbol> <sqlValue2> caused overflow."
     ]
   },
   "_LEGACY_ERROR_TEMP_2045" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -35,7 +35,7 @@
     ],
     "sqlState" : "22003"
   },
-  "BINARY_ARITHMETIC_CAUSE_OVERFLOW" : {
+  "BINARY_ARITHMETIC_OVERFLOW" : {
     "message" : [
       "<value1> <symbol> <value2> caused overflow."
     ],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -654,11 +654,11 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
   def binaryArithmeticCauseOverflowError(
       eval1: Short, symbol: String, eval2: Short): SparkArithmeticException = {
     new SparkArithmeticException(
-      errorClass = "_LEGACY_ERROR_TEMP_2044",
+      errorClass = "BINARY_ARITHMETIC_CAUSE_OVERFLOW",
       messageParameters = Map(
-        "sqlValue1" -> toSQLValue(eval1, ShortType),
+        "value1" -> toSQLValue(eval1, ShortType),
         "symbol" -> symbol,
-        "sqlValue2" -> toSQLValue(eval2, ShortType)),
+        "value2" -> toSQLValue(eval2, ShortType)),
       context = Array.empty,
       summary = "")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -654,7 +654,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
   def binaryArithmeticCauseOverflowError(
       eval1: Short, symbol: String, eval2: Short): SparkArithmeticException = {
     new SparkArithmeticException(
-      errorClass = "BINARY_ARITHMETIC_CAUSE_OVERFLOW",
+      errorClass = "BINARY_ARITHMETIC_OVERFLOW",
       messageParameters = Map(
         "value1" -> toSQLValue(eval1, ShortType),
         "symbol" -> symbol,

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -21,9 +21,11 @@ import java.io.{File, IOException}
 import java.net.{URI, URL}
 import java.sql.{Connection, Driver, DriverManager, PreparedStatement, ResultSet, ResultSetMetaData}
 import java.util.{Locale, Properties, ServiceConfigurationError}
+
 import org.apache.hadoop.fs.{LocalFileSystem, Path}
 import org.apache.hadoop.fs.permission.FsPermission
 import org.mockito.Mockito.{mock, spy, when}
+
 import org.apache.spark._
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.FunctionIdentifier

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -637,7 +637,7 @@ class QueryExecutionErrorsSuite
           "symbol" -> "+",
           "value2" -> "5S"),
         sqlState = "22003")
-  }
+    }
   }
 
   test("UNSUPPORTED_DATATYPE: invalid StructType raw format") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -21,11 +21,9 @@ import java.io.{File, IOException}
 import java.net.{URI, URL}
 import java.sql.{Connection, Driver, DriverManager, PreparedStatement, ResultSet, ResultSetMetaData}
 import java.util.{Locale, Properties, ServiceConfigurationError}
-
 import org.apache.hadoop.fs.{LocalFileSystem, Path}
 import org.apache.hadoop.fs.permission.FsPermission
 import org.mockito.Mockito.{mock, spy, when}
-
 import org.apache.spark._
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
@@ -624,6 +622,21 @@ class QueryExecutionErrorsSuite
       }
     }
   }
+
+  test("BINARY_ARITHMETIC_CAUSE_OVERFLOW: byte plus byte result overflow") {
+    checkError(
+      exception = intercept[SparkArithmeticException] {
+        sql(s"select CAST('5' AS TINYINT) + CAST('5' AS TINYINT)").collect()
+      },
+      errorClass = "BINARY_ARITHMETIC_CAUSE_OVERFLOW",
+      parameters = Map(
+        "value1" -> "5",
+        "symbol" -> "+",
+        "value2" -> "5",
+      ),
+      sqlState = "22003")
+  }
+
 
   test("UNSUPPORTED_DATATYPE: invalid StructType raw format") {
     checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -628,12 +628,11 @@ class QueryExecutionErrorsSuite
   test("BINARY_ARITHMETIC_CAUSE_OVERFLOW: byte plus byte result overflow") {
     checkError(
       exception = intercept[SparkArithmeticException] {
-          sql(s"select CAST('${Short.MaxValue}' AS TINYINT) + CAST('5' AS TINYINT)")
-            .collect()
+          sql(s"select CAST('127' AS TINYINT) + CAST('5' AS TINYINT)").collect()
       },
       errorClass = "BINARY_ARITHMETIC_CAUSE_OVERFLOW",
       parameters = Map(
-        "value1" -> Short.MaxValue.toString,
+        "value1" -> "127",
         "symbol" -> "+",
         "value2" -> "5"),
       sqlState = "22003")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -628,14 +628,14 @@ class QueryExecutionErrorsSuite
   test("BINARY_ARITHMETIC_CAUSE_OVERFLOW: byte plus byte result overflow") {
     checkError(
       exception = intercept[SparkArithmeticException] {
-        sql(s"select CAST('5' AS TINYINT) + CAST('5' AS TINYINT)").collect()
+          sql(s"select CAST('${Short.MaxValue}' AS TINYINT) + CAST('5' AS TINYINT)")
+            .collect()
       },
       errorClass = "BINARY_ARITHMETIC_CAUSE_OVERFLOW",
       parameters = Map(
-        "value1" -> "5",
+        "value1" -> Short.MaxValue.toString,
         "symbol" -> "+",
-        "value2" -> "5",
-      ),
+        "value2" -> "5"),
       sqlState = "22003")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -639,7 +639,6 @@ class QueryExecutionErrorsSuite
       sqlState = "22003")
   }
 
-
   test("UNSUPPORTED_DATATYPE: invalid StructType raw format") {
     checkError(
       exception = intercept[SparkIllegalArgumentException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -626,16 +626,18 @@ class QueryExecutionErrorsSuite
   }
 
   test("BINARY_ARITHMETIC_CAUSE_OVERFLOW: byte plus byte result overflow") {
-    checkError(
-      exception = intercept[SparkArithmeticException] {
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      checkError(
+        exception = intercept[SparkArithmeticException] {
           sql(s"select CAST('127' AS TINYINT) + CAST('5' AS TINYINT)").collect()
-      },
-      errorClass = "BINARY_ARITHMETIC_CAUSE_OVERFLOW",
-      parameters = Map(
-        "value1" -> "127",
-        "symbol" -> "+",
-        "value2" -> "5"),
-      sqlState = "22003")
+        },
+        errorClass = "BINARY_ARITHMETIC_CAUSE_OVERFLOW",
+        parameters = Map(
+          "value1" -> "127S",
+          "symbol" -> "+",
+          "value2" -> "5S"),
+        sqlState = "22003")
+  }
   }
 
   test("UNSUPPORTED_DATATYPE: invalid StructType raw format") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -625,13 +625,13 @@ class QueryExecutionErrorsSuite
     }
   }
 
-  test("BINARY_ARITHMETIC_CAUSE_OVERFLOW: byte plus byte result overflow") {
-    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+  test("BINARY_ARITHMETIC_OVERFLOW: byte plus byte result overflow") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       checkError(
         exception = intercept[SparkArithmeticException] {
-          sql(s"select CAST('127' AS TINYINT) + CAST('5' AS TINYINT)").collect()
+          sql(s"select 127Y + 5Y").collect()
         },
-        errorClass = "BINARY_ARITHMETIC_CAUSE_OVERFLOW",
+        errorClass = "BINARY_ARITHMETIC_OVERFLOW",
         parameters = Map(
           "value1" -> "127S",
           "symbol" -> "+",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR proposes to assign name to _LEGACY_ERROR_TEMP_2044, "BINARY_ARITHMETIC_OVERFLOW".
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Assign proper name to LEGACY_ERROR_TEMP
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
 ./build/sbt "testOnly org.apache.spark.sql.errors.QueryExecutionErrorsSuite"
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
