### PR TITLE
[SPARK-43237][CORE] Handle null exception message in event log

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1565,7 +1565,8 @@ private[spark] object JsonProtocol {
   }
 
   def exceptionFromJson(json: JsonNode): Exception = {
-    val e = new Exception(json.get("Message").extractString)
+    val message = jsonOption(json.get("Message")).map(_.extractString).orNull
+    val e = new Exception(message)
     e.setStackTrace(stackTraceFromJson(json.get("Stack Trace")))
     e
   }

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -810,6 +810,11 @@ class JsonProtocolSuite extends SparkFunSuite {
     assert(exceptionFailure.description == null)
   }
 
+  test("SPARK-43237: Handle null exception message in event log") {
+    val exception = new Exception()
+    testException(exception)
+  }
+
   test("SPARK-43052: Handle stackTrace with null file name") {
     val stackTrace = Seq(new StackTraceElement("class", "method", null, -1)).toArray
     testStackTrace(stackTrace)
@@ -932,6 +937,12 @@ private[spark] object JsonProtocolSuite extends Assertions {
     val newValue = JsonProtocol.accumValueFromJson(name, json)
     val expectedValue = if (name.exists(_.startsWith(METRICS_PREFIX))) value else value.toString
     assert(newValue === expectedValue)
+  }
+
+  private def testException(exception: Exception): Unit = {
+    val newException = JsonProtocol.exceptionFromJson(
+      toJsonString(JsonProtocol.exceptionToJson(exception, _)))
+    assertEquals(exception, newException)
   }
 
   /** -------------------------------- *

--- a/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/JsonProtocolSuite.scala
@@ -816,8 +816,9 @@ class JsonProtocolSuite extends SparkFunSuite {
   }
 
   test("SPARK-43052: Handle stackTrace with null file name") {
-    val stackTrace = Seq(new StackTraceElement("class", "method", null, -1)).toArray
-    testStackTrace(stackTrace)
+    val ex = new Exception()
+    ex.setStackTrace(Array(new StackTraceElement("class", "method", null, -1)))
+    testException(ex)
   }
 }
 
@@ -912,12 +913,6 @@ private[spark] object JsonProtocolSuite extends Assertions {
     val newReason = JsonProtocol.taskEndReasonFromJson(
       toJsonString(JsonProtocol.taskEndReasonToJson(reason, _)))
     assertEquals(reason, newReason)
-  }
-
-  private def testStackTrace(stackTrace: Array[StackTraceElement]): Unit = {
-    val newStackTrace = JsonProtocol.stackTraceFromJson(
-      toJsonString(JsonProtocol.stackTraceToJson(stackTrace, _)))
-    assertSeqEquals(stackTrace, newStackTrace, assertStackTraceElementEquals)
   }
 
   private def testBlockId(blockId: BlockId): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Handle null exception message in event log

### Why are the changes needed?
NPE error when handling null exception message in event log

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added test in JsonProtocolSuite