### PR TITLE
[SPARK-43121][SQL] Use `BytesWritable.copyBytes` instead of manual copy in `HiveInspectors

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala
@@ -623,13 +623,7 @@ private[hive] trait HiveInspectors {
         case x: BinaryObjectInspector if x.preferWritable() =>
           data: Any => {
             if (data != null) {
-              // BytesWritable.copyBytes() only available since Hadoop2
-              // In order to keep backward-compatible, we have to copy the
-              // bytes with old apis
-              val bw = x.getPrimitiveWritableObject(data)
-              val result = new Array[Byte](bw.getLength())
-              System.arraycopy(bw.getBytes(), 0, result, 0, bw.getLength())
-              result
+              x.getPrimitiveWritableObject(data).copyBytes()
             } else {
               null
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/blob/891a142b9141489f3872cc4c8b9ffd50a889f524/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveInspectors.scala#L625-L632

The above code comments are no longer applicable to the current Spark version , so this pr change to call `BytesWritable.copyBytes` directly.

https://github.com/apache/hadoop/blob/706d88266abcee09ed78fbaa0ad5f74d818ab0e9/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/BytesWritable.java#L69-L79

https://github.com/apache/hadoop/blob/rel/release-2.7.4/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/BytesWritable.java#L69-L79

### Why are the changes needed?
Using existing `BytesWritable` api




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions