### PR TITLE
[SPARK-43141][BUILD] Ignore generated Java files in checkstyle

### DIFF
--- a/dev/checkstyle-suppressions.xml
+++ b/dev/checkstyle-suppressions.xml
@@ -29,6 +29,8 @@
 
 <suppressions>
     <suppress checks=".*"
+              files="core/target/*"/>
+    <suppress checks=".*"
               files="core/src/main/java/org/apache/spark/util/collection/TimSort.java"/>
     <suppress checks=".*"
               files="connector/spark-ganglia-lgpl/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java"/>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes Java files in `core/target` when running checkstyle with SBT.

### Why are the changes needed?

Files such as .../spark/core/target/scala-2.12/src_managed/main/org/apache/spark/status/protobuf/StoreTypes.java are checked in checkstyle. We shouldn't check them in the linter.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually ran:

```bash
./dev/sbt-checkstyle
```