### PR TITLE
[SPARK-42774][SQL]Expose VectorTypes API for DataSourceV2 Batch Scans

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/PartitionReaderFactory.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/PartitionReaderFactory.java
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connector.read;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -65,4 +66,12 @@ public interface PartitionReaderFactory extends Serializable {
   default boolean supportColumnarReads(InputPartition partition) {
     return false;
   }
+
+  /**
+   * Returns exact java types of the columns that are output in columnar processing mode.
+   */
+  default Optional<Iterable<String>> getVectorTypes() {
+    return Optional.empty();
+  }
+
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, RowOrdering, SortOrder}
@@ -60,6 +62,10 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
     val result =
       s"$nodeName${truncatedString(output, "[", ", ", "]", maxFields)} ${scan.description()}"
     redact(result)
+  }
+
+  override def vectorTypes: Option[Seq[String]] = {
+    Option(readerFactory.getVectorTypes.get.asScala.toSeq)
   }
 
   def partitions: Seq[Seq[InputPartition]] =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetPartitionReaderFactory.scala
@@ -17,6 +17,9 @@
 package org.apache.spark.sql.execution.datasources.v2.parquet
 
 import java.time.ZoneId
+import java.util.Optional
+
+import scala.collection.JavaConverters._
 
 import org.apache.hadoop.mapred.FileSplit
 import org.apache.hadoop.mapreduce._
@@ -39,6 +42,7 @@ import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.datasources.{AggregatePushDownUtils, DataSourceUtils, PartitionedFile, RecordReaderIterator}
 import org.apache.spark.sql.execution.datasources.parquet._
 import org.apache.spark.sql.execution.datasources.v2._
+import org.apache.spark.sql.execution.vectorized.{ConstantColumnVector, OffHeapColumnVector, OnHeapColumnVector}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
@@ -106,6 +110,26 @@ case class ParquetPartitionReaderFactory(
 
   override def supportColumnarReads(partition: InputPartition): Boolean = {
     supportsColumnar
+  }
+
+  override def getVectorTypes: Optional[java.lang.Iterable[String]] = {
+
+//    Optional.of(Seq.fill(readDataSchema.fields.length)(
+//      if (!enableOffHeapColumnVector) {
+//        classOf[OnHeapColumnVector].getName
+//      } else {
+//        classOf[OffHeapColumnVector].getName
+//      }
+//    ) ++ Seq.fill(partitionSchema.fields.length)(classOf[ConstantColumnVector].getName))
+
+    val data: Iterable[String] = Iterable.fill(readDataSchema.fields.length)(
+      if (!enableOffHeapColumnVector) {
+        classOf[OnHeapColumnVector].getName
+      } else {
+        classOf[OffHeapColumnVector].getName
+      }
+    ) ++ Seq.fill(partitionSchema.fields.length)(classOf[ConstantColumnVector].getName)
+    Optional.of(data.asJava)
   }
 
   override def buildReader(file: PartitionedFile): PartitionReader[InternalRow] = {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaColumnarDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaColumnarDataSourceV2.java
@@ -18,7 +18,6 @@
 package test.org.apache.spark.sql.connector;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.TestingV2Source;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaColumnarDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaColumnarDataSourceV2.java
@@ -69,10 +69,6 @@ public class JavaColumnarDataSourceV2 implements TestingV2Source {
     public boolean supportColumnarReads(InputPartition partition) {
       return true;
     }
-    @Override
-    public Optional<Iterable<String>> getVectorTypes() {
-      return Optional.empty();
-    }
 
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaColumnarDataSourceV2.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaColumnarDataSourceV2.java
@@ -18,6 +18,7 @@
 package test.org.apache.spark.sql.connector;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.TestingV2Source;
@@ -67,6 +68,10 @@ public class JavaColumnarDataSourceV2 implements TestingV2Source {
     @Override
     public boolean supportColumnarReads(InputPartition partition) {
       return true;
+    }
+    @Override
+    public Optional<Iterable<String>> getVectorTypes() {
+      return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an override to BatchScanExecBase which delegates to a new default method on PartitionReaderFactory to expose vectoryTypes.
### Why are the changes needed?

SparkPlan's vectorType's attribute can be used to specialize codegen however BatchScanExecBase does not override this so we DSv2 sources do not get any benefit of concrete class dispatch.

### Does this PR introduce *any* user-facing change?

NO

### How was this patch tested?

Pass GitHub Actions
