### PR TITLE
[WIP][SPARK-43160][PYTHON]: Removed typing.io deprecated namespace

### DIFF
--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -24,6 +24,7 @@ import pickle
 from typing import (
     overload,
     Any,
+    BinaryIO,
     Callable,
     Dict,
     Generic,
@@ -35,7 +36,6 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-from typing.io import BinaryIO  # type: ignore[import]
 
 from pyspark.java_gateway import local_connect_and_auth
 from pyspark.serializers import ChunkedStream, pickle_protocol

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -24,7 +24,7 @@ import pickle
 from typing import (
     overload,
     Any,
-    BinaryIO,
+    BinaryIO, # type: ignore[import]
     Callable,
     Dict,
     Generic,

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -24,7 +24,7 @@ import pickle
 from typing import (
     overload,
     Any,
-    BinaryIO, # type: ignore[import]
+    BinaryIO,  # type: ignore[import]
     Callable,
     Dict,
     Generic,

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -94,7 +94,7 @@ class Broadcast(Generic[T]):
         ...
 
     @overload  # On worker with decryption server
-    def __init__(self: "Broadcast[Any]", *, sock_file: str):  # type: ignore
+    def __init__(self: "Broadcast[Any]", *, sock_file: str):
         ...
 
     def __init__(
@@ -104,7 +104,7 @@ class Broadcast(Generic[T]):
         pickle_registry: Optional["BroadcastPickleRegistry"] = None,
         path: Optional[str] = None,
         sock_file: Optional[BinaryIO] = None,
-    ):
+    ):  # type: ignore
         """
         Should not be called directly by users -- use :meth:`SparkContext.broadcast`
         instead.

--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -24,7 +24,7 @@ import pickle
 from typing import (
     overload,
     Any,
-    BinaryIO,  # type: ignore[import]
+    BinaryIO,
     Callable,
     Dict,
     Generic,
@@ -94,7 +94,7 @@ class Broadcast(Generic[T]):
         ...
 
     @overload  # On worker with decryption server
-    def __init__(self: "Broadcast[Any]", *, sock_file: str):
+    def __init__(self: "Broadcast[Any]", *, sock_file: str):  # type: ignore
         ...
 
     def __init__(


### PR DESCRIPTION
### Problem Description
From python 3.12 and onward or 3.13 according to the references [1](https://bugs.python.org/issue35089), [2](https://docs.python.org/3/library/typing.html#typing.IO) the typing.io namespace will be removed.

```
/python/3.11.1/lib/python3.11/site-packages/pyspark/broadcast.py:38: DeprecationWarning: typing.io is deprecated, import directly from typing instead. typing.io will be removed in Python 3.12.
    from typing.io import BinaryIO  # type: ignore[import]
```

### What changes were proposed in this pull request?
I am fixing the issue with the usage of typing.io


### Why are the changes needed?
Because typing.io namespace will be removed [1](https://bugs.python.org/issue35089), [2](https://docs.python.org/3/library/typing.html#typing.IO)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
By running the tests: https://github.com/aimtsou/spark/actions/runs/4718557460

### Jira ticket
https://issues.apache.org/jira/browse/SPARK-43160
