### PR TITLE
[SPARK-42855][SQL] Use runtime null checks in TableOutputResolver

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
@@ -55,10 +56,7 @@ object TableOutputResolver {
           tableName, actualExpectedCols, query)
       }
 
-      query.output.zip(actualExpectedCols).flatMap {
-        case (queryExpr, tableAttr) =>
-          checkField(tableAttr, queryExpr, byName, conf, err => errors += err, Seq(tableAttr.name))
-      }
+      resolveColumnsByPosition(query.output, actualExpectedCols, conf, errors += _)
     }
 
     if (errors.nonEmpty) {
@@ -99,17 +97,17 @@ object TableOutputResolver {
         }
         (matchedCol.dataType, expectedCol.dataType) match {
           case (matchedType: StructType, expectedType: StructType) =>
-            checkNullability(matchedCol, expectedCol, conf, addError, newColPath)
             resolveStructType(
-              matchedCol, matchedType, expectedType, expectedName, conf, addError, newColPath)
+              matchedCol, matchedType, expectedCol, expectedType,
+              byName = true, conf, addError, newColPath)
           case (matchedType: ArrayType, expectedType: ArrayType) =>
-            checkNullability(matchedCol, expectedCol, conf, addError, newColPath)
             resolveArrayType(
-              matchedCol, matchedType, expectedType, expectedName, conf, addError, newColPath)
+              matchedCol, matchedType, expectedCol, expectedType,
+              byName = true, conf, addError, newColPath)
           case (matchedType: MapType, expectedType: MapType) =>
-            checkNullability(matchedCol, expectedCol, conf, addError, newColPath)
             resolveMapType(
-              matchedCol, matchedType, expectedType, expectedName, conf, addError, newColPath)
+              matchedCol, matchedType, expectedCol, expectedType,
+              byName = true, conf, addError, newColPath)
           case _ =>
             checkField(expectedCol, matchedCol, byName = true, conf, addError, newColPath)
         }
@@ -130,38 +128,93 @@ object TableOutputResolver {
     }
   }
 
