### PR TITLE
[SPARK-43080][BUILD] Upgrade `zstd-jni` to 1.5.5-1

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -6,22 +6,22 @@ OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            525            586          76          0.0       52549.5       1.0X
-Compression 10000 times at level 2 without buffer pool            588            590           2          0.0       58820.6       0.9X
-Compression 10000 times at level 3 without buffer pool            797            798           1          0.0       79683.9       0.7X
-Compression 10000 times at level 1 with buffer pool               299            300           1          0.0       29912.7       1.8X
-Compression 10000 times at level 2 with buffer pool               366            367           1          0.0       36601.0       1.4X
-Compression 10000 times at level 3 with buffer pool               556            557           1          0.0       55581.0       0.9X
+Compression 10000 times at level 1 without buffer pool            523            608          96          0.0       52324.2       1.0X
+Compression 10000 times at level 2 without buffer pool            597            598           1          0.0       59668.8       0.9X
+Compression 10000 times at level 3 without buffer pool            792            794           2          0.0       79185.9       0.7X
+Compression 10000 times at level 1 with buffer pool               332            333           1          0.0       33188.3       1.6X
+Compression 10000 times at level 2 with buffer pool               398            399           1          0.0       39798.4       1.3X
+Compression 10000 times at level 3 with buffer pool               589            590           1          0.0       58927.7       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            719            720           1          0.0       71876.1       1.0X
-Decompression 10000 times from level 2 without buffer pool            719            720           1          0.0       71935.5       1.0X
-Decompression 10000 times from level 3 without buffer pool            719            721           2          0.0       71905.8       1.0X
-Decompression 10000 times from level 1 with buffer pool               527            528           2          0.0       52678.4       1.4X
-Decompression 10000 times from level 2 with buffer pool               527            528           1          0.0       52706.1       1.4X
-Decompression 10000 times from level 3 with buffer pool               527            528           1          0.0       52653.2       1.4X
+Decompression 10000 times from level 1 without buffer pool            722            722           1          0.0       72153.7       1.0X
+Decompression 10000 times from level 2 without buffer pool            723            724           2          0.0       72298.9       1.0X
+Decompression 10000 times from level 3 without buffer pool            722            722           1          0.0       72190.6       1.0X
+Decompression 10000 times from level 1 with buffer pool               530            531           1          0.0       53047.3       1.4X
+Decompression 10000 times from level 2 with buffer pool               529            530           0          0.0       52938.3       1.4X
+Decompression 10000 times from level 3 with buffer pool               530            531           1          0.0       52954.7       1.4X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1033-azure
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            521            528          10          0.0       52128.1       1.0X
-Compression 10000 times at level 2 without buffer pool            762            766           6          0.0       76186.6       0.7X
-Compression 10000 times at level 3 without buffer pool            956            961           5          0.0       95621.0       0.5X
-Compression 10000 times at level 1 with buffer pool               470            473           4          0.0       46977.0       1.1X
-Compression 10000 times at level 2 with buffer pool               531            534           2          0.0       53141.9       1.0X
-Compression 10000 times at level 3 with buffer pool               728            728           0          0.0       72777.9       0.7X
+Compression 10000 times at level 1 without buffer pool            525            586          76          0.0       52549.5       1.0X
+Compression 10000 times at level 2 without buffer pool            588            590           2          0.0       58820.6       0.9X
+Compression 10000 times at level 3 without buffer pool            797            798           1          0.0       79683.9       0.7X
+Compression 10000 times at level 1 with buffer pool               299            300           1          0.0       29912.7       1.8X
+Compression 10000 times at level 2 with buffer pool               366            367           1          0.0       36601.0       1.4X
+Compression 10000 times at level 3 with buffer pool               556            557           1          0.0       55581.0       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1033-azure
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            650            651           1          0.0       64985.4       1.0X
-Decompression 10000 times from level 2 without buffer pool            646            647           1          0.0       64607.7       1.0X
-Decompression 10000 times from level 3 without buffer pool            647            648           1          0.0       64694.4       1.0X
-Decompression 10000 times from level 1 with buffer pool               456            458           2          0.0       45640.6       1.4X
-Decompression 10000 times from level 2 with buffer pool               455            456           0          0.0       45544.2       1.4X
-Decompression 10000 times from level 3 with buffer pool               456            456           0          0.0       45555.6       1.4X
+Decompression 10000 times from level 1 without buffer pool            719            720           1          0.0       71876.1       1.0X
+Decompression 10000 times from level 2 without buffer pool            719            720           1          0.0       71935.5       1.0X
+Decompression 10000 times from level 3 without buffer pool            719            721           2          0.0       71905.8       1.0X
+Decompression 10000 times from level 1 with buffer pool               527            528           2          0.0       52678.4       1.4X
+Decompression 10000 times from level 2 with buffer pool               527            528           1          0.0       52706.1       1.4X
+Decompression 10000 times from level 3 with buffer pool               527            528           1          0.0       52653.2       1.4X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1033-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           2788           2790           2          0.0      278818.1       1.0X
-Compression 10000 times at level 2 without buffer pool           2843           2845           2          0.0      284333.7       1.0X
-Compression 10000 times at level 3 without buffer pool           3010           3035          35          0.0      300966.0       0.9X
-Compression 10000 times at level 1 with buffer pool              2655           2655           0          0.0      265474.7       1.1X
-Compression 10000 times at level 2 with buffer pool              2691           2692           0          0.0      269145.5       1.0X
-Compression 10000 times at level 3 with buffer pool              2825           2828           4          0.0      282471.8       1.0X
+Compression 10000 times at level 1 without buffer pool           2788           2788           0          0.0      278808.0       1.0X
+Compression 10000 times at level 2 without buffer pool           2842           2851          13          0.0      284181.1       1.0X
+Compression 10000 times at level 3 without buffer pool           2979           2980           0          0.0      297949.3       0.9X
+Compression 10000 times at level 1 with buffer pool              2649           2649           0          0.0      264862.0       1.1X
+Compression 10000 times at level 2 with buffer pool              2694           2697           4          0.0      269383.6       1.0X
+Compression 10000 times at level 3 with buffer pool              2817           2821           5          0.0      281706.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1033-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           2740           2749          14          0.0      273978.5       1.0X
-Decompression 10000 times from level 2 without buffer pool           2743           2745           2          0.0      274344.7       1.0X
-Decompression 10000 times from level 3 without buffer pool           2744           2746           2          0.0      274396.1       1.0X
-Decompression 10000 times from level 1 with buffer pool              2617           2617           1          0.0      261670.1       1.0X
-Decompression 10000 times from level 2 with buffer pool              2615           2617           3          0.0      261500.1       1.0X
-Decompression 10000 times from level 3 with buffer pool              2616           2616           1          0.0      261565.9       1.0X
+Decompression 10000 times from level 1 without buffer pool            468            469           1          0.0       46824.4       1.0X
+Decompression 10000 times from level 2 without buffer pool            472            473           1          0.0       47164.8       1.0X
+Decompression 10000 times from level 3 without buffer pool            468            468           1          0.0       46758.2       1.0X
+Decompression 10000 times from level 1 with buffer pool               340            341           2          0.0       33963.6       1.4X
+Decompression 10000 times from level 2 with buffer pool               339            340           1          0.0       33870.6       1.4X
+Decompression 10000 times from level 3 with buffer pool               340            340           0          0.0       33977.4       1.4X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
@@ -3,25 +3,25 @@ Benchmark ZStandardCompressionCodec
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           2442           2454          17          0.0      244211.4       1.0X
-Compression 10000 times at level 2 without buffer pool           2210           2271          87          0.0      221014.1       1.1X
-Compression 10000 times at level 3 without buffer pool           2454           2461          10          0.0      245369.7       1.0X
-Compression 10000 times at level 1 with buffer pool              2036           2055          27          0.0      203594.9       1.2X
-Compression 10000 times at level 2 with buffer pool              2007           2023          23          0.0      200720.6       1.2X
-Compression 10000 times at level 3 with buffer pool              2253           2263          14          0.0      225287.2       1.1X
+Compression 10000 times at level 1 without buffer pool           2786           2787           1          0.0      278556.4       1.0X
+Compression 10000 times at level 2 without buffer pool           2826           2832           8          0.0      282635.1       1.0X
+Compression 10000 times at level 3 without buffer pool           2960           2961           1          0.0      296039.0       0.9X
+Compression 10000 times at level 1 with buffer pool              2648           2648           0          0.0      264758.0       1.1X
+Compression 10000 times at level 2 with buffer pool              2683           2684           0          0.0      268340.8       1.0X
+Compression 10000 times at level 3 with buffer pool              2806           2806           1          0.0      280608.1       1.0X
 
 OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           2251           2285          49          0.0      225078.6       1.0X
