### PR TITLE
[SPARK-43014][CORE][K8S] Support `spark.kubernetes.setSubmitTimeInDriver`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -904,7 +904,10 @@ private[spark] class SparkSubmit extends Logging {
       childArgs ++= Seq("--verbose")
     }
 
-    sparkConf.set("spark.app.submitTime", System.currentTimeMillis().toString)
+    if (!isKubernetesClusterModeDriver) {
+      // SubmitTime should not be overwritten when run Driver in k8s cluster mode
+      sparkConf.set("spark.app.submitTime", System.currentTimeMillis().toString)
+    }
 
     if (childClasspath.nonEmpty && isCustomClasspathInClusterModeDisallowed) {
       childClasspath.clear()

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -904,10 +904,10 @@ private[spark] class SparkSubmit extends Logging {
       childArgs ++= Seq("--verbose")
     }
 
-    sparkConf.setIfMissing("spark.app.submitTime", System.currentTimeMillis().toString)
     val setSubmitTimeInClusterModeDriver =
       sparkConf.getBoolean("spark.kubernetes.setSubmitTimeInDriver", false)
-    if (isKubernetesClusterModeDriver && setSubmitTimeInClusterModeDriver) {
+    if (!sparkConf.contains("spark.app.submitTime")
+      || isKubernetesClusterModeDriver && setSubmitTimeInClusterModeDriver ) {
       sparkConf.set("spark.app.submitTime", System.currentTimeMillis().toString)
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -904,8 +904,10 @@ private[spark] class SparkSubmit extends Logging {
       childArgs ++= Seq("--verbose")
     }
 
-    if (!isKubernetesClusterModeDriver) {
-      // SubmitTime should not be overwritten when run Driver in k8s cluster mode
+    sparkConf.setIfMissing("spark.app.submitTime", System.currentTimeMillis().toString)
+    val setSubmitTimeInClusterModeDriver =
+      sparkConf.getBoolean("spark.kubernetes.setSubmitTimeInDriver", false)
+    if (isKubernetesClusterModeDriver && setSubmitTimeInClusterModeDriver) {
       sparkConf.set("spark.app.submitTime", System.currentTimeMillis().toString)
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -907,7 +907,7 @@ private[spark] class SparkSubmit extends Logging {
     val setSubmitTimeInClusterModeDriver =
       sparkConf.getBoolean("spark.kubernetes.setSubmitTimeInDriver", true)
     if (!sparkConf.contains("spark.app.submitTime")
-      || isKubernetesClusterModeDriver && setSubmitTimeInClusterModeDriver ) {
+      || isKubernetesClusterModeDriver && setSubmitTimeInClusterModeDriver) {
       sparkConf.set("spark.app.submitTime", System.currentTimeMillis().toString)
     }
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -905,7 +905,7 @@ private[spark] class SparkSubmit extends Logging {
     }
 
     val setSubmitTimeInClusterModeDriver =
-      sparkConf.getBoolean("spark.kubernetes.setSubmitTimeInDriver", false)
+      sparkConf.getBoolean("spark.kubernetes.setSubmitTimeInDriver", true)
     if (!sparkConf.contains("spark.app.submitTime")
       || isKubernetesClusterModeDriver && setSubmitTimeInClusterModeDriver ) {
       sparkConf.set("spark.app.submitTime", System.currentTimeMillis().toString)

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -550,6 +550,20 @@ class SparkSubmitSuite
     Files.delete(Paths.get("TestUDTF.jar"))
   }
 
+  test("SPARK-43014: Do not overwrite `spark.app.submitTime` in k8s cluster mode driver") {
+    val submitTime = 1234567.toString
+    val clArgs = Seq(
+      "--deploy-mode", "client",
+      "--master", "k8s://host:port",
+      "--class", "org.SomeClass",
+      "--conf", "spark.app.submitTime=" + submitTime,
+      "--conf", "spark.kubernetes.submitInDriver=true",
+      "/home/thejar.jar")
+    val appArgs = new SparkSubmitArguments(clArgs)
+    val (_, _, conf, _) = submit.prepareSubmitEnvironment(appArgs)
+    conf.get("spark.app.submitTime") should be (submitTime)
+  }
+
   /**
    * Helper function for testing main class resolution on remote JAR files.
    *

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -560,7 +560,7 @@ class SparkSubmitSuite
     val (_, _, conf1, _) = submit.prepareSubmitEnvironment(appArgs1)
     conf1.getOption("spark.app.submitTime").isDefined should be(true)
 
-    val submitTime = 1234567.toString
+    val submitTime = "1234567"
     val clArgs2 = Seq(
       "--deploy-mode", "client",
       "--master", "k8s://host:port",
@@ -572,8 +572,8 @@ class SparkSubmitSuite
     conf2.get("spark.app.submitTime") should be (submitTime)
   }
 
-  test("SPARK-43014: Overwrite `spark.app.submitTime` in k8s cluster mode driver " +
-    "when `spark.kubernetes.setSubmitTimeInDriver` is true") {
+  test("SPARK-43014: Do not overwrite `spark.app.submitTime` in k8s cluster mode driver " +
+    "when `spark.kubernetes.setSubmitTimeInDriver` is false") {
     val submitTime = System.currentTimeMillis() - 1000
     val clArgs = Seq(
       "--deploy-mode", "client",
@@ -581,11 +581,11 @@ class SparkSubmitSuite
       "--class", "org.SomeClass",
       "--conf", "spark.app.submitTime=" + submitTime,
       "--conf", "spark.kubernetes.submitInDriver=true",
-      "--conf", "spark.kubernetes.setSubmitTimeInDriver=true",
+      "--conf", "spark.kubernetes.setSubmitTimeInDriver=false",
       "/home/thejar.jar")
     val appArgs = new SparkSubmitArguments(clArgs)
     val (_, _, conf, _) = submit.prepareSubmitEnvironment(appArgs)
-    conf.getLong("spark.app.submitTime", -1) should be > submitTime
+    conf.getLong("spark.app.submitTime", -1) should be (submitTime)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new configuration `spark.kubernetes.setSubmitTimeInDriver`.
When an application is deployed using spark-submit in k8s cluster mode, let `spark.app.submitTime` be the time spark-submit executed.

### Why are the changes needed?
Currently, when an application is deployed using spark-submit in k8s cluster mode, `spark.app.submitTime` is the time driver pod started.
Driver pod pending time is not included in the time between `spark.app.submitTime` and `spark.app.startTime`.


### Does this PR introduce _any_ user-facing change?
'No'


### How was this patch tested?
Add test:
* "SPARK-43014: Set `spark.app.submitTime` if missing" 
* "SPARK-43014: Overwrite `spark.app.submitTime` in k8s cluster mode driver when `spark.kubernetes.setSubmitTimeInDriver` is true"
