### PR TITLE
[SPARK-42985][CONNECT][PYTHON] Fix createDataFrame to respect the SQL configs

### DIFF
--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -179,16 +179,27 @@ class LocalDataToArrowConversion:
 
             return convert_binary
 
-        elif isinstance(dataType, (TimestampType, TimestampNTZType)):
+        elif isinstance(dataType, TimestampType):
 
-            def convert_timestample(value: Any) -> Any:
+            def convert_timestamp(value: Any) -> Any:
                 if value is None:
                     return None
                 else:
                     assert isinstance(value, datetime.datetime)
                     return value.astimezone(datetime.timezone.utc)
 
-            return convert_timestample
+            return convert_timestamp
+
+        elif isinstance(dataType, TimestampNTZType):
+
+            def convert_timestamp_ntz(value: Any) -> Any:
+                if value is None:
+                    return None
+                else:
+                    assert isinstance(value, datetime.datetime) and value.tzinfo is None
+                    return value
+
+            return convert_timestamp_ntz
 
         elif isinstance(dataType, DecimalType):
 
@@ -383,20 +394,27 @@ class ArrowTableToRowsConversion:
 
             return convert_binary
 
-        elif isinstance(dataType, (TimestampType, TimestampNTZType)):
+        elif isinstance(dataType, TimestampType):
 
             def convert_timestample(value: Any) -> Any:
                 if value is None:
                     return None
                 else:
                     assert isinstance(value, datetime.datetime)
-                    if value.tzinfo is not None:
-                        # always remove the time zone for now
-                        return value.replace(tzinfo=None)
-                    else:
-                        return value
+                    return value.astimezone().replace(tzinfo=None)
 
             return convert_timestample
+
+        elif isinstance(dataType, TimestampNTZType):
+
+            def convert_timestample_ntz(value: Any) -> Any:
+                if value is None:
+                    return None
+                else:
+                    assert isinstance(value, datetime.datetime)
+                    return value
+
+            return convert_timestample_ntz
 
         elif isinstance(dataType, UserDefinedType):
             udt: UserDefinedType = dataType

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -102,11 +102,6 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase):
     def test_toPandas_with_map_type_nulls(self):
         self.check_toPandas_with_map_type_nulls(True)
 
-    # TODO(SPARK-42985): Respect session timezone
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_createDataFrame_respect_session_timezone(self):
-        self.check_createDataFrame_respect_session_timezone(True)
-
     def test_createDataFrame_with_array_type(self):
         self.check_createDataFrame_with_array_type(True)
 

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -47,8 +47,8 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
         super().test_infer_array_element_type_with_struct()
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
-    def test_infer_array_merge_element_types(self):
-        super().test_infer_array_merge_element_types()
+    def test_infer_array_merge_element_types_with_rdd(self):
+        super().test_infer_array_merge_element_types_with_rdd()
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_infer_binary_type(self):
@@ -59,8 +59,8 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
         super().test_infer_long_type()
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
-    def test_infer_nested_dict_as_struct(self):
-        super().test_infer_nested_dict_as_struct()
+    def test_infer_nested_dict_as_struct_with_rdd(self):
+        super().test_infer_nested_dict_as_struct_with_rdd()
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_infer_nested_schema(self):
@@ -69,11 +69,6 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_infer_schema(self):
         super().test_infer_schema()
-
-    # TODO(SPARK-42020): createDataFrame with UDT
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_infer_schema_specification(self):
-        super().test_infer_schema_specification()
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_infer_schema_to_local(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `createDataFrame` to respect the SQL configs.

### Why are the changes needed?

Currently some configs for `createDataFrame` are not effective.

- `spark.sql.timestampType`
- `spark.sql.pyspark.inferNestedDictAsStruct.enabled`
- `spark.sql.pyspark.legacy.inferArrayTypeFromFirstElement.enabled`
- `spark.sql.execution.pandas.convertToArrowArraySafely`

### Does this PR introduce _any_ user-facing change?

The configs will be respected.

### How was this patch tested?

Enabled/modified the related tests.