### PR TITLE
[MINOR][CONNECT][PYTHON][DOCS] Fix the doc of parameter `num` in `DataFrame.offset`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1907,8 +1907,7 @@ class DataFrame:
         Parameters
         ----------
         num : int
-            Number of records to return. Will return this number of records
-            or all records if the DataFrame contains less than this number of records.
+            Number of records to skip.
 
         Returns
         -------


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix the incorrect doc

### Why are the changes needed?
the description of parameter `num` is incorrect, it actually describes the `num` in `DataFrame.{limit, tail}`


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
existing UT
