### PR TITLE
[SPARK-43100][CORE] Mismatch of field name in log event writer and parser for push shuffle metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -545,7 +545,7 @@ private[spark] object JsonProtocol {
       g.writeNumberField("Total Records Read", taskMetrics.shuffleReadMetrics.recordsRead)
       g.writeNumberField("Remote Requests Duration",
         taskMetrics.shuffleReadMetrics.remoteReqsDuration)
-      g.writeFieldName("Push Based Shuffle")
+      g.writeFieldName("Shuffle Push Read Metrics")
       writeShufflePushReadMetrics()
       g.writeEndObject()
     }

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -1705,7 +1705,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |      "Local Bytes Read": 1100,
       |      "Total Records Read": 10,
       |      "Remote Requests Duration": 900,
-      |      "Push Based Shuffle": {
+      |      "Shuffle Push Read Metrics": {
       |         "Corrupt Merged Block Chunks" : 100,
       |         "Merged Fetch Fallback Count" : 100,
       |         "Merged Remote Blocks Fetched" : 0,
@@ -1844,7 +1844,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |      "Local Bytes Read" : 0,
       |      "Total Records Read" : 0,
       |      "Remote Requests Duration": 0,
-      |      "Push Based Shuffle": {
+      |      "Shuffle Push Read Metrics": {
       |         "Corrupt Merged Block Chunks" : 0,
       |         "Merged Fetch Fallback Count" : 0,
       |         "Merged Remote Blocks Fetched" : 0,
@@ -1983,7 +1983,7 @@ private[spark] object JsonProtocolSuite extends Assertions {
       |      "Local Bytes Read" : 0,
       |      "Total Records Read" : 0,
       |      "Remote Requests Duration": 0,
-      |      "Push Based Shuffle": {
+      |      "Shuffle Push Read Metrics": {
       |         "Corrupt Merged Block Chunks" : 0,
       |         "Merged Fetch Fallback Count" : 0,
       |         "Merged Remote Blocks Fetched" : 0,


### PR DESCRIPTION
### What changes were proposed in this pull request?
For push based shuffle metrics, when writting out the event to log file, the field name is ["Push Based Shuffle"](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala#L548).
But when parsing it out in SHS, the expected field name is ["Shuffle Push Read Metrics"](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala#L1264). This mismatch makes all the push shuffle metrics 0 from SHS rest calls.

### Why are the changes needed?
Without this change, all the push shuffle metrics will not be rendered correctly through SHS rest calls.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Launched Spark-shell application in Yarn client mode in our cluster, get the log file to local, and started a local Spark History Server to parse the log file. The metrics are shown correctly after this patch.