### PR TITLE
[SPARK-42980][CORE] Implement a lightweight SmallBroadcast

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/SmallBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/SmallBroadcast.scala
@@ -120,7 +120,10 @@ private[spark] class SmallBroadcastTrackerMaster(conf: SparkConf)
   extends SmallBroadcastTracker(conf) {
 
   private val serializationWorker = ExecutionContext.fromExecutorService(
-    ThreadUtils.newDaemonSingleThreadExecutor("small-broadcast-tracker-master-worker"))
+    ThreadUtils.newDaemonFixedThreadPool(
+      conf.get(config.SMALL_BROADCAST_SERIALIZATION_WORKER_NUM),
+      "small-broadcast-tracker-master-worker")
+  )
 
   /**
    * When registering data, serialization will be run in worker thread asynchronously,

--- a/core/src/main/scala/org/apache/spark/broadcast/SmallBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/SmallBroadcast.scala
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.broadcast
+
+import java.io._
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+import scala.util.Failure
+import scala.util.Success
+
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import com.google.common.cache.LoadingCache
+
+import org.apache.spark._
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config
+import org.apache.spark.rpc.RpcCallContext
+import org.apache.spark.rpc.RpcEndpoint
+import org.apache.spark.rpc.RpcEndpointRef
+import org.apache.spark.rpc.RpcEnv
+import org.apache.spark.util.ByteBufferInputStream
+import org.apache.spark.util.RpcUtils
+import org.apache.spark.util.SerializableBuffer
+import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.Utils
+
+
+private[spark] sealed trait SmallBroadcastTrackerMessage
+
+private[spark] case class GetSmallBroadcastData(id: Long)
+  extends SmallBroadcastTrackerMessage
+
+private[spark] case class RemoveSmallBroadcastData(id: Long)
+  extends SmallBroadcastTrackerMessage
+
+/** RpcEndpoint class for SmallBroadcastTrackerMaster */
+private[spark] class SmallBroadcastTrackerMasterEndpoint(
+  override val rpcEnv: RpcEnv, val tracker: SmallBroadcastTrackerMaster)
+  extends RpcEndpoint with Logging {
+
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+    case GetSmallBroadcastData(id: Long) =>
+      val hostPort = context.senderAddress.hostPort
+      logInfo(s"Asked from $hostPort to send small broadcast data for $id")
+      val bytesOpt = tracker.getSerialized(id)
+        .map(bytes => new SerializableBuffer(ByteBuffer.wrap(bytes, 0, bytes.length)))
+      context.reply(bytesOpt)
+    case RemoveSmallBroadcastData(id: Long) =>
+      val hostPort = context.senderAddress.hostPort
+      logInfo(s"Asked from $hostPort to remove small broadcast data for $id")
+      tracker.unregister(id)
+      context.reply(true)
+  }
+}
+
+private[spark] abstract class SmallBroadcastTracker(val conf: SparkConf)
+  extends Logging {
+  // This points to SmallBroadcastTrackerMasterEndpoint
+  var trackerEndpoint: RpcEndpointRef = _
+
+  /**
+   * Send a message to the trackerEndpoint and get its result within a default timeout, or
+   * throw a SparkException if this fails.
+   */
+  protected def askTracker[T: ClassTag](message: Any): T = {
+    try {
+      trackerEndpoint.askSync[T](message)
+    } catch {
+      case e: Exception =>
+        val errMsg = "Error communicating with SmallBroadcastTracker " + message
+        logError(errMsg, e)
+        throw new SparkException(errMsg, e)
+    }
+  }
+
+  def register[T: ClassTag](id: Long, obj: T): Unit
+
+  def unregister(id: Long): Unit
+
+  def get[T: ClassTag](id: Long): Option[T]
+
+  def destroy(id: Long, blocking: Boolean): Unit = {
+    // We only remove from master, data in worker will be expired automatically
+    val future = trackerEndpoint.ask[Boolean](RemoveSmallBroadcastData(id))
+    future.failed.foreach(e => {
+      logWarning(s"Failed to remove SmallBroadcast $id ${e.getMessage}", e)
+    })(ThreadUtils.sameThread)
+    if (blocking) {
+      // the underlying Futures will timeout anyway, so it's safe to use infinite timeout here
+      RpcUtils.INFINITE_TIMEOUT.awaitResult(future)
+    }
+  }
+
+  def stop(): Unit
+}
+
+private[spark] class SmallBroadcastTrackerMaster(conf: SparkConf)
+  extends SmallBroadcastTracker(conf) {
+
+  private val serializationWorker = ExecutionContext.fromExecutorService(
+    ThreadUtils.newDaemonSingleThreadExecutor("small-broadcast-tracker-master-worker"))
+
+  /**
+   * When registering data, serialization will be run in worker thread asynchronously,
+   * which will update the value to future later
+   */
+  private[spark] val cache = new ConcurrentHashMap[Long, (Any, Future[Array[Byte]])]
+
+  override def register[T: ClassTag](id: Long, obj: T): Unit = {
+    cache.computeIfAbsent(id, id => {
+      (obj, Future {
+        SmallBroadcastTracker.serializeData(obj)
+      }(serializationWorker))
+    })._2.failed.foreach(exception => {
+      logError(s"Error during broadcast ${id} serialization: $exception, will remove data" +
+        s" from cache")
+      cache.remove(id)
+    })(serializationWorker)
+  }
+
+  override def unregister(id: Long): Unit = {
+    cache.remove(id)
+  }
+
+  override def get[T: ClassTag](id: Long): Option[T] = {
+    Option(cache.get(id)).map(_._1.asInstanceOf[T])
+  }
+
+  /**
+   * If key not exist => return None
+   * If key exist, block until serialization done
+   *    - success => return Some(data)
+   *    - fail => return None
+   */
+  def getSerialized(id: Long): Option[Array[Byte]] = {
+    Option(cache.get(id)).flatMap(value => {
+      val completedFuture = ThreadUtils.awaitReady(value._2, 10.seconds)
+      completedFuture.value.get match {
+        case Success(value) =>
+          Some(value)
+        case Failure(exception) =>
+          logError(s"exception during SmallBroadcast $id serialization: $exception")
+          None
+      }
+    })
+  }
+
+  override def stop(): Unit = {
+    serializationWorker.shutdown()
+    cache.clear()
+  }
+}
+
+private[spark] class SmallBroadcastTrackerWorker(conf: SparkConf)
+  extends SmallBroadcastTracker(conf) {
+  /**
+   * Use LoadingCache with time eviction policy to expire old data, since executor is not aware of
+   * stage completion
+   */
+  private[spark] val cache: LoadingCache[java.lang.Long, AnyRef] = {
+    CacheBuilder.newBuilder()
+      .maximumSize(conf.get(config.SMALL_BROADCAST_EXECUTOR_CACHE_SIZE))
+      .expireAfterAccess(
+        conf.get(config.SMALL_BROADCAST_EXECUTOR_CACHE_EXPIRE_SECONDS), TimeUnit.SECONDS)
+      .build[java.lang.Long, AnyRef](
+        new CacheLoader[java.lang.Long, AnyRef]() {
+          /**
+           * Fetch from remote if not exist in cache. If another thread is currently loading the
+           * value for this key, simply waits for that thread to finish and returns that value. So
+           * we don't need extra synchronization here
+           */
+          override def load(key: java.lang.Long): AnyRef = {
+            logInfo("Smallbroadcast load data from remote " + key)
+            askTracker[Option[SerializableBuffer]](GetSmallBroadcastData(key))
+              .map(buf => SmallBroadcastTracker.deserializeData(buf.buffer))
+              .getOrElse(throw new Exception(s"failed to load SmallBroadcast ${key} from remote"))
+          }
+        })
+  }
+
+  /**
+   * Get data in local cache or fetch from remote.
+   */
+  override def get[T: ClassTag](id: Long): Option[T] = {
+    Option(cache.get(id).asInstanceOf[T])
+  }
+
+  override def register[T: ClassTag](id: Long, obj: T): Unit = {
+    cache.put(id, obj.asInstanceOf[AnyRef])
+  }
+
+  override def unregister(id: Long): Unit = {
+    cache.invalidate(id)
+  }
+
+  override def stop(): Unit = {
+    cache.invalidateAll()
+  }
+}
+
+
+private[spark] object SmallBroadcastTracker {
+
+  val ENDPOINT_NAME = "SmallBroadcastTracker"
+
+  def serializeData[T: ClassTag](obj: T): Array[Byte] = {
+    val out = new ByteArrayOutputStream(1024)
+    val objOut = new ObjectOutputStream(out)
+    Utils.tryWithSafeFinally {
+      objOut.writeObject(obj)
+    } {
+      objOut.close()
+    }
+    out.toByteArray
+  }
+
+  def deserializeData(buffer: ByteBuffer): AnyRef = {
+    assert(buffer.limit() > 0)
+    val objIn = new ObjectInputStream(new ByteBufferInputStream(buffer))
+    Utils.tryWithSafeFinally {
+      objIn.readObject()
+    } {
+      objIn.close()
+    }
+  }
+}
+
+/**
+ * A lightweight implementation of [[org.apache.spark.broadcast.Broadcast]] with star topology and
+ * in-memory storage.
+ *
+ * The mechanism is as follows:
+ *
+ * The driver store the serialized object in memory.
+ *
+ * On each executor, the executor first attempts to get the data from local cache, if not exist
+ * then fetch from driver and cache it.
+ *
+ * In terms of small data, this won't create too much pressure on driver side and will be more
+ * efficient, which is suitable for lightweight and latency sensitive job.
+ *
+ * When initialized, SmallBroadcast objects read SparkEnv.get.conf.
+ *
+ * @param obj object to broadcast
+ * @param id A unique identifier for the broadcast variable.
+ */
+private[spark] class SmallBroadcast[T: ClassTag](obj: T, id: Long)
+  extends Broadcast[T](id) with Logging with Serializable {
+
+  /**
+   * The value should always exist on driver broadcast object. On executor, it's fetched from
+   * remote and cached in tracker
+   */
+  @transient private var _value: Option[T] = None
+  /** Is the execution in local mode. */
+  @transient private var isLocalMaster: Boolean = _
+
+  private def setConf(conf: SparkConf): Unit = {
+    isLocalMaster = Utils.isLocalMaster(conf)
+  }
+  setConf(SparkEnv.get.conf)
+
+  override protected def getValue(): T = synchronized {
+    if (_value.isEmpty) {
+      _value = Some(SparkEnv.get.broadcastManager.smallBroadcastTracker.get(id).get)
+    }
+    _value.get
+  }
+
+  override protected def doUnpersist(blocking: Boolean): Unit = {
+    SparkEnv.get.broadcastManager.smallBroadcastTracker.destroy(id, blocking)
+  }
+
+  override protected def doDestroy(blocking: Boolean): Unit = {
+    SparkEnv.get.broadcastManager.smallBroadcastTracker.destroy(id, blocking)
+  }
+
+  private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
+    in.defaultReadObject()
+    _value = None
+  }
+
+  /** Used by the JVM when serializing this object. */
+  private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    assertValid()
+    out.defaultWriteObject()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/broadcast/SmallBroadcastFactory.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/SmallBroadcastFactory.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.broadcast
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkEnv
+
+/**
+ * A [[org.apache.spark.broadcast.Broadcast]] implementation that is lightweight and low latency.
+ * Refer to [[org.apache.spark.broadcast.SmallBroadcast]] for more details.
+ */
+private[spark] class SmallBroadcastFactory extends BroadcastFactory {
+
+  private var isDriver = false
+
+  override def initialize(isDriver: Boolean, conf: SparkConf): Unit = {
+    this.isDriver = isDriver
+  }
+
+  override def newBroadcast[T: ClassTag](
+    value_ : T,
+    isLocal: Boolean,
+    id: Long,
+    serializedOnly: Boolean = false): Broadcast[T] = {
+    assert(isDriver, "can only create SmallBroadcast on driver")
+    // serializedOnly and isLocal params are not used in SmallBroadcast
+    SparkEnv.get.broadcastManager.smallBroadcastTracker.register(id, value_)
+    new SmallBroadcast[T](value_, id)
+  }
+
+  override def stop(): Unit = { }
+
+  override def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean): Unit = {
+    SparkEnv.get.broadcastManager.smallBroadcastTracker.destroy(id, blocking)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1942,6 +1942,14 @@ package object config {
       .checkValue(v => v >= 0, "The threshold should be non-negative.")
       .createWithDefault(1L * 1024 * 1024)
 
+  private[spark] val SMALL_BROADCAST_SERIALIZATION_WORKER_NUM =
+    ConfigBuilder("spark.smallBroadcast.serialization.workerNum")
+      .internal()
+      .doc("Small broadcast serialization worker num")
+      .version("3.5.0")
+      .intConf
+      .createWithDefault(2)
+
   private[spark] val SMALL_BROADCAST_EXECUTOR_CACHE_SIZE =
     ConfigBuilder("spark.smallBroadcast.executor.cacheSize")
       .internal()

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1942,6 +1942,22 @@ package object config {
       .checkValue(v => v >= 0, "The threshold should be non-negative.")
       .createWithDefault(1L * 1024 * 1024)
 
+  private[spark] val SMALL_BROADCAST_EXECUTOR_CACHE_SIZE =
+    ConfigBuilder("spark.smallBroadcast.executor.cacheSize")
+      .internal()
+      .doc("Small broadcast cache size in executor side")
+      .version("3.5.0")
+      .intConf
+      .createWithDefault(1000)
+
+  private[spark] val SMALL_BROADCAST_EXECUTOR_CACHE_EXPIRE_SECONDS =
+    ConfigBuilder("spark.smallBroadcast.executor.cacheExpireSeconds")
+      .internal()
+      .doc("Expire duration for small broadcast cache in executor side")
+      .version("3.5.0")
+      .intConf
+      .createWithDefault(600)
+
   private[spark] val RDD_COMPRESS = ConfigBuilder("spark.rdd.compress")
     .doc("Whether to compress serialized RDD partitions " +
       "(e.g. for StorageLevel.MEMORY_ONLY_SER in Scala " +

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -43,7 +43,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
   private val conf = new SparkConf
 
   private def newTrackerMaster(sparkConf: SparkConf = conf) = {
-    val broadcastManager = new BroadcastManager(true, sparkConf)
+    val broadcastManager = new BroadcastManager(true, sparkConf, null)
     new MapOutputTrackerMaster(sparkConf, broadcastManager, true)
   }
 

--- a/core/src/test/scala/org/apache/spark/broadcast/SmallBroadcastSuite.scala
+++ b/core/src/test/scala/org/apache/spark/broadcast/SmallBroadcastSuite.scala
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.broadcast
+
+import java.util.Locale
+
+import org.apache.spark.LocalSparkContext
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkEnv
+import org.apache.spark.SparkException
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.TestUtils
+
+class SmallBroadcastSuite extends SparkFunSuite with LocalSparkContext {
+
+  test("Using SmallBroadcast locally") {
+    sc = new SparkContext("local", "test")
+    val list = List[Int](1, 2, 3, 4)
+    val broadcast = sc.smallBroadcast(list)
+    val results = sc.parallelize(1 to 2).map(x => (x, broadcast.value.sum))
+    assert(results.collect().toSet === Set((1, 10), (2, 10)))
+  }
+
+  test("Accessing SmallBroadcast variables from multiple threads") {
+    sc = new SparkContext("local[10]", "test")
+    val list = List[Int](1, 2, 3, 4)
+    val broadcast = sc.broadcast(list)
+    val results = sc.parallelize(1 to 10).map(x => (x, broadcast.value.sum))
+    assert(results.collect().toSet === (1 to 10).map(x => (x, 10)).toSet)
+  }
+
+  test("Accessing SmallBroadcast variables in a local cluster") {
+    val numWorkers = 4
+    sc = new SparkContext("local-cluster[%d, 1, 1024]".format(numWorkers), "test")
+    val list = List[Int](1, 2, 3, 4)
+    val broadcast = sc.broadcast(list)
+    val results = sc.parallelize(1 to numWorkers).map(x => (x, broadcast.value.sum))
+    assert(results.collect().toSet === (1 to numWorkers).map(x => (x, 10)).toSet)
+  }
+
+  /**
+   * Verify the persistence of state associated with a SmallBroadcast in a local-cluster.
+   *
+   * This test creates a broadcast variable, uses it on all executors, and then destroy it.
+   * In between each step, this test verifies that the broadcast object are present only on the
+   * expected nodes.
+   */
+  test("Unpersisting SmallBroadcast") {
+    val numWorkers = 2
+
+    // Verify that blocks are persisted only on the driver
+    def afterCreation(broadcastId: Long): Unit = {
+      val trackerMaster = sc.env.broadcastManager.smallBroadcastTracker
+        .asInstanceOf[SmallBroadcastTrackerMaster]
+      assert(trackerMaster.get(broadcastId).isDefined)
+      assert(trackerMaster.getSerialized(broadcastId).isDefined)
+    }
+
+    // Verify that blocks are persisted in both the executors and the driver
+    def afterUsingBroadcast(broadcastId: Long): Unit = {
+      val trackerMaster = sc.env.broadcastManager.smallBroadcastTracker
+        .asInstanceOf[SmallBroadcastTrackerMaster]
+      assert(trackerMaster.get(broadcastId).isDefined)
+      assert(trackerMaster.getSerialized(broadcastId).isDefined)
+      sc.range(0, numWorkers, 1, 2).mapPartitions(_ =>
+        Iterator(Seq(SparkEnv.get.broadcastManager.smallBroadcastTracker
+          .asInstanceOf[SmallBroadcastTrackerWorker].cache.size()))).collect()
+        .foreach(value => assert(value.head > 0))
+    }
+
+    // Verify that blocks are unpersisted on all executors, and on all nodes if removeFromDriver
+    // is true.
+    def afterUnpersist(broadcastId: Long): Unit = {
+      val trackerMaster = sc.env.broadcastManager.smallBroadcastTracker
+        .asInstanceOf[SmallBroadcastTrackerMaster]
+      assert(trackerMaster.get(broadcastId).isEmpty)
+      assert(trackerMaster.getSerialized(broadcastId).isEmpty)
+    }
+
+    testUnpersistBroadcast(numWorkers, afterCreation, afterUsingBroadcast, afterUnpersist)
+  }
+
+  test("Using broadcast after destroy is not allowed") {
+    sc = new SparkContext("local", "test")
+    val broadcast = sc.smallBroadcast(Array(1, 2, 3, 4))
+    broadcast.destroy(blocking = true)
+    intercept[SparkException] {
+      broadcast.value
+    }
+  }
+
+  test("Broadcast variables cannot be created after SparkContext is stopped (SPARK-5065)") {
+    sc = new SparkContext("local", "test")
+    sc.stop()
+    val thrown = intercept[IllegalStateException] {
+      sc.smallBroadcast(Seq(1, 2, 3))
+    }
+    assert(thrown.getMessage.toLowerCase(Locale.ROOT).contains("stopped"))
+  }
+
+  test("Forbid broadcasting RDD directly") {
+    sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+    val rdd = sc.parallelize(1 to 4)
+    intercept[IllegalArgumentException] {
+      sc.smallBroadcast(rdd)
+    }
+    sc.stop()
+  }
+
+  test("One small broadcast value instance per executor") {
+    val conf = new SparkConf()
+      .setMaster("local[4]")
+      .setAppName("test")
+
+    sc = new SparkContext(conf)
+    val list = List[Int](1, 2, 3, 4)
+    val broadcast = sc.smallBroadcast(list)
+    val instances = sc.parallelize(1 to 10)
+      .map(_ => System.identityHashCode(broadcast.value))
+      .collect()
+      .toSet
+
+    assert(instances.size === 1)
+  }
+
+  /**
+   * This test runs in 4 steps:
+   *
+   * 1) Create broadcast variable, and verify that all state is persisted on the driver.
+   * 2) Use the broadcast variable on all executors, and verify that all state is persisted
+   * on both the driver and the executors.
+   * 3) Unpersist the broadcast, and verify that all state is removed where they should be.
+   * 4) [Optional] If removeFromDriver is false, we verify that the broadcast is re-usable.
+   */
+  private def testUnpersistBroadcast(
+    numWorkers: Int, // used only when distributed = true
+    afterCreation: Long => Unit,
+    afterUsingBroadcast: Long => Unit,
+    afterUnpersist: Long => Unit): Unit = {
+
+    sc = {
+      val _sc =
+        new SparkContext("local-cluster[%d, 1, 1024]".format(numWorkers), "test")
+      // Wait until all salves are up
+      try {
+        TestUtils.waitUntilExecutorsUp(_sc, numWorkers, 60000)
+        _sc
+      } catch {
+        case e: Throwable =>
+          _sc.stop()
+          throw e
+      }
+    }
+    val list = List[Int](1, 2, 3, 4)
+
+    // Create broadcast variable
+    val broadcast = sc.smallBroadcast(list)
+    afterCreation(broadcast.id)
+
+    // Use broadcast variable on all executors
+    val partitions = 10
+    assert(partitions > numWorkers)
+    val results = sc.parallelize(1 to partitions, partitions).map(x => (x, broadcast.value.sum))
+    assert(results.collect().toSet === (1 to partitions).map(x => (x, list.sum)).toSet)
+    afterUsingBroadcast(broadcast.id)
+
+    // destroy broadcast
+    broadcast.destroy(blocking = true)
+
+    afterUnpersist(broadcast.id)
+
+    // After destroy, all subsequent uses of the broadcast variable should throw SparkExceptions.
+    intercept[SparkException] {
+      broadcast.value
+    }
+    intercept[SparkException] {
+      broadcast.unpersist(blocking = true)
+    }
+    intercept[SparkException] {
+      broadcast.destroy(blocking = true)
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/broadcast/SmallBroadcastTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/broadcast/SmallBroadcastTrackerSuite.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.broadcast
+
+import org.mockito.Mockito.{spy, times, verify}
+
+import org.apache.spark.LocalSparkContext
+import org.apache.spark.SecurityManager
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.config
+import org.apache.spark.rpc.RpcEnv
+import org.apache.spark.util.Utils
+
+class SmallBroadcastTrackerMasterTester(conf: SparkConf)
+  extends SmallBroadcastTrackerMaster(conf) {
+
+  var getSerializedSmallBroadcastCnt = 0
+  override  def getSerialized(id: Long): Option[Array[Byte]] = {
+    getSerializedSmallBroadcastCnt += 1
+    super.getSerialized(id)
+  }
+}
+
+class SmallBroadcastTrackerSuite extends SparkFunSuite with LocalSparkContext {
+
+  private val cache_expire_seconds = 5
+
+  private val conf = new SparkConf()
+    .set(config.SMALL_BROADCAST_EXECUTOR_CACHE_EXPIRE_SECONDS, cache_expire_seconds)
+
+  private val hostname = "localhost"
+
+  def createRpcEnv(name: String, host: String = "localhost", port: Int = 0,
+    securityManager: SecurityManager = new SecurityManager(conf)): RpcEnv = {
+    RpcEnv.create(name, host, port, conf, securityManager)
+  }
+
+  def withTrackerMaster(f: (RpcEnv, SmallBroadcastTrackerMaster) => Unit): Unit = {
+    val masterRpcEnv = createRpcEnv("spark-master", hostname, 0, new SecurityManager(conf))
+    val masterTracker = spy(new SmallBroadcastTrackerMaster(conf))
+    masterRpcEnv.setupEndpoint(SmallBroadcastTracker.ENDPOINT_NAME,
+      new SmallBroadcastTrackerMasterEndpoint(masterRpcEnv, masterTracker))
+    Utils.tryWithSafeFinally {
+      f(masterRpcEnv, masterTracker)
+    } {
+      masterTracker.stop()
+      masterRpcEnv.shutdown()
+    }
+  }
+
+  def withTrackerWorker(masterRpcEnv: RpcEnv)
+    (f: (RpcEnv, SmallBroadcastTrackerWorker) => Unit): Unit = {
+    val workerRpcEnv = createRpcEnv("spark-worker", hostname, 0, new SecurityManager(conf))
+    val workerTracker = new SmallBroadcastTrackerWorker(conf)
+    workerTracker.trackerEndpoint = workerRpcEnv.setupEndpointRef(
+      masterRpcEnv.address, SmallBroadcastTracker.ENDPOINT_NAME)
+    Utils.tryWithSafeFinally {
+      f(workerRpcEnv, workerTracker)
+    } {
+      workerTracker.stop()
+      workerRpcEnv.shutdown()
+    }
+  }
+
+  test("master register and unregister") {
+    withTrackerMaster((_, tracker) => {
+      val bid = 0
+      val obj = List(1, 2, 3)
+      tracker.register(bid, obj)
+      assert(tracker.get(bid).isDefined)
+      tracker.unregister(bid)
+      assert(tracker.cache.isEmpty)
+    })
+  }
+
+  test("remote fetch and cache") {
+    withTrackerMaster((masterEnv, masterTracker) => {
+      val bid = 0
+      val obj = List(1, 2, 3)
+      masterTracker.register(bid, obj)
+      withTrackerWorker(masterEnv)((_, workerTracker) => {
+        assert(workerTracker.get(bid).isDefined)
+        verify(masterTracker, times(1)).getSerialized(bid)
+        // cached in local, should not fetch from remote
+        assert(workerTracker.get(bid).isDefined)
+        verify(masterTracker, times(1)).getSerialized(bid)
+        // wait for cache expire
+        Thread.sleep(cache_expire_seconds * 1000)
+        workerTracker.cache.cleanUp() // force cleanup expired entries
+        assert(workerTracker.cache.size() == 0)
+      })
+    })
+  }
+}

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -401,7 +401,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     cacheLocations.clear()
     results.clear()
     securityMgr = new SecurityManager(sc.getConf)
-    broadcastManager = new BroadcastManager(true, sc.getConf)
+    broadcastManager = new BroadcastManager(true, sc.getConf, null)
     mapOutputTracker = spy(new MyMapOutputTrackerMaster(sc.getConf, broadcastManager))
     blockManagerMaster = spy(new MyBlockManagerMaster(sc.getConf))
     doNothing().when(blockManagerMaster).updateRDDBlockVisibility(any(), any())

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
@@ -55,7 +55,7 @@ trait BlockManagerReplicationBehavior extends SparkFunSuite
   protected var rpcEnv: RpcEnv = null
   protected var master: BlockManagerMaster = null
   protected lazy val securityMgr = new SecurityManager(conf)
-  protected lazy val bcastManager = new BroadcastManager(true, conf)
+  protected lazy val bcastManager = new BroadcastManager(true, conf, null)
   protected lazy val mapOutputTracker = new MapOutputTrackerMaster(conf, bcastManager, true)
   protected lazy val shuffleManager = new SortShuffleManager(conf)
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -82,7 +82,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
   var master: BlockManagerMaster = null
   var liveListenerBus: LiveListenerBus = null
   val securityMgr = new SecurityManager(new SparkConf(false))
-  val bcastManager = new BroadcastManager(true, new SparkConf(false))
+  val bcastManager = new BroadcastManager(true, new SparkConf(false), null)
   val mapOutputTracker = new MapOutputTrackerMaster(new SparkConf(false), bcastManager, true)
   val shuffleManager = new SortShuffleManager(new SparkConf(false))
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
@@ -71,7 +71,7 @@ abstract class BaseReceivedBlockHandlerSuite(enableEncryption: Boolean)
   val hadoopConf = new Configuration()
   val streamId = 1
   val securityMgr = new SecurityManager(conf, encryptionKey)
-  val broadcastManager = new BroadcastManager(true, conf)
+  val broadcastManager = new BroadcastManager(true, conf, null)
   val mapOutputTracker = new MapOutputTrackerMaster(conf, broadcastManager, true)
   val shuffleManager = new SortShuffleManager(conf)
   val serializer = new KryoSerializer(conf)


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current TorrentBroadcast implementation is originally designed for large data transmission where driver might become the bottleneck and memory might also be the concern. Therefore it's kind of heavy and comes with some fixed overhead:

- torrent protocol: more round traffic
- disk level persistency, BlockManager, extra overhead

which makes it inefficient for some small data transmission.

We can have a lightweight broadcast implementation, e.g, SmallBroadcast, which implement star-topology broadcast(which avoids the unnecessary round traffic), and maybe in-memory only.

Note:

The current factory style API seem to encourage only one broadcast style on runtime, however this small broadcast implementation is a supplement to `TorrentBroadcast`. So I introduce new small broadcast APIs along the code path.

### Why are the changes needed?
Provide a lightweight implementation of `Broadcast`, which is suitable for situation where data size is small and latency is critical.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?

Unit test. More testcases are from `BroadcastSuite`
