### PR TITLE
[SPARK-43172] [CONNECT] Expose host and token from spark connect client

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -621,6 +621,21 @@ class SparkConnectClient(object):
         """
         self._channel.close()
 
+    @property
+    def host(self) -> str:
+        """
+        The hostname where this client intends to connect.
+        """
+        return self._builder.host
+
+    @property
+    def token(self) -> Optional[str]:
+        """
+        The authentication bearer token during connection.
+        If authentication is not using a bearer token, None will be returned.
+        """
+        return self._builder._token
+
     def _execute_plan_request_with_metadata(self) -> pb2.ExecutePlanRequest:
         req = pb2.ExecutePlanRequest()
         req.client_id = self._session_id

--- a/python/pyspark/sql/tests/connect/test_client.py
+++ b/python/pyspark/sql/tests/connect/test_client.py
@@ -45,7 +45,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
         self.assertIsNotNone(mock.req, "ExecutePlan API was not called when expected")
         self.assertEqual(mock.req.client_type, "_SPARK_CONNECT_PYTHON")
 
-    def test_attributes(self):
+    def test_properties(self):
         client = SparkConnectClient("sc://foo/;token=bar")
         self.assertEqual(client.token, "bar")
         self.assertEqual(client.host, "foo")

--- a/python/pyspark/sql/tests/connect/test_client.py
+++ b/python/pyspark/sql/tests/connect/test_client.py
@@ -45,6 +45,13 @@ class SparkConnectClientTestCase(unittest.TestCase):
         self.assertIsNotNone(mock.req, "ExecutePlan API was not called when expected")
         self.assertEqual(mock.req.client_type, "_SPARK_CONNECT_PYTHON")
 
+    def test_attributes(self):
+        client = SparkConnectClient("sc://foo/;token=bar")
+        self.assertEqual(client.token, "bar")
+        self.assertEqual(client.host, "foo")
+
+        client = SparkConnectClient("sc://foo/")
+        self.assertIsNone(client.token)
 
 class MockService:
     # Simplest mock of the SparkConnectService.

--- a/python/pyspark/sql/tests/connect/test_client.py
+++ b/python/pyspark/sql/tests/connect/test_client.py
@@ -53,6 +53,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
         client = SparkConnectClient("sc://foo/")
         self.assertIsNone(client.token)
 
+
 class MockService:
     # Simplest mock of the SparkConnectService.
     # If this needs more complex logic, it needs to be replaced with Python mocking.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Expose the host and bearer token as properties of the
`SparkConnectClient`.

### Why are the changes needed?

This allows for querying the connecting host and bearer token
given an instance of spark connect client.

### Does this PR introduce _any_ user-facing change?

Introduces two new properties `host` and `token` to the
`SparkConnectClient` class

### How was this patch tested?

Unit tests