### PR TITLE
[SPARK-41537][INFRA][CONNECT][FOLLOW-UP] Removes breaking changes within master branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,6 +30,7 @@ on:
         description: Branch to run the build against
         required: false
         type: string
+        # Change 'master' to 'branch-3.5' in branch-3.5 branch after cutting it.
         default: master
       hadoop:
         description: Hadoop version to run with. HADOOP_PROFILE environment variable should accept it.
@@ -101,7 +102,7 @@ jobs:
               \"java-11-17\": \"true\",
               \"lint\" : \"true\",
               \"k8s-integration-tests\" : \"true\",
-              \"proto-breaking-changes-check\" : \"true\",
+              \"breaking-changes-buf\" : \"true\",
             }"
           echo $precondition # For debugging
           # Remove `\n` to avoid "Invalid format" error
@@ -494,17 +495,12 @@ jobs:
         name: test-results-sparkr--8-${{ inputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
 
-  proto-breaking-changes-check-master:
+  breaking-changes-buf:
     needs: [precondition]
-    if: always() && fromJson(needs.precondition.outputs.required).proto-breaking-changes-check == 'true'
-    name: Spark Connect proto backwards compatibility check (master)
-    continue-on-error: true
+    if: always() && fromJson(needs.precondition.outputs.required).breaking-changes-buf == 'true'
+    # Change 'branch-3.4' to 'branch-3.5' in master branch after cutting branch-3.5 branch.
+    name: Breaking change detection with Buf (branch-3.4)
     runs-on: ubuntu-22.04
-    env:
-      LC_ALL: C.UTF-8
-      LANG: C.UTF-8
-      PYSPARK_DRIVER_PYTHON: python3.9
-      PYSPARK_PYTHON: python3.9
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v3
@@ -512,57 +508,18 @@ jobs:
         fetch-depth: 0
         repository: apache/spark
         ref: ${{ inputs.branch }}
-    - name: Add GITHUB_WORKSPACE to git trust safe.directory
-      run: |
-        git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
         git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
-    # Install the `buf` CLI
-    - uses: bufbuild/buf-setup-action@v1
+    - name: Install Buf
+      uses: bufbuild/buf-setup-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-    # Run buf breaking.
-    - uses: bufbuild/buf-breaking-action@v1
-      with:
-        input: connector/connect/common/src/main
-        against: 'https://github.com/apache/spark.git#branch=master,subdir=connector/connect/common/src/main'
-
-  proto-breaking-changes-check-release:
-    needs: [precondition]
-    if: always() && fromJson(needs.precondition.outputs.required).proto-breaking-changes-check == 'true'
-    name: Spark Connect proto backwards compatibility check (master)
-    runs-on: ubuntu-22.04
-    env:
-      LC_ALL: C.UTF-8
-      LANG: C.UTF-8
-      PYSPARK_DRIVER_PYTHON: python3.9
-      PYSPARK_PYTHON: python3.9
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ inputs.branch }}
-    - name: Add GITHUB_WORKSPACE to git trust safe.directory
-      run: |
-        git config --global --add safe.directory ${GITHUB_WORKSPACE}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
-    # Install the `buf` CLI
-    - uses: bufbuild/buf-setup-action@v1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-    # Run buf breaking.
-    - uses: bufbuild/buf-breaking-action@v1
+    - name: Detect breaking changes
+      uses: bufbuild/buf-breaking-action@v1
       with:
         input: connector/connect/common/src/main
         against: 'https://github.com/apache/spark.git#branch=branch-3.4,subdir=connector/connect/common/src/main'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/39294 that proposes to remove the breaking change detection within `master` branch. 

### Why are the changes needed?

Apache Spark does not guarantee the compatibility between individual commits but between releases according to semantic versioning.

It would have been great if we can use this job as a sort of warning but this feature is missing in GitHub Actions. See also:
- https://github.com/orgs/community/discussions/15452
- https://github.com/actions/runner/issues/2347

Therefore, we cannot use this as a warning.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will be tested within my fork first.
