### PR TITLE
[SPARK-43069][BUILD] Use `sbt-eclipse` instead of `sbteclipse-plugin`

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,7 +27,7 @@ libraryDependencies += "com.google.guava" % "guava" % "31.0.1-jre"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.0")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
+addSbtPlugin("com.github.sbt" % "sbt-eclipse" % "6.0.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `sbt-eclipse` instead of `sbteclipse-plugin`.

### Why are the changes needed?

Thanks to SPARK-34959, Apache Spark 3.2+ uses SBT 1.5.0 and we can use `set-eclipse` instead of old `sbteclipse-plugin`.
- https://github.com/sbt/sbt-eclipse/releases/tag/6.0.0
  - Add support for Java Execution Environments 9, 10, 11, 12, 13

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only plugin.

### How was this patch tested?

Pass the CIs and manual tests.

```
$ build/sbt eclipse
Using /Users/dongjoon/.jenv/versions/1.8 as default JAVA_HOME.
Note, this will be overridden by -java-home if it is set.
Using SPARK_LOCAL_IP=localhost
Attempting to fetch sbt
Launching sbt from build/sbt-launch-1.8.2.jar
[info] welcome to sbt 1.8.2 (AppleJDK-8.0.302.8.1 Java 1.8.0_302)
[info] loading settings for project spark-merge-build from plugins.sbt ...
[info] loading project definition from /Users/dongjoon/APACHE/spark-merge/project
[info] Updating
https://repo1.maven.org/maven2/com/github/sbt/sbt-eclipse_2.12_1.0/6.0.0/sbt-eclipse-6.0.0.pom
  100.0% [##########] 2.5 KiB (4.5 KiB / s)
...
```