### PR TITLE
[SPARK-43140][SQL][TESTS] Override computeStats in `DummyLeafNode`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/StreamingJoinHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/StreamingJoinHelperSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet}
 import org.apache.spark.sql.catalyst.optimizer.SimpleTestOptimizer
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
-import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, Filter, LeafNode}
+import org.apache.spark.sql.catalyst.plans.logical.{EventTimeWatermark, Filter, LeafNode, Statistics}
 import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, TimestampType}
 
 class StreamingJoinHelperSuite extends AnalysisTest {
@@ -39,6 +39,8 @@ class StreamingJoinHelperSuite extends AnalysisTest {
     case class DummyLeafNode() extends LeafNode {
       override def output: Seq[Attribute] =
         attributesToFindConstraintFor ++ attributesWithWatermark
+      // override computeStats to avoid UnsupportedOperationException.
+      override def computeStats(): Statistics = Statistics(sizeInBytes = BigInt(0))
     }
 
     def watermarkFrom(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `DummyLeafNode` override computeStats.

### Why are the changes needed?

To avoid `UnsupportedOperationException` if we add a rule(for example: the following `TestRule`) use statistics even the rule after the [Early Filter and Projection Push-Down](https://github.com/apache/spark/blob/0e9e34c1bd9bd16ad5efca77ce2763eb950f3103/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala#L194-L197).
```scala
object TestRule extends Rule[LogicalPlan] {
  def apply(plan: LogicalPlan): LogicalPlan = plan.transform {
    case f: Filter if f.stats.rowCount.nonEmpty =>
      f
  }
}
```


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.
