### PR TITLE
[WIP]Speed up parquet reading with Java Vector API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <kafka.version>3.4.0</kafka.version>
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
-    <parquet.version>1.12.3</parquet.version>
+    <parquet.version>1.13.0</parquet.version>
     <orc.version>1.8.3</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>9.4.51.v20230217</jetty.version>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1068,6 +1068,13 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val PARQUET_VECTOR512_READ_ENABLED = buildConf("sql.parquet.vector512.read.enabled")
+    .doc("If true and CPU contains avx512vbmi & avx512_vbmi2 instruction set, speed up parquet read " +
+      "with using Java Vector API. For Intel CPU, Ice Lake or newer contains the required instruction set.")
+    .version("3.5.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val PARQUET_WRITE_LEGACY_FORMAT = buildConf("spark.sql.parquet.writeLegacyFormat")
     .doc("If true, data will be written in a way of Spark 1.4 and earlier. For example, decimal " +
       "values will be written in Apache Parquet's fixed-length byte array format, which other " +
@@ -4501,6 +4508,8 @@ class SQLConf extends Serializable with Logging {
     getConf(PARQUET_FILTER_PUSHDOWN_INFILTERTHRESHOLD)
 
   def parquetAggregatePushDown: Boolean = getConf(PARQUET_AGGREGATE_PUSHDOWN_ENABLED)
+
+  def parquetVector512Read: Boolean = getConf(PARQUET_VECTOR512_READ_ENABLED, false)
 
   def orcFilterPushDown: Boolean = getConf(ORC_FILTER_PUSHDOWN_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1068,7 +1068,7 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val PARQUET_VECTOR512_READ_ENABLED = buildConf("sql.parquet.vector512.read.enabled")
+  val PARQUET_VECTOR512_READ_ENABLED = buildConf("spark.sql.parquet.vector512.read.enabled")
     .doc("If true and CPU contains avx512vbmi & avx512_vbmi2 instruction set, speed up parquet read " +
       "with using Java Vector API. For Intel CPU, Ice Lake or newer contains the required instruction set.")
     .version("3.5.0")

--- a/sql/core/benchmarks/ParquetVectorizedBytePackerDecoderBenchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/ParquetVectorizedBytePackerDecoderBenchmark-jdk17-results.txt
@@ -1,0 +1,6 @@
+Java HotSpot(TM) 64-Bit Server VM 17.0.5+9-LTS-191 on Linux 5.15.0-60-generic
+Intel(R) Xeon(R) Platinum 8358P CPU @ 2.60GHz
+Selection:                                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without Java Vector API                            4696           4802          89         21.3          47.0       1.0X
+With Java Vector API                               3742           3927         230         26.7          37.4       1.3X

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -113,6 +113,11 @@
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
     </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.apache.parquet</groupId>-->
+<!--      <artifactId>parquet-encoding-vector</artifactId>-->
+<!--      <version>1.13.0-SNAPSHOT</version>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-encoding</artifactId>

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -79,7 +79,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
   private static final int NUM_VALUES_TO_PACK = 8;
   private static final Boolean vector512Support;
   static {
-    if (supportVector512FromCPUFlags() && SQLConf.get().parquetVector512Read()) {
+    if (supportVector512FromCPUFlags()) {
       vector512Support = true;
     } else {
       vector512Support = false;
@@ -956,7 +956,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
           }
           currentBufferIdx = 0;
           int valueIndex = 0;
-          if (vector512Support) {
+          if (vector512Support && SQLConf.get().parquetVector512Read()) {
             int byteIndex = 0;
             int unpackCount = packerVector512.getUnpackCount();
             int inputByteCountPerVector = packerVector512.getUnpackCount() / BITS_PER_BYTE * bitWidth;

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetVectorizedBytePackerDecoderBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetVectorizedBytePackerDecoderBenchmark.scala
@@ -41,7 +41,7 @@ object ParquetVectorizedBytePackerDecoderBenchmark extends SqlBasedBenchmark {
     val dataSourceName: String = "parquet"
     val benchmarkName: String = "Vector Decode Benchmark For Parquet"
 
-    private val N = 1000000
+    private val N = 100000000
     private val numIters = 10
 
     private val df = spark
@@ -65,9 +65,8 @@ object ParquetVectorizedBytePackerDecoderBenchmark extends SqlBasedBenchmark {
             df.write.format(dataSourceName).save(path)
             spark.read.format(dataSourceName).load(path).createOrReplaceTempView(s"t1")
             val benchmark = new Benchmark(s"Selection", numRows, numIters, output = output)
-            addCase(benchmark, "Selection after optimization", "true", "select * from t1")
-            addCase(benchmark, "Selection before optimization", "false", "select * from t1")
-
+            addCase(benchmark, "Without Java Vector API", "false", "select * from t1")
+            addCase(benchmark, "With Java Vector API", "true", "select * from t1")
             benchmark.run()
         }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetVectorizedBytePackerDecoderBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/ParquetVectorizedBytePackerDecoderBenchmark.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Synthetic benchmark for nested schema pruning performance for Parquet datasource.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> <sql core test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/ParquetVectorizedBytePackerDecoderBenchmark-results.txt".
+ * }}}
+ */
+object ParquetVectorizedBytePackerDecoderBenchmark extends SqlBasedBenchmark {
+    import spark.implicits._
+
+    spark.conf.set(SQLConf.PARQUET_VECTOR512_READ_ENABLED.key, true)
+
+    val dataSourceName: String = "parquet"
+    val benchmarkName: String = "Vector Decode Benchmark For Parquet"
+
+    private val N = 1000000
+    private val numIters = 10
+
+    private val df = spark
+      .range(N)
+      .map(x => (x % 128, x % 64, x % 4))
+      .toDF("col1", "col2", "col3")
+
+    private def addCase(benchmark: Benchmark, name: String,
+                        vector512ReadEnabled: String, sql: String): Unit = {
+        benchmark.addCase(name) { _ =>
+            withSQLConf((SQLConf.PARQUET_VECTOR512_READ_ENABLED.key -> vector512ReadEnabled)) {
+                spark.sql(sql).noop()
+            }
+        }
+    }
+
+    protected def selectBenchmark(numRows: Int, numIters: Int): Unit = {
+        withTempPath { dir =>
+            val path = dir.getCanonicalPath
+
+            df.write.format(dataSourceName).save(path)
+            spark.read.format(dataSourceName).load(path).createOrReplaceTempView(s"t1")
+            val benchmark = new Benchmark(s"Selection", numRows, numIters, output = output)
+            addCase(benchmark, "Selection after optimization", "true", "select * from t1")
+            addCase(benchmark, "Selection before optimization", "false", "select * from t1")
+
+            benchmark.run()
+        }
+    }
+
+    override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+        runBenchmark(benchmarkName) {
+            selectBenchmark(N, numIters)
+        }
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Parquet has supported vector read speed up with this PR https://github.com/apache/parquet-mr/pull/1011
The performance gain is 4x ~ 8x according to the parquet microbenchmark
TPC-H(SF100) Q6 has 11% performance increase with Apache Spark integrating parquet vector optimization

### Why are the changes needed?
This PR used to support parquet vector optimization

### Does this PR introduce _any_ user-facing change?
Add configuration spark.sql.parquet.vector512.read.enabled, If true and CPU contains avx512vbmi & avx512_vbmi2 instruction set, parquet decodes using Java Vector API. For Intel CPU, Ice Lake or newer contains the required instruction set.

### How was this patch tested?
For the test case, there are some problems to fix:
1. It is necessary to Parquet-mr community release new java version to use the parquet vector optimization.
2. Parquet Vector optimization does not release default, so users have to build parquet with mvn clean install -P vector-plugins manually to get the parquet-encoding-vector-{VERSION}.jar and put it on the {SPARK_HOME}/jars path
3. github doesn't support select runners with specific instruction set. So it is impossible (a self-hosted runner can do it) to verify the optimization on github runners machine.
