### PR TITLE
[SPARK-43044][CONNECT][BUILD] Upgrade buf to v1.17.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -655,7 +655,7 @@ jobs:
     - name: Install dependencies for Python code generation check
       run: |
         # See more in "Installation" https://docs.buf.build/installation#tarball
-        curl -LO https://github.com/bufbuild/buf/releases/download/v1.16.0/buf-Linux-x86_64.tar.gz
+        curl -LO https://github.com/bufbuild/buf/releases/download/v1.17.0/buf-Linux-x86_64.tar.gz
         mkdir -p $HOME/buf
         tar -xvzf buf-Linux-x86_64.tar.gz -C $HOME/buf --strip-components 1
         python3.9 -m pip install 'protobuf==3.19.5' 'mypy-protobuf==3.3.0'

--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -120,7 +120,7 @@ Prerequisite
 
 PySpark development requires to build Spark that needs a proper JDK installed, etc. See `Building Spark <https://spark.apache.org/docs/latest/building-spark.html>`_ for more details.
 
-Note that if you intend to contribute to Spark Connect in Python, ``buf`` version ``1.16.0`` is required, see `Buf Installation <https://docs.buf.build/installation>`_ for more details.
+Note that if you intend to contribute to Spark Connect in Python, ``buf`` version ``1.17.0`` is required, see `Buf Installation <https://docs.buf.build/installation>`_ for more details.
 
 Conda
 ~~~~~


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade buf from 1.16.0 to 1.17.0

### Why are the changes needed?
Release Notes: https://github.com/bufbuild/buf/releases
<img width="640" alt="image" src="https://user-images.githubusercontent.com/15246973/230250728-97bcbdc9-c79b-4480-a732-a84072aa16fe.png">

https://github.com/bufbuild/buf/compare/v1.16.0...v1.17.0

Manually test: dev/connect-gen-protos.sh
This upgrade will not change the generated files.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test and Pass GA.