### PR TITLE
[SPARK-43137][SQL] Improve ArrayInsert if the position is foldable and equals to zero.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -4806,7 +4806,7 @@ case class ArrayInsert(srcArrayExpr: Expression, posExpr: Expression, itemExpr: 
     }
   }
 
-  private lazy val isPrepend = second match {
+  private lazy val canBeOptimizedForPrepend = second match {
     case e: Expression if e.foldable =>
       e.eval().asInstanceOf[Int] == 1
     case _ => false
@@ -4828,7 +4828,7 @@ case class ArrayInsert(srcArrayExpr: Expression, posExpr: Expression, itemExpr: 
     val baseArr = arr.asInstanceOf[ArrayData]
     val arrayElementType = dataType.asInstanceOf[ArrayType].elementType
 
-    if (isPrepend) {
+    if (canBeOptimizedForPrepend) {
       val newArrayLength = baseArr.numElements() + 1
       if (newArrayLength > ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
         throw QueryExecutionErrors.concatArraysWithElementsExceedLimitError(newArrayLength)
@@ -4912,7 +4912,7 @@ case class ArrayInsert(srcArrayExpr: Expression, posExpr: Expression, itemExpr: 
       val assignment = CodeGenerator.createArrayAssignment(values, elementType, arr,
         adjustedAllocIdx, i, first.dataType.asInstanceOf[ArrayType].containsNull)
 
-      if (isPrepend) {
+      if (canBeOptimizedForPrepend) {
         val zero = "0"
         s"""
            |int $resLength = $arr.numElements() + 1;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark supports the `array_insert` and `array_prepend`. Users insert an element into the head of array is common operation. Considered, we want make `array_prepend` reuse the implementation of `array_insert`, but it seems a bit performance worse if the position is foldable and equals to zero.
The reason is that always do the check for position is negative or positive, and the code is too long. Too long code will lead to JIT failed.  


### Why are the changes needed?
Improve `ArrayInsert` if the position is foldable and equals to zero.


### Does this PR introduce _any_ user-facing change?
'No'.
Just change the inner implementation.


### How was this patch tested?
Exists test cases.