-Decompression 10000 times from level 2 without buffer pool           2244           2286          59          0.0      224396.5       1.0X
-Decompression 10000 times from level 3 without buffer pool           2418           2425           9          0.0      241842.4       0.9X
-Decompression 10000 times from level 1 with buffer pool              2167           2195          41          0.0      216668.6       1.0X
-Decompression 10000 times from level 2 with buffer pool              2144           2202          82          0.0      214429.4       1.0X
-Decompression 10000 times from level 3 with buffer pool              2133           2151          27          0.0      213252.7       1.1X
+Decompression 10000 times from level 1 without buffer pool           2742           2744           3          0.0      274226.6       1.0X
+Decompression 10000 times from level 2 without buffer pool           2739           2742           4          0.0      273917.2       1.0X
+Decompression 10000 times from level 3 without buffer pool           2745           2746           2          0.0      274476.4       1.0X
+Decompression 10000 times from level 1 with buffer pool              2612           2613           1          0.0      261204.1       1.0X
+Decompression 10000 times from level 2 with buffer pool              2616           2620           5          0.0      261623.1       1.0X
+Decompression 10000 times from level 3 with buffer pool              2614           2621          11          0.0      261357.8       1.0X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
@@ -3,25 +3,25 @@ Benchmark ZStandardCompressionCodec
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           2788           2788           0          0.0      278808.0       1.0X
-Compression 10000 times at level 2 without buffer pool           2842           2851          13          0.0      284181.1       1.0X
-Compression 10000 times at level 3 without buffer pool           2979           2980           0          0.0      297949.3       0.9X
-Compression 10000 times at level 1 with buffer pool              2649           2649           0          0.0      264862.0       1.1X
-Compression 10000 times at level 2 with buffer pool              2694           2697           4          0.0      269383.6       1.0X
-Compression 10000 times at level 3 with buffer pool              2817           2821           5          0.0      281706.1       1.0X
+Compression 10000 times at level 1 without buffer pool           2442           2454          17          0.0      244211.4       1.0X
+Compression 10000 times at level 2 without buffer pool           2210           2271          87          0.0      221014.1       1.1X
+Compression 10000 times at level 3 without buffer pool           2454           2461          10          0.0      245369.7       1.0X
+Compression 10000 times at level 1 with buffer pool              2036           2055          27          0.0      203594.9       1.2X
+Compression 10000 times at level 2 with buffer pool              2007           2023          23          0.0      200720.6       1.2X
+Compression 10000 times at level 3 with buffer pool              2253           2263          14          0.0      225287.2       1.1X
 
 OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            468            469           1          0.0       46824.4       1.0X
