### PR TITLE
[SPARK-43142] Fix DSL expressions on attributes with special characters

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -271,7 +271,7 @@ package object dsl {
       override def expr: Expression = Literal(s)
       def attr: UnresolvedAttribute = analysis.UnresolvedAttribute(s)
     }
-    implicit class DslAttr(attr: UnresolvedAttribute) extends ImplicitAttribute {
+    implicit class DslAttr(override val attr: UnresolvedAttribute) extends ImplicitAttribute {
       def s: String = attr.sql
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.plans.{Inner, JoinType}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.quoteIfNeeded
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -266,16 +265,12 @@ package object dsl {
     def windowExpr(windowFunc: Expression, windowSpec: WindowSpecDefinition): WindowExpression =
       WindowExpression(windowFunc, windowSpec)
 
-    implicit class DslSymbol(sym: Symbol) extends ImplicitAttribute {
-      def s: String = quoteIfNeeded(sym.name)
-    }
-
+    implicit class DslSymbol(sym: Symbol) extends ImplicitAttribute { def s: String = sym.name }
     // TODO more implicit class for literal?
     implicit class DslString(val s: String) extends ImplicitOperators {
       override def expr: Expression = Literal(s)
       def attr: UnresolvedAttribute = analysis.UnresolvedAttribute(s)
     }
-
     implicit class DslAttr(attr: UnresolvedAttribute) extends ImplicitAttribute {
       def s: String = attr.sql
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -271,9 +271,8 @@ package object dsl {
       override def expr: Expression = Literal(s)
       def attr: UnresolvedAttribute = analysis.UnresolvedAttribute(s)
     }
-    implicit class DslAttr(a: UnresolvedAttribute) extends ImplicitAttribute {
-      def s: String = a.name
-      override def attr: UnresolvedAttribute = a
+    implicit class DslAttr(attr: UnresolvedAttribute) extends ImplicitAttribute {
+      def s: String = attr.sql
     }
 
     abstract class ImplicitAttribute extends ImplicitOperators {
@@ -282,89 +281,108 @@ package object dsl {
       def attr: UnresolvedAttribute = analysis.UnresolvedAttribute(s)
 
       /** Creates a new AttributeReference of type boolean */
-      def boolean: AttributeReference = AttributeReference(s, BooleanType, nullable = true)()
+      def boolean: AttributeReference =
+        AttributeReference(attr.nameParts.last, BooleanType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type byte */
-      def byte: AttributeReference = AttributeReference(s, ByteType, nullable = true)()
+      def byte: AttributeReference =
+        AttributeReference(attr.nameParts.last, ByteType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type short */
-      def short: AttributeReference = AttributeReference(s, ShortType, nullable = true)()
+      def short: AttributeReference =
+        AttributeReference(attr.nameParts.last, ShortType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type int */
-      def int: AttributeReference = AttributeReference(s, IntegerType, nullable = true)()
+      def int: AttributeReference =
+        AttributeReference(attr.nameParts.last, IntegerType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type long */
-      def long: AttributeReference = AttributeReference(s, LongType, nullable = true)()
+      def long: AttributeReference =
+        AttributeReference(attr.nameParts.last, LongType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type float */
-      def float: AttributeReference = AttributeReference(s, FloatType, nullable = true)()
+      def float: AttributeReference =
+        AttributeReference(attr.nameParts.last, FloatType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type double */
-      def double: AttributeReference = AttributeReference(s, DoubleType, nullable = true)()
+      def double: AttributeReference =
+        AttributeReference(attr.nameParts.last, DoubleType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type string */
-      def string: AttributeReference = AttributeReference(s, StringType, nullable = true)()
+      def string: AttributeReference = AttributeReference(attr.nameParts.last, StringType)(
+        qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type date */
-      def date: AttributeReference = AttributeReference(s, DateType, nullable = true)()
+      def date: AttributeReference =
+        AttributeReference(attr.nameParts.last, DateType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type decimal */
       def decimal: AttributeReference =
-        AttributeReference(s, DecimalType.SYSTEM_DEFAULT, nullable = true)()
+        AttributeReference(attr.nameParts.last, DecimalType.SYSTEM_DEFAULT)(
+          qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type decimal */
       def decimal(precision: Int, scale: Int): AttributeReference =
-        AttributeReference(s, DecimalType(precision, scale), nullable = true)()
+        AttributeReference(attr.nameParts.last, DecimalType(precision, scale))(
+          qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type timestamp */
-      def timestamp: AttributeReference = AttributeReference(s, TimestampType, nullable = true)()
+      def timestamp: AttributeReference =
+        AttributeReference(attr.nameParts.last, TimestampType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type timestamp without time zone */
       def timestampNTZ: AttributeReference =
-        AttributeReference(s, TimestampNTZType, nullable = true)()
+        AttributeReference(attr.nameParts.last, TimestampNTZType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of the day-time interval type */
-      def dayTimeInterval(startField: Byte, endField: Byte): AttributeReference = {
-        AttributeReference(s, DayTimeIntervalType(startField, endField), nullable = true)()
-      }
+      def dayTimeInterval(startField: Byte, endField: Byte): AttributeReference =
+        AttributeReference(attr.nameParts.last, DayTimeIntervalType(startField, endField))(
+          qualifier = attr.nameParts.init)
+
       def dayTimeInterval(): AttributeReference = {
-        AttributeReference(s, DayTimeIntervalType(), nullable = true)()
+        AttributeReference(attr.nameParts.last, DayTimeIntervalType())(
+          qualifier = attr.nameParts.init)
       }
 
       /** Creates a new AttributeReference of the year-month interval type */
       def yearMonthInterval(startField: Byte, endField: Byte): AttributeReference = {
-        AttributeReference(s, YearMonthIntervalType(startField, endField), nullable = true)()
-      }
-      def yearMonthInterval(): AttributeReference = {
-        AttributeReference(s, YearMonthIntervalType(), nullable = true)()
+        AttributeReference(attr.nameParts.last, YearMonthIntervalType(startField, endField))(
+          qualifier = attr.nameParts.init)
       }
 
+      def yearMonthInterval(): AttributeReference =
+        AttributeReference(attr.nameParts.last, YearMonthIntervalType())(
+          qualifier = attr.nameParts.init)
+
       /** Creates a new AttributeReference of type binary */
-      def binary: AttributeReference = AttributeReference(s, BinaryType, nullable = true)()
+      def binary: AttributeReference =
+        AttributeReference(attr.nameParts.last, BinaryType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type array */
       def array(dataType: DataType): AttributeReference =
-        AttributeReference(s, ArrayType(dataType), nullable = true)()
+        AttributeReference(attr.nameParts.last, ArrayType(dataType))(
+          qualifier = attr.nameParts.init)
 
       def array(arrayType: ArrayType): AttributeReference =
-        AttributeReference(s, arrayType)()
+        AttributeReference(attr.nameParts.last, arrayType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type map */
       def map(keyType: DataType, valueType: DataType): AttributeReference =
         map(MapType(keyType, valueType))
 
       def map(mapType: MapType): AttributeReference =
-        AttributeReference(s, mapType, nullable = true)()
+        AttributeReference(attr.nameParts.last, mapType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type struct */
       def struct(structType: StructType): AttributeReference =
-        AttributeReference(s, structType, nullable = true)()
+        AttributeReference(attr.nameParts.last, structType)(qualifier = attr.nameParts.init)
+
       def struct(attrs: AttributeReference*): AttributeReference =
         struct(StructType.fromAttributes(attrs))
 
       /** Creates a new AttributeReference of object type */
       def obj(cls: Class[_]): AttributeReference =
-        AttributeReference(s, ObjectType(cls), nullable = true)()
+        AttributeReference(attr.nameParts.last, ObjectType(cls))(qualifier = attr.nameParts.init)
 
       /** Create a function. */
       def function(exprs: Expression*): UnresolvedFunction =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -271,8 +271,9 @@ package object dsl {
       override def expr: Expression = Literal(s)
       def attr: UnresolvedAttribute = analysis.UnresolvedAttribute(s)
     }
-    implicit class DslAttr(attr: UnresolvedAttribute) extends ImplicitAttribute {
-      def s: String = attr.name
+    implicit class DslAttr(a: UnresolvedAttribute) extends ImplicitAttribute {
+      def s: String = a.name
+      override def attr: UnresolvedAttribute = a
     }
 
     abstract class ImplicitAttribute extends ImplicitOperators {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -280,109 +280,83 @@ package object dsl {
       def expr: UnresolvedAttribute = attr
       def attr: UnresolvedAttribute = analysis.UnresolvedAttribute(s)
 
+      private def attrRef(dataType: DataType): AttributeReference =
+        AttributeReference(attr.nameParts.last, dataType)(qualifier = attr.nameParts.init)
+
       /** Creates a new AttributeReference of type boolean */
-      def boolean: AttributeReference =
-        AttributeReference(attr.nameParts.last, BooleanType)(qualifier = attr.nameParts.init)
+      def boolean: AttributeReference = attrRef(BooleanType)
 
       /** Creates a new AttributeReference of type byte */
-      def byte: AttributeReference =
-        AttributeReference(attr.nameParts.last, ByteType)(qualifier = attr.nameParts.init)
+      def byte: AttributeReference = attrRef(ByteType)
 
       /** Creates a new AttributeReference of type short */
-      def short: AttributeReference =
-        AttributeReference(attr.nameParts.last, ShortType)(qualifier = attr.nameParts.init)
+      def short: AttributeReference = attrRef(ShortType)
 
       /** Creates a new AttributeReference of type int */
-      def int: AttributeReference =
-        AttributeReference(attr.nameParts.last, IntegerType)(qualifier = attr.nameParts.init)
+      def int: AttributeReference = attrRef(IntegerType)
 
       /** Creates a new AttributeReference of type long */
-      def long: AttributeReference =
-        AttributeReference(attr.nameParts.last, LongType)(qualifier = attr.nameParts.init)
+      def long: AttributeReference = attrRef(LongType)
 
       /** Creates a new AttributeReference of type float */
-      def float: AttributeReference =
-        AttributeReference(attr.nameParts.last, FloatType)(qualifier = attr.nameParts.init)
+      def float: AttributeReference = attrRef(FloatType)
 
       /** Creates a new AttributeReference of type double */
-      def double: AttributeReference =
-        AttributeReference(attr.nameParts.last, DoubleType)(qualifier = attr.nameParts.init)
+      def double: AttributeReference = attrRef(DoubleType)
 
       /** Creates a new AttributeReference of type string */
-      def string: AttributeReference =
-        AttributeReference(attr.nameParts.last, StringType)(qualifier = attr.nameParts.init)
+      def string: AttributeReference = attrRef(StringType)
 
       /** Creates a new AttributeReference of type date */
-      def date: AttributeReference =
-        AttributeReference(attr.nameParts.last, DateType)(qualifier = attr.nameParts.init)
+      def date: AttributeReference = attrRef(DateType)
 
       /** Creates a new AttributeReference of type decimal */
-      def decimal: AttributeReference =
-        AttributeReference(attr.nameParts.last, DecimalType.SYSTEM_DEFAULT)(
-          qualifier = attr.nameParts.init)
+      def decimal: AttributeReference = attrRef(DecimalType.SYSTEM_DEFAULT)
 
       /** Creates a new AttributeReference of type decimal */
       def decimal(precision: Int, scale: Int): AttributeReference =
-        AttributeReference(attr.nameParts.last, DecimalType(precision, scale))(
-          qualifier = attr.nameParts.init)
+        attrRef(DecimalType(precision, scale))
 
       /** Creates a new AttributeReference of type timestamp */
-      def timestamp: AttributeReference =
-        AttributeReference(attr.nameParts.last, TimestampType)(qualifier = attr.nameParts.init)
+      def timestamp: AttributeReference = attrRef(TimestampType)
 
       /** Creates a new AttributeReference of type timestamp without time zone */
-      def timestampNTZ: AttributeReference =
-        AttributeReference(attr.nameParts.last, TimestampNTZType)(qualifier = attr.nameParts.init)
+      def timestampNTZ: AttributeReference = attrRef(TimestampNTZType)
 
       /** Creates a new AttributeReference of the day-time interval type */
       def dayTimeInterval(startField: Byte, endField: Byte): AttributeReference =
-        AttributeReference(attr.nameParts.last, DayTimeIntervalType(startField, endField))(
-          qualifier = attr.nameParts.init)
+        attrRef(DayTimeIntervalType(startField, endField))
 
-      def dayTimeInterval(): AttributeReference = {
-        AttributeReference(attr.nameParts.last, DayTimeIntervalType())(
-          qualifier = attr.nameParts.init)
-      }
+      def dayTimeInterval(): AttributeReference = attrRef(DayTimeIntervalType())
 
       /** Creates a new AttributeReference of the year-month interval type */
-      def yearMonthInterval(startField: Byte, endField: Byte): AttributeReference = {
-        AttributeReference(attr.nameParts.last, YearMonthIntervalType(startField, endField))(
-          qualifier = attr.nameParts.init)
-      }
+      def yearMonthInterval(startField: Byte, endField: Byte): AttributeReference =
+        attrRef(YearMonthIntervalType(startField, endField))
 
-      def yearMonthInterval(): AttributeReference =
-        AttributeReference(attr.nameParts.last, YearMonthIntervalType())(
-          qualifier = attr.nameParts.init)
+      def yearMonthInterval(): AttributeReference = attrRef(YearMonthIntervalType())
 
       /** Creates a new AttributeReference of type binary */
-      def binary: AttributeReference =
-        AttributeReference(attr.nameParts.last, BinaryType)(qualifier = attr.nameParts.init)
+      def binary: AttributeReference = attrRef(BinaryType)
 
       /** Creates a new AttributeReference of type array */
-      def array(dataType: DataType): AttributeReference =
-        AttributeReference(attr.nameParts.last, ArrayType(dataType))(
-          qualifier = attr.nameParts.init)
+      def array(dataType: DataType): AttributeReference = attrRef(ArrayType(dataType))
 
-      def array(arrayType: ArrayType): AttributeReference =
-        AttributeReference(attr.nameParts.last, arrayType)(qualifier = attr.nameParts.init)
+      def array(arrayType: ArrayType): AttributeReference = attrRef(arrayType)
 
       /** Creates a new AttributeReference of type map */
       def map(keyType: DataType, valueType: DataType): AttributeReference =
         map(MapType(keyType, valueType))
 
-      def map(mapType: MapType): AttributeReference =
-        AttributeReference(attr.nameParts.last, mapType)(qualifier = attr.nameParts.init)
+      def map(mapType: MapType): AttributeReference = attrRef(mapType)
 
       /** Creates a new AttributeReference of type struct */
-      def struct(structType: StructType): AttributeReference =
-        AttributeReference(attr.nameParts.last, structType)(qualifier = attr.nameParts.init)
+      def struct(structType: StructType): AttributeReference = attrRef(structType)
 
       def struct(attrs: AttributeReference*): AttributeReference =
         struct(StructType.fromAttributes(attrs))
 
       /** Creates a new AttributeReference of object type */
-      def obj(cls: Class[_]): AttributeReference =
-        AttributeReference(attr.nameParts.last, ObjectType(cls))(qualifier = attr.nameParts.init)
+      def obj(cls: Class[_]): AttributeReference = attrRef(ObjectType(cls))
 
       /** Create a function. */
       def function(exprs: Expression*): UnresolvedFunction =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -309,8 +309,8 @@ package object dsl {
         AttributeReference(attr.nameParts.last, DoubleType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type string */
-      def string: AttributeReference = AttributeReference(attr.nameParts.last, StringType)(
-        qualifier = attr.nameParts.init)
+      def string: AttributeReference =
+        AttributeReference(attr.nameParts.last, StringType)(qualifier = attr.nameParts.init)
 
       /** Creates a new AttributeReference of type date */
       def date: AttributeReference =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.plans.{Inner, JoinType}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.catalyst.util.quoteIfNeeded
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -265,12 +266,16 @@ package object dsl {
     def windowExpr(windowFunc: Expression, windowSpec: WindowSpecDefinition): WindowExpression =
       WindowExpression(windowFunc, windowSpec)
 
-    implicit class DslSymbol(sym: Symbol) extends ImplicitAttribute { def s: String = sym.name }
+    implicit class DslSymbol(sym: Symbol) extends ImplicitAttribute {
+      def s: String = quoteIfNeeded(sym.name)
+    }
+
     // TODO more implicit class for literal?
     implicit class DslString(val s: String) extends ImplicitOperators {
       override def expr: Expression = Literal(s)
       def attr: UnresolvedAttribute = analysis.UnresolvedAttribute(s)
     }
+
     implicit class DslAttr(attr: UnresolvedAttribute) extends ImplicitAttribute {
       def s: String = attr.sql
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSQLBuilderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSQLBuilderSuite.scala
@@ -95,7 +95,7 @@ class ExpressionSQLBuilderSuite extends SparkFunSuite {
 
   test("attributes") {
     checkSQL($"a".int, "a")
-    checkSQL(Symbol("foo bar").int, "`foo bar`")
+    checkSQL(Symbol("`foo bar`").int, "`foo bar`")
     // Keyword
     checkSQL($"int".int, "int")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategySuite.scala
@@ -27,18 +27,18 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
 class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
   val attrInts = Seq(
     $"cint".int,
-    $"c.int".int,
+    $"`c.int`".int,
     GetStructField($"a".struct(StructType(
       StructField("cstr", StringType, nullable = true) ::
         StructField("cint", IntegerType, nullable = true) :: Nil)), 1, None),
     GetStructField($"a".struct(StructType(
       StructField("c.int", IntegerType, nullable = true) ::
         StructField("cstr", StringType, nullable = true) :: Nil)), 0, None),
-    GetStructField($"a.b".struct(StructType(
+    GetStructField($"`a.b`".struct(StructType(
       StructField("cstr1", StringType, nullable = true) ::
         StructField("cstr2", StringType, nullable = true) ::
         StructField("cint", IntegerType, nullable = true) :: Nil)), 2, None),
-    GetStructField($"a.b".struct(StructType(
+    GetStructField($"`a.b`".struct(StructType(
       StructField("c.int", IntegerType, nullable = true) :: Nil)), 0, None),
     GetStructField(GetStructField($"a".struct(StructType(
       StructField("cstr1", StringType, nullable = true) ::
@@ -56,18 +56,18 @@ class DataSourceStrategySuite extends PlanTest with SharedSparkSession {
 
   val attrStrs = Seq(
     $"cstr".string,
-    $"c.str".string,
+    $"`c.str`".string,
     GetStructField($"a".struct(StructType(
       StructField("cint", IntegerType, nullable = true) ::
         StructField("cstr", StringType, nullable = true) :: Nil)), 1, None),
     GetStructField($"a".struct(StructType(
       StructField("c.str", StringType, nullable = true) ::
         StructField("cint", IntegerType, nullable = true) :: Nil)), 0, None),
-    GetStructField($"a.b".struct(StructType(
+    GetStructField($"`a.b`".struct(StructType(
       StructField("cint1", IntegerType, nullable = true) ::
         StructField("cint2", IntegerType, nullable = true) ::
         StructField("cstr", StringType, nullable = true) :: Nil)), 2, None),
-    GetStructField($"a.b".struct(StructType(
+    GetStructField($"`a.b`".struct(StructType(
       StructField("c.str", StringType, nullable = true) :: Nil)), 0, None),
     GetStructField(GetStructField($"a".struct(StructType(
       StructField("cint1", IntegerType, nullable = true) ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -29,18 +29,18 @@ import org.apache.spark.unsafe.types.UTF8String
 class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
   val attrInts = Seq(
     $"cint".int,
-    $"c.int".int,
+    $"`c.int`".int,
     GetStructField($"a".struct(StructType(
       StructField("cstr", StringType, nullable = true) ::
         StructField("cint", IntegerType, nullable = true) :: Nil)), 1, None),
     GetStructField($"a".struct(StructType(
       StructField("c.int", IntegerType, nullable = true) ::
         StructField("cstr", StringType, nullable = true) :: Nil)), 0, None),
-    GetStructField($"a.b".struct(StructType(
+    GetStructField($"`a.b`".struct(StructType(
       StructField("cstr1", StringType, nullable = true) ::
         StructField("cstr2", StringType, nullable = true) ::
         StructField("cint", IntegerType, nullable = true) :: Nil)), 2, None),
-    GetStructField($"a.b".struct(StructType(
+    GetStructField($"`a.b`".struct(StructType(
       StructField("c.int", IntegerType, nullable = true) :: Nil)), 0, None),
     GetStructField(GetStructField($"a".struct(StructType(
       StructField("cstr1", StringType, nullable = true) ::
@@ -58,18 +58,18 @@ class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
 
   val attrStrs = Seq(
     $"cstr".string,
-    $"c.str".string,
+    $"`c.str`".string,
     GetStructField($"a".struct(StructType(
       StructField("cint", IntegerType, nullable = true) ::
         StructField("cstr", StringType, nullable = true) :: Nil)), 1, None),
     GetStructField($"a".struct(StructType(
       StructField("c.str", StringType, nullable = true) ::
         StructField("cint", IntegerType, nullable = true) :: Nil)), 0, None),
-    GetStructField($"a.b".struct(StructType(
+    GetStructField($"`a.b`".struct(StructType(
       StructField("cint1", IntegerType, nullable = true) ::
         StructField("cint2", IntegerType, nullable = true) ::
         StructField("cstr", StringType, nullable = true) :: Nil)), 2, None),
-    GetStructField($"a.b".struct(StructType(
+    GetStructField($"`a.b`".struct(StructType(
       StructField("c.str", StringType, nullable = true) :: Nil)), 0, None),
     GetStructField(GetStructField($"a".struct(StructType(
       StructField("cint1", IntegerType, nullable = true) ::


### PR DESCRIPTION
Re-attempting #40794. #40794 tried to more safely create `AttributeReference` objects from multi-part attributes in `ImplicitAttribute`. But that broke things and we had to revert. This PR is limiting the fix to the `UnresolvedAttribute` object returned by `DslAttr.attr`, which is enough to fix the issue here.

### What changes were proposed in this pull request?
This PR fixes DSL expressions on attributes with special characters by making `DslAttr.attr` and `DslAttr.expr` return the implicitly wrapped attribute instead of creating a new one.

### Why are the changes needed?
SPARK-43142: DSL expressions on attributes with special characters don't work even if the attribute names are quoted:

```scala
scala> "`slashed/col`".attr
res0: org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute = 'slashed/col

scala> "`slashed/col`".attr.asc
org.apache.spark.sql.catalyst.parser.ParseException:
mismatched input '/' expecting {<EOF>, '.', '-'}(line 1, pos 7)

== SQL ==
slashed/col
-------^^^
```

DSL expressions rely on a call to `expr` to get child of the new expression [(e.g.)](https://github.com/apache/spark/blob/87a5442f7ed96b11051d8a9333476d080054e5a0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala#L149).

`expr` here is a call on implicit class `DslAttr` that's wrapping the `UnresolvedAttribute` returned by `"...".attr` is wrapped by the implicit class `DslAttr`.

`DslAttr` and its super class implement `DslAttr.expr` such that a new `UnresolvedAttribute` is created from `UnresolvedAttribute.name` of the wrapped attribute [(here)](https://github.com/apache/spark/blob/87a5442f7ed96b11051d8a9333476d080054e5a0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala#L273-L280).

But `UnresolvedAttribute.name` drops the quotes and thus the newly created `UnresolvedAttribute` parses an identifier that should be quoted but isn't:
```scala
scala> "`col/slash`".attr.name
res5: String = col/slash
```

### Does this PR introduce _any_ user-facing change?
DSL expressions on attributes with special characters no longer fail.

### How was this patch tested?
I couldn't find a suite testing the implicit classes in the DSL package, but the DSL package seems used widely enough that I'm confident this doesn't break existing behavior.

Locally, I was able to reproduce with this test; it was failing before and passes now:
```scala
test("chained DSL expressions on attributes with special characters") {
  $"`slashed/col`".asc
}
```