### PR TITLE
[SPARK-43085][SQL] Support column DEFAULT assignment for multi-part table names

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -313,7 +313,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       TimeWindowing ::
       SessionWindowing ::
       ResolveWindowTime ::
-      ResolveDefaultColumns(ResolveRelations) ::
+      ResolveDefaultColumns(ResolveRelations.resolveRelationOrTempView) ::
       ResolveInlineTables ::
       ResolveLambdaVariables ::
       ResolveTimeZone ::
@@ -1273,6 +1273,11 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           case _ => None
         }
       }
+    }
+
+    /** Consumes an unresolved relation and resolves it to a v1 or v2 relation or temporary view. */
+    def resolveRelationOrTempView(u: UnresolvedRelation): LogicalPlan = {
+      EliminateSubqueryAliases(resolveRelation(u).getOrElse(u))
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -313,7 +313,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       TimeWindowing ::
       SessionWindowing ::
       ResolveWindowTime ::
-      ResolveDefaultColumns(catalogManager) ::
+      ResolveDefaultColumns(ResolveRelations) ::
       ResolveInlineTables ::
       ResolveLambdaVariables ::
       ResolveTimeZone ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -313,7 +313,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       TimeWindowing ::
       SessionWindowing ::
       ResolveWindowTime ::
-      ResolveDefaultColumns(v1SessionCatalog, catalogManager) ::
+      ResolveDefaultColumns(catalogManager) ::
       ResolveInlineTables ::
       ResolveLambdaVariables ::
       ResolveTimeZone ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -313,7 +313,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       TimeWindowing ::
       SessionWindowing ::
       ResolveWindowTime ::
-      ResolveDefaultColumns(v1SessionCatalog) ::
+      ResolveDefaultColumns(v1SessionCatalog, catalogManager) ::
       ResolveInlineTables ::
       ResolveLambdaVariables ::
       ResolveTimeZone ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -49,11 +49,12 @@ import org.apache.spark.sql.types._
  * (1, 5)
  * (4, 6)
  *
- * @param catalog  the catalog to use for looking up the schema of INSERT INTO table objects.
+ * @param catalogManager the catalog manager to use for looking up the schema of INSERT INTO table
+ *                       objects.
  */
-case class ResolveDefaultColumns(
-    catalog: SessionCatalog, override val catalogManager: CatalogManager)
+case class ResolveDefaultColumns(override val catalogManager: CatalogManager)
   extends Rule[LogicalPlan] with LookupCatalog {
+  val catalog: SessionCatalog = catalogManager.v1SessionCatalog
   override def apply(plan: LogicalPlan): LogicalPlan = {
     plan.resolveOperatorsWithPruning(
       (_ => SQLConf.get.enableDefaultColumns), ruleId) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -558,17 +558,14 @@ case class ResolveDefaultColumns(
       case other =>
         other
     }
-    var result: Option[StructType] = None
-    resolved.foreach {
+    resolved.collectFirst {
       case r: UnresolvedCatalogRelation =>
-        result = Some(r.tableMeta.schema)
+        r.tableMeta.schema
       case d: DataSourceV2Relation if !d.skipSchemaResolution && !d.isStreaming =>
-        result = Some(CatalogV2Util.v2ColumnsToStructType(d.table.columns()))
+        CatalogV2Util.v2ColumnsToStructType(d.table.columns())
       case v: View if v.isTempViewStoringAnalyzedPlan =>
-        result = Some(v.schema)
-      case _ =>
+        v.schema
     }
-    result
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns._
 import org.apache.spark.sql.connector.catalog.{CatalogManager, LookupCatalog}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -580,7 +581,7 @@ case class ResolveDefaultColumns(
               database = if (identifier.namespace().nonEmpty) {
                 Some(identifier.namespace().head)
               } else {
-                None
+                Some(catalogManager.currentNamespace.quoted)
               },
               catalog = Some(catalog.name))
           case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -562,7 +562,7 @@ case class ResolveDefaultColumns(
     resolved.foreach {
       case r: UnresolvedCatalogRelation =>
         result = Some(r.tableMeta.schema)
-      case d: DataSourceV2Relation =>
+      case d: DataSourceV2Relation if !d.skipSchemaResolution && !d.isStreaming =>
         result = Some(CatalogV2Util.v2ColumnsToStructType(d.table.columns()))
       case v: View if v.isTempViewStoringAnalyzedPlan =>
         result = Some(v.schema)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -572,7 +572,6 @@ case class ResolveDefaultColumns(
     // Lookup the relation from the catalog by name. This either succeeds or returns some "not
     // found" error. In the latter cases, return out of this rule without changing anything and let
     // the analyzer return a proper error message elsewhere.
-    // var viewCheck: S
     val tableName: TableIdentifier = source match {
       case Some(r: UnresolvedRelation) =>
         r.multipartIdentifier match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
@@ -76,19 +76,19 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-43085: Column DEFAULT assignment for target tables with three-part names") {
-    withDatabase("main.demos") {
-      sql("create database main.demos")
-      withTable("main.demos.test_ts") {
-        sql("create table main.demos.test_ts (id int, ts timestamp) using parquet")
-        sql("insert into main.demos.test_ts(ts) values (timestamp'2023-01-01')")
-        checkAnswer(spark.table("main.demos.test_ts"),
+    withDatabase("demos") {
+      sql("create database demos")
+      withTable("demos.test_ts") {
+        sql("create table demos.test_ts (id int, ts timestamp) using parquet")
+        sql("insert into demos.test_ts(ts) values (timestamp'2023-01-01')")
+        checkAnswer(spark.table("demos.test_ts"),
           sql("select null, timestamp'2023-01-01'"))
       }
-      withTable("main.demos.test_ts") {
-        sql("create table main.demos.test_ts (id int, ts timestamp) using parquet")
-        sql("use catalog main")
-        sql("insert into demos.test_ts(ts) values (timestamp'2023-01-01')")
-        checkAnswer(spark.table("main.demos.test_ts"),
+      withTable("demos.test_ts") {
+        sql("create table demos.test_ts (id int, ts timestamp) using parquet")
+        sql("use database demos")
+        sql("insert into test_ts(ts) values (timestamp'2023-01-01')")
+        checkAnswer(spark.table("demos.test_ts"),
           sql("select null, timestamp'2023-01-01'"))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
 
 class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
-  val rule = ResolveDefaultColumns(catalog = null)
+  val rule = ResolveDefaultColumns(catalog = null, catalogManager = null)
   // This is the internal storage for the timestamp 2020-12-31 00:00:00.0.
   val literal = Literal(1609401600000000L, TimestampType)
   val table = UnresolvedInlineTable(
@@ -72,6 +72,25 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
       sql("insert into t (ts) values (timestamp'2020-12-31')")
       checkAnswer(spark.table("t"),
         sql("select null, timestamp'2020-12-31'").collect().head)
+    }
+  }
+
+  test("SPARK-43085: Column DEFAULT assignment for target tables with three-part names") {
+    withDatabase("main.demos") {
+      sql("create database main.demos")
+      withTable("main.demos.test_ts") {
+        sql("create table main.demos.test_ts (id int, ts timestamp) using parquet")
+        sql("insert into main.demos.test_ts(ts) values (timestamp'2023-01-01')")
+        checkAnswer(spark.table("main.demos.test_ts"),
+          sql("select null, timestamp'2023-01-01'"))
+      }
+      withTable("main.demos.test_ts") {
+        sql("create table main.demos.test_ts (id int, ts timestamp) using parquet")
+        sql("use catalog main")
+        sql("insert into demos.test_ts(ts) values (timestamp'2023-01-01')")
+        checkAnswer(spark.table("main.demos.test_ts"),
+          sql("select null, timestamp'2023-01-01'"))
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
 
 class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
-  val rule = ResolveDefaultColumns(resolveRelations = null)
+  val rule = ResolveDefaultColumns(null)
   // This is the internal storage for the timestamp 2020-12-31 00:00:00.0.
   val literal = Literal(1609401600000000L, TimestampType)
   val table = UnresolvedInlineTable(

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
@@ -75,7 +75,7 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-43085: Column DEFAULT assignment for target tables with three-part names") {
+  test("SPARK-43085: Column DEFAULT assignment for target tables with multi-part names") {
     withDatabase("demos") {
       sql("create database demos")
       withTable("demos.test_ts") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
 
 class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
-  val rule = ResolveDefaultColumns(catalogManager = null)
+  val rule = ResolveDefaultColumns(resolveRelations = null)
   // This is the internal storage for the timestamp 2020-12-31 00:00:00.0.
   val literal = Literal(1609401600000000L, TimestampType)
   val table = UnresolvedInlineTable(

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
 
 class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
-  val rule = ResolveDefaultColumns(catalog = null, catalogManager = null)
+  val rule = ResolveDefaultColumns(catalogManager = null)
   // This is the internal storage for the timestamp 2020-12-31 00:00:00.0.
   val literal = Literal(1609401600000000L, TimestampType)
   val table = UnresolvedInlineTable(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for column DEFAULT assignment for multi-part table names.

### Why are the changes needed?

Spark SQL workloads that refer to tables with multi-part names may want to use column DEFAULT functionality. This PR enables this.

### Does this PR introduce _any_ user-facing change?

Yes, column DEFAULT assignment now works with multi-part table names.

### How was this patch tested?

This PR adds unit tests.