### PR TITLE
[SPARK-42994][TESTS][FOLLOWUP] Skip `TorchDistributorLocalUnitTestsOnConnect`

### DIFF
--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -47,7 +47,7 @@ class TorchDistributorBaselineUnitTestsOnConnect(
         self.spark.stop()
 
 
-@unittest.skipIf(not have_torch, "torch is required")
+@unittest.skip("unstable, ignore for now")
 class TorchDistributorLocalUnitTestsOnConnect(
     TorchDistributorLocalUnitTestsMixin, unittest.TestCase
 ):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip `TorchDistributorLocalUnitTestsOnConnect`


### Why are the changes needed?
it seems that `TorchDistributorLocalUnitTestsOnConnect` is also unstable in Github Action, but I cannot repro the issue locally.
Not sure whether it is related to resources limit, this needs more investigation, track it in https://issues.apache.org/jira/browse/SPARK-43122

### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
CI