### PR TITLE
[SPARK-41971][SQL] Use deduplicated field names when creating Arrow RecordBatch

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.connect.service
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import scala.collection.JavaConverters._
 
 import com.google.protobuf.ByteString
@@ -40,7 +38,7 @@ import org.apache.spark.sql.connect.service.SparkConnectStreamHandler.processAsA
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, QueryStageExec}
 import org.apache.spark.sql.execution.arrow.ArrowConverters
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType, UserDefinedType}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.{ThreadUtils, Utils}
 
 class SparkConnectStreamHandler(responseObserver: StreamObserver[ExecutePlanResponse])
@@ -124,38 +122,8 @@ object SparkConnectStreamHandler {
       sessionId: String,
       dataframe: DataFrame,
       responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
-
-    def deduplicateFieldNames(dt: DataType): DataType = dt match {
-      case udt: UserDefinedType[_] => deduplicateFieldNames(udt.sqlType)
-      case st @ StructType(fields) =>
-        val newNames = if (st.names.toSet.size == st.names.length) {
-          st.names
-        } else {
-          val genNawName = st.names.groupBy(identity).map {
-            case (name, names) if names.length > 1 =>
-              val i = new AtomicInteger()
-              name -> { () => s"${name}_${i.getAndIncrement()}" }
-            case (name, _) => name -> { () => name }
-          }
-          st.names.map(genNawName(_)())
-        }
-        val newFields =
-          fields.zip(newNames).map { case (StructField(_, dataType, nullable, metadata), name) =>
-            StructField(name, deduplicateFieldNames(dataType), nullable, metadata)
-          }
-        StructType(newFields)
-      case ArrayType(elementType, containsNull) =>
-        ArrayType(deduplicateFieldNames(elementType), containsNull)
-      case MapType(keyType, valueType, valueContainsNull) =>
-        MapType(
-          deduplicateFieldNames(keyType),
-          deduplicateFieldNames(valueType),
-          valueContainsNull)
-      case _ => dt
-    }
-
     val spark = dataframe.sparkSession
-    val schema = deduplicateFieldNames(dataframe.schema).asInstanceOf[StructType]
+    val schema = dataframe.schema
     val maxRecordsPerBatch = spark.sessionState.conf.arrowMaxRecordsPerBatch
     val timeZoneId = spark.sessionState.conf.sessionLocalTimeZone
     // Conservatively sets it 70% because the size is not accurate but estimated.

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -691,7 +691,8 @@ class SparkConnectClient(object):
         schema = schema or types.from_arrow_schema(table.schema)
         assert schema is not None and isinstance(schema, StructType)
 
-        pdf = table.to_pandas()
+        # Rename columns to avoid duplicated column names.
+        pdf = table.rename_columns([f"col_{i}" for i in range(table.num_columns)]).to_pandas()
         pdf.columns = schema.fieldNames()
 
         for field, pa_field in zip(schema, table.schema):

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -105,6 +105,9 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase):
     def test_timestamp_nat(self):
         self.check_timestamp_nat(True)
 
+    def test_toPandas_duplicate_field_names(self):
+        self.check_toPandas_duplicate_field_names(True)
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_arrow import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -858,6 +858,41 @@ class ArrowTestsMixin:
         self.assertEqual([Row(c1=1, c2="string")], df.collect())
         self.assertGreater(self.spark.sparkContext.defaultParallelism, len(pdf))
 
+    def test_toPandas_duplicate_field_names(self):
+        for arrow_enabled in [True, False]:
+            with self.subTest(arrow_enabled=arrow_enabled):
+                self.check_toPandas_duplicate_field_names(arrow_enabled)
+
+    def check_toPandas_duplicate_field_names(self, arrow_enabled):
+        data = [Row(Row("a", 1), Row(2, 3, "b", 4, "c")), Row(Row("x", 6), Row(7, 8, "y", 9, "z"))]
+        schema = (
+            StructType()
+            .add("struct", StructType().add("x", StringType()).add("x", IntegerType()))
+            .add(
+                "struct",
+                StructType()
+                .add("a", IntegerType())
+                .add("x", IntegerType())
+                .add("x", StringType())
+                .add("y", IntegerType())
+                .add("y", StringType()),
+            )
+        )
+        if arrow_enabled:
+            expected = pd.DataFrame(
+                [
+                    [{"x_0": "a", "x_1": 1}, {"a": 2, "x_0": 3, "x_1": "b", "y_0": 4, "y_1": "c"}],
+                    [{"x_0": "x", "x_1": 6}, {"a": 7, "x_0": 8, "x_1": "y", "y_0": 9, "y_1": "z"}],
+                ],
+                columns=schema.names,
+            )
+        else:
+            expected = pd.DataFrame.from_records(data, columns=schema.names)
+
+        df = self.spark.createDataFrame(data, schema=schema)
+        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
+            assert_frame_equal(df.toPandas(), expected)
+
 
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Uses deduplicated field names when creating Arrow `RecordBatch`.

The result pandas DataFrame will contain `dict` with suffix `_0`, `_1`, etc. if there are duplicated field names.

For example:

```py
>>> spark.conf.set('spark.sql.execution.arrow.pyspark.enabled', True)
>>> spark.sql("values (1, struct(1 as a, 2 as a, 3 as b)) as t(x, y)").toPandas()
   x                             y
0  1  {'a_0': 1, 'a_1': 2, 'b': 3}
```

### Why are the changes needed?

Currently `df.toPandas()` with Arrow enabled fails when there are duplicated field names.

```py
>>> spark.conf.set('spark.sql.execution.arrow.pyspark.enabled', True)
>>> spark.sql("values (1, struct(1 as a, 2 as a, 3 as b)) as t(x, y)").toPandas()
Traceback (most recent call last):
...
pyarrow.lib.ArrowInvalid: Ran out of field metadata, likely malformed
```

### Does this PR introduce _any_ user-facing change?

`df.toPandas()` with Arrow enabled fails when there are duplicated field names will work.

### How was this patch tested?

Added a test.
