### PR TITLE
[SPARK-32064][SQL] Support temporary table

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1819,6 +1819,11 @@
           "Table <tableName> does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by \"spark.sql.catalog\"."
         ]
       },
+      "TEMPORARY_TABLE_UNSUPPORTED" : {
+        "message" : [
+          "<tableName> is a temporary table. <cmd> are not supported on temporary tables."
+        ]
+      },
       "TOO_MANY_TYPE_ARGUMENTS_FOR_UDF_CLASS" : {
         "message" : [
           "UDF class with <num> type arguments."

--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -32,6 +32,7 @@ import scala.util.control.NonFatal
 import com.google.common.primitives.Longs
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
+import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.token.{Token, TokenIdentifier}
@@ -648,4 +649,28 @@ private[spark] object SparkHadoopUtil extends Logging {
     }
   }
 
+  def createSessionDir(dir: String, conf: Configuration): String = {
+    createSessionDir(new Path(dir), conf)
+  }
+
+  def createSessionDir(path: Path, conf: Configuration): String = {
+    val fs = path.getFileSystem(conf)
+    if (!fs.mkdirs(path, new FsPermission("700"))) {
+      throw new IOException(s"Failed to create dir: $path.")
+    }
+    fs.makeQualified(path).toString
+  }
+
+  def deleteDir(path: String, conf: Configuration): Boolean = {
+    deleteDir(new Path(path), conf)
+  }
+
+  def deleteDir(path: Path, conf: Configuration): Boolean = {
+    val fs = path.getFileSystem(conf)
+    if (fs.exists(path)) {
+      fs.delete(path, true)
+    } else {
+      true
+    }
+  }
 }

--- a/docs/sql-ref-syntax-ddl-create-table-datasource.md
+++ b/docs/sql-ref-syntax-ddl-create-table-datasource.md
@@ -26,7 +26,7 @@ The `CREATE TABLE` statement defines a new table using a Data Source.
 ### Syntax
 
 ```sql
-CREATE TABLE [ IF NOT EXISTS ] table_identifier
+CREATE [ TEMPORARY ] TABLE [ IF NOT EXISTS ] table_identifier
     [ ( col_name1 col_type1 [ COMMENT col_comment1 ], ... ) ]
     USING data_source
     [ OPTIONS ( key1=val1, key2=val2, ... ) ]
@@ -44,6 +44,10 @@ Note that, the clauses between the USING clause and the AS SELECT clause can com
 as any order. For example, you can write COMMENT table_comment after TBLPROPERTIES.
 
 ### Parameters
+
+* **TEMPORARY**
+
+  Temporary table only works if user set `spark.sql.scratch.dir`. Temporary table data persists only during the current Spark session. Spark drops the table at the end of the session. If you use the name of a permanent table to create the temporary table, the permanent table is inaccessible during the session unless you drop the temporary table. Temporary tables do not support partitioned columns.
 
 * **table_identifier**
 
@@ -110,6 +114,9 @@ input query, to make sure the table gets created contains exactly the same data 
 ### Examples
 
 ```sql
+
+-- Start Spark session with --conf spark.sql.scratch.dir=/tmp/spark-scratch and create temporary table
+CREATE TEMPORARY TABLE student_tmp AS SELECT * FROM student;
 
 --Use data source
 CREATE TABLE student (id INT, name STRING, age INT) USING CSV;

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -91,7 +91,7 @@ statement
     | createTableHeader (LEFT_PAREN createOrReplaceTableColTypeList RIGHT_PAREN)? tableProvider?
         createTableClauses
         (AS? query)?                                                   #createTable
-    | CREATE TABLE (IF NOT EXISTS)? target=tableIdentifier
+    | CREATE (TEMPORARY)? TABLE (IF NOT EXISTS)? target=tableIdentifier
         LIKE source=tableIdentifier
         (tableProvider |
         rowFormat |
@@ -285,7 +285,7 @@ unsupportedHiveNativeCommands
     ;
 
 createTableHeader
-    : CREATE TEMPORARY? EXTERNAL? TABLE (IF NOT EXISTS)? multipartIdentifier
+    : CREATE (TEMPORARY)? EXTERNAL? TABLE (IF NOT EXISTS)? multipartIdentifier
     ;
 
 replaceTableHeader

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -256,6 +256,8 @@ case class CatalogTable(
 
   import CatalogTable._
 
+  val isTemporary: Boolean = tableType == CatalogTableType.TEMPORARY
+
   /**
    * schema of this table's partition columns
    */
@@ -757,8 +759,9 @@ object CatalogTableType {
   val EXTERNAL = new CatalogTableType("EXTERNAL")
   val MANAGED = new CatalogTableType("MANAGED")
   val VIEW = new CatalogTableType("VIEW")
+  val TEMPORARY = new CatalogTableType("TEMPORARY")
 
-  val tableTypes = Seq(EXTERNAL, MANAGED, VIEW)
+  val tableTypes = Seq(EXTERNAL, MANAGED, VIEW, TEMPORARY)
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1356,4 +1356,5 @@ case class TableSpec(
     location: Option[String],
     comment: Option[String],
     serde: Option[SerdeInfo],
-    external: Boolean)
+    external: Boolean,
+    temporary: Boolean)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3499,4 +3499,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       errorClass = "CANNOT_RENAME_ACROSS_SCHEMA", messageParameters = Map("type" -> "table")
     )
   }
