### PR TITLE
[SPARK-43052][CORE] Handle stacktrace with null file name in event log

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1558,7 +1558,7 @@ private[spark] object JsonProtocol {
     json.extractElements.map { line =>
       val declaringClass = line.get("Declaring Class").extractString
       val methodName = line.get("Method Name").extractString
-      val fileName = line.get("File Name").extractString
+      val fileName = jsonOption(line.get("File Name")).map(_.extractString).orNull
       val lineNumber = line.get("Line Number").extractInt
       new StackTraceElement(declaringClass, methodName, fileName, lineNumber)
     }.toArray

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -809,6 +809,11 @@ class JsonProtocolSuite extends SparkFunSuite {
       JsonProtocol.taskEndReasonFromJson(exceptionFailureJson).asInstanceOf[ExceptionFailure]
     assert(exceptionFailure.description == null)
   }
+
+  test("SPARK-43052: Handle stackTrace with null file name") {
+    val stackTrace = Seq(new StackTraceElement("class", "method", null, -1)).toArray
+    testStackTrace(stackTrace)
+  }
 }
 
 
@@ -902,6 +907,12 @@ private[spark] object JsonProtocolSuite extends Assertions {
     val newReason = JsonProtocol.taskEndReasonFromJson(
       toJsonString(JsonProtocol.taskEndReasonToJson(reason, _)))
     assertEquals(reason, newReason)
+  }
+
+  private def testStackTrace(stackTrace: Array[StackTraceElement]): Unit = {
+    val newStackTrace = JsonProtocol.stackTraceFromJson(
+      toJsonString(JsonProtocol.stackTraceToJson(stackTrace, _)))
+    assertSeqEquals(stackTrace, newStackTrace, assertStackTraceElementEquals)
   }
 
   private def testBlockId(blockId: BlockId): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Handle stacktrace with null file name in event log

### Why are the changes needed?
NPE error when handling stacktrace with null file name in event log

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added test in JsonProtocolSuite
