### PR TITLE
[SPARK-43086][CORE] Support bin pack task scheduling on executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2051,6 +2051,14 @@ package object config {
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
+  private[spark] val BIN_PACK_ENABLED =
+    ConfigBuilder("spark.scheduler.binPack.enabled")
+      .doc(s"Whether to enable bin packing task scheduling on executors. This could help save" +
+        s" resource when ${DYN_ALLOCATION_ENABLED.key} is enabled.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val SPECULATION_ENABLED =
     ConfigBuilder("spark.speculation")
       .version("0.6.0")

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -193,6 +193,21 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
     assert(!failedTaskSet)
   }
 
+  test("SPARK-43086: Scheduler should schedule task on fewest executors" +
+    " when bin pack enabled") {
+    val taskScheduler = setupScheduler((config.BIN_PACK_ENABLED.key -> "true"))
+    val numFreeCores = 4
+    val workerOffers = IndexedSeq(WorkerOffer("executor0", "host0", numFreeCores),
+      WorkerOffer("executor1", "host1", numFreeCores - 1))
+    val numTasks = 3
+    val taskSet = FakeTask.createTaskSet(3)
+    taskScheduler.submitTasks(taskSet)
+    val taskDescriptions = taskScheduler.resourceOffers(workerOffers).flatten
+    assert(numTasks === taskDescriptions.length)
+    assert(taskDescriptions.forall(t => t.executorId == "executor1"))
+    assert(!failedTaskSet)
+  }
+
   test("Scheduler correctly accounts for multiple CPUs per task") {
     val taskCpus = 2
     val taskScheduler = setupSchedulerWithMaster(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support bin pack task scheduling on executors. This is controlled by `spark.scheduler.binPack.enabled`

### Why are the changes needed?
Dynamic allocation only remove or decommission idle executors. The default task scheduler use round robin to do task assignment on executors. This leads to resource waste.

For example, we have 4 tasks to run, 4 executors(each has 4 cpu cores). Default task scheduler will assign 1 task per executors. With bin pack, 1 executor will be assigned 4 tasks, then dynamic allocation could remove other 3 idle executors to reduce resource waste.

In prod, we have seen 20~50 percent resource save based on executor size, the more saving with more cpu cores per executor. For the issue could be caused by bin-packed executors, it's still possible to happen when all executor cores are occupied. If it indeed happen, the better solution might be large partition num.

The purpose of change is to provide one more scheduling option, customer still can use the old way.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added test in TaskSchedulerImplSuite
