### PR TITLE
[SPARK-43077][SQL] Improve the error message of UNRECOGNIZED_SQL_TYPE

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -290,7 +290,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
         val dfRead = sqlContext.read.jdbc(jdbcUrl, "ts_with_timezone", new Properties)
         dfRead.collect()
       }.getMessage
-      assert(e.contains("Unrecognized SQL type -101"))
+      assert(e.contains("Unrecognized SQL type - name: TIMESTAMP WITH TZ, id: -101"))
     }
   }
 

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1535,7 +1535,7 @@
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [
-      "Unrecognized SQL type <typeName>."
+      "Unrecognized SQL type - name: <typeName>, id: <jdbcType>."
     ],
     "sqlState" : "42704"
   },

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1155,7 +1155,7 @@ All unpivot value columns must have the same size as there are value column name
 
 [SQLSTATE: 42704](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
-Unrecognized SQL type `<typeName>`.
+Unrecognized SQL type - name: `<typeName>`, id: `<jdbcType>`.
 
 ### UNRESOLVED_ALL_IN_GROUP_BY
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1007,10 +1007,10 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       messageParameters = Map("catalogString" -> dt.catalogString))
   }
 
-  def unrecognizedSqlTypeError(sqlType: Int): Throwable = {
+  def unrecognizedSqlTypeError(jdbcTypeId: String, typeName: String): Throwable = {
     new SparkSQLException(
       errorClass = "UNRECOGNIZED_SQL_TYPE",
-      messageParameters = Map("typeName" -> sqlType.toString))
+      messageParameters = Map("typeName" -> typeName, "jdbcType" -> jdbcTypeId))
   }
 
   def unsupportedJdbcTypeError(content: String): SparkSQLException = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -177,68 +177,56 @@ object JdbcUtils extends Logging with SQLConfHelper {
    */
   private def getCatalystType(
       sqlType: Int,
+      typeName: String,
       precision: Int,
       scale: Int,
       signed: Boolean,
-      isTimestampNTZ: Boolean): DataType = {
-    val answer = sqlType match {
-      // scalastyle:off
-      case java.sql.Types.ARRAY         => null
-      case java.sql.Types.BIGINT        => if (signed) { LongType } else { DecimalType(20,0) }
-      case java.sql.Types.BINARY        => BinaryType
-      case java.sql.Types.BIT           => BooleanType // @see JdbcDialect for quirks
-      case java.sql.Types.BLOB          => BinaryType
-      case java.sql.Types.BOOLEAN       => BooleanType
-      case java.sql.Types.CHAR          => StringType
-      case java.sql.Types.CLOB          => StringType
-      case java.sql.Types.DATALINK      => null
-      case java.sql.Types.DATE          => DateType
-      case java.sql.Types.DECIMAL
-        if precision != 0 || scale != 0 => DecimalType.bounded(precision, scale)
-      case java.sql.Types.DECIMAL       => DecimalType.SYSTEM_DEFAULT
-      case java.sql.Types.DISTINCT      => null
-      case java.sql.Types.DOUBLE        => DoubleType
-      case java.sql.Types.FLOAT         => FloatType
-      case java.sql.Types.INTEGER       => if (signed) { IntegerType } else { LongType }
-      case java.sql.Types.JAVA_OBJECT   => null
-      case java.sql.Types.LONGNVARCHAR  => StringType
-      case java.sql.Types.LONGVARBINARY => BinaryType
-      case java.sql.Types.LONGVARCHAR   => StringType
-      case java.sql.Types.NCHAR         => StringType
-      case java.sql.Types.NCLOB         => StringType
-      case java.sql.Types.NULL          => null
-      case java.sql.Types.NUMERIC
-        if precision != 0 || scale != 0 => DecimalType.bounded(precision, scale)
-      case java.sql.Types.NUMERIC       => DecimalType.SYSTEM_DEFAULT
-      case java.sql.Types.NVARCHAR      => StringType
-      case java.sql.Types.OTHER         => null
-      case java.sql.Types.REAL          => DoubleType
-      case java.sql.Types.REF           => StringType
-      case java.sql.Types.REF_CURSOR    => null
-      case java.sql.Types.ROWID         => StringType
-      case java.sql.Types.SMALLINT      => IntegerType
-      case java.sql.Types.SQLXML        => StringType
-      case java.sql.Types.STRUCT        => StringType
-      case java.sql.Types.TIME          => TimestampType
-      case java.sql.Types.TIME_WITH_TIMEZONE
-                                        => null
-      case java.sql.Types.TIMESTAMP
-        if isTimestampNTZ               => TimestampNTZType
-      case java.sql.Types.TIMESTAMP     => TimestampType
-      case java.sql.Types.TIMESTAMP_WITH_TIMEZONE
-                                        => null
-      case java.sql.Types.TINYINT       => IntegerType
-      case java.sql.Types.VARBINARY     => BinaryType
-      case java.sql.Types.VARCHAR       => StringType
-      case _                            =>
-        throw QueryExecutionErrors.unrecognizedSqlTypeError(sqlType)
-      // scalastyle:on
-    }
-
-    if (answer == null) {
-      throw QueryExecutionErrors.unsupportedJdbcTypeError(JDBCType.valueOf(sqlType).getName)
-    }
-    answer
+      isTimestampNTZ: Boolean): DataType = sqlType match {
+    case java.sql.Types.BIGINT => if (signed) LongType else DecimalType(20, 0)
+    case java.sql.Types.BINARY => BinaryType
+    case java.sql.Types.BIT => BooleanType // @see JdbcDialect for quirks
+    case java.sql.Types.BLOB => BinaryType
+    case java.sql.Types.BOOLEAN => BooleanType
+    case java.sql.Types.CHAR => StringType
+    case java.sql.Types.CLOB => StringType
+    case java.sql.Types.DATE => DateType
+    case java.sql.Types.DECIMAL if precision != 0 || scale != 0 =>
+      DecimalType.bounded(precision, scale)
+    case java.sql.Types.DECIMAL => DecimalType.SYSTEM_DEFAULT
+    case java.sql.Types.DOUBLE => DoubleType
+    case java.sql.Types.FLOAT => FloatType
+    case java.sql.Types.INTEGER => if (signed) IntegerType else LongType
+    case java.sql.Types.LONGNVARCHAR => StringType
+    case java.sql.Types.LONGVARBINARY => BinaryType
+    case java.sql.Types.LONGVARCHAR => StringType
+    case java.sql.Types.NCHAR => StringType
+    case java.sql.Types.NCLOB => StringType
+    case java.sql.Types.NUMERIC if precision != 0 || scale != 0 =>
+      DecimalType.bounded(precision, scale)
+    case java.sql.Types.NUMERIC => DecimalType.SYSTEM_DEFAULT
+    case java.sql.Types.NVARCHAR => StringType
+    case java.sql.Types.REAL => DoubleType
+    case java.sql.Types.REF => StringType
+    case java.sql.Types.ROWID => StringType
+    case java.sql.Types.SMALLINT => IntegerType
+    case java.sql.Types.SQLXML => StringType
+    case java.sql.Types.STRUCT => StringType
+    case java.sql.Types.TIME => TimestampType
+    case java.sql.Types.TIMESTAMP if isTimestampNTZ => TimestampNTZType
+    case java.sql.Types.TIMESTAMP => TimestampType
+    case java.sql.Types.TINYINT => IntegerType
+    case java.sql.Types.VARBINARY => BinaryType
+    case java.sql.Types.VARCHAR => StringType
+    case _ =>
+      // For unmatched types:
+      // including java.sql.Types.ARRAY,DATALINK,DISTINCT,JAVA_OBJECT,NULL,OTHER,REF_CURSOR,
+      // TIME_WITH_TIMEZONE,TIMESTAMP_WITH_TIMEZONE, and among others.
+      val jdbcType = classOf[JDBCType].getEnumConstants()
+        .filter(_.getVendorTypeNumber == sqlType)
+        .headOption
+        .map(_.getName)
+        .getOrElse(sqlType.toString)
+      throw QueryExecutionErrors.unrecognizedSqlTypeError(jdbcType, typeName)
   }
 
   /**
@@ -318,7 +306,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
 
       val columnType =
         dialect.getCatalystType(dataType, typeName, fieldSize, metadata).getOrElse(
-          getCatalystType(dataType, fieldSize, fieldScale, isSigned, isTimestampNTZ))
+          getCatalystType(dataType, typeName, fieldSize, fieldScale, isSigned, isTimestampNTZ))
       fields(i) = StructField(columnName, columnType, nullable, metadata.build())
       i = i + 1
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -471,7 +471,7 @@ class QueryExecutionErrorsSuite
     }
   }
 
-  test("UNRECOGNIZED_SQL_TYPE: unrecognized SQL type -100") {
+  test("UNRECOGNIZED_SQL_TYPE: unrecognized SQL type DATALINK") {
     Utils.classForName("org.h2.Driver")
 
     val properties = new Properties()

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -481,7 +481,8 @@ class QueryExecutionErrorsSuite
     val url = "jdbc:h2:mem:testdb0"
     val urlWithUserAndPass = "jdbc:h2:mem:testdb0;user=testUser;password=testPass"
     val tableName = "test.table1"
-    val unrecognizedColumnType = -100
+    val unrecognizedColumnType = java.sql.Types.DATALINK
+    val unrecognizedColumnTypeName = "h2" + java.sql.Types.DATALINK.toString
 
     var conn: java.sql.Connection = null
     try {
@@ -518,6 +519,7 @@ class QueryExecutionErrorsSuite
           val resultSetMetaData = mock(classOf[ResultSetMetaData])
           when(resultSetMetaData.getColumnCount).thenReturn(1)
           when(resultSetMetaData.getColumnType(1)).thenReturn(unrecognizedColumnType)
+          when(resultSetMetaData.getColumnTypeName(1)).thenReturn(unrecognizedColumnTypeName)
 
           val resultSet = mock(classOf[ResultSet])
           when(resultSet.next()).thenReturn(true).thenReturn(false)
@@ -545,7 +547,7 @@ class QueryExecutionErrorsSuite
         spark.read.jdbc(urlWithUserAndPass, tableName, new Properties()).collect()
       },
       errorClass = "UNRECOGNIZED_SQL_TYPE",
-      parameters = Map("typeName" -> unrecognizedColumnType.toString),
+      parameters = Map("typeName" -> unrecognizedColumnTypeName, "jdbcType" -> "DATALINK"),
       sqlState = "42704")
 
     JdbcDialects.unregisterDialect(testH2DialectUnrecognizedSQLType)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR makes UNRECOGNIZED_SQL_TYPE print both the column type name and the id.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

UNRECOGNIZED_SQL_TYPE prints the jdbc type id in the error message currently. This is difficult for spark users to understand the meaning of this kind of error, especially when the type id is from a vendor extension.

For example, 

```java
 org.apache.spark.SparkSQLException: Unrecognized SQL type -102
```

While -102 is nonstandard, it's hard to know what type it is

```
classOf[java.sql.JDBCType].getEnumConstants.foreach(t => println(t.getName + "|" + t.getVendorTypeNumber))
BIT|-7
TINYINT|-6
SMALLINT|5
INTEGER|4
BIGINT|-5
FLOAT|6
REAL|7
DOUBLE|8
NUMERIC|2
DECIMAL|3
CHAR|1
VARCHAR|12
LONGVARCHAR|-1
DATE|91
TIME|92
TIMESTAMP|93
BINARY|-2
VARBINARY|-3
LONGVARBINARY|-4
NULL|0
OTHER|1111
JAVA_OBJECT|2000
DISTINCT|2001
STRUCT|2002
ARRAY|2003
BLOB|2004
CLOB|2005
REF|2006
DATALINK|70
BOOLEAN|16
ROWID|-8
NCHAR|-15
NVARCHAR|-9
LONGNVARCHAR|-16
NCLOB|2011
SQLXML|2009
REF_CURSOR|2012
TIME_WITH_TIMEZONE|2013
TIMESTAMP_WITH_TIMEZONE|2014
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, the unrecognized jdbc type error will also print the type name 

For example, 

```java
 org.apache.spark.SparkSQLException: Unrecognized SQL type - name: TIMESTAMP WITH LOCAL TIME ZONE, id: -102
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new tests
