### PR TITLE
[SPARK-43171][K8S] Support custom Unix username in Pod

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -36,6 +36,8 @@ if [ -z "$uidentry" ] ; then
     fi
 fi
 
+echo "login user is `id -un`"
+
 if [ -z "$JAVA_HOME" ]; then
   JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | awk '{print $3}')
 fi

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -30,7 +30,7 @@ set -e
 # If there is no passwd entry for the container UID, attempt to create one
 if [ -z "$uidentry" ] ; then
     if [ -w /etc/passwd ] ; then
-        echo "$myuid:x:$myuid:$mygid:${SPARK_USER_NAME:-anonymous uid}:$SPARK_HOME:/bin/false" >> /etc/passwd
+        echo "${SPARK_USER_NAME:-$myuid}:x:$myuid:$mygid:${SPARK_USER_NAME:-anonymous uid}:$SPARK_HOME:/bin/false" >> /etc/passwd
     else
         echo "Container ENTRYPOINT failed to add passwd entry for anonymous UID"
     fi

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers._
 import org.scalatest.time.{Seconds, Span}
 
 import org.apache.spark.{SparkFunSuite, TestUtils}
-import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite.{usernameTestTag, MinikubeTag, SPARK_PI_MAIN_CLASS}
+import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite.{usernameTestTag, SPARK_PI_MAIN_CLASS}
 import org.apache.spark.launcher.SparkLauncher
 
 private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
@@ -169,8 +169,7 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
       })
   }
 
-  test("SPARK-43171: Support custom Unix username in Pod",
-    k8sTestTag, usernameTestTag, MinikubeTag) {
+  test("SPARK-43171: Support custom Unix username in Pod", k8sTestTag, usernameTestTag) {
     sparkAppConf
       .set("spark.kubernetes.driverEnv.SPARK_USER_NAME", "spark-kube")
       .set("spark.executorEnv.SPARK_USER_NAME", "spark-kube")

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -32,7 +32,7 @@ import org.scalatest.time.{Minutes, Span}
 
 import org.apache.spark.SparkException
 import org.apache.spark.deploy.k8s.integrationtest.DepsTestsSuite.{DEPS_TIMEOUT, FILE_CONTENTS, HOST_PATH}
-import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite.{INTERVAL, MinikubeTag, SPARK_PI_MAIN_CLASS, TIMEOUT}
+import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite.{usernameTestTag, INTERVAL, MinikubeTag, SPARK_PI_MAIN_CLASS, TIMEOUT}
 import org.apache.spark.deploy.k8s.integrationtest.Utils.getExamplesJarName
 import org.apache.spark.deploy.k8s.integrationtest.backend.minikube.Minikube
 import org.apache.spark.internal.config.{ARCHIVES, PYSPARK_DRIVER_PYTHON, PYSPARK_PYTHON}
@@ -269,15 +269,36 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
           "Python runtime version check is: True",
           "Python environment version check is: True",
           "Python runtime version check for executor is: True"),
-        Some(outDepsFile))
+        depsFile = Some(outDepsFile))
     } finally {
       Files.delete(new File(outDepsFile).toPath)
     }
   }
 
