### PR TITLE
[WIP][SPARK-NNNNN] Updating AES-CBC support to not use OpenSSL's KDF

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -973,7 +973,7 @@
       "The value of parameter(s) <parameter> in <functionName> is invalid:"
     ],
     "subClass" : {
-      "AES_KEY" : {
+      "AES_CRYPTO_ERROR" : {
         "message" : [
           "detail message: <detailMessage>"
         ]
@@ -981,6 +981,11 @@
       "AES_KEY_LENGTH" : {
         "message" : [
           "expects a binary value with 16, 24 or 32 bytes, but got <actualLength> bytes."
+        ]
+      },
+      "AES_IV_LENGTH" : {
+        "message" : [
+          "supports 16-byte CBC IVs and 12-byte GCM IVs, but got <actualLength> bytes for <mode>."
         ]
       },
       "AES_SALTED_MAGIC" : {
@@ -1697,6 +1702,16 @@
       "AES_MODE" : {
         "message" : [
           "AES-<mode> with the padding <padding> by the <functionName> function."
+        ]
+      },
+      "AES_MODE_IV" : {
+        "message" : [
+          "<functionName> with AES-<mode> does not support initialization vectors (IVs)."
+        ]
+      },
+      "AES_MODE_AAD" : {
+        "message" : [
+          "<functionName> with AES-<mode> does not support additional authenticate data (AAD)."
         ]
       },
       "ANALYZE_UNCACHED_TEMP_VIEW" : {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
@@ -35,34 +35,31 @@ import java.security.spec.AlgorithmParameterSpec;
  */
 public class ExpressionImplUtils {
   private static final ThreadLocal<SecureRandom> threadLocalSecureRandom =
-    new ThreadLocal<SecureRandom>() {
-      @Override
-      public SecureRandom initialValue() {
-        return new SecureRandom();
-      }
-    };
+    ThreadLocal.withInitial(() -> new SecureRandom());
 
   private static final int GCM_IV_LEN = 12;
   private static final int GCM_TAG_LEN = 128;
   private static final int CBC_IV_LEN = 16;
 
   enum CipherMode {
-    ECB("ECB", 0, 0, "AES/ECB/PKCS5Padding", false),
-    CBC("CBC", CBC_IV_LEN, 0, "AES/CBC/PKCS5Padding", true),
-    GCM("GCM", GCM_IV_LEN, GCM_TAG_LEN, "AES/GCM/NoPadding", true);
+    ECB("ECB", 0, 0, "AES/ECB/PKCS5Padding", false, false),
+    CBC("CBC", CBC_IV_LEN, 0, "AES/CBC/PKCS5Padding", true, false),
+    GCM("GCM", GCM_IV_LEN, GCM_TAG_LEN, "AES/GCM/NoPadding", true, true);
 
     private final String name;
     final int ivLength;
     final int tagLength;
     final String transformation;
     final boolean usesSpec;
+    final boolean supportsAad;
 
-    CipherMode(String name, int ivLen, int tagLen, String transformation, boolean usesSpec) {
+    CipherMode(String name, int ivLen, int tagLen, String transformation, boolean usesSpec, boolean supportsAad) {
       this.name = name;
       this.ivLength = ivLen;
       this.tagLength = tagLen;
       this.transformation = transformation;
       this.usesSpec = usesSpec;
+      this.supportsAad = supportsAad;
     }
 
     static CipherMode fromString(String modeName, String padding) {
@@ -110,11 +107,19 @@ public class ExpressionImplUtils {
   }
 
   public static byte[] aesEncrypt(byte[] input, byte[] key, UTF8String mode, UTF8String padding) {
-    return aesInternal(input, key, mode.toString(), padding.toString(), Cipher.ENCRYPT_MODE);
+    return aesEncrypt(input, key, mode, padding, null, null);
   }
 
   public static byte[] aesDecrypt(byte[] input, byte[] key, UTF8String mode, UTF8String padding) {
-    return aesInternal(input, key, mode.toString(), padding.toString(), Cipher.DECRYPT_MODE);
+    return aesDecrypt(input, key, mode, padding, null);
+  }
+
+  public static byte[] aesEncrypt(byte[] input, byte[] key, UTF8String mode, UTF8String padding, byte[] iv, byte[] aad) {
+    return aesInternal(input, key, mode.toString(), padding.toString(), Cipher.ENCRYPT_MODE, iv, aad);
+  }
+
+  public static byte[] aesDecrypt(byte[] input, byte[] key, UTF8String mode, UTF8String padding, byte[] aad) {
+    return aesInternal(input, key, mode.toString(), padding.toString(), Cipher.DECRYPT_MODE, null, aad);
   }
 
   private static SecretKeySpec getSecretKeySpec(byte[] key) {
@@ -148,20 +153,40 @@ public class ExpressionImplUtils {
       byte[] key,
       String mode,
       String padding,
-      int opmode) {
+      int opmode,
+      byte[] iv,
+      byte[] aad) {
     try {
       SecretKeySpec secretKey = getSecretKeySpec(key);
       CipherMode cipherMode = CipherMode.fromString(mode, padding);
       Cipher cipher = Cipher.getInstance(cipherMode.transformation);
       if (opmode == Cipher.ENCRYPT_MODE) {
         // This may be 0-length for ECB
-        byte[] iv = generateIv(cipherMode);
+        if (iv == null) {
+          iv = generateIv(cipherMode);
+        } else if (!cipherMode.usesSpec) {
+          // If the caller passes an IV, ensure the mode actually uses it.
+          throw QueryExecutionErrors.aesUnsupportedIv(mode);
+        }
+        if (iv.length != cipherMode.ivLength) {
+          throw QueryExecutionErrors.invalidAesIvLengthError(mode, iv.length);
+        }
+
         if (cipherMode.usesSpec) {
           AlgorithmParameterSpec algSpec = getParameterSpec(cipherMode, iv, 0);
           cipher.init(opmode, secretKey, algSpec);
         } else {
           cipher.init(opmode, secretKey);
         }
+
+        // If the cipher mode supports additional authenticated data and it is provided, update it
+        if (aad != null) {
+          if (cipherMode.supportsAad != true) {
+            throw QueryExecutionErrors.aesUnsupportedAad(mode);
+          }
+          cipher.updateAAD(aad);
+        }
+
         byte[] encrypted = cipher.doFinal(input, 0, input.length);
         if (iv.length > 0) {
           ByteBuffer byteBuffer = ByteBuffer.allocate(iv.length + encrypted.length);
@@ -175,6 +200,12 @@ public class ExpressionImplUtils {
         if (cipherMode.usesSpec) {
           AlgorithmParameterSpec algSpec = getParameterSpec(cipherMode, input, 0);
           cipher.init(opmode, secretKey, algSpec);
+          if (aad != null) {
+            if (cipherMode.supportsAad != true) {
+              throw QueryExecutionErrors.aesUnsupportedAad(mode);
+            }
+            cipher.updateAAD(aad);
+          }
           return cipher.doFinal(input, cipherMode.ivLength, input.length - cipherMode.ivLength);
         } else {
           cipher.init(opmode, secretKey);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
@@ -26,27 +26,59 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Arrays;
+import java.security.spec.AlgorithmParameterSpec;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * An utility class for constructing expressions.
  */
 public class ExpressionImplUtils {
-  private static final SecureRandom secureRandom = new SecureRandom();
+  private static final ThreadLocal<SecureRandom> threadLocalSecureRandom =
+    new ThreadLocal<SecureRandom>() {
+      @Override
+      public SecureRandom initialValue() {
+        return new SecureRandom();
+      }
+    };
+
   private static final int GCM_IV_LEN = 12;
   private static final int GCM_TAG_LEN = 128;
-
   private static final int CBC_IV_LEN = 16;
-  private static final int CBC_SALT_LEN = 8;
-  /** OpenSSL's magic initial bytes. */
-  private static final String SALTED_STR = "Salted__";
-  private static final byte[] SALTED_MAGIC = SALTED_STR.getBytes(US_ASCII);
 
+  enum CipherMode {
+    ECB("ECB", 0, 0, "AES/ECB/PKCS5Padding", false),
+    CBC("CBC", CBC_IV_LEN, 0, "AES/CBC/PKCS5Padding", true),
+    GCM("GCM", GCM_IV_LEN, GCM_TAG_LEN, "AES/GCM/NoPadding", true);
+
+    private final String name;
+    final int ivLength;
+    final int tagLength;
+    final String transformation;
+    final boolean usesSpec;
+
+    CipherMode(String name, int ivLen, int tagLen, String transformation, boolean usesSpec) {
+      this.name = name;
+      this.ivLength = ivLen;
+      this.tagLength = tagLen;
+      this.transformation = transformation;
+      this.usesSpec = usesSpec;
+    }
+
+    static CipherMode fromString(String modeName, String padding) {
+      if (modeName.equalsIgnoreCase("ECB") &&
+              (padding.equalsIgnoreCase("PKCS") || padding.equalsIgnoreCase("DEFAULT"))) {
+        return ECB;
+      } else if (modeName.equalsIgnoreCase("CBC") &&
+              (padding.equalsIgnoreCase("PKCS") || padding.equalsIgnoreCase("DEFAULT"))) {
+        return CBC;
+      } else if (modeName.equalsIgnoreCase("GCM") &&
+              (padding.equalsIgnoreCase("NONE") || padding.equalsIgnoreCase("DEFAULT"))) {
+        return GCM;
+      }
+      throw QueryExecutionErrors.aesModeUnsupportedError(modeName, padding);
+    }
+  }
 
   /**
    * Function to check if a given number string is a valid Luhn number
@@ -85,85 +117,68 @@ public class ExpressionImplUtils {
     return aesInternal(input, key, mode.toString(), padding.toString(), Cipher.DECRYPT_MODE);
   }
 
+  private static SecretKeySpec getSecretKeySpec(byte[] key) {
+    switch (key.length) {
+      case 16: case 24: case 32:
+        return new SecretKeySpec(key, 0, key.length, "AES");
+      default:
+        throw QueryExecutionErrors.invalidAesKeyLengthError(key.length);
+    }
+  }
+
+  private static byte[] generateIv(CipherMode mode) {
+    byte[] iv = new byte[mode.ivLength];
+    threadLocalSecureRandom.get().nextBytes(iv);
+    return iv;
+  }
+
+  private static AlgorithmParameterSpec getParameterSpec(CipherMode mode, byte[] input, int offset) {
+    switch (mode) {
+      case CBC:
+        return new IvParameterSpec(input, offset, mode.ivLength);
+      case GCM:
+        return new GCMParameterSpec(mode.tagLength, input, offset, mode.ivLength);
+      default:
+        return null;
+    }
+  }
+
   private static byte[] aesInternal(
       byte[] input,
       byte[] key,
       String mode,
       String padding,
       int opmode) {
-    SecretKeySpec secretKey;
-
-    switch (key.length) {
-      case 16:
-      case 24:
-      case 32:
-        secretKey = new SecretKeySpec(key, 0, key.length, "AES");
-        break;
-      default:
-        throw QueryExecutionErrors.invalidAesKeyLengthError(key.length);
-      }
-
     try {
-      if (mode.equalsIgnoreCase("ECB") &&
-          (padding.equalsIgnoreCase("PKCS") || padding.equalsIgnoreCase("DEFAULT"))) {
-        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
-        cipher.init(opmode, secretKey);
-        return cipher.doFinal(input, 0, input.length);
-      } else if (mode.equalsIgnoreCase("GCM") &&
-          (padding.equalsIgnoreCase("NONE") || padding.equalsIgnoreCase("DEFAULT"))) {
-        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-        if (opmode == Cipher.ENCRYPT_MODE) {
-          byte[] iv = new byte[GCM_IV_LEN];
-          secureRandom.nextBytes(iv);
-          GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_LEN, iv);
-          cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec);
-          byte[] encrypted = cipher.doFinal(input, 0, input.length);
+      SecretKeySpec secretKey = getSecretKeySpec(key);
+      CipherMode cipherMode = CipherMode.fromString(mode, padding);
+      Cipher cipher = Cipher.getInstance(cipherMode.transformation);
+      if (opmode == Cipher.ENCRYPT_MODE) {
+        // This may be 0-length for ECB
+        byte[] iv = generateIv(cipherMode);
+        if (cipherMode.usesSpec) {
+          AlgorithmParameterSpec algSpec = getParameterSpec(cipherMode, iv, 0);
+          cipher.init(opmode, secretKey, algSpec);
+        } else {
+          cipher.init(opmode, secretKey);
+        }
+        byte[] encrypted = cipher.doFinal(input, 0, input.length);
+        if (iv.length > 0) {
           ByteBuffer byteBuffer = ByteBuffer.allocate(iv.length + encrypted.length);
           byteBuffer.put(iv);
           byteBuffer.put(encrypted);
           return byteBuffer.array();
         } else {
-          assert(opmode == Cipher.DECRYPT_MODE);
-          GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_LEN, input, 0, GCM_IV_LEN);
-          cipher.init(Cipher.DECRYPT_MODE, secretKey, parameterSpec);
-          return cipher.doFinal(input, GCM_IV_LEN, input.length - GCM_IV_LEN);
+          return encrypted;
         }
-      } else if (mode.equalsIgnoreCase("CBC") &&
-          (padding.equalsIgnoreCase("PKCS") || padding.equalsIgnoreCase("DEFAULT"))) {
-        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-        if (opmode == Cipher.ENCRYPT_MODE) {
-          byte[] salt = new byte[CBC_SALT_LEN];
-          secureRandom.nextBytes(salt);
-          final byte[] keyAndIv = getKeyAndIv(key, salt);
-          final byte[] keyValue = Arrays.copyOfRange(keyAndIv, 0, key.length);
-          final byte[] iv = Arrays.copyOfRange(keyAndIv, key.length, key.length + CBC_IV_LEN);
-          cipher.init(
-            Cipher.ENCRYPT_MODE,
-            new SecretKeySpec(keyValue, "AES"),
-            new IvParameterSpec(iv));
-          byte[] encrypted = cipher.doFinal(input, 0, input.length);
-          ByteBuffer byteBuffer = ByteBuffer.allocate(
-            SALTED_MAGIC.length + CBC_SALT_LEN + encrypted.length);
-          byteBuffer.put(SALTED_MAGIC);
-          byteBuffer.put(salt);
-          byteBuffer.put(encrypted);
-          return byteBuffer.array();
+      } else if (opmode == Cipher.DECRYPT_MODE) {
+        if (cipherMode.usesSpec) {
+          AlgorithmParameterSpec algSpec = getParameterSpec(cipherMode, input, 0);
+          cipher.init(opmode, secretKey, algSpec);
+          return cipher.doFinal(input, cipherMode.ivLength, input.length - cipherMode.ivLength);
         } else {
-          assert(opmode == Cipher.DECRYPT_MODE);
-          final byte[] shouldBeMagic = Arrays.copyOfRange(input, 0, SALTED_MAGIC.length);
-          if (!Arrays.equals(shouldBeMagic, SALTED_MAGIC)) {
-            throw QueryExecutionErrors.aesInvalidSalt(shouldBeMagic);
-          }
-          final byte[] salt = Arrays.copyOfRange(
-            input, SALTED_MAGIC.length, SALTED_MAGIC.length + CBC_SALT_LEN);
-          final byte[] keyAndIv = getKeyAndIv(key, salt);
-          final byte[] keyValue = Arrays.copyOfRange(keyAndIv, 0, key.length);
-          final byte[] iv = Arrays.copyOfRange(keyAndIv, key.length, key.length + CBC_IV_LEN);
-          cipher.init(
-            Cipher.DECRYPT_MODE,
-            new SecretKeySpec(keyValue, "AES"),
-            new IvParameterSpec(iv, 0, CBC_IV_LEN));
-          return cipher.doFinal(input, CBC_IV_LEN, input.length - CBC_IV_LEN);
+          cipher.init(opmode, secretKey);
+          return cipher.doFinal(input, 0, input.length);
         }
       } else {
         throw QueryExecutionErrors.aesModeUnsupportedError(mode, padding);
@@ -171,27 +186,5 @@ public class ExpressionImplUtils {
     } catch (GeneralSecurityException e) {
       throw QueryExecutionErrors.aesCryptoError(e.getMessage());
     }
-  }
-
-  // Derive the key and init vector in the same way as OpenSSL's EVP_BytesToKey
-  // since the version 1.1.0c which switched to SHA-256 as the hash.
-  private static byte[] getKeyAndIv(byte[] key, byte[] salt) throws NoSuchAlgorithmException {
-    final byte[] keyAndSalt = arrConcat(key, salt);
-    byte[] hash = new byte[0];
-    byte[] keyAndIv = new byte[0];
-    for (int i = 0; i < 3 && keyAndIv.length < key.length + CBC_IV_LEN; i++) {
-      final byte[] hashData = arrConcat(hash, keyAndSalt);
-      final MessageDigest md = MessageDigest.getInstance("SHA-256");
-      hash = md.digest(hashData);
-      keyAndIv = arrConcat(keyAndIv, hash);
-    }
-    return keyAndIv;
-  }
-
-  private static byte[] arrConcat(final byte[] arr1, final byte[] arr2) {
-    final byte[] res = new byte[arr1.length + arr2.length];
-    System.arraycopy(arr1, 0, res, 0, arr1.length);
-    System.arraycopy(arr2, 0, res, arr1.length, arr2.length);
-    return res;
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2644,20 +2644,37 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
 
   def aesCryptoError(detailMessage: String): RuntimeException = {
     new SparkRuntimeException(
-      errorClass = "INVALID_PARAMETER_VALUE.AES_KEY",
+      errorClass = "INVALID_PARAMETER_VALUE.AES_CRYPTO_ERROR",
       messageParameters = Map(
         "parameter" -> (toSQLId("expr") + ", " + toSQLId("key")),
         "functionName" -> aesFuncName,
         "detailMessage" -> detailMessage))
   }
 
-  def aesInvalidSalt(saltedMagic: Array[Byte]): RuntimeException = {
+  def invalidAesIvLengthError(mode: String, actualLength: Int): RuntimeException = {
     new SparkRuntimeException(
-      errorClass = "INVALID_PARAMETER_VALUE.AES_SALTED_MAGIC",
+      errorClass = "INVALID_PARAMETER_VALUE.AES_IV_LENGTH",
       messageParameters = Map(
-        "parameter" -> toSQLId("expr"),
-        "functionName" -> toSQLId("aes_decrypt"),
-        "saltedMagic" -> saltedMagic.map("%02X" format _).mkString("0x", "", "")))
+        "mode" -> mode,
+        "parameter" -> toSQLId("iv"),
+        "functionName" -> aesFuncName,
+        "actualLength" -> actualLength.toString()))
+  }
+
+  def aesUnsupportedIv(mode: String): RuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "UNSUPPORTED_FEATURE.AES_MODE_IV",
+      messageParameters = Map(
+        "mode" -> mode,
+        "functionName" -> toSQLId("aes_encrypt")))
+  }
+
+  def aesUnsupportedAad(mode: String): RuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "UNSUPPORTED_FEATURE.AES_MODE_AAD",
+      messageParameters = Map(
+        "mode" -> mode,
+        "functionName" -> toSQLId("aes_encrypt")))
   }
 
   def hiveTableWithAnsiIntervalsError(tableName: String): SparkUnsupportedOperationException = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -344,6 +344,30 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("misc aes function") {
+    val key32 = "abcdefghijklmnop12345678ABCDEFGH"
+    val encryptedEcb = "9J3iZbIxnmaG+OIA9Amd+A=="
+    val encryptedGcm = "y5la3muiuxN2suj6VsYXB+0XUFjtrUD0/zv5eDafsA3U"
+    val encryptedCbc = "+MgyzJxhusYVGWCljk7fhhl6C6oUqWmtdqoaG93KvhY="
+    val df1 = Seq("Spark").toDF
+
+    // Successful decryption of fixed values
+    Seq(
+      (key32, encryptedEcb, "ECB"),
+      (key32, encryptedGcm, "GCM"),
+      (key32, encryptedCbc, "CBC")).foreach {
+      case (key, encryptedText, mode) =>
+        checkAnswer(
+          df1.selectExpr(
+            s"cast(aes_decrypt(unbase64('$encryptedText'), '$key', '$mode') as string)"),
+          Seq(Row("Spark")))
+        checkAnswer(
+          df1.selectExpr(
+            s"cast(aes_decrypt(unbase64('$encryptedText'), binary('$key'), '$mode') as string)"),
+          Seq(Row("Spark")))
+    }
+  }
+
+  test("misc aes ECB function") {
     val key16 = "abcdefghijklmnop"
     val key24 = "abcdefghijklmnop12345678"
     val key32 = "abcdefghijklmnop12345678ABCDEFGH"
@@ -358,15 +382,15 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
 
     // Successful encryption
     Seq(
-      (key16, encryptedText16, encryptedEmptyText16),
-      (key24, encryptedText24, encryptedEmptyText24),
-      (key32, encryptedText32, encryptedEmptyText32)).foreach {
-      case (key, encryptedText, encryptedEmptyText) =>
+      (key16, encryptedText16, encryptedEmptyText16, "ECB"),
+      (key24, encryptedText24, encryptedEmptyText24, "ECB"),
+      (key32, encryptedText32, encryptedEmptyText32, "ECB")).foreach {
+      case (key, encryptedText, encryptedEmptyText, mode) =>
         checkAnswer(
-          df1.selectExpr(s"base64(aes_encrypt(value, '$key', 'ECB'))"),
+          df1.selectExpr(s"base64(aes_encrypt(value, '$key', '$mode'))"),
           Seq(Row(encryptedText), Row(encryptedEmptyText)))
         checkAnswer(
-          df1.selectExpr(s"base64(aes_encrypt(binary(value), '$key', 'ECB'))"),
+          df1.selectExpr(s"base64(aes_encrypt(binary(value), '$key', '$mode'))"),
           Seq(Row(encryptedText), Row(encryptedEmptyText)))
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
@@ -17,22 +17,29 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.unsafe.types.UTF8String
 
-
 class ExpressionImplUtilsSuite extends SparkFunSuite {
+  private val b64decoder = java.util.Base64.getDecoder
+  private val b64encoder = java.util.Base64.getEncoder
+
   case class TestCase(
     plaintext: String,
     key: String,
     base64CiphertextExpected: String,
     mode: String,
-    padding: String = "Default") {
+    padding: String = "Default",
+    ivHex: String = null,
+    aad: String = null,
+    expectedErrorClass: String = null) {
     val plaintextBytes = plaintext.getBytes("UTF-8")
     val keyBytes = key.getBytes("UTF-8")
     val utf8mode = UTF8String.fromString(mode)
     val utf8Padding = UTF8String.fromString(padding)
-    val deterministic = mode.equalsIgnoreCase("ECB")
+    val deterministic = mode.equalsIgnoreCase("ECB") || (ivHex != null)
+    val ivBytes = if (ivHex == null) null else Hex.unhex(ivHex.getBytes("UTF-8"))
+    val aadBytes = if (aad == null) null else aad.getBytes("UTF-8")
   }
 
   val testCases = Seq(
@@ -81,29 +88,173 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
   )
 
   test("AesDecrypt Only") {
-    val decoder = java.util.Base64.getDecoder
-    testCases.foreach { t =>
-      val expectedBytes = decoder.decode(t.base64CiphertextExpected)
-      val decryptedBytes =
-        ExpressionImplUtils.aesDecrypt(expectedBytes, t.keyBytes, t.utf8mode, t.utf8Padding)
-      val decryptedString = new String(decryptedBytes)
-      assert(decryptedString == t.plaintext)
-    }
+    testCases.map(decOnlyCase)
   }
 
   test("AesEncrypt and AesDecrypt") {
-    val encoder = java.util.Base64.getEncoder
-    testCases.foreach { t =>
-      val ciphertextBytes =
-        ExpressionImplUtils.aesEncrypt(t.plaintextBytes, t.keyBytes, t.utf8mode, t.utf8Padding)
-      val ciphertextBase64 = encoder.encodeToString(ciphertextBytes)
-      val decryptedBytes =
-        ExpressionImplUtils.aesDecrypt(ciphertextBytes, t.keyBytes, t.utf8mode, t.utf8Padding)
-      val decryptedString = new String(decryptedBytes)
-      assert(decryptedString == t.plaintext)
-      if (t.deterministic) {
-        assert(t.base64CiphertextExpected == ciphertextBase64)
+    testCases.map(encDecCase)
+  }
+
+  val ivAadTestCases = Seq(
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg=",
+      "CBC",
+      ivHex = "00000000000000000000000000000000"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "AAAAAAAAAAAAAAAAQiYi+sRNYDAOTjdSEcYBFsAWPL1f",
+      "GCM",
+      ivHex = "000000000000000000000000"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "AAAAAAAAAAAAAAAAQiYi+sTLm7KD9UcZ2nlRdYDe/PX4",
+      "GCM",
+      ivHex = "000000000000000000000000",
+      aad = "This is an AAD mixed into the input"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "AAAAAAAAAAAAAAAAQiYi+sTLm7KD9UcZ2nlRdYDe/PX4",
+      "GCM",
+      aad = "This is an AAD mixed into the input")
+  )
+
+  test("AesDecrypt only with IVs or AADs") {
+    ivAadTestCases.map(decOnlyCase)
+  }
+
+  test("AesEncrypt and AesDecrypt with IVs or AADs") {
+    ivAadTestCases.map(encDecCase)
+  }
+
+  def decOnlyCase(t: TestCase): Unit = {
+    val expectedBytes = b64decoder.decode(t.base64CiphertextExpected)
+    val decryptedBytes = ExpressionImplUtils.aesDecrypt(
+      expectedBytes,
+      t.keyBytes,
+      t.utf8mode,
+      t.utf8Padding,
+      t.aadBytes
+    )
+    val decryptedString = new String(decryptedBytes)
+    assert(decryptedString == t.plaintext)
+  }
+
+  def encDecCase(t: TestCase): Unit = {
+    val ciphertextBytes = ExpressionImplUtils.aesEncrypt(
+      t.plaintextBytes,
+      t.keyBytes,
+      t.utf8mode,
+      t.utf8Padding,
+      t.ivBytes,
+      t.aadBytes
+    )
+    val ciphertextBase64 = b64encoder.encodeToString(ciphertextBytes)
+    val decryptedBytes = ExpressionImplUtils.aesDecrypt(
+      ciphertextBytes,
+      t.keyBytes,
+      t.utf8mode,
+      t.utf8Padding,
+      t.aadBytes
+    )
+    val decryptedString = new String(decryptedBytes)
+    assert(decryptedString == t.plaintext)
+    if (t.deterministic) {
+      assert(t.base64CiphertextExpected == ciphertextBase64)
+    }
+  }
+
+  val unsupportedErrorCases = Seq(
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "unused",
+      "ECB",
+      ivHex = "0000000000000000",
+      expectedErrorClass = "UNSUPPORTED_FEATURE.AES_MODE_IV"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "unused",
+      "ECB",
+      aad = "ECB does not support AAD mode",
+      expectedErrorClass = "UNSUPPORTED_FEATURE.AES_MODE_AAD"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "unused",
+      "CBC",
+      ivHex = "0000000000",
+      expectedErrorClass = "INVALID_PARAMETER_VALUE.AES_IV_LENGTH"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "unused",
+      "GCM",
+      ivHex = "0000000000",
+      expectedErrorClass = "INVALID_PARAMETER_VALUE.AES_IV_LENGTH"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "unused",
+      "GCM",
+      padding = "PKCS",
+      expectedErrorClass = "UNSUPPORTED_FEATURE.AES_MODE"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "unused",
+      "CBC",
+      aad = "CBC doesn't support AADs",
+      expectedErrorClass = "UNSUPPORTED_FEATURE.AES_MODE_AAD")
+  )
+
+  test("AesEncrypt unsupported errors") {
+    unsupportedErrorCases.foreach { t =>
+      val e1 = intercept[SparkRuntimeException] {
+        encDecCase(t)
       }
+      assert(e1.isInstanceOf[SparkRuntimeException])
+      assert(e1.getErrorClass == t.expectedErrorClass)
+    }
+  }
+
+  val corruptedCiphertexts = Seq(
+    // This is truncated
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "+MgyzJxhusYVGWCljk7fhhl6C6oUqWmtdqoaG93=",
+      "CBC",
+      expectedErrorClass = "INVALID_PARAMETER_VALUE.AES_CRYPTO_ERROR"),
+    // The ciphertext is corrupted
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "y5la3muiuxN2suj6VsYXB+1XUFjtrUD0/zv5eDafsA3U",
+      "GCM",
+      expectedErrorClass = "INVALID_PARAMETER_VALUE.AES_CRYPTO_ERROR"),
+    // Valid ciphertext, wrong AAD
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "AAAAAAAAAAAAAAAAQiYi+sTLm7KD9UcZ2nlRdYDe/PX4",
+      "GCM",
+      aad = "The ciphertext is valid, but the AAD is wrong",
+      expectedErrorClass = "INVALID_PARAMETER_VALUE.AES_CRYPTO_ERROR")
+  )
+
+  test("AesEncrypt Expected Errors") {
+    corruptedCiphertexts.foreach { t =>
+      val e1 = intercept[SparkRuntimeException] {
+        decOnlyCase(t)
+      }
+      assert(e1.isInstanceOf[SparkRuntimeException])
+      assert(e1.getErrorClass == t.expectedErrorClass)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.unsafe.types.UTF8String
+
+
+class ExpressionImplUtilsSuite extends SparkFunSuite {
+  case class TestCase(
+    plaintext: String,
+    key: String,
+    base64CiphertextExpected: String,
+    mode: String,
+    padding: String = "Default") {
+    val plaintextBytes = plaintext.getBytes("UTF-8")
+    val keyBytes = key.getBytes("UTF-8")
+    val utf8mode = UTF8String.fromString(mode)
+    val utf8Padding = UTF8String.fromString(padding)
+    val deterministic = mode.equalsIgnoreCase("ECB")
+  }
+
+  val testCases = Seq(
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop",
+      "4Hv0UKCx6nfUeAoPZo1z+w==",
+      "ECB"),
+    TestCase("Spark",
+      "abcdefghijklmnop12345678",
+      "NeTYNgA+PCQBN50DA//O2w==",
+      "ECB"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "9J3iZbIxnmaG+OIA9Amd+A==",
+      "ECB"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "+MgyzJxhusYVGWCljk7fhhl6C6oUqWmtdqoaG93KvhY=",
+      "CBC"),
+    TestCase(
+      "Spark",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "y5la3muiuxN2suj6VsYXB+0XUFjtrUD0/zv5eDafsA3U",
+      "GCM"),
+    TestCase(
+      "This message is longer than a single AES block and should work fine.",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "agUfTbLT8KPsqbAmQn/YdpohvxqX5bBsfFjtxE5UwqvO6EWSUVy" +
+        "jeDA6r30XyS0ARebsBgXKSExaAVZ40NMgDLQa6/o9pieYwLT5YXI7flU=",
+      "ECB"),
+    TestCase(
+      "This message is longer than a single AES block and should work fine.",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "cxUKNdlZa/6hT6gdhp46OThPcdNONdBwJj/Ctl6z4gWVKfcA6DE" +
+        "lJg84LbkueIifjNOTloduKgidk9G9a4BDsn0NjlGLUeG8GH1moPWb/+knBC7oT/OOA06W6rJXudDo",
+      "CBC"),
+    TestCase(
+      "This message is longer than a single AES block and should work fine.",
+      "abcdefghijklmnop12345678ABCDEFGH",
+      "73B0tHM3F7bvmG7yIZB9vMKnzHyuCYjD9PzAI7NJ+kDBWtaFO22" +
+        "n2cKlkNcCzr45a4Uol+sNtQwQAV7iRhBdt6YmXoviemyXJWOZ89G279SgxabaomEIyN/HZwenxeN4",
+      "GCM")
+  )
+
+  test("AesDecrypt Only") {
+    val decoder = java.util.Base64.getDecoder
+    testCases.foreach { t =>
+      val expectedBytes = decoder.decode(t.base64CiphertextExpected)
+      val decryptedBytes =
+        ExpressionImplUtils.aesDecrypt(expectedBytes, t.keyBytes, t.utf8mode, t.utf8Padding)
+      val decryptedString = new String(decryptedBytes)
+      assert(decryptedString == t.plaintext)
+    }
+  }
+
+  test("AesEncrypt and AesDecrypt") {
+    val encoder = java.util.Base64.getEncoder
+    testCases.foreach { t =>
+      val ciphertextBytes =
+        ExpressionImplUtils.aesEncrypt(t.plaintextBytes, t.keyBytes, t.utf8mode, t.utf8Padding)
+      val ciphertextBase64 = encoder.encodeToString(ciphertextBytes)
+      val decryptedBytes =
+        ExpressionImplUtils.aesDecrypt(ciphertextBytes, t.keyBytes, t.utf8mode, t.utf8Padding)
+      val decryptedString = new String(decryptedBytes)
+      assert(decryptedString == t.plaintext)
+      if (t.deterministic) {
+        assert(t.base64CiphertextExpected == ciphertextBase64)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

The current implementation of AES-CBC mode called via `aes_encrypt` and `aes_decrypt` uses a key derivation function (KDF) based on OpenSSL's [EVP_BytesToKey](https://www.openssl.org/docs/man3.0/man3/EVP_BytesToKey.html). This is intended for generating keys based on passwords and OpenSSL's documents discourage its use: "Newer applications should use a more modern algorithm".

`aes_encrypt` and `aes_decrypt` should use the key directly in CBC mode, as it does for both GCM and ECB mode. The output should then be the initialization vector (IV) prepended to the ciphertext – as is done with GCM mode:
`[16-byte randomly generated IV | AES-CBC encrypted ciphertext]`

### Why are the changes needed?

We want to have the ciphertext output similar across different modes. OpenSSL's EVP_BytesToKey is effectively deprecated and their own documentation says not to use it. Instead, CBC mode will generate a random vector.

### Does this PR introduce _any_ user-facing change?

AES-CBC output generated by the previous format will be incompatible with this change. That change was recently landed and we want to land this before CBC mode is used in practice.

### How was this patch tested?

A new unit test in `DataFrameFunctionsSuite` was added to test both GCM and CBC modes. Also, a new standalone unit test suite was added in `ExpressionImplUtilsSuite` to test all the modes and various key lengths.

CBC values can be verified with `openssl enc` using the following command:
```
echo -n "[INPUT]" | openssl enc -a -e -aes-256-cbc -iv [HEX IV] -K [HEX KEY]
echo -n "Spark" | openssl enc -a -e -aes-256-cbc -iv f8c832cc9c61bac6151960a58e4edf86 -K 6162636465666768696a6b6c6d6e6f7031323334353637384142434445464748
```
