### PR TITLE
[SPARK-43055][CONNECT][PYTHON][FOLLOWUP] Fix deduplicate field names and refactor

### DIFF
--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -49,7 +49,6 @@ import pyspark.sql.connect.proto as pb2
 from typing import (
     Any,
     Callable,
-    Dict,
     Sequence,
     List,
 )

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1710,7 +1710,10 @@ class DataFrameTestsMixin:
         )
 
     def test_duplicate_field_names(self):
-        data = [Row(Row("a", 1), Row(2, 3, "b", 4, "c")), Row(Row("x", 6), Row(7, 8, "y", 9, "z"))]
+        data = [
+            Row(Row("a", 1), Row(2, 3, "b", 4, "c", "d")),
+            Row(Row("w", 6), Row(7, 8, "x", 9, "y", "z")),
+        ]
         schema = (
             StructType()
             .add("struct", StructType().add("x", StringType()).add("x", IntegerType()))
@@ -1721,7 +1724,8 @@ class DataFrameTestsMixin:
                 .add("x", IntegerType())
                 .add("x", StringType())
                 .add("y", IntegerType())
-                .add("y", StringType()),
+                .add("y", StringType())
+                .add("x", StringType()),
             )
         )
         df = self.spark.createDataFrame(data, schema=schema)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes deduplicate field names, and refactor to use the same renaming rule between `ArrowTableToRowsConversion.convert` and `LocalDataToArrowConversion.convert`.

### Why are the changes needed?

If there is a duplicated field name in a separate position, it fails to deduplicate and returns a wrong result.

```py
>>> from pyspark.sql.types import *
>>> data = [
...     Row(Row("a", 1), Row(2, 3, "b", 4, "c", "d")),
...     Row(Row("w", 6), Row(7, 8, "x", 9, "y", "z")),
... ]
>>> schema = (
...     StructType()
...     .add("struct", StructType().add("x", StringType()).add("x", IntegerType()))
...     .add(
...         "struct",
...         StructType()
...         .add("a", IntegerType())
...         .add("x", IntegerType())
...         .add("x", StringType())
...         .add("y", IntegerType())
...         .add("y", StringType())
...         .add("x", StringType()),
...     )
... )
>>> df = spark.createDataFrame(data, schema=schema)
>>>
>>> df.collect()
[Row(struct=Row(x='a', x=1), struct=Row(a=2, x=None, x=None, y=4, y='c', x=None)), Row(struct=Row(x='w', x=6), struct=Row(a=7, x=None, x=None, y=9, y='y', x=None))]
```

It should be:

```py
>>> df.collect()
[Row(struct=Row(x='a', x=1), struct=Row(a=2, x=3, x='b', y=4, y='c', x='d')), Row(struct=Row(x='w', x=6), struct=Row(a=7, x=8, x='x', y=9, y='y', x='z'))]
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related test.