+  test("SPARK-43171: Support custom Unix username in Pod",
+    k8sTestTag, usernameTestTag, MinikubeTag) {
+    val fileName = Utils.createTempFile(
+      """#!/usr/bin/env bash
+        |export IS_CUSTOM_PYTHON=1
+        |echo "login user is `id -un`"
+        |python3 "$@"
+      """.stripMargin, HOST_PATH)
+    Utils.createTarGzFile(s"$HOST_PATH/$fileName", s"$HOST_PATH/$fileName.tgz")
+    sparkAppConf
+      .set(ARCHIVES.key, s"$HOST_PATH/$fileName.tgz#test_env")
+      .set(PYSPARK_PYTHON.key, s"./test_env/$fileName")
+      .set("spark.kubernetes.driverEnv.SPARK_USER_NAME", "spark-kube")
+      .set("spark.executorEnv.SPARK_USER_NAME", "spark-kube")
+    val pySparkFiles = Utils.getTestFileAbsolutePath("python_executable_check.py", sparkHomeDir)
+    testPython(pySparkFiles,
+      expectedDriverLogs = Seq("login user is spark-kube"),
+      expectedExecutorLogs = Seq("login user is spark-kube"))
+  }
+
   private def testPython(
       pySparkFiles: String,
       expectedDriverLogs: Seq[String],
+      expectedExecutorLogs: Seq[String] = Seq.empty,
       depsFile: Option[String] = None,
       env: Map[String, String] = Map.empty[String, String]): Unit = {
     tryDepsTest {
@@ -286,6 +307,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
         appResource = pySparkFiles,
         mainClass = "",
         expectedDriverLogOnCompletion = expectedDriverLogs,
+        expectedExecutorLogOnCompletion = expectedExecutorLogs,
         appArgs = Array("python3"),
         driverPodChecker = doBasicDriverPyPodCheck,
         executorPodChecker = doBasicExecutorPyPodCheck,

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -618,6 +618,7 @@ class KubernetesSuite extends SparkFunSuite
 
 private[spark] object KubernetesSuite {
   val k8sTestTag = Tag("k8s")
+  val usernameTestTag = Tag("username")
   val localTestTag = Tag("local")
   val schedulingTestTag = Tag("schedule")
   val decomTestTag = Tag("decom")

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -623,6 +623,7 @@ private[spark] object KubernetesSuite {
   val decomTestTag = Tag("decom")
   val rTestTag = Tag("r")
   val MinikubeTag = Tag("minikube")
+  val usernameTestTag = Tag("username")
   val SPARK_PI_MAIN_CLASS: String = "org.apache.spark.examples.SparkPi"
   val SPARK_DFS_READ_WRITE_TEST = "org.apache.spark.examples.DFSReadWriteTest"
   val SPARK_MINI_READ_WRITE_TEST = "org.apache.spark.examples.MiniReadWriteTest"

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -618,7 +618,6 @@ class KubernetesSuite extends SparkFunSuite
 
 private[spark] object KubernetesSuite {
   val k8sTestTag = Tag("k8s")
-  val usernameTestTag = Tag("username")
   val localTestTag = Tag("local")
   val schedulingTestTag = Tag("schedule")
   val decomTestTag = Tag("decom")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR allows the users to custom Unix username in Pod by setting env var `SPARK_USER_NAME`, which reduces the gap between Spark on YARN and K8s.

Each line in `/etc/passwd` is compose of
```
username:password:UID:GID:comment:home_directory:shell
```
This PR simply changes the first item from `$myuid` to `${SPARK_USER_NAME:-$myuid}` to achieve the above ability.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In Spark on YARN, when we launch a Spark application via `spark-submit --proxy-user jack ...`, the YARN will launch containers(usually Linux processes) using Unix user "jack", and some components/libraries rely on the login user in default, one example is Alluxio
https://github.com/Alluxio/alluxio/blob/da77d688bdbb0cf0c6477bed4d3187897fe2a2e1/core/common/src/main/java/alluxio/conf/PropertyKey.java#L6469-L6476
```
  public static final PropertyKey SECURITY_LOGIN_USERNAME =
      stringBuilder(Name.SECURITY_LOGIN_USERNAME)
          .setDescription("When alluxio.security.authentication.type is set to SIMPLE or "
              + "CUSTOM, user application uses this property to indicate the user requesting "
              + "Alluxio service. If it is not set explicitly, the OS login user will be used.")
          .setConsistencyCheckLevel(ConsistencyCheckLevel.ENFORCE)
          .setScope(Scope.CLIENT)
          .build();
```
To reduce the difference between Spark on YARN and Spark on K8s, we hope Spark on K8s keeps the same ability to allow to dynamically change login user on submitting Spark application.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it allows the user to custom Pod Unix username by setting env var `SPARK_USER_NAME` in K8s, reducing the gap between Spark on YARN and K8s.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New IT is added.

Also manually testing in our internal K8s cluster.

```
spark-submit --master=k8s://xxxx \
        --conf spark.kubernetes.driverEnv.SPARK_USER_NAME=tom \
	--conf spark.executorEnv.SPARK_USER_NAME=tom \
	--proxy-user tom \
        ...
```

Then login the Pod, verify the Unix username by `id -un` is `tom` instead of `185`