### PR TITLE
[SPARK-43302][SQL] Make Python UDAF an AggregateFunction

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1170,8 +1170,8 @@ class SparkConnectPlanner(val session: SparkSession) {
       func = transformPythonFunction(udf),
       dataType = transformDataType(udf.getOutputType),
       pythonEvalType = udf.getEvalType,
-      udfDeterministic = fun.getDeterministic
-    ).builder(fun.getArgumentsList.asScala.map(transformExpression).toSeq) match {
+      udfDeterministic = fun.getDeterministic)
+      .builder(fun.getArgumentsList.asScala.map(transformExpression).toSeq) match {
       case udaf: PythonUDAF => udaf.toAggregateExpression()
       case other => other
     }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1171,7 +1171,10 @@ class SparkConnectPlanner(val session: SparkSession) {
       dataType = transformDataType(udf.getOutputType),
       pythonEvalType = udf.getEvalType,
       udfDeterministic = fun.getDeterministic
-    ).apply(fun.getArgumentsList.asScala.map(transformExpression).toSeq).expr
+    ).builder(fun.getArgumentsList.asScala.map(transformExpression).toSeq) match {
+      case udaf: PythonUDAF => udaf.toAggregateExpression()
+      case other => other
+    }
   }
 
   private def transformPythonFunction(fun: proto.PythonUDF): SimplePythonFunction = {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1171,7 +1171,7 @@ class SparkConnectPlanner(val session: SparkSession) {
       dataType = transformDataType(udf.getOutputType),
       pythonEvalType = udf.getEvalType,
       udfDeterministic = fun.getDeterministic
-    ).builder(fun.getArgumentsList.asScala.map(transformExpression).toSeq)
+    ).apply(fun.getArgumentsList.asScala.map(transformExpression).toSeq).expr
   }
 
   private def transformPythonFunction(fun: proto.PythonUDF): SimplePythonFunction = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -606,7 +606,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         groupingAttrs: Seq[Expression],
         gid: Attribute): Seq[NamedExpression] = {
       def replaceExprs(e: Expression): Expression = e match {
-        case e if AggregateExpression.isAggregate(e) => e
+        case e: AggregateExpression => e
         case e =>
           // Replace expression by expand output attribute.
           val index = groupByAliases.indexWhere(_.child.semanticEquals(e))
@@ -864,9 +864,12 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     // Support any aggregate expression that can appear in an Aggregate plan except Pandas UDF.
     // TODO: Support Pandas UDF.
     private def checkValidAggregateExpression(expr: Expression): Unit = expr match {
-      case _: AggregateExpression => // OK and leave the argument check to CheckAnalysis.
-      case expr: PythonUDF if PythonUDF.isGroupedAggPandasUDF(expr) =>
-        throw QueryCompilationErrors.pandasUDFAggregateNotSupportedInPivotError()
+      case a: AggregateExpression =>
+        if (a.aggregateFunction.isInstanceOf[PythonUDAF]) {
+          throw QueryCompilationErrors.pandasUDFAggregateNotSupportedInPivotError()
+        } else {
+          // OK and leave the argument check to CheckAnalysis.
+        }
       case e: Attribute =>
         throw QueryCompilationErrors.aggregateExpressionRequiredForPivotError(e.sql)
       case e => e.children.foreach(checkValidAggregateExpression)
@@ -2495,17 +2498,13 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       val windowedAggExprs: Set[Expression] = exprs.flatMap { expr =>
         expr.collect {
           case WindowExpression(ae: AggregateExpression, _) => ae
-          case WindowExpression(e: PythonUDF, _) if PythonUDF.isGroupedAggPandasUDF(e) => e
           case UnresolvedWindowExpression(ae: AggregateExpression, _) => ae
-          case UnresolvedWindowExpression(e: PythonUDF, _)
-            if PythonUDF.isGroupedAggPandasUDF(e) => e
         }
       }.toSet
 
       // Find the first Aggregate Expression that is not Windowed.
       exprs.exists(_.exists {
         case ae: AggregateExpression => !windowedAggExprs.contains(ae)
-        case e: PythonUDF => PythonUDF.isGroupedAggPandasUDF(e) && !windowedAggExprs.contains(e)
         case _ => false
       })
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -330,7 +330,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   messageParameters = Map("aggFunc" -> agg.aggregateFunction.prettyName))
               case _: AggregateExpression | _: FrameLessOffsetWindowFunction |
                   _: AggregateWindowFunction => // OK
-              case f: PythonUDF if PythonUDF.isWindowPandasUDF(f) => // OK
+              case f: PythonFuncExpression if PythonUDF.isWindowPandasUDF(f) => // OK
               case other =>
                 other.failAnalysis(
                   errorClass = "UNSUPPORTED_EXPR_FOR_WINDOW",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -330,7 +330,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   messageParameters = Map("aggFunc" -> agg.aggregateFunction.prettyName))
               case _: AggregateExpression | _: FrameLessOffsetWindowFunction |
                   _: AggregateWindowFunction => // OK
-              case f: PythonFuncExpression if PythonUDF.isWindowPandasUDF(f) => // OK
               case other =>
                 other.failAnalysis(
                   errorClass = "UNSUPPORTED_EXPR_FOR_WINDOW",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -403,14 +403,11 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
 
           case Aggregate(groupingExprs, aggregateExprs, _) =>
             def checkValidAggregateExpression(expr: Expression): Unit = expr match {
-              case expr: Expression if AggregateExpression.isAggregate(expr) =>
-                val aggFunction = expr match {
-                  case agg: AggregateExpression => agg.aggregateFunction
-                  case udf: PythonUDF => udf
-                }
+              case expr: AggregateExpression =>
+                val aggFunction = expr.aggregateFunction
                 aggFunction.children.foreach { child =>
                   child.foreach {
-                    case expr: Expression if AggregateExpression.isAggregate(expr) =>
+                    case expr: AggregateExpression =>
                       expr.failAnalysis(
                         errorClass = "NESTED_AGGREGATE_FUNCTION",
                         messageParameters = Map.empty)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
@@ -204,7 +204,7 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
           // in group by, once transformed, will throw a different exception: missing input.
           def eligibleToLiftUp(exp: Expression): Boolean = {
             exp match {
-              case e if AggregateExpression.isAggregate(e) => true
+              case _: AggregateExpression => true
               case e if groupingExpressions.exists(_.semanticEquals(e)) => true
               case a: Attribute => false
               case s: ScalarSubquery if s.children.nonEmpty

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
@@ -148,7 +148,7 @@ object ResolveReferencesInAggregate extends SQLConfHelper
    * Aggregate.
    */
   private def expandGroupByAll(selectList: Seq[NamedExpression]): Option[Seq[Expression]] = {
-    val groupingExprs = selectList.filter(!_.exists(AggregateExpression.isAggregate))
+    val groupingExprs = selectList.filter(e => !AggregateExpression.containsAggregate(e))
     // If the grouping exprs are empty, this could either be (1) a valid global aggregate, or
     // (2) we simply fail to infer the grouping columns. As an example, in "i + sum(j)", we will
     // not automatically infer the grouping column to be "i".
@@ -181,7 +181,7 @@ object ResolveReferencesInAggregate extends SQLConfHelper
    *  "sum(j) / 2" -> false
    */
   private def containsAttribute(expr: Expression): Boolean = expr match {
-    case _ if AggregateExpression.isAggregate(expr) =>
+    case _: AggregateExpression =>
       // Don't recurse into AggregateExpressions
       false
     case _: Attribute =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -37,8 +37,7 @@ trait AliasHelper {
     // Find all the aliased expressions in the aggregate list that don't include any actual
     // AggregateExpression or PythonUDF, and create a map from the alias to the expression
     val aliasMap = plan.aggregateExpressions.collect {
-      case a: Alias if a.child.find(e => e.isInstanceOf[AggregateExpression] ||
-        PythonUDF.isGroupedAggPandasUDF(e)).isEmpty =>
+      case a: Alias if a.child.find(_.isInstanceOf[AggregateExpression]).isEmpty =>
         (a.toAttribute, a)
     }
     AttributeMap(aliasMap)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -460,7 +460,7 @@ trait NonSQLExpression extends Expression {
     transform {
       case a: Attribute => new PrettyAttribute(a)
       case a: Alias => PrettyAttribute(a.sql, a.dataType)
-      case p: PythonUDF => PrettyPythonUDF(p.name, p.dataType, p.children)
+      case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
     }.toString
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -457,7 +457,7 @@ trait RuntimeReplaceableAggregate extends RuntimeReplaceable { self: AggregateFu
  */
 trait NonSQLExpression extends Expression {
   final override def sql: String = {
-    transformUp {
+    transform {
       case a: Attribute => new PrettyAttribute(a)
       case a: Alias => PrettyAttribute(a.sql, a.dataType)
       case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -457,7 +457,7 @@ trait RuntimeReplaceableAggregate extends RuntimeReplaceable { self: AggregateFu
  */
 trait NonSQLExpression extends Expression {
   final override def sql: String = {
-    transform {
+    transformUp {
       case a: Attribute => new PrettyAttribute(a)
       case a: Alias => PrettyAttribute(a.sql, a.dataType)
       case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -123,6 +123,11 @@ case class PythonUDAF(
     s"$name($distinct${children.mkString(", ")})"
   }
 
+  override def toAggString(isDistinct: Boolean): String = {
+    val start = if (isDistinct) "(distinct " else "("
+    name + children.mkString(start, ", ", ")") + s"#${resultId.id}$typeSuffix"
+  }
+
   final override val nodePatterns: Seq[TreePattern] = Seq(PYTHON_UDAF)
 
   override lazy val canonicalized: Expression = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -41,11 +41,10 @@ object PythonUDF {
     e.isInstanceOf[PythonUDF] && SCALAR_TYPES.contains(e.asInstanceOf[PythonUDF].evalType)
   }
 
-  def isWindowPandasUDF(e: Expression): Boolean = {
-    e.isInstanceOf[PythonUDF] &&
-      // This is currently SQL_GROUPED_AGG_PANDAS_UDF, but we might support new types in the future,
-      // e.g, N -> N transform.
-      e.asInstanceOf[PythonUDF].evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
+  def isWindowPandasUDF(e: PythonFuncExpression): Boolean = {
+    // This is currently only `PythonUDAF` (which means SQL_GROUPED_AGG_PANDAS_UDF), but we might
+    // support new types in the future, e.g, N -> N transform.
+    e.isInstanceOf[PythonUDAF]
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -158,13 +158,8 @@ case class PrettyPythonUDF(
   override def toString: String = s"$name(${children.mkString(", ")})"
 
   override def sql(isDistinct: Boolean): String = {
-    val prettyChildren = children.map(_.transform {
-      case a: Attribute => new PrettyAttribute(a)
-      case a: Alias => PrettyAttribute(a.sql, a.dataType)
-      case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
-    })
     val distinct = if (isDistinct) "DISTINCT " else ""
-    s"$name($distinct${prettyChildren.mkString(", ")})"
+    s"$name($distinct${children.mkString(", ")})"
   }
 
   override def nullable: Boolean = true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -17,10 +17,15 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.spark.SparkException
 import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
-import org.apache.spark.sql.catalyst.trees.TreePattern.{PYTHON_UDF, TreePattern}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{PYTHON_UDAF, PYTHON_UDF, TreePattern}
 import org.apache.spark.sql.catalyst.util.toPrettySQL
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.types.{DataType, StructType}
 
 /**
  * Helper functions for [[PythonUDF]]
@@ -36,14 +41,26 @@ object PythonUDF {
     e.isInstanceOf[PythonUDF] && SCALAR_TYPES.contains(e.asInstanceOf[PythonUDF].evalType)
   }
 
-  def isGroupedAggPandasUDF(e: Expression): Boolean = {
+  def isWindowPandasUDF(e: Expression): Boolean = {
     e.isInstanceOf[PythonUDF] &&
+      // This is currently SQL_GROUPED_AGG_PANDAS_UDF, but we might support new types in the future,
+      // e.g, N -> N transform.
       e.asInstanceOf[PythonUDF].evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
   }
+}
 
-  // This is currently same as GroupedAggPandasUDF, but we might support new types in the future,
-  // e.g, N -> N transform.
-  def isWindowPandasUDF(e: Expression): Boolean = isGroupedAggPandasUDF(e)
+
+trait PythonFuncExpression extends NonSQLExpression with UserDefinedExpression { self: Expression =>
+  def name: String
+  def func: PythonFunction
+  def udfDeterministic: Boolean
+  def resultId: ExprId
+
+  override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
+
+  override def toString: String = s"$name(${children.mkString(", ")})#${resultId.id}$typeSuffix"
+
+  override def nullable: Boolean = true
 }
 
 /**
@@ -58,18 +75,12 @@ case class PythonUDF(
     evalType: Int,
     udfDeterministic: Boolean,
     resultId: ExprId = NamedExpression.newExprId)
-  extends Expression with Unevaluable with NonSQLExpression with UserDefinedExpression {
-
-  override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
-
-  override def toString: String = s"$name(${children.mkString(", ")})#${resultId.id}$typeSuffix"
-
-  final override val nodePatterns: Seq[TreePattern] = Seq(PYTHON_UDF)
+  extends Expression with PythonFuncExpression with Unevaluable {
 
   lazy val resultAttribute: Attribute = AttributeReference(toPrettySQL(this), dataType, nullable)(
     exprId = resultId)
 
-  override def nullable: Boolean = true
+  final override val nodePatterns: Seq[TreePattern] = Seq(PYTHON_UDF)
 
   override lazy val canonicalized: Expression = {
     val canonicalizedChildren = children.map(_.canonicalized)
@@ -78,6 +89,43 @@ case class PythonUDF(
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): PythonUDF =
+    copy(children = newChildren)
+}
+
+/**
+ * A serialized version of a Python lambda function for aggregation. This is a special expression,
+ * which needs a dedicated physical operator to execute it, instead of the normal Aggregate
+ * operator.
+ */
+case class PythonUDAF(
+    name: String,
+    func: PythonFunction,
+    dataType: DataType,
+    children: Seq[Expression],
+    udfDeterministic: Boolean,
+    resultId: ExprId = NamedExpression.newExprId)
+  extends AggregateFunction with PythonFuncExpression {
+
+  override def aggBufferSchema: StructType =
+    throw SparkException.internalError("PythonUDAF.aggBufferSchema should not be called.")
+  override def aggBufferAttributes: Seq[AttributeReference] =
+    throw SparkException.internalError("PythonUDAF.aggBufferAttributes should not be called.")
+  override def inputAggBufferAttributes: Seq[AttributeReference] =
+    throw SparkException.internalError("PythonUDAF.inputAggBufferAttributes should not be called.")
+  final override def eval(input: InternalRow = null): Any =
+    throw QueryExecutionErrors.cannotEvaluateExpressionError(this)
+  final override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
+    throw QueryExecutionErrors.cannotGenerateCodeForExpressionError(this)
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(PYTHON_UDAF)
+
+  override lazy val canonicalized: Expression = {
+    val canonicalizedChildren = children.map(_.canonicalized)
+    // `resultId` can be seen as cosmetic variation in PythonUDAF, as it doesn't affect the result.
+    this.copy(resultId = ExprId(-1)).withNewChildren(canonicalizedChildren)
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): PythonUDAF =
     copy(children = newChildren)
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -125,6 +125,8 @@ case class PythonUDAF(
     this.copy(resultId = ExprId(-1)).withNewChildren(canonicalizedChildren)
   }
 
+  override def sql(isDistinct: Boolean): String = this.sql
+
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): PythonUDAF =
     copy(children = newChildren)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -86,11 +86,7 @@ object AggregateExpression {
   }
 
   def containsAggregate(expr: Expression): Boolean = {
-    expr.exists(isAggregate)
-  }
-
-  def isAggregate(expr: Expression): Boolean = {
-    expr.isInstanceOf[AggregateExpression] || PythonUDF.isGroupedAggPandasUDF(expr)
+    expr.exists(_.isInstanceOf[AggregateExpression])
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -376,8 +376,10 @@ object WindowFunctionType {
 
   def functionType(windowExpression: NamedExpression): WindowFunctionType = {
     val t = windowExpression.collectFirst {
-      case _: WindowFunction | _: AggregateFunction => SQL
       case udf: PythonFuncExpression if PythonUDF.isWindowPandasUDF(udf) => Python
+      // We should match `AggregateFunction` after the python function, as `PythonUDAF` extends
+      // `AggregateFunction` but the function type should be Python.
+      case _: WindowFunction | _: AggregateFunction => SQL
     }
 
     // Normally a window expression would either have a SQL window function, a SQL

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -377,7 +377,7 @@ object WindowFunctionType {
   def functionType(windowExpression: NamedExpression): WindowFunctionType = {
     val t = windowExpression.collectFirst {
       case _: WindowFunction | _: AggregateFunction => SQL
-      case udf: PythonUDF if PythonUDF.isWindowPandasUDF(udf) => Python
+      case udf: PythonFuncExpression if PythonUDF.isWindowPandasUDF(udf) => Python
     }
 
     // Normally a window expression would either have a SQL window function, a SQL

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutGroupingExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutGroupingExpressions.scala
@@ -60,7 +60,7 @@ object PullOutGroupingExpressions extends Rule[LogicalPlan] {
         if (complexGroupingExpressionMap.nonEmpty) {
           def replaceComplexGroupingExpressions(e: Expression): Expression = {
             e match {
-              case _ if AggregateExpression.isAggregate(e) => e
+              case _: AggregateExpression => e
               case _ if e.foldable => e
               case _ if complexGroupingExpressionMap.contains(e.canonicalized) =>
                 complexGroupingExpressionMap.get(e.canonicalized).map(_.toAttribute).getOrElse(e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAggregates.scala
@@ -58,7 +58,7 @@ object RemoveRedundantAggregates extends Rule[LogicalPlan] with AliasHelper {
       .aggregateExpressions
       .forall(expr => !expr.exists {
         case ae: AggregateExpression => isDuplicateSensitive(ae)
-        case e => AggregateExpression.isAggregate(e)
+        case _ => false
       })
 
     lazy val upperRefsOnlyDeterministicNonAgg = upper.references.subsetOf(AttributeSet(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -76,6 +76,7 @@ object TreePattern extends Enumeration  {
   val PARAMETERIZED_QUERY: Value = Value
   val PIVOT: Value = Value
   val PLAN_EXPRESSION: Value = Value
+  val PYTHON_UDAF: Value = Value
   val PYTHON_UDF: Value = Value
   val REGEXP_EXTRACT_FAMILY: Value = Value
   val REGEXP_REPLACE: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -121,7 +121,7 @@ package object util extends Logging {
       PrettyAttribute(r.makeSQLString(r.parameters.map(toPrettySQL)), r.dataType)
     case c: Cast if !c.getTagValue(Cast.USER_SPECIFIED_CAST).getOrElse(false) =>
       PrettyAttribute(usePrettyExpression(c.child).sql, c.dataType)
-    case p: PythonUDF => PrettyPythonUDF(p.name, p.dataType, p.children)
+    case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
   }
 
   def quoteIdentifier(name: String): String = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAggregatesSuite.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Expression, PythonUDF}
+import org.apache.spark.sql.catalyst.expressions.{Expression, PythonUDAF}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical.{Distinct, LocalRelation, LogicalPlan}
@@ -41,8 +40,8 @@ class RemoveRedundantAggregatesSuite extends PlanTest {
   private def aggregates(e: Expression): Seq[Expression] = {
     Seq(
       count(e),
-      PythonUDF("pyUDF", null, IntegerType, Seq(e),
-        PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF, udfDeterministic = true)
+      PythonUDAF("pyUDAF", null, IntegerType, Seq(e), udfDeterministic = true)
+        .toAggregateExpression()
     )
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
@@ -93,6 +93,8 @@ trait PlanTestBase extends PredicateHelper with SQLHelper with SQLConfHelper { s
         lv.copy(exprId = ExprId(0), value = null)
       case udf: PythonUDF =>
         udf.copy(resultId = ExprId(0))
+      case udaf: PythonUDAF =>
+        udaf.copy(resultId = ExprId(0))
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
@@ -84,14 +84,15 @@ case class AggregateInPandasExec(
     case None => Seq(groupingExpressions.map(SortOrder(_, Ascending)))
   }
 
-  private def collectFunctions(udf: PythonUDAF): (ChainedPythonFunctions, Seq[Expression]) = {
+  private def collectFunctions(
+      udf: PythonFuncExpression): (ChainedPythonFunctions, Seq[Expression]) = {
     udf.children match {
-      case Seq(u: PythonUDAF) =>
+      case Seq(u: PythonFuncExpression) =>
         val (chained, children) = collectFunctions(u)
         (ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)), children)
       case children =>
         // There should not be any other UDFs, or the children can't be evaluated directly.
-        assert(children.forall(!_.exists(_.isInstanceOf[PythonUDAF])))
+        assert(children.forall(!_.exists(_.isInstanceOf[PythonFuncExpression])))
         (ChainedPythonFunctions(Seq(udf.func)), udf.children)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -39,7 +39,6 @@ object ExtractPythonUDFFromAggregate extends Rule[LogicalPlan] {
    */
   private def belongAggregate(e: Expression, agg: Aggregate): Boolean = {
     e.isInstanceOf[AggregateExpression] ||
-      PythonUDF.isGroupedAggPandasUDF(e) ||
       agg.groupingExpressions.exists(_.semanticEquals(e))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.execution.python
 
-import org.apache.spark.api.python.PythonFunction
+import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
 import org.apache.spark.sql.Column
-import org.apache.spark.sql.catalyst.expressions.{Expression, PythonUDF}
+import org.apache.spark.sql.catalyst.expressions.{Expression, PythonUDAF, PythonUDF}
 import org.apache.spark.sql.types.DataType
 
 /**
@@ -33,12 +33,18 @@ case class UserDefinedPythonFunction(
     udfDeterministic: Boolean) {
 
   def builder(e: Seq[Expression]): Expression = {
-    PythonUDF(name, func, dataType, e, pythonEvalType, udfDeterministic)
+    if (pythonEvalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF) {
+      PythonUDAF(name, func, dataType, e, udfDeterministic)
+    } else {
+      PythonUDF(name, func, dataType, e, pythonEvalType, udfDeterministic)
+    }
   }
 
   /** Returns a [[Column]] that will evaluate to calling this UDF with the given input. */
   def apply(exprs: Column*): Column = {
-    val udf = builder(exprs.map(_.expr))
-    Column(udf)
+    builder(exprs.map(_.expr)) match {
+      case udaf: PythonUDAF => Column(udaf.toAggregateExpression())
+      case udf => Column(udf)
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExecBase.scala
@@ -190,7 +190,6 @@ trait WindowExecBase extends UnaryExecNode {
                 case _ => collect("AGGREGATE", frame, e, f)
               }
             case f: AggregateWindowFunction => collect("AGGREGATE", frame, e, f)
-            case f: PythonUDF => collect("AGGREGATE", frame, e, f)
             case f => throw new IllegalStateException(s"Unsupported window function: $f")
           }
         case _ =>
@@ -210,7 +209,7 @@ trait WindowExecBase extends UnaryExecNode {
         // in a single Window physical node. Therefore, we can assume no SQL aggregation
         // functions if Pandas UDF exists. In the future, we might mix Pandas UDF and SQL
         // aggregation function in a single physical node.
-        def processor = if (functions.exists(_.isInstanceOf[PythonUDF])) {
+        def processor = if (functions.exists(_.isInstanceOf[PythonFuncExpression])) {
           null
         } else {
           AggregateProcessor(

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by-ordinal.sql.out
@@ -93,12 +93,19 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "MISSING_AGGREGATION",
-  "sqlState" : "42803",
+  "errorClass" : "GROUP_BY_POS_AGGREGATE",
+  "sqlState" : "42903",
   "messageParameters" : {
-    "expression" : "\"a\"",
-    "expressionAnyValue" : "\"any_value(a)\""
-  }
+    "aggExpr" : "udaf(b#x) AS `udaf(b)`",
+    "index" : "3"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 41,
+    "stopIndex" : 41,
+    "fragment" : "3"
+  } ]
 }
 
 
@@ -109,12 +116,19 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "MISSING_AGGREGATION",
-  "sqlState" : "42803",
+  "errorClass" : "GROUP_BY_POS_AGGREGATE",
+  "sqlState" : "42903",
   "messageParameters" : {
-    "expression" : "\"a\"",
-    "expressionAnyValue" : "\"any_value(a)\""
-  }
+    "aggExpr" : "(udaf(b#x) + 2) AS `(udaf(b) + 2)`",
+    "index" : "3"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 45,
+    "stopIndex" : 45,
+    "fragment" : "3"
+  } ]
 }
 
 
@@ -351,12 +365,19 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "MISSING_AGGREGATION",
-  "sqlState" : "42803",
+  "errorClass" : "GROUP_BY_POS_AGGREGATE",
+  "sqlState" : "42903",
   "messageParameters" : {
-    "expression" : "\"b\"",
-    "expressionAnyValue" : "\"any_value(b)\""
-  }
+    "aggExpr" : "udaf(1) AS `udaf(1)`",
+    "index" : "3"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 44,
+    "stopIndex" : 44,
+    "fragment" : "3"
+  } ]
 }
 
 
@@ -390,14 +411,18 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "MISSING_GROUP_BY",
-  "sqlState" : "42803",
+  "errorClass" : "GROUP_BY_POS_AGGREGATE",
+  "sqlState" : "42903",
+  "messageParameters" : {
+    "aggExpr" : "udaf(1) AS `udaf(1)`",
+    "index" : "3"
+  },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 32,
-    "stopIndex" : 50,
-    "fragment" : "group by cube(1, 3)"
+    "startIndex" : 49,
+    "stopIndex" : 49,
+    "fragment" : "3"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udaf/udaf-group-by.sql.out
@@ -162,7 +162,7 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_1023",
   "messageParameters" : {
-    "prettyName" : "pythonudf",
+    "prettyName" : "pythonudaf",
     "syntax" : "DISTINCT"
   },
   "queryContext" : [ {
@@ -315,24 +315,9 @@ struct<1:int>
 -- !query
 SELECT 1 FROM range(10) HAVING udaf(id) > 0
 -- !query schema
-struct<>
+struct<1:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "UNRESOLVED_COLUMN.WITH_SUGGESTION",
-  "sqlState" : "42703",
-  "messageParameters" : {
-    "objectName" : "`id`",
-    "proposal" : "`1`"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 37,
-    "stopIndex" : 38,
-    "fragment" : "id"
-  } ]
-}
+1
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
@@ -473,7 +473,7 @@ object IntegratedUDFTestUtils extends SQLHelper {
         broadcastVars = List.empty[Broadcast[PythonBroadcast]].asJava,
         accumulator = null),
       dataType = NullType,  // This is not respected.
-      pythonEvalType = PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
+      pythonEvalType = PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE,
       udfDeterministic = true)
 
     def apply(exprs: Column*): Column = udf(exprs: _*)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -103,4 +103,12 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
       assert(executionMetrics.contains(metric))
     }
   }
+
+  test("PythonUDAF pretty name") {
+    assume(shouldTestPandasUDFs)
+    val udfName = "pandas_udf"
+    val df = spark.range(1)
+    val pandasTestUDF = TestGroupedAggPandasUDF(name = udfName)
+    assert(df.agg(pandasTestUDF(df("id"))).schema.fieldNames.exists(_.startsWith(udfName)))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Today, `PythonUDF` can be used as an aggregate function according to the eval type. However, this is done in a tricky way, as `PythonUDF` does not extend `AggregateFunction` and we need to add special handling of it here and there. This is pretty error-prone, and we have hit issues such as https://github.com/apache/spark/pull/39824

This PR adds a new `PythonUDAF` expression which extends `AggregateFunction`. Now python udaf will be handled the same as normal aggregate functions, except for the places that we need to extract python functions. After this, we can remove most of the special handling of `PythonUDF`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
code cleanup

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests