### PR TITLE
[SPARK-43063][SQL][FOLLOWUP] Add ToPrettyString expression for Dataset.show

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyString.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyString.scala
@@ -55,7 +55,7 @@ case class ToPrettyString(child: Expression, timeZoneId: Option[String] = None)
 
   override def eval(input: InternalRow): Any = {
     val v = child.eval(input)
-    if (v == null) UTF8String.fromString("NULL") else castFunc(v)
+    if (v == null) UTF8String.fromString(nullString) else castFunc(v)
   }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -66,7 +66,7 @@ case class ToPrettyString(child: Expression, timeZoneId: Option[String] = None)
          |${childCode.code}
          |UTF8String ${ev.value};
          |if (${childCode.isNull}) {
-         |  ${ev.value} = UTF8String.fromString("NULL");
+         |  ${ev.value} = UTF8String.fromString("$nullString");
          |} else {
          |  $toStringCode
          |}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyString.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyString.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode, FalseLiteral}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.types.{DataType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * An internal expressions which is used to generate pretty string for all kinds of values. It has
+ * several differences with casting value to string:
+ *  - It prints null values (either from column or struct field) as "NULL".
+ *  - It prints binary values (either from column or struct field) using the hex format.
+ */
+case class ToPrettyString(child: Expression, timeZoneId: Option[String] = None)
+  extends UnaryExpression with TimeZoneAwareExpression with ToStringBase {
+
+  override def dataType: DataType = StringType
+
+  override def nullable: Boolean = false
+
+  override def withTimeZone(timeZoneId: String): ToPrettyString =
+    copy(timeZoneId = Some(timeZoneId))
+
+  override protected def withNewChildInternal(newChild: Expression): Expression =
+    copy(child = newChild)
+
+  override protected def leftBracket: String = "{"
+  override protected def rightBracket: String = "}"
+
+  override protected def nullString: String = "NULL"
+
+  override protected def useDecimalPlainString: Boolean = true
+
+  override protected def useHexFormatForBinary: Boolean = true
+
+  private[this] lazy val castFunc: Any => Any = castToString(child.dataType)
+
+  override def eval(input: InternalRow): Any = {
+    val v = child.eval(input)
+    if (v == null) UTF8String.fromString("NULL") else castFunc(v)
+  }
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val childCode = child.genCode(ctx)
+    val toStringCode = castToStringCode(child.dataType, ctx).apply(childCode.value, ev.value)
+    val finalCode =
+      code"""
+         |${childCode.code}
+         |UTF8String ${ev.value};
+         |if (${childCode.isNull}) {
+         |  ${ev.value} = UTF8String.fromString("NULL");
+         |} else {
+         |  $toStringCode
+         |}
+         |""".stripMargin
+    ev.copy(code = finalCode, isNull = FalseLiteral)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import java.time.ZoneOffset
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.util.{ArrayData, DateFormatter, IntervalStringStyles, IntervalUtils, MapData, StringUtils, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.IntervalStringStyles.ANSI_STYLE
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.UTF8StringBuilder
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
+
+  private lazy val dateFormatter = DateFormatter()
+  private lazy val timestampFormatter = TimestampFormatter.getFractionFormatter(zoneId)
+  private lazy val timestampNTZFormatter = TimestampFormatter.getFractionFormatter(ZoneOffset.UTC)
+
+  // The brackets that are used in casting structs and maps to strings
+  protected def leftBracket: String
+  protected def rightBracket: String
+
+  // The string value to use to represent null elements in array/struct/map.
+  protected def nullString: String
+
+  protected def useDecimalPlainString: Boolean
+
+  protected def useHexFormatForBinary: Boolean
+
+  // Makes the function accept Any type input by doing `asInstanceOf[T]`.
+  @inline private def acceptAny[T](func: T => Any): Any => Any = i => func(i.asInstanceOf[T])
+
+  // Returns a function to convert a value to pretty string. The function assumes input is not null.
+  protected final def castToString(from: DataType): Any => Any = from match {
+    case CalendarIntervalType =>
+      acceptAny[CalendarInterval](i => UTF8String.fromString(i.toString))
+    case BinaryType if useHexFormatForBinary =>
+      acceptAny[Array[Byte]](binary => UTF8String.fromString(StringUtils.getHexString(binary)))
+    case BinaryType =>
+      acceptAny[Array[Byte]](UTF8String.fromBytes)
+    case DateType =>
+      acceptAny[Int](d => UTF8String.fromString(dateFormatter.format(d)))
+    case TimestampType =>
+      acceptAny[Long](t => UTF8String.fromString(timestampFormatter.format(t)))
+    case TimestampNTZType =>
+      acceptAny[Long](t => UTF8String.fromString(timestampNTZFormatter.format(t)))
+    case ArrayType(et, _) =>
+      acceptAny[ArrayData](array => {
+        val builder = new UTF8StringBuilder
+        builder.append("[")
+        if (array.numElements > 0) {
+          val toUTF8String = castToString(et)
+          if (array.isNullAt(0)) {
+            if (nullString.nonEmpty) builder.append(nullString)
+          } else {
+            builder.append(toUTF8String(array.get(0, et)).asInstanceOf[UTF8String])
+          }
+          var i = 1
+          while (i < array.numElements) {
+            builder.append(",")
+            if (array.isNullAt(i)) {
+              if (nullString.nonEmpty) builder.append(" " + nullString)
+            } else {
+              builder.append(" ")
+              builder.append(toUTF8String(array.get(i, et)).asInstanceOf[UTF8String])
+            }
+            i += 1
+          }
+        }
+        builder.append("]")
+        builder.build()
+      })
+    case MapType(kt, vt, _) =>
+      acceptAny[MapData](map => {
+        val builder = new UTF8StringBuilder
+        builder.append(leftBracket)
+        if (map.numElements > 0) {
+          val keyArray = map.keyArray()
+          val valueArray = map.valueArray()
+          val keyToUTF8String = castToString(kt)
+          val valueToUTF8String = castToString(vt)
+          builder.append(keyToUTF8String(keyArray.get(0, kt)).asInstanceOf[UTF8String])
+          builder.append(" ->")
+          if (valueArray.isNullAt(0)) {
+            if (nullString.nonEmpty) builder.append(nullString)
+          } else {
+            builder.append(" ")
+            builder.append(valueToUTF8String(valueArray.get(0, vt)).asInstanceOf[UTF8String])
+          }
+          var i = 1
+          while (i < map.numElements) {
+            builder.append(", ")
+            builder.append(keyToUTF8String(keyArray.get(i, kt)).asInstanceOf[UTF8String])
+            builder.append(" ->")
+            if (valueArray.isNullAt(i)) {
+              if (nullString.nonEmpty) builder.append(" " + nullString)
+            } else {
+              builder.append(" ")
+              builder.append(valueToUTF8String(valueArray.get(i, vt))
+                .asInstanceOf[UTF8String])
+            }
+            i += 1
+          }
+        }
+        builder.append(rightBracket)
+        builder.build()
+      })
+    case StructType(fields) =>
+      acceptAny[InternalRow](row => {
+        val builder = new UTF8StringBuilder
+        builder.append(leftBracket)
+        if (row.numFields > 0) {
+          val st = fields.map(_.dataType)
+          val toUTF8StringFuncs = st.map(castToString)
+          if (row.isNullAt(0)) {
+            if (nullString.nonEmpty) builder.append(nullString)
+          } else {
+            builder.append(toUTF8StringFuncs(0)(row.get(0, st(0))).asInstanceOf[UTF8String])
+          }
+          var i = 1
+          while (i < row.numFields) {
+            builder.append(",")
+            if (row.isNullAt(i)) {
+              if (nullString.nonEmpty) builder.append(" " + nullString)
+            } else {
+              builder.append(" ")
+              builder.append(toUTF8StringFuncs(i)(row.get(i, st(i))).asInstanceOf[UTF8String])
+            }
+            i += 1
+          }
+        }
+        builder.append(rightBracket)
+        builder.build()
+      })
+    case pudt: PythonUserDefinedType => castToString(pudt.sqlType)
+    case udt: UserDefinedType[_] =>
+      o => UTF8String.fromString(udt.deserialize(o).toString)
+    case YearMonthIntervalType(startField, endField) =>
+      acceptAny[Int](i => UTF8String.fromString(
+        IntervalUtils.toYearMonthIntervalString(i, ANSI_STYLE, startField, endField)))
+    case DayTimeIntervalType(startField, endField) =>
+      acceptAny[Long](i => UTF8String.fromString(
+        IntervalUtils.toDayTimeIntervalString(i, ANSI_STYLE, startField, endField)))
+    case _: DecimalType if useDecimalPlainString =>
+      acceptAny[Decimal](d => UTF8String.fromString(d.toPlainString))
+    case StringType => identity
+    case _ => o => UTF8String.fromString(o.toString)
+  }
+
+  // Returns a function to generate code to convert a value to pretty string. It assumes the input
+  // is not null.
+  @scala.annotation.tailrec
+  protected final def castToStringCode(
+      from: DataType, ctx: CodegenContext): (ExprValue, ExprValue) => Block = {
+    from match {
+      case BinaryType if useHexFormatForBinary =>
+        (c, evPrim) =>
+          val utilCls = StringUtils.getClass.getName.stripSuffix("$")
+          code"$evPrim = UTF8String.fromString($utilCls.getHexString($c));"
+      case BinaryType =>
+        (c, evPrim) => code"$evPrim = UTF8String.fromBytes($c);"
+      case DateType =>
+        val df = JavaCode.global(
+          ctx.addReferenceObj("dateFormatter", dateFormatter),
+          dateFormatter.getClass)
+        (c, evPrim) => code"$evPrim = UTF8String.fromString($df.format($c));"
+      case TimestampType =>
+        val tf = JavaCode.global(
+          ctx.addReferenceObj("timestampFormatter", timestampFormatter),
+          timestampFormatter.getClass)
+        (c, evPrim) => code"$evPrim = UTF8String.fromString($tf.format($c));"
+      case TimestampNTZType =>
+        val tf = JavaCode.global(
+          ctx.addReferenceObj("timestampNTZFormatter", timestampNTZFormatter),
+          timestampNTZFormatter.getClass)
+        (c, evPrim) => code"$evPrim = UTF8String.fromString($tf.format($c));"
+      case CalendarIntervalType =>
+        (c, evPrim) => code"$evPrim = UTF8String.fromString($c.toString());"
+      case ArrayType(et, _) =>
+        (c, evPrim) => {
+          val buffer = ctx.freshVariable("buffer", classOf[UTF8StringBuilder])
+          val bufferClass = JavaCode.javaType(classOf[UTF8StringBuilder])
+          val writeArrayElemCode = writeArrayToStringBuilder(et, c, buffer, ctx)
+          code"""
+             |$bufferClass $buffer = new $bufferClass();
+             |$writeArrayElemCode;
+             |$evPrim = $buffer.build();
+           """.stripMargin
+        }
+      case MapType(kt, vt, _) =>
+        (c, evPrim) => {
+          val buffer = ctx.freshVariable("buffer", classOf[UTF8StringBuilder])
+          val bufferClass = JavaCode.javaType(classOf[UTF8StringBuilder])
+          val writeMapElemCode = writeMapToStringBuilder(kt, vt, c, buffer, ctx)
+          code"""
+             |$bufferClass $buffer = new $bufferClass();
+             |$writeMapElemCode;
+             |$evPrim = $buffer.build();
+           """.stripMargin
+        }
+      case StructType(fields) =>
+        (c, evPrim) => {
+          val row = ctx.freshVariable("row", classOf[InternalRow])
+          val buffer = ctx.freshVariable("buffer", classOf[UTF8StringBuilder])
+          val bufferClass = JavaCode.javaType(classOf[UTF8StringBuilder])
+          val writeStructCode = writeStructToStringBuilder(fields.map(_.dataType), row, buffer, ctx)
+          code"""
+             |InternalRow $row = $c;
+             |$bufferClass $buffer = new $bufferClass();
+             |$writeStructCode
+             |$evPrim = $buffer.build();
+           """.stripMargin
+        }
+      case pudt: PythonUserDefinedType => castToStringCode(pudt.sqlType, ctx)
+      case udt: UserDefinedType[_] =>
+        val udtRef = JavaCode.global(ctx.addReferenceObj("udt", udt), udt.sqlType)
+        (c, evPrim) =>
+          code"$evPrim = UTF8String.fromString($udtRef.deserialize($c).toString());"
+      case i: YearMonthIntervalType =>
+        val iu = IntervalUtils.getClass.getName.stripSuffix("$")
+        val iss = IntervalStringStyles.getClass.getName.stripSuffix("$")
+        val style = s"$iss$$.MODULE$$.ANSI_STYLE()"
+        (c, evPrim) =>
+          // scalastyle:off line.size.limit
+          code"$evPrim = UTF8String.fromString($iu.toYearMonthIntervalString($c, $style, (byte)${i.startField}, (byte)${i.endField}));"
+          // scalastyle:on line.size.limit
+      case i: DayTimeIntervalType =>
+        val iu = IntervalUtils.getClass.getName.stripSuffix("$")
+        val iss = IntervalStringStyles.getClass.getName.stripSuffix("$")
+        val style = s"$iss$$.MODULE$$.ANSI_STYLE()"
+        (c, evPrim) =>
+          // scalastyle:off line.size.limit
+          code"$evPrim = UTF8String.fromString($iu.toDayTimeIntervalString($c, $style, (byte)${i.startField}, (byte)${i.endField}));"
+          // scalastyle:on line.size.limit
+      // In ANSI mode, Spark always use plain string representation on casting Decimal values
+      // as strings. Otherwise, the casting is using `BigDecimal.toString` which may use scientific
+      // notation if an exponent is needed.
+      case _: DecimalType if useDecimalPlainString =>
+        (c, evPrim) => code"$evPrim = UTF8String.fromString($c.toPlainString());"
+      case StringType =>
+        (c, evPrim) => code"$evPrim = $c;"
+      case _ =>
+        (c, evPrim) => code"$evPrim = UTF8String.fromString(String.valueOf($c));"
+    }
+  }
+
+  private def appendNull(buffer: ExprValue, isFirstElement: Boolean): Block = {
+    if (nullString.isEmpty) {
+      EmptyBlock
+    } else if (isFirstElement) {
+      code"""$buffer.append("$nullString");"""
+    } else {
+      code"""$buffer.append(" $nullString");"""
+    }
+  }
+
+  private def writeArrayToStringBuilder(
+      et: DataType,
+      array: ExprValue,
+      buffer: ExprValue,
+      ctx: CodegenContext): Block = {
+    val elementToStringCode = castToStringCode(et, ctx)
+    val funcName = ctx.freshName("elementToString")
+    val element = JavaCode.variable("element", et)
+    val elementStr = JavaCode.variable("elementStr", StringType)
+    val elementToStringFunc = inline"${ctx.addNewFunction(funcName,
+      s"""
+         |private UTF8String $funcName(${CodeGenerator.javaType(et)} $element) {
+         |  UTF8String $elementStr = null;
+         |  ${elementToStringCode(element, elementStr)}
+         |  return elementStr;
+         |}
+       """.stripMargin)}"
+
+    val loopIndex = ctx.freshVariable("loopIndex", IntegerType)
+    code"""
+       |$buffer.append("[");
+       |if ($array.numElements() > 0) {
+       |  if ($array.isNullAt(0)) {
+       |    ${appendNull(buffer, isFirstElement = true)}
+       |  } else {
+       |    $buffer.append($elementToStringFunc(${CodeGenerator.getValue(array, et, "0")}));
+       |  }
+       |  for (int $loopIndex = 1; $loopIndex < $array.numElements(); $loopIndex++) {
+       |    $buffer.append(",");
+       |    if ($array.isNullAt($loopIndex)) {
+       |      ${appendNull(buffer, isFirstElement = false)}
+       |    } else {
+       |      $buffer.append(" ");
+       |      $buffer.append($elementToStringFunc(${CodeGenerator.getValue(array, et, loopIndex)}));
+       |    }
+       |  }
+       |}
+       |$buffer.append("]");
+     """.stripMargin
+  }
+
+  private def writeMapToStringBuilder(
+      kt: DataType,
+      vt: DataType,
+      map: ExprValue,
+      buffer: ExprValue,
+      ctx: CodegenContext): Block = {
+
+    def dataToStringFunc(func: String, dataType: DataType) = {
+      val funcName = ctx.freshName(func)
+      val dataToStringCode = castToStringCode(dataType, ctx)
+      val data = JavaCode.variable("data", dataType)
+      val dataStr = JavaCode.variable("dataStr", StringType)
+      val functionCall = ctx.addNewFunction(funcName,
+        s"""
+           |private UTF8String $funcName(${CodeGenerator.javaType(dataType)} $data) {
+           |  UTF8String $dataStr = null;
+           |  ${dataToStringCode(data, dataStr)}
+           |  return dataStr;
+           |}
+         """.stripMargin)
+      inline"$functionCall"
+    }
+
+    val keyToStringFunc = dataToStringFunc("keyToString", kt)
+    val valueToStringFunc = dataToStringFunc("valueToString", vt)
+    val loopIndex = ctx.freshVariable("loopIndex", IntegerType)
+    val mapKeyArray = JavaCode.expression(s"$map.keyArray()", classOf[ArrayData])
+    val mapValueArray = JavaCode.expression(s"$map.valueArray()", classOf[ArrayData])
+    val getMapFirstKey = CodeGenerator.getValue(mapKeyArray, kt, JavaCode.literal("0", IntegerType))
+    val getMapFirstValue = CodeGenerator.getValue(mapValueArray, vt,
+      JavaCode.literal("0", IntegerType))
+    val getMapKeyArray = CodeGenerator.getValue(mapKeyArray, kt, loopIndex)
+    val getMapValueArray = CodeGenerator.getValue(mapValueArray, vt, loopIndex)
+    code"""
+       |$buffer.append("$leftBracket");
+       |if ($map.numElements() > 0) {
+       |  $buffer.append($keyToStringFunc($getMapFirstKey));
+       |  $buffer.append(" ->");
+       |  if ($map.valueArray().isNullAt(0)) {
+       |    ${appendNull(buffer, isFirstElement = true)}
+       |  } else {
+       |    $buffer.append(" ");
+       |    $buffer.append($valueToStringFunc($getMapFirstValue));
+       |  }
+       |  for (int $loopIndex = 1; $loopIndex < $map.numElements(); $loopIndex++) {
+       |    $buffer.append(", ");
+       |    $buffer.append($keyToStringFunc($getMapKeyArray));
+       |    $buffer.append(" ->");
+       |    if ($map.valueArray().isNullAt($loopIndex)) {
+       |      ${appendNull(buffer, isFirstElement = false)}
+       |    } else {
+       |      $buffer.append(" ");
+       |      $buffer.append($valueToStringFunc($getMapValueArray));
+       |    }
+       |  }
+       |}
+       |$buffer.append("$rightBracket");
+     """.stripMargin
+  }
+
+  private def writeStructToStringBuilder(
+      st: Seq[DataType],
+      row: ExprValue,
+      buffer: ExprValue,
+      ctx: CodegenContext): Block = {
+    val structToStringCode = st.zipWithIndex.map { case (ft, i) =>
+      val fieldToStringCode = castToStringCode(ft, ctx)
+      val field = ctx.freshVariable("field", ft)
+      val fieldStr = ctx.freshVariable("fieldStr", StringType)
+      val javaType = JavaCode.javaType(ft)
+      code"""
+         |${if (i != 0) code"""$buffer.append(",");""" else EmptyBlock}
+         |if ($row.isNullAt($i)) {
+         |  ${appendNull(buffer, isFirstElement = i == 0)}
+         |} else {
+         |  ${if (i != 0) code"""$buffer.append(" ");""" else EmptyBlock}
+         |
+         |  // Append $i field into the string buffer
+         |  $javaType $field = ${CodeGenerator.getValue(row, ft, s"$i")};
+         |  UTF8String $fieldStr = null;
+         |  ${fieldToStringCode(field, fieldStr)}
+         |  $buffer.append($fieldStr);
+         |}
+       """.stripMargin
+    }
+
+    val writeStructCode = ctx.splitExpressions(
+      expressions = structToStringCode.map(_.code),
+      funcName = "fieldToString",
+      arguments = ("InternalRow", row.code) ::
+        (classOf[UTF8StringBuilder].getName, buffer.code) :: Nil)
+
+    code"""
+       |$buffer.append("$leftBracket");
+       |$writeStructCode
+       |$buffer.append("$rightBracket");
+     """.stripMargin
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -67,6 +67,8 @@ object StringUtils extends Logging {
     "(?s)" + out.result() // (?s) enables dotall mode, causing "." to match new lines
   }
 
+  def getHexString(bytes: Array[Byte]): String = bytes.map("%02X".format(_)).mkString("[", " ", "]")
+
   private[this] val trueStrings =
     Set("t", "true", "y", "yes", "1").map(UTF8String.fromString)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -67,6 +67,10 @@ object StringUtils extends Logging {
     "(?s)" + out.result() // (?s) enables dotall mode, causing "." to match new lines
   }
 
+  /**
+   * Returns a pretty string of the byte array which prints each byte as a hex digit and add spaces
+   * between them. For example, [1A C0].
+   */
   def getHexString(bytes: Array[Byte]): String = bytes.map("%02X".format(_)).mkString("[", " ", "]")
 
   private[this] val trueStrings =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -784,7 +784,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     Seq(false, true).foreach { omitNull =>
       withSQLConf(SQLConf.LEGACY_COMPLEX_TYPES_TO_STRING.key -> omitNull.toString) {
         val ret3 = cast(Literal.create(Array("ab", null, "c")), StringType)
-        checkEvaluation(ret3, s"[ab,${if (omitNull) "" else " NULL"}, c]")
+        checkEvaluation(ret3, s"[ab,${if (omitNull) "" else " null"}, c]")
       }
     }
     val ret4 =
@@ -813,7 +813,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         val ret1 = cast(Literal.create(Array(null, null)), StringType)
         checkEvaluation(
           ret1,
-          s"[${if (omitNull) "" else "NULL"},${if (omitNull) "" else " NULL"}]")
+          s"[${if (omitNull) "" else "null"},${if (omitNull) "" else " null"}]")
       }
     }
   }
