### PR TITLE
[SPARK-43007][TESTS][FOLLOWUP] Regenerate benchmark results of `StateStoreBasicOperationsBenchmark`

### DIFF
--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk11-results.txt
@@ -2,182 +2,182 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8             10           1          1.2         809.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              59             74          10          0.2        5888.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                             15             18           2          0.7        1476.8       0.5X
+In-memory                                                            9             11           1          1.2         869.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              55             59           1          0.2        5544.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             15             17           1          0.7        1466.2       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (7500 rows to overwrite - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8             10           1          1.2         813.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            54             68           9          0.2        5406.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             19           2          0.6        1594.1       0.5X
+In-memory                                                          9             10           1          1.2         851.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            52             55           1          0.2        5168.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             17           1          0.7        1521.9       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             11           1          1.1         871.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            50             58           6          0.2        4988.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             19           2          0.6        1597.5       0.5X
+In-memory                                                          9             10           1          1.2         864.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            46             49           1          0.2        4568.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           16             17           1          0.6        1561.6       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (2500 rows to overwrite - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             11           1          1.1         877.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            44             50           5          0.2        4387.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             18           2          0.7        1486.8       0.6X
+In-memory                                                          9             10           1          1.2         862.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            40             43           1          0.3        3968.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             17           1          0.7        1519.9       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8             10           1          1.2         800.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            36             44           5          0.3        3576.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             17           1          0.7        1460.8       0.5X
+In-memory                                                          8             10           1          1.2         842.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            36             38           1          0.3        3579.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             17           1          0.6        1542.7       0.5X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (500 rows to overwrite - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                        8             10           1          1.2         806.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                          34             41           4          0.3        3436.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                         15             17           1          0.7        1461.2       0.6X
+In-memory                                                        8             10           1          1.2         839.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                          34             37           1          0.3        3400.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                         15             17           1          0.7        1530.3       0.5X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      8              9           1          1.3         781.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        32             39           4          0.3        3201.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       15             17           1          0.7        1450.6       0.5X
+In-memory                                                      8             10           1          1.2         834.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        33             36           1          0.3        3316.0       0.3X
+RocksDB (trackTotalNumberOfRows: false)                       15             17           1          0.7        1517.5       0.5X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         13.8          72.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          30             37           4          0.3        3048.6       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         13             16           2          0.8        1306.5       0.1X
+In-memory                                                                                        1              1           0         11.5          86.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          31             33           1          0.3        3076.2       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         13             15           1          0.8        1318.3       0.1X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(7500 rows are non-existing - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           1          1.7         582.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        40             47           5          0.2        4033.0       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       13             16           2          0.8        1287.1       0.5X
+In-memory                                                                                      6              7           1          1.7         584.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        37             39           1          0.3        3655.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       13             14           1          0.8        1303.6       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              8           1          1.6         630.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        49             56           6          0.2        4901.4       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       14             17           1          0.7        1424.2       0.4X
+In-memory                                                                                      6              8           1          1.6         638.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        42             45           1          0.2        4235.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       13             14           1          0.8        1311.7       0.5X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(2500 rows are non-existing - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              9           1          1.5         682.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        52             64           9          0.2        5179.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       13             15           1          0.8        1295.2       0.5X
+In-memory                                                                                      7              8           1          1.5         684.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        48             51           1          0.2        4824.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       13             14           1          0.8        1309.5       0.5X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.5         654.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        55             68           9          0.2        5488.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       14             16           1          0.7        1355.0       0.5X
+In-memory                                                                                      7              8           1          1.4         722.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        52             54           1          0.2        5160.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       13             14           1          0.8        1301.6       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(500 rows are non-existing - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                    7              9           2          1.4         705.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                      57             70           9          0.2        5718.9       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                     13             16           2          0.8        1293.3       0.5X
+In-memory                                                                                    7              9           1          1.4         729.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                      52             56           1          0.2        5232.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                     13             15           1          0.8        1314.2       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              8           1          1.5         662.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    57             71          10          0.2        5672.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   13             15           1          0.8        1264.9       0.5X
+In-memory                                                                                  7              9           1          1.4         719.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    52             56           1          0.2        5242.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   13             14           1          0.8        1255.1       0.6X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              8           1          1.5         666.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              54             68          11          0.2        5385.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             13             16           2          0.8        1252.6       0.5X
+In-memory                                                                            7              8           1          1.4         702.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              51             54           1          0.2        5067.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             12             14           0          0.8        1234.6       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 7500 rows (maxTimestampToEvictInMillis: 7499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           7              8           1          1.5         652.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             42             54           9          0.2        4222.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                            12             13           1          0.9        1151.5       0.6X
+In-memory                                                                           7              8           1          1.5         670.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             39             42           1          0.3        3934.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                            11             12           0          0.9        1065.4       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              8           1          1.6         626.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             30             38           7          0.3        2997.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                            10             11           1          1.0         959.9       0.7X
+In-memory                                                                           6              7           1          1.6         621.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             28             30           1          0.4        2763.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             9             10           0          1.1         901.2       0.7X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 2500 rows (maxTimestampToEvictInMillis: 2499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           1          1.8         571.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             18             22           3          0.5        1841.1       0.3X
-RocksDB (trackTotalNumberOfRows: false)                                             7              9           1          1.3         748.9       0.8X
+In-memory                                                                           6              7           0          1.7         573.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             16             17           0          0.6        1640.5       0.3X
+RocksDB (trackTotalNumberOfRows: false)                                             7              8           0          1.5         683.8       0.8X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          5              7           1          1.9         530.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            10             12           2          1.0        1024.8       0.5X
-RocksDB (trackTotalNumberOfRows: false)                                            6              7           1          1.7         577.5       0.9X
+In-memory                                                                          5              6           0          1.9         532.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            10             10           0          1.0         954.0       0.6X
+RocksDB (trackTotalNumberOfRows: false)                                            6              6           0          1.8         561.2       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 500 rows (maxTimestampToEvictInMillis: 499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                         5              6           1          2.0         489.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            8              9           1          1.3         796.0       0.6X
-RocksDB (trackTotalNumberOfRows: false)                                           6              7           1          1.8         558.4       0.9X
+In-memory                                                                         5              6           0          1.9         533.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            7              8           0          1.4         734.9       0.7X
+RocksDB (trackTotalNumberOfRows: false)                                           5              6           0          2.0         503.3       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         15.4          65.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         5              6           1          1.9         513.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        5              6           1          2.0         492.1       0.1X
+In-memory                                                                      1              1           0         12.3          81.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         5              6           0          2.0         499.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                        5              6           0          2.0         490.6       0.2X
 
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk17-results.txt
@@ -2,182 +2,182 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            9             10           1          1.2         854.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              52             54           1          0.2        5197.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             14             15           0          0.7        1420.1       0.6X
+In-memory                                                            8              9           1          1.2         804.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              50             52           1          0.2        5047.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             13             14           0          0.8        1313.9       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (7500 rows to overwrite - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             11           1          1.1         878.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            48             50           1          0.2        4819.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           14             16           1          0.7        1385.6       0.6X
+In-memory                                                          8              9           0          1.2         816.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            46             47           1          0.2        4563.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           13             13           0          0.8        1270.7       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             11           1          1.1         888.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            41             43           1          0.2        4143.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             15           1          0.8        1331.0       0.7X
+In-memory                                                          8              9           0          1.2         818.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            41             42           1          0.2        4050.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1286.8       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (2500 rows to overwrite - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             11           1          1.1         881.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            36             38           1          0.3        3591.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             15           0          0.8        1320.7       0.7X
+In-memory                                                          8              9           1          1.2         813.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            35             37           1          0.3        3537.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1285.6       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8             10           1          1.2         833.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            32             34           1          0.3        3190.2       0.3X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1313.1       0.6X
+In-memory                                                          8              9           0          1.2         806.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            32             33           1          0.3        3196.0       0.3X
+RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1279.3       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (500 rows to overwrite - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                        9             10           1          1.1         878.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                          31             32           1          0.3        3102.5       0.3X
-RocksDB (trackTotalNumberOfRows: false)                         13             14           0          0.8        1307.7       0.7X
+In-memory                                                        8              9           0          1.2         808.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                          31             32           1          0.3        3077.1       0.3X
+RocksDB (trackTotalNumberOfRows: false)                         13             14           0          0.8        1269.1       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      9             11           1          1.1         906.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        30             31           1          0.3        2957.7       0.3X
-RocksDB (trackTotalNumberOfRows: false)                       13             14           0          0.8        1316.4       0.7X
+In-memory                                                      8              9           0          1.2         806.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        30             31           0          0.3        2981.7       0.3X
+RocksDB (trackTotalNumberOfRows: false)                       13             13           0          0.8        1277.3       0.6X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         14.9          67.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          28             30           1          0.4        2821.1       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         12             12           0          0.9        1158.1       0.1X
+In-memory                                                                                        1              1           0         15.2          65.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          28             29           0          0.4        2800.2       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         11             12           0          0.9        1142.8       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(7500 rows are non-existing - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           0          1.6         623.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        34             35           1          0.3        3401.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             13           0          0.9        1142.8       0.5X
+In-memory                                                                                      6              6           0          1.7         581.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        33             34           1          0.3        3306.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1128.5       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.5         683.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        39             40           1          0.3        3921.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1144.1       0.6X
+In-memory                                                                                      6              7           0          1.6         639.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        38             40           1          0.3        3802.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1126.0       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(2500 rows are non-existing - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.4         707.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        45             46           1          0.2        4465.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1148.8       0.6X
+In-memory                                                                                      7              7           1          1.5         674.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        43             45           1          0.2        4325.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1135.1       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              9           1          1.4         727.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        47             49           1          0.2        4742.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1136.6       0.6X
+In-memory                                                                                      7              7           0          1.5         689.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        46             48           1          0.2        4606.9       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1125.4       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(500 rows are non-existing - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                    7              8           1          1.4         731.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                      49             50           1          0.2        4878.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                     11             13           0          0.9        1146.3       0.6X
+In-memory                                                                                    7              8           1          1.4         702.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                      47             49           1          0.2        4708.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                     11             12           0          0.9        1129.9       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              8           1          1.4         720.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    49             51           1          0.2        4942.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   11             12           0          0.9        1131.1       0.6X
+In-memory                                                                                  7              7           0          1.5         681.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    48             49           1          0.2        4793.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   11             12           0          0.9        1103.6       0.6X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              8           0          1.4         725.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              47             49           1          0.2        4722.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             11             12           0          0.9        1133.0       0.6X
+In-memory                                                                            7              7           0          1.5         681.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              46             48           1          0.2        4637.0       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             12             12           0          0.9        1155.1       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 7500 rows (maxTimestampToEvictInMillis: 7499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           7              7           0          1.4         690.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             37             38           1          0.3        3663.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                            10             10           0          1.0         981.3       0.7X
+In-memory                                                                           7              7           0          1.5         661.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             36             37           1          0.3        3600.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                            10             11           0          1.0        1008.5       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           0          1.5         647.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             26             27           1          0.4        2595.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             8              8           0          1.2         812.3       0.8X
+In-memory                                                                           6              7           0          1.6         619.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             26             26           1          0.4        2571.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             8              9           0          1.2         848.0       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 2500 rows (maxTimestampToEvictInMillis: 2499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           0          1.6         606.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             15             16           0          0.7        1525.0       0.4X
-RocksDB (trackTotalNumberOfRows: false)                                             6              7           0          1.6         632.9       1.0X
+In-memory                                                                           6              6           0          1.7         572.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             15             16           0          0.6        1548.5       0.4X
+RocksDB (trackTotalNumberOfRows: false)                                             7              7           0          1.5         688.2       0.8X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          6              6           0          1.8         566.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             9              9           0          1.1         884.3       0.6X
-RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          1.9         524.3       1.1X
+In-memory                                                                          5              6           0          1.9         540.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             9             10           0          1.1         940.6       0.6X
+RocksDB (trackTotalNumberOfRows: false)                                            6              6           0          1.7         595.9       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 500 rows (maxTimestampToEvictInMillis: 499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                         6              6           0          1.8         554.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            7              7           0          1.5         667.7       0.8X
-RocksDB (trackTotalNumberOfRows: false)                                           5              5           0          2.0         488.7       1.1X
+In-memory                                                                         5              6           0          1.9         533.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            7              7           0          1.4         738.8       0.7X
+RocksDB (trackTotalNumberOfRows: false)                                           6              6           0          1.8         565.4       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         16.1          62.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         5              5           0          2.2         452.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        5              5           0          2.2         453.0       0.1X
+In-memory                                                                      1              1           0         16.8          59.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         5              5           0          1.9         524.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        5              5           0          1.9         522.9       0.1X
 
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
@@ -2,182 +2,182 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8              8           1          1.3         762.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              51             52           1          0.2        5096.4       0.1X
-RocksDB (trackTotalNumberOfRows: false)                             13             14           0          0.8        1292.1       0.6X
+In-memory                                                            8              9           1          1.3         776.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              50             52           1          0.2        5024.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             13             14           0          0.8        1290.8       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (7500 rows to overwrite - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           0          1.3         789.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            47             48           1          0.2        4670.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1326.8       0.6X
+In-memory                                                          8              9           1          1.2         800.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            47             48           1          0.2        4667.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           13             15           0          0.8        1316.2       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           0          1.3         785.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            41             43           1          0.2        4127.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1326.5       0.6X
+In-memory                                                          8              9           1          1.3         786.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            42             43           1          0.2        4157.9       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           13             15           0          0.7        1345.1       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (2500 rows to overwrite - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           0          1.3         768.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            36             37           1          0.3        3583.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1308.1       0.6X
+In-memory                                                          8              9           1          1.3         755.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            36             38           1          0.3        3638.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1308.7       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           0          1.3         754.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            32             33           0          0.3        3211.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1305.4       0.6X
+In-memory                                                          8              9           1          1.3         763.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            32             34           1          0.3        3238.4       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1323.3       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (500 rows to overwrite - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                        8              8           0          1.3         754.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                          31             32           1          0.3        3089.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                         13             14           0          0.8        1320.2       0.6X
+In-memory                                                        8              9           1          1.3         783.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                          31             33           1          0.3        3142.9       0.2X
+RocksDB (trackTotalNumberOfRows: false)                         13             14           0          0.8        1316.3       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      7              8           0          1.3         746.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        29             30           0          0.3        2929.9       0.3X
-RocksDB (trackTotalNumberOfRows: false)                       13             14           0          0.8        1312.6       0.6X
+In-memory                                                      8              9           1          1.3         751.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        30             32           1          0.3        3020.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       13             14           0          0.8        1325.2       0.6X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         19.9          50.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          28             29           0          0.4        2795.6       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         12             12           0          0.9        1168.3       0.0X
+In-memory                                                                                        1              1           0         17.0          58.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          27             28           0          0.4        2725.2       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         12             12           0          0.9        1162.0       0.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(7500 rows are non-existing - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      5              6           0          1.9         526.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        34             35           0          0.3        3390.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       12             13           1          0.8        1192.9       0.4X
+In-memory                                                                                      5              6           0          1.9         535.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        32             34           1          0.3        3243.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1148.5       0.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              6           1          1.7         579.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        39             40           0          0.3        3917.9       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       12             13           0          0.8        1185.0       0.5X
+In-memory                                                                                      6              7           0          1.7         595.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        38             39           0          0.3        3762.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       12             13           1          0.9        1153.6       0.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(2500 rows are non-existing - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           0          1.6         628.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        45             46           0          0.2        4458.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       12             13           0          0.8        1188.7       0.5X
+In-memory                                                                                      7              8           1          1.5         671.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        42             44           0          0.2        4242.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       12             13           0          0.9        1171.3       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              7           0          1.5         650.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        48             49           1          0.2        4764.9       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       12             13           0          0.8        1191.7       0.5X
+In-memory                                                                                      7              8           1          1.5         671.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        45             47           1          0.2        4521.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       12             13           0          0.9        1161.1       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(500 rows are non-existing - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                    7              7           0          1.5         664.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                      49             50           1          0.2        4888.2       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                     12             13           0          0.8        1188.5       0.6X
+In-memory                                                                                    7              8           1          1.5         680.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                      46             48           1          0.2        4632.1       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                     12             13           0          0.9        1169.2       0.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              7           0          1.5         659.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    49             50           0          0.2        4916.1       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   12             13           0          0.8        1204.1       0.5X
+In-memory                                                                                  7              8           1          1.5         683.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    46             48           1          0.2        4640.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   11             12           0          0.9        1132.0       0.6X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            6              7           0          1.5         646.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              45             46           1          0.2        4454.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             11             12           0          0.9        1112.2       0.6X
+In-memory                                                                            6              7           1          1.5         649.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              44             46           1          0.2        4402.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             10             10           0          1.0         979.8       0.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 7500 rows (maxTimestampToEvictInMillis: 7499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           0          1.6         614.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             35             36           0          0.3        3499.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             9             10           0          1.1         942.8       0.7X
+In-memory                                                                           6              7           0          1.6         610.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             34             35           0          0.3        3402.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             8              9           0          1.2         825.0       0.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              6           0          1.8         564.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             25             25           0          0.4        2474.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             8              8           0          1.3         777.8       0.7X
+In-memory                                                                           6              6           0          1.8         565.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             24             25           0          0.4        2383.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             7              7           0          1.5         665.8       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 2500 rows (maxTimestampToEvictInMillis: 2499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           5              6           0          1.9         518.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             14             15           0          0.7        1430.8       0.4X
-RocksDB (trackTotalNumberOfRows: false)                                             6              6           1          1.7         589.0       0.9X
+In-memory                                                                           5              6           0          1.9         520.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             14             14           0          0.7        1370.5       0.4X
+RocksDB (trackTotalNumberOfRows: false)                                             5              5           1          2.0         508.8       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          5              5           0          2.1         482.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             8              9           0          1.2         806.1       0.6X
-RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.0         510.5       0.9X
+In-memory                                                                          5              6           0          2.0         496.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             8              8           0          1.3         759.3       0.7X
+RocksDB (trackTotalNumberOfRows: false)                                            4              4           0          2.4         418.6       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 500 rows (maxTimestampToEvictInMillis: 499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                         5              5           0          2.1         475.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            6              6           0          1.7         603.0       0.8X
-RocksDB (trackTotalNumberOfRows: false)                                           4              5           0          2.3         438.8       1.1X
+In-memory                                                                         5              6           0          2.0         488.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            6              6           0          1.8         560.2       0.9X
+RocksDB (trackTotalNumberOfRows: false)                                           4              4           0          2.6         388.5       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         17.0          58.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.6         380.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.6         381.3       0.2X
+In-memory                                                                      1              1           0         15.0          66.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.8         357.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.8         357.3       0.2X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr regenerate benchmark results of `StateStoreBasicOperationsBenchmark`.


### Why are the changes needed?
https://github.com/apache/spark/pull/40639 upgrade rocksdbjni from 7.10.2 to 8.0.0, we need check and update the relevant benchmark results.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions