### PR TITLE
[WIP][PYTHON][TESTS] Reduce the required resources in PyTorch related tests

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -781,7 +781,7 @@ pyspark_connect = Module(
         # ml doctests
         "pyspark.ml.connect.functions",
         # ml unittests
-        "pyspark.ml.tests.connect.test_connect_function",
+        # "pyspark.ml.tests.connect.test_connect_function",
         "pyspark.ml.tests.connect.test_parity_torch_distributor",
     ],
     excluded_python_implementations=[

--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -58,7 +58,7 @@ class TorchDistributorLocalUnitTestsOnConnect(
         for k, v in conf.getAll():
             if k not in ["spark.master", "spark.remote", "spark.app.name"]:
                 builder = builder.config(k, v)
-        self.spark = builder.remote("local-cluster[2,2,1024]").getOrCreate()
+        self.spark = builder.remote("local-cluster[2,2,512]").getOrCreate()
         self.mnist_dir_path = tempfile.mkdtemp()
 
     def tearDown(self) -> None:
@@ -86,7 +86,7 @@ class TorchDistributorLocalUnitTestsIIOnConnect(
         for k, v in conf.getAll():
             if k not in ["spark.master", "spark.remote", "spark.app.name"]:
                 builder = builder.config(k, v)
-        self.spark = builder.remote("local[4]").getOrCreate()
+        self.spark = builder.remote("local[2]").getOrCreate()
         self.mnist_dir_path = tempfile.mkdtemp()
 
     def tearDown(self) -> None:
@@ -115,7 +115,7 @@ class TorchDistributorDistributedUnitTestsOnConnect(
             if k not in ["spark.master", "spark.remote", "spark.app.name"]:
                 builder = builder.config(k, v)
 
-        self.spark = builder.remote("local-cluster[2,2,1024]").getOrCreate()
+        self.spark = builder.remote("local-cluster[2,2,512]").getOrCreate()
         self.mnist_dir_path = tempfile.mkdtemp()
 
     def tearDown(self) -> None:

--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -75,7 +75,7 @@ class TorchDistributorLocalUnitTestsOnConnect(
         ]
 
 
-@unittest.skip("unstable, ignore for now")
+@unittest.skipIf(not have_torch, "torch is required")
 class TorchDistributorLocalUnitTestsIIOnConnect(
     TorchDistributorLocalUnitTestsMixin, unittest.TestCase
 ):

--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -47,7 +47,7 @@ class TorchDistributorBaselineUnitTestsOnConnect(
         self.spark.stop()
 
 
-@unittest.skip("unstable, ignore for now")
+@unittest.skipIf(not have_torch, "torch is required")
 class TorchDistributorLocalUnitTestsOnConnect(
     TorchDistributorLocalUnitTestsMixin, unittest.TestCase
 ):

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -296,6 +296,8 @@ class TorchDistributorLocalUnitTestsMixin:
         )
 
         conf = SparkConf().set("spark.test.home", SPARK_HOME)
+        conf = conf.set("spark.driver.memory", "512M")
+        conf = conf.set("spark.executor.memory", "512M")
         conf = conf.set("spark.driver.resource.gpu.amount", "3")
         conf = conf.set(
             "spark.driver.resource.gpu.discoveryScript", self.gpu_discovery_script_file.name
@@ -426,6 +428,8 @@ class TorchDistributorDistributedUnitTestsMixin:
         )
 
         conf = SparkConf().set("spark.test.home", SPARK_HOME)
+        conf = conf.set("spark.driver.memory", "512M")
+        conf = conf.set("spark.executor.memory", "512M")
         conf = conf.set(
             "spark.worker.resource.gpu.discoveryScript", self.gpu_discovery_script_file.name
         )

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -385,7 +385,7 @@ class TorchDistributorLocalUnitTests(TorchDistributorLocalUnitTestsMixin, unitte
     def setUp(self) -> None:
         class_name = self.__class__.__name__
         conf = self._get_spark_conf()
-        sc = SparkContext("local-cluster[2,2,1024]", class_name, conf=conf)
+        sc = SparkContext("local-cluster[2,2,512]", class_name, conf=conf)
         self.spark = SparkSession(sc)
         self.mnist_dir_path = tempfile.mkdtemp()
 
@@ -400,7 +400,7 @@ class TorchDistributorLocalUnitTestsII(TorchDistributorLocalUnitTestsMixin, unit
     def setUp(self) -> None:
         class_name = self.__class__.__name__
         conf = self._get_spark_conf()
-        sc = SparkContext("local[4]", class_name, conf=conf)
+        sc = SparkContext("local[2]", class_name, conf=conf)
         self.spark = SparkSession(sc)
         self.mnist_dir_path = tempfile.mkdtemp()
 
@@ -485,7 +485,7 @@ class TorchDistributorDistributedUnitTests(
     def setUp(self) -> None:
         class_name = self.__class__.__name__
         conf = self._get_spark_conf()
-        sc = SparkContext("local-cluster[2,2,1024]", class_name, conf=conf)
+        sc = SparkContext("local-cluster[2,2,512]", class_name, conf=conf)
         self.spark = SparkSession(sc)
         self.mnist_dir_path = tempfile.mkdtemp()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
PyTorch distributor run on barrier mode, when the resources is not enough for some reason, `test_parity_torch_distributor` can wait for hours.


### Why are the changes needed?
for tests


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI
