### PR TITLE
[SPARK-43130][SQL] Move InternalType to PhysicalDataType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects._
+import org.apache.spark.sql.catalyst.types.{PhysicalBinaryType, PhysicalIntegerType, PhysicalLongType}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, MapData}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
@@ -728,10 +729,10 @@ object ScalaReflection extends ScalaReflection {
     FloatType -> classOf[Float],
     DoubleType -> classOf[Double],
     StringType -> classOf[UTF8String],
-    DateType -> classOf[DateType.InternalType],
-    TimestampType -> classOf[TimestampType.InternalType],
-    TimestampNTZType -> classOf[TimestampNTZType.InternalType],
-    BinaryType -> classOf[BinaryType.InternalType],
+    DateType -> classOf[PhysicalIntegerType.InternalType],
+    TimestampType -> classOf[PhysicalLongType.InternalType],
+    TimestampNTZType -> classOf[PhysicalLongType.InternalType],
+    BinaryType -> classOf[PhysicalBinaryType.InternalType],
     CalendarIntervalType -> classOf[CalendarInterval]
   )
 
@@ -751,8 +752,8 @@ object ScalaReflection extends ScalaReflection {
   def dataTypeJavaClass(dt: DataType): Class[_] = {
     dt match {
       case _: DecimalType => classOf[Decimal]
-      case it: DayTimeIntervalType => classOf[it.InternalType]
-      case it: YearMonthIntervalType => classOf[it.InternalType]
+      case _: DayTimeIntervalType => classOf[PhysicalLongType.InternalType]
+      case _: YearMonthIntervalType => classOf[PhysicalIntegerType.InternalType]
       case _: StructType => classOf[InternalRow]
       case _: ArrayType => classOf[ArrayData]
       case _: MapType => classOf[MapData]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxCountDistinctForIntervals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproxCountDistinctForIntervals.scala
@@ -140,7 +140,8 @@ case class ApproxCountDistinctForIntervals(
       // convert the value into a double value for searching in the double array
       val doubleValue = child.dataType match {
         case n: NumericType =>
-          PhysicalNumericType.numeric(n).toDouble(value.asInstanceOf[n.InternalType])
+          PhysicalNumericType.numeric(n)
+            .toDouble(value.asInstanceOf[PhysicalNumericType#InternalType])
         case _: DateType | _: YearMonthIntervalType =>
           value.asInstanceOf[Int].toDouble
         case TimestampType | TimestampNTZType | _: DayTimeIntervalType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -180,7 +180,8 @@ case class ApproximatePercentile(
         case TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
           value.asInstanceOf[Long].toDouble
         case n: NumericType =>
-          PhysicalNumericType.numeric(n).toDouble(value.asInstanceOf[n.InternalType])
+          PhysicalNumericType.numeric(n)
+            .toDouble(value.asInstanceOf[PhysicalNumericType#InternalType])
         case other: DataType =>
           throw QueryExecutionErrors.dataTypeUnexpectedError(other)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/AbstractDataType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.TypeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -121,10 +119,7 @@ protected[sql] object AnyDataType extends AbstractDataType with Serializable {
 /**
  * An internal type used to represent everything that is not null, UDTs, arrays, structs, and maps.
  */
-protected[sql] abstract class AtomicType extends DataType {
-  private[sql] type InternalType
-  private[sql] val tag: TypeTag[InternalType]
-}
+protected[sql] abstract class AtomicType extends DataType
 
 object AtomicType {
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/BinaryType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/BinaryType.scala
@@ -17,11 +17,8 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalBinaryType, PhysicalDataType}
-import org.apache.spark.unsafe.types.ByteArray
 
 /**
  * The data type representing `Array[Byte]` values.
@@ -29,17 +26,6 @@ import org.apache.spark.unsafe.types.ByteArray
  */
 @Stable
 class BinaryType private() extends AtomicType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "BinaryType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-
-  private[sql] type InternalType = Array[Byte]
-
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
-  private[sql] val ordering =
-    (x: Array[Byte], y: Array[Byte]) => ByteArray.compareBinary(x, y)
-
   /**
    * The default size of a value of the BinaryType is 100 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/BooleanType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/BooleanType.scala
@@ -17,9 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.math.Ordering
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalBooleanType, PhysicalDataType}
 
@@ -30,13 +27,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalBooleanType, PhysicalDataTyp
  */
 @Stable
 class BooleanType private() extends AtomicType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "BooleanType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-  private[sql] type InternalType = Boolean
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-  private[sql] val ordering = implicitly[Ordering[InternalType]]
-
   /**
    * The default size of a value of the BooleanType is 1 byte.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ByteType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ByteType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalByteType, PhysicalDataType}
 
@@ -29,12 +27,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalByteType, PhysicalDataType}
  */
 @Stable
 class ByteType private() extends IntegralType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "ByteType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-  private[sql] type InternalType = Byte
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the ByteType is 1 byte.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/CharType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/CharType.scala
@@ -17,20 +17,12 @@
 
 package org.apache.spark.sql.types
 
-import scala.math.Ordering
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalStringType}
-import org.apache.spark.unsafe.types.UTF8String
 
 @Experimental
 case class CharType(length: Int) extends AtomicType {
   require(length >= 0, "The length of char type cannot be negative.")
-
-  private[sql] type InternalType = UTF8String
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-  private[sql] val ordering = implicitly[Ordering[InternalType]]
 
   override def defaultSize: Int = length
   private[sql] override def physicalDataType: PhysicalDataType = PhysicalStringType

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DateType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DateType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalIntegerType}
 
@@ -31,14 +29,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalIntegerTyp
  */
 @Stable
 class DateType private() extends DatetimeType {
-  /**
-   * Internally, a date is stored as a simple incrementing count of days
-   * where day 0 is 1970-01-01. Negative numbers represent earlier days.
-   */
-  private[sql] type InternalType = Int
-
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the DateType is 4 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DayTimeIntervalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DayTimeIntervalType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Unstable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalLongType}
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -43,15 +41,6 @@ import org.apache.spark.sql.types.DayTimeIntervalType.fieldToString
  */
 @Unstable
 case class DayTimeIntervalType(startField: Byte, endField: Byte) extends AnsiIntervalType {
-  /**
-   * Internally, values of day-time intervals are stored in `Long` values as amount of time in terms
-   * of microseconds that are calculated by the formula:
-   *   -/+ (24*60*60 * DAY + 60*60 * HOUR + 60 * MINUTE + SECOND) * 1000000
-   */
-  private[sql] type InternalType = Long
-
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The day-time interval type has constant precision. A value of the type always occupies 8 bytes.
    * The DAY field is constrained by the upper bound 106751991 to fit to `Long`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalType.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.types
 import java.util.Locale
 
 import scala.annotation.tailrec
-import scala.reflect.runtime.universe.typeTag
 
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
@@ -58,9 +57,6 @@ case class DecimalType(precision: Int, scale: Int) extends FractionalType {
   // default constructor for Java
   def this(precision: Int) = this(precision, 0)
   def this() = this(10)
-
-  private[sql] type InternalType = Decimal
-  @transient private[sql] lazy val tag = typeTag[InternalType]
 
   override def typeName: String = s"decimal($precision,$scale)"
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DoubleType.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
 import scala.util.Try
 
 import org.apache.spark.annotation.Stable
@@ -30,12 +29,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalDoubleType
  */
 @Stable
 class DoubleType private() extends FractionalType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "DoubleType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-  private[sql] type InternalType = Double
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the DoubleType is 8 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/FloatType.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
 import scala.util.Try
 
 import org.apache.spark.annotation.Stable
@@ -30,12 +29,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalFloatType}
  */
 @Stable
 class FloatType private() extends FractionalType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "FloatType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-  private[sql] type InternalType = Float
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the FloatType is 4 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/IntegerType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/IntegerType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalIntegerType}
 
@@ -29,12 +27,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalIntegerTyp
  */
 @Stable
 class IntegerType private() extends IntegralType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "IntegerType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-  private[sql] type InternalType = Int
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the IntegerType is 4 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/LongType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/LongType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalLongType}
 
@@ -29,12 +27,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalLongType}
  */
 @Stable
 class LongType private() extends IntegralType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "LongType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-  private[sql] type InternalType = Long
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the LongType is 8 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ShortType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/ShortType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalShortType}
 
@@ -29,12 +27,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalShortType}
  */
 @Stable
 class ShortType private() extends IntegralType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "ShortType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-  private[sql] type InternalType = Short
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the ShortType is 2 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -17,12 +17,8 @@
 
 package org.apache.spark.sql.types
 
-import scala.math.Ordering
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalStringType}
-import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * The data type representing `String` values. Please use the singleton `DataTypes.StringType`.
@@ -31,13 +27,6 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 @Stable
 class StringType private() extends AtomicType {
-  // The companion object and this class is separated so the companion object also subclasses
-  // this type. Otherwise, the companion object would be of type "StringType$" in byte code.
-  // Defined with a private constructor so the companion object is the only possible instantiation.
-  private[sql] type InternalType = UTF8String
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-  private[sql] val ordering = implicitly[Ordering[InternalType]]
-
   /**
    * The default size of a value of the StringType is 20 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Unstable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalLongType}
 
@@ -33,14 +31,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalLongType}
  */
 @Unstable
 class TimestampNTZType private() extends DatetimeType {
-  /**
-   * Internally, a timestamp is stored as the number of microseconds from
-   * the epoch of 1970-01-01T00:00:00.000000(Unix system time zero)
-   */
-  private[sql] type InternalType = Long
-
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the TimestampNTZType is 8 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalLongType}
 
@@ -33,14 +31,6 @@ import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalLongType}
  */
 @Stable
 class TimestampType private() extends DatetimeType {
-  /**
-   * Internally, a timestamp is stored as the number of microseconds from
-   * the epoch of 1970-01-01T00:00:00.000000Z (UTC+00:00)
-   */
-  private[sql] type InternalType = Long
-
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * The default size of a value of the TimestampType is 8 bytes.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/VarcharType.scala
@@ -16,21 +16,14 @@
  */
 package org.apache.spark.sql.types
 
-import scala.math.Ordering
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalStringType}
-import org.apache.spark.unsafe.types.UTF8String
 
 @Experimental
 case class VarcharType(length: Int) extends AtomicType {
   require(length >= 0, "The length of varchar type cannot be negative.")
 
-  private[sql] type InternalType = UTF8String
   private[sql] override def physicalDataType: PhysicalDataType = PhysicalStringType
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-  private[sql] val ordering = implicitly[Ordering[InternalType]]
 
   override def defaultSize: Int = length
   override def typeName: String = s"varchar($length)"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/YearMonthIntervalType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/YearMonthIntervalType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.types
 
-import scala.reflect.runtime.universe.typeTag
-
 import org.apache.spark.annotation.Unstable
 import org.apache.spark.sql.catalyst.types.{PhysicalDataType, PhysicalIntegerType}
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -41,15 +39,6 @@ import org.apache.spark.sql.types.YearMonthIntervalType.fieldToString
  */
 @Unstable
 case class YearMonthIntervalType(startField: Byte, endField: Byte) extends AnsiIntervalType {
-  /**
-   * Internally, values of year-month intervals are stored in `Int` values as amount of months
-   * that are calculated by the formula:
-   *   -/+ (12 * YEAR + MONTH)
-   */
-  private[sql] type InternalType = Int
-
-  @transient private[sql] lazy val tag = typeTag[InternalType]
-
   /**
    * Year-month interval values always occupy 4 bytes.
    * The YEAR field is constrained by the upper bound 178956970 to fit to `Int`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/ColumnAccessor.scala
@@ -23,6 +23,7 @@ import scala.annotation.tailrec
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{UnsafeArrayData, UnsafeMapData, UnsafeRow}
+import org.apache.spark.sql.catalyst.types.{PhysicalArrayType, PhysicalDataType, PhysicalMapType, PhysicalStructType}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.columnar.compression.CompressibleColumnAccessor
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
@@ -71,7 +72,7 @@ private[columnar] class NullColumnAccessor(buffer: ByteBuffer)
   extends BasicColumnAccessor[Any](buffer, NULL)
   with NullableColumnAccessor
 
-private[columnar] abstract class NativeColumnAccessor[T <: AtomicType](
+private[columnar] abstract class NativeColumnAccessor[T <: PhysicalDataType](
     override protected val buffer: ByteBuffer,
     override protected val columnType: NativeColumnType[T])
   extends BasicColumnAccessor(buffer, columnType)
@@ -118,15 +119,17 @@ private[columnar] class DecimalColumnAccessor(buffer: ByteBuffer, dataType: Deci
   with NullableColumnAccessor
 
 private[columnar] class StructColumnAccessor(buffer: ByteBuffer, dataType: StructType)
-  extends BasicColumnAccessor[UnsafeRow](buffer, STRUCT(dataType))
+  extends BasicColumnAccessor[UnsafeRow](buffer, STRUCT(PhysicalStructType(dataType.fields)))
   with NullableColumnAccessor
 
 private[columnar] class ArrayColumnAccessor(buffer: ByteBuffer, dataType: ArrayType)
-  extends BasicColumnAccessor[UnsafeArrayData](buffer, ARRAY(dataType))
+  extends BasicColumnAccessor[UnsafeArrayData](
+    buffer, ARRAY(PhysicalArrayType(dataType.elementType, dataType.containsNull)))
   with NullableColumnAccessor
 
 private[columnar] class MapColumnAccessor(buffer: ByteBuffer, dataType: MapType)
-  extends BasicColumnAccessor[UnsafeMapData](buffer, MAP(dataType))
+  extends BasicColumnAccessor[UnsafeMapData](
+    buffer, MAP(PhysicalMapType(dataType.keyType, dataType.valueType, dataType.valueContainsNull)))
   with NullableColumnAccessor
 
 private[sql] object ColumnAccessor {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressibleColumnAccessor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressibleColumnAccessor.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.sql.execution.columnar.compression
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.columnar.{ColumnAccessor, NativeColumnAccessor}
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
-import org.apache.spark.sql.types.AtomicType
 
-private[columnar] trait CompressibleColumnAccessor[T <: AtomicType] extends ColumnAccessor {
+private[columnar] trait CompressibleColumnAccessor[T <: PhysicalDataType] extends ColumnAccessor {
   this: NativeColumnAccessor[T] =>
 
   private var decoder: Decoder[T] = _

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressibleColumnBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressibleColumnBuilder.scala
@@ -21,8 +21,8 @@ import java.nio.{ByteBuffer, ByteOrder}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.columnar.{ColumnBuilder, NativeColumnBuilder}
-import org.apache.spark.sql.types.AtomicType
 import org.apache.spark.unsafe.Platform
 
 /**
@@ -41,7 +41,7 @@ import org.apache.spark.unsafe.Platform
  *     header         body
  * }}}
  */
-private[columnar] trait CompressibleColumnBuilder[T <: AtomicType]
+private[columnar] trait CompressibleColumnBuilder[T <: PhysicalDataType]
   extends ColumnBuilder with Logging {
 
   this: NativeColumnBuilder[T] with WithCompressionSchemes =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/compression/CompressionScheme.scala
@@ -20,12 +20,12 @@ package org.apache.spark.sql.execution.columnar.compression
 import java.nio.{ByteBuffer, ByteOrder}
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.columnar.{ColumnType, NativeColumnType}
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
-import org.apache.spark.sql.types.AtomicType
 
-private[columnar] trait Encoder[T <: AtomicType] {
+private[columnar] trait Encoder[T <: PhysicalDataType] {
   def gatherCompressibilityStats(row: InternalRow, ordinal: Int): Unit = {}
 
   def compressedSize: Int
@@ -39,7 +39,7 @@ private[columnar] trait Encoder[T <: AtomicType] {
   def compress(from: ByteBuffer, to: ByteBuffer): ByteBuffer
 }
 
-private[columnar] trait Decoder[T <: AtomicType] {
+private[columnar] trait Decoder[T <: PhysicalDataType] {
   def next(row: InternalRow, ordinal: Int): Unit
 
   def hasNext: Boolean
@@ -52,9 +52,11 @@ private[columnar] trait CompressionScheme {
 
   def supports(columnType: ColumnType[_]): Boolean
 
-  def encoder[T <: AtomicType](columnType: NativeColumnType[T]): Encoder[T]
+  def encoder[T <: PhysicalDataType](columnType: NativeColumnType[T]): Encoder[T]
 
-  def decoder[T <: AtomicType](buffer: ByteBuffer, columnType: NativeColumnType[T]): Decoder[T]
+  def decoder[T <: PhysicalDataType](
+    buffer: ByteBuffer,
+    columnType: NativeColumnType[T]): Decoder[T]
 }
 
 private[columnar] trait WithCompressionSchemes {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -34,6 +34,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.{BINARY, FIXED_
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.types.{PhysicalByteType, PhysicalShortType}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, CaseInsensitiveMap, DateTimeUtils, GenericArrayData}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns._
@@ -316,13 +317,13 @@ private[parquet] class ParquetRowConverter(
       case ByteType =>
         new ParquetPrimitiveConverter(updater) {
           override def addInt(value: Int): Unit =
-            updater.setByte(value.asInstanceOf[ByteType#InternalType])
+            updater.setByte(value.asInstanceOf[PhysicalByteType#InternalType])
         }
 
       case ShortType =>
         new ParquetPrimitiveConverter(updater) {
           override def addInt(value: Int): Unit =
-            updater.setShort(value.asInstanceOf[ShortType#InternalType])
+            updater.setShort(value.asInstanceOf[PhysicalShortType#InternalType])
         }
 
       // For INT32 backed decimals

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnTypeSuite.scala
@@ -25,15 +25,16 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection}
+import org.apache.spark.sql.catalyst.types.{PhysicalArrayType, PhysicalDataType, PhysicalMapType, PhysicalStructType}
 import org.apache.spark.sql.execution.columnar.ColumnarTestUtils._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 
 class ColumnTypeSuite extends SparkFunSuite {
   private val DEFAULT_BUFFER_SIZE = 512
-  private val MAP_TYPE = MAP(MapType(IntegerType, StringType))
-  private val ARRAY_TYPE = ARRAY(ArrayType(IntegerType))
-  private val STRUCT_TYPE = STRUCT(StructType(StructField("a", StringType) :: Nil))
+  private val MAP_TYPE = MAP(PhysicalMapType(IntegerType, StringType, true))
+  private val ARRAY_TYPE = ARRAY(PhysicalArrayType(IntegerType, true))
+  private val STRUCT_TYPE = STRUCT(PhysicalStructType(Array(StructField("a", StringType))))
 
   test("defaultSize") {
     val checks = Map(
@@ -58,7 +59,8 @@ class ColumnTypeSuite extends SparkFunSuite {
       assertResult(expected, s"Wrong actualSize for $columnType") {
         val row = new GenericInternalRow(1)
         row.update(0, CatalystTypeConverters.convertToCatalyst(value))
-        val proj = UnsafeProjection.create(Array[DataType](columnType.dataType))
+        val proj = UnsafeProjection.create(
+          Array[DataType](ColumnarDataTypeUtils.toLogicalDataType(columnType.dataType)))
         columnType.actualSize(proj(row), 0)
       }
     }
@@ -101,14 +103,16 @@ class ColumnTypeSuite extends SparkFunSuite {
   testColumnType(MAP_TYPE)
   testColumnType(CALENDAR_INTERVAL)
 
-  def testNativeColumnType[T <: AtomicType](columnType: NativeColumnType[T]): Unit = {
+  def testNativeColumnType[T <: PhysicalDataType](columnType: NativeColumnType[T]): Unit = {
     testColumnType[T#InternalType](columnType)
   }
 
   def testColumnType[JvmType](columnType: ColumnType[JvmType]): Unit = {
 
-    val proj = UnsafeProjection.create(Array[DataType](columnType.dataType))
-    val converter = CatalystTypeConverters.createToScalaConverter(columnType.dataType)
+    val proj = UnsafeProjection.create(
+      Array[DataType](ColumnarDataTypeUtils.toLogicalDataType(columnType.dataType)))
+    val converter = CatalystTypeConverters.createToScalaConverter(
+      ColumnarDataTypeUtils.toLogicalDataType(columnType.dataType))
     val seq = (0 until 4).map(_ => proj(makeRandomRow(columnType)).copy())
     val totalSize = seq.map(_.getSizeInBytes).sum
     val bufferSize = Math.max(DEFAULT_BUFFER_SIZE, totalSize)
@@ -120,7 +124,8 @@ class ColumnTypeSuite extends SparkFunSuite {
       buffer.rewind()
       seq.foreach { row =>
         logInfo("buffer = " + buffer + ", expected = " + row)
-        val expected = converter(row.get(0, columnType.dataType))
+        val expected = converter(row.get(0,
+          ColumnarDataTypeUtils.toLogicalDataType(columnType.dataType)))
         val extracted = converter(columnType.extract(buffer))
         assert(expected === extracted,
           s"Extracted value didn't equal to the original one. $expected != $extracted, buffer =" +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnarDataTypeUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnarDataTypeUtils.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.types._
 
 object ColumnarDataTypeUtils {
   def toLogicalDataType(dataType: PhysicalDataType): DataType = dataType match {
+    case PhysicalBooleanType => BooleanType
     case PhysicalIntegerType => IntegerType
     case PhysicalLongType => LongType
     case PhysicalByteType => ByteType

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnarDataTypeUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnarDataTypeUtils.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.types._
 
 object ColumnarDataTypeUtils {
   def toLogicalDataType(dataType: PhysicalDataType): DataType = dataType match {
+    case PhysicalNullType => NullType
     case PhysicalBooleanType => BooleanType
     case PhysicalIntegerType => IntegerType
     case PhysicalLongType => LongType

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnarDataTypeUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnarDataTypeUtils.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.columnar
+
+import org.apache.spark.sql.catalyst.types._
+import org.apache.spark.sql.types._
+
+object ColumnarDataTypeUtils {
+  def toLogicalDataType(dataType: PhysicalDataType): DataType = dataType match {
+    case PhysicalIntegerType => IntegerType
+    case PhysicalLongType => LongType
+    case PhysicalByteType => ByteType
+    case PhysicalShortType => ShortType
+    case PhysicalBinaryType => BinaryType
+    case PhysicalCalendarIntervalType => CalendarIntervalType
+    case PhysicalFloatType => FloatType
+    case PhysicalDoubleType => DoubleType
+    case PhysicalStringType => StringType
+    case PhysicalDecimalType(precision, scale) => DecimalType(precision, scale)
+    case PhysicalArrayType(elementType, containsNull) => ArrayType(elementType, containsNull)
+    case PhysicalStructType(fields) => StructType(fields)
+    case PhysicalMapType(keyType, valueType, valueContainsNull) =>
+      MapType(keyType, valueType, valueContainsNull)
+    case _ => throw new UnsupportedOperationException()
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnarTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/ColumnarTestUtils.scala
@@ -22,8 +22,9 @@ import scala.util.Random
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
-import org.apache.spark.sql.types.{AtomicType, Decimal}
+import org.apache.spark.sql.types.Decimal
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 object ColumnarTestUtils {
@@ -95,7 +96,7 @@ object ColumnarTestUtils {
     row
   }
 
-  def makeUniqueValuesAndSingleValueRows[T <: AtomicType](
+  def makeUniqueValuesAndSingleValueRows[T <: PhysicalDataType](
       columnType: NativeColumnType[T],
       count: Int): (Seq[T#InternalType], Seq[GenericInternalRow]) = {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/CompressionSchemeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/CompressionSchemeBenchmark.scala
@@ -25,8 +25,8 @@ import org.apache.commons.math3.distribution.LogNormalDistribution
 
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.columnar.{BOOLEAN, INT, LONG, NativeColumnType, SHORT, STRING}
-import org.apache.spark.sql.types.AtomicType
 import org.apache.spark.util.Utils._
 
 /**
@@ -57,7 +57,7 @@ object CompressionSchemeBenchmark extends BenchmarkBase with AllCompressionSchem
     () => rng.sample
   }
 
-  private[this] def prepareEncodeInternal[T <: AtomicType](
+  private[this] def prepareEncodeInternal[T <: PhysicalDataType](
     count: Int,
     tpe: NativeColumnType[T],
     supportedScheme: CompressionScheme,
@@ -80,7 +80,7 @@ object CompressionSchemeBenchmark extends BenchmarkBase with AllCompressionSchem
     (encoder.compress, encoder.compressionRatio, allocateLocal(4 + compressedSize))
   }
 
-  private[this] def runEncodeBenchmark[T <: AtomicType](
+  private[this] def runEncodeBenchmark[T <: PhysicalDataType](
       name: String,
       iters: Int,
       count: Int,
@@ -104,7 +104,7 @@ object CompressionSchemeBenchmark extends BenchmarkBase with AllCompressionSchem
     benchmark.run()
   }
 
-  private[this] def runDecodeBenchmark[T <: AtomicType](
+  private[this] def runDecodeBenchmark[T <: PhysicalDataType](
       name: String,
       iters: Int,
       count: Int,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/DictionaryEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/DictionaryEncodingSuite.scala
@@ -21,10 +21,10 @@ import java.nio.ByteBuffer
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.columnar.ColumnarTestUtils._
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
-import org.apache.spark.sql.types.AtomicType
 
 class DictionaryEncodingSuite extends SparkFunSuite {
   val nullValue = -1
@@ -32,7 +32,7 @@ class DictionaryEncodingSuite extends SparkFunSuite {
   testDictionaryEncoding(new LongColumnStats, LONG)
   testDictionaryEncoding(new StringColumnStats, STRING, false)
 
-  def testDictionaryEncoding[T <: AtomicType](
+  def testDictionaryEncoding[T <: PhysicalDataType](
       columnStats: ColumnStats,
       columnType: NativeColumnType[T],
       testDecompress: Boolean = true): Unit = {
@@ -142,7 +142,8 @@ class DictionaryEncodingSuite extends SparkFunSuite {
       assertResult(DictionaryEncoding.typeId, "Wrong compression scheme ID")(buffer.getInt())
 
       val decoder = DictionaryEncoding.decoder(buffer, columnType)
-      val columnVector = new OnHeapColumnVector(inputSeq.length, columnType.dataType)
+      val columnVector = new OnHeapColumnVector(inputSeq.length,
+        ColumnarDataTypeUtils.toLogicalDataType(columnType.dataType))
       decoder.decompress(columnVector, inputSeq.length)
 
       if (inputSeq.nonEmpty) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/IntegralDeltaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/IntegralDeltaSuite.scala
@@ -19,17 +19,17 @@ package org.apache.spark.sql.execution.columnar.compression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.columnar.ColumnarTestUtils._
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
-import org.apache.spark.sql.types.IntegralType
 
 class IntegralDeltaSuite extends SparkFunSuite {
   val nullValue = -1
   testIntegralDelta(new IntColumnStats, INT, IntDelta)
   testIntegralDelta(new LongColumnStats, LONG, LongDelta)
 
-  def testIntegralDelta[I <: IntegralType](
+  def testIntegralDelta[I <: PhysicalDataType](
       columnStats: ColumnStats,
       columnType: NativeColumnType[I],
       scheme: CompressionScheme): Unit = {
@@ -136,7 +136,8 @@ class IntegralDeltaSuite extends SparkFunSuite {
       assertResult(scheme.typeId, "Wrong compression scheme ID")(buffer.getInt())
 
       val decoder = scheme.decoder(buffer, columnType)
-      val columnVector = new OnHeapColumnVector(input.length, columnType.dataType)
+      val columnVector = new OnHeapColumnVector(input.length,
+        ColumnarDataTypeUtils.toLogicalDataType(columnType.dataType))
       decoder.decompress(columnVector, input.length)
 
       if (input.nonEmpty) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/PassThroughEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/PassThroughEncodingSuite.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.execution.columnar.compression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.columnar.ColumnarTestUtils._
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
-import org.apache.spark.sql.types.AtomicType
 
 class PassThroughSuite extends SparkFunSuite {
   val nullValue = -1
@@ -33,7 +33,7 @@ class PassThroughSuite extends SparkFunSuite {
   testPassThrough(new FloatColumnStats, FLOAT)
   testPassThrough(new DoubleColumnStats, DOUBLE)
 
-  def testPassThrough[T <: AtomicType](
+  def testPassThrough[T <: PhysicalDataType](
       columnStats: ColumnStats,
       columnType: NativeColumnType[T]): Unit = {
 
@@ -117,7 +117,8 @@ class PassThroughSuite extends SparkFunSuite {
       assertResult(PassThrough.typeId, "Wrong compression scheme ID")(buffer.getInt())
 
       val decoder = PassThrough.decoder(buffer, columnType)
-      val columnVector = new OnHeapColumnVector(input.length, columnType.dataType)
+      val columnVector = new OnHeapColumnVector(input.length,
+        ColumnarDataTypeUtils.toLogicalDataType(columnType.dataType))
       decoder.decompress(columnVector, input.length)
 
       if (input.nonEmpty) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/RunLengthEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/RunLengthEncodingSuite.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.execution.columnar.compression
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.columnar.ColumnarTestUtils._
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
-import org.apache.spark.sql.types.AtomicType
 
 class RunLengthEncodingSuite extends SparkFunSuite {
   val nullValue = -1
@@ -33,7 +33,7 @@ class RunLengthEncodingSuite extends SparkFunSuite {
   testRunLengthEncoding(new LongColumnStats, LONG)
   testRunLengthEncoding(new StringColumnStats, STRING, false)
 
-  def testRunLengthEncoding[T <: AtomicType](
+  def testRunLengthEncoding[T <: PhysicalDataType](
       columnStats: ColumnStats,
       columnType: NativeColumnType[T],
       testDecompress: Boolean = true): Unit = {
@@ -126,7 +126,8 @@ class RunLengthEncodingSuite extends SparkFunSuite {
       assertResult(RunLengthEncoding.typeId, "Wrong compression scheme ID")(buffer.getInt())
 
       val decoder = RunLengthEncoding.decoder(buffer, columnType)
-      val columnVector = new OnHeapColumnVector(inputSeq.length, columnType.dataType)
+      val columnVector = new OnHeapColumnVector(inputSeq.length,
+        ColumnarDataTypeUtils.toLogicalDataType(columnType.dataType))
       decoder.decompress(columnVector, inputSeq.length)
 
       if (inputSeq.nonEmpty) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/TestCompressibleColumnBuilder.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/TestCompressibleColumnBuilder.scala
@@ -17,10 +17,11 @@
 
 package org.apache.spark.sql.execution.columnar.compression
 
+import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.execution.columnar._
-import org.apache.spark.sql.types.{AtomicType, DataType}
+import org.apache.spark.sql.types.DataType
 
-class TestCompressibleColumnBuilder[T <: AtomicType](
+class TestCompressibleColumnBuilder[T <: PhysicalDataType](
     override val columnStats: ColumnStats,
     override val columnType: NativeColumnType[T],
     override val schemes: Seq[CompressionScheme])
@@ -32,7 +33,7 @@ class TestCompressibleColumnBuilder[T <: AtomicType](
 }
 
 object TestCompressibleColumnBuilder {
-  def apply[T <: AtomicType](
+  def apply[T <: PhysicalDataType](
       columnStats: ColumnStats,
       columnType: NativeColumnType[T],
       scheme: CompressionScheme): TestCompressibleColumnBuilder[T] = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR drops `InternalType` from the logical data type and refactors to use the PhysicalDataType and InternalType.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To simplify DataType interface.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT