### PR TITLE
[SPARK-43090][CONNECT][TESTS] Move `withTable` from `RemoteSparkSession` to `SQLHelper`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SQLHelper.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SQLHelper.scala
@@ -93,4 +93,15 @@ trait SQLHelper {
     try f(path)
     finally Utils.deleteRecursively(path)
   }
+
+  /**
+   * Drops table `tableName` after calling `f`.
+   */
+  protected def withTable(tableNames: String*)(f: => Unit): Unit = {
+    Utils.tryWithSafeFinally(f) {
+      tableNames.foreach { name =>
+        spark.sql(s"DROP TABLE IF EXISTS $name").collect()
+      }
+    }
+  }
 }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connect.client.SparkConnectClient
 import org.apache.spark.sql.connect.client.util.IntegrationTestUtils._
 import org.apache.spark.sql.connect.common.config.ConnectCommon
-import org.apache.spark.util.Utils
 
 /**
  * An util class to start a local spark connect server in a different process for local E2E tests.
@@ -175,16 +174,5 @@ trait RemoteSparkSession extends ConnectFunSuite with BeforeAndAfterAll {
     }
     spark = null
     super.afterAll()
-  }
-
-  /**
-   * Drops table `tableName` after calling `f`.
-   */
-  protected def withTable(tableNames: String*)(f: => Unit): Unit = {
-    Utils.tryWithSafeFinally(f) {
-      tableNames.foreach { name =>
-        spark.sql(s"DROP TABLE IF EXISTS $name").collect()
-      }
-    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
A minor refactor,  just move  `withTable` function from `RemoteSparkSession` to `SQLHelper`, put it together with functions like `withSQLConf`, `withTempDatabase`, etc.



### Why are the changes needed?
`withTable` function is more suitable in `SQLHelper`.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions