### PR TITLE
[SPARK-42994][TESTS][FOLLOWUP] Skip `TorchDistributorLocalUnitTestsIIOnConnect` for now

### DIFF
--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -75,7 +75,7 @@ class TorchDistributorLocalUnitTestsOnConnect(
         ]
 
 
-@unittest.skipIf(not have_torch, "torch is required")
+@unittest.skip("unstable, ignore for now")
 class TorchDistributorLocalUnitTestsIIOnConnect(
     TorchDistributorLocalUnitTestsMixin, unittest.TestCase
 ):


### PR DESCRIPTION
### What changes were proposed in this pull request?

`TorchDistributorLocalUnitTestsIIOnConnect` was recently added in https://github.com/apache/spark/commit/f8751e2afeb5042a17d86763f965bc8f479784bf , but after that  `test_parity_torch_distributor` became unstable and sometime got stuck


### Why are the changes needed?
to make CI happy, I file [SPARK-43122](https://issues.apache.org/jira/browse/SPARK-43122) to track it.


### Does this PR introduce _any_ user-facing change?
No, test only


### How was this patch tested?
CI