### PR TITLE
[SPARK-42984][CONNECT][PYTHON][TESTS] Enable test_createDataFrame_with_single_data_type

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -43,8 +43,6 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase):
     def test_createDataFrame_with_ndarray(self):
         self.check_createDataFrame_with_ndarray(True)
 
-    # TODO(SPARK-42984): ValueError not raised
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_createDataFrame_with_single_data_type(self):
         self.check_createDataFrame_with_single_data_type()
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -533,8 +533,10 @@ class ArrowTestsMixin:
             self.check_createDataFrame_with_single_data_type()
 
     def check_createDataFrame_with_single_data_type(self):
-        with self.assertRaisesRegex(ValueError, ".*IntegerType.*not supported.*"):
-            self.spark.createDataFrame(pd.DataFrame({"a": [1]}), schema="int").collect()
+        for schema in ["int", IntegerType()]:
+            with self.subTest(schema=schema):
+                with self.assertRaisesRegex(ValueError, ".*IntegerType.*not supported.*"):
+                    self.spark.createDataFrame(pd.DataFrame({"a": [1]}), schema=schema).collect()
 
     def test_createDataFrame_does_not_modify_input(self):
         # Some series get converted for Spark to consume, this makes sure input is unchanged


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enables `ArrowParityTests.test_createDataFrame_with_single_data_type`.

### Why are the changes needed?

The test is already fixed by previous commits.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Enabled/updated the related tests.