### PR TITLE
[SPARK-43114][SQL][TESTS] Add interval types to TypeCoercionSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1763,8 +1763,8 @@ object TypeCoercionSuite {
     Seq(DoubleType, FloatType, DecimalType.SYSTEM_DEFAULT, DecimalType(10, 2))
   val numericTypes: Seq[DataType] = integralTypes ++ fractionalTypes
   val datetimeTypes: Seq[DataType] = Seq(DateType, TimestampType, TimestampNTZType)
-  val intervalTypes: Seq[DataType] = Seq(CalendarIntervalType, DayTimeIntervalType.DEFAULT,
-    YearMonthIntervalType.DEFAULT)
+  val intervalTypes: Seq[DataType] = Seq(CalendarIntervalType,
+    DayTimeIntervalType.defaultConcreteType, YearMonthIntervalType.defaultConcreteType)
   val atomicTypes: Seq[DataType] =
     numericTypes ++ datetimeTypes ++ Seq(BinaryType, BooleanType, StringType)
   val complexTypes: Seq[DataType] =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -517,7 +517,7 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
   test("implicit type cast - StringType") {
     val checkedType = StringType
     val nonCastableTypes =
-      complexTypes ++ Seq(BooleanType, NullType, CalendarIntervalType)
+      intervalTypes ++ complexTypes ++ Seq(BooleanType, NullType)
     checkTypeCasting(checkedType, castableTypes = allTypes.filterNot(nonCastableTypes.contains))
     shouldCast(checkedType, DecimalType, DecimalType.SYSTEM_DEFAULT)
     shouldCast(checkedType, NumericType, NumericType.defaultConcreteType)
@@ -528,7 +528,7 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
   test("implicit type cast - ArrayType(StringType)") {
     val checkedType = ArrayType(StringType)
     val nonCastableTypes =
-      complexTypes ++ Seq(BooleanType, NullType, CalendarIntervalType)
+      intervalTypes ++ complexTypes ++ Seq(BooleanType, NullType)
     checkTypeCasting(checkedType,
       castableTypes = allTypes.filterNot(nonCastableTypes.contains).map(ArrayType(_)))
     nonCastableTypes.map(ArrayType(_)).foreach(shouldNotCast(checkedType, _))
@@ -1763,6 +1763,8 @@ object TypeCoercionSuite {
     Seq(DoubleType, FloatType, DecimalType.SYSTEM_DEFAULT, DecimalType(10, 2))
   val numericTypes: Seq[DataType] = integralTypes ++ fractionalTypes
   val datetimeTypes: Seq[DataType] = Seq(DateType, TimestampType, TimestampNTZType)
+  val intervalTypes: Seq[DataType] = Seq(CalendarIntervalType, DayTimeIntervalType.DEFAULT,
+    YearMonthIntervalType.DEFAULT)
   val atomicTypes: Seq[DataType] =
     numericTypes ++ datetimeTypes ++ Seq(BinaryType, BooleanType, StringType)
   val complexTypes: Seq[DataType] =
@@ -1772,7 +1774,7 @@ object TypeCoercionSuite {
       new StructType().add("a1", StringType),
       new StructType().add("a1", StringType).add("a2", IntegerType))
   val allTypes: Seq[DataType] =
-    atomicTypes ++ complexTypes ++ Seq(NullType, CalendarIntervalType)
+    atomicTypes ++ intervalTypes ++ complexTypes ++ Seq(NullType)
 
   case class AnyTypeUnaryExpression(child: Expression)
     extends UnaryExpression with ExpectsInputTypes with Unevaluable {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `DayTimeIntervalType` and `YearMonthIntervalType` to `TypeCoercionSuite`.

### Why are the changes needed?

Increase test coverage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.