### PR TITLE
[SPARK-42475][DOCS][FOLLOW-UP] Fix the version string with dev0 to work in Binder integration

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -20,7 +20,7 @@
 # This file is used for Binder integration to install PySpark available in
 # Jupyter notebook.
 
-VERSION=$(python -c "exec(open('python/pyspark/version.py').read()); print(__version__)")
+VERSION=$(python -c "exec(open('python/pyspark/version.py').read()); from distutils.version import LooseVersion; print('.'.join(map(str, LooseVersion(__version__).version[:3])))")
 TAG=$(git describe --tags --exact-match 2>/dev/null)
 
 # If a commit is tagged, exactly specified version of pyspark should be installed to avoid


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes Binder integration version strings in case `dev0` is specified. It should work in master branch too (when users manually build the docs and test)

### Why are the changes needed?

For end users to run quickstarts.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes the user-facing quick start.

### How was this patch tested?
Manually tested at https://mybinder.org/v2/gh/HyukjinKwon/spark/SPARK-42475-followup-2?labpath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb
