### PR TITLE
[SPARK-43145][SQL] Reduce ClassNotFound of hive storage handler table

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -417,6 +417,7 @@ private[hive] object HiveTableUtil {
   def configureJobPropertiesForStorageHandler(
       tableDesc: TableDesc, conf: Configuration, input: Boolean): Unit = {
     val property = tableDesc.getProperties.getProperty(META_TABLE_STORAGE)
+    if (property == null) { return }
     val storageHandler =
       org.apache.hadoop.hive.ql.metadata.HiveUtils.getStorageHandler(conf, property)
     if (storageHandler != null) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -417,7 +417,6 @@ private[hive] object HiveTableUtil {
   def configureJobPropertiesForStorageHandler(
       tableDesc: TableDesc, conf: Configuration, input: Boolean): Unit = {
     val property = tableDesc.getProperties.getProperty(META_TABLE_STORAGE)
-    if (property == null) { return }
     val storageHandler =
       org.apache.hadoop.hive.ql.metadata.HiveUtils.getStorageHandler(conf, property)
     if (storageHandler != null) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -489,7 +489,7 @@ private[hive] class HiveClientImpl(
       unsupportedFeatures += "skewed columns"
     }
 
-    if (h.getStorageHandler != null) {
+    if (h.getProperty(org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE) != null) {
       unsupportedFeatures += "storage handler"
     }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -489,8 +489,7 @@ private[hive] class HiveClientImpl(
       unsupportedFeatures += "skewed columns"
     }
 
-    if (h.getProperty(
-      org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE) != null) {
+    if (h.getProperty("storage_handler") != null) {
       unsupportedFeatures += "storage handler"
     }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -489,7 +489,8 @@ private[hive] class HiveClientImpl(
       unsupportedFeatures += "skewed columns"
     }
 
-    if (h.getProperty(org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE) != null) {
+    if (h.getProperty(
+      org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE) != null) {
       unsupportedFeatures += "storage handler"
     }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
@@ -907,3 +907,19 @@ object SPARK_34772 {
     }
   }
 }
+
+object SPARK_43145 {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .config(UI_ENABLED.key, "false")
+      .enableHiveSupport()
+      .getOrCreate()
+    try {
+      spark.sql("CREATE TABLE t (c int)")
+      spark.sql("ALTER TABLE t SET TBLPROPERTIES('storage_handler'='not_a_real_storage') ")
+      spark.sql("DESC t").collect()
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS t")
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
where hive table.getStorageHandler call is used, check hive table parameter "storage_handler" first.  purpose is that hive table.getStorageHandler initializes the storagehandler class, if not necessary can just check on hive table parameter first. the table parameter is required for storagehandler table in hive.


### Why are the changes needed?
for desc table, or use case where user just want to load HiveTableRelation, user do not need to provide the storagehandler jar.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
past unit tests and also local test.