-Decompression 10000 times from level 2 without buffer pool            472            473           1          0.0       47164.8       1.0X
-Decompression 10000 times from level 3 without buffer pool            468            468           1          0.0       46758.2       1.0X
-Decompression 10000 times from level 1 with buffer pool               340            341           2          0.0       33963.6       1.4X
-Decompression 10000 times from level 2 with buffer pool               339            340           1          0.0       33870.6       1.4X
-Decompression 10000 times from level 3 with buffer pool               340            340           0          0.0       33977.4       1.4X
+Decompression 10000 times from level 1 without buffer pool           2251           2285          49          0.0      225078.6       1.0X
+Decompression 10000 times from level 2 without buffer pool           2244           2286          59          0.0      224396.5       1.0X
+Decompression 10000 times from level 3 without buffer pool           2418           2425           9          0.0      241842.4       0.9X
+Decompression 10000 times from level 1 with buffer pool              2167           2195          41          0.0      216668.6       1.0X
+Decompression 10000 times from level 2 with buffer pool              2144           2202          82          0.0      214429.4       1.0X
+Decompression 10000 times from level 3 with buffer pool              2133           2151          27          0.0      213252.7       1.1X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -3,25 +3,25 @@ Benchmark ZStandardCompressionCodec
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            404            498          52          0.0       40422.4       1.0X
-Compression 10000 times at level 2 without buffer pool            533            534           2          0.0       53256.8       0.8X
-Compression 10000 times at level 3 without buffer pool            717            720           4          0.0       71650.7       0.6X
-Compression 10000 times at level 1 with buffer pool               324            327           2          0.0       32425.5       1.2X
-Compression 10000 times at level 2 with buffer pool               376            380           4          0.0       37591.0       1.1X
-Compression 10000 times at level 3 with buffer pool               549            556           8          0.0       54924.8       0.7X
+Compression 10000 times at level 1 without buffer pool            277            348         107          0.0       27655.0       1.0X
+Compression 10000 times at level 2 without buffer pool            320            321           1          0.0       32020.3       0.9X
+Compression 10000 times at level 3 without buffer pool            460            464           3          0.0       46009.5       0.6X
+Compression 10000 times at level 1 with buffer pool               257            258           1          0.0       25654.4       1.1X
+Compression 10000 times at level 2 with buffer pool               297            299           2          0.0       29662.2       0.9X
+Compression 10000 times at level 3 with buffer pool               431            434           2          0.0       43139.0       0.6X
 
 OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            668            670           2          0.0       66847.7       1.0X
