### PR TITLE
[SPARK-43083][SQL][TESTS] Mark `*StateStoreSuite` as `ExtendedSQLTest`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -30,9 +30,11 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.StatefulOperatorStateInfo
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.Utils
 
+@ExtendedSQLTest
 class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvider]
   with BeforeAndAfter {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -42,9 +42,11 @@ import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
 
+@ExtendedSQLTest
 class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
   with BeforeAndAfter {
   import StateStoreTestsHelper._


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark `StateStoreSuite` and `RocksDBStateStoreSuite` as `ExtendedSQLTest`.

### Why are the changes needed?

To balance GitHub Action jobs by offloading heavy tests.

- `sql - other tests` took [2 hour 55 minutes](https://github.com/apache/spark/actions/runs/4641961434/jobs/8215437737)
- `sql - slow tests` took [1 hour 46 minutes](https://github.com/apache/spark/actions/runs/4641961434/jobs/8215437616)

```
- maintenance (2 seconds, 4 milliseconds)
- SPARK-40492: maintenance before unload (2 minutes)
- snapshotting (1 second, 96 milliseconds)
- SPARK-21145: Restarted queries create new provider instances (1 second, 261 milliseconds)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Pass the CIs.