### PR TITLE
[SPARK-43232][SQL] Improve ObjectHashAggregateExec performance for high cardinality

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SpecificInternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SpecificInternalRow.scala
@@ -218,6 +218,17 @@ final class SpecificInternalRow(val values: Array[MutableValue]) extends BaseGen
     }
   }
 
+  // avoid scala implicit conversion from `Array` to `Seq`
+  def this(dataTypes: Array[DataType]) = {
+    this(new Array[MutableValue](dataTypes.length))
+    val length = values.length
+    var i = 0
+    while (i < length) {
+      values(i) = dataTypeToMutableValue(dataTypes(i))
+      i += 1
+    }
+  }
+
   def this() = this(Seq.empty)
 
   def this(schema: StructType) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationIterator.scala
@@ -137,7 +137,7 @@ class ObjectAggregationIterator(
 
   // This function is used to read and process input rows. When processing input rows, it first uses
   // hash-based aggregation by putting groups and their buffers in `hashMap`. If `hashMap` grows too
-  // large, it destroys the `hashMap` and falls back to sort-based aggregation.
+  // large, it destroys and sorts the `hashMap` and falls back to sort-based aggregation.
   private def processInputs(): Unit = {
     // In-memory map to store aggregation buffer for hash-based aggregation.
     val hashMap = new ObjectAggregationMap()
@@ -252,14 +252,14 @@ class SortBasedAggregator(
       private var groupingKey: UnsafeRow = _
       /**
        * A flag to represent how to process row for current grouping key:
-       *  0: update input row to aggregation buffer
-       *  1: merge input aggregation buffer to sort based aggregation buffer
-       *  2: first update input row to aggregation buffer then merge it to sort based
-       *     aggregation buffer
+       *  0: update input row to `sortBasedAggregationBuffer`
+       *  1: merge input aggregation buffer to `sortBasedAggregationBuffer`
+       *  2: first update input row to aggregation buffer then merge it to
+       *     `sortBasedAggregationBuffer`
        *
        * The state transition is:
        * - If `initialAggBufferIterator` has no more row, then it's 0
-       * - If `inputIterator` has no more row, then then it's 1
+       * - If `inputIterator` has no more row, then it's 1
        * - If the grouping key of `initialAggBufferIterator` is bigger, then it's 0
        * - If the grouping key of `inputIterator` is bigger, then it's 1
        * - If the grouping key of `initialAggBufferIterator` and `inputIterator` are equivalent,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectAggregationIterator.scala
@@ -254,8 +254,8 @@ class SortBasedAggregator(
        * A flag to represent how to process row for current grouping key:
        *  0: update input row to `sortBasedAggregationBuffer`
        *  1: merge input aggregation buffer to `sortBasedAggregationBuffer`
-       *  2: first update input row to aggregation buffer then merge it to
-       *     `sortBasedAggregationBuffer`
+       *  2: first update input row to `sortBasedAggregationBuffer` then merge
+       *     input aggregation buffer to `sortBasedAggregationBuffer`
        *
        * The state transition is:
        * - If `initialAggBufferIterator` has no more row, then it's 0

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregationStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregationStoreSuite.scala
@@ -78,7 +78,11 @@ class SortBasedAggregationStoreSuite  extends SparkFunSuite with LocalSparkConte
       groupingSchema,
       updateInputRow,
       mergeAggBuffer,
-      createNewAggregationBuffer)
+      1,
+      {
+        buffer => buffer.setInt(0, 0)
+      }
+    )
 
     (5000 to 100000).foreach { _ =>
       randomKV(inputRow, group)

--- a/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-jdk11-results.txt
+++ b/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-jdk11-results.txt
@@ -2,44 +2,57 @@
 Hive UDAF vs Spark AF
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 hive udaf vs spark af:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hive udaf w/o group by                             6348           6413          73          0.0       96858.7       1.0X
-spark af w/o group by                                36             48          13          1.8         543.6     178.2X
-hive udaf w/ group by                              5243           5334         115          0.0       79997.2       1.2X
-spark af w/ group by w/o fallback                    39             45           7          1.7         602.2     160.8X
-spark af w/ group by w/ fallback                     47             56          16          1.4         717.9     134.9X
+hive udaf w/o group by                             6033           6257         155          0.0       92048.9       1.0X
+spark af w/o group by                                37             48          15          1.8         568.8     161.8X
+hive udaf w/ group by                              5100           5185          61          0.0       77823.6       1.2X
+spark af w/ group by w/o fallback                    42             47           5          1.6         633.3     145.3X
+spark af w/ group by w/ fallback                     48             53           7          1.4         732.2     125.7X
+
+
+================================================================================================
+ObjectHashAggregateExec vs SortAggregateExec - high cardinality
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+object agg v.s. sort agg with high cardinality:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+sort agg                                                11247          11559         378          0.9        1124.7       1.0X
+object agg w/o fallback                                 18166          18422         337          0.6        1816.6       0.6X
+object agg w/ fallback                                  13676          13735          81          0.7        1367.6       0.8X
 
 
 ================================================================================================
 ObjectHashAggregateExec vs SortAggregateExec - typed_count
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 object agg v.s. sort agg:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-sort agg w/ group by                              38088          38682         840          2.8         363.2       1.0X
-object agg w/ group by w/o fallback                8711           8729          13         12.0          83.1       4.4X
-object agg w/ group by w/ fallback                23137          25662         NaN          4.5         220.7       1.6X
-sort agg w/o group by                              5997           6011          15         17.5          57.2       6.4X
-object agg w/o group by w/o fallback               5448           5456           5         19.2          52.0       7.0X
+sort agg w/ group by                              37221          37233          17          2.8         355.0       1.0X
+object agg w/ group by w/o fallback                9490           9527          57         11.0          90.5       3.9X
+object agg w/ group by w/ fallback                22344          25224         NaN          4.7         213.1       1.7X
+sort agg w/o group by                              6164           6172           7         17.0          58.8       6.0X
+object agg w/o group by w/o fallback               5691           5708          17         18.4          54.3       6.5X
 
 
 ================================================================================================
 ObjectHashAggregateExec vs SortAggregateExec - percentile_approx
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 object agg v.s. sort agg:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-sort agg w/ group by                                775            873          74          2.7         369.6       1.0X
-object agg w/ group by w/o fallback                 655            812         216          3.2         312.2       1.2X
-object agg w/ group by w/ fallback                  816            866          43          2.6         388.9       1.0X
-sort agg w/o group by                               617            677          53          3.4         294.1       1.3X
-object agg w/o group by w/o fallback                636            708          62          3.3         303.1       1.2X
+sort agg w/ group by                                872            999         168          2.4         415.9       1.0X
+object agg w/ group by w/o fallback                 732            837          94          2.9         348.9       1.2X
+object agg w/ group by w/ fallback                  835            939          96          2.5         398.1       1.0X
+sort agg w/o group by                               644            725          66          3.3         307.0       1.4X
+object agg w/o group by w/o fallback                638            742         222          3.3         304.3       1.4X
 
 

--- a/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-jdk17-results.txt
+++ b/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-jdk17-results.txt
@@ -2,44 +2,57 @@
 Hive UDAF vs Spark AF
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 hive udaf vs spark af:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hive udaf w/o group by                             6581           6637          44          0.0      100418.2       1.0X
-spark af w/o group by                                39             48           9          1.7         591.9     169.7X
-hive udaf w/ group by                              5243           5286          33          0.0       79995.5       1.3X
-spark af w/ group by w/o fallback                    39             45           5          1.7         597.7     168.0X
-spark af w/ group by w/ fallback                     46             51           5          1.4         708.4     141.7X
+hive udaf w/o group by                             5391           5564         148          0.0       82255.6       1.0X
+spark af w/o group by                                40             51          10          1.6         612.0     134.4X
+hive udaf w/ group by                              4446           4568         138          0.0       67843.5       1.2X
+spark af w/ group by w/o fallback                    41             49           9          1.6         621.7     132.3X
+spark af w/ group by w/ fallback                     49             53           4          1.3         745.0     110.4X
+
+
+================================================================================================
+ObjectHashAggregateExec vs SortAggregateExec - high cardinality
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+object agg v.s. sort agg with high cardinality:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+sort agg                                                 9351           9563         236          1.1         935.1       1.0X
+object agg w/o fallback                                 17081          17864         705          0.6        1708.1       0.5X
+object agg w/ fallback                                  12428          12478          83          0.8        1242.8       0.8X
 
 
 ================================================================================================
 ObjectHashAggregateExec vs SortAggregateExec - typed_count
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 object agg v.s. sort agg:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-sort agg w/ group by                              31248          31468         311          3.4         298.0       1.0X
-object agg w/ group by w/o fallback                8470           8519          36         12.4          80.8       3.7X
-object agg w/ group by w/ fallback                20002          21558         NaN          5.2         190.8       1.6X
-sort agg w/o group by                              5748           5770          29         18.2          54.8       5.4X
-object agg w/o group by w/o fallback               4987           5008          18         21.0          47.6       6.3X
+sort agg w/ group by                              32604          32833         324          3.2         310.9       1.0X
+object agg w/ group by w/o fallback                9520           9606          62         11.0          90.8       3.4X
+object agg w/ group by w/ fallback                20542          23215         NaN          5.1         195.9       1.6X
+sort agg w/o group by                              6395           6433          33         16.4          61.0       5.1X
+object agg w/o group by w/o fallback               5513           5577          65         19.0          52.6       5.9X
 
 
 ================================================================================================
 ObjectHashAggregateExec vs SortAggregateExec - percentile_approx
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 object agg v.s. sort agg:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-sort agg w/ group by                                750            777          18          2.8         357.9       1.0X
-object agg w/ group by w/o fallback                 618            634          10          3.4         294.7       1.2X
-object agg w/ group by w/ fallback                  786            814          18          2.7         374.7       1.0X
-sort agg w/o group by                               549            611          23          3.8         261.9       1.4X
-object agg w/o group by w/o fallback                546            582          26          3.8         260.5       1.4X
+sort agg w/ group by                                825            863          31          2.5         393.3       1.0X
+object agg w/ group by w/o fallback                 605            646          36          3.5         288.6       1.4X
+object agg w/ group by w/ fallback                  796            819          19          2.6         379.7       1.0X
+sort agg w/o group by                               572            588          12          3.7         272.9       1.4X
+object agg w/o group by w/o fallback                562            573           6          3.7         267.7       1.5X
 
 

--- a/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-results.txt
+++ b/sql/hive/benchmarks/ObjectHashAggregateExecBenchmark-results.txt
@@ -2,44 +2,57 @@
 Hive UDAF vs Spark AF
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 hive udaf vs spark af:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-hive udaf w/o group by                             5404           5452          35          0.0       82452.9       1.0X
-spark af w/o group by                                30             36           7          2.2         461.6     178.6X
-hive udaf w/ group by                              4717           4739          42          0.0       71975.1       1.1X
-spark af w/ group by w/o fallback                    32             36           4          2.0         494.5     166.7X
-spark af w/ group by w/ fallback                     40             48          11          1.6         616.8     133.7X
+hive udaf w/o group by                             5400           5492         141          0.0       82398.5       1.0X
+spark af w/o group by                                30             36           6          2.2         460.7     178.9X
+hive udaf w/ group by                              4735           4749          13          0.0       72254.0       1.1X
+spark af w/ group by w/o fallback                    34             37           5          1.9         520.1     158.4X
+spark af w/ group by w/ fallback                     39             43          11          1.7         594.2     138.7X
+
+
+================================================================================================
+ObjectHashAggregateExec vs SortAggregateExec - high cardinality
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+object agg v.s. sort agg with high cardinality:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+sort agg                                                10273          10594         306          1.0        1027.3       1.0X
+object agg w/o fallback                                 19664          20330         686          0.5        1966.4       0.5X
+object agg w/ fallback                                  12125          12211          77          0.8        1212.5       0.8X
 
 
 ================================================================================================
 ObjectHashAggregateExec vs SortAggregateExec - typed_count
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 object agg v.s. sort agg:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-sort agg w/ group by                              31370          33120        2475          3.3         299.2       1.0X
-object agg w/ group by w/o fallback                8131           8271         128         12.9          77.5       3.9X
-object agg w/ group by w/ fallback                18268          18317          71          5.7         174.2       1.7X
-sort agg w/o group by                              5145           5184          39         20.4          49.1       6.1X
-object agg w/o group by w/o fallback               4609           4647          50         22.8          44.0       6.8X
+sort agg w/ group by                              31079          31976        1268          3.4         296.4       1.0X
+object agg w/ group by w/o fallback                9425           9516          86         11.1          89.9       3.3X
+object agg w/ group by w/ fallback                18556          19844        1142          5.7         177.0       1.7X
+sort agg w/o group by                              5915           5963          54         17.7          56.4       5.3X
+object agg w/o group by w/o fallback               5036           5102          59         20.8          48.0       6.2X
 
 
 ================================================================================================
 ObjectHashAggregateExec vs SortAggregateExec - percentile_approx
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1031-azure
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 object agg v.s. sort agg:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-sort agg w/ group by                                599            611           7          3.5         285.7       1.0X
-object agg w/ group by w/o fallback                 518            529           7          4.0         247.1       1.2X
-object agg w/ group by w/ fallback                  575            585           7          3.6         274.0       1.0X
-sort agg w/o group by                               414            422           6          5.1         197.4       1.4X
-object agg w/o group by w/o fallback                406            414           5          5.2         193.5       1.5X
+sort agg w/ group by                                665            682          10          3.2         316.9       1.0X
+object agg w/ group by w/o fallback                 516            525           8          4.1         246.1       1.3X
+object agg w/ group by w/ fallback                  609            621           8          3.4         290.5       1.1X
+sort agg w/o group by                               446            458           9          4.7         212.9       1.5X
+object agg w/o group by w/o fallback                433            446           6          4.8         206.6       1.5X
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The `ObjectHashAggregateExec` has three preformance issues:
- heavy overhead of scala sugar in `createNewAggregationBuffer`
- unnecessary grouping key comparation after fallback to sort based aggregator
- the aggregation buffer in sort based aggregator is not reused for all rest rows

Then the performance is poor with high cardinality grouping keys.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve performance

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
The test should be covered by `org.apache.spark.sql.execution.aggregate.SortBasedAggregationStoreSuite`

Add benchmark for high cardinality case. Note, in this case the performance with no fallback is slower than others.

```sql
-- 10 * 1000 * 1000 rows
df.groupBy("key1", "key2")
  .agg(sum($"value"), count($"value"), avg($"value"), max($"value"), min($"value"),
    collect_set($"value"))
  .noop()
```

before
```
OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Mac OS X 13.2
Apple M1 Pro
object agg v.s. sort agg with high cardinality:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------------------------
sort agg                                                 4997           5099         118          2.0         499.7       1.0X
object agg w/o fallback                                 12634          12944         311          0.8        1263.4       0.4X
object agg w/ fallback                                   8792           8871          84          1.1         879.2       0.6X
```
after
```
OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Mac OS X 13.2
Apple M1 Pro
object agg v.s. sort agg with high cardinality:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
sort agg                                                 4831           5060         199          2.1         483.1       1.0X
object agg w/o fallback                                  8971           9257         259          1.1         897.1       0.5X
object agg w/ fallback                                   5612           5706         102          1.8         561.2       0.9X
```
