### PR TITLE
[SPARK-42983][CONNECT][PYTHON] Fix createDataFrame to handle 0-dim numpy array properly

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -227,7 +227,9 @@ class SparkSession:
             _cols = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
             _num_cols = len(_cols)
 
-        if isinstance(data, Sized) and len(data) == 0:
+        if isinstance(data, np.ndarray) and data.ndim not in [1, 2]:
+            raise ValueError("NumPy array input should be of 1 or 2 dimensions.")
+        elif isinstance(data, Sized) and len(data) == 0:
             if _schema is not None:
                 return DataFrame.withPlan(LocalRelation(table=None, schema=_schema.json()), self)
             elif _schema_str is not None:
@@ -284,9 +286,6 @@ class SparkSession:
                 _table = _table.rename_columns(schema.names).cast(arrow_schema)
 
         elif isinstance(data, np.ndarray):
-            if data.ndim not in [1, 2]:
-                raise ValueError("NumPy array input should be of 1 or 2 dimensions.")
-
             if _cols is None:
                 if data.ndim == 1 or data.shape[1] == 1:
                     _cols = ["value"]

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -42,8 +42,6 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase):
     def test_createDataFrame_with_map_type(self):
         self.check_createDataFrame_with_map_type(True)
 
-    # TODO(SPARK-42983): len() of unsized object
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_createDataFrame_with_ndarray(self):
         self.check_createDataFrame_with_ndarray(True)
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -567,14 +567,16 @@ class ArrowTestsMixin:
         )
         arrs = self.create_np_arrs
 
-        for arr, dtypes in zip(arrs, expected_dtypes):
-            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
+        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
+            for arr, dtypes in zip(arrs, expected_dtypes):
                 df = self.spark.createDataFrame(arr)
-            self.assertEqual(df.dtypes, dtypes)
-            np.array_equal(np.array(df.collect()), arr)
+                self.assertEqual(df.dtypes, dtypes)
+                np.array_equal(np.array(df.collect()), arr)
 
-        with self.assertRaisesRegex(ValueError, "NumPy array input should be of 1 or 2 dimensions"):
-            self.spark.createDataFrame(np.array(0))
+            with self.assertRaisesRegex(
+                ValueError, "NumPy array input should be of 1 or 2 dimensions"
+            ):
+                self.spark.createDataFrame(np.array(0))
 
     def test_createDataFrame_with_array_type(self):
         for arrow_enabled in [True, False]:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `createDataFrame` to handle 0-dim numpy array properly.

### Why are the changes needed?

When 0-dim numpy array is passed to `createDataFrame`, it raises an unexpected error:

```py
>>> import numpy as np
>>> spark.createDataFrame(np.array(0))
Traceback (most recent call last):
...
TypeError: len() of unsized object
```

The error message should be:

```py
ValueError: NumPy array input should be of 1 or 2 dimensions.
```

### Does this PR introduce _any_ user-facing change?

It will show a proper error message.

### How was this patch tested?

Enabled/updated the related test.