### PR TITLE
[SPARK-42419][FOLLOWUP][CONNECT][PYTHON] Remove unused exception

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -251,11 +251,6 @@ class Column:
             start_expr = startPos._expr
         elif isinstance(startPos, int):
             start_expr = LiteralExpression._from_value(startPos)
-        else:
-            raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_INT",
-                message_parameters={"arg_name": "startPos", "arg_type": type(startPos).__name__},
-            )
 
         return Column(UnresolvedFunction("substring", [self._expr, start_expr, length_expr]))
 

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -239,7 +239,7 @@ class Column:
 
         if isinstance(length, Column):
             length_expr = length._expr
-            start_expr = startPos._expr
+            start_expr = startPos._expr  # type: ignore[union-attr]
         elif isinstance(length, int):
             length_expr = LiteralExpression._from_value(length)
             start_expr = LiteralExpression._from_value(startPos)

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -239,19 +239,15 @@ class Column:
 
         if isinstance(length, Column):
             length_expr = length._expr
+            start_expr = startPos._expr
         elif isinstance(length, int):
             length_expr = LiteralExpression._from_value(length)
+            start_expr = LiteralExpression._from_value(startPos)
         else:
             raise PySparkTypeError(
                 error_class="NOT_COLUMN_OR_INT",
                 message_parameters={"arg_name": "length", "arg_type": type(length).__name__},
             )
-
-        if isinstance(startPos, Column):
-            start_expr = startPos._expr
-        elif isinstance(startPos, int):
-            start_expr = LiteralExpression._from_value(startPos)
-
         return Column(UnresolvedFunction("substring", [self._expr, start_expr, length_expr]))
 
     substr.__doc__ = PySparkColumn.substr.__doc__


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This is follow-up for https://github.com/apache/spark/pull/39991 to remove unused exception.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`PySparkTypeError` never raises because we checked the type already in the codes above `if type(startPos) != type(length):` and raise `PySparkTypeError` for unsupported type for `length`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. it's minor code cleanup

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

The existing CI should pass.
