### PR TITLE
[SPARK-43135][INFRA] Remove `branch-3.2` from `publish_snapshot` GitHub Action job

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -34,7 +34,6 @@ jobs:
           - master
           - branch-3.4
           - branch-3.3
-          - branch-3.2
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `branch-3.2` from `publish_snapshot` GitHub Action job.

### Why are the changes needed?

We already released Apache Spark 3.2.4 as an End-Of-Life version. To save the community resource, we need to stop publishing snapshot from `branch-3.2` from Today.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.