### PR TITLE
Fix ExecutorAllocationManager cannot allocate new instances when all …

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManager.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManager.scala
@@ -102,6 +102,11 @@ private[streaming] class ExecutorAllocationManager(
         logDebug("Killing executors")
         killExecutor()
       }
+    } else {
+      if (client.getExecutorIds().isEmpty) {
+        logWarning("All executors down, Requesting new executors")
+        requestExecutors(minNumExecutors)
+      }
     }
     batchProcTimeSum = 0
     batchProcTimeCount = 0


### PR DESCRIPTION
### What changes were proposed in this pull request?
the PR fix ExecutorAllocationManager cannot allocate new instances when all executors down.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As described in the issue [SPARK-42972](https://issues.apache.org/jira/browse/SPARK-42972)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I test this in our cluster and the spark streaming app runs normally.