-Decompression 10000 times from level 2 without buffer pool            668            669           2          0.0       66754.5       1.0X
-Decompression 10000 times from level 3 without buffer pool            670            671           2          0.0       66951.6       1.0X
-Decompression 10000 times from level 1 with buffer pool               482            483           1          0.0       48187.9       1.4X
-Decompression 10000 times from level 2 with buffer pool               480            482           2          0.0       47994.2       1.4X
-Decompression 10000 times from level 3 with buffer pool               480            483           3          0.0       47953.9       1.4X
+Decompression 10000 times from level 1 without buffer pool            550            552           2          0.0       54986.3       1.0X
+Decompression 10000 times from level 2 without buffer pool            552            555           2          0.0       55247.1       1.0X
+Decompression 10000 times from level 3 without buffer pool            545            552           6          0.0       54513.2       1.0X
+Decompression 10000 times from level 1 with buffer pool               438            439           1          0.0       43831.4       1.3X
+Decompression 10000 times from level 2 with buffer pool               441            443           1          0.0       44138.4       1.2X
+Decompression 10000 times from level 3 with buffer pool               440            443           3          0.0       43966.3       1.3X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -3,25 +3,25 @@ Benchmark ZStandardCompressionCodec
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            277            348         107          0.0       27655.0       1.0X
-Compression 10000 times at level 2 without buffer pool            320            321           1          0.0       32020.3       0.9X
-Compression 10000 times at level 3 without buffer pool            460            464           3          0.0       46009.5       0.6X
-Compression 10000 times at level 1 with buffer pool               257            258           1          0.0       25654.4       1.1X
-Compression 10000 times at level 2 with buffer pool               297            299           2          0.0       29662.2       0.9X
-Compression 10000 times at level 3 with buffer pool               431            434           2          0.0       43139.0       0.6X
+Compression 10000 times at level 1 without buffer pool            394            527         151          0.0       39420.6       1.0X
+Compression 10000 times at level 2 without buffer pool            453            455           3          0.0       45251.2       0.9X
+Compression 10000 times at level 3 without buffer pool            640            645           3          0.0       64045.8       0.6X
+Compression 10000 times at level 1 with buffer pool               193            197           3          0.1       19278.3       2.0X
+Compression 10000 times at level 2 with buffer pool               244            251           3          0.0       24416.2       1.6X
+Compression 10000 times at level 3 with buffer pool               420            436          10          0.0       42020.0       0.9X
 
 OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            550            552           2          0.0       54986.3       1.0X
