### PR TITLE
[SPARK-42953][Connect][Followup] Fix maven test build for Scala client UDF tests

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -28,8 +28,8 @@ import org.apache.spark.connect.proto
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders._
 import org.apache.spark.sql.catalyst.expressions.RowOrdering
-import org.apache.spark.sql.connect.client.{SparkResult, UdfUtils}
-import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, StorageLevelProtoConverter}
+import org.apache.spark.sql.connect.client.SparkResult
+import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, StorageLevelProtoConverter, UdfUtils}
 import org.apache.spark.sql.expressions.ScalarUserDefinedFunction
 import org.apache.spark.sql.functions.{struct, to_json}
 import org.apache.spark.sql.streaming.DataStreamWriter

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -25,7 +25,7 @@ import scala.language.existentials
 import org.apache.spark.api.java.function._
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
-import org.apache.spark.sql.connect.client.UdfUtils
+import org.apache.spark.sql.connect.common.UdfUtils
 import org.apache.spark.sql.expressions.ScalarUserDefinedFunction
 import org.apache.spark.sql.functions.col
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionE2ETestSuite.scala
@@ -30,8 +30,7 @@ import org.apache.spark.sql.connect.client.util.RemoteSparkSession
 import org.apache.spark.sql.functions.{col, udf}
 
 /**
- * All tests in this class requires client UDF artifacts synced with the server. TODO: It means
- * these tests only works with SBT for now.
+ * All tests in this class requires client UDF defined in this test class synced with the server.
  */
 class UserDefinedFunctionE2ETestSuite extends RemoteSparkSession {
   test("Dataset typed filter") {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/util/RemoteSparkSession.scala
@@ -61,31 +61,14 @@ object SparkConnectServerUtils {
       "connector/connect/server",
       "spark-connect-assembly",
       "spark-connect").getCanonicalPath
-    val driverClassPath = connectJar + ":" +
-      findJar("sql/catalyst", "spark-catalyst", "spark-catalyst", test = true).getCanonicalPath
-    val catalogImplementation = if (IntegrationTestUtils.isSparkHiveJarAvailable) {
-      "hive"
-    } else {
-      // scalastyle:off println
-      println(
-        "Will start Spark Connect server with `spark.sql.catalogImplementation=in-memory`, " +
-          "some tests that rely on Hive will be ignored. If you don't want to skip them:\n" +
-          "1. Test with maven: run `build/mvn install -DskipTests -Phive` before testing\n" +
-          "2. Test with sbt: run test with `-Phive` profile")
-      // scalastyle:on println
-      "in-memory"
-    }
+
     val builder = Process(
       Seq(
         "bin/spark-submit",
         "--driver-class-path",
-        driverClassPath,
+        connectJar,
         "--conf",
-        s"spark.connect.grpc.binding.port=$port",
-        "--conf",
-        "spark.sql.catalog.testcat=org.apache.spark.sql.connector.catalog.InMemoryTableCatalog",
-        "--conf",
-        s"spark.sql.catalogImplementation=$catalogImplementation") ++ debugConfig ++ Seq(
+        s"spark.connect.grpc.binding.port=$port") ++ testConfigs ++ debugConfigs ++ Seq(
         "--class",
         "org.apache.spark.sql.connect.SimpleSparkConnectService",
         connectJar),
@@ -100,6 +83,56 @@ object SparkConnectServerUtils {
     // Adding JVM shutdown hook
     sys.addShutdownHook(stop())
     process
+  }
+
+  /**
+   * As one shared spark will be started for all E2E tests, for tests that needs some special
+   * configs, we add them here
+   */
+  private def testConfigs: Seq[String] = {
+    // Use InMemoryTableCatalog for V2 writer tests
+    val writerV2Configs = {
+      val catalystTestJar = findJar( // To find InMemoryTableCatalog for V2 writer tests
+        "sql/catalyst",
+        "spark-catalyst",
+        "spark-catalyst",
+        test = true).getCanonicalPath
+      Seq(
+        "--jars",
+        catalystTestJar,
+        "--conf",
+        "spark.sql.catalog.testcat=org.apache.spark.sql.connector.catalog.InMemoryTableCatalog")
+    }
+
+    // Run tests using hive
+    val hiveTestConfigs = {
+      val catalogImplementation = if (IntegrationTestUtils.isSparkHiveJarAvailable) {
+        "hive"
+      } else {
+        // scalastyle:off println
+        println(
+          "Will start Spark Connect server with `spark.sql.catalogImplementation=in-memory`, " +
+            "some tests that rely on Hive will be ignored. If you don't want to skip them:\n" +
+            "1. Test with maven: run `build/mvn install -DskipTests -Phive` before testing\n" +
+            "2. Test with sbt: run test with `-Phive` profile")
+        // scalastyle:on println
+        "in-memory"
+      }
+      Seq("--conf", s"spark.sql.catalogImplementation=$catalogImplementation")
+    }
+
+    // For UDF maven E2E tests, the server needs the client code to find the UDFs defined in tests.
+    val udfTestConfigs = tryFindJar(
+      "connector/connect/client/jvm",
+      // SBT passes the client & test jars to the server process automatically.
+      // So we skip building or finding this jar for SBT.
+      "sbt-tests-do-not-need-this-jar",
+      "spark-connect-client-jvm",
+      test = true)
+      .map(clientTestJar => Seq("--jars", clientTestJar.getCanonicalPath))
+      .getOrElse(Seq.empty)
+
+    writerV2Configs ++ hiveTestConfigs ++ udfTestConfigs
   }
 
   def start(): Unit = {

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/UdfUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/UdfUtils.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.connect.client
+package org.apache.spark.sql.connect.common
 
 import scala.collection.JavaConverters._
 
@@ -23,11 +23,12 @@ import org.apache.spark.sql.Row
 
 /**
  * Util functions to help convert input functions between typed filter, map, flatMap,
- * mapPartitions etc. These functions cannot be defined inside the client Dataset class as it will
- * cause Dataset sync conflicts when used together with UDFs. Thus we define them outside, in the
- * client package.
+ * mapPartitions etc. This class is shared between the client and the server so that when the
+ * methods are used in client UDFs, the server will be able to find them when actually executing
+ * the UDFs.
  */
-private[sql] object UdfUtils {
+@SerialVersionUID(8464839273647598302L)
+private[sql] object UdfUtils extends Serializable {
 
   def mapFuncToMapPartitionsAdaptor[T, U](f: T => U): Iterator[T] => Iterator[U] = _.map(f(_))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Moved UDFUtils to common.
Fixed the client `UserDefinedFunctionE2ETestSuite` and `KeyValueGroupedDatasetE2ETestSuite` tests to be able to run on maven.

Verified the code works with the following maven commands.
```
build/mvn clean install -pl connector/connect/server -am -DskipTests
build/mvn clean install -pl assembly -am -DskipTests
build/mvn clean install -pl connector/connect/client/jvm
```

### Why are the changes needed?
Fix maven failing tests

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tests
Fixed tests for https://github.com/apache/spark/pull/40581 and https://github.com/apache/spark/pull/40729