### PR TITLE
Improve IDE build experience against jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3583,6 +3583,16 @@
     </profile>
 
     <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <properties>
+        <java.version>11</java.version>
+      </properties>
+    </profile>
+    
+    <profile>
       <id>scala-2.12</id>
       <properties>
         <!--


### PR DESCRIPTION
### What changes were proposed in this pull request?
Building the project against jdk11 on IDE shows errors because `Platform.java` depends on `sun.misc` which is in `jdk.unsupported` module in jdk11. The problem goes away when we pass `java.version` as `11` to maven as system D parameters.

This PR set `java.version` to `11` by detecting jdk version automatically and improves build experience.

### Why are the changes needed?
It makes build experience on IDE against jdk11 smoother.

### Does this PR introduce _any_ user-facing change?
Users won't have to specify java.version in maven parameters any more since the profile gets activated automagically based on the jdk version.


### How was this patch tested?
This patch was tested by building locally.