### PR TITLE
[SPARK-43105][CONNECT] Abbreviate Bytes and Strings in proto message

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
@@ -24,31 +24,53 @@ import com.google.protobuf.Descriptors.FieldDescriptor
 
 private[connect] object ProtoUtils {
   private val format = java.text.NumberFormat.getInstance()
+  private val NUM_FIRST_BYTES = 8
 
-  def redact(message: Message): Message = {
+  def abbreviateBytes(message: Message): Message = {
     val builder = message.toBuilder
 
     message.getAllFields.asScala.iterator.foreach {
-      case (field: FieldDescriptor, bytes: ByteString)
-          if field.getJavaType == FieldDescriptor.JavaType.BYTE_STRING && bytes != null =>
-        builder.setField(
-          field,
-          ByteString.copyFromUtf8(s"bytes (size=${format.format(bytes.size)})"))
+      case (field: FieldDescriptor, byteString: ByteString)
+          if field.getJavaType == FieldDescriptor.JavaType.BYTE_STRING && byteString != null =>
+        val size = byteString.size()
+        if (size > NUM_FIRST_BYTES) {
+          val bytes = Array.ofDim[Byte](NUM_FIRST_BYTES)
+          var i = 0
+          while (i < NUM_FIRST_BYTES) {
+            bytes(i) = byteString.byteAt(i)
+            i += 1
+          }
+          builder.setField(field, createByteString(Some(bytes), size))
+        } else {
+          builder.setField(field, createByteString(None, size))
+        }
 
-      case (field: FieldDescriptor, bytes: Array[_])
-          if field.getJavaType == FieldDescriptor.JavaType.BYTE_STRING && bytes != null =>
-        builder.setField(
-          field,
-          ByteString.copyFromUtf8(s"bytes (size=${format.format(bytes.length)})"))
+      case (field: FieldDescriptor, byteArray: Array[Byte])
+          if field.getJavaType == FieldDescriptor.JavaType.BYTE_STRING && byteArray != null =>
+        val size = byteArray.length
+        if (size > NUM_FIRST_BYTES) {
+          builder.setField(field, createByteString(Some(byteArray.take(NUM_FIRST_BYTES)), size))
+        } else {
+          builder.setField(field, createByteString(None, size))
+        }
 
-      // TODO: should also take 1, repeated msg; 2, map<xxx, msg> into account
+      // TODO: should also support 1, repeated msg; 2, map<xxx, msg>
       case (field: FieldDescriptor, msg: Message)
           if field.getJavaType == FieldDescriptor.JavaType.MESSAGE && msg != null =>
-        builder.setField(field, redact(msg))
+        builder.setField(field, abbreviateBytes(msg))
 
       case (field: FieldDescriptor, value: Any) => builder.setField(field, value)
     }
 
     builder.build()
+  }
+
+  private def createByteString(firstBytes: Option[Array[Byte]], size: Int): ByteString = {
+    var byteStrings = Array.empty[ByteString]
+    firstBytes.foreach { bytes =>
+      byteStrings :+= ByteString.copyFrom(bytes)
+    }
+    byteStrings :+= ByteString.copyFromUtf8(s"*********(redacted, size=${format.format(size)})")
+    ByteString.copyFrom(byteStrings.toIterable.asJava)
   }
 }

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.common
+
+import scala.collection.JavaConverters._
+
+import com.google.protobuf.{ByteString, Message}
+import com.google.protobuf.Descriptors.FieldDescriptor
+
+private[connect] object ProtoUtils {
+  private val format = java.text.NumberFormat.getInstance()
+
+  def redact(message: Message): Message = {
+    val builder = message.toBuilder
+
+    message.getAllFields.asScala.iterator.foreach {
+      case (field: FieldDescriptor, bytes: ByteString)
+          if field.getJavaType == FieldDescriptor.JavaType.BYTE_STRING && bytes != null =>
+        builder.setField(
+          field,
+          ByteString.copyFromUtf8(s"bytes (size=${format.format(bytes.size)})"))
+
+      case (field: FieldDescriptor, bytes: Array[_])
+          if field.getJavaType == FieldDescriptor.JavaType.BYTE_STRING && bytes != null =>
+        builder.setField(
+          field,
+          ByteString.copyFromUtf8(s"bytes (size=${format.format(bytes.length)})"))
+
+      // TODO: should also take 1, repeated msg; 2, map<xxx, msg> into account
+      case (field: FieldDescriptor, msg: Message)
+          if field.getJavaType == FieldDescriptor.JavaType.MESSAGE && msg != null =>
+        builder.setField(field, redact(msg))
+
+      case (field: FieldDescriptor, value: Any) => builder.setField(field, value)
+    }
+
+    builder.build()
+  }
+}

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
@@ -60,7 +60,7 @@ private[connect] object ProtoUtils {
           builder.setField(field, byteArray)
         }
 
-      // TODO: should also support 1, repeated msg; 2, map<xxx, msg>
+      // TODO(SPARK-43117): should also support 1, repeated msg; 2, map<xxx, msg>
       case (field: FieldDescriptor, msg: Message)
           if field.getJavaType == FieldDescriptor.JavaType.MESSAGE && msg != null =>
         builder.setField(field, abbreviate(msg))

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
@@ -75,10 +75,10 @@ private[connect] object ProtoUtils {
     ByteString.copyFrom(
       List(
         ByteString.copyFrom(prefix),
-        ByteString.copyFromUtf8(s"*********(redacted, size=${format.format(size)})")).asJava)
+        ByteString.copyFromUtf8(s"[truncated(size=${format.format(size)})]")).asJava)
   }
 
   private def createString(prefix: String, size: Int): String = {
-    s"$prefix*********(redacted, size=${format.format(size)})"
+    s"$prefix[truncated(size=${format.format(size)})]"
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
@@ -56,7 +56,7 @@ class SparkConnectStreamHandler(responseObserver: StreamObserver[ExecutePlanResp
       // Add debug information to the query execution so that the jobs are traceable.
       val debugString = Utils.redact(
         session.sessionState.conf.stringRedactionPattern,
-        ProtoUtils.redact(v).toString)
+        ProtoUtils.abbreviateBytes(v).toString)
       session.sparkContext.setLocalProperty(
         "callSite.short",
         s"Spark Connect - ${StringUtils.abbreviate(debugString, 128)}")


### PR DESCRIPTION
### What changes were proposed in this pull request?
To abbreviate the `BYTES` and `STRING` fields in proto message.

**Note that the `repeated` and `map<...>` fields are always skipped for now**


### Why are the changes needed?
1, for abbreviation:

```
In [6]: spark.createDataFrame(range(0, 1000)).show()

In [7]: query = "SELECT /* " + "bla" * 8192 + " */ 1"

In [8]: spark.sql(query).show()
```

before:
![image](https://user-images.githubusercontent.com/7322292/231615429-010d028f-f113-47fa-ac6a-696371cb81d0.png)


after:
![image](https://user-images.githubusercontent.com/7322292/231614931-dda0fc34-77d1-401a-b7c2-ffcfe9b076b8.png)

2, `Message.toString` may cause OOM when the message is large
This PR try to abbreviate the bytes and string, which are the main parts of `LocalRelation` and `PythonUDF`

### Does this PR introduce _any_ user-facing change?
yes, when `BYTES` and `STRING` fields are too long, abbreviate them and show the size


### How was this patch tested?
manually check