### PR TITLE
[SPARK-43089][CONNECT] Redact debug string in UI

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, QueryStageExec}
 import org.apache.spark.sql.execution.arrow.ArrowConverters
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 class SparkConnectStreamHandler(responseObserver: StreamObserver[ExecutePlanResponse])
     extends Logging {
@@ -53,7 +53,8 @@ class SparkConnectStreamHandler(responseObserver: StreamObserver[ExecutePlanResp
 
       // Add debug information to the query execution so that the jobs are traceable.
       try {
-        val debugString = v.toString
+        val debugString =
+          Utils.redact(session.sessionState.conf.stringRedactionPattern, v.toString)
         session.sparkContext.setLocalProperty(
           "callSite.short",
           s"Spark Connect - ${StringUtils.abbreviate(debugString, 128)}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/40603 which redacts the debug string shown in UI.

### Why are the changes needed?

To leverage existing redaction feature in UI.

### Does this PR introduce _any_ user-facing change?

Yes, it redacts the sensitive information as configured `spark.sql.redaction.string.regex`

### How was this patch tested?

Manually tested:
![Screenshot 2023-04-11 at 11 07 22 AM](https://user-images.githubusercontent.com/6477701/231036919-fc73b9f0-b2e6-4d95-be25-60421f99ee4f.png)

