### PR TITLE
[SPARK-43093][SQL][TESTS] Refactor `Add a directory when spark.sql.legacy.addSingleFileInAddFile set to false` to test using tempDir with non-fixed root dir

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2071,6 +2071,8 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test(s"Add a directory when ${SQLConf.LEGACY_ADD_SINGLE_FILE_IN_ADD_FILE.key} set to false") {
+    // SPARK-43093: Don't use `withTempDir` to clean up temp dir, it will cause test cases in
+    // shared session that need to execute `Executor.updateDependencies` test fail.
     val directoryToAdd = Utils.createDirectory(
       root = Utils.createTempDir().getCanonicalPath, namePrefix = "addDirectory")
     val testFile = File.createTempFile("testFile", "1", directoryToAdd)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2071,7 +2071,8 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test(s"Add a directory when ${SQLConf.LEGACY_ADD_SINGLE_FILE_IN_ADD_FILE.key} set to false") {
-    val directoryToAdd = Utils.createTempDir("/tmp/spark/addDirectory/")
+    val directoryToAdd = Utils.createDirectory(
+      root = Utils.createTempDir().getCanonicalPath, namePrefix = "addDirectory")
     val testFile = File.createTempFile("testFile", "1", directoryToAdd)
     spark.sql(s"ADD FILE $directoryToAdd")
     assert(new File(SparkFiles.get(s"${directoryToAdd.getName}/${testFile.getName}")).exists())


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to refactor `Add a directory when spark.sql.legacy.addSingleFileInAddFile set to false` in `HiveCatalogedDDLSuite` to test using a temporary directory with non-fixed root directory.


### Why are the changes needed?
Before this PR, this test case used a fixed directory `/tmp/spark/addDirectory/` as the root directory of the temporary directory for testing, this can lead to the following scenarios



1. Execute the following command to test 

```
build/mvn clean install -Phadoop-3 -pl sql/hive -Dtest=none -DwildcardSuites=org.apache.spark.sql.hive.execution.HiveCatalogedDDLSuite -am
```

2. Execute `ls -R /tmp/spark`, we can see the permission of the `/tmp/spark/addDirectory` directory is `drwxrwxr-x` and  the content of `/tmp/spark/addDirectory`  was cleaned up, but the xx directory still exists


```
/tmp/spark:
total 4
drwxrwxr-x 2 userA groupA 4096 Apr 11 10:55 addDirectory

/tmp/spark/addDirectory:
total 0
```

3. Switch to userB to re-run the test commands

```
build/mvn clean install -Phadoop-3 -pl sql/hive -Dtest=none -DwildcardSuites=org.apache.spark.sql.hive.execution.HiveCatalogedDDLSuite -am
```

then we can see the test fail with following message:

```
- Add a directory when spark.sql.legacy.addSingleFileInAddFile set to false *** FAILED ***
  java.io.IOException: Failed to create a temp directory (under /tmp/spark/addDirectory/) after 10 attempts!
  at org.apache.spark.util.Utils$.createDirectory(Utils.scala:314)
  at org.apache.spark.util.Utils$.createTempDir(Utils.scala:334)
  at org.apache.spark.sql.execution.command.DDLSuite.$anonfun$new$371(DDLSuite.scala:2497)
  at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
  at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
  at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
  at org.scalatest.Transformer.apply(Transformer.scala:22)
  at org.scalatest.Transformer.apply(Transformer.scala:20)
  at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
  at org.apache.spark.SparkFunSuite.withFixture(SparkFunSuite.scala:190)
  ...
```

So this pr changes the case to use a temporary directory with non-fixed root directory for tesing to solve the bad case mentioned above, and ensure the temporary directory for testing under root dir is better cleaned up.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual checked: the temporary directory has been cleaned from the first level under root after test