### PR TITLE
[SPARK-43181][SQL] Show UI WebURL in `spark-sql` shell

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -371,6 +371,9 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
   def printMasterAndAppId(): Unit = {
     val master = SparkSQLEnv.sparkContext.master
     val appId = SparkSQLEnv.sparkContext.applicationId
+    SparkSQLEnv.sparkContext.uiWebUrl.foreach {
+      webUrl => console.printInfo(s"Spark Web UI available at $webUrl")
+    }
     console.printInfo(s"Spark master: $master, Application Id: $appId")
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to display `the Spark WEB UI address` when spark-sql startup.

### Why are the changes needed?
Promoting user experience.

Like `spark-shell`, it would be great if `spark-sql` show the UI information.

```
$ bin/spark-sql
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
23/05/07 13:58:26 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
23/05/07 13:58:27 WARN HiveConf: HiveConf of name hive.stats.jdbc.timeout does not exist
23/05/07 13:58:27 WARN HiveConf: HiveConf of name hive.stats.retries.wait does not exist
23/05/07 13:58:28 WARN ObjectStore: Version information not found in metastore. hive.metastore.schema.verification is not enabled so recording the schema version 2.3.0
23/05/07 13:58:28 WARN ObjectStore: setMetaStoreSchemaVersion called but recording version is disabled: version = 2.3.0, comment = Set by MetaStore dongjoon@127.0.0.1
Spark Web UI available at http://localhost:4040
Spark master: local[*], Application Id: local-1683493106875
spark-sql (default)>
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA & Manually test.