### PR TITLE
[SPARK-43002][YARN] Modify yarn client application report logging frequency to reduce noise

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -647,6 +647,16 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>0.9.0</td>
 </tr>
 <tr>
+  <td><code>spark.yarn.report.logging.frequency</code></td>
+  <td><code>30</code></td>
+  <td>
+    Maximum number of application reports processed until the next application status 
+    is logged. If there is a change of state, the application status will be logged regardless
+    of the number of application reports processed.
+  </td>
+  <td>3.5.0</td>
+</tr>
+<tr>
   <td><code>spark.yarn.clientLaunchMonitorInterval</code></td>
   <td><code>1s</code></td>
   <td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -647,7 +647,7 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>0.9.0</td>
 </tr>
 <tr>
-  <td><code>spark.yarn.report.logging.frequency</code></td>
+  <td><code>spark.yarn.report.loggingFrequency</code></td>
   <td><code>30</code></td>
   <td>
     Maximum number of application reports processed until the next application status 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1164,7 +1164,7 @@ private[spark] class Client(
       val state = report.getYarnApplicationState
       reportsSinceLastLog += 1
       if (logApplicationReport) {
-        if (reportsSinceLastLog >= reportsTillNextLog || lastState != state) {
+        if (lastState != state || reportsSinceLastLog >= reportsTillNextLog) {
           logInfo(s"Application report for $appId (state: $state)")
           reportsSinceLastLog = 0
         }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1169,7 +1169,6 @@ private[spark] class Client(
           reportsSinceLastLog = 0
         }
 
-
         // If DEBUG is enabled, log report details every iteration
         // Otherwise, log them every time the application changes state
         if (log.isDebugEnabled) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1138,9 +1138,9 @@ private[spark] class Client(
    * @return A pair of the yarn application state and the final application state.
    */
   def monitorApplication(
-     returnOnRunning: Boolean = false,
-     logApplicationReport: Boolean = true,
-     interval: Long = sparkConf.get(REPORT_INTERVAL)): YarnAppReport = {
+      returnOnRunning: Boolean = false,
+      logApplicationReport: Boolean = true,
+      interval: Long = sparkConf.get(REPORT_INTERVAL)): YarnAppReport = {
     var lastState: YarnApplicationState = null
     val reportsTillNextLog: Int = sparkConf.get(REPORT_LOG_FREQUENCY)
     var reportsSinceLastLog: Int = 0
@@ -1202,8 +1202,8 @@ private[spark] class Client(
       }
 
       if (state == YarnApplicationState.FINISHED ||
-         state == YarnApplicationState.FAILED ||
-         state == YarnApplicationState.KILLED) {
+          state == YarnApplicationState.FAILED ||
+          state == YarnApplicationState.KILLED) {
         cleanupStagingDir()
         return createAppReport(report)
       }
@@ -1212,7 +1212,7 @@ private[spark] class Client(
         return createAppReport(report)
       }
       if (state == YarnApplicationState.ACCEPTED && isClientUnmanagedAMEnabled &&
-         appMaster == null && report.getAMRMToken != null) {
+          appMaster == null && report.getAMRMToken != null) {
         appMaster = startApplicationMasterService(report)
       }
       lastState = state

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1146,7 +1146,6 @@ private[spark] class Client(
     var reportsSinceLastLog: Int = 0
     while (true) {
       Thread.sleep(interval)
-      reportsSinceLastLog += 1
       val report: ApplicationReport =
         try {
           getApplicationReport
@@ -1163,9 +1162,9 @@ private[spark] class Client(
               Some(msg))
         }
       val state = report.getYarnApplicationState
-
+      reportsSinceLastLog += 1
       if (logApplicationReport) {
-        if (reportsSinceLastLog == reportsTillNextLog || lastState != state) {
+        if (reportsSinceLastLog >= reportsTillNextLog || lastState != state) {
           logInfo(s"Application report for $appId (state: $state)")
           reportsSinceLastLog = 0
         }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -230,8 +230,7 @@ package object config extends Logging {
       .doc("Maximum number of application reports processed " +
         "until the next application status is logged. " +
         "If there is a change of state, the application status will be logged " +
-        "regardless of the number of application reports processed. " +
-        "This property is dependent on the spark.yarn.report.interval")
+        "regardless of the number of application reports processed.")
       .version("3.5.0")
       .intConf
       .createWithDefault(30)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -226,13 +226,14 @@ package object config extends Logging {
     .createWithDefaultString("1s")
 
   private[spark] val REPORT_LOG_FREQUENCY = {
-    ConfigBuilder("spark.yarn.report.logging.frequency")
+    ConfigBuilder("spark.yarn.report.loggingFrequency")
       .doc("Maximum number of application reports processed " +
         "until the next application status is logged. " +
         "If there is a change of state, the application status will be logged " +
         "regardless of the number of application reports processed.")
       .version("3.5.0")
       .intConf
+      .checkValue(_ > 0, "logging frequency should be positive")
       .createWithDefault(30)
   }
 

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -227,7 +227,10 @@ package object config extends Logging {
 
   private[spark] val REPORT_LOG_FREQUENCY = {
     ConfigBuilder("spark.yarn.report.logging.frequency")
-      .doc("Number of application reports processed until the next application status is logged." +
+      .doc("Maximum number of application reports processed " +
+        "until the next application status is logged. " +
+        "If there is a change of state, the application status will be logged " +
+        "regardless of the number of application reports processed. " +
         "This property is dependent on the spark.yarn.report.interval")
       .version("3.5.0")
       .intConf

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -225,6 +225,15 @@ package object config extends Logging {
     .timeConf(TimeUnit.MILLISECONDS)
     .createWithDefaultString("1s")
 
+  private[spark] val REPORT_LOG_FREQUENCY = {
+    ConfigBuilder("spark.yarn.report.logging.frequency")
+      .doc("Number of application reports processed until the next application status is logged." +
+        "This property is dependent on the spark.yarn.report.interval")
+      .version("3.5.0")
+      .intConf
+      .createWithDefault(30)
+  }
+
   private[spark] val CLIENT_LAUNCH_MONITOR_INTERVAL =
     ConfigBuilder("spark.yarn.clientLaunchMonitorInterval")
       .doc("Interval between requests for status the client mode AM when starting the app.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
* Added a new config property — `spark.yarn.report.loggingFrequency`
* Limit the number of times the yarn application report is logged based on the number of reports processed.
   
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Currently, an application report is generated every second, this tends to add a lot of noise especially for long running applications. This bloats the log file and makes it hard to navigate. With this change, we can limit the amount of times the application status report is logged based on the number of reports processed.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
The logs are now ~30s apart
```
31-03-2023 15:00:08 PDT countByCountryFlow_countByCountry INFO - 23/03/31 22:00:08 INFO yarn.Client: Application report for application_1676870052658_5870144 (state: RUNNING)
31-03-2023 15:00:38 PDT countByCountryFlow_countByCountry INFO - 23/03/31 22:00:38 INFO yarn.Client: Application report for application_1676870052658_5870144 (state: RUNNING)
31-03-2023 15:01:08 PDT countByCountryFlow_countByCountry INFO - 23/03/31 22:01:08 INFO yarn.Client: Application report for application_1676870052658_5870144 (state: RUNNING)
31-03-2023 15:01:38 PDT countByCountryFlow_countByCountry INFO - 23/03/31 22:01:38 INFO yarn.Client: Application report for application_1676870052658_5870144 (state: RUNNING)
31-03-2023 15:02:09 PDT countByCountryFlow_countByCountry INFO - 23/03/31 22:02:09 INFO yarn.Client: Application report for application_1676870052658_5870144 (state: RUNNING)
31-03-2023 15:02:31 PDT countByCountryFlow_countByCountry INFO - 23/03/31 22:02:31 INFO yarn.Client: Application report for application_1676870052658_5870144 (state: FINISHED)
```

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Tested locally to ensure the behavior was as expected
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