+  private def resolveColumnsByPosition(
+      inputCols: Seq[NamedExpression],
+      expectedCols: Seq[Attribute],
+      conf: SQLConf,
+      addError: String => Unit,
+      colPath: Seq[String] = Nil): Seq[NamedExpression] = {
+
+    if (inputCols.size > expectedCols.size) {
+      val extraColsStr = inputCols.takeRight(inputCols.size - expectedCols.size)
+        .map(col => s"'${col.name}'")
+        .mkString(", ")
+      addError(s"Cannot write extra fields to struct '${colPath.quoted}': $extraColsStr")
+      return Nil
+    } else if (inputCols.size < expectedCols.size) {
+      val missingColsStr = expectedCols.takeRight(expectedCols.size - inputCols.size)
+        .map(col => s"'${col.name}'")
+        .mkString(", ")
+      addError(s"Struct '${colPath.quoted}' missing fields: $missingColsStr")
+      return Nil
+    }
+
+    inputCols.zip(expectedCols).flatMap { case (inputCol, expectedCol) =>
+      val newColPath = colPath :+ expectedCol.name
+      (inputCol.dataType, expectedCol.dataType) match {
+        case (inputType: StructType, expectedType: StructType) =>
+          resolveStructType(
+            inputCol, inputType, expectedCol, expectedType,
+            byName = false, conf, addError, newColPath)
+        case (inputType: ArrayType, expectedType: ArrayType) =>
+          resolveArrayType(
+            inputCol, inputType, expectedCol, expectedType,
+            byName = false, conf, addError, newColPath)
+        case (inputType: MapType, expectedType: MapType) =>
+          resolveMapType(
+            inputCol, inputType, expectedCol, expectedType,
+            byName = false, conf, addError, newColPath)
+        case _ =>
+          checkField(expectedCol, inputCol, byName = false, conf, addError, newColPath)
+      }
+    }
+  }
+
   private def checkNullability(
       input: Expression,
       expected: Attribute,
       conf: SQLConf,
-      addError: String => Unit,
-      colPath: Seq[String]): Unit = {
-    if (input.nullable && !expected.nullable &&
-      conf.storeAssignmentPolicy != StoreAssignmentPolicy.LEGACY) {
-      addError(s"Cannot write nullable values to non-null column '${colPath.quoted}'")
+      colPath: Seq[String]): Expression = {
+    if (requiresNullChecks(input, expected, conf)) {
+      AssertNotNull(input, colPath)
+    } else {
+      input
     }
+  }
+
+  private def requiresNullChecks(
+      input: Expression,
+      attr: Attribute,
+      conf: SQLConf): Boolean = {
+    input.nullable && !attr.nullable && conf.storeAssignmentPolicy != StoreAssignmentPolicy.LEGACY
   }
 
   private def resolveStructType(
       input: NamedExpression,
       inputType: StructType,
+      expected: Attribute,
       expectedType: StructType,
-      expectedName: String,
+      byName: Boolean,
       conf: SQLConf,
       addError: String => Unit,
       colPath: Seq[String]): Option[NamedExpression] = {
+    val nullCheckedInput = checkNullability(input, expected, conf, colPath)
     val fields = inputType.zipWithIndex.map { case (f, i) =>
-      Alias(GetStructField(input, i, Some(f.name)), f.name)()
+      Alias(GetStructField(nullCheckedInput, i, Some(f.name)), f.name)()
     }
-    val reordered = reorderColumnsByName(fields, expectedType.toAttributes, conf, addError, colPath)
-    if (reordered.length == expectedType.length) {
-      val struct = CreateStruct(reordered)
-      val res = if (input.nullable) {
-        If(IsNull(input), Literal(null, struct.dataType), struct)
+    val resolved = if (byName) {
+      reorderColumnsByName(fields, expectedType.toAttributes, conf, addError, colPath)
+    } else {
+      resolveColumnsByPosition(fields, expectedType.toAttributes, conf, addError, colPath)
+    }
+    if (resolved.length == expectedType.length) {
+      val struct = CreateStruct(resolved)
+      val res = if (nullCheckedInput.nullable) {
+        If(IsNull(nullCheckedInput), Literal(null, struct.dataType), struct)
       } else {
         struct
       }
-      Some(Alias(res, expectedName)())
+      Some(Alias(res, expected.name)())
     } else {
       None
     }
@@ -170,61 +223,66 @@ object TableOutputResolver {
   private def resolveArrayType(
       input: NamedExpression,
       inputType: ArrayType,
+      expected: Attribute,
       expectedType: ArrayType,
-      expectedName: String,
+      byName: Boolean,
       conf: SQLConf,
       addError: String => Unit,
       colPath: Seq[String]): Option[NamedExpression] = {
-    if (inputType.containsNull && !expectedType.containsNull) {
-      addError(s"Cannot write nullable elements to array of non-nulls: '${colPath.quoted}'")
-      None
+    val nullCheckedInput = checkNullability(input, expected, conf, colPath)
+    val param = NamedLambdaVariable("element", inputType.elementType, inputType.containsNull)
+    val fakeAttr =
+      AttributeReference("element", expectedType.elementType, expectedType.containsNull)()
+    val res = if (byName) {
+      reorderColumnsByName(Seq(param), Seq(fakeAttr), conf, addError, colPath)
     } else {
-      val param = NamedLambdaVariable("element", inputType.elementType, inputType.containsNull)
-      val fakeAttr =
-        AttributeReference("element", expectedType.elementType, expectedType.containsNull)()
-      val res = reorderColumnsByName(Seq(param), Seq(fakeAttr), conf, addError, colPath)
-      if (res.length == 1) {
-        val func = LambdaFunction(res.head, Seq(param))
-        Some(Alias(ArrayTransform(input, func), expectedName)())
-      } else {
-        None
-      }
+      resolveColumnsByPosition(Seq(param), Seq(fakeAttr), conf, addError, colPath)
+    }
+    if (res.length == 1) {
+      val func = LambdaFunction(res.head, Seq(param))
+      Some(Alias(ArrayTransform(nullCheckedInput, func), expected.name)())
+    } else {
+      None
     }
   }
 
   private def resolveMapType(
       input: NamedExpression,
       inputType: MapType,
+      expected: Attribute,
       expectedType: MapType,
-      expectedName: String,
+      byName: Boolean,
       conf: SQLConf,
       addError: String => Unit,
       colPath: Seq[String]): Option[NamedExpression] = {
-    if (inputType.valueContainsNull && !expectedType.valueContainsNull) {
-      addError(s"Cannot write nullable values to map of non-nulls: '${colPath.quoted}'")
-      None
+    val nullCheckedInput = checkNullability(input, expected, conf, colPath)
+
+    val keyParam = NamedLambdaVariable("key", inputType.keyType, nullable = false)
+    val fakeKeyAttr = AttributeReference("key", expectedType.keyType, nullable = false)()
+    val resKey = if (byName) {
+      reorderColumnsByName(Seq(keyParam), Seq(fakeKeyAttr), conf, addError, colPath)
     } else {
-      val keyParam = NamedLambdaVariable("key", inputType.keyType, nullable = false)
-      val fakeKeyAttr = AttributeReference("key", expectedType.keyType, nullable = false)()
-      val resKey = reorderColumnsByName(
-        Seq(keyParam), Seq(fakeKeyAttr), conf, addError, colPath)
+      resolveColumnsByPosition(Seq(keyParam), Seq(fakeKeyAttr), conf, addError, colPath)
+    }
 
-      val valueParam =
-        NamedLambdaVariable("value", inputType.valueType, inputType.valueContainsNull)
-      val fakeValueAttr =
-        AttributeReference("value", expectedType.valueType, expectedType.valueContainsNull)()
-      val resValue = reorderColumnsByName(
-        Seq(valueParam), Seq(fakeValueAttr), conf, addError, colPath)
+    val valueParam =
+      NamedLambdaVariable("value", inputType.valueType, inputType.valueContainsNull)
+    val fakeValueAttr =
+      AttributeReference("value", expectedType.valueType, expectedType.valueContainsNull)()
+    val resValue = if (byName) {
+      reorderColumnsByName(Seq(valueParam), Seq(fakeValueAttr), conf, addError, colPath)
+    } else {
+      resolveColumnsByPosition(Seq(valueParam), Seq(fakeValueAttr), conf, addError, colPath)
+    }
 
-      if (resKey.length == 1 && resValue.length == 1) {
-        val keyFunc = LambdaFunction(resKey.head, Seq(keyParam))
-        val valueFunc = LambdaFunction(resValue.head, Seq(valueParam))
-        val newKeys = ArrayTransform(MapKeys(input), keyFunc)
-        val newValues = ArrayTransform(MapValues(input), valueFunc)
-        Some(Alias(MapFromArrays(newKeys, newValues), expectedName)())
-      } else {
-        None
-      }
+    if (resKey.length == 1 && resValue.length == 1) {
+      val keyFunc = LambdaFunction(resKey.head, Seq(keyParam))
+      val valueFunc = LambdaFunction(resValue.head, Seq(valueParam))
+      val newKeys = ArrayTransform(MapKeys(nullCheckedInput), keyFunc)
+      val newValues = ArrayTransform(MapValues(nullCheckedInput), valueFunc)
+      Some(Alias(MapFromArrays(newKeys, newValues), expected.name)())
+    } else {
+      None
     }
   }
 
@@ -254,6 +312,12 @@ object TableOutputResolver {
       !Cast.canUpCast(cast.child.dataType, cast.dataType)
   }
 
+  private def isCompatible(tableAttr: Attribute, queryExpr: NamedExpression): Boolean = {
+    DataTypeUtils.sameType(tableAttr.dataType, queryExpr.dataType) &&
+      tableAttr.name == queryExpr.name &&
+      tableAttr.metadata == queryExpr.metadata
+  }
+
   private def checkField(
       tableAttr: Attribute,
       queryExpr: NamedExpression,
@@ -269,12 +333,16 @@ object TableOutputResolver {
       tableAttr.dataType
     }
     val storeAssignmentPolicy = conf.storeAssignmentPolicy
-    lazy val outputField = if (DataTypeUtils.sameType(tableAttr.dataType, queryExpr.dataType) &&
-      tableAttr.name == queryExpr.name &&
-      tableAttr.metadata == queryExpr.metadata) {
-      Some(queryExpr)
+    lazy val outputField = if (isCompatible(tableAttr, queryExpr)) {
+      if (requiresNullChecks(queryExpr, tableAttr, conf)) {
+        val assert = AssertNotNull(queryExpr, colPath)
+        Some(Alias(assert, tableAttr.name)(explicitMetadata = Some(tableAttr.metadata)))
+      } else {
+        Some(queryExpr)
+      }
     } else {
-      val casted = cast(queryExpr, attrTypeWithoutCharVarchar, conf, colPath.quoted)
+      val nullCheckedQueryExpr = checkNullability(queryExpr, tableAttr, conf, colPath)
+      val casted = cast(nullCheckedQueryExpr, attrTypeWithoutCharVarchar, conf, colPath.quoted)
       val exprWithStrLenCheck = if (conf.charVarcharAsString || !attrTypeHasCharVarchar) {
         casted
       } else {
@@ -295,16 +363,8 @@ object TableOutputResolver {
         val canWrite = DataType.canWrite(
           queryExpr.dataType, attrTypeWithoutCharVarchar, byName, conf.resolver, colPath.quoted,
           storeAssignmentPolicy, addError)
-        if (queryExpr.nullable && !tableAttr.nullable) {
-          addError(s"Cannot write nullable values to non-null column '${colPath.quoted}'")
-          None
 
-        } else if (!canWrite) {
-          None
-
-        } else {
-          outputField
-        }
+        if (canWrite) outputField else None
     }
   }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/columnresolution.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/columnresolution.sql.out
@@ -337,7 +337,7 @@ CreateDataSourceTableCommand `spark_catalog`.`mydb1`.`t5`, false
 INSERT INTO t5 VALUES(1, (2, 3))
 -- !query analysis
 InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/mydb1.db/t5, false, Parquet, [path=file:[not included in comparison]/{warehouse_dir}/mydb1.db/t5], Append, `spark_catalog`.`mydb1`.`t5`, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(file:[not included in comparison]/{warehouse_dir}/mydb1.db/t5), [i1, t5]
-+- Project [cast(col1#x as int) AS i1#x, cast(col2#x as struct<i1:int,i2:int>) AS t5#x]
++- Project [cast(col1#x as int) AS i1#x, named_struct(i1, cast(col2#x.col1 as int), i2, cast(col2#x.col2 as int)) AS t5#x]
    +- LocalRelation [col1#x, col2#x]
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/RuntimeNullChecksV2Writes.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RuntimeNullChecksV2Writes.scala
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.util.Collections
+
+import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.sql.connector.catalog.{Column => ColumnV2, Identifier, InMemoryTableCatalog}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StructType}
+
+class RuntimeNullChecksV2Writes extends QueryTest with SQLTestUtils with SharedSparkSession {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  private final val FORMAT = "foo"
+  private final val CATALOG_NAME = "testcat"
+
+  protected override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.sql.catalog." + CATALOG_NAME, classOf[InMemoryTableCatalog].getName)
+      .set(SQLConf.DEFAULT_CATALOG.key, CATALOG_NAME)
+  }
+
+  protected def catalog: InMemoryTableCatalog = {
+    val catalog = spark.sessionState.catalogManager.catalog(CATALOG_NAME)
+    catalog.asTableCatalog.asInstanceOf[InMemoryTableCatalog]
+  }
+
+  test("NOT NULL checks for atomic top-level fields (byName)") {
+    checkNotNullTopLevelFields(byName = true)
+  }
+
+  test("NOT NULL checks for atomic top-level fields (byPosition)") {
+    checkNotNullTopLevelFields(byName = false)
+  }
+
+  private def checkNotNullTopLevelFields(byName: Boolean): Unit = {
+    withTable("t") {
+      sql(s"CREATE TABLE t (s STRING, i INT NOT NULL) USING $FORMAT")
+
+      val e = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql("SELECT 'txt' AS s, null AS i")
+          inputDF.writeTo("t").append()
+        } else {
+          sql("INSERT INTO t VALUES ('txt', null)")
+        }
+      }
+      assertNotNullException(e, Seq("i"))
+    }
+  }
+
+  test("NOT NULL checks for nested structs, arrays, maps (byName)") {
+    checkNotNullNestedStructArrayMap(byName = true)
+  }
+
+  test("NOT NULL checks for nested structs, arrays, maps (byPosition)") {
+    checkNotNullNestedStructArrayMap(byName = false)
+  }
+
+  private def checkNotNullNestedStructArrayMap(byName: Boolean): Unit = {
+    withTable("t") {
+      sql(
+        s"""CREATE TABLE t (
+           | i INT,
+           | s STRUCT<
+           |  ns: STRUCT<x: INT, y: INT> NOT NULL,
+           |  arr: ARRAY<INT> NOT NULL,
+           |  m: MAP<INT, INT> NOT NULL>)
+           |USING $FORMAT
+         """.stripMargin)
+
+      val e1 = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql(
+            s"""SELECT
+               | 1 AS i,
+               | named_struct('ns', null, 'arr', array(1), 'm', map(1, 1)) AS s
+             """.stripMargin)
+          inputDF.writeTo("t").append()
+        } else {
+          sql(
+            s"""INSERT INTO t VALUES (
+               | 1 AS i,
+               | named_struct('ns', null, 'arr', array(1), 'm', map(1, 1)) AS s)
+             """.stripMargin)
+        }
+      }
+      assertNotNullException(e1, Seq("s", "ns"))
+
+      val e2 = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql(
+            s"""SELECT
+               | 1 AS i,
+               | named_struct('ns', named_struct('x', 1, 'y', 1), 'arr', null, 'm', map(1, 1)) AS s
+           """.stripMargin)
+          inputDF.writeTo("t").append()
+        } else {
+          sql(
+            s"""INSERT INTO t VALUES (
+               | 1 AS i,
+               | named_struct('ns', named_struct('x', 1, 'y', 1), 'arr', null, 'm', map(1, 1)) AS s)
+             """.stripMargin)
+        }
+      }
+      assertNotNullException(e2, Seq("s", "arr"))
+
+      val e3 = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql(
+            s"""SELECT
+               | 1 AS i,
+               | named_struct('ns', named_struct('x', 1, 'y', 1), 'arr', array(1), 'm', null) AS s
+           """.stripMargin)
+          inputDF.writeTo("t").append()
+        } else {
+          sql(
+            s"""INSERT INTO t VALUES (
+               | 1 AS i,
+               | named_struct('ns', named_struct('x', 1, 'y', 1), 'arr', array(1), 'm', null))
+             """.stripMargin)
+        }
+      }
+      assertNotNullException(e3, Seq("s", "m"))
+    }
+  }
+
+  test("NOT NULL checks for nested struct fields (byName)") {
+    checkNotNullNestedStructFields(byName = true)
+  }
+
+  test("NOT NULL checks for nested struct fields (byPosition)") {
+    checkNotNullNestedStructFields(byName = false)
+  }
+
+  private def checkNotNullNestedStructFields(byName: Boolean): Unit = {
+    withTable("t") {
+      sql(
+        s"""CREATE TABLE t (
+           | i INT,
+           | s STRUCT<ni: INT, ns: STRUCT<x: INT NOT NULL, y: INT>>)
+           |USING $FORMAT
+         """.stripMargin)
+
+      if (byName) {
+        val inputDF = sql(
+          s"""SELECT
+             | 1 AS i,
+             | named_struct('ni', 1, 'ns', null) AS s
+           """.stripMargin)
+        inputDF.writeTo("t").append()
+      } else {
+        sql(
+          s"""INSERT INTO t VALUES (
+             | 1 AS i,
+             | named_struct('ni', 1, 'ns', null) AS s)
+           """.stripMargin)
+      }
+      checkAnswer(spark.table("t"), Row(1, Row(1, null)))
+
+      val e = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql(
+            s"""SELECT
+               | 1 AS i,
+               | named_struct('ni', 1, 'ns', named_struct('x', null, 'y', 1)) AS s
+             """.stripMargin)
+          inputDF.writeTo("t").append()
+        } else {
+          sql(
+            s"""INSERT INTO t VALUES (
+               | 1 AS i,
+               | named_struct('ni', 1, 'ns', named_struct('x', null, 'y', 1)) AS s)
+             """.stripMargin)
+        }
+      }
+      assertNotNullException(e, Seq("s", "ns", "x"))
+    }
+  }
+
+  test("NOT NULL checks for nullable array with required element (byName)") {
+    checkNullableArrayWithNotNullElement(byName = true)
+  }
+
+  test("NOT NULL checks for nullable array with required element (byPosition)") {
+    checkNullableArrayWithNotNullElement(byName = false)
+  }
+
+  private def checkNullableArrayWithNotNullElement(byName: Boolean): Unit = {
+    withTable("t") {
+      val structType = new StructType().add("x", "int").add("y", "int")
+      catalog.createTable(
+        ident = Identifier.of(Array(), "t"),
+        columns = Array(
+          ColumnV2.create("i", IntegerType),
+          ColumnV2.create("arr", ArrayType(structType, containsNull = false))),
+        partitions = Array.empty[Transform],
+        properties = Collections.emptyMap[String, String])
+
+      if (byName) {
+        val inputDF = sql("SELECT 1 AS i, null AS arr")
+        inputDF.writeTo("t").append()
+      } else {
+        sql("INSERT INTO t VALUES (1 AS i, null AS arr)")
+      }
+      checkAnswer(spark.table("t"), Row(1, null))
+
+      val e = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql(
+            s"""SELECT
+               | 1 AS i,
+               | array(null, named_struct('x', 1, 'y', 1)) AS arr
+             """.stripMargin)
+          inputDF.writeTo("t").append()
+        } else {
+          sql(
+            s"""INSERT INTO t VALUES (
+               | 1 AS i,
+               | array(null, named_struct('x', 1, 'y', 1)) AS arr)
+             """.stripMargin)
+        }
+      }
+      assertNotNullException(e, Seq("arr", "element"))
+    }
+  }
+
+  test("NOT NULL checks for fields inside nullable array (byName)") {
+    checkNotNullFieldsInsideNullableArray(byName = true)
+  }
+
+  test("not null checks for fields inside nullable array (byPosition)") {
+    checkNotNullFieldsInsideNullableArray(byName = false)
+  }
+
+  private def checkNotNullFieldsInsideNullableArray(byName: Boolean): Unit = {
+    withTable("t") {
+      val structType = new StructType().add("x", "int", nullable = false).add("y", "int")
+      catalog.createTable(
+        ident = Identifier.of(Array(), "t"),
+        columns = Array(
+          ColumnV2.create("i", IntegerType),
+          ColumnV2.create("arr", ArrayType(structType, containsNull = true))),
+        partitions = Array.empty[Transform],
+        properties = Collections.emptyMap[String, String])
+
+      if (byName) {
+        val inputDF = sql(
+          s"""SELECT
+             | 1 AS i,
+             | array(null, named_struct('x', 1, 'y', 1)) AS arr
+           """.stripMargin)
+        inputDF.writeTo("t").append()
+      } else {
+        sql(
+          s"""INSERT INTO t VALUES (
+             | 1 AS i,
+             | array(null, named_struct('x', 1, 'y', 1)) AS arr)
+           """.stripMargin)
+      }
+      checkAnswer(spark.table("t"), Row(1, List(null, Row(1, 1))))
+
+      val e = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql(
+            s"""SELECT
+               | 1 AS i,
+               | array(null, named_struct('x', null, 'y', 1)) AS arr
+             """.stripMargin)
+          inputDF.writeTo("t").append()
+        } else {
+          sql(
+            s"""INSERT INTO t VALUES (
+               | 1 AS i,
+               | array(null, named_struct('x', null, 'y', 1)) AS arr)
+             """.stripMargin)
+        }
+      }
+      assertNotNullException(e, Seq("arr", "element", "x"))
+    }
+  }
+
+  test("NOT NULL checks for nullable map with required values (byName)") {
+    checkNullableMapWithNonNullValues(byName = true)
+  }
+
+  test("NOT NULL checks for nullable map with required values (byPosition)") {
+    checkNullableMapWithNonNullValues(byName = false)
+  }
+
+  private def checkNullableMapWithNonNullValues(byName: Boolean): Unit = {
+    withTable("t") {
+      catalog.createTable(
+        ident = Identifier.of(Array(), "t"),
+        columns = Array(
+          ColumnV2.create("i", IntegerType),
+          ColumnV2.create("m", MapType(IntegerType, IntegerType, valueContainsNull = false))),
+        partitions = Array.empty[Transform],
+        properties = Collections.emptyMap[String, String])
+
+      if (byName) {
+        val inputDF = sql("SELECT 1 AS i, null AS m")
+        inputDF.writeTo("t").append()
+      } else {
+        sql("INSERT INTO t VALUES (1 AS i, null AS m)")
+      }
+      checkAnswer(spark.table("t"), Row(1, null))
+
+      val e = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql("SELECT 1 AS i, map(1, null) AS m")
+          inputDF.writeTo("t").append()
+        } else {
+          sql("INSERT INTO t VALUES (1 AS i, map(1, null) AS m)")
+        }
+      }
+      assertNotNullException(e, Seq("m", "value"))
+    }
+  }
+
+  test("NOT NULL checks for fields inside nullable maps (byName)") {
+    checkNotNullFieldsInsideNullableMap(byName = true)
+  }
+
+  test("NOT NULL checks for fields inside nullable maps (byPosition)") {
+    checkNotNullFieldsInsideNullableMap(byName = false)
+  }
+
+  private def checkNotNullFieldsInsideNullableMap(byName: Boolean): Unit = {
+    withTable("t") {
+      val structType = new StructType().add("x", "int", nullable = false).add("y", "int")
+      catalog.createTable(
+        ident = Identifier.of(Array(), "t"),
+        columns = Array(
+          ColumnV2.create("i", IntegerType),
+          ColumnV2.create("m", MapType(structType, structType, valueContainsNull = true))),
+        partitions = Array.empty[Transform],
+        properties = Collections.emptyMap[String, String])
+
+      if (byName) {
+        val inputDF = sql("SELECT 1 AS i, map(named_struct('x', 1, 'y', 1), null) AS m")
+        inputDF.writeTo("t").append()
+      } else {
+        sql("INSERT INTO t VALUES (1 AS i, map(named_struct('x', 1, 'y', 1), null) AS m)")
+      }
+      checkAnswer(spark.table("t"), Row(1, Map(Row(1, 1) -> null)))
+
+      val e1 = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql(
+            s"""SELECT
+               | 1 AS i,
+               | map(named_struct('x', null, 'y', 1), null) AS m
+             """.stripMargin)
+          inputDF.writeTo("t").append()
+        } else {
+          sql(
+            s"""INSERT INTO t VALUES (
+               | 1 AS i,
+               | map(named_struct('x', null, 'y', 1), null) AS m)
+             """.stripMargin)
+        }
+      }
+      assertNotNullException(e1, Seq("m", "key", "x"))
+
+      val e2 = intercept[SparkException] {
+        if (byName) {
+          val inputDF = sql(
+            s"""SELECT
+               | 1 AS i,
+               | map(named_struct('x', 1, 'y', 1), named_struct('x', null, 'y', 1)) AS m
+             """.stripMargin)
+          inputDF.writeTo("t").append()
+        } else {
+          sql(
+            s"""INSERT INTO t VALUES (
+               | 1 AS i,
+               | map(named_struct('x', 1, 'y', 1), named_struct('x', null, 'y', 1)) AS m)
+             """.stripMargin)
+        }
+      }
+      assertNotNullException(e2, Seq("m", "value", "x"))
+    }
+  }
+
+  private def assertNotNullException(e: SparkException, colPath: Seq[String]): Unit = {
+    e.getCause match {
+      case npe: NullPointerException =>
+        assert(npe.getMessage.contains("Null value appeared in non-nullable field"))
+        assert(npe.getMessage.contains(colPath.mkString("\n", "\n", "\n")))
+      case other =>
+        fail(s"Unexpected exception cause: $other")
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -855,10 +855,10 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
       spark.sessionState.catalog.createTable(newTable, false)
 
       sql("INSERT INTO TABLE test_table SELECT 1, 'a'")
-      val msg = intercept[AnalysisException] {
+      val msg = intercept[SparkException] {
         sql("INSERT INTO TABLE test_table SELECT 2, null")
-      }.getMessage
-      assert(msg.contains("Cannot write nullable values to non-null column 's'"))
+      }.getCause.getMessage
+      assert(msg.contains("Null value appeared in non-nullable field"))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR migrates `TableOutputResolver` to use runtime NOT NULL checks instead of checking type compatibility during the analysis phase.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed per discussion that happened [here](https://github.com/apache/spark/pull/40308#discussion_r1127081206).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Nullability exceptions will be thrown at runtime (instead of analysis) but there is no API change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This PR comes with tests.
