### PR TITLE
[SPARK-43064][SQL] Spark SQL CLI SQL tab should only show once statement once

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -67,7 +67,7 @@ private[hive] class SparkSQLDriver(val context: SQLContext = SparkSQLEnv.sqlCont
       context.sparkContext.setJobDescription(substitutorCommand)
       val execution = context.sessionState.executePlan(context.sql(command).logicalPlan)
       // The SQL command has been executed above via `executePlan`, therefore we don't need to
-      // wrap it again with a new execution ID when getting Hive result
+      // wrap it again with a new execution ID when getting Hive result.
       execution.logical match {
         case _: CommandResult =>
           hiveResponse = hiveResultString(execution.executedPlan)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -66,8 +66,10 @@ private[hive] class SparkSQLDriver(val context: SQLContext = SparkSQLEnv.sqlCont
       }
       context.sparkContext.setJobDescription(substitutorCommand)
       val execution = context.sessionState.executePlan(context.sql(command).logicalPlan)
+      // Command type sql have been executed when call `context.sql(command).logicalPlan`,
+      // here Spark SQL CLI don't need to wrap it with new execution id when get hive result.
       execution.logical match {
-        case CommandResult(_, _, _, _) =>
+        case _: CommandResult =>
           hiveResponse = hiveResultString(execution.executedPlan)
         case _ =>
           hiveResponse = SQLExecution.withNewExecutionId(execution, Some("cli")) {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse
 import org.apache.spark.SparkThrowable
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.catalyst.plans.logical.CommandResult
 import org.apache.spark.sql.execution.{QueryExecution, SQLExecution}
 import org.apache.spark.sql.execution.HiveResult.hiveResultString
 import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
@@ -65,8 +66,13 @@ private[hive] class SparkSQLDriver(val context: SQLContext = SparkSQLEnv.sqlCont
       }
       context.sparkContext.setJobDescription(substitutorCommand)
       val execution = context.sessionState.executePlan(context.sql(command).logicalPlan)
-      hiveResponse = SQLExecution.withNewExecutionId(execution, Some("cli")) {
-        hiveResultString(execution.executedPlan)
+      execution.logical match {
+        case CommandResult(_, _, _, _) =>
+          hiveResponse = hiveResultString(execution.executedPlan)
+        case _ =>
+          hiveResponse = SQLExecution.withNewExecutionId(execution, Some("cli")) {
+            hiveResultString(execution.executedPlan)
+          }
       }
       tableSchema = getResultSetSchema(execution)
       new CommandProcessorResponse(0)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -66,8 +66,8 @@ private[hive] class SparkSQLDriver(val context: SQLContext = SparkSQLEnv.sqlCont
       }
       context.sparkContext.setJobDescription(substitutorCommand)
       val execution = context.sessionState.executePlan(context.sql(command).logicalPlan)
-      // Command type sql have been executed when call `context.sql(command).logicalPlan`,
-      // here Spark SQL CLI don't need to wrap it with new execution id when get hive result.
+      // The SQL command has been executed above via `executePlan`, therefore we don't need to
+      // wrap it again with a new execution ID when getting Hive result
       execution.logical match {
         case _: CommandResult =>
           hiveResponse = hiveResultString(execution.executedPlan)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Before 
<img width="1789" alt="截屏2023-04-07 下午4 22 54" src="https://user-images.githubusercontent.com/46485123/230573688-42acb9f2-6fa0-48d0-bfde-c7ceeb306aef.png">

After 
<img width="1792" alt="截屏2023-04-07 下午4 24 02" src="https://user-images.githubusercontent.com/46485123/230573720-2c2a7731-d776-439c-ba6f-0dad9dc87a42.png">



### Why are the changes needed?
Don't need show twice, too weird


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
MT
