### PR TITLE
[SPARK-42552][SQL] Correct the two-stage parsing strategy of antlr parser

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -119,25 +119,18 @@ abstract class AbstractSqlParser extends ParserInterface with SQLConfHelper with
     parser.SQL_standard_keyword_behavior = conf.enforceReservedKeywords
     parser.double_quoted_identifiers = conf.doubleQuotedIdentifiers
 
-    // You can save a great deal of time on correct inputs by using a two-stage parsing strategy.
-    //
-    // 1. Attempt to parse the input using BailErrorStrategy and PredictionMode.SLL.
-    //    If no exception is thrown, you know the answer is correct.
-    //
-    // 2. If a ParseCancellationException is thrown, retry the parse using the default
-    //    settings (DefaultErrorStrategy and PredictionMode.LL).
-    //
     // https://github.com/antlr/antlr4/issues/192#issuecomment-15238595
+    // Save a great deal of time on correct inputs by using a two-stage parsing strategy.
     try {
       try {
-        // first, try parsing with potentially faster SLL mode
+        // first, try parsing with potentially faster SLL mode w/ SparkParserBailErrorStrategy
         parser.setErrorHandler(new SparkParserBailErrorStrategy())
         parser.getInterpreter.setPredictionMode(PredictionMode.SLL)
         toResult(parser)
       }
       catch {
         case e: ParseCancellationException =>
-          // if we fail, parse with LL mode
+          // if we fail, parse with LL mode w/ SparkParserErrorStrategy
           tokenStream.seek(0) // rewind input stream
           parser.reset()
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SparkParserErrorStrategy.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SparkParserErrorStrategy.scala
@@ -123,7 +123,8 @@ class SparkParserErrorStrategy() extends DefaultErrorStrategy {
  */
 class SparkParserBailErrorStrategy() extends SparkParserErrorStrategy {
 
-  /** Instead of recovering from exception e, re-throw it wrapped
+  /**
+   * Instead of recovering from exception e, re-throw it wrapped
    * in a [[ParseCancellationException]] so it is not caught by the
    * rule function catches.  Use [[Exception#getCause]] to get the
    * original [[RecognitionException]].
@@ -137,7 +138,8 @@ class SparkParserBailErrorStrategy() extends SparkParserErrorStrategy {
     throw new ParseCancellationException(e)
   }
 
-  /** Make sure we don't attempt to recover inline; if the parser
+  /**
+   * Make sure we don't attempt to recover inline; if the parser
    * successfully recovers, it won't throw an exception.
    */
   @throws[RecognitionException]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SparkParserErrorStrategy.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SparkParserErrorStrategy.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.parser
 
 import org.antlr.v4.runtime.{DefaultErrorStrategy, InputMismatchException, IntStream, NoViableAltException, Parser, ParserRuleContext, RecognitionException, Recognizer, Token}
+import org.antlr.v4.runtime.misc.ParseCancellationException
 
 /**
  * A [[SparkRecognitionException]] extends the [[RecognitionException]] with more information
@@ -111,4 +112,46 @@ class SparkParserErrorStrategy() extends DefaultErrorStrategy {
       recognizer.notifyErrorListeners(recognizer.getCurrentToken, "", exceptionWithErrorClass)
     }
   }
+}
+
+/**
+ * This class is inspired by [[org.antlr.v4.runtime.BailErrorStrategy]], which is
+ * used in Two-stage parsing: This error strategy allows the first stage of two-stage
+ * parsing to immediately terminate if an error is encountered, and immediately
+ * fall back to the second stage. In addition to avoiding wasted work by attempting
+ * to recover from errors here, the empty implementation of sync improves the
+ * performance of the first stage.
+ */
+class SparkParserBailErrorStrategy() extends SparkParserErrorStrategy {
+
+  /** Instead of recovering from exception e, re-throw it wrapped
+   * in a [[ParseCancellationException]] so it is not caught by the
+   * rule function catches.  Use [[Exception#getCause]] to get the
+   * original [[RecognitionException]].
+   */
+  override def recover(recognizer: Parser, e: RecognitionException): Unit = {
+    var context = recognizer.getContext
+    while (context != null) {
+      context.exception = e
+      context = context.getParent
+    }
+    throw new ParseCancellationException(e)
+  }
+
+  /** Make sure we don't attempt to recover inline; if the parser
+   * successfully recovers, it won't throw an exception.
+   */
+  @throws[RecognitionException]
+  override def recoverInline(recognizer: Parser): Token = {
+    val e = new InputMismatchException(recognizer)
+    var context = recognizer.getContext
+    while (context != null) {
+      context.exception = e
+      context = context.getParent
+    }
+    throw new ParseCancellationException(e)
+  }
+
+  /** Make sure we don't attempt to recover from problems in subrules. */
+  override def sync(recognizer: Parser): Unit = {}
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SparkParserErrorStrategy.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SparkParserErrorStrategy.scala
@@ -115,12 +115,11 @@ class SparkParserErrorStrategy() extends DefaultErrorStrategy {
 }
 
 /**
- * This class is inspired by [[org.antlr.v4.runtime.BailErrorStrategy]], which is
- * used in Two-stage parsing: This error strategy allows the first stage of two-stage
- * parsing to immediately terminate if an error is encountered, and immediately
- * fall back to the second stage. In addition to avoiding wasted work by attempting
- * to recover from errors here, the empty implementation of sync improves the
- * performance of the first stage.
+ * Inspired by [[org.antlr.v4.runtime.BailErrorStrategy]], which is used in two-stage parsing:
+ * This error strategy allows the first stage of two-stage parsing to immediately terminate
+ * if an error is encountered, and immediately fall back to the second stage. In addition to
+ * avoiding wasted work by attempting to recover from errors here, the empty implementation
+ * of sync improves the performance of the first stage.
  */
 class SparkParserBailErrorStrategy() extends SparkParserErrorStrategy {
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -66,7 +66,7 @@ class DDLParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sql),
       errorClass = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "':'", "hint" -> ": extra input ':'"))
+      parameters = Map("error" -> "':'", "hint" -> ""))
   }
 
   test("create/replace table - with IF NOT EXISTS") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -725,7 +725,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(".e3"),
       errorClass = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "'.'", "hint" -> ": extra input '.'"))
