### PR TITLE
[SPARK-43010][PYTHON] Migrate Column errors into error class

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -24,6 +24,21 @@ ERROR_CLASSES_JSON = """
       "Argument `<arg_name>` is required when <condition>."
     ]
   },
+  "CANNOT_ACCESS_TO_DUNDER": {
+    "message": [
+      "Dunder(double underscore) attribute is for internal use only."
+    ]
+  },
+  "CANNOT_APPLY_IN_FOR_COLUMN": {
+    "message": [
+      "Cannot apply 'in' operator against a column: please use 'contains' in a string column or 'array_contains' function for an array column."
+    ]
+  },
+  "CANNOT_CONVERT_COLUMN_INTO_BOOL": {
+    "message": [
+      "Cannot convert column into bool: please use '&' for 'and', '|' for 'or', '~' for 'not' when building DataFrame boolean expressions."
+    ]
+  },
   "COLUMN_IN_LIST": {
     "message": [
       "`<func_name>` does not allow a Column in a list."
@@ -167,6 +182,21 @@ ERROR_CLASSES_JSON = """
   "NO_ACTIVE_SESSION" : {
     "message" : [
       "No active Spark session found. Please create a new Spark session before running the code."
+    ]
+  },
+  "ONLY_ALLOWED_FOR_SINGLE_COLUMN" : {
+    "message" : [
+      "Argument `<arg_name>` can only be provided for a single column."
+    ]
+  },
+  "SLICE_WITH_STEP" : {
+    "message" : [
+      "Slice with step is not supported."
+    ]
+  },
+  "UNSUPPORTED_NUMPY_ARRAY_SCALAR" : {
+    "message" : [
+      "The type of array scalar '<dtype>' is not supported."
     ]
   },
   "UNSUPPORTED_NUMPY_ARRAY_SCALAR" : {

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -199,11 +199,6 @@ ERROR_CLASSES_JSON = """
       "The type of array scalar '<dtype>' is not supported."
     ]
   },
-  "UNSUPPORTED_NUMPY_ARRAY_SCALAR" : {
-    "message" : [
-      "The type of array scalar '<dtype>' is not supported."
-    ]
-  },
   "UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION" : {
     "message" : [
       "Function `<func_name>` should use only POSITIONAL or POSITIONAL OR KEYWORD arguments."

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -35,7 +35,7 @@ from py4j.java_gateway import JavaObject, JVMView
 
 from pyspark import copy_func
 from pyspark.context import SparkContext
-from pyspark.errors import PySparkTypeError
+from pyspark.errors import PySparkAttributeError, PySparkTypeError, PySparkValueError
 from pyspark.sql.types import DataType
 from pyspark.sql.utils import get_active_spark_context
 
@@ -62,11 +62,9 @@ def _to_java_column(col: "ColumnOrName") -> JavaObject:
     elif isinstance(col, str):
         jcol = _create_column_from_name(col)
     else:
-        raise TypeError(
-            "Invalid argument, not a string or column: "
-            "{0} of type {1}. "
-            "For column literals, use 'lit', 'array', 'struct' or 'create_map' "
-            "function.".format(col, type(col))
+        raise PySparkTypeError(
+            error_class="NOT_COLUMN_OR_STR",
+            message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
         )
     return jcol
 
@@ -352,9 +350,8 @@ class Column:
 
     # container operators
     def __contains__(self, item: Any) -> None:
-        raise ValueError(
-            "Cannot apply 'in' operator against a column: please use 'contains' "
-            "in a string column or 'array_contains' function for an array column."
+        raise PySparkValueError(
+            error_class="CANNOT_APPLY_IN_FOR_COLUMN",
         )
 
     # bitwise operators
@@ -665,7 +662,9 @@ class Column:
         +------+
         """
         if item.startswith("__"):
-            raise AttributeError(item)
+            raise PySparkAttributeError(
+                error_class="CANNOT_ACCESS_TO_DUNDER",
+            )
         return self[item]
 
     def __getitem__(self, k: Any) -> "Column":
@@ -701,13 +700,17 @@ class Column:
         """
         if isinstance(k, slice):
             if k.step is not None:
-                raise ValueError("slice with step is not supported.")
+                raise PySparkValueError(
+                    error_class="SLICE_WITH_STEP",
+                )
             return self.substr(k.start, k.stop)
         else:
             return _bin_op("apply")(self, k)
 
     def __iter__(self) -> None:
-        raise TypeError("Column is not iterable")
+        raise PySparkTypeError(
+            error_class="NOT_ITERABLE", message_parameters={"objectName": "Column"}
+        )
 
     # string methods
     _contains_doc = """
@@ -920,7 +923,10 @@ class Column:
         elif isinstance(startPos, Column):
             jc = self._jc.substr(startPos._jc, cast("Column", length)._jc)
         else:
-            raise TypeError("Unexpected type: %s" % type(startPos))
+            raise PySparkTypeError(
+                error_class="NOT_COLUMN_OR_INT",
+                message_parameters={"arg_name": "startPos", "arg_type": type(startPos).__name__},
+            )
         return Column(jc)
 
     def isin(self, *cols: Any) -> "Column":
@@ -1149,7 +1155,10 @@ class Column:
                 return Column(getattr(self._jc, "as")(alias[0]))
         else:
             if metadata:
-                raise ValueError("metadata can only be provided for a single column")
+                raise PySparkValueError(
+                    error_class="ONLY_ALLOWED_FOR_SINGLE_COLUMN",
+                    message_parameters={"arg_name": "metadata"},
+                )
             return Column(getattr(self._jc, "as")(_to_seq(sc, list(alias))))
 
     name = copy_func(alias, sinceversion=2.0, doc=":func:`name` is an alias for :func:`alias`.")
@@ -1193,7 +1202,10 @@ class Column:
             jdt = spark._jsparkSession.parseDataType(dataType.json())
             jc = self._jc.cast(jdt)
         else:
-            raise TypeError("unexpected type: %s" % type(dataType))
+            raise PySparkTypeError(
+                error_class="NOT_DATATYPE_OR_STR",
+                message_parameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
+            )
         return Column(jc)
 
     astype = copy_func(cast, sinceversion=1.4, doc=":func:`astype` is an alias for :func:`cast`.")
@@ -1278,7 +1290,10 @@ class Column:
         pyspark.sql.functions.when
         """
         if not isinstance(condition, Column):
-            raise TypeError("condition should be a Column")
+            raise PySparkTypeError(
+                error_class="NOT_COLUMN",
+                message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+            )
         v = value._jc if isinstance(value, Column) else value
         jc = self._jc.when(condition._jc, v)
         return Column(jc)
@@ -1361,14 +1376,16 @@ class Column:
         from pyspark.sql.window import WindowSpec
 
         if not isinstance(window, WindowSpec):
-            raise TypeError("window should be WindowSpec")
+            raise PySparkTypeError(
+                error_class="NOT_WINDOWSPEC",
+                message_parameters={"arg_name": "window", "arg_type": type(window).__name__},
+            )
         jc = self._jc.over(window._jspec)
         return Column(jc)
 
     def __nonzero__(self) -> None:
-        raise ValueError(
-            "Cannot convert column into bool: please use '&' for 'and', '|' for 'or', "
-            "'~' for 'not' when building DataFrame boolean expressions."
+        raise PySparkValueError(
+            error_class="CANNOT_CONVERT_COLUMN_INTO_BOOL",
         )
 
     __bool__ = __nonzero__

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -352,6 +352,7 @@ class Column:
     def __contains__(self, item: Any) -> None:
         raise PySparkValueError(
             error_class="CANNOT_APPLY_IN_FOR_COLUMN",
+            message_parameters={},
         )
 
     # bitwise operators
@@ -664,6 +665,7 @@ class Column:
         if item.startswith("__"):
             raise PySparkAttributeError(
                 error_class="CANNOT_ACCESS_TO_DUNDER",
+                message_parameters={},
             )
         return self[item]
 
@@ -702,6 +704,7 @@ class Column:
             if k.step is not None:
                 raise PySparkValueError(
                     error_class="SLICE_WITH_STEP",
+                    message_parameters={},
                 )
             return self.substr(k.start, k.stop)
         else:
@@ -1386,6 +1389,7 @@ class Column:
     def __nonzero__(self) -> None:
         raise PySparkValueError(
             error_class="CANNOT_CONVERT_COLUMN_INTO_BOOL",
+            message_parameters={},
         )
 
     __bool__ = __nonzero__

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -46,8 +46,13 @@ class ColumnTestsMixin:
         self.assertTrue("Column" in _to_java_column("a").getClass().toString())
         self.assertTrue("Column" in _to_java_column(self.spark.range(1).id).getClass().toString())
 
-        self.assertRaisesRegex(
-            TypeError, "Invalid argument, not a string or column", lambda: _to_java_column(1)
+        with self.assertRaises(PySparkTypeError) as pe:
+            _to_java_column(1)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STR",
+            message_parameters={"arg_name": "col", "arg_type": "int"},
         )
 
         class A:
@@ -56,8 +61,13 @@ class ColumnTestsMixin:
         self.assertRaises(TypeError, lambda: _to_java_column(A()))
         self.assertRaises(TypeError, lambda: _to_java_column([]))
 
-        self.assertRaisesRegex(
-            TypeError, "Invalid argument, not a string or column", lambda: udf(lambda x: x)(None)
+        with self.assertRaises(PySparkTypeError) as pe:
+            udf(lambda x: x)(None)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_COLUMN_OR_STR",
+            message_parameters={"arg_name": "col", "arg_type": "NoneType"},
         )
         self.assertRaises(TypeError, lambda: to_json(1))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to migrate errors from `python/pyspark/sql/column.py` into error classes.


### Why are the changes needed?

To leverage the PySpark error framework.


### Does this PR introduce _any_ user-facing change?

No, it's about the error message improvement. No API changes.


### How was this patch tested?

The existing CI should pass.