-Decompression 10000 times from level 2 without buffer pool            552            555           2          0.0       55247.1       1.0X
-Decompression 10000 times from level 3 without buffer pool            545            552           6          0.0       54513.2       1.0X
-Decompression 10000 times from level 1 with buffer pool               438            439           1          0.0       43831.4       1.3X
-Decompression 10000 times from level 2 with buffer pool               441            443           1          0.0       44138.4       1.2X
-Decompression 10000 times from level 3 with buffer pool               440            443           3          0.0       43966.3       1.3X
+Decompression 10000 times from level 1 without buffer pool            612            615           3          0.0       61241.3       1.0X
+Decompression 10000 times from level 2 without buffer pool            611            615           3          0.0       61124.5       1.0X
+Decompression 10000 times from level 3 without buffer pool            614            617           2          0.0       61402.7       1.0X
+Decompression 10000 times from level 1 with buffer pool               423            424           1          0.0       42257.6       1.4X
+Decompression 10000 times from level 2 with buffer pool               423            424           1          0.0       42305.5       1.4X
+Decompression 10000 times from level 3 with buffer pool               423            424           2          0.0       42259.3       1.4X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1033-azure
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            396            527         150          0.0       39554.9       1.0X
-Compression 10000 times at level 2 without buffer pool            451            453           2          0.0       45109.2       0.9X
-Compression 10000 times at level 3 without buffer pool            639            640           1          0.0       63949.2       0.6X
-Compression 10000 times at level 1 with buffer pool               192            197           3          0.1       19199.2       2.1X
-Compression 10000 times at level 2 with buffer pool               243            250           4          0.0       24310.4       1.6X
-Compression 10000 times at level 3 with buffer pool               417            431           9          0.0       41711.5       0.9X
+Compression 10000 times at level 1 without buffer pool            404            498          52          0.0       40422.4       1.0X
+Compression 10000 times at level 2 without buffer pool            533            534           2          0.0       53256.8       0.8X
+Compression 10000 times at level 3 without buffer pool            717            720           4          0.0       71650.7       0.6X
+Compression 10000 times at level 1 with buffer pool               324            327           2          0.0       32425.5       1.2X
+Compression 10000 times at level 2 with buffer pool               376            380           4          0.0       37591.0       1.1X
+Compression 10000 times at level 3 with buffer pool               549            556           8          0.0       54924.8       0.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1033-azure
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            687            689           2          0.0       68670.4       1.0X
-Decompression 10000 times from level 2 without buffer pool            685            688           3          0.0       68507.1       1.0X
-Decompression 10000 times from level 3 without buffer pool            686            687           2          0.0       68591.8       1.0X
-Decompression 10000 times from level 1 with buffer pool               497            499           2          0.0       49662.2       1.4X
-Decompression 10000 times from level 2 with buffer pool               496            498           2          0.0       49645.5       1.4X
-Decompression 10000 times from level 3 with buffer pool               496            498           2          0.0       49649.5       1.4X
+Decompression 10000 times from level 1 without buffer pool            668            670           2          0.0       66847.7       1.0X
+Decompression 10000 times from level 2 without buffer pool            668            669           2          0.0       66754.5       1.0X
+Decompression 10000 times from level 3 without buffer pool            670            671           2          0.0       66951.6       1.0X
+Decompression 10000 times from level 1 with buffer pool               482            483           1          0.0       48187.9       1.4X
+Decompression 10000 times from level 2 with buffer pool               480            482           2          0.0       47994.2       1.4X
+Decompression 10000 times from level 3 with buffer pool               480            483           3          0.0       47953.9       1.4X
 
 

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -270,4 +270,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.4-2//zstd-jni-1.5.4-2.jar
+zstd-jni/1.5.5-1//zstd-jni-1.5.5-1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -254,4 +254,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.4-2//zstd-jni-1.5.4-2.jar
+zstd-jni/1.5.5-1//zstd-jni-1.5.5-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -808,7 +808,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.4-2</version>
+        <version>1.5.5-1</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `zstd-jni` from 1.5.4-2 to 1.5.5-1.


### Why are the changes needed?
New version includes a bug fix about `Closing ZstdOutputStream without any write produces empty files`:
- https://github.com/luben/zstd-jni/issues/249  | https://github.com/luben/zstd-jni/commit/2b6f2eca3e07817f4713ec43a047100c26cc51a1

Other changes as follows:
- https://github.com/luben/zstd-jni/compare/v1.5.4-2...v1.5.5-1


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions