### PR TITLE
[SPARK-43239][PS] Remove `null_counts` from info()

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -12057,7 +12057,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         verbose: Optional[bool] = None,
         buf: Optional[IO[str]] = None,
         max_cols: Optional[int] = None,
-        null_counts: Optional[bool] = None,
     ) -> None:
         """
         Print a concise summary of a DataFrame.
@@ -12170,7 +12169,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     buf=buf,
                     max_cols=max_cols,
                     memory_usage=False,
-                    null_counts=null_counts,
                 )
             finally:
                 del self._data


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove `null_counts` from info()

### Why are the changes needed?
Pandas 2.0 
_Removed deprecated null_counts argument in [DataFrame.info()](https://pandas.pydata.org/pandas-docs/version/2.0/reference/api/pandas.DataFrame.info.html#pandas.DataFrame.info). Use show_counts instead ([GH37999](https://github.com/pandas-dev/pandas/issues/37999))_

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Tested local 

### Before this PR

`F05.info()`

```
TypeError                                 Traceback (most recent call last)
Cell In[12], line 1
----> 1 F05.info()

File /opt/spark/python/pyspark/pandas/frame.py:12167, in DataFrame.info(self, verbose, buf, max_cols, null_counts)
  12163     count_func = self.count
  12164     self.count = (  # type: ignore[assignment]
  12165         lambda: count_func()._to_pandas()  # type: ignore[assignment, misc, union-attr]
  12166     )
> 12167     return pd.DataFrame.info(
  12168         self,  # type: ignore[arg-type]
  12169         verbose=verbose,
  12170         buf=buf,
  12171         max_cols=max_cols,
  12172         memory_usage=False,
  12173         null_counts=null_counts,
  12174     )
  12175 finally:
  12176     del self._data

TypeError: DataFrame.info() got an unexpected keyword argument 'null_counts'

```

### With this PR

`F05.info()`

```
<class 'pyspark.pandas.frame.DataFrame'>
Int64Index: 5257 entries, 0 to 5256
Data columns (total 203 columns):
 #    Column                                                               Non-Null Count  Dtype  
---   ------                                                               --------------  -----  
 0    DOFFIN_APPENDIX:EXPRESSION_OF_INTEREST_URL                           471 non-null    object
(...)

```
