### PR TITLE
[SPARK-43238][CORE] Support only decommission idle workers in standalone

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -134,8 +134,11 @@ private[deploy] object DeployMessages {
    * Used by the MasterWebUI to request the master to decommission all workers that are active on
    * any of the given hostnames.
    * @param hostnames: A list of hostnames without the ports. Like "localhost", "foo.bar.com" etc
+   * @param idleOnly: only decommission idle workers
    */
-  case class DecommissionWorkersOnHosts(hostnames: Seq[String])
+  case class DecommissionWorkersOnHosts(
+    hostnames: Seq[String],
+    idleOnly: Boolean = false)
 
   // Master to Worker
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
@@ -144,6 +144,8 @@ private[spark] class WorkerInfo(
 
   def isAlive(): Boolean = this.state == WorkerState.ALIVE
 
+  def isIdle: Boolean = coresUsed == 0 && memoryUsed == 0
+
   /**
    * acquire specified amount resources for driver/executor from the worker
    * @param resourceReqs the resources requirement from driver/executor

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
@@ -58,11 +58,12 @@ class MasterWebUI(
       override def doPost(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
         val hostnames: Seq[String] = Option(req.getParameterValues("host"))
           .getOrElse(Array[String]()).toSeq
+        val idleOnly: Boolean = Option(req.getParameter("idleOnly")).exists(_.toBoolean)
         if (!isDecommissioningRequestAllowed(req)) {
           resp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED)
         } else {
           val removedWorkers = masterEndpointRef.askSync[Integer](
-            DecommissionWorkersOnHosts(hostnames))
+            DecommissionWorkersOnHosts(hostnames, idleOnly))
           logInfo(s"Decommissioning of hosts $hostnames decommissioned $removedWorkers workers")
           if (removedWorkers > 0) {
             resp.setStatus(HttpServletResponse.SC_OK)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support only decommission idle workers in standalone

### Why are the changes needed?
Currently, standalone master web ui supports kill/decommission workers. But when graceful decommission is enabled, running task, shuffle and rdd migration could take long time. While waiting for running task, shuffle and rdd migration, decommissioned workers can't run new executors and decommissioned executors can't run new tasks. This caused lot of resource waste.

If only idle workers to be decommissioned, these workers could be shutdown and removed to save cost without waiting long decommissioning process.

### Does this PR introduce _any_ user-facing change?
Yes. 

POST http://masterWebUI:port/workers/kill/idleOnly=true
Default: false

### How was this patch tested?
Added test in MasterSuite
