### PR TITLE
[SPARK-42656][FOLLOWUP] Rename BUILD parameter to SCBUILD to avoid clashes

### DIFF
--- a/connector/connect/bin/spark-connect
+++ b/connector/connect/bin/spark-connect
@@ -20,6 +20,8 @@
 # Start the spark-connect with server logs printed in the standard output. The script rebuild the
 # server dependencies and start the server at the default port. This can be used to debug client
 # during client development.
+#
+# Set SCBUILD=0 to skip rebuilding the spark-connect server.
 
 # Go to the Spark project root directory
 FWDIR="$(cd "`dirname "$0"`"/../../..; pwd)"
@@ -30,8 +32,8 @@ export SPARK_HOME=$FWDIR
 SCALA_BINARY_VER=`grep "scala.binary.version" "${SPARK_HOME}/pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
 SCALA_ARG="-Pscala-${SCALA_BINARY_VER}"
 
-BUILD="${BUILD:-1}"
-if [ "$BUILD" -eq "1" ]; then
+SCBUILD="${SCBUILD:-1}"
+if [ "$SCBUILD" -eq "1" ]; then
   # Build the jars needed for spark submit and spark connect
   build/sbt "${SCALA_ARG}" -Phive -Pconnect package || exit 1
 fi

--- a/connector/connect/bin/spark-connect-scala-client
+++ b/connector/connect/bin/spark-connect-scala-client
@@ -28,6 +28,9 @@
 # To connect to a remote server, use env var `SPARK_REMOTE` to configure the client connection
 # string. e.g.
 #  `export SPARK_REMOTE="sc://<URL>:<port>/;token=<auth token>;<param1>=<value1>"`
+#
+# Set SCBUILD=0 to skip rebuilding the spark-connect server.
+# Set SCCLASSPATH to the client classpath to skip resolving it with sbt.
 
 # Go to the Spark project root directory
 FWDIR="$(cd "`dirname "$0"`"/../../..; pwd)"
@@ -39,8 +42,8 @@ SCALA_BINARY_VER=`grep "scala.binary.version" "${SPARK_HOME}/pom.xml" | head -n1
 SCALA_VER=`grep "scala.version" "${SPARK_HOME}/pom.xml" | grep ${SCALA_BINARY_VER} | head -n1 | awk -F '[<>]' '{print $3}'`
 SCALA_ARG="-Pscala-${SCALA_BINARY_VER}"
 
-BUILD="${BUILD:-1}"
-if [ "$BUILD" -eq "1" ]; then
+SCBUILD="${SCBUILD:-1}"
+if [ "$SCBUILD" -eq "1" ]; then
   # Build the jars needed for spark connect JVM client
   build/sbt "${SCALA_ARG}" "sql/package;connect-client-jvm/assembly" || exit 1
 fi

--- a/connector/connect/bin/spark-connect-shell
+++ b/connector/connect/bin/spark-connect-shell
@@ -19,7 +19,7 @@
 
 # The spark connect shell for development. This shell script builds the spark connect server with
 # all dependencies and starts the server at the default port.
-# Use `/bin/spark-connect-shell` instead if rebuilding the dependency jars are not needed.
+# Use `/bin/spark-connect-shell` or set SCBUILD=0 if rebuilding the dependency jars are not needed.
 
 # Go to the Spark project root directory
 FWDIR="$(cd "`dirname "$0"`"/../../..; pwd)"
@@ -30,8 +30,8 @@ export SPARK_HOME=$FWDIR
 SCALA_BINARY_VER=`grep "scala.binary.version" "${SPARK_HOME}/pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
 SCALA_ARG="-Pscala-${SCALA_BINARY_VER}"
 
-BUILD="${BUILD:-1}"
-if [ "$BUILD" -eq "1" ]; then
+SCBUILD="${SCBUILD:-1}"
+if [ "$SCBUILD" -eq "1" ]; then
   # Build the jars needed for spark submit and spark connect
   build/sbt "${SCALA_ARG}" -Phive -Pconnect package || exit 1
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename BUILD added in https://github.com/apache/spark/pull/40676/ to SCBUILD to avoid env var clashes.

### Why are the changes needed?

Avoid name clashes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual build.