### PR TITLE
[SPARK-43006][PYTHON][TESTS] Fix DataFrameTests.test_cache_dataframe

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1036,7 +1036,7 @@ class DataFrameTestsMixin:
             self.assertEqual(df.storageLevel, StorageLevel.NONE)
 
             df.cache()
-            self.assertEqual(df.storageLevel, StorageLevel.MEMORY_AND_DISK)
+            self.assertEqual(df.storageLevel, StorageLevel.MEMORY_AND_DISK_DESER)
 
             df.unpersist()
             self.assertEqual(df.storageLevel, StorageLevel.NONE)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #40619.

Fixes `DataFrameTests.test_cache_dataframe`.

### Why are the changes needed?

The storage level when `df.cache()` should be `StorageLevel.MEMORY_AND_DISK_DESER` in Python.

The test passed before #40619 because the difference is `deserialized`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Fixed the test.