+
+  def temporaryTableUnsupported(table: TableIdentifier, cmd: String): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_FEATURE.TEMPORARY_TABLE_UNSUPPORTED",
+      messageParameters = Map(
+        "cmd" -> cmd,
+        "tableName" -> table.identifier))
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5037,6 +5037,8 @@ class SQLConf extends Serializable with Logging {
 
   def usePartitionEvaluator: Boolean = getConf(SQLConf.USE_PARTITION_EVALUATOR)
 
+  def enableTemporayTable: Boolean = getConf(StaticSQLConf.SCRATCH_DIR).nonEmpty
+
   /** ********************** SQLConf functionality methods ************ */
 
   /** Set Spark SQL configuration properties. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -278,4 +278,11 @@ object StaticSQLConf {
       .version("3.1.0")
       .stringConf
       .createWithDefault("")
+
+  val SCRATCH_DIR = buildStaticConf("spark.sql.scratch.dir")
+    .doc("Scratch space for Spark temporary table. It will automatically cleaned when " +
+      "stopping Spark context.")
+    .version("3.5.0")
+    .stringConf
+    .createOptional
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/CreateTablePartitioningValidationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/CreateTablePartitioningValidationSuite.scala
@@ -30,7 +30,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
   test("CreateTableAsSelect: fail missing top-level column") {
     val tableSpec = TableSpec(Map.empty, None, Map.empty,
-      None, None, None, false)
+      None, None, None, false, false)
     val plan = CreateTableAsSelect(
       UnresolvedIdentifier(Array("table_name")),
       Expressions.bucket(4, "does_not_exist") :: Nil,
@@ -47,7 +47,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
   test("CreateTableAsSelect: fail missing top-level column nested reference") {
     val tableSpec = TableSpec(Map.empty, None, Map.empty,
-      None, None, None, false)
+      None, None, None, false, false)
     val plan = CreateTableAsSelect(
       UnresolvedIdentifier(Array("table_name")),
       Expressions.bucket(4, "does_not_exist.z") :: Nil,
@@ -64,7 +64,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
   test("CreateTableAsSelect: fail missing nested column") {
     val tableSpec = TableSpec(Map.empty, None, Map.empty,
-      None, None, None, false)
+      None, None, None, false, false)
     val plan = CreateTableAsSelect(
       UnresolvedIdentifier(Array("table_name")),
       Expressions.bucket(4, "point.z") :: Nil,
@@ -81,7 +81,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
   test("CreateTableAsSelect: fail with multiple errors") {
     val tableSpec = TableSpec(Map.empty, None, Map.empty,
-      None, None, None, false)
+      None, None, None, false, false)
     val plan = CreateTableAsSelect(
       UnresolvedIdentifier(Array("table_name")),
       Expressions.bucket(4, "does_not_exist", "point.z") :: Nil,
@@ -98,7 +98,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
   test("CreateTableAsSelect: success with top-level column") {
     val tableSpec = TableSpec(Map.empty, None, Map.empty,
-      None, None, None, false)
+      None, None, None, false, false)
     val plan = CreateTableAsSelect(
       UnresolvedIdentifier(Array("table_name")),
       Expressions.bucket(4, "id") :: Nil,
@@ -112,7 +112,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
   test("CreateTableAsSelect: success using nested column") {
     val tableSpec = TableSpec(Map.empty, None, Map.empty,
-      None, None, None, false)
+      None, None, None, false, false)
     val plan = CreateTableAsSelect(
       UnresolvedIdentifier(Array("table_name")),
       Expressions.bucket(4, "point.x") :: Nil,
@@ -126,7 +126,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
   test("CreateTableAsSelect: success using complex column") {
     val tableSpec = TableSpec(Map.empty, None, Map.empty,
-      None, None, None, false)
+      None, None, None, false, false)
     val plan = CreateTableAsSelect(
       UnresolvedIdentifier(Array("table_name")),
       Expressions.bucket(4, "point") :: Nil,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1799,4 +1799,14 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
       assert(catalog.getCachedTable(qualifiedName2) != null)
     }
   }
+
+  test("Set scratch dir if user want to use temporary table") {
+    withBasicCatalog { catalog =>
+      val e = intercept[AnalysisException] {
+        catalog.sessionDir
+      }
+      e.getMessage.contains(s"Please set ${StaticSQLConf.SCRATCH_DIR.key} if you want to " +
+        "use temporary table")
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2573,7 +2573,7 @@ class DDLParserSuite extends AnalysisTest {
     val createTableResult =
       CreateTable(UnresolvedIdentifier(Seq("my_tab")), schemaWithDefaultColumn,
         Seq.empty[Transform], LogicalTableSpec(Map.empty[String, String], Some("parquet"),
-          Map.empty[String, String], None, None, None, false), false)
+          Map.empty[String, String], None, None, None, false, false), false)
     // Parse the CREATE TABLE statement twice, swapping the order of the NOT NULL and DEFAULT
     // options, to make sure that the parser accepts any ordering of these options.
     comparePlans(parsePlan(
@@ -2586,7 +2586,7 @@ class DDLParserSuite extends AnalysisTest {
       "b STRING NOT NULL DEFAULT \"abc\") USING parquet"),
       ReplaceTable(UnresolvedIdentifier(Seq("my_tab")), schemaWithDefaultColumn,
         Seq.empty[Transform], LogicalTableSpec(Map.empty[String, String], Some("parquet"),
-          Map.empty[String, String], None, None, None, false), false))
+          Map.empty[String, String], None, None, None, false, false), false))
     // These ALTER TABLE statements should parse successfully.
     comparePlans(
       parsePlan("ALTER TABLE t1 ADD COLUMN x int NOT NULL DEFAULT 42"),
@@ -2742,12 +2742,12 @@ class DDLParserSuite extends AnalysisTest {
       "CREATE TABLE my_tab(a INT, b INT NOT NULL GENERATED ALWAYS AS (a+1)) USING parquet"),
       CreateTable(UnresolvedIdentifier(Seq("my_tab")), schemaWithGeneratedColumn,
         Seq.empty[Transform], LogicalTableSpec(Map.empty[String, String], Some("parquet"),
-          Map.empty[String, String], None, None, None, false), false))
+          Map.empty[String, String], None, None, None, false, false), false))
     comparePlans(parsePlan(
       "REPLACE TABLE my_tab(a INT, b INT NOT NULL GENERATED ALWAYS AS (a+1)) USING parquet"),
       ReplaceTable(UnresolvedIdentifier(Seq("my_tab")), schemaWithGeneratedColumn,
         Seq.empty[Transform], LogicalTableSpec(Map.empty[String, String], Some("parquet"),
-          Map.empty[String, String], None, None, None, false), false))
+          Map.empty[String, String], None, None, None, false, false), false))
     // Two generation expressions
     checkError(
       exception = parseException("CREATE TABLE my_tab(a INT, " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -333,7 +333,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
                 location = extraOptions.get("path"),
                 comment = extraOptions.get(TableCatalog.PROP_COMMENT),
                 serde = None,
-                external = false)
+                external = false,
+                temporary = false)
               runCommand(df.sparkSession) {
                 CreateTableAsSelect(
                   UnresolvedIdentifier(catalog.name +: ident.namespace.toSeq :+ ident.name),
@@ -598,7 +599,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           location = extraOptions.get("path"),
           comment = extraOptions.get(TableCatalog.PROP_COMMENT),
           serde = None,
-          external = false)
+          external = false,
+          temporary = false)
         ReplaceTableAsSelect(
           UnresolvedIdentifier(nameParts),
           partitioningAsV2,
@@ -618,7 +620,8 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           location = extraOptions.get("path"),
           comment = extraOptions.get(TableCatalog.PROP_COMMENT),
           serde = None,
-          external = false)
+          external = false,
+          temporary = false)
 
         CreateTableAsSelect(
           UnresolvedIdentifier(nameParts),

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
@@ -114,7 +114,8 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
       location = None,
       comment = None,
       serde = None,
-      external = false)
+      external = false,
+      temporary = false)
     runCommand(
       CreateTableAsSelect(
         UnresolvedIdentifier(tableName),
@@ -203,7 +204,8 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
       location = None,
       comment = None,
       serde = None,
-      external = false)
+      external = false,
+      temporary = false)
     runCommand(ReplaceTableAsSelect(
       UnresolvedIdentifier(tableName),
       partitioning.getOrElse(Seq.empty),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -310,7 +310,7 @@ class SparkSqlAstBuilder extends AstBuilder {
   override def visitCreateTable(ctx: CreateTableContext): LogicalPlan = withOrigin(ctx) {
     val (ident, temp, ifNotExists, external) = visitCreateTableHeader(ctx.createTableHeader)
 
-    if (!temp || ctx.query != null) {
+    if (!temp || ctx.query != null || (temp && conf.enableTemporayTable)) {
       super.visitCreateTable(ctx)
     } else {
       if (external) {
@@ -664,6 +664,7 @@ class SparkSqlAstBuilder extends AstBuilder {
   override def visitCreateTableLike(ctx: CreateTableLikeContext): LogicalPlan = withOrigin(ctx) {
     val targetTable = visitTableIdentifier(ctx.target)
     val sourceTable = visitTableIdentifier(ctx.source)
+    val isTemp = ctx.TEMPORARY != null
     checkDuplicateClauses(ctx.tableProvider, "PROVIDER", ctx)
     checkDuplicateClauses(ctx.createFileFormat, "STORED AS/BY", ctx)
     checkDuplicateClauses(ctx.rowFormat, "ROW FORMAT", ctx)
@@ -693,7 +694,7 @@ class SparkSqlAstBuilder extends AstBuilder {
     val properties = Option(ctx.tableProps).map(visitPropertyKeyValues).getOrElse(Map.empty)
     val cleanedProperties = cleanTableProperties(ctx, properties)
     CreateTableLikeCommand(
-      targetTable, sourceTable, storage, provider, cleanedProperties, ctx.EXISTS != null)
+      targetTable, sourceTable, storage, provider, cleanedProperties, ctx.EXISTS != null, isTemp)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -300,6 +300,7 @@ case class AlterTableSetPropertiesCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableRawMetadata(tableName)
+    DDLUtils.verifyOperationNotSupported(table, "Set table properties")
     // This overrides old properties and update the comment parameter of CatalogTable
     // with the newly added/modified comment since CatalogTable also holds comment as its
     // direct property.
@@ -332,6 +333,7 @@ case class AlterTableUnsetPropertiesCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableRawMetadata(tableName)
+    DDLUtils.verifyOperationNotSupported(table, "Unset table properties")
     if (!ifExists) {
       propKeys.foreach { k =>
         if (!table.properties.contains(k) && k != TableCatalog.PROP_COMMENT) {
@@ -372,6 +374,7 @@ case class AlterTableChangeColumnCommand(
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableRawMetadata(tableName)
     val resolver = sparkSession.sessionState.conf.resolver
+    DDLUtils.verifyOperationNotSupported(table, "Change table column")
     DDLUtils.verifyAlterTableType(catalog, table, isView = false)
 
     // Find the origin column from dataSchema by column name.
@@ -461,6 +464,7 @@ case class AlterTableSerDePropertiesCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableRawMetadata(tableName)
+    DDLUtils.verifyOperationNotSupported(table, "Alter table serde")
     // For datasource tables, disallow setting serde or specifying partition
     if (partSpec.isDefined && DDLUtils.isDatasourceTable(table)) {
       throw QueryCompilationErrors.alterTableSetSerdeForSpecificPartitionNotSupportedError()
@@ -506,6 +510,7 @@ case class AlterTableAddPartitionCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableMetadata(tableName)
+    DDLUtils.verifyOperationNotSupported(table, "Alter table add partition")
     DDLUtils.verifyPartitionProviderIsHive(sparkSession, table, "ALTER TABLE ADD PARTITION")
     val parts = partitionSpecsAndLocs.map { case (spec, location) =>
       val normalizedSpec = PartitioningUtils.normalizePartitionSpec(
@@ -562,6 +567,7 @@ case class AlterTableRenamePartitionCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableMetadata(tableName)
+    DDLUtils.verifyOperationNotSupported(table, "Alter table rename partition")
     DDLUtils.verifyPartitionProviderIsHive(sparkSession, table, "ALTER TABLE RENAME PARTITION")
 
     val normalizedOldPartition = PartitioningUtils.normalizePartitionSpec(
@@ -609,6 +615,7 @@ case class AlterTableDropPartitionCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableMetadata(tableName)
+    DDLUtils.verifyOperationNotSupported(table, "Alter table drop partition")
     DDLUtils.verifyPartitionProviderIsHive(sparkSession, table, "ALTER TABLE DROP PARTITION")
 
     val normalizedSpecs = specs.map { spec =>
@@ -892,6 +899,7 @@ case class AlterTableSetLocationCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val catalog = sparkSession.sessionState.catalog
     val table = catalog.getTableMetadata(tableName)
+    DDLUtils.verifyOperationNotSupported(table, "Set table location")
     val locUri = CatalogUtils.stringToURI(location)
     partitionSpec match {
       case Some(spec) =>
@@ -977,6 +985,12 @@ object DDLUtils extends Logging {
           throw QueryCompilationErrors.cannotAlterTableWithAlterViewError()
         case _ =>
       }
+    }
+  }
+
+  def verifyOperationNotSupported(tableMetadata: CatalogTable, cmd: String): Unit = {
+    if (tableMetadata.isTemporary) {
+      throw QueryCompilationErrors.temporaryTableUnsupported(tableMetadata.identifier, cmd)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -432,7 +432,8 @@ object PreprocessTableInsertion extends Rule[LogicalPlan] {
 object HiveOnlyCheck extends (LogicalPlan => Unit) {
   def apply(plan: LogicalPlan): Unit = {
     plan.foreach {
-      case CreateTableV1(tableDesc, _, _) if DDLUtils.isHiveTable(tableDesc) =>
+      case CreateTableV1(tableDesc, _, _)
+          if DDLUtils.isHiveTable(tableDesc) && !tableDesc.isTemporary =>
         throw QueryCompilationErrors.ddlWithoutHiveSupportEnabledError(
           "CREATE Hive TABLE (AS SELECT)")
       case i: InsertIntoDir if DDLUtils.isHiveTable(i.provider) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, CharVarcharUtils}
-import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Table, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Table, TableCatalog, V1Table}
 import org.apache.spark.sql.connector.expressions.BucketTransform
 import org.apache.spark.sql.execution.LeafExecNode
 import org.apache.spark.unsafe.types.UTF8String
@@ -42,7 +42,7 @@ case class ShowCreateTableExec(
   }
 
   private def showCreateTable(table: Table, builder: StringBuilder): Unit = {
-    builder ++= s"CREATE TABLE ${table.name()} "
+    builder ++= s"CREATE${temporary(table)}TABLE ${table.name()} "
 
     showTableDataColumns(table, builder)
     showTableUsing(table, builder)
@@ -152,5 +152,10 @@ case class ShowCreateTableExec(
 
   private def concatByMultiLines(iter: Iterable[String]): String = {
     iter.mkString("(\n  ", ",\n  ", ")\n")
+  }
+
+  private def temporary(table: Table): String = table match {
+    case v: V1Table if v.v1Table.isTemporary => " TEMPORARY "
+    case _ => " "
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExec.scala
@@ -49,7 +49,7 @@ case class ShowTablesExec(
 
   private def isTempView(ident: Identifier): Boolean = {
     catalog match {
-      case s: V2SessionCatalog => s.isTempView(ident)
+      case s: V2SessionCatalog => s.isTempView(ident) || s.isTempTable(ident)
       case _ => false
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -327,6 +327,10 @@ class V2SessionCatalog(catalog: SessionCatalog)
     catalog.isTempView(ident.namespace() :+ ident.name())
   }
 
+  def isTempTable(ident: Identifier): Boolean = {
+    catalog.tempTableExists(ident.asTableIdentifier)
+  }
+
   override def loadFunction(ident: Identifier): UnboundFunction = {
     V1Function(catalog.lookupPersistentFunction(ident.asFunctionIdentifier))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -158,7 +158,8 @@ abstract class BaseSessionStateBuilder(
       SessionState.newHadoopConf(session.sparkContext.hadoopConfiguration, conf),
       sqlParser,
       resourceLoader,
-      new SparkUDFExpressionBuilder)
+      new SparkUDFExpressionBuilder,
+      scratchSessionDir = session.scratchSessionDir)
     parentState.foreach(_.catalog.copyStateTo(catalog))
     catalog
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -626,7 +626,8 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       location = location,
       comment = { if (description.isEmpty) None else Some(description) },
       serde = None,
-      external = tableType == CatalogTableType.EXTERNAL)
+      external = tableType == CatalogTableType.EXTERNAL,
+      temporary = tableType == CatalogTableType.TEMPORARY)
 
     val plan = CreateTable(
       name = UnresolvedIdentifier(ident),

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -296,6 +296,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
         extraOptions.get("path"),
         None,
         None,
+        false,
         false)
       val cmd = CreateTable(
         UnresolvedIdentifier(originalMultipartIdentifier),

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar.sql.out
@@ -55,7 +55,7 @@ DescribeColumnCommand `spark_catalog`.`default`.`char_tbl2`, [spark_catalog, def
 -- !query
 create table char_tbl3 like char_tbl
 -- !query analysis
-CreateTableLikeCommand `char_tbl3`, `char_tbl`, Storage(), false
+CreateTableLikeCommand `char_tbl3`, `char_tbl`, Storage(), false, false
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/TemporaryTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TemporaryTableSuite.scala
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class TemporaryTableSuite extends QueryTest
+  with SharedSparkSession
+  with AdaptiveSparkPlanHelper {
+
+  private val sparkScratch = "/tmp/spark-scratch"
+
+  override protected def sparkConf: SparkConf =
+    super
+      .sparkConf
+      .set(StaticSQLConf.SCRATCH_DIR, sparkScratch)
+
+  override def afterEach(): Unit = {
+    try {
+      spark.sessionState.catalog.dropAllTempTables()
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  test("Scratch dir is set and temporary tables are supported") {
+    assert(spark.sessionState.catalog.sessionDir.contains(sparkScratch))
+    assert(spark.sessionState.conf.enableTemporayTable)
+  }
+
+  test("create temporary table across different sessions") {
+    val sparkSession1 = spark.newSession()
+    val sparkSession2 = spark.newSession()
+
+    val t1 = TableIdentifier("t1")
+
+    sparkSession1.sql("CREATE TEMPORARY TABLE t1 AS SELECT * FROM range(2)")
+    sparkSession2.sql("CREATE TEMPORARY TABLE t1 AS SELECT * FROM range(3)")
+
+    assert(sparkSession1.sessionState.catalog.getTableMetadata(t1).isTemporary)
+    assert(sparkSession1.sessionState.catalog.getTableMetadata(t1).tableType ===
+      CatalogTableType.TEMPORARY)
+    assert(sparkSession1.sessionState.catalog.getTableMetadata(t1).location.toString
+      .contains(sparkScratch))
+    assert(sparkSession2.sessionState.catalog.getTableMetadata(t1).isTemporary)
+    assert(sparkSession2.sessionState.catalog.getTableMetadata(t1).tableType ===
+      CatalogTableType.TEMPORARY)
+    assert(sparkSession2.sessionState.catalog.getTableMetadata(t1).location.toString
+      .contains(sparkScratch))
+
+    checkAnswer(sparkSession1.table("t1"), Seq(Row(0), Row(1)))
+    checkAnswer(sparkSession2.table("t1"), Seq(Row(0), Row(1), Row(2)))
+  }
+
+  test("drop temporary table") {
+    withDatabase("db1") {
+      withTable("t1", "db1.t1") {
+        sql("create temporary table t1 using parquet as select 1")
+        checkAnswer(spark.table("t1"), Seq(Row(1)))
+        assert(spark.sessionState.catalog.tempTableExists(TableIdentifier("t1")))
+        assert(spark.sessionState.catalog.tableExists(TableIdentifier("t1")))
+        sql("drop table t1")
+        assert(!spark.sessionState.catalog.tempTableExists(TableIdentifier("t1")))
+        assert(!spark.sessionState.catalog.tableExists(TableIdentifier("t1")))
+
+        sql("CREATE DATABASE db1")
+        sql("create temporary table db1.t1 using parquet as select 1")
+        checkAnswer(spark.table("db1.t1"), Seq(Row(1)))
+        assert(spark.sessionState.catalog.tempTableExists(TableIdentifier("t1", Some("db1"))))
+        assert(spark.sessionState.catalog.tableExists(TableIdentifier("t1", Some("db1"))))
+        sql("drop table db1.t1")
+        assert(!spark.sessionState.catalog.tempTableExists(TableIdentifier("t1", Some("db1"))))
+        assert(!spark.sessionState.catalog.tempTableExists(TableIdentifier("t1", Some("db1"))))
+        assert(!spark.sessionState.catalog.tableExists(TableIdentifier("t1", Some("db1"))))
+      }
+    }
+  }
+
+  test("create temp table in database") {
+    withDatabase("db1") {
+      spark.sql("create database db1")
+      val sparkSession = spark.newSession()
+      sparkSession.sql("create temporary table db1.t1 as select 1 as id")
+      checkAnswer(sparkSession.table("db1.t1"), Seq(Row(1)))
+      sparkSession.sql("use db1")
+      checkAnswer(sparkSession.table("t1"), Seq(Row(1)))
+    }
+  }
+
+  test("analyze temporary table") {
+    spark.sql("CREATE TEMPORARY TABLE t1 AS SELECT * FROM range(100)")
+    spark.sql("ANALYZE TABLE t1 COMPUTE STATISTICS FOR ALL COLUMNS")
+
+    val t1 = TableIdentifier("t1")
+
+    val stats = spark.sessionState.catalog.getTableMetadata(t1).stats
+    assert(stats.nonEmpty)
+    assert(stats.get.rowCount.contains(100))
+    assert(stats.get.colStats.contains("id"))
+  }
+
+  test("create temporary table and insert values") {
+    spark.sql("CREATE TEMPORARY TABLE t1(id bigint)")
+    spark.sql("INSERT INTO t1 SELECT * FROM range(2)")
+    spark.sql("INSERT INTO t1 VALUES (2), (3)")
+    spark.sql("INSERT INTO t1(id) VALUES (4), (5)")
+
+    checkAnswer(spark.table("t1"), Seq(Row(0), Row(1), Row(2), Row(3), Row(4), Row(5)))
+  }
+
+  test("temporary table and temporary view") {
+    withTempView("t1") {
+      spark.sql("CREATE TEMPORARY VIEW t1 AS SELECT * FROM range(2)")
+      val e1 = intercept[TableAlreadyExistsException] {
+        spark.sql("CREATE TEMPORARY TABLE t1 AS SELECT * FROM range(3)")
+      }
+      assert(e1.getMessage.contains("TABLE_OR_VIEW_ALREADY_EXISTS"))
+    }
+  }
+
+  test("temporary table and non-temporary table") {
+    spark.sql("CREATE TABLE t1 using parquet AS SELECT * FROM range(2)")
+    spark.sql("CREATE TEMPORARY TABLE t1 using parquet AS SELECT * FROM range(3)")
+    checkAnswer(spark.table("t1"), Seq(Row(0), Row(1), Row(2)))
+    spark.sql("DROP TABLE t1") // drop temporary table
+    checkAnswer(spark.table("t1"), Seq(Row(0), Row(1)))
+    spark.sql("DROP TABLE t1") // drop non-temporary table
+    assert(!spark.sessionState.catalog.tableExists(TableIdentifier("t1")))
+  }
+
+  test("show create temporary table") {
+    spark.sql("CREATE TEMPORARY TABLE t1 using ORC AS SELECT id FROM range(5)")
+    checkKeywordsExist(spark.sql("SHOW CREATE TABLE t1"), "CREATE TEMPORARY TABLE default.t1")
+  }
+
+  test("create temporary table like") {
+    withTable("t3") {
+      spark.sql("CREATE TEMPORARY TABLE t1(id int)")
+      spark.sql("CREATE TEMPORARY TABLE t2 LIKE t1")
+      spark.sql("CREATE TABLE t3 LIKE t2 USING parquet")
+      assert(spark.sessionState.catalog.tempTableExists(TableIdentifier("t1")))
+      assert(spark.sessionState.catalog.tempTableExists(TableIdentifier("t2")))
+      assert(!spark.sessionState.catalog.tempTableExists(TableIdentifier("t3")))
+    }
+  }
+
+  test("show tables with temporary tables") {
+    withDatabase("db1") {
+      withTable("tt1", "tt2", "db1.tt1", "db1.tt2") {
+        sql("create database db1")
+        sql("create temporary table tt1 using parquet as select 1")
+        sql("create table tt2 using parquet as select 1")
+        sql("create temporary table db1.tt1 using parquet as select 1")
+        sql("create table db1.tt2 using parquet as select 1")
+
+        checkAnswer(sql("show tables in db1"),
+          Seq(Row("db1", "tt1", true), Row("db1", "tt2", false)))
+        checkAnswer(sql("show tables"),
+          Seq(Row("default", "tt1", true), Row("default", "tt2", false)))
+      }
+    }
+  }
+
+  test("create temporary table without using should use parquet by default") {
+    def checkTemporaryTableProvider(name: String, provider: String): Unit = {
+      assert(spark.sessionState.catalog.getTableMetadata(TableIdentifier(name)).provider ===
+        Some(provider))
+      assert(spark.sessionState.catalog.getTableMetadata(TableIdentifier(name)).tableType
+        === CatalogTableType.TEMPORARY)
+    }
+
+    withTable("t1", "t2", "t3", "t4") {
+      spark.sql("CREATE TEMPORARY TABLE t1 AS SELECT 1")
+      checkTemporaryTableProvider("t1", "parquet")
+      spark.sql("CREATE TEMPORARY TABLE t2 (id int)")
+      checkTemporaryTableProvider("t2", "parquet")
+      spark.sql("CREATE TEMPORARY TABLE t3 LIKE t2")
+      checkTemporaryTableProvider("t3", "parquet")
+      spark.sql("CREATE TEMPORARY TABLE t4 using ORC AS SELECT 1")
+      checkTemporaryTableProvider("t4", "ORC")
+    }
+  }
+
+  test("Create temporary table using data source") {
+    withTable("tt1", "sameName", "`bad.name`") {
+      sql("create temporary table tt1 (id int) using parquet")
+      sql("insert into table tt1 values (1)")
+      assert(spark.table("tt1").collect === Array(Row(1)))
+
+      withTempView("same") {
+        sql("create temporary view same as select 1")
+        val e = intercept[AnalysisException](
+          sql("create temporary table same (id int) using parquet"))
+        assert(e.message.contains("`spark_catalog`.`default`.`same` because it already exists"))
+      }
+
+      withTempView("same") {
+        sql("create temporary table same using parquet as select 1")
+        val e = intercept[AnalysisException](
+          sql("create temporary view same (id int) using parquet"))
+        assert(e.message.contains("the temporary view `same` because it already exists"))
+      }
+
+      val e = intercept[AnalysisException](
+        sql("create temporary table `bad.name` (id int) using parquet"))
+      assert(e.message.contains("`bad.name` is not a valid name for tables/databases."))
+    }
+  }
+
+  test("Create temporary table using data source as select") {
+    withTable("tt1", "sameName", "`bad.name`") {
+      sql("create temporary table tt1 using parquet as select 1")
+      assert(spark.table("tt1").collect === Array(Row(1)))
+
+      withTempView("same") {
+        sql("create temporary view same as select 1")
+        val e = intercept[AnalysisException](
+          sql("create temporary table same using parquet as select 1"))
+        assert(e.message.contains("`spark_catalog`.`default`.`same` because it already exists"))
+      }
+
+      withTempView("same") {
+        sql("create temporary table same using parquet as select 1")
+        val e = intercept[AnalysisException](
+          sql("create temporary view same as select 1"))
+        assert(e.message.contains("temporary view `same` because it already exists"))
+      }
+
+      val e = intercept[AnalysisException](
+        sql("create temporary table `bad.name` using parquet as select 1"))
+      assert(e.message.contains("`bad.name` is not a valid name for tables/databases."))
+    }
+  }
+
+  test("Create a same name temporary table and permanent table") {
+    withDatabase("db1") {
+      sql("create database db1")
+      withTable("same1", "same2", "same3", "same4", "same5", "same6") {
+        withTable("same1", "same2", "same3", "same4", "same5", "same6") {
+          sql("create temporary table same1 using parquet as select 'temp_table'")
+          sql("create table same1 using parquet as select 'table'")
+
+          sql("create temporary table same2 (key int) using parquet")
+          sql("create table same2 (key int) using parquet")
+
+          sql("create temporary table db1.same3 (key int) using parquet")
+          sql("create table same3 (key int) using parquet")
+          sql("create table db1.same3 (key int) using parquet")
+
+          // create table then create temporary table
+          sql("create table same4 using parquet as select 'table'")
+          sql("create temporary table same4 using parquet as select 'temp_table'")
+
+          sql("create table same5 (key int) using parquet")
+          sql("create temporary table same5 (key int) using parquet")
+
+          sql("create table db1.same6 (key int) using parquet")
+          sql("create temporary table same6 (key int) using parquet")
+          sql("create temporary table db1.same6 (key int) using parquet")
+        }
+      }
+    }
+  }
+
+  // test unsupported command
+  test("Create temporary table with location is not allowed") {
+    withTable("tt1") {
+      val e = intercept[AnalysisException](
+        sql(
+          """
+            |create temporary table tt1 (id int) using parquet
+            |LOCATION '/PATH'
+            |""".stripMargin))
+      assert(e.message.contains("specify LOCATION on temporary table"))
+    }
+  }
+
+  test("Create temporary partitioned table") {
+    val e1 = intercept[ParseException] {
+      spark.newSession().sql(
+        """
+          |CREATE temporary TABLE t1 using parquet partitioned BY (part) AS
+          |SELECT id,
+          |       id % 2 AS part
+          |FROM   range(10)
+          |""".stripMargin)
+    }
+    assert(e1.getMessage.contains("Operation not allowed"))
+
+    withTable("t1") {
+      withTable("tt1") {
+        sql("CREATE TABLE t1 (id int, dt int) USING parquet PARTITIONED BY (dt)")
+        val e2 = intercept[AnalysisException] {
+          sql("CREATE TEMPORARY TABLE tt1 LIKE t1 USING PARQUET")
+        }
+        assert(e2.getMessage.contains("The feature is not supported"))
+      }
+    }
+  }
+
+  test("Unsupported commands") {
+    def testUnsupportedCommand(sqlStr: String): Unit = {
+      val e = intercept[AnalysisException] {
+        spark.sql(sqlStr)
+      }
+      assert(e.getMessage.contains("The feature is not supported"))
+    }
+
+    spark.sql("CREATE TEMPORARY TABLE t1 using parquet AS SELECT * FROM range(3)")
+
+    testUnsupportedCommand("ALTER TABLE t1 SET TBLPROPERTIES ('key1' = 'val1')")
+    testUnsupportedCommand("ALTER TABLE t1 UNSET TBLPROPERTIES IF EXISTS ('key1')")
+    testUnsupportedCommand("ALTER TABLE t1 RENAME COLUMN id TO user_id")
+    testUnsupportedCommand("ALTER TABLE t1 ADD COLUMNS (name string)")
+    testUnsupportedCommand("ALTER TABLE t1 SET serdeproperties ('test'='test')")
+    testUnsupportedCommand("ALTER TABLE t1 SET LOCATION '/tmp/spark'")
+    testUnsupportedCommand("ALTER TABLE t1 RENAME TO t2")
+    testUnsupportedCommand("ALTER TABLE t1 ADD PARTITION (part = '1')")
+    testUnsupportedCommand("ALTER TABLE t1 DROP PARTITION (a='1', b='2')")
+    testUnsupportedCommand("ALTER TABLE t1 PARTITION (a='1') RENAME TO PARTITION (a='100')")
+    testUnsupportedCommand("ALTER TABLE t1 CHANGE COLUMN id TYPE bigint")
+    testUnsupportedCommand("ALTER TABLE t1 SET SERDE 'whatever'")
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V2CommandsCaseSensitivitySuite.scala
@@ -52,7 +52,7 @@ class V2CommandsCaseSensitivitySuite
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
         Seq("ID", "iD").foreach { ref =>
           val tableSpec = TableSpec(Map.empty, None, Map.empty,
-            None, None, None, false)
+            None, None, None, false, false)
           val plan = CreateTableAsSelect(
             UnresolvedIdentifier(Array("table_name")),
             Expressions.identity(ref) :: Nil,
@@ -76,7 +76,7 @@ class V2CommandsCaseSensitivitySuite
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
         Seq("POINT.X", "point.X", "poInt.x", "poInt.X").foreach { ref =>
           val tableSpec = TableSpec(Map.empty, None, Map.empty,
-            None, None, None, false)
+            None, None, None, false, false)
           val plan = CreateTableAsSelect(
             UnresolvedIdentifier(Array("table_name")),
             Expressions.bucket(4, ref) :: Nil,
@@ -101,7 +101,7 @@ class V2CommandsCaseSensitivitySuite
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
         Seq("ID", "iD").foreach { ref =>
           val tableSpec = TableSpec(Map.empty, None, Map.empty,
-            None, None, None, false)
+            None, None, None, false, false)
           val plan = ReplaceTableAsSelect(
             UnresolvedIdentifier(Array("table_name")),
             Expressions.identity(ref) :: Nil,
@@ -125,7 +125,7 @@ class V2CommandsCaseSensitivitySuite
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
         Seq("POINT.X", "point.X", "poInt.x", "poInt.X").foreach { ref =>
           val tableSpec = TableSpec(Map.empty, None, Map.empty,
-            None, None, None, false)
+            None, None, None, false, false)
           val plan = ReplaceTableAsSelect(
             UnresolvedIdentifier(Array("table_name")),
             Expressions.bucket(4, ref) :: Nil,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -758,7 +758,7 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     val v1 = "CREATE TABLE table1 LIKE table2"
     val (target, source, fileFormat, provider, properties, exists) =
       parser.parsePlan(v1).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
+        case CreateTableLikeCommand(t, s, f, p, pr, e, _) => (t, s, f, p, pr, e)
       }.head
     assert(exists == false)
     assert(target.database.isEmpty)
@@ -771,7 +771,7 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     val v2 = "CREATE TABLE IF NOT EXISTS table1 LIKE table2"
     val (target2, source2, fileFormat2, provider2, properties2, exists2) =
       parser.parsePlan(v2).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
+        case CreateTableLikeCommand(t, s, f, p, pr, e, _) => (t, s, f, p, pr, e)
       }.head
     assert(exists2)
     assert(target2.database.isEmpty)
@@ -784,7 +784,7 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     val v3 = "CREATE TABLE table1 LIKE table2 LOCATION '/spark/warehouse'"
     val (target3, source3, fileFormat3, provider3, properties3, exists3) =
       parser.parsePlan(v3).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
+        case CreateTableLikeCommand(t, s, f, p, pr, e, _) => (t, s, f, p, pr, e)
       }.head
     assert(!exists3)
     assert(target3.database.isEmpty)
@@ -797,7 +797,7 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     val v4 = "CREATE TABLE IF NOT EXISTS table1 LIKE table2 LOCATION '/spark/warehouse'"
     val (target4, source4, fileFormat4, provider4, properties4, exists4) =
       parser.parsePlan(v4).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
+        case CreateTableLikeCommand(t, s, f, p, pr, e, _) => (t, s, f, p, pr, e)
       }.head
     assert(exists4)
     assert(target4.database.isEmpty)
@@ -810,7 +810,7 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     val v5 = "CREATE TABLE IF NOT EXISTS table1 LIKE table2 USING parquet"
     val (target5, source5, fileFormat5, provider5, properties5, exists5) =
       parser.parsePlan(v5).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
+        case CreateTableLikeCommand(t, s, f, p, pr, e, _) => (t, s, f, p, pr, e)
       }.head
     assert(exists5)
     assert(target5.database.isEmpty)
@@ -823,7 +823,7 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     val v6 = "CREATE TABLE IF NOT EXISTS table1 LIKE table2 USING ORC"
     val (target6, source6, fileFormat6, provider6, properties6, exists6) =
       parser.parsePlan(v6).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
+        case CreateTableLikeCommand(t, s, f, p, pr, e, _) => (t, s, f, p, pr, e)
       }.head
     assert(exists6)
     assert(target6.database.isEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/util/DataFrameCallbackSuite.scala
@@ -253,7 +253,7 @@ class DataFrameCallbackSuite extends QueryTest
       assert(commands(5)._1 == "command")
       assert(commands(5)._2.isInstanceOf[CreateDataSourceTableAsSelectCommand])
       assert(commands(5)._2.asInstanceOf[CreateDataSourceTableAsSelectCommand]
-        .table.partitionColumnNames == Seq("p"))
+        .catalogTable.partitionColumnNames == Seq("p"))
     }
 
     withTable("tab") {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperation.scala
@@ -25,7 +25,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.CurrentUserContext.CURRENT_USER
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
-import org.apache.spark.sql.catalyst.catalog.CatalogTableType.{EXTERNAL, MANAGED, VIEW}
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType.{EXTERNAL, MANAGED, TEMPORARY, VIEW}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
@@ -92,6 +92,7 @@ private[hive] trait SparkOperation extends Operation with Logging {
   def tableTypeString(tableType: CatalogTableType): String = tableType match {
     case EXTERNAL | MANAGED => "TABLE"
     case VIEW => "VIEW"
+    case TEMPORARY => "TEMPORARY"
     case t =>
       throw new IllegalArgumentException(s"Unknown table type is found: $t")
   }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -88,6 +88,7 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
     HiveThriftServer2.eventManager.onSessionClosed(sessionHandle.getSessionId.toString)
     val ctx = sparkSqlOperationManager.sessionToContexts.getOrDefault(sessionHandle, sqlContext)
     ctx.sparkSession.sessionState.catalog.getTempViewNames().foreach(ctx.uncacheTable)
+    ctx.sparkSession.sessionState.catalog.dropAllTempTables()
     super.closeSession(sessionHandle)
     sparkSqlOperationManager.sessionToContexts.remove(sessionHandle)
   }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkMetadataOperationSuite.scala
@@ -205,7 +205,7 @@ class SparkMetadataOperationSuite extends HiveThriftServer2TestBase {
 
     withJdbcStatement() { statement =>
       val metaData = statement.getConnection.getMetaData
-      checkResult(metaData.getTableTypes, Seq("TABLE", "VIEW"))
+      checkResult(metaData.getTableTypes, Seq("TABLE", "VIEW", "TEMPORARY"))
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionCatalog.scala
@@ -32,7 +32,8 @@ private[sql] class HiveSessionCatalog(
     hadoopConf: Configuration,
     parser: ParserInterface,
     functionResourceLoader: FunctionResourceLoader,
-    functionExpressionBuilder: FunctionExpressionBuilder)
+    functionExpressionBuilder: FunctionExpressionBuilder,
+    scratchSessionDir: Option[String])
   extends SessionCatalog(
     externalCatalogBuilder,
     globalTempViewManagerBuilder,
@@ -41,5 +42,6 @@ private[sql] class HiveSessionCatalog(
     hadoopConf,
     parser,
     functionResourceLoader,
-    functionExpressionBuilder) {
+    functionExpressionBuilder,
+    scratchSessionDir = scratchSessionDir) {
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -74,7 +74,8 @@ class HiveSessionStateBuilder(
       SessionState.newHadoopConf(session.sparkContext.hadoopConfiguration, conf),
       sqlParser,
       resourceLoader,
-      HiveUDFExpressionBuilder)
+      HiveUDFExpressionBuilder,
+      scratchSessionDir = session.scratchSessionDir)
     parentState.foreach(_.catalog.copyStateTo(catalog))
     catalog
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Many databases and data warehouse SQL engines support temporary tables. A temporary table, as its named implied, is a short-lived table that its life will be only for current session. 

* [Hive Temporary Table](https://docs.cloudera.com/HDPDocuments/HDP3/HDP-3.0.1/using-hiveql/content/hive_create_a_hive_temporary_table.html)
* [Teradata Volatile Table](https://docs.teradata.com/reader/rgAb27O_xRmMVc_aQq2VGw/mpJF1z_vSlpMbZYxFmRJfA) 
* [PostgreSQL Temporary Table](https://www.postgresql.org/docs/12/sql-createtable.html)

In Spark, there is no temporary table. the DDL “CREATE TEMPORARY TABLE AS SELECT” will create a temporary view. A temporary view is totally different with a temporary table.

### Why are the changes needed?
A temporary view is just a VIEW. It doesn’t materialize data in storage. So it has below shortage:

1. View will not give improved performance. Materialize intermediate data in temporary tables for a complex query will accurate queries, especially in an ETL pipeline.
2. View which calls other views can cause severe performance issues. Even, executing a very complex view may fail in Spark.
3. Temporary view has no database namespace. In some complex ETL pipelines or data warehouse applications, without database prefix is not convenient. It needs some tables which only used in current session.

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?
Add unit tests.