### PR TITLE
[SPARK-40609][SQL] Unwrap cast in the join condition to unlock bucketed read

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3960,6 +3960,14 @@ object SQLConf {
       .checkValue(_ > 0, "The difference must be positive.")
       .createWithDefault(4)
 
+  val UNWRAP_CAST_IN_JOIN_CONDITION_ENABLED =
+    buildConf("spark.sql.bucketing.unwrapCastInJoinCondition.enabled")
+      .doc("When true, unwrap the cast in the join condition to unlock bucketed reads if they " +
+        "are integral types.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val BROADCAST_HASH_JOIN_OUTPUT_PARTITIONING_EXPAND_LIMIT =
     buildConf("spark.sql.execution.broadcastHashJoin.outputPartitioningExpandLimit")
       .internal()
@@ -4984,6 +4992,9 @@ class SQLConf extends Serializable with Logging {
 
   def coalesceBucketsInJoinMaxBucketRatio: Int =
     getConf(SQLConf.COALESCE_BUCKETS_IN_JOIN_MAX_BUCKET_RATIO)
+
+  def unwrapCastInJoinConditionEnabled: Boolean =
+    getConf(SQLConf.UNWRAP_CAST_IN_JOIN_CONDITION_ENABLED)
 
   def optimizeNullAwareAntiJoin: Boolean =
     getConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.rules.{PlanChangeLogger, Rule}
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.adaptive.{AdaptiveExecutionContext, InsertAdaptiveSparkPlan}
-import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableUnnecessaryBucketedScan}
+import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableUnnecessaryBucketedScan, UnwrapCastInJoinCondition}
 import org.apache.spark.sql.execution.dynamicpruning.PlanDynamicPruningFilters
 import org.apache.spark.sql.execution.exchange.EnsureRequirements
 import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
@@ -425,6 +425,7 @@ object QueryExecution {
     adaptiveExecutionRule.toSeq ++
     Seq(
       CoalesceBucketsInJoin,
+      UnwrapCastInJoinCondition,
       PlanDynamicPruningFilters(sparkSession),
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec._
-import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableUnnecessaryBucketedScan}
+import org.apache.spark.sql.execution.bucketing.{CoalesceBucketsInJoin, DisableUnnecessaryBucketedScan, UnwrapCastInJoinCondition}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLAdaptiveExecutionUpdate, SparkListenerSQLAdaptiveSQLMetricUpdates, SQLPlanMetric}
@@ -121,6 +121,7 @@ case class AdaptiveSparkPlanExec(
     // EnsureRequirements
     Seq(
       CoalesceBucketsInJoin,
+      UnwrapCastInJoinCondition,
       RemoveRedundantProjects,
       ensureRequirements,
       AdjustShuffleExchangePosition,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/BucketJoinHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/BucketJoinHelper.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.bucketing
+
+import scala.annotation.tailrec
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.optimizer.BuildLeft
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
+import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, ProjectExec, SparkPlan}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
+
+trait BucketJoinHelper {
+  @tailrec
+  final protected def hasScanOperation(plan: SparkPlan): Boolean = plan match {
+    case f: FilterExec => hasScanOperation(f.child)
+    case p: ProjectExec => hasScanOperation(p.child)
+    case j: BroadcastHashJoinExec =>
+      if (j.buildSide == BuildLeft) hasScanOperation(j.right) else hasScanOperation(j.left)
+    case j: BroadcastNestedLoopJoinExec =>
+      if (j.buildSide == BuildLeft) hasScanOperation(j.right) else hasScanOperation(j.left)
+    case f: FileSourceScanExec => f.relation.bucketSpec.nonEmpty
+    case _ => false
+  }
+
+  /**
+   * The join keys should match with expressions for output partitioning. Note that
+   * the ordering does not matter because it will be handled in `EnsureRequirements`.
+   */
+  protected def satisfiesOutputPartitioning(
+      keys: Seq[Expression],
+      partitioning: Partitioning): Boolean = {
+    partitioning match {
+      case HashPartitioning(exprs, _) if exprs.length == keys.length =>
+        exprs.forall(e => keys.exists(_.semanticEquals(e)))
+      case _ => false
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/UnwrapCastInJoinCondition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/bucketing/UnwrapCastInJoinCondition.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.bucketing
+
+import org.apache.spark.sql.catalyst.analysis.AnsiTypeCoercion.findWiderTypeForTwo
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, EvalMode, Expression}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, ShuffledJoin, SortMergeJoinExec}
+import org.apache.spark.sql.types.{DataType, DecimalType, IntegralType}
+
+/**
+ * This rule unwrap the cast in one side of the `SortMergeJoin` and `ShuffledHashJoin` join keys.
+ */
+object UnwrapCastInJoinCondition extends Rule[SparkPlan] {
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.unwrapCastInJoinConditionEnabled) {
+      return plan
+    }
+
+    plan transform {
+      case ExtractJoinWithUnwrapCastInJoinCondition(join, joinKeys) =>
+        val (leftKeys, rightKeys) = joinKeys.unzip
+        join match {
+          case j: SortMergeJoinExec =>
+            j.copy(leftKeys = leftKeys, rightKeys = rightKeys)
+          case j: ShuffledHashJoinExec =>
+            j.copy(leftKeys = leftKeys, rightKeys = rightKeys)
+          case other => other
+        }
+      case other => other
+    }
+  }
+}
+
+/**
+ * An extractor that extracts `SortMergeJoinExec` and `ShuffledHashJoin`,
+ * where one sides can do bucketed read after unwrap cast in join keys.
+ */
+object ExtractJoinWithUnwrapCastInJoinCondition extends BucketJoinHelper {
+  private def isIntegralType(dt: DataType): Boolean = dt match {
+    case _: IntegralType => true
+    case DecimalType.Fixed(_, 0) => true
+    case _ => false
+  }
+
+  private def unwrapCastInJoinKeys(joinKeys: Seq[Expression]): Seq[Expression] = {
+    joinKeys.map {
+      case Cast(a: Attribute, _, _, _) if isIntegralType(a.dataType) => a
+      case e => e
+    }
+  }
+
+  private def followLeftJoinKeyType(
+      unwrapLeftKeys: Seq[Expression],
+      unwrapRightKeys: Seq[Expression]): Seq[(Expression, Expression)] = {
+    unwrapLeftKeys.zip(unwrapRightKeys).map {
+      case (l, r) if l.dataType != r.dataType =>
+        // Use TRY mode to avoid runtime exception in ANSI mode or data issue in non-ANSI mode.
+        l -> Cast(r, l.dataType, evalMode = EvalMode.TRY)
+      case (l, r) => l -> r
+    }
+  }
+
+  private def followRightJoinKeyType(
+      unwrapLeftKeys: Seq[Expression],
+      unwrapRightKeys: Seq[Expression]): Seq[(Expression, Expression)] = {
+    unwrapLeftKeys.zip(unwrapRightKeys).map {
+      case (l, r) if l.dataType != r.dataType =>
+        Cast(l, r.dataType, evalMode = EvalMode.TRY) -> r
+      case (l, r) => l -> r
+    }
+  }
+
+  private def unwrapCastInJoinCondition(
+      j: ShuffledJoin): Option[Seq[(Expression, Expression)]] = {
+    val unwrapLeftKeys = unwrapCastInJoinKeys(j.leftKeys)
+    val unwrapRightKeys = unwrapCastInJoinKeys(j.rightKeys)
+    // Make sure cast to wider type.
+    // For example, we do not support: cast(longCol as int) = cast(decimalCol as int).
+    val isCastToWiderType = unwrapLeftKeys.zip(unwrapRightKeys).zipWithIndex.forall {
+      case ((e1, e2), i) =>
+        findWiderTypeForTwo(e1.dataType, e2.dataType).contains(j.leftKeys(i).dataType)
+    }
+    if (isCastToWiderType) {
+      val leftOutputPart = j.left.outputPartitioning
+      val rightOutputPart = j.right.outputPartitioning
+      val leftSatisfies = satisfiesOutputPartitioning(j.leftKeys, leftOutputPart)
+      val leftUnwrapSatisfies = satisfiesOutputPartitioning(unwrapLeftKeys, leftOutputPart)
+      val rightSatisfies = satisfiesOutputPartitioning(j.rightKeys, rightOutputPart)
+      val rightUnwrapSatisfies = satisfiesOutputPartitioning(unwrapRightKeys, rightOutputPart)
+
+      (leftSatisfies, leftUnwrapSatisfies, rightSatisfies, rightUnwrapSatisfies) match {
+        case (_, true, _, true) =>
+          // Follows join side key types with larger bucket numbers.
+          if (j.left.outputPartitioning.numPartitions > j.right.outputPartitioning.numPartitions) {
+            Some(followLeftJoinKeyType(unwrapLeftKeys, unwrapRightKeys))
+          } else {
+            Some(followRightJoinKeyType(unwrapLeftKeys, unwrapRightKeys))
+          }
+        case (false, true, _, _) =>
+          Some(followLeftJoinKeyType(unwrapLeftKeys, unwrapRightKeys))
+        case (_, _, false, true) =>
+          Some(followRightJoinKeyType(unwrapLeftKeys, unwrapRightKeys))
+        case _ =>
+          None
+      }
+    } else {
+      None
+    }
+  }
+
+  def unapply(plan: SparkPlan): Option[(ShuffledJoin, Seq[(Expression, Expression)])] = {
+    plan match {
+      case j: ShuffledJoin if (hasScanOperation(j.left) &&
+        !satisfiesOutputPartitioning(j.leftKeys, j.left.outputPartitioning)) ||
+        (hasScanOperation(j.right) &&
+          !satisfiesOutputPartitioning(j.rightKeys, j.right.outputPartitioning)) =>
+        unwrapCastInJoinCondition(j) match {
+          case Some(joinKeys) => Some(j, joinKeys)
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.types.{DataType, DecimalType, IntegerType, LongType}
 import org.apache.spark.util.collection.BitSet
 
 class BucketedReadWithoutHiveSupportSuite
@@ -1074,6 +1075,70 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils with Adapti
             |        FROM   t1 LEFT JOIN t3 ON t1.i = t3.i AND t1.j = t3.j) t
             |       LEFT JOIN t2 ON t.i = t2.i AND t.j = t2.j
             |""".stripMargin, 2, None)
+      }
+    }
+  }
+
+  test("SPARK-40609: Unwrap cast in join condition") {
+    def verify(
+        query: String,
+        expectedNumShuffles: Int,
+        numPartitions: Option[Int] = None,
+        partitioningKeyTypes: Option[Seq[DataType]] = None): Unit = {
+      Seq(true, false).foreach { ansiEnabled =>
+        Seq(true, false).foreach { aqeEnabled =>
+          withSQLConf(
+            SQLConf.ANSI_ENABLED.key -> ansiEnabled.toString,
+            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> aqeEnabled.toString) {
+            val df = sql(query)
+            val plan = df.queryExecution.executedPlan
+            val shuffles = collect(plan) {
+              case s: ShuffleExchangeExec => s
+            }
+            assert(shuffles.size === expectedNumShuffles)
+            if (shuffles.size == 1) {
+              val outputPartitioning = shuffles.head.outputPartitioning
+              assert(outputPartitioning.numPartitions === numPartitions.get)
+              assert(outputPartitioning.asInstanceOf[HashPartitioning]
+                .expressions.map(_.dataType) === partitioningKeyTypes.get)
+
+              collect(plan) { case s: SortMergeJoinExec => s }.flatMap(_.expressions).foreach {
+                case c: Cast => assert(c.evalMode === EvalMode.TRY) // The EvalMode should be try.
+                case _ =>
+              }
+
+              checkAnswer(df, Row(1, 1) :: Nil)
+            }
+          }
+        }
+      }
+    }
+
+    withTable("t1", "t2", "t3", "t4") {
+      sql(
+        s"""
+           |CREATE TABLE t1 USING parquet CLUSTERED BY (i) INTO 8 buckets AS
+           |SELECT CAST(v AS int) AS i FROM values(1), (${Int.MaxValue}) AS data(v)
+           |""".stripMargin)
+      sql(
+        s"""
+           |CREATE TABLE t2 USING parquet CLUSTERED BY (i) INTO 8 buckets AS
+           |SELECT CAST(v AS bigint) AS i FROM values(1), (${Long.MaxValue}) AS data(v)
+           |""".stripMargin)
+      sql(
+        s"""
+           |CREATE TABLE t3 USING parquet CLUSTERED BY (i) INTO 4 buckets AS
+           |SELECT CAST(v AS decimal(18, 0)) AS i FROM values(1), (${"9" * 18}) AS data(v)
+           |""".stripMargin)
+      spark.table("t2").write.saveAsTable("t4")
+
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0",
+        SQLConf.UNWRAP_CAST_IN_JOIN_CONDITION_ENABLED.key -> "true") {
+        verify("SELECT * FROM t2 JOIN t3 ON t2.i = t3.i", 1, Some(8), Some(Seq(LongType)))
+        verify("SELECT * FROM t1 JOIN t4 ON t1.i = t4.i", 1, Some(8), Some(Seq(IntegerType)))
+        verify("SELECT * FROM t3 JOIN t4 ON t3.i = t4.i", 1, Some(4), Some(Seq(DecimalType(18, 0))))
+        // Do not unwrap cast if it is added by user.
+        verify("SELECT * FROM t2 JOIN t3 ON cast(t2.i as int) = cast(t3.i as int)", 2)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

It will invalidate the bucketed read if add a cast on bucket keys:
```sql
set spark.sql.autoBroadcastJoinThreshold=-1;
CREATE TABLE t2 USING parquet CLUSTERED BY (i) INTO 8 buckets AS
SELECT CAST(v AS bigint) AS i FROM values(1), (9223372036854775807) AS data(v);

CREATE TABLE t3 USING parquet CLUSTERED BY (i) INTO 4 buckets AS
SELECT CAST(v AS decimal(18, 0)) AS i FROM values(1), (999999999999999999) AS data(v);

EXPLAIN SELECT * FROM t2 JOIN t3 ON t2.i = t3.i;
```

```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortMergeJoin [cast(i#6L as decimal(20,0))], [cast(i#19 as decimal(20,0))], Inner
   :- Sort [cast(i#6L as decimal(20,0)) ASC NULLS FIRST], false, 0
   :  +- Exchange hashpartitioning(cast(i#6L as decimal(20,0)), 5), ENSURE_REQUIREMENTS, [plan_id=128]
   :     +- Filter isnotnull(i#6L)
   :        +- FileScan parquet spark_catalog.default.t2[i#6L] Batched: true, Bucketed: false (disabled by query planner)
   +- Sort [cast(i#19 as decimal(20,0)) ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(cast(i#19 as decimal(20,0)), 5), ENSURE_REQUIREMENTS, [plan_id=132]
         +- Filter isnotnull(i#19)
            +- FileScan parquet spark_catalog.default.t3[i#19] Batched: true, Bucketed: false (disabled by query planner)
```

This PR adds a new rule(`UnwrapCastInJoinCondition`) before `EnsureRequirements` to unwrap cast in join condition to unlock bucketed read if they are integral types. The key idea here is that casting to either of these two types will not affect the result of join for integral types join keys. For example: `a.intCol = try_cast(b.bigIntCol AS int)`, if the value of `bigIntCol` exceeds the range of int, the result of `try_cast(b.bigIntCol AS int)` is `null`, and the result of  `a.intCol = try_cast(b.bigIntCol AS int)` in the join condition is `false`. The result is consistent with `cast(a.intCol AS bigint) = b.bigIntCol`.

After This PR:
```
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortMergeJoin [i#6L], [try_cast(i#29 as bigint)], Inner
   :- Sort [i#6L ASC NULLS FIRST], false, 0
   :  +- Filter isnotnull(i#6L)
   :     +- FileScan parquet spark_catalog.default.t2[i#6L] Batched: true, Bucketed: true, SelectedBucketsCount: 8 out of 8
   +- Sort [try_cast(i#29 as bigint) ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(try_cast(i#29 as bigint), 8), ENSURE_REQUIREMENTS, [plan_id=132]
         +- Filter isnotnull(i#29)
            +- FileScan parquet spark_catalog.default.t3[i#29] Batched: true, Bucketed: false (disabled by query planner)
```

### Why are the changes needed?

Reduce shuffle to improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.