### PR TITLE
[SPARK-43095][SQL] Avoid Once strategy's idempotence is broken for batch: `Infer Filters`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1430,10 +1430,6 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
       .union(constructIsNotNullConstraints(constraints, plan.output))
       .filter { c =>
         c.references.nonEmpty && c.references.subsetOf(plan.outputSet) && c.deterministic
-      }.filterNot {
-        // Avoid once strategy idempotence is broken.
-        case a EqualNullSafe b => a.semanticEquals(b)
-        case _ => false
       } -- plan.constraints
     if (newPredicates.isEmpty) {
       plan

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1430,6 +1430,10 @@ object InferFiltersFromConstraints extends Rule[LogicalPlan]
       .union(constructIsNotNullConstraints(constraints, plan.output))
       .filter { c =>
         c.references.nonEmpty && c.references.subsetOf(plan.outputSet) && c.deterministic
+      }.filterNot {
+        // Avoid once strategy idempotence is broken.
+        case a EqualNullSafe b => a.semanticEquals(b)
+        case _ => false
       } -- plan.constraints
     if (newPredicates.isEmpty) {
       plan

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -75,7 +75,10 @@ trait ConstraintHelper {
         inferredConstraints ++= replaceConstraints(predicates - eq, l, r)
       case _ => // No inference
     }
-    inferredConstraints -- constraints
+    (inferredConstraints -- constraints).filterNot {
+      case a EqualNullSafe b => a.semanticEquals(b)
+      case _ => false
+    }
   }
 
   private def replaceConstraints(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -67,7 +67,7 @@ trait ConstraintHelper {
     predicates.foreach {
       case eq @ EqualTo(l: Attribute, r: Attribute) =>
         // Also remove EqualNullSafe with the same l and r to avoid Once strategy's idempotence
-        // is broken.
+        // is broken. l = r and l <=> r can infer l <=> l and r <=> r which is useless.
         val candidateConstraints = predicates - eq - EqualNullSafe(l, r)
         inferredConstraints ++= replaceConstraints(candidateConstraints, l, r)
         inferredConstraints ++= replaceConstraints(candidateConstraints, r, l)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/QueryPlanConstraints.scala
@@ -66,6 +66,8 @@ trait ConstraintHelper {
     val predicates = constraints.filterNot(_.isInstanceOf[IsNotNull])
     predicates.foreach {
       case eq @ EqualTo(l: Attribute, r: Attribute) =>
+        // Also remove EqualNullSafe with the same l and r to avoid Once strategy's idempotence
+        // is broken.
         val candidateConstraints = predicates - eq - EqualNullSafe(l, r)
         inferredConstraints ++= replaceConstraints(candidateConstraints, l, r)
         inferredConstraints ++= replaceConstraints(candidateConstraints, r, l)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes it also remove `EqualNullSafe` when removing `EqualTo` if their children are same when constructing candidate constraints in `ConstraintHelper.inferAdditionalConstraints`.
For example: `l = r and l <=> r`. Before this PR, `l = r and l <=> r` can infer `l <=> l and r <=> r` which is useless. After This PR, it can't infer anything.

### Why are the changes needed?

Avoid Once strategy's idempotence is broken for batch: `Infer Filters`:
```sql
export SPARK_TESTING=1

CREATE TABLE t1 (i INT, j INT, k STRING) USING parquet;
CREATE TABLE t2 (i INT, j INT, k STRING) USING parquet;
CREATE TABLE t3 (i INT, j INT, k STRING) USING parquet;

SELECT *
FROM   (SELECT t1.i, t1.i as t1i
        FROM t1 JOIN t3 ON t1.i = t3.i) t
       JOIN t2 ON t.i = t2.i;
```

Before this PR:
```
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.InferFiltersFromConstraints ===
 Join Inner, (i#72 = i#78)                                               Join Inner, (i#72 = i#78)
!:- Project [i#72, i#72 AS t1i#71]                                       :- Filter ((i#72 <=> i#72) AND (t1i#71 <=> t1i#71))
!:  +- Join Inner, (i#72 = i#75)                                         :  +- Project [i#72, i#72 AS t1i#71]
!:     :- Project [i#72]                                                 :     +- Join Inner, (i#72 = i#75)
!:     :  +- Relation spark_catalog.default.t1[i#72,j#73,k#74] parquet   :        :- Filter isnotnull(i#72)
!:     +- Project [i#75]                                                 :        :  +- Project [i#72]
!:        +- Relation spark_catalog.default.t3[i#75,j#76,k#77] parquet   :        :     +- Relation spark_catalog.default.t1[i#72,j#73,k#74] parquet
!+- Relation spark_catalog.default.t2[i#78,j#79,k#80] parquet            :        +- Filter isnotnull(i#75)
!                                                                        :           +- Project [i#75]
!                                                                        :              +- Relation spark_catalog.default.t3[i#75,j#76,k#77] parquet
!                                                                        +- Filter isnotnull(i#78)
!                                                                           +- Relation spark_catalog.default.t2[i#78,j#79,k#80] parquet


org.apache.spark.SparkRuntimeException: Once strategy's idempotence is broken for batch Infer Filters
 Join Inner, (i#72 = i#78)                                                     Join Inner, (i#72 = i#78)
 :- Filter ((i#72 <=> i#72) AND (t1i#71 <=> t1i#71))                           :- Filter ((i#72 <=> i#72) AND (t1i#71 <=> t1i#71))
 :  +- Project [i#72, i#72 AS t1i#71]                                          :  +- Project [i#72, i#72 AS t1i#71]
 :     +- Join Inner, (i#72 = i#75)                                            :     +- Join Inner, (i#72 = i#75)
 :        :- Filter isnotnull(i#72)                                            :        :- Filter isnotnull(i#72)
 :        :  +- Project [i#72]                                                 :        :  +- Project [i#72]
 :        :     +- Relation spark_catalog.default.t1[i#72,j#73,k#74] parquet   :        :     +- Relation spark_catalog.default.t1[i#72,j#73,k#74] parquet
 :        +- Filter isnotnull(i#75)                                            :        +- Filter isnotnull(i#75)
 :           +- Project [i#75]                                                 :           +- Project [i#75]
 :              +- Relation spark_catalog.default.t3[i#75,j#76,k#77] parquet   :              +- Relation spark_catalog.default.t3[i#75,j#76,k#77] parquet
!+- Filter isnotnull(i#78)                                                     +- Filter (i#78 <=> i#78)
!   +- Relation spark_catalog.default.t2[i#78,j#79,k#80] parquet                  +- Filter isnotnull(i#78)
!                                                                                    +- Relation spark_catalog.default.t2[i#78,j#79,k#80] parquet.
```

After this PR:
```
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.InferFiltersFromConstraints ===
 Join Inner, (i#72 = i#78)                                               Join Inner, (i#72 = i#78)
 :- Project [i#72, i#72 AS t1i#71]                                       :- Project [i#72, i#72 AS t1i#71]
 :  +- Join Inner, (i#72 = i#75)                                         :  +- Join Inner, (i#72 = i#75)
!:     :- Project [i#72]                                                 :     :- Filter isnotnull(i#72)
!:     :  +- Relation spark_catalog.default.t1[i#72,j#73,k#74] parquet   :     :  +- Project [i#72]
!:     +- Project [i#75]                                                 :     :     +- Relation spark_catalog.default.t1[i#72,j#73,k#74] parquet
!:        +- Relation spark_catalog.default.t3[i#75,j#76,k#77] parquet   :     +- Filter isnotnull(i#75)
!+- Relation spark_catalog.default.t2[i#78,j#79,k#80] parquet            :        +- Project [i#75]
!                                                                        :           +- Relation spark_catalog.default.t3[i#75,j#76,k#77] parquet
!                                                                        +- Filter isnotnull(i#78)
!                                                                           +- Relation spark_catalog.default.t2[i#78,j#79,k#80] parquet
 
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.