@@ -828,7 +828,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         val ret2 = cast(
           Literal.create(Map("1" -> "a".getBytes, "2" -> null, "3" -> "c".getBytes)),
           StringType)
-        checkEvaluation(ret2, s"${lb}1 -> a, 2 ->${if (legacyCast) "" else " NULL"}, 3 -> c$rb")
+        checkEvaluation(ret2, s"${lb}1 -> a, 2 ->${if (legacyCast) "" else " null"}, 3 -> c$rb")
         val ret3 = cast(
           Literal.create(Map(
             1 -> Date.valueOf("2014-12-03"),
@@ -860,7 +860,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         val ret1 = cast(Literal.create((1, "a", 0.1)), StringType)
         checkEvaluation(ret1, s"${lb}1, a, 0.1$rb")
         val ret2 = cast(Literal.create(Tuple3[Int, String, String](1, null, "a")), StringType)
-        checkEvaluation(ret2, s"${lb}1,${if (legacyCast) "" else " NULL"}, a$rb")
+        checkEvaluation(ret2, s"${lb}1,${if (legacyCast) "" else " null"}, a$rb")
         val ret3 = cast(Literal.create(
           (Date.valueOf("2014-12-03"), Timestamp.valueOf("2014-12-03 15:05:00"))), StringType)
         checkEvaluation(ret3, s"${lb}2014-12-03, 2014-12-03 15:05:00$rb")
@@ -882,7 +882,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         val ret1 = cast(Literal.create(Tuple2[String, String](null, null)), StringType)
         checkEvaluation(
           ret1,
-          s"$lb${if (legacyCast) "" else "NULL"},${if (legacyCast) "" else " NULL"}$rb")
+          s"$lb${if (legacyCast) "" else "null"},${if (legacyCast) "" else " null"}$rb")
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -289,6 +289,7 @@ class Dataset[T] private[sql](
     // first `truncate-3` and "..."
     schema.fieldNames.map(SchemaUtils.escapeMetaCharacters).toSeq +: data.map { row =>
       row.toSeq.map { cell =>
+        assert(cell != null, "ToPrettyString is not nullable and should not return null value")
         // Escapes meta-characters not to break the `showString` format
         val str = SchemaUtils.escapeMetaCharacters(cell.toString)
         if (truncate > 0 && str.length > truncate) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/40699 to avoid changing the Cast behavior. It pulls out the cast-to-string code into a base trait, and add a new Expression `ToPrettyString` to extend this trait with a little customization.

It also handles binary value inside array/struct/map to also print hex format, for `df.show` only, not `Cast`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
avoid behavior change

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
change back the behavior of casting array/map/struct to string regarding null elements. It was `null`, then changed to `NULL` in #40699 , and is `null` again after this PR.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests