### PR TITLE
[SPARK-43195][BUILD][FOLLOWUP] Fix mima check for Scala 2.13

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -37,7 +37,12 @@ object MimaExcludes {
   // Exclude rules for 3.5.x from 3.4.0
   lazy val v35excludes = defaultExcludes ++ Seq(
     // [SPARK-43165][SQL] Move canWrite to DataTypeUtils
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.DataType.canWrite")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.DataType.canWrite"),
+    // [SPARK-43195][CORE] Remove unnecessary serializable wrapper in HadoopFSUtils
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.util.HadoopFSUtils$SerializableBlockLocation"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.util.HadoopFSUtils$SerializableBlockLocation$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.util.HadoopFSUtils$SerializableFileStatus"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.util.HadoopFSUtils$SerializableFileStatus$")
   )
 
   // Defulat exclude rules


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix mima check for Scala 2.13.


### Why are the changes needed?
Scala 2.13 daily test failed due to mima check failed:

- https://github.com/apache/spark/actions/runs/4757950254/jobs/8455416083

<img width="1668" alt="image" src="https://user-images.githubusercontent.com/1475305/233678713-30c661e6-d5d0-424a-8b7f-c8a59bb0680a.png">

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual check with this pr

```
dev/change-scala-version.sh 2.13
dev/mima -Pscala-2.13
```

check passed

```
[success] Total time: 39 s, completed 2023-4-21 23:41:52
```