### PR TITLE
SPARK-43166: name docker users

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -38,6 +38,7 @@ RUN set -ex && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
+    useradd -u ${spark_uid} spark && \
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
     rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
 

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
@@ -17,6 +17,9 @@
 
 ARG base_img
 
+# Specify the User that the actual main process will run as
+ARG spark_uid=185
+
 FROM $base_img
 WORKDIR /
 
@@ -29,7 +32,8 @@ RUN mkdir ${SPARK_HOME}/R
 RUN \
   apt-get update && \
   apt install -y r-base r-base-dev && \
-  rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
+  rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && \
+  useradd -u ${spark_uid} spark
 
 COPY R ${SPARK_HOME}/R
 ENV R_HOME /usr/lib/R
@@ -37,6 +41,4 @@ ENV R_HOME /usr/lib/R
 WORKDIR /opt/spark/work-dir
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
 
-# Specify the User that the actual main process will run as
-ARG spark_uid=185
 USER ${spark_uid}

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
@@ -17,6 +17,9 @@
 
 ARG base_img
 
+# Specify the User that the actual main process will run as
+ARG spark_uid=185
+
 FROM $base_img
 WORKDIR /
 
@@ -28,7 +31,9 @@ RUN apt-get update && \
     apt install -y python3 python3-pip && \
     pip3 install --upgrade pip setuptools && \
     # Removed the .cache to save space
-    rm -rf /root/.cache && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
+    rm -rf /root/.cache && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && \
+    # Add the spark user
+     useradd -u ${spark_uid} spark
 
 COPY python/pyspark ${SPARK_HOME}/python/pyspark
 COPY python/lib ${SPARK_HOME}/python/lib
@@ -36,6 +41,4 @@ COPY python/lib ${SPARK_HOME}/python/lib
 WORKDIR /opt/spark/work-dir
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
 
-# Specify the User that the actual main process will run as
-ARG spark_uid=185
 USER ${spark_uid}


### PR DESCRIPTION
### What changes were proposed in this pull request? / Why are the changes needed?
- Currently, the official Spark docker images run as the UID `185`, but no corresponding entry exists in `/etc/passwd`. This causes [issues](https://stackoverflow.com/questions/41864985/hadoop-ioexception-failure-to-login) when libraries try to fetch the current unix username. 
- This PR invokes the `useradd` function as part of the `Dockerfile`, to ensure that a name exists for these users.  

### Does this PR introduce _any_ user-facing change?
- No. No user-facing changes are expected.

### How was this patch tested?
- Docker build succeeds locally.