### PR TITLE
[SPARK-43070][BUILD] Upgrade `sbt-unidoc` to 0.5.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,7 +33,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
+addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `sbt-unidoc` to 0.5.0 for Apache Spark 3.5.0.

### Why are the changes needed?

Since v0.5.0, organization has moved from `com.eed3si9n` to `com.github.sbt`

- https://github.com/sbt/sbt-unidoc/releases/tag/v0.5.0
  - Add support for Scala 3

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only change.

### How was this patch tested?

Pass the documentation generation CIs.