+      parameters = Map("error" -> "'.'", "hint" -> ""))
 
     // Tiny Int Literal
     assertEqual("10Y", Literal(10.toByte))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -244,6 +244,12 @@ class PlanParserSuite extends AnalysisTest {
         stop = 25))
   }
 
+  test("SPARK-42552: select and union without parentheses") {
+    val plan = Distinct(OneRowRelation().select(Literal(1))
+      .union(OneRowRelation().select(Literal(1))))
+    assertEqual("select 1 union select 1", plan)
+  }
+
   test("set operations") {
     val a = table("a").select(star())
     val b = table("b").select(star())

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableSchemaParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableSchemaParserSuite.scala
@@ -87,7 +87,7 @@ class TableSchemaParserSuite extends SparkFunSuite {
     checkError(
       exception = parseException("a INT,, b long"),
       errorClass = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "','", "hint" -> ": extra input ','"))
+      parameters = Map("error" -> "','", "hint" -> ""))
     checkError(
       exception = parseException("a INT, b long,,"),
       errorClass = "PARSE_SYNTAX_ERROR",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/union.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/union.sql.out
@@ -100,29 +100,33 @@ Union false, false
 -- !query
 SELECT 1 AS three UNION SELECT 2 UNION SELECT 3 ORDER BY 1
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Sort [three#x ASC NULLS FIRST], true
++- Distinct
+   +- Union false, false
+      :- Distinct
+      :  +- Union false, false
+      :     :- Project [1 AS three#x]
+      :     :  +- OneRowRelation
+      :     +- Project [2 AS 2#x]
+      :        +- OneRowRelation
+      +- Project [3 AS 3#x]
+         +- OneRowRelation
 
 
 -- !query
 SELECT 1 AS two UNION SELECT 2 UNION SELECT 2 ORDER BY 1
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Sort [two#x ASC NULLS FIRST], true
++- Distinct
+   +- Union false, false
+      :- Distinct
+      :  +- Union false, false
+      :     :- Project [1 AS two#x]
+      :     :  +- OneRowRelation
+      :     +- Project [2 AS 2#x]
+      :        +- OneRowRelation
+      +- Project [2 AS 2#x]
+         +- OneRowRelation
 
 
 -- !query
@@ -221,29 +225,37 @@ Sort [two#x ASC NULLS FIRST], true
 -- !query
 SELECT 1.1 AS three UNION SELECT 2 UNION SELECT 3 ORDER BY 1
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Sort [three#x ASC NULLS FIRST], true
++- Distinct
+   +- Union false, false
+      :- Distinct
+      :  +- Union false, false
+      :     :- Project [cast(three#x as decimal(11,1)) AS three#x]
+      :     :  +- Project [1.1 AS three#x]
+      :     :     +- OneRowRelation
+      :     +- Project [cast(2#x as decimal(11,1)) AS 2#x]
+      :        +- Project [2 AS 2#x]
+      :           +- OneRowRelation
+      +- Project [cast(3#x as decimal(11,1)) AS 3#x]
+         +- Project [3 AS 3#x]
+            +- OneRowRelation
 
 
 -- !query
 SELECT double(1.1) AS two UNION SELECT 2 UNION SELECT double(2.0) ORDER BY 1
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Sort [two#x ASC NULLS FIRST], true
++- Distinct
+   +- Union false, false
+      :- Distinct
+      :  +- Union false, false
+      :     :- Project [cast(1.1 as double) AS two#x]
+      :     :  +- OneRowRelation
+      :     +- Project [cast(2#x as double) AS 2#x]
+      :        +- Project [2 AS 2#x]
+      :           +- OneRowRelation
+      +- Project [cast(2.0 as double) AS 2.0#x]
+         +- OneRowRelation
 
 
 -- !query
@@ -606,57 +618,59 @@ Sort [q1#xL ASC NULLS FIRST], true
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6) INTERSECT SELECT 4,5,6
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Intersect false
+:- Distinct
+:  +- Union false, false
+:     :- Project [1 AS 1#x, 2 AS 2#x, 3 AS 3#x]
+:     :  +- OneRowRelation
+:     +- Project [4 AS 4#x, 5 AS 5#x, 6 AS 6#x]
+:        +- OneRowRelation
++- Project [4 AS 4#x, 5 AS 5#x, 6 AS 6#x]
+   +- OneRowRelation
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6 ORDER BY 1,2) INTERSECT SELECT 4,5,6
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Intersect false
+:- Sort [1#x ASC NULLS FIRST, 2#x ASC NULLS FIRST], true
+:  +- Distinct
+:     +- Union false, false
+:        :- Project [1 AS 1#x, 2 AS 2#x, 3 AS 3#x]
+:        :  +- OneRowRelation
+:        +- Project [4 AS 4#x, 5 AS 5#x, 6 AS 6#x]
+:           +- OneRowRelation
++- Project [4 AS 4#x, 5 AS 5#x, 6 AS 6#x]
+   +- OneRowRelation
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6) EXCEPT SELECT 4,5,6
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Except false
+:- Distinct
+:  +- Union false, false
+:     :- Project [1 AS 1#x, 2 AS 2#x, 3 AS 3#x]
+:     :  +- OneRowRelation
+:     +- Project [4 AS 4#x, 5 AS 5#x, 6 AS 6#x]
+:        +- OneRowRelation
++- Project [4 AS 4#x, 5 AS 5#x, 6 AS 6#x]
+   +- OneRowRelation
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6 ORDER BY 1,2) EXCEPT SELECT 4,5,6
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Except false
+:- Sort [1#x ASC NULLS FIRST, 2#x ASC NULLS FIRST], true
+:  +- Distinct
+:     +- Union false, false
+:        :- Project [1 AS 1#x, 2 AS 2#x, 3 AS 3#x]
+:        :  +- OneRowRelation
+:        +- Project [4 AS 4#x, 5 AS 5#x, 6 AS 6#x]
+:           +- OneRowRelation
++- Project [4 AS 4#x, 5 AS 5#x, 6 AS 6#x]
+   +- OneRowRelation
 
 
 -- !query
@@ -1164,15 +1178,14 @@ Except All true
 -- !query
 SELECT cast('3.4' as decimal(38, 18)) UNION SELECT 'foo'
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+Distinct
++- Union false, false
+   :- Project [cast(CAST(3.4 AS DECIMAL(38,18))#x as double) AS CAST(3.4 AS DECIMAL(38,18))#x]
+   :  +- Project [cast(3.4 as decimal(38,18)) AS CAST(3.4 AS DECIMAL(38,18))#x]
+   :     +- OneRowRelation
+   +- Project [cast(foo#x as double) AS foo#x]
+      +- Project [foo AS foo#x]
+         +- OneRowRelation
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/union.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/union.sql.out
@@ -73,33 +73,20 @@ struct<two:int>
 -- !query
 SELECT 1 AS three UNION SELECT 2 UNION SELECT 3 ORDER BY 1
 -- !query schema
-struct<>
+struct<three:int>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+1
+2
+3
 
 
 -- !query
 SELECT 1 AS two UNION SELECT 2 UNION SELECT 2 ORDER BY 1
 -- !query schema
-struct<>
+struct<two:int>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+1
+2
 
 
 -- !query
@@ -168,33 +155,20 @@ struct<two:double>
 -- !query
 SELECT 1.1 AS three UNION SELECT 2 UNION SELECT 3 ORDER BY 1
 -- !query schema
-struct<>
+struct<three:decimal(11,1)>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+1.1
+2.0
+3.0
 
 
 -- !query
 SELECT double(1.1) AS two UNION SELECT 2 UNION SELECT double(2.0) ORDER BY 1
 -- !query schema
-struct<>
+struct<two:double>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+1.1
+2.0
 
 
 -- !query
@@ -382,65 +356,33 @@ struct<q1:bigint>
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6) INTERSECT SELECT 4,5,6
 -- !query schema
-struct<>
+struct<1:int,2:int,3:int>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+4	5	6
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6 ORDER BY 1,2) INTERSECT SELECT 4,5,6
 -- !query schema
-struct<>
+struct<1:int,2:int,3:int>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+4	5	6
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6) EXCEPT SELECT 4,5,6
 -- !query schema
-struct<>
+struct<1:int,2:int,3:int>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+1	2	3
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6 ORDER BY 1,2) EXCEPT SELECT 4,5,6
 -- !query schema
-struct<>
+struct<1:int,2:int,3:int>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-{
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
-  "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
-}
+1	2	3
 
 
 -- !query
@@ -753,14 +695,23 @@ SELECT cast('3.4' as decimal(38, 18)) UNION SELECT 'foo'
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkNumberFormatException
 {
-  "errorClass" : "PARSE_SYNTAX_ERROR",
-  "sqlState" : "42601",
+  "errorClass" : "CAST_INVALID_INPUT",
+  "sqlState" : "22018",
   "messageParameters" : {
-    "error" : "'SELECT'",
-    "hint" : ""
-  }
+    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
+    "expression" : "'foo'",
+    "sourceType" : "\"STRING\"",
+    "targetType" : "\"DOUBLE\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 56,
+    "fragment" : "SELECT cast('3.4' as decimal(38, 18)) UNION SELECT 'foo'"
+  } ]
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableRenameParserSuite.scala
@@ -51,6 +51,6 @@ class AlterTableRenameParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(parsePlan)(sql2),
       errorClass = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "'.'", "hint" -> ": extra input '.'"))
+      parameters = Map("error" -> "'.'", "hint" -> ""))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -2377,7 +2377,7 @@ class PlanResolutionSuite extends AnalysisTest {
     checkError(
       exception = parseException(parsePlan)(sql),
       errorClass = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "':'", "hint" -> ": extra input ':'"))
+      parameters = Map("error" -> "':'", "hint" -> ""))
   }
 
   test("create hive table - table file format") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -515,7 +515,7 @@ class JDBCWriteSuite extends SharedSparkSession with BeforeAndAfter {
           .jdbc(url1, "TEST.USERDBTYPETEST", properties)
       },
       errorClass = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "'`'", "hint" -> ": extra input '`'"))
+      parameters = Map("error" -> "'`'", "hint" -> ""))
   }
 
   test("SPARK-10849: jdbc CreateTableColumnTypes duplicate columns") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR follows the https://github.com/antlr/antlr4/issues/192#issuecomment-15238595 to correct the current implementation of the **two-stage parsing strategy** in `AbstractSqlParser`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This should be a long-standing issue, before [SPARK-38385](https://issues.apache.org/jira/browse/SPARK-38385), Spark uses `DefaultErrorStrategy`, and after [SPARK-38385](https://issues.apache.org/jira/browse/SPARK-38385) Spark uses class `SparkParserErrorStrategy() extends DefaultErrorStrategy`. It is not a correct implementation of the "two-stage parsing strategy"

As mentioned in https://github.com/antlr/antlr4/issues/192#issuecomment-15238595

> You can save a great deal of time on correct inputs by using a two-stage parsing strategy.
>
> 1. Attempt to parse the input using BailErrorStrategy and PredictionMode.SLL.
>    If no exception is thrown, you know the answer is correct.
> 2. If a ParseCancellationException is thrown, retry the parse using the default
>    settings (DefaultErrorStrategy and PredictionMode.LL).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the Spark SQL parser becomes more powerful, SQL like `SELECT 1 UNION SELECT 2` parse succeeded after this change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT is added.