### PR TITLE
[SPARK-42780][BUILD] Upgrade `Tink` to 1.9.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -62,7 +62,7 @@ dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-met
 flatbuffers-java/1.12.0//flatbuffers-java-1.12.0.jar
 gcs-connector/hadoop3-2.2.11/shaded/gcs-connector-hadoop3-2.2.11-shaded.jar
 gmetric4j/1.0.10//gmetric4j-1.0.10.jar
-gson/2.10.1//gson-2.10.1.jar
+gson/2.2.4//gson-2.2.4.jar
 guava/14.0.1//guava-14.0.1.jar
 hadoop-aliyun/3.3.5//hadoop-aliyun-3.3.5.jar
 hadoop-annotations/3.3.5//hadoop-annotations-3.3.5.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -59,9 +59,12 @@ datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
 derby/10.14.2.0//derby-10.14.2.0.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
+error_prone_annotations/2.18.0//error_prone_annotations-2.18.0.jar
 flatbuffers-java/1.12.0//flatbuffers-java-1.12.0.jar
 gcs-connector/hadoop3-2.2.11/shaded/gcs-connector-hadoop3-2.2.11-shaded.jar
 gmetric4j/1.0.10//gmetric4j-1.0.10.jar
+google-http-client/1.43.1//google-http-client-1.43.1.jar
+grpc-context/1.27.2//grpc-context-1.27.2.jar
 gson/2.2.4//gson-2.2.4.jar
 guava/14.0.1//guava-14.0.1.jar
 hadoop-aliyun/3.3.5//hadoop-aliyun-3.3.5.jar
@@ -97,6 +100,7 @@ httpcore/4.4.16//httpcore-4.4.16.jar
 ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.5.1//ivy-2.5.1.jar
+j2objc-annotations/1.3//j2objc-annotations-1.3.jar
 jackson-annotations/2.14.2//jackson-annotations-2.14.2.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.14.2//jackson-core-2.14.2.jar
@@ -205,6 +209,8 @@ netty-transport/4.1.89.Final//netty-transport-4.1.89.Final.jar
 objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.15.0//okio-1.15.0.jar
+opencensus-api/0.31.1//opencensus-api-0.31.1.jar
+opencensus-contrib-http-util/0.31.1//opencensus-contrib-http-util-0.31.1.jar
 opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
@@ -245,7 +251,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.7.1//threeten-extra-1.7.1.jar
-tink/1.7.0//tink-1.7.0.jar
+tink/1.9.0//tink-1.9.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 wildfly-openssl/1.1.3.Final//wildfly-openssl-1.1.3.Final.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -59,13 +59,10 @@ datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
 derby/10.14.2.0//derby-10.14.2.0.jar
 dropwizard-metrics-hadoop-metrics2-reporter/0.1.2//dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
-error_prone_annotations/2.18.0//error_prone_annotations-2.18.0.jar
 flatbuffers-java/1.12.0//flatbuffers-java-1.12.0.jar
 gcs-connector/hadoop3-2.2.11/shaded/gcs-connector-hadoop3-2.2.11-shaded.jar
 gmetric4j/1.0.10//gmetric4j-1.0.10.jar
-google-http-client/1.43.1//google-http-client-1.43.1.jar
-grpc-context/1.27.2//grpc-context-1.27.2.jar
-gson/2.2.4//gson-2.2.4.jar
+gson/2.10.1//gson-2.10.1.jar
 guava/14.0.1//guava-14.0.1.jar
 hadoop-aliyun/3.3.5//hadoop-aliyun-3.3.5.jar
 hadoop-annotations/3.3.5//hadoop-annotations-3.3.5.jar
@@ -100,7 +97,6 @@ httpcore/4.4.16//httpcore-4.4.16.jar
 ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.5.1//ivy-2.5.1.jar
-j2objc-annotations/1.3//j2objc-annotations-1.3.jar
 jackson-annotations/2.14.2//jackson-annotations-2.14.2.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.14.2//jackson-core-2.14.2.jar
@@ -209,8 +205,6 @@ netty-transport/4.1.89.Final//netty-transport-4.1.89.Final.jar
 objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.15.0//okio-1.15.0.jar
-opencensus-api/0.31.1//opencensus-api-0.31.1.jar
-opencensus-contrib-http-util/0.31.1//opencensus-contrib-http-util-0.31.1.jar
 opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,21 @@
       <artifactId>unused</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.crypto.tink</groupId>
+      <artifactId>tink</artifactId>
+      <version>${tink.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!--
          This is needed by the scalatest plugin, and so is declared here to be available in
          all child modules, just as scalatest is run in all children

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.60</bouncycastle.version>
-    <tink.version>1.7.0</tink.version>
+    <tink.version>1.9.0</tink.version>
     <netty.version>4.1.89.Final</netty.version>
     <!--
     If you are changing Arrow version specification, please check

--- a/pom.xml
+++ b/pom.xml
@@ -399,21 +399,6 @@
       <artifactId>unused</artifactId>
       <version>1.0.0</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.crypto.tink</groupId>
-      <artifactId>tink</artifactId>
-      <version>${tink.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!--
          This is needed by the scalatest plugin, and so is declared here to be available in
          all child modules, just as scalatest is run in all children
@@ -2707,6 +2692,16 @@
         <groupId>com.google.crypto.tink</groupId>
         <artifactId>tink</artifactId>
         <version>${tink.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.arrow</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade google Tink from 1.7.0 to 1.9.0

[Release note for 1.8.0](https://github.com/tink-crypto/tink-java/releases/tag/v1.8.0)

[Release note for 1.9.0](https://github.com/tink-crypto/tink-java/releases/tag/v1.9.0)

### Why are the changes needed?
[SNYK-JAVA-COMGOOGLEPROTOBUF-3040284](https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3040284)

[SNYK-JAVA-COMGOOGLEPROTOBUF-3167772](https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
This have be benchmarks tested 
With
"com.google.crypto.tink" % "tink" % "1.6.1"
(min, avg, max) = (75024163.500, 76331532.832, 77324718.069), stdev = 652319.870

With
"com.google.crypto.tink" % "tink" % "1.9.0"
(min, avg, max) = (76279051.841, 77512667.749, 78590966.453), stdev = 632832.384

Almost the same.. Think 1.9.0 is perhaps a bit slower.

Pass GA