### PR TITLE
[SPARK-42382][BUILD] Upgrade `cyclonedx-maven-plugin` to 2.7.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3439,7 +3439,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.3</version>
+        <version>2.7.6</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `cyclonedx-maven-plugin` to 2.7.6 for Apache Spark 3.5.0.


### Why are the changes needed?
The release notes as follows:

- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.4
- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.5
- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.6

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- Pass GitHub Actions.
- Manual check the `cyclonedx.xml` file can be generated